### PR TITLE
Remove redundant null checks

### DIFF
--- a/modules/flowable-engine/src/main/java/org/activiti/engine/impl/HistoricVariableInstanceQueryImpl.java
+++ b/modules/flowable-engine/src/main/java/org/activiti/engine/impl/HistoricVariableInstanceQueryImpl.java
@@ -225,7 +225,7 @@ public class HistoricVariableInstanceQueryImpl extends AbstractQuery<HistoricVar
       for (HistoricVariableInstance historicVariableInstance : historicVariableInstances) {
         if (historicVariableInstance instanceof HistoricVariableInstanceEntity) {
           HistoricVariableInstanceEntity variableEntity = (HistoricVariableInstanceEntity) historicVariableInstance;
-          if (variableEntity != null && variableEntity.getVariableType() != null) {
+          if (variableEntity.getVariableType() != null) {
             variableEntity.getValue();
 
             // make sure JPA entities are cached for later retrieval

--- a/modules/flowable-engine/src/main/java/org/activiti/engine/impl/cmd/GetDataObjectCmd.java
+++ b/modules/flowable-engine/src/main/java/org/activiti/engine/impl/cmd/GetDataObjectCmd.java
@@ -120,7 +120,7 @@ public class GetDataObjectCmd implements Command<DataObject>, Serializable {
         ObjectNode languageNode = Context.getLocalizationElementProperties(locale, foundDataObject.getId(), 
             execution.getProcessDefinitionId(), withLocalizationFallback);
         
-        if (variableEntity != null && languageNode != null) {
+        if (languageNode != null) {
           JsonNode nameNode = languageNode.get(DynamicBpmnConstants.LOCALIZATION_NAME);
           if (nameNode != null) {
             localizedName = nameNode.asText();

--- a/modules/flowable-engine/src/main/java/org/activiti/engine/impl/cmd/SaveProcessDefinitionInfoCmd.java
+++ b/modules/flowable-engine/src/main/java/org/activiti/engine/impl/cmd/SaveProcessDefinitionInfoCmd.java
@@ -57,13 +57,11 @@ public class SaveProcessDefinitionInfoCmd implements Command<Void>, Serializable
       commandContext.getProcessDefinitionInfoEntityManager().insertProcessDefinitionInfo(definitionInfoEntity);
     }
     
-    if (infoNode != null) {
-      try {
-        ObjectWriter writer = commandContext.getProcessEngineConfiguration().getObjectMapper().writer();
-        commandContext.getProcessDefinitionInfoEntityManager().updateInfoJson(definitionInfoEntity.getId(), writer.writeValueAsBytes(infoNode));
-      } catch (Exception e) {
-        throw new ActivitiException("Unable to serialize info node " + infoNode);
-      }
+    try {
+      ObjectWriter writer = commandContext.getProcessEngineConfiguration().getObjectMapper().writer();
+      commandContext.getProcessDefinitionInfoEntityManager().updateInfoJson(definitionInfoEntity.getId(), writer.writeValueAsBytes(infoNode));
+    } catch (Exception e) {
+      throw new ActivitiException("Unable to serialize info node " + infoNode);
     }
     
     return null;

--- a/modules/flowable-engine/src/main/java/org/activiti/engine/impl/history/DefaultHistoryManager.java
+++ b/modules/flowable-engine/src/main/java/org/activiti/engine/impl/history/DefaultHistoryManager.java
@@ -297,8 +297,7 @@ public class DefaultHistoryManager extends AbstractManager implements HistoryMan
       }
     }
     
-    if (createOnNotFound 
-        && activityId != null
+    if (createOnNotFound
         && ( (execution.getCurrentFlowElement() != null && execution.getCurrentFlowElement() instanceof FlowNode) || execution.getCurrentFlowElement() == null)) {
       return createHistoricActivityInstanceEntity(execution);
     }


### PR DESCRIPTION
The details for each change:

- DefaultHistoryManager: remove check for activitiyId as already checked on line 265
- GetDataObjectCmd: remove check for variableEntity as already checked on line 93
- HistoricVariableInstanceQueryImpl: remove check for variableEntity as if it was null then the instanceof check on line 227 would have failed
- SaveProcessDefinitionInfoCmd: remove check for infoNode as already checked on line 48

