### PR TITLE
Add interface CandidateManager for getGroupsForCandidateUser

### DIFF
--- a/modules/flowable-engine/src/main/java/org/activiti/engine/CandidateManager.java
+++ b/modules/flowable-engine/src/main/java/org/activiti/engine/CandidateManager.java
@@ -1,0 +1,9 @@
+package org.activiti.engine;
+
+import java.util.List;
+
+public interface CandidateManager {
+
+  List<String> getGroupsForCandidateUser(String candidateUser);
+  
+}

--- a/modules/flowable-engine/src/main/java/org/activiti/engine/DefaultCandidateManager.java
+++ b/modules/flowable-engine/src/main/java/org/activiti/engine/DefaultCandidateManager.java
@@ -1,0 +1,27 @@
+package org.activiti.engine;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.activiti.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.activiti.engine.impl.persistence.AbstractManager;
+import org.activiti.idm.api.Group;
+import org.activiti.idm.api.IdmIdentityService;
+
+public class DefaultCandidateManager extends AbstractManager implements CandidateManager {
+
+  public DefaultCandidateManager(ProcessEngineConfigurationImpl processEngineConfiguration) {
+    super(processEngineConfiguration);
+  }
+
+  @Override
+  public List<String> getGroupsForCandidateUser(String candidateUser) {
+    IdmIdentityService identityService = getProcessEngineConfiguration().getIdmIdentityService();
+    List<Group> groups = identityService.createGroupQuery().groupMember(candidateUser).list();
+    List<String> groupIds = new ArrayList<String>();
+    for (Group group : groups) {
+      groupIds.add(group.getId());
+    }
+    return groupIds;
+  }
+}

--- a/modules/flowable-engine/src/main/java/org/activiti/engine/impl/HistoricTaskInstanceQueryImpl.java
+++ b/modules/flowable-engine/src/main/java/org/activiti/engine/impl/HistoricTaskInstanceQueryImpl.java
@@ -20,7 +20,6 @@ import java.util.List;
 import org.activiti.engine.ActivitiException;
 import org.activiti.engine.ActivitiIllegalArgumentException;
 import org.activiti.engine.DynamicBpmnConstants;
-import org.activiti.engine.IdentityService;
 import org.activiti.engine.history.HistoricTaskInstance;
 import org.activiti.engine.history.HistoricTaskInstanceQuery;
 import org.activiti.engine.impl.context.Context;
@@ -28,7 +27,6 @@ import org.activiti.engine.impl.interceptor.CommandContext;
 import org.activiti.engine.impl.interceptor.CommandExecutor;
 import org.activiti.engine.impl.persistence.entity.HistoricTaskInstanceEntity;
 import org.activiti.engine.impl.variable.VariableTypes;
-import org.activiti.idm.api.Group;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -1247,13 +1245,7 @@ public class HistoricTaskInstanceQueryImpl extends AbstractVariableQueryImpl<His
   }
 
   protected List<String> getGroupsForCandidateUser(String candidateUser) {
-    IdentityService identityService = Context.getProcessEngineConfiguration().getIdentityService();
-    List<Group> groups = identityService.createGroupQuery().groupMember(candidateUser).list();
-    List<String> groupIds = new ArrayList<String>();
-    for (Group group : groups) {
-      groupIds.add(group.getId());
-    }
-    return groupIds;
+    return Context.getProcessEngineConfiguration().getCandidateManager().getGroupsForCandidateUser(candidateUser);
   }
 
   // getters and setters

--- a/modules/flowable-engine/src/main/java/org/activiti/engine/impl/ProcessDefinitionQueryImpl.java
+++ b/modules/flowable-engine/src/main/java/org/activiti/engine/impl/ProcessDefinitionQueryImpl.java
@@ -13,20 +13,17 @@
 
 package org.activiti.engine.impl;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
 import org.activiti.engine.ActivitiException;
 import org.activiti.engine.ActivitiIllegalArgumentException;
-import org.activiti.engine.IdentityService;
 import org.activiti.engine.impl.context.Context;
 import org.activiti.engine.impl.interceptor.CommandContext;
 import org.activiti.engine.impl.interceptor.CommandExecutor;
 import org.activiti.engine.impl.persistence.entity.SuspensionState;
 import org.activiti.engine.repository.ProcessDefinition;
 import org.activiti.engine.repository.ProcessDefinitionQuery;
-import org.activiti.idm.api.Group;
 
 /**
  * @author Tom Baeyens
@@ -276,17 +273,10 @@ public class ProcessDefinitionQueryImpl extends AbstractQuery<ProcessDefinitionQ
   }
 
   public List<String> getAuthorizationGroups() {
-    // Similar behaviour as the TaskQuery.taskCandidateUser() which includes the groups the candidate user is part of
-    if (authorizationUserId != null) {
-      IdentityService identityService = Context.getProcessEngineConfiguration().getIdentityService();
-      List<Group> groups = identityService.createGroupQuery().groupMember(authorizationUserId).list();
-      List<String> groupIds = new ArrayList<String>();
-      for (Group group : groups) {
-        groupIds.add(group.getId());
-      }
-      return groupIds;
+    if (authorizationUserId == null) {
+      return null;
     }
-    return null;
+    return Context.getProcessEngineConfiguration().getCandidateManager().getGroupsForCandidateUser(authorizationUserId);
   }
 
   // sorting ////////////////////////////////////////////

--- a/modules/flowable-engine/src/main/java/org/activiti/engine/impl/TaskQueryImpl.java
+++ b/modules/flowable-engine/src/main/java/org/activiti/engine/impl/TaskQueryImpl.java
@@ -19,7 +19,6 @@ import java.util.List;
 import org.activiti.engine.ActivitiException;
 import org.activiti.engine.ActivitiIllegalArgumentException;
 import org.activiti.engine.DynamicBpmnConstants;
-import org.activiti.engine.IdentityService;
 import org.activiti.engine.impl.context.Context;
 import org.activiti.engine.impl.interceptor.CommandContext;
 import org.activiti.engine.impl.interceptor.CommandExecutor;
@@ -28,7 +27,6 @@ import org.activiti.engine.impl.variable.VariableTypes;
 import org.activiti.engine.task.DelegationState;
 import org.activiti.engine.task.Task;
 import org.activiti.engine.task.TaskQuery;
-import org.activiti.idm.api.Group;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -1117,13 +1115,7 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
   }
 
   protected List<String> getGroupsForCandidateUser(String candidateUser) {
-    IdentityService identityService = Context.getProcessEngineConfiguration().getIdentityService();
-    List<Group> groups = identityService.createGroupQuery().groupMember(candidateUser).list();
-    List<String> groupIds = new ArrayList<String>();
-    for (Group group : groups) {
-      groupIds.add(group.getId());
-    }
-    return groupIds;
+    return Context.getProcessEngineConfiguration().getCandidateManager().getGroupsForCandidateUser(candidateUser);
   }
 
   protected void ensureVariablesInitialized() {

--- a/modules/flowable-engine/src/main/java/org/activiti/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/modules/flowable-engine/src/main/java/org/activiti/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -43,6 +43,8 @@ import javax.xml.namespace.QName;
 import org.activiti.dmn.api.DmnRepositoryService;
 import org.activiti.dmn.api.DmnRuleService;
 import org.activiti.engine.ActivitiException;
+import org.activiti.engine.CandidateManager;
+import org.activiti.engine.DefaultCandidateManager;
 import org.activiti.engine.DynamicBpmnService;
 import org.activiti.engine.FormService;
 import org.activiti.engine.HistoryService;
@@ -462,6 +464,10 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   protected TaskEntityManager taskEntityManager;
   protected VariableInstanceEntityManager variableInstanceEntityManager;
   
+  // Candidate Manager
+  
+  protected CandidateManager candidateManager;
+
   // History Manager
   
   protected HistoryManager historyManager;
@@ -954,6 +960,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     initSessionFactories();
     initDataManagers();
     initEntityManagers();
+    initCandidateManager();
     initHistoryManager();
     initJpa();
     initDeployers();
@@ -1497,6 +1504,14 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     }
     if (variableInstanceEntityManager == null) {
       variableInstanceEntityManager = new VariableInstanceEntityManagerImpl(this, variableInstanceDataManager);
+    }
+  }
+  
+  // CandidateManager //////////////////////////////
+  
+  public void initCandidateManager() {
+    if (candidateManager == null) {
+      candidateManager = new DefaultCandidateManager(this);
     }
   }
   
@@ -3685,6 +3700,14 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   public ProcessEngineConfigurationImpl setTableDataManager(TableDataManager tableDataManager) {
     this.tableDataManager = tableDataManager;
     return this;
+  }
+  
+  public CandidateManager getCandidateManager() {
+    return candidateManager;
+  }
+  
+  public void setCandidateManager(CandidateManager candidateManager) {
+    this.candidateManager = candidateManager;
   }
 
   public HistoryManager getHistoryManager() {


### PR DESCRIPTION
Most projects will have their own user/group/role management, so will not need the IdmIdentityManager. This PR greatly simplifies the interface to implement for getGroupsForCandidateUser support in such cases.