### PR TITLE
Update CallActivityBehavior to send VARIABLE_UPDATED events.

### DIFF
--- a/modules/flowable-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/CallActivityBehavior.java
+++ b/modules/flowable-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/CallActivityBehavior.java
@@ -120,7 +120,9 @@ public class CallActivityBehavior extends AbstractBpmnActivityBehavior implement
     }
 
     // process template-defined data objects
-    Map<String, Object> variables = processDataObjects(subProcess.getDataObjects());
+    subProcessInstance.setVariables(processDataObjects(subProcess.getDataObjects()));
+    
+    Map<String, Object> variables = new HashMap<String,Object>();
     
     if (callActivity.isInheritVariables()) {
       Map<String, Object> executionVariables = execution.getVariables();

--- a/modules/flowable-engine/src/test/java/org/activiti/engine/test/api/event/VariableEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/activiti/engine/test/api/event/VariableEventsTest.java
@@ -16,6 +16,7 @@ import org.activiti.engine.delegate.event.ActivitiEvent;
 import org.activiti.engine.delegate.event.ActivitiEventType;
 import org.activiti.engine.delegate.event.ActivitiVariableEvent;
 import org.activiti.engine.impl.history.HistoryLevel;
+import org.activiti.engine.impl.persistence.entity.ExecutionEntity;
 import org.activiti.engine.impl.test.PluggableActivitiTestCase;
 import org.activiti.engine.runtime.Execution;
 import org.activiti.engine.runtime.ProcessInstance;
@@ -349,6 +350,82 @@ public class VariableEventsTest extends PluggableActivitiTestCase {
       }
     }
 
+  }
+
+  @Deployment(resources = { "org/activiti/engine/test/api/runtime/processVariableEvent.bpmn20.xml" })
+  public void testProcessInstanceVariableEventsForModeledDataObjectOnStart() throws Exception {
+
+    HashMap<String, Object> vars = new HashMap<String, Object>();
+    vars.put("var2", "The value");
+
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("processVariableEvent", vars);
+    assertNotNull(processInstance);
+
+    // Check create event
+    assertEquals(2, listener.getEventsReceived().size());
+    ActivitiVariableEvent event = (ActivitiVariableEvent) listener.getEventsReceived().get(0);
+    assertEquals(ActivitiEventType.VARIABLE_CREATED, event.getType());
+    assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
+    assertEquals(processInstance.getId(), event.getExecutionId());
+    assertEquals(processInstance.getId(), event.getProcessInstanceId());
+    assertNull(event.getTaskId());
+    assertEquals("var2", event.getVariableName());
+    assertEquals("var2 value", event.getVariableValue());
+
+    event = (ActivitiVariableEvent) listener.getEventsReceived().get(1);
+    assertEquals(ActivitiEventType.VARIABLE_UPDATED, event.getType());
+    assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
+    assertEquals(processInstance.getId(), event.getExecutionId());
+    assertEquals(processInstance.getId(), event.getProcessInstanceId());
+    assertNull(event.getTaskId());
+    assertEquals("var2", event.getVariableName());
+    assertEquals("The value", event.getVariableValue());
+
+    listener.clearEventsReceived();
+  }
+
+  /**
+   * Test variables event for modeled data objects on callActivity.
+   */
+  @Deployment(resources = { "org/activiti/engine/test/api/runtime/callActivity.bpmn20.xml", "org/activiti/engine/test/api/runtime/calledActivity.bpmn20.xml" })
+  public void testProcessInstanceVariableEventsForModeledDataObjectOnCallActivityStart() throws Exception {
+
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("callActivity");
+    assertNotNull(processInstance);
+
+    // Check create event
+    assertEquals(3, listener.getEventsReceived().size());
+
+    ActivitiVariableEvent event = (ActivitiVariableEvent) listener.getEventsReceived().get(0);
+    assertEquals(ActivitiEventType.VARIABLE_CREATED, event.getType());
+    assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
+    assertEquals(processInstance.getId(), event.getExecutionId());
+    assertEquals(processInstance.getId(), event.getProcessInstanceId());
+    assertNull(event.getTaskId());
+    assertEquals("var1", event.getVariableName());
+    assertEquals("var1 value", event.getVariableValue());
+
+    ExecutionEntity subprocessInstance = (ExecutionEntity) runtimeService.createExecutionQuery().rootProcessInstanceId(processInstance.getId()).onlySubProcessExecutions()
+            .singleResult();
+    assertNotNull(subprocessInstance);
+
+    event = (ActivitiVariableEvent) listener.getEventsReceived().get(1);
+    assertEquals(ActivitiEventType.VARIABLE_CREATED, event.getType());
+    assertEquals(subprocessInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
+    assertEquals(subprocessInstance.getId(), event.getExecutionId());
+    assertEquals(subprocessInstance.getId(), event.getProcessInstanceId());
+    assertNull(event.getTaskId());
+    assertEquals("var3", event.getVariableName());
+    assertEquals("var3 value", event.getVariableValue());
+
+    event = (ActivitiVariableEvent) listener.getEventsReceived().get(2);
+    assertEquals(ActivitiEventType.VARIABLE_UPDATED, event.getType());
+    assertEquals(subprocessInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
+    assertEquals(subprocessInstance.getId(), event.getExecutionId());
+    assertEquals(subprocessInstance.getId(), event.getProcessInstanceId());
+    assertNull(event.getTaskId());
+    assertEquals("var3", event.getVariableName());
+    assertEquals("var1 value", event.getVariableValue());
   }
 
   @Override

--- a/modules/flowable-engine/src/test/resources/org/activiti/engine/test/api/runtime/callActivity.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/activiti/engine/test/api/runtime/callActivity.bpmn20.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:activiti="http://activiti.org/bpmn"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  targetNamespace="org.activiti.enginge.test.api.runtime.Category">
+
+  <process id="callActivity" name="callActivity">
+	<documentation>oneTaskProcessDescription</documentation>
+
+    <dataObject itemSubjectRef="xsd:string" name="var1" id="var1">
+      <extensionElements>
+        <activiti:value>var1 value</activiti:value>
+      </extensionElements>
+    </dataObject>    
+
+    <startEvent id="theStart" />
+    
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="callSubProcess" />
+    
+    <callActivity id="callSubProcess" calledElement="calledActivity">
+      <extensionElements>
+        <activiti:in source="var1" target="var3" />
+      </extensionElements>
+    </callActivity>
+      
+    <sequenceFlow id="flow2" sourceRef="callSubProcess" targetRef="theEnd" />
+    <endEvent id="theEnd" />
+    
+  </process>
+
+</definitions>

--- a/modules/flowable-engine/src/test/resources/org/activiti/engine/test/api/runtime/calledActivity.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/activiti/engine/test/api/runtime/calledActivity.bpmn20.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:activiti="http://activiti.org/bpmn"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  targetNamespace="org.activiti.enginge.test.api.runtime.Category">
+
+  <process id="calledActivity" name="calledActivity">
+    
+    <dataObject itemSubjectRef="xsd:string" name="var3" id="var3">
+      <extensionElements>
+        <activiti:value>var3 value</activiti:value>
+      </extensionElements>
+    </dataObject>
+
+    <startEvent id="theStart" />
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="theTask" />
+    <userTask id="theTask" name="my task" />    
+    <sequenceFlow id="flow2" sourceRef="theTask" targetRef="theEnd" />
+    <endEvent id="theEnd" />
+    
+  </process>
+
+</definitions>

--- a/modules/flowable-engine/src/test/resources/org/activiti/engine/test/api/runtime/processVariableEvent.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/activiti/engine/test/api/runtime/processVariableEvent.bpmn20.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:activiti="http://activiti.org/bpmn"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  targetNamespace="org.activiti.enginge.test.api.runtime.Category">
+
+  <process id="processVariableEvent" name="processVariableEvent">
+    
+    <dataObject itemSubjectRef="xsd:string" name="var2" id="var2">
+      <extensionElements>
+        <activiti:value>var2 value</activiti:value>
+      </extensionElements>
+    </dataObject>
+
+    <startEvent id="theStart" />
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="theTask" />
+    <userTask id="theTask" name="my task" />    
+    <sequenceFlow id="flow2" sourceRef="theTask" targetRef="theEnd" />
+    <endEvent id="theEnd" />
+    
+  </process>
+
+</definitions>


### PR DESCRIPTION
This change makes CallActivityBehavior consistent with the variable event behavior for starting a process via the API.
- Modeled DataObjects - send VARIABLE_CREATED event
- Variables passed in via API call or CallActivity send a VARIABLE_UPDATED event if the variable was modeled as a dataobject otherwise a VARIABLE_CREATED event is sent.
