### PR TITLE
Fixed search variables by activityInstanceID in HistoricDetailQuery

### DIFF
--- a/modules/flowable-engine/src/main/java/org/activiti/engine/impl/persistence/entity/VariableScopeImpl.java
+++ b/modules/flowable-engine/src/main/java/org/activiti/engine/impl/persistence/entity/VariableScopeImpl.java
@@ -690,8 +690,16 @@ public abstract class VariableScopeImpl extends AbstractEntity implements Serial
         } else {
 
           VariableScopeImpl parent = getParentVariableScope();
+          //if (parent != null) {
+          //  parent.setVariable(variableName, value, sourceExecution, fetchAllVariables);
+          //  return;
+          //}
           if (parent != null) {
-            parent.setVariable(variableName, value, sourceExecution, fetchAllVariables);
+            if (sourceExecution == null) {
+               parent.setVariable(variableName, value, fetchAllVariables);
+            } else {
+               parent.setVariable(variableName, value, sourceExecution, fetchAllVariables);
+            }
             return;
           }
 

--- a/modules/flowable-engine/src/test/java/org/activiti/engine/test/api/task/TaskServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/activiti/engine/test/api/task/TaskServiceTest.java
@@ -29,8 +29,10 @@ import org.activiti.engine.ActivitiIllegalArgumentException;
 import org.activiti.engine.ActivitiObjectNotFoundException;
 import org.activiti.engine.ActivitiOptimisticLockingException;
 import org.activiti.engine.ActivitiTaskAlreadyClaimedException;
+import org.activiti.engine.history.HistoricActivityInstance;
 import org.activiti.engine.history.HistoricDetail;
 import org.activiti.engine.history.HistoricTaskInstance;
+import org.activiti.engine.history.HistoricVariableUpdate;
 import org.activiti.engine.impl.TaskServiceImpl;
 import org.activiti.engine.impl.history.HistoryLevel;
 import org.activiti.engine.impl.persistence.entity.CommentEntity;
@@ -1303,6 +1305,29 @@ public class TaskServiceTest extends PluggableActivitiTestCase {
     } catch (ActivitiIllegalArgumentException ae) {
       assertTextPresent("taskId is null", ae.getMessage());
     }
+  }
+
+  @Deployment(resources = { "org/activiti/engine/test/api/oneTaskProcess.bpmn20.xml" })
+  public void testGetVariableByHistoricActivityInstance() {
+     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+     assertNotNull(processInstance);
+     Task task = taskService.createTaskQuery().singleResult();
+
+     taskService.setVariable(task.getId(), "variable1", "value1");
+     taskService.setVariable(task.getId(), "variable1", "value2");
+
+     HistoricActivityInstance historicActivitiInstance = historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstance.getId())
+            .activityId("theTask").singleResult();
+     assertNotNull(historicActivitiInstance);
+
+     List<HistoricDetail> resultSet = historyService.createHistoricDetailQuery().variableUpdates().activityInstanceId(historicActivitiInstance.getId())
+            .orderByTime().asc().list();
+
+    assertEquals(2, resultSet.size());
+    assertEquals("variable1", ((HistoricVariableUpdate) resultSet.get(0)).getVariableName());
+    assertEquals("value1", ((HistoricVariableUpdate) resultSet.get(0)).getValue());
+    assertEquals("variable1", ((HistoricVariableUpdate) resultSet.get(1)).getVariableName());
+    assertEquals("value2", ((HistoricVariableUpdate) resultSet.get(1)).getValue());
   }
 
   @Deployment(resources = { "org/activiti/engine/test/api/oneTaskProcess.bpmn20.xml" })


### PR DESCRIPTION
This fixes a bug in the treatment of HistoricDetail (VariableUpdate type). It is occurs when variables stored in a UserTask with "processEngine.getTaskService().setVariable()" without completing the UserTask.

There is a unit test to validate the change.
