### PR TITLE
AsyncExecutor improvements

### DIFF
--- a/modules/flowable-engine/src/main/java/org/activiti/engine/impl/asyncexecutor/AbstractAsyncJobExecutor.java
+++ b/modules/flowable-engine/src/main/java/org/activiti/engine/impl/asyncexecutor/AbstractAsyncJobExecutor.java
@@ -15,6 +15,7 @@ package org.activiti.engine.impl.asyncexecutor;
 import java.util.LinkedList;
 import java.util.UUID;
 
+import org.activiti.engine.impl.cmd.UnacquireOwnedJobsCmd;
 import org.activiti.engine.impl.context.Context;
 import org.activiti.engine.impl.interceptor.Command;
 import org.activiti.engine.impl.interceptor.CommandContext;
@@ -106,6 +107,10 @@ public abstract class AbstractAsyncJobExecutor implements AsyncExecutor {
     commandContext.getJobEntityManager().unacquireJob(job.getId());
   }
   
+  protected void unlockOwnedJobs() {
+    commandExecutor.execute(new UnacquireOwnedJobsCmd(lockOwner, null));
+  }
+
   protected Runnable createRunnableForJob(JobEntity job) {
     return executeAsyncRunnableFactory.createExecuteAsyncRunnable(job, commandExecutor);
   }

--- a/modules/flowable-engine/src/main/java/org/activiti/engine/impl/asyncexecutor/AsyncExecutor.java
+++ b/modules/flowable-engine/src/main/java/org/activiti/engine/impl/asyncexecutor/AsyncExecutor.java
@@ -38,6 +38,7 @@ public interface AsyncExecutor {
    */
   boolean executeAsyncJob(JobEntity job);
   
+  int getRemainingCapacity();
   
   /* Getters and Setters */
   

--- a/modules/flowable-engine/src/main/java/org/activiti/engine/impl/cfg/multitenant/MultiSchemaMultiTenantProcessEngineConfiguration.java
+++ b/modules/flowable-engine/src/main/java/org/activiti/engine/impl/cfg/multitenant/MultiSchemaMultiTenantProcessEngineConfiguration.java
@@ -12,7 +12,6 @@
  */
 package org.activiti.engine.impl.cfg.multitenant;
 
-import java.util.Collection;
 import java.util.concurrent.ExecutorService;
 
 import javax.sql.DataSource;
@@ -31,7 +30,6 @@ import org.activiti.engine.impl.jobexecutor.JobExecutor;
 import org.activiti.engine.impl.persistence.StrongUuidGenerator;
 import org.activiti.engine.impl.persistence.deploy.MultiSchemaMultiTenantProcessDefinitionCache;
 import org.activiti.engine.repository.DeploymentBuilder;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/modules/flowable-engine/src/main/java/org/activiti/engine/impl/cfg/multitenant/TenantAwareDataSource.java
+++ b/modules/flowable-engine/src/main/java/org/activiti/engine/impl/cfg/multitenant/TenantAwareDataSource.java
@@ -58,7 +58,7 @@ public class TenantAwareDataSource implements DataSource {
   }
 
   public Connection getConnection(String username, String password) throws SQLException {
-    return  getCurrentDataSource().getConnection(username, password);
+    return getCurrentDataSource().getConnection(username, password);
   }
   
   protected DataSource getCurrentDataSource() {

--- a/modules/flowable-engine/src/main/java/org/activiti/engine/impl/cmd/UnacquireJobsCmd.java
+++ b/modules/flowable-engine/src/main/java/org/activiti/engine/impl/cmd/UnacquireJobsCmd.java
@@ -1,0 +1,28 @@
+package org.activiti.engine.impl.cmd;
+
+import java.util.List;
+
+import org.activiti.engine.impl.interceptor.Command;
+import org.activiti.engine.impl.interceptor.CommandContext;
+import org.activiti.engine.impl.persistence.entity.JobEntity;
+
+/**
+ *
+ * @author Marcus Klimstra
+ */
+public class UnacquireJobsCmd implements Command<Void> {
+
+  private final List<JobEntity> jobs;
+  
+  public UnacquireJobsCmd(List<JobEntity> jobs) {
+    this.jobs = jobs;
+  }
+
+  @Override
+  public Void execute(CommandContext commandContext) {
+    for (JobEntity job : jobs) {
+      commandContext.getJobEntityManager().unacquireJob(job.getId());
+    }
+    return null;
+  }
+}

--- a/modules/flowable-engine/src/main/java/org/activiti/engine/impl/cmd/UnacquireOwnedJobsCmd.java
+++ b/modules/flowable-engine/src/main/java/org/activiti/engine/impl/cmd/UnacquireOwnedJobsCmd.java
@@ -1,0 +1,21 @@
+package org.activiti.engine.impl.cmd;
+
+import org.activiti.engine.impl.interceptor.Command;
+import org.activiti.engine.impl.interceptor.CommandContext;
+
+public class UnacquireOwnedJobsCmd implements Command<Void> {
+
+  private final String lockOwner;
+  private final String tenantId;
+  
+  public UnacquireOwnedJobsCmd(String lockOwner, String tenantId) {
+    this.lockOwner = lockOwner;
+    this.tenantId = tenantId;
+  }
+
+  @Override
+  public Void execute(CommandContext commandContext) {
+    commandContext.getJobEntityManager().unacquireOwnedJobs(lockOwner, tenantId);
+    return null;
+  }
+}

--- a/modules/flowable-engine/src/main/java/org/activiti/engine/impl/persistence/entity/JobEntityManager.java
+++ b/modules/flowable-engine/src/main/java/org/activiti/engine/impl/persistence/entity/JobEntityManager.java
@@ -233,6 +233,13 @@ public class JobEntityManager extends AbstractManager {
   	getDbSqlSession().update("unacquireJob", params);
   }
 
+  public void unacquireOwnedJobs(String lockOwner, String tenantId) {
+    Map<String, Object> params = new HashMap<String, Object>(2);
+    params.put("lockOwner", lockOwner);
+    params.put("tenantId", tenantId);
+    getDbSqlSession().update("unacquireOwnedJobs", params);
+  }
+
   public long findJobCountByQueryCriteria(JobQueryImpl jobQuery) {
     return (Long) getDbSqlSession().selectOne("selectJobCountByQueryCriteria", jobQuery);
   }
@@ -251,5 +258,4 @@ public class JobEntityManager extends AbstractManager {
     params.put("dueDate", Context.getProcessEngineConfiguration().getClock().getCurrentTime());
     return getDbSqlSession().update("updateJobLockForAllJobs", params);
   }
-  
 }

--- a/modules/flowable-engine/src/main/resources/org/activiti/db/mapping/entity/Job.xml
+++ b/modules/flowable-engine/src/main/resources/org/activiti/db/mapping/entity/Job.xml
@@ -657,5 +657,14 @@
     set DUEDATE_ = #{dueDate,jdbcType=TIMESTAMP}, LOCK_OWNER_ = null, LOCK_EXP_TIME_ = null
     where ID_ = #{id,jdbcType=VARCHAR}
   </update>
+  
+  <update id="unacquireOwnedJobs" parameterType="java.util.Map">
+    update ${prefix}ACT_RU_JOB
+    set LOCK_OWNER_ = null, LOCK_EXP_TIME_ = null
+    where LOCK_OWNER_ = #{lockOwner,jdbcType=VARCHAR}
+    <if test="tenantId != null">
+      and RES.TENANT_ID_ = #{tenantId}
+    </if>
+  </update>
 
 </mapper>

--- a/modules/flowable-engine/src/test/java/org/activiti/engine/test/cfg/multitenant/DummyTenantInfoHolder.java
+++ b/modules/flowable-engine/src/test/java/org/activiti/engine/test/cfg/multitenant/DummyTenantInfoHolder.java
@@ -58,9 +58,9 @@ public class DummyTenantInfoHolder implements TenantInfoHolder {
     return currentTenantId.get();
   }
   
- public void clearCurrentTenantId() {
-   currentTenantId.set(null);
-}
+  public void clearCurrentTenantId() {
+    currentTenantId.set(null);
+  }
   
   public void addTenant(String tenantId) {
     tenantToUserMapping.put(tenantId, new ArrayList<String>());


### PR DESCRIPTION
- only attempt to acquire new jobs if the queue has capacity.
- only attempt to acquire at most the number of jobs that fit in the queue.
- if there are still rejected jobs, unacquire them.
- option to unacquire all jobs by lock owner at startup.