### PR TITLE
Refactor deprecated usages

### DIFF
--- a/modules/flowable-bpmn-model/src/main/java/org/activiti/bpmn/model/Process.java
+++ b/modules/flowable-bpmn-model/src/main/java/org/activiti/bpmn/model/Process.java
@@ -112,10 +112,10 @@ public class Process extends BaseElement implements FlowElementsContainer, HasEx
   }
 
   /**
-   * @param searchRecurive: searches the whole process, including subprocesses
+   * @param searchRecursive: searches the whole process, including subprocesses
    */
-  public FlowElement getFlowElement(String flowElementId, boolean searchRecurive) {
-    if (searchRecurive) {
+  public FlowElement getFlowElement(String flowElementId, boolean searchRecursive) {
+    if (searchRecursive) {
       return flowElementMap.get(flowElementId);
     } else {
       return findFlowElementInList(flowElementId);

--- a/modules/flowable-content-engine/src/main/java/org/activiti/content/engine/impl/AbstractNativeQuery.java
+++ b/modules/flowable-content-engine/src/main/java/org/activiti/content/engine/impl/AbstractNativeQuery.java
@@ -149,9 +149,7 @@ public abstract class AbstractNativeQuery<T extends NativeQuery<?, ?>, U> implem
    * 
    * @param maxResults
    * @param firstResult
-   * 
-   * @param page
-   *          used if the results must be paged. If null, no paging will be applied.
+   *
    */
   public abstract List<U> executeList(CommandContext commandContext, Map<String, Object> parameterMap, int firstResult, int maxResults);
 

--- a/modules/flowable-content-engine/src/main/java/org/activiti/content/engine/impl/AbstractNativeQuery.java
+++ b/modules/flowable-content-engine/src/main/java/org/activiti/content/engine/impl/AbstractNativeQuery.java
@@ -16,6 +16,7 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.activiti.content.engine.impl.context.Context;
 import org.activiti.content.engine.impl.interceptor.Command;
@@ -23,7 +24,6 @@ import org.activiti.content.engine.impl.interceptor.CommandContext;
 import org.activiti.content.engine.impl.interceptor.CommandExecutor;
 import org.activiti.engine.common.api.ActivitiException;
 import org.activiti.engine.common.api.query.NativeQuery;
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -119,7 +119,7 @@ public abstract class AbstractNativeQuery<T extends NativeQuery<?, ?>, U> implem
       parameterMap.put("resultType", "LIST_PAGE");
       parameterMap.put("firstResult", firstResult);
       parameterMap.put("maxResults", maxResults);
-      if (StringUtils.isNotBlank(ObjectUtils.toString(parameterMap.get("orderBy")))) {
+      if (StringUtils.isNotBlank(Objects.toString(parameterMap.get("orderBy"), ""))) {
         parameterMap.put("orderByColumns", "RES." + parameterMap.get("orderBy"));
       } else {
         parameterMap.put("orderByColumns", "RES.ID_ asc");

--- a/modules/flowable-dmn-engine/src/main/java/org/activiti/dmn/engine/impl/AbstractNativeQuery.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/activiti/dmn/engine/impl/AbstractNativeQuery.java
@@ -149,9 +149,7 @@ public abstract class AbstractNativeQuery<T extends NativeQuery<?, ?>, U> implem
    * 
    * @param maxResults
    * @param firstResult
-   * 
-   * @param page
-   *          used if the results must be paged. If null, no paging will be applied.
+   *
    */
   public abstract List<U> executeList(CommandContext commandContext, Map<String, Object> parameterMap, int firstResult, int maxResults);
 

--- a/modules/flowable-dmn-engine/src/main/java/org/activiti/dmn/engine/impl/AbstractNativeQuery.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/activiti/dmn/engine/impl/AbstractNativeQuery.java
@@ -16,6 +16,7 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.activiti.dmn.engine.impl.context.Context;
 import org.activiti.dmn.engine.impl.interceptor.Command;
@@ -23,7 +24,6 @@ import org.activiti.dmn.engine.impl.interceptor.CommandContext;
 import org.activiti.dmn.engine.impl.interceptor.CommandExecutor;
 import org.activiti.engine.common.api.ActivitiException;
 import org.activiti.engine.common.api.query.NativeQuery;
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -119,7 +119,7 @@ public abstract class AbstractNativeQuery<T extends NativeQuery<?, ?>, U> implem
       parameterMap.put("resultType", "LIST_PAGE");
       parameterMap.put("firstResult", firstResult);
       parameterMap.put("maxResults", maxResults);
-      if (StringUtils.isNotBlank(ObjectUtils.toString(parameterMap.get("orderBy")))) {
+      if (StringUtils.isNotBlank(Objects.toString(parameterMap.get("orderBy"), ""))) {
         parameterMap.put("orderByColumns", "RES." + parameterMap.get("orderBy"));
       } else {
         parameterMap.put("orderByColumns", "RES.ID_ asc");

--- a/modules/flowable-dmn-json-converter/src/main/java/org/activiti/editor/dmn/converter/DmnJsonConverter.java
+++ b/modules/flowable-dmn-json-converter/src/main/java/org/activiti/editor/dmn/converter/DmnJsonConverter.java
@@ -114,7 +114,7 @@ public class DmnJsonConverter {
             inputExpressionsNode.add(inputExpressionNode);
         }
 
-        modelNode.put("inputExpressions", inputExpressionsNode);
+        modelNode.set("inputExpressions", inputExpressionsNode);
 
         // output expressions
         Map<String, OutputClause> outputClauseMap = new HashMap<>();
@@ -133,7 +133,7 @@ public class DmnJsonConverter {
             outputExpressionsNode.add(outputExpressionNode);
         }
 
-        modelNode.put("outputExpressions", outputExpressionsNode);
+        modelNode.set("outputExpressions", outputExpressionsNode);
 
         // rules
         ArrayNode rulesNode = objectMapper.createArrayNode();
@@ -156,7 +156,7 @@ public class DmnJsonConverter {
             rulesNode.add(ruleNode);
         }
 
-        modelNode.put("rules", rulesNode);
+        modelNode.set("rules", rulesNode);
 
         return modelNode;
     }

--- a/modules/flowable-engine/src/main/java/org/activiti/engine/impl/AbstractNativeQuery.java
+++ b/modules/flowable-engine/src/main/java/org/activiti/engine/impl/AbstractNativeQuery.java
@@ -16,6 +16,7 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.activiti.engine.common.api.ActivitiException;
 import org.activiti.engine.common.api.query.NativeQuery;
@@ -23,7 +24,6 @@ import org.activiti.engine.impl.context.Context;
 import org.activiti.engine.impl.interceptor.Command;
 import org.activiti.engine.impl.interceptor.CommandContext;
 import org.activiti.engine.impl.interceptor.CommandExecutor;
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -119,7 +119,7 @@ public abstract class AbstractNativeQuery<T extends NativeQuery<?, ?>, U> implem
       parameterMap.put("resultType", "LIST_PAGE");
       parameterMap.put("firstResult", firstResult);
       parameterMap.put("maxResults", maxResults);
-      if (StringUtils.isNotBlank(ObjectUtils.toString(parameterMap.get("orderBy")))) {
+      if (StringUtils.isNotBlank(Objects.toString(parameterMap.get("orderBy"), ""))) {
         parameterMap.put("orderByColumns", "RES." + parameterMap.get("orderBy"));
       } else {
         parameterMap.put("orderByColumns", "RES.ID_ asc");

--- a/modules/flowable-engine/src/main/java/org/activiti/engine/impl/AbstractNativeQuery.java
+++ b/modules/flowable-engine/src/main/java/org/activiti/engine/impl/AbstractNativeQuery.java
@@ -149,9 +149,7 @@ public abstract class AbstractNativeQuery<T extends NativeQuery<?, ?>, U> implem
    * 
    * @param maxResults
    * @param firstResult
-   * 
-   * @param page
-   *          used if the results must be paged. If null, no paging will be applied.
+   *
    */
   public abstract List<U> executeList(CommandContext commandContext, Map<String, Object> parameterMap, int firstResult, int maxResults);
 

--- a/modules/flowable-engine/src/test/java/org/activiti/engine/test/json/JsonTest.java
+++ b/modules/flowable-engine/src/test/java/org/activiti/engine/test/json/JsonTest.java
@@ -231,7 +231,7 @@ public class JsonTest extends PluggableActivitiTestCase {
       childNode.put("test2", "this is a simple test2 text");
       childNode.put("test3", "this is a simple test3 text");
       childNode.put("test4", "this is a simple test4 text");
-      valueNode.put("var" + i, childNode);
+      valueNode.set("var" + i, childNode);
     }
     return valueNode;
   }

--- a/modules/flowable-form-engine/src/main/java/org/activiti/form/engine/impl/AbstractNativeQuery.java
+++ b/modules/flowable-form-engine/src/main/java/org/activiti/form/engine/impl/AbstractNativeQuery.java
@@ -16,6 +16,7 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.activiti.engine.common.api.ActivitiException;
 import org.activiti.engine.common.api.query.NativeQuery;
@@ -23,7 +24,6 @@ import org.activiti.form.engine.impl.context.Context;
 import org.activiti.form.engine.impl.interceptor.Command;
 import org.activiti.form.engine.impl.interceptor.CommandContext;
 import org.activiti.form.engine.impl.interceptor.CommandExecutor;
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -119,7 +119,7 @@ public abstract class AbstractNativeQuery<T extends NativeQuery<?, ?>, U> implem
       parameterMap.put("resultType", "LIST_PAGE");
       parameterMap.put("firstResult", firstResult);
       parameterMap.put("maxResults", maxResults);
-      if (StringUtils.isNotBlank(ObjectUtils.toString(parameterMap.get("orderBy")))) {
+      if (StringUtils.isNotBlank(Objects.toString(parameterMap.get("orderBy"), ""))) {
         parameterMap.put("orderByColumns", "RES." + parameterMap.get("orderBy"));
       } else {
         parameterMap.put("orderByColumns", "RES.ID_ asc");

--- a/modules/flowable-form-engine/src/main/java/org/activiti/form/engine/impl/AbstractNativeQuery.java
+++ b/modules/flowable-form-engine/src/main/java/org/activiti/form/engine/impl/AbstractNativeQuery.java
@@ -149,9 +149,7 @@ public abstract class AbstractNativeQuery<T extends NativeQuery<?, ?>, U> implem
    * 
    * @param maxResults
    * @param firstResult
-   * 
-   * @param page
-   *          used if the results must be paged. If null, no paging will be applied.
+   *
    */
   public abstract List<U> executeList(CommandContext commandContext, Map<String, Object> parameterMap, int firstResult, int maxResults);
 

--- a/modules/flowable-idm-engine/src/main/java/org/activiti/idm/engine/impl/AbstractNativeQuery.java
+++ b/modules/flowable-idm-engine/src/main/java/org/activiti/idm/engine/impl/AbstractNativeQuery.java
@@ -149,9 +149,7 @@ public abstract class AbstractNativeQuery<T extends NativeQuery<?, ?>, U> implem
    * 
    * @param maxResults
    * @param firstResult
-   * 
-   * @param page
-   *          used if the results must be paged. If null, no paging will be applied.
+   *
    */
   public abstract List<U> executeList(CommandContext commandContext, Map<String, Object> parameterMap, int firstResult, int maxResults);
 

--- a/modules/flowable-idm-engine/src/main/java/org/activiti/idm/engine/impl/AbstractNativeQuery.java
+++ b/modules/flowable-idm-engine/src/main/java/org/activiti/idm/engine/impl/AbstractNativeQuery.java
@@ -16,6 +16,7 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.activiti.engine.common.api.ActivitiException;
 import org.activiti.engine.common.api.query.NativeQuery;
@@ -23,7 +24,6 @@ import org.activiti.idm.engine.impl.context.Context;
 import org.activiti.idm.engine.impl.interceptor.Command;
 import org.activiti.idm.engine.impl.interceptor.CommandContext;
 import org.activiti.idm.engine.impl.interceptor.CommandExecutor;
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -119,7 +119,7 @@ public abstract class AbstractNativeQuery<T extends NativeQuery<?, ?>, U> implem
       parameterMap.put("resultType", "LIST_PAGE");
       parameterMap.put("firstResult", firstResult);
       parameterMap.put("maxResults", maxResults);
-      if (StringUtils.isNotBlank(ObjectUtils.toString(parameterMap.get("orderBy")))) {
+      if (StringUtils.isNotBlank(Objects.toString(parameterMap.get("orderBy"), ""))) {
         parameterMap.put("orderByColumns", "RES." + parameterMap.get("orderBy"));
       } else {
         parameterMap.put("orderByColumns", "RES.ID_ asc");

--- a/modules/flowable-rest/src/main/java/org/activiti/rest/service/api/runtime/process/ProcessDefinitionPropertiesResource.java
+++ b/modules/flowable-rest/src/main/java/org/activiti/rest/service/api/runtime/process/ProcessDefinitionPropertiesResource.java
@@ -81,7 +81,7 @@ public class ProcessDefinitionPropertiesResource {
             Map<String, String> valuesMap = (Map<String, String>) property.getType().getInformation("values");
             if (valuesMap != null) {
               ArrayNode valuesArray = objectMapper.createArrayNode();
-              propertyJSON.put("enumValues", valuesArray);
+              propertyJSON.set("enumValues", valuesArray);
 
               for (String key : valuesMap.keySet()) {
                 ObjectNode valueJSON = objectMapper.createObjectNode();
@@ -104,7 +104,7 @@ public class ProcessDefinitionPropertiesResource {
       }
     }
 
-    responseJSON.put("data", propertiesJSON);
+    responseJSON.set("data", propertiesJSON);
     return responseJSON;
   }
 }

--- a/modules/flowable-rest/src/test/java/org/activiti/rest/service/api/form/FormDataResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/activiti/rest/service/api/form/FormDataResourceTest.java
@@ -196,10 +196,10 @@ public class FormDataResourceTest extends BaseSpringRestTestCase {
     ObjectNode requestNode = objectMapper.createObjectNode();
     requestNode.put("taskId", task.getId());
     ArrayNode propertyArray = objectMapper.createArrayNode();
-    requestNode.put("properties", propertyArray);
+    requestNode.set("properties", propertyArray);
     ObjectNode propNode = objectMapper.createObjectNode();
     propNode.put("id", "room");
-    propNode.put("value", 123l);
+    propNode.put("value", 123L);
     propertyArray.add(propNode);
 
     HttpPost httpPost = new HttpPost(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_FORM_DATA));
@@ -260,7 +260,7 @@ public class FormDataResourceTest extends BaseSpringRestTestCase {
     requestNode = objectMapper.createObjectNode();
     requestNode.put("processDefinitionId", processDefinitionId);
     propertyArray = objectMapper.createArrayNode();
-    requestNode.put("properties", propertyArray);
+    requestNode.set("properties", propertyArray);
     propNode = objectMapper.createObjectNode();
     propNode.put("id", "number");
     propNode.put("value", 123);

--- a/modules/flowable-rest/src/test/java/org/activiti/rest/service/api/history/HistoricProcessInstanceQueryResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/activiti/rest/service/api/history/HistoricProcessInstanceQueryResourceTest.java
@@ -59,7 +59,7 @@ public class HistoricProcessInstanceQueryResourceTest extends BaseSpringRestTest
     ArrayNode variableArray = objectMapper.createArrayNode();
     ObjectNode variableNode = objectMapper.createObjectNode();
     variableArray.add(variableNode);
-    requestNode.put("variables", variableArray);
+    requestNode.set("variables", variableArray);
 
     // String equals
     variableNode.put("name", "stringVar");

--- a/modules/flowable-rest/src/test/java/org/activiti/rest/service/api/history/HistoricTaskInstanceQueryResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/activiti/rest/service/api/history/HistoricTaskInstanceQueryResourceTest.java
@@ -78,7 +78,7 @@ public class HistoricTaskInstanceQueryResourceTest extends BaseSpringRestTestCas
     ArrayNode variableArray = objectMapper.createArrayNode();
     ObjectNode variableNode = objectMapper.createObjectNode();
     variableArray.add(variableNode);
-    requestNode.put("processVariables", variableArray);
+    requestNode.set("processVariables", variableArray);
 
     variableNode.put("name", "stringVar");
     variableNode.put("value", "Azerty");
@@ -134,7 +134,7 @@ public class HistoricTaskInstanceQueryResourceTest extends BaseSpringRestTestCas
     variableArray = objectMapper.createArrayNode();
     variableNode = objectMapper.createObjectNode();
     variableArray.add(variableNode);
-    requestNode.put("taskVariables", variableArray);
+    requestNode.set("taskVariables", variableArray);
     variableNode.put("name", "local");
     variableNode.put("value", "test");
     variableNode.put("operation", "equals");

--- a/modules/flowable-rest/src/test/java/org/activiti/rest/service/api/history/HistoricVariableInstanceQueryResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/activiti/rest/service/api/history/HistoricVariableInstanceQueryResourceTest.java
@@ -105,21 +105,21 @@ public class HistoricVariableInstanceQueryResourceTest extends BaseSpringRestTes
     ArrayNode variableArray = objectMapper.createArrayNode();
     ObjectNode variableNode = objectMapper.createObjectNode();
     variableArray.add(variableNode);
-    requestNode.put("variables", variableArray);
+    requestNode.set("variables", variableArray);
     variableNode.put("name", "stringVar");
     variableNode.put("value", "Azerty");
     variableNode.put("operation", "equals");
     assertResultsPresentInDataResponse(url, requestNode, 2, "stringVar", "Azerty");
 
     variableNode.removeAll();
-    requestNode.put("variables", variableArray);
+    requestNode.set("variables", variableArray);
     variableNode.put("name", "taskVariable");
     variableNode.put("value", "test");
     variableNode.put("operation", "equals");
     assertResultsPresentInDataResponse(url, requestNode, 1, "taskVariable", "test");
 
     variableNode.removeAll();
-    requestNode.put("variables", variableArray);
+    requestNode.set("variables", variableArray);
     variableNode.put("name", "taskVariable");
     variableNode.put("value", "test");
     variableNode.put("operation", "notEquals");

--- a/modules/flowable-rest/src/test/java/org/activiti/rest/service/api/identity/GroupResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/activiti/rest/service/api/identity/GroupResourceTest.java
@@ -195,8 +195,8 @@ public class GroupResourceTest extends BaseSpringRestTestCase {
       identityService.saveGroup(testGroup);
 
       ObjectNode requestNode = objectMapper.createObjectNode();
-      requestNode.put("name", (JsonNode) null);
-      requestNode.put("type", (JsonNode) null);
+      requestNode.set("name", null);
+      requestNode.set("type", null);
 
       HttpPut httpPut = new HttpPut(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_GROUP, "testgroup"));
       httpPut.setEntity(new StringEntity(requestNode.toString()));

--- a/modules/flowable-rest/src/test/java/org/activiti/rest/service/api/runtime/ExecutionCollectionResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/activiti/rest/service/api/runtime/ExecutionCollectionResourceTest.java
@@ -160,7 +160,7 @@ public class ExecutionCollectionResourceTest extends BaseSpringRestTestCase {
     ObjectNode requestNode = objectMapper.createObjectNode();
     requestNode.put("action", "signalEventReceived");
     requestNode.put("signalName", "alert");
-    requestNode.put("variables", variables);
+    requestNode.set("variables", variables);
 
     ObjectNode varNode = objectMapper.createObjectNode();
     variables.add(varNode);

--- a/modules/flowable-rest/src/test/java/org/activiti/rest/service/api/runtime/ExecutionQueryResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/activiti/rest/service/api/runtime/ExecutionQueryResourceTest.java
@@ -54,7 +54,7 @@ public class ExecutionQueryResourceTest extends BaseSpringRestTestCase {
     ArrayNode variableArray = objectMapper.createArrayNode();
     ObjectNode variableNode = objectMapper.createObjectNode();
     variableArray.add(variableNode);
-    requestNode.put("variables", variableArray);
+    requestNode.set("variables", variableArray);
 
     // String equals
     variableNode.put("name", "stringVar");
@@ -123,7 +123,7 @@ public class ExecutionQueryResourceTest extends BaseSpringRestTestCase {
     variableArray = objectMapper.createArrayNode();
     variableNode = objectMapper.createObjectNode();
     variableArray.add(variableNode);
-    requestNode.put("processInstanceVariables", variableArray);
+    requestNode.set("processInstanceVariables", variableArray);
 
     // String equals
     variableNode.put("name", "stringVar");

--- a/modules/flowable-rest/src/test/java/org/activiti/rest/service/api/runtime/ExecutionResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/activiti/rest/service/api/runtime/ExecutionResourceTest.java
@@ -169,7 +169,7 @@ public class ExecutionResourceTest extends BaseSpringRestTestCase {
     ObjectNode requestNode = objectMapper.createObjectNode();
     requestNode.put("action", "signalEventReceived");
     requestNode.put("signalName", "alert");
-    requestNode.put("variables", variables);
+    requestNode.set("variables", variables);
 
     ObjectNode varNode = objectMapper.createObjectNode();
     variables.add(varNode);
@@ -240,7 +240,7 @@ public class ExecutionResourceTest extends BaseSpringRestTestCase {
     ObjectNode requestNode = objectMapper.createObjectNode();
     requestNode.put("action", "messageEventReceived");
     requestNode.put("messageName", "paymentMessage");
-    requestNode.put("variables", variables);
+    requestNode.set("variables", variables);
 
     ObjectNode varNode = objectMapper.createObjectNode();
     variables.add(varNode);

--- a/modules/flowable-rest/src/test/java/org/activiti/rest/service/api/runtime/ProcessInstanceCollectionResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/activiti/rest/service/api/runtime/ProcessInstanceCollectionResourceTest.java
@@ -347,7 +347,7 @@ public class ProcessInstanceCollectionResourceTest extends BaseSpringRestTestCas
 
     // Start using process definition key, passing in variables
     requestNode.put("processDefinitionKey", "processOne");
-    requestNode.put("variables", variablesNode);
+    requestNode.set("variables", variablesNode);
 
     HttpPost httpPost = new HttpPost(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_COLLECTION));
     httpPost.setEntity(new StringEntity(requestNode.toString()));
@@ -398,7 +398,7 @@ public class ProcessInstanceCollectionResourceTest extends BaseSpringRestTestCas
     // Start using process definition key, passing in variables
     requestNode.put("processDefinitionKey", "processOne");
     requestNode.put("returnVariables", true);
-    requestNode.put("variables", variablesNode);
+    requestNode.set("variables", variablesNode);
 
     HttpPost httpPost = new HttpPost(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_COLLECTION));
     httpPost.setEntity(new StringEntity(requestNode.toString()));

--- a/modules/flowable-rest/src/test/java/org/activiti/rest/service/api/runtime/ProcessInstanceQueryResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/activiti/rest/service/api/runtime/ProcessInstanceQueryResourceTest.java
@@ -54,7 +54,7 @@ public class ProcessInstanceQueryResourceTest extends BaseSpringRestTestCase {
     ArrayNode variableArray = objectMapper.createArrayNode();
     ObjectNode variableNode = objectMapper.createObjectNode();
     variableArray.add(variableNode);
-    requestNode.put("variables", variableArray);
+    requestNode.set("variables", variableArray);
 
     // String equals
     variableNode.put("name", "stringVar");

--- a/modules/flowable-rest/src/test/java/org/activiti/rest/service/api/runtime/TaskQueryResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/activiti/rest/service/api/runtime/TaskQueryResourceTest.java
@@ -164,7 +164,7 @@ public class TaskQueryResourceTest extends BaseSpringRestTestCase {
       arrayNode.add("sales");
       arrayNode.add("someOtherGroup");
 
-      requestNode.put("candidateGroupIn", arrayNode);
+      requestNode.set("candidateGroupIn", arrayNode);
       assertResultsPresentInPostDataResponse(url, requestNode, processTask.getId());
 
       // Involved user filtering
@@ -324,7 +324,7 @@ public class TaskQueryResourceTest extends BaseSpringRestTestCase {
     ArrayNode variableArray = objectMapper.createArrayNode();
     ObjectNode variableNode = objectMapper.createObjectNode();
     variableArray.add(variableNode);
-    requestNode.put("taskVariables", variableArray);
+    requestNode.set("taskVariables", variableArray);
 
     String url = RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_QUERY);
 
@@ -453,7 +453,7 @@ public class TaskQueryResourceTest extends BaseSpringRestTestCase {
     variableArray = objectMapper.createArrayNode();
     variableNode = objectMapper.createObjectNode();
     variableArray.add(variableNode);
-    requestNode.put("processInstanceVariables", variableArray);
+    requestNode.set("processInstanceVariables", variableArray);
 
     // String equals
     variableNode.put("name", "stringVar");

--- a/modules/flowable-rest/src/test/java/org/activiti/rest/service/api/runtime/TaskResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/activiti/rest/service/api/runtime/TaskResourceTest.java
@@ -384,7 +384,7 @@ public class TaskResourceTest extends BaseSpringRestTestCase {
       requestNode = objectMapper.createObjectNode();
       ArrayNode variablesNode = objectMapper.createArrayNode();
       requestNode.put("action", "complete");
-      requestNode.put("variables", variablesNode);
+      requestNode.set("variables", variablesNode);
 
       ObjectNode var1 = objectMapper.createObjectNode();
       variablesNode.add(var1);

--- a/modules/flowable-ui-admin/src/main/java/org/activiti/service/engine/FormInstanceService.java
+++ b/modules/flowable-ui-admin/src/main/java/org/activiti/service/engine/FormInstanceService.java
@@ -97,10 +97,10 @@ public class FormInstanceService {
 
           ObjectNode formFieldValue = objectMapper.createObjectNode();
 
-          formFieldValue.put("id", fieldNode.get("id"));
-          formFieldValue.put("name", fieldNode.get("name"));
-          formFieldValue.put("type", fieldNode.get("type"));
-          formFieldValue.put("value", fieldNode.get("value"));
+          formFieldValue.set("id", fieldNode.get("id"));
+          formFieldValue.set("name", fieldNode.get("name"));
+          formFieldValue.set("type", fieldNode.get("type"));
+          formFieldValue.set("value", fieldNode.get("value"));
 
           formFieldValues.add(formFieldValue);
         }
@@ -108,7 +108,7 @@ public class FormInstanceService {
 
       returnNode.put("size", formFieldValues.size());
       returnNode.put("total", formFieldValues.size());
-      returnNode.put("data", formFieldValues);
+      returnNode.set("data", formFieldValues);
     } catch (Exception ex) {
       throw new ActivitiServiceException(ex.getMessage(), ex);
     }

--- a/modules/flowable-ui-admin/src/main/java/org/activiti/web/rest/client/DisplayJsonClientResource.java
+++ b/modules/flowable-ui-admin/src/main/java/org/activiti/web/rest/client/DisplayJsonClientResource.java
@@ -65,7 +65,7 @@ public class DisplayJsonClientResource extends AbstractClientResource {
 
 	@Autowired
 	protected ProcessDefinitionService clientService;
-	
+
 	@Autowired
 	protected ProcessInstanceService processInstanceService;
 
@@ -89,19 +89,19 @@ public class DisplayJsonClientResource extends AbstractClientResource {
 
 		ServerConfig config = retrieveServerConfig(EndpointType.PROCESS);
 		ObjectNode displayNode = objectMapper.createObjectNode();
-		
+
 		BpmnModel pojoModel = clientService.getProcessDefinitionModel(config, processDefinitionId);
-		
+
 		if (!pojoModel.getLocationMap().isEmpty()) {
 			try {
 				GraphicInfo diagramInfo = new GraphicInfo();
 				processProcessElements(config, pojoModel, displayNode, diagramInfo, null, null);
-	
+
 				displayNode.put("diagramBeginX", diagramInfo.getX());
 				displayNode.put("diagramBeginY", diagramInfo.getY());
 				displayNode.put("diagramWidth", diagramInfo.getWidth());
 				displayNode.put("diagramHeight", diagramInfo.getHeight());
-	
+
 			} catch (Exception e) {
 				log.error("Error creating model JSON", e);
 			}
@@ -109,58 +109,58 @@ public class DisplayJsonClientResource extends AbstractClientResource {
 
 		return displayNode;
 	}
-	
+
 	@RequestMapping(value = "/rest/activiti/process-instances/{processInstanceId}/model-json", method = RequestMethod.GET, produces = "application/json")
 	public JsonNode getProcessInstanceModelJSON(@PathVariable String processInstanceId, @RequestParam(required=true) String processDefinitionId) {
 		ObjectNode displayNode = objectMapper.createObjectNode();
-		
+
 		ServerConfig config = retrieveServerConfig(EndpointType.PROCESS);
 		BpmnModel pojoModel = clientService.getProcessDefinitionModel(config, processDefinitionId);
-		
+
 		if (!pojoModel.getLocationMap().isEmpty()) {
-			
+
 			// Fetch process-instance activities
 			List<String> completedActivityInstances = processInstanceService.getCompletedActivityInstancesAndProcessDefinitionId(config, processInstanceId);
 			List<String> currentActivityinstances = processInstanceService.getCurrentActivityInstances(config, processInstanceId);
-			
+
 			// Gather completed flows
 			List<String> completedFlows = gatherCompletedFlows(completedActivityInstances, currentActivityinstances, pojoModel);
-			
+
 			try {
 				GraphicInfo diagramInfo = new GraphicInfo();
 				Set<String> completedElements = new HashSet<String>(completedActivityInstances);
 				completedElements.addAll(completedFlows);
-				
+
 				Set<String> currentElements = new HashSet<String>(currentActivityinstances);
-				
+
 				processProcessElements(config, pojoModel, displayNode, diagramInfo, completedElements, currentElements);
-				
+
 				displayNode.put("diagramBeginX", diagramInfo.getX());
 				displayNode.put("diagramBeginY", diagramInfo.getY());
 				displayNode.put("diagramWidth", diagramInfo.getWidth());
 				displayNode.put("diagramHeight", diagramInfo.getHeight());
-				
+
 				if(completedActivityInstances != null) {
 					ArrayNode completedActivities = displayNode.putArray("completedActivities");
 					for(String completed : completedActivityInstances) {
 						completedActivities.add(completed);
 					}
 				}
-				
+
 				if(currentActivityinstances != null) {
 					ArrayNode currentActivities = displayNode.putArray("currentActivities");
 					for(String current : currentActivityinstances) {
 						currentActivities.add(current);
 					}
 				}
-				
+
 				if(completedFlows != null) {
 					ArrayNode completedSequenceFlows = displayNode.putArray("completedSequenceFlows");
 					for(String current : completedFlows) {
 						completedSequenceFlows.add(current);
 					}
 				}
-				
+
 			} catch (Exception e) {
 				log.error("Error creating model JSON", e);
 			}
@@ -171,11 +171,11 @@ public class DisplayJsonClientResource extends AbstractClientResource {
 
 	protected List<String> gatherCompletedFlows(List<String> completedActivityInstances,
       List<String> currentActivityinstances, BpmnModel pojoModel) {
-		
+
 		List<String> completedFlows = new ArrayList<String>();
 		List<String> activities = new ArrayList<String>(completedActivityInstances);
 		activities.addAll(currentActivityinstances);
-		
+
 		// TODO: not a robust way of checking when parallel paths are active, should be revisited
 		// Go over all activities and check if it's possible to match any outgoing paths against the activities
     for (FlowElement activity : pojoModel.getMainProcess().getFlowElements()) {
@@ -197,7 +197,7 @@ public class DisplayJsonClientResource extends AbstractClientResource {
 
 	protected void processProcessElements(ServerConfig config, BpmnModel pojoModel, ObjectNode displayNode, GraphicInfo diagramInfo, Set<String> completedElements, Set<String> currentElements) throws Exception {
 
-		
+
 		if (pojoModel.getLocationMap().isEmpty()) return;
 
 		ArrayNode elementArray = objectMapper.createArrayNode();
@@ -222,7 +222,7 @@ public class DisplayJsonClientResource extends AbstractClientResource {
 						fillGraphicInfo(laneNode, pojoModel.getGraphicInfo(lane.getId()), true);
 						laneArray.add(laneNode);
 					}
-					poolNode.put("lanes", laneArray);
+					poolNode.set("lanes", laneArray);
 				}
 				poolArray.add(poolNode);
 
@@ -243,8 +243,8 @@ public class DisplayJsonClientResource extends AbstractClientResource {
 				}
 				firstElement = false;
 			}
-			displayNode.put("pools", poolArray);
-			
+			displayNode.set("pools", poolArray);
+
 		} else {
 			// in initialize with fake x and y to make sure the minimal
 			// values are set
@@ -256,33 +256,33 @@ public class DisplayJsonClientResource extends AbstractClientResource {
 			processElements(process.getFlowElements(), pojoModel, elementArray, flowArray, diagramInfo, completedElements, currentElements);
 		}
 
-		displayNode.put("elements", elementArray);
-		displayNode.put("flows", flowArray);
+		displayNode.set("elements", elementArray);
+		displayNode.set("flows", flowArray);
 	}
 
 	protected void processElements(Collection<FlowElement> elementList,
 			BpmnModel model, ArrayNode elementArray, ArrayNode flowArray,
 			GraphicInfo diagramInfo, Set<String> completedElements, Set<String> currentElements) {
 
-	
+
 		for (FlowElement element : elementList) {
 
 			ObjectNode elementNode = objectMapper.createObjectNode();
 			if(completedElements != null) {
 				elementNode.put("completed", completedElements.contains(element.getId()));
 			}
-			
+
 			if(currentElements != null) {
 				elementNode.put("current", currentElements.contains(element.getId()));
 			}
-			
+
 			if (element instanceof SequenceFlow) {
 				SequenceFlow flow = (SequenceFlow) element;
 				elementNode.put("id", flow.getId());
 				elementNode.put("type", "sequenceFlow");
 				elementNode.put("sourceRef", flow.getSourceRef());
 				elementNode.put("targetRef", flow.getTargetRef());
-				
+
 				List<GraphicInfo> flowInfo = model.getFlowLocationGraphicInfo(flow.getId());
 				ArrayNode waypointArray = objectMapper.createArrayNode();
 				for (GraphicInfo graphicInfo : flowInfo) {
@@ -291,7 +291,7 @@ public class DisplayJsonClientResource extends AbstractClientResource {
 					waypointArray.add(pointNode);
 					fillDiagramInfo(graphicInfo, diagramInfo);
 				}
-				elementNode.put("waypoints", waypointArray);
+				elementNode.set("waypoints", waypointArray);
 				flowArray.add(elementNode);
 
 			} else {
@@ -305,7 +305,7 @@ public class DisplayJsonClientResource extends AbstractClientResource {
 					for (SequenceFlow flow : flowNode.getIncomingFlows()) {
 						incomingFlows.add(flow.getId());
 					}
-					elementNode.put("incomingFlows", incomingFlows);
+					elementNode.set("incomingFlows", incomingFlows);
 				}
 
 				GraphicInfo graphicInfo = model.getGraphicInfo(element.getId());
@@ -326,7 +326,7 @@ public class DisplayJsonClientResource extends AbstractClientResource {
 				}
 
 				if (propertyMappers.containsKey(className)) {
-					elementNode.put("properties", propertyMappers.get(className).map(element));
+					elementNode.set("properties", propertyMappers.get(className).map(element));
 				}
 
 				elementArray.add(elementNode);
@@ -379,7 +379,7 @@ public class DisplayJsonClientResource extends AbstractClientResource {
 						eventNode.put("messageRef", messageDef.getMessageRef());
 					}
 				}
-				elementNode.put("eventDefinition", eventNode);
+				elementNode.set("eventDefinition", eventNode);
 			}
 		}
 	}
@@ -392,7 +392,7 @@ public class DisplayJsonClientResource extends AbstractClientResource {
 
 	protected void commonFillGraphicInfo(ObjectNode elementNode, double x,
 			double y, double width, double height, boolean includeWidthAndHeight) {
-		
+
 		elementNode.put("x", x);
 		elementNode.put("y", y);
 		if (includeWidthAndHeight) {
@@ -400,7 +400,7 @@ public class DisplayJsonClientResource extends AbstractClientResource {
 			elementNode.put("height", height);
 		}
 	}
-	
+
 	protected void fillDiagramInfo(GraphicInfo graphicInfo, GraphicInfo diagramInfo) {
 		double rightX = graphicInfo.getX() + graphicInfo.getWidth();
 		double bottomY = graphicInfo.getY() + graphicInfo.getHeight();

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/activiti/app/service/editor/AppDefinitionExportService.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/activiti/app/service/editor/AppDefinitionExportService.java
@@ -131,7 +131,7 @@ public class AppDefinitionExportService {
     modelJson.put("description", model.getDescription());
     
     try {
-      modelJson.put("editorJson", objectMapper.readTree(model.getModelEditorJson()));
+      modelJson.set("editorJson", objectMapper.readTree(model.getModelEditorJson()));
     } catch (Exception e) {
       logger.error("Error exporting model json for id " + model.getId(), e);
       throw new InternalServerErrorException("Error exporting model json for id " + model.getId());

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/activiti/app/service/editor/BpmnDisplayJsonConverter.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/activiti/app/service/editor/BpmnDisplayJsonConverter.java
@@ -118,7 +118,7 @@ public class BpmnDisplayJsonConverter {
                         fillGraphicInfo(laneNode, pojoModel.getGraphicInfo(lane.getId()), true);
                         laneArray.add(laneNode);
                     }
-                    poolNode.put("lanes", laneArray);
+                    poolNode.set("lanes", laneArray);
                 }
                 poolArray.add(poolNode);
 
@@ -139,7 +139,7 @@ public class BpmnDisplayJsonConverter {
                 }
                 firstElement = false;
             }
-            displayNode.put("pools", poolArray);
+            displayNode.set("pools", poolArray);
             
         } else {
             // in initialize with fake x and y to make sure the minimal
@@ -153,8 +153,8 @@ public class BpmnDisplayJsonConverter {
             processArtifacts(process.getArtifacts(), pojoModel, elementArray, flowArray, diagramInfo);
         }
 
-        displayNode.put("elements", elementArray);
-        displayNode.put("flows", flowArray);
+        displayNode.set("elements", elementArray);
+        displayNode.set("flows", flowArray);
         
         displayNode.put("diagramBeginX", diagramInfo.getX());
         displayNode.put("diagramBeginY", diagramInfo.getY());
@@ -182,11 +182,11 @@ public class BpmnDisplayJsonConverter {
                         waypointArray.add(pointNode);
                         fillDiagramInfo(graphicInfo, diagramInfo);
                     }
-                    elementNode.put("waypoints", waypointArray);
+                    elementNode.set("waypoints", waypointArray);
                     
                     String className = element.getClass().getSimpleName();
                     if (propertyMappers.containsKey(className)) {
-                        elementNode.put("properties", propertyMappers.get(className).map(element));
+                        elementNode.set("properties", propertyMappers.get(className).map(element));
                     }
                     
                     flowArray.add(elementNode);
@@ -222,7 +222,7 @@ public class BpmnDisplayJsonConverter {
                 }
 
                 if (propertyMappers.containsKey(className)) {
-                    elementNode.put("properties", propertyMappers.get(className).map(element));
+                    elementNode.set("properties", propertyMappers.get(className).map(element));
                 }
 
                 elementArray.add(elementNode);
@@ -285,7 +285,7 @@ public class BpmnDisplayJsonConverter {
             waypointArray.add(pointNode);
             fillDiagramInfo(graphicInfo, diagramInfo);
         }
-        elementNode.put("waypoints", waypointArray);
+        elementNode.set("waypoints", waypointArray);
     }
 
     protected void fillEventTypes(String className, FlowElement element, ObjectNode elementNode) {
@@ -328,7 +328,7 @@ public class BpmnDisplayJsonConverter {
                         eventNode.put("messageRef", messageDef.getMessageRef());
                     }
                 }
-                elementNode.put("eventDefinition", eventNode);
+                elementNode.set("eventDefinition", eventNode);
             }
         }
     }

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/activiti/app/service/editor/mapper/AbstractInfoMapper.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/activiti/app/service/editor/mapper/AbstractInfoMapper.java
@@ -160,7 +160,7 @@ public abstract class AbstractInfoMapper implements InfoMapper {
 			ObjectNode propertyNode = objectMapper.createObjectNode();
             propertyNode.put("name", name);
             propertyNode.put("type", "list");
-            propertyNode.put("value", itemsNode);
+            propertyNode.set("value", itemsNode);
 			propertiesNode.add(propertyNode);
 		}
 	}

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-rest/src/main/java/org/activiti/app/rest/editor/ModelResource.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-rest/src/main/java/org/activiti/app/rest/editor/ModelResource.java
@@ -152,7 +152,7 @@ public class ModelResource {
       try {
         ObjectNode editorJsonNode = (ObjectNode) objectMapper.readTree(model.getModelEditorJson());
         editorJsonNode.put("modelType", "model");
-        modelNode.put("model", editorJsonNode);
+        modelNode.set("model", editorJsonNode);
       } catch (Exception e) {
         log.error("Error reading editor json " + modelId, e);
         throw new InternalServerErrorException("Error reading editor json " + modelId);
@@ -165,7 +165,7 @@ public class ModelResource {
       ObjectNode stencilSetNode = objectMapper.createObjectNode();
       stencilSetNode.put("namespace", "http://b3mn.org/stencilset/bpmn2.0#");
       editorJsonNode.put("modelType", "model");
-      modelNode.put("model", editorJsonNode);
+      modelNode.set("model", editorJsonNode);
     }
     return modelNode;
   }

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-rest/src/main/java/org/activiti/app/rest/editor/ModelsResource.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-rest/src/main/java/org/activiti/app/rest/editor/ModelsResource.java
@@ -140,35 +140,35 @@ public class ModelsResource {
       editorNode.put("resourceId", "canvas");
       ObjectNode stencilSetNode = objectMapper.createObjectNode();
       stencilSetNode.put("namespace", "http://b3mn.org/stencilset/bpmn2.0#");
-      editorNode.put("stencilset", stencilSetNode);
+      editorNode.set("stencilset", stencilSetNode);
       ObjectNode propertiesNode = objectMapper.createObjectNode();
       propertiesNode.put("process_id", modelRepresentation.getKey());
       propertiesNode.put("name", modelRepresentation.getName());
       if (StringUtils.isNotEmpty(modelRepresentation.getDescription())) {
         propertiesNode.put("documentation", modelRepresentation.getDescription());
       }
-      editorNode.put("properties", propertiesNode);
+      editorNode.set("properties", propertiesNode);
 
       ArrayNode childShapeArray = objectMapper.createArrayNode();
-      editorNode.put("childShapes", childShapeArray);
+      editorNode.set("childShapes", childShapeArray);
       ObjectNode childNode = objectMapper.createObjectNode();
       childShapeArray.add(childNode);
       ObjectNode boundsNode = objectMapper.createObjectNode();
-      childNode.put("bounds", boundsNode);
+      childNode.set("bounds", boundsNode);
       ObjectNode lowerRightNode = objectMapper.createObjectNode();
-      boundsNode.put("lowerRight", lowerRightNode);
+      boundsNode.set("lowerRight", lowerRightNode);
       lowerRightNode.put("x", 130);
       lowerRightNode.put("y", 193);
       ObjectNode upperLeftNode = objectMapper.createObjectNode();
-      boundsNode.put("upperLeft", upperLeftNode);
+      boundsNode.set("upperLeft", upperLeftNode);
       upperLeftNode.put("x", 100);
       upperLeftNode.put("y", 163);
-      childNode.put("childShapes", objectMapper.createArrayNode());
-      childNode.put("dockers", objectMapper.createArrayNode());
-      childNode.put("outgoing", objectMapper.createArrayNode());
+      childNode.set("childShapes", objectMapper.createArrayNode());
+      childNode.set("dockers", objectMapper.createArrayNode());
+      childNode.set("outgoing", objectMapper.createArrayNode());
       childNode.put("resourceId", "startEvent1");
       ObjectNode stencilNode = objectMapper.createObjectNode();
-      childNode.put("stencil", stencilNode);
+      childNode.set("stencil", stencilNode);
       stencilNode.put("id", "StartNoneEvent");
       json = editorNode.toString();
     }
@@ -210,7 +210,7 @@ public class ModelsResource {
         if (StringUtils.isNotEmpty(model.getDescription())) {
           propertiesNode.put("documentation", model.getDescription());
         }
-        editorNode.put("properties", propertiesNode);
+        editorNode.set("properties", propertiesNode);
 
       } catch (IOException e) {
         e.printStackTrace();

--- a/modules/flowable-ui-task/flowable-ui-task-logic/src/main/java/org/activiti/app/service/editor/mapper/AbstractInfoMapper.java
+++ b/modules/flowable-ui-task/flowable-ui-task-logic/src/main/java/org/activiti/app/service/editor/mapper/AbstractInfoMapper.java
@@ -160,7 +160,7 @@ public abstract class AbstractInfoMapper implements InfoMapper {
 			ObjectNode propertyNode = objectMapper.createObjectNode();
             propertyNode.put("name", name);
             propertyNode.put("type", "list");
-            propertyNode.put("value", itemsNode);
+            propertyNode.set("value", itemsNode);
 			propertiesNode.add(propertyNode);
 		}
 	}

--- a/modules/flowable-ui-task/flowable-ui-task-rest/src/main/java/org/activiti/app/rest/runtime/RuntimeDisplayJsonClientResource.java
+++ b/modules/flowable-ui-task/flowable-ui-task-rest/src/main/java/org/activiti/app/rest/runtime/RuntimeDisplayJsonClientResource.java
@@ -269,7 +269,7 @@ public class RuntimeDisplayJsonClientResource {
             fillGraphicInfo(laneNode, pojoModel.getGraphicInfo(lane.getId()), true);
             laneArray.add(laneNode);
           }
-          poolNode.put("lanes", laneArray);
+          poolNode.set("lanes", laneArray);
         }
         poolArray.add(poolNode);
 
@@ -290,7 +290,7 @@ public class RuntimeDisplayJsonClientResource {
         }
         firstElement = false;
       }
-      displayNode.put("pools", poolArray);
+      displayNode.set("pools", poolArray);
 
     } else {
       // in initialize with fake x and y to make sure the minimal
@@ -304,8 +304,8 @@ public class RuntimeDisplayJsonClientResource {
       processArtifacts(process.getArtifacts(), pojoModel, elementArray, flowArray, diagramInfo);
     }
 
-    displayNode.put("elements", elementArray);
-    displayNode.put("flows", flowArray);
+    displayNode.set("elements", elementArray);
+    displayNode.set("flows", flowArray);
 
     displayNode.put("diagramBeginX", diagramInfo.getX());
     displayNode.put("diagramBeginY", diagramInfo.getY());
@@ -343,11 +343,11 @@ public class RuntimeDisplayJsonClientResource {
             waypointArray.add(pointNode);
             fillDiagramInfo(graphicInfo, diagramInfo);
           }
-          elementNode.put("waypoints", waypointArray);
+          elementNode.set("waypoints", waypointArray);
 
           String className = element.getClass().getSimpleName();
           if (propertyMappers.containsKey(className)) {
-            elementNode.put("properties", propertyMappers.get(className).map(element));
+            elementNode.set("properties", propertyMappers.get(className).map(element));
           }
 
           flowArray.add(elementNode);
@@ -382,7 +382,7 @@ public class RuntimeDisplayJsonClientResource {
         }
 
         if (propertyMappers.containsKey(className)) {
-          elementNode.put("properties", propertyMappers.get(className).map(element));
+          elementNode.set("properties", propertyMappers.get(className).map(element));
         }
 
         elementArray.add(elementNode);
@@ -443,7 +443,7 @@ public class RuntimeDisplayJsonClientResource {
       waypointArray.add(pointNode);
       fillDiagramInfo(graphicInfo, diagramInfo);
     }
-    elementNode.put("waypoints", waypointArray);
+    elementNode.set("waypoints", waypointArray);
   }
 
   protected void fillEventTypes(String className, FlowElement element, ObjectNode elementNode) {
@@ -486,7 +486,7 @@ public class RuntimeDisplayJsonClientResource {
             eventNode.put("messageRef", messageDef.getMessageRef());
           }
         }
-        elementNode.put("eventDefinition", eventNode);
+        elementNode.set("eventDefinition", eventNode);
       }
     }
   }

--- a/modules/flowable5-engine/src/main/java/org/activiti5/engine/impl/AbstractNativeQuery.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti5/engine/impl/AbstractNativeQuery.java
@@ -16,6 +16,7 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.activiti5.engine.ActivitiException;
 import org.activiti5.engine.impl.context.Context;
@@ -23,7 +24,6 @@ import org.activiti5.engine.impl.interceptor.Command;
 import org.activiti5.engine.impl.interceptor.CommandContext;
 import org.activiti5.engine.impl.interceptor.CommandExecutor;
 import org.activiti5.engine.query.NativeQuery;
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -120,7 +120,7 @@ public abstract class AbstractNativeQuery<T extends NativeQuery< ? , ? >, U> imp
       parameterMap.put("resultType", "LIST_PAGE");
       parameterMap.put("firstResult", firstResult);
       parameterMap.put("maxResults", maxResults);
-      if (StringUtils.isNotBlank(ObjectUtils.toString(parameterMap.get("orderBy")))) {
+      if (StringUtils.isNotBlank(Objects.toString(parameterMap.get("orderBy"), ""))) {
         parameterMap.put("orderByColumns", "RES." + parameterMap.get("orderBy"));
       } else {
         parameterMap.put("orderByColumns", "RES.ID_ asc");

--- a/modules/flowable5-engine/src/main/java/org/activiti5/engine/impl/AbstractNativeQuery.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti5/engine/impl/AbstractNativeQuery.java
@@ -149,10 +149,7 @@ public abstract class AbstractNativeQuery<T extends NativeQuery< ? , ? >, U> imp
    * Executes the actual query to retrieve the list of results.
    * @param maxResults 
    * @param firstResult 
-   * 
-   * @param page
-   *          used if the results must be paged. If null, no paging will be
-   *          applied.
+   *
    */
   public abstract List<U> executeList(CommandContext commandContext, Map<String, Object> parameterMap, int firstResult, int maxResults);
 

--- a/modules/flowable5-engine/src/main/java/org/activiti5/engine/impl/DynamicBpmnServiceImpl.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti5/engine/impl/DynamicBpmnServiceImpl.java
@@ -275,7 +275,7 @@ public class DynamicBpmnServiceImpl extends ServiceImpl implements DynamicBpmnSe
   protected void setElementProperty(String id, String propertyName, String propertyValue, ObjectNode infoNode) {
     ObjectNode bpmnNode = createOrGetBpmnNode(infoNode);
     if (bpmnNode.has(id) == false) {
-      bpmnNode.put(id, processEngineConfiguration.getObjectMapper().createObjectNode());
+      bpmnNode.set(id, processEngineConfiguration.getObjectMapper().createObjectNode());
     }
     
     ((ObjectNode) bpmnNode.get(id)).put(propertyName, propertyValue);
@@ -284,15 +284,15 @@ public class DynamicBpmnServiceImpl extends ServiceImpl implements DynamicBpmnSe
   protected void setElementProperty(String id, String propertyName, JsonNode propertyValue, ObjectNode infoNode) {
     ObjectNode bpmnNode = createOrGetBpmnNode(infoNode);
     if (bpmnNode.has(id) == false) {
-      bpmnNode.put(id, processEngineConfiguration.getObjectMapper().createObjectNode());
+      bpmnNode.set(id, processEngineConfiguration.getObjectMapper().createObjectNode());
     }
     
-    ((ObjectNode) bpmnNode.get(id)).put(propertyName, propertyValue);
+    ((ObjectNode) bpmnNode.get(id)).replace(propertyName, propertyValue);
   }
   
   protected ObjectNode createOrGetBpmnNode(ObjectNode infoNode) {
     if (infoNode.has(BPMN_NODE) == false) {
-      infoNode.put(BPMN_NODE, processEngineConfiguration.getObjectMapper().createObjectNode());
+      infoNode.set(BPMN_NODE, processEngineConfiguration.getObjectMapper().createObjectNode());
     }
     return (ObjectNode) infoNode.get(BPMN_NODE);
   }
@@ -304,12 +304,12 @@ public class DynamicBpmnServiceImpl extends ServiceImpl implements DynamicBpmnSe
   protected void setLocalizationProperty(String language, String id, String propertyName, String propertyValue, ObjectNode infoNode) {
     ObjectNode localizationNode = createOrGetLocalizationNode(infoNode);
     if (localizationNode.has(language) == false) {
-      localizationNode.put(language, processEngineConfiguration.getObjectMapper().createObjectNode());
+      localizationNode.set(language, processEngineConfiguration.getObjectMapper().createObjectNode());
     }
     
     ObjectNode languageNode = (ObjectNode) localizationNode.get(language);
     if (languageNode.has(id) == false) {
-      languageNode.put(id, processEngineConfiguration.getObjectMapper().createObjectNode());
+      languageNode.set(id, processEngineConfiguration.getObjectMapper().createObjectNode());
     }
     
     ((ObjectNode) languageNode.get(id)).put(propertyName, propertyValue);
@@ -317,7 +317,7 @@ public class DynamicBpmnServiceImpl extends ServiceImpl implements DynamicBpmnSe
   
   protected ObjectNode createOrGetLocalizationNode(ObjectNode infoNode) {
     if (infoNode.has(LOCALIZATION_NODE) == false) {
-      infoNode.put(LOCALIZATION_NODE, processEngineConfiguration.getObjectMapper().createObjectNode());
+      infoNode.set(LOCALIZATION_NODE, processEngineConfiguration.getObjectMapper().createObjectNode());
     }
     return (ObjectNode) infoNode.get(LOCALIZATION_NODE);
   }

--- a/modules/flowable5-engine/src/main/java/org/activiti5/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti5/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -20,16 +20,7 @@ import java.net.URL;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.ServiceLoader;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
@@ -223,7 +214,6 @@ import org.activiti5.engine.impl.variable.ShortType;
 import org.activiti5.engine.impl.variable.StringType;
 import org.activiti5.engine.impl.variable.UUIDType;
 import org.activiti5.engine.parse.BpmnParseHandler;
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.ibatis.builder.xml.XMLConfigBuilder;
 import org.apache.ibatis.builder.xml.XMLMapperBuilder;
 import org.apache.ibatis.datasource.pooled.PooledDataSource;
@@ -916,7 +906,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
           properties.put("limitBetween" , DbSqlSessionFactory.databaseSpecificLimitBetweenStatements.get(databaseType));
           properties.put("limitOuterJoinBetween" , DbSqlSessionFactory.databaseOuterJoinLimitBetweenStatements.get(databaseType));
           properties.put("orderBy" , DbSqlSessionFactory.databaseSpecificOrderByStatements.get(databaseType));
-          properties.put("limitBeforeNativeQuery" , ObjectUtils.toString(DbSqlSessionFactory.databaseSpecificLimitBeforeNativeQueryStatements.get(databaseType)));
+          properties.put("limitBeforeNativeQuery" , Objects.toString(DbSqlSessionFactory.databaseSpecificLimitBeforeNativeQueryStatements.get(databaseType), ""));
         }
         
         Configuration configuration = initMybatisConfiguration(environment, reader, properties);

--- a/modules/flowable5-test/src/test/java/org/activiti5/engine/test/json/JsonTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti5/engine/test/json/JsonTest.java
@@ -185,7 +185,7 @@ public class JsonTest extends PluggableActivitiTestCase {
       childNode.put("test2", "this is a simple test2 text");
       childNode.put("test3", "this is a simple test3 text");
       childNode.put("test4", "this is a simple test4 text");
-      valueNode.put("var" + i, childNode);
+      valueNode.set("var" + i, childNode);
     }
     return valueNode;
   }


### PR DESCRIPTION
- `ObjectUtils.toString(obj, nullStr)` to `Objects.toString(o, nullDefault)`
- `jsonNode.put(fieldName, jsonNode)` to `jsonNode.set(fieldName, jsonNode)`
-  typo
- removing some not existing param in javadocs