### PR TITLE
Do not deference a known null value

### DIFF
--- a/modules/flowable-engine/src/main/java/org/activiti/engine/impl/cmd/GetTaskFormModelCmd.java
+++ b/modules/flowable-engine/src/main/java/org/activiti/engine/impl/cmd/GetTaskFormModelCmd.java
@@ -55,7 +55,7 @@ public class GetTaskFormModelCmd implements Command<FormModel>, Serializable {
     
     HistoricTaskInstance task = processEngineConfiguration.getHistoricTaskInstanceEntityManager().findById(taskId);
     if (task == null) {
-      throw new ActivitiObjectNotFoundException("Task not found with id " + task.getId());
+      throw new ActivitiObjectNotFoundException("Task not found with id " + taskId);
     }
     
     Map<String, Object> variables = new HashMap<String, Object>();


### PR DESCRIPTION
An exception message was using a known null value.

Change:
`throw new ActivitiObjectNotFoundException("Task not found with id " + task.getId()); `
to
`throw new ActivitiObjectNotFoundException("Task not found with id " + taskId);`