### PR TITLE
Fix double checked locking pattern.

### DIFF
--- a/modules/flowable5-compatibility/src/main/java/org/activiti/compatibility/DefaultActiviti5CompatibilityHandler.java
+++ b/modules/flowable5-compatibility/src/main/java/org/activiti/compatibility/DefaultActiviti5CompatibilityHandler.java
@@ -83,7 +83,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 public class DefaultActiviti5CompatibilityHandler implements Activiti5CompatibilityHandler {
 
   protected DefaultProcessEngineFactory processEngineFactory;
-  protected ProcessEngine processEngine;
+  protected volatile ProcessEngine processEngine;
   
   public ProcessDefinition getProcessDefinition(final String processDefinitionId) {
     final ProcessEngineConfigurationImpl processEngineConfig = (ProcessEngineConfigurationImpl) getProcessEngine().getProcessEngineConfiguration();


### PR DESCRIPTION
Partially created objects can be returned by the Double Checked Locking pattern when used in Java. An optimizing JRE may assign a reference to the baz variable before it calls the constructor of the object the reference points to.

The fix is to make the variable 'volatile'.

For more details refer to [this JavaWord article]( http://www.javaworld.com/javaworld/jw-02-2001/jw-0209-double.html) or this [discussion](http://www.cs.umd.edu/~pugh/java/memoryModel/DoubleCheckedLocking.html).

This code has been present since the file was created given the git history.