### PR TITLE
Remove unnecessary 'null' check before 'instanceof' expression.

### DIFF
--- a/modules/flowable-cxf/src/main/java/org/flowable/engine/impl/webservice/CxfWSDLImporter.java
+++ b/modules/flowable-cxf/src/main/java/org/flowable/engine/impl/webservice/CxfWSDLImporter.java
@@ -208,7 +208,7 @@ public class CxfWSDLImporter implements XMLImporter {
   protected static void _importFields(final JDefinedClass theClass, final AtomicInteger index, final SimpleStructureDefinition structure) {
       
     final JClass parentClass = theClass._extends();
-    if (parentClass != null && parentClass instanceof JDefinedClass) {
+    if (parentClass instanceof JDefinedClass) {
       _importFields((JDefinedClass)parentClass, index, structure);
     }
     for (Entry<String, JFieldVar> entry : theClass.fields().entrySet()) {

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/deployer/BpmnDeployer.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/deployer/BpmnDeployer.java
@@ -180,7 +180,7 @@ public class BpmnDeployer implements Deployer {
       processDefinition.setId(getIdForNewProcessDefinition(processDefinition));
       Process process = parsedDeployment.getProcessModelForProcessDefinition(processDefinition);
       FlowElement initialElement = process.getInitialFlowElement();
-      if (initialElement != null && initialElement instanceof StartEvent) {
+      if (initialElement instanceof StartEvent) {
         StartEvent startEvent = (StartEvent) initialElement;
         if (startEvent.getFormKey() != null) {
           processDefinition.setHasStartFormKey(true);

--- a/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/cmd/GetVariablesFromFormSubmissionCmd.java
+++ b/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/cmd/GetVariablesFromFormSubmissionCmd.java
@@ -123,7 +123,7 @@ public class GetVariablesFromFormSubmissionCmd implements Command<Map<String, Ob
       }
       
     } else if (formField.getType().equals(FormFieldTypes.DROPDOWN)) {
-      if (formFieldValue != null && formFieldValue instanceof Map<?, ?>) {
+      if (formFieldValue instanceof Map<?, ?>) {
         result = ((Map<?, ?>) formFieldValue).get("id");
         if (result == null) {
           // fallback to name for manual config options
@@ -135,7 +135,7 @@ public class GetVariablesFromFormSubmissionCmd implements Command<Map<String, Ob
       result = (String) formFieldValue;
 
     } else if (formField.getType().equals(FormFieldTypes.PEOPLE) || formField.getType().equals(FormFieldTypes.FUNCTIONAL_GROUP)) {
-      if (formFieldValue != null && formFieldValue instanceof Map<?, ?>) {
+      if (formFieldValue instanceof Map<?, ?>) {
         Map<String, Object> value = (Map<String, Object>) formFieldValue;
         Object id = value.get("id");
         if (id instanceof Number) {

--- a/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/el/JsonNodeELResolver.java
+++ b/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/el/JsonNodeELResolver.java
@@ -322,11 +322,10 @@ public class JsonNodeELResolver extends ELResolver {
    * 
    * @param base
    *            The bean to analyze.
-   * @param property
-   *            The name of the property to analyze. Will be coerced to a String.
+   *            The bean to analyze.
    * @return base != null
    */
   private final boolean isResolvable(Object base) {
-    return base != null && base instanceof JsonNode;
+    return base instanceof JsonNode;
   }
 }

--- a/modules/flowable-json-converter/src/main/java/org/flowable/editor/language/json/converter/BpmnJsonConverter.java
+++ b/modules/flowable-json-converter/src/main/java/org/flowable/editor/language/json/converter/BpmnJsonConverter.java
@@ -708,7 +708,7 @@ public class BpmnJsonConverter implements EditorJsonConstants, StencilConstants,
       } else if (flowElement instanceof SequenceFlow) {
         SequenceFlow sequenceFlow = (SequenceFlow) flowElement;
         FlowElement sourceFlowElement = parentContainer.getFlowElement(sequenceFlow.getSourceRef());
-        if (sourceFlowElement != null && sourceFlowElement instanceof FlowNode) {
+        if (sourceFlowElement instanceof FlowNode) {
 
           FlowWithContainer flowWithContainer = new FlowWithContainer(sequenceFlow, parentContainer);
           if (sequenceFlow.getExtensionElements().get("EDITOR_RESOURCEID") != null && sequenceFlow.getExtensionElements().get("EDITOR_RESOURCEID").size() > 0) {
@@ -730,7 +730,7 @@ public class BpmnJsonConverter implements EditorJsonConstants, StencilConstants,
           }
         }
         FlowElement targetFlowElement = parentContainer.getFlowElement(sequenceFlow.getTargetRef());
-        if (targetFlowElement != null && targetFlowElement instanceof FlowNode) {
+        if (targetFlowElement instanceof FlowNode) {
           ((FlowNode) targetFlowElement).getIncomingFlows().add(sequenceFlow);
         }
       }

--- a/modules/flowable-ui-common/src/main/java/org/flowable/app/security/SecurityUtils.java
+++ b/modules/flowable-ui-common/src/main/java/org/flowable/app/security/SecurityUtils.java
@@ -59,7 +59,7 @@ public final class SecurityUtils {
     SecurityContext securityContext = SecurityContextHolder.getContext();
     if (securityContext != null && securityContext.getAuthentication() != null) {
       Object principal = securityContext.getAuthentication().getPrincipal();
-      if (principal != null && principal instanceof FlowableAppUser) {
+      if (principal instanceof FlowableAppUser) {
         user = (FlowableAppUser) principal;
       }
     }

--- a/modules/flowable-ui-task/flowable-ui-task-logic/src/main/java/org/flowable/app/service/runtime/FlowableAbstractTaskService.java
+++ b/modules/flowable-ui-task/flowable-ui-task-logic/src/main/java/org/flowable/app/service/runtime/FlowableAbstractTaskService.java
@@ -72,7 +72,7 @@ public abstract class FlowableAbstractTaskService {
         processInstanceStartUserId = historicProcessInstance.getStartUserId();
         BpmnModel bpmnModel = repositoryService.getBpmnModel(task.getProcessDefinitionId());
         FlowElement flowElement = bpmnModel.getFlowElement(task.getTaskDefinitionKey());
-        if (flowElement != null && flowElement instanceof UserTask) {
+        if (flowElement instanceof UserTask) {
           UserTask userTask = (UserTask) flowElement;
           List<ExtensionElement> extensionElements = userTask.getExtensionElements().get("initiator-can-complete");
           if (CollectionUtils.isNotEmpty(extensionElements)) {

--- a/modules/flowable-ui-task/flowable-ui-task-logic/src/main/java/org/flowable/app/service/runtime/PermissionService.java
+++ b/modules/flowable-ui-task/flowable-ui-task-logic/src/main/java/org/flowable/app/service/runtime/PermissionService.java
@@ -129,7 +129,7 @@ public class PermissionService {
         if (String.valueOf(user.getId()).equals(processInstanceStartUserId)) {
           BpmnModel bpmnModel = repositoryService.getBpmnModel(task.getProcessDefinitionId());
           FlowElement flowElement = bpmnModel.getFlowElement(task.getTaskDefinitionKey());
-          if (flowElement != null && flowElement instanceof UserTask) {
+          if (flowElement instanceof UserTask) {
             UserTask userTask = (UserTask) flowElement;
             List<ExtensionElement> extensionElements = userTask.getExtensionElements().get("initiator-can-complete");
             if (CollectionUtils.isNotEmpty(extensionElements)) {


### PR DESCRIPTION
Since the instanceof operator always returns false for null, there is no need to have an additional null check.

Here is an example of the change:
   ` if (x != null && x instanceof String) { ... }`
Becomes:
    `if (x instanceof String) { ... }`

Also made a small change to one Javadoc instance that defined a parameter that did not exist.