### PR TITLE
Clean up more deprecated usages

### DIFF
--- a/modules/flowable-camel/src/test/java/org/flowable/camel/CustomContextTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/CustomContextTest.java
@@ -47,7 +47,7 @@ public class CustomContextTest extends SpringActivitiTestCase {
       public void configure() throws Exception {
         from("direct:start").to("activiti:camelProcess");
 
-        from("activiti:camelProcess:serviceTask1").setBody().property("var1").to("mock:service1").setProperty("var2").constant("var2").setBody().properties();
+        from("activiti:camelProcess:serviceTask1").setBody().exchangeProperty("var1").to("mock:service1").setProperty("var2").constant("var2").setBody().properties();
 
         from("activiti:camelProcess:serviceTask2?copyVariablesToBodyAsMap=true").to("mock:service2");
 

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/SimpleProcessTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/SimpleProcessTest.java
@@ -49,7 +49,7 @@ public class SimpleProcessTest extends SpringActivitiTestCase {
       @Override
       public void configure() throws Exception {
         from("direct:start").to("activiti:camelProcess");
-        from("activiti:camelProcess:serviceTask1").setBody().property("var1").to("mock:service1").setProperty("var2").constant("var2").setBody().properties();
+        from("activiti:camelProcess:serviceTask1").setBody().exchangeProperty("var1").to("mock:service1").setProperty("var2").constant("var2").setBody().properties();
         from("direct:receive").to("activiti:camelProcess:receive");
         from("activiti:camelProcess:serviceTask2?copyVariablesToBodyAsMap=true").to("mock:service2");
       }

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/error/route/OutboundErrorRoute.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/error/route/OutboundErrorRoute.java
@@ -30,14 +30,14 @@ public class OutboundErrorRoute extends RouteBuilder {
 
     // always fails with default error handling: propagates exception back
     // to the caller
-    from("activiti:ErrorHandling:ProvokeError").routeId("error").log(LoggingLevel.INFO, "Provoked error").beanRef("brokenService") // <--
+    from("activiti:ErrorHandling:ProvokeError").routeId("error").log(LoggingLevel.INFO, "Provoked error").bean("brokenService") // <--
                                                                                                                                    // throws
                                                                                                                                    // Exception
         .to("seda:inbound");
 
     // always fails with specific error handler: exception is not propagated
     // back
-    from("activiti:ErrorHandling:HandleError").routeId("errorWithDlq").errorHandler(deadLetterChannel("seda:dlq")).log(LoggingLevel.INFO, "Provoked error").beanRef("brokenService") // <--
+    from("activiti:ErrorHandling:HandleError").routeId("errorWithDlq").errorHandler(deadLetterChannel("seda:dlq")).log(LoggingLevel.INFO, "Provoked error").bean("brokenService") // <--
                                                                                                                                                                                      // throws
                                                                                                                                                                                      // Exception
         .to("seda:inbound");

--- a/modules/flowable-mule/src/test/java/org/flowable/mule/MuleHttpBasicAuthTest.java
+++ b/modules/flowable-mule/src/test/java/org/flowable/mule/MuleHttpBasicAuthTest.java
@@ -45,7 +45,7 @@ public class MuleHttpBasicAuthTest extends AbstractMuleTest {
   }
 
   @Override
-  protected String getConfigResources() {
+  protected String getConfigFile() {
     return "mule-http-basicauth-config.xml";
   }
 }

--- a/modules/flowable-mule/src/test/java/org/flowable/mule/MuleHttpTest.java
+++ b/modules/flowable-mule/src/test/java/org/flowable/mule/MuleHttpTest.java
@@ -45,7 +45,7 @@ public class MuleHttpTest extends AbstractMuleTest {
   }
 
   @Override
-  protected String getConfigResources() {
+  protected String getConfigFile() {
     return "mule-http-config.xml";
   }
 }

--- a/modules/flowable-mule/src/test/java/org/flowable/mule/MuleVMTest.java
+++ b/modules/flowable-mule/src/test/java/org/flowable/mule/MuleVMTest.java
@@ -49,7 +49,7 @@ public class MuleVMTest extends AbstractMuleTest {
   }
 
   @Override
-  protected String getConfigResources() {
+  protected String getConfigFile() {
     return "mule-config.xml";
   }
 }

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/engine/EventResponse.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/engine/EventResponse.java
@@ -18,8 +18,8 @@ import java.util.List;
 
 import org.flowable.rest.util.DateToStringSerializer;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize.Inclusion;
 
 /**
  * @author Frederik Heremans
@@ -76,7 +76,7 @@ public class EventResponse {
     this.taskUrl = taskUrl;
   }
 
-  @JsonSerialize(include = Inclusion.NON_NULL)
+  @JsonInclude(JsonInclude.Include.NON_NULL)
   public String getProcessInstanceUrl() {
     return processInstanceUrl;
   }

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/engine/variable/RestVariable.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/engine/variable/RestVariable.java
@@ -15,9 +15,8 @@ package org.flowable.rest.service.api.engine.variable;
 
 import org.flowable.engine.common.api.FlowableIllegalArgumentException;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize.Inclusion;
 
 /**
  * Pojo representing a variable used in REST-service which definies it's name, variable, scope and type.
@@ -44,7 +43,7 @@ public class RestVariable {
     this.name = name;
   }
 
-  @JsonSerialize(include = Inclusion.NON_NULL)
+  @JsonInclude(JsonInclude.Include.NON_NULL)
   public String getType() {
     return type;
   }
@@ -86,7 +85,7 @@ public class RestVariable {
     this.valueUrl = valueUrl;
   }
 
-  @JsonSerialize(include = Inclusion.NON_NULL)
+  @JsonInclude(JsonInclude.Include.NON_NULL)
   public String getValueUrl() {
     return valueUrl;
   }

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/identity/UserInfoRequest.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/identity/UserInfoRequest.java
@@ -13,8 +13,7 @@
 
 package org.flowable.rest.service.api.identity;
 
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize.Inclusion;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 /**
  * @author Frederik Heremans
@@ -32,7 +31,7 @@ public class UserInfoRequest {
     return key;
   }
 
-  @JsonSerialize(include = Inclusion.NON_NULL)
+  @JsonInclude(JsonInclude.Include.NON_NULL)
   public void setValue(String value) {
     this.value = value;
   }

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/identity/UserResponse.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/identity/UserResponse.java
@@ -13,8 +13,7 @@
 
 package org.flowable.rest.service.api.identity;
 
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize.Inclusion;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 /**
  * @author Frederik Hermans
@@ -69,7 +68,7 @@ public class UserResponse {
     this.lastName = lastName;
   }
 
-  @JsonSerialize(include = Inclusion.NON_NULL)
+  @JsonInclude(JsonInclude.Include.NON_NULL)
   public String getPassword() {
     return passWord;
   }

--- a/modules/flowable-secure-javascript/src/main/java/org/flowable/scripting/secure/impl/SecureScriptContext.java
+++ b/modules/flowable-secure-javascript/src/main/java/org/flowable/scripting/secure/impl/SecureScriptContext.java
@@ -13,6 +13,7 @@
 package org.flowable.scripting.secure.impl;
 
 import org.mozilla.javascript.Context;
+import org.mozilla.javascript.ContextFactory;
 
 /**
  * @author Joram Barrez
@@ -22,6 +23,10 @@ public class SecureScriptContext extends Context {
     private long startTime;
     private long threadId;
     private long startMemory;
+
+    protected SecureScriptContext(ContextFactory factory) {
+        super(factory);
+    }
 
     public long getStartTime() {
         return startTime;

--- a/modules/flowable5-camel-test/src/test/java/org/activiti/camel/CustomContextTest.java
+++ b/modules/flowable5-camel-test/src/test/java/org/activiti/camel/CustomContextTest.java
@@ -47,7 +47,7 @@ public class CustomContextTest extends SpringActivitiTestCase {
       public void configure() throws Exception {
         from("direct:start").to("activiti:camelProcess");
 
-        from("activiti:camelProcess:serviceTask1").setBody().property("var1").to("mock:service1").setProperty("var2").constant("var2").setBody().properties();
+        from("activiti:camelProcess:serviceTask1").setBody().exchangeProperty("var1").to("mock:service1").setProperty("var2").constant("var2").setBody().properties();
 
         from("activiti:camelProcess:serviceTask2?copyVariablesToBodyAsMap=true").to("mock:service2");
 

--- a/modules/flowable5-camel-test/src/test/java/org/activiti/camel/SimpleProcessTest.java
+++ b/modules/flowable5-camel-test/src/test/java/org/activiti/camel/SimpleProcessTest.java
@@ -49,7 +49,7 @@ public class SimpleProcessTest extends SpringActivitiTestCase {
       @Override
       public void configure() throws Exception {
         from("direct:start").to("activiti:camelProcess");
-        from("activiti:camelProcess:serviceTask1").setBody().property("var1").to("mock:service1").setProperty("var2").constant("var2").setBody().properties();
+        from("activiti:camelProcess:serviceTask1").setBody().exchangeProperty("var1").to("mock:service1").setProperty("var2").constant("var2").setBody().properties();
         from("direct:receive").to("activiti:camelProcess:receive");
         from("activiti:camelProcess:serviceTask2?copyVariablesToBodyAsMap=true").to("mock:service2");
       }

--- a/modules/flowable5-camel-test/src/test/java/org/activiti/camel/error/route/OutboundErrorRoute.java
+++ b/modules/flowable5-camel-test/src/test/java/org/activiti/camel/error/route/OutboundErrorRoute.java
@@ -30,14 +30,14 @@ public class OutboundErrorRoute extends RouteBuilder {
 
     // always fails with default error handling: propagates exception back
     // to the caller
-    from("activiti:ErrorHandling:ProvokeError").routeId("error").log(LoggingLevel.INFO, "Provoked error").beanRef("brokenService") // <--
+    from("activiti:ErrorHandling:ProvokeError").routeId("error").log(LoggingLevel.INFO, "Provoked error").bean("brokenService") // <--
                                                                                                                                    // throws
                                                                                                                                    // Exception
         .to("seda:inbound");
 
     // always fails with specific error handler: exception is not propagated
     // back
-    from("activiti:ErrorHandling:HandleError").routeId("errorWithDlq").errorHandler(deadLetterChannel("seda:dlq")).log(LoggingLevel.INFO, "Provoked error").beanRef("brokenService") // <--
+    from("activiti:ErrorHandling:HandleError").routeId("errorWithDlq").errorHandler(deadLetterChannel("seda:dlq")).log(LoggingLevel.INFO, "Provoked error").bean("brokenService") // <--
                                                                                                                                                                                      // throws
                                                                                                                                                                                      // Exception
         .to("seda:inbound");

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ByteArrayEntity.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ByteArrayEntity.java
@@ -14,11 +14,11 @@ package org.activiti.engine.impl.persistence.entity;
 
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.Objects;
 
 import org.activiti.engine.impl.context.Context;
 import org.activiti.engine.impl.db.HasRevision;
 import org.activiti.engine.impl.db.PersistentObject;
-import org.apache.commons.lang3.ObjectUtils;
 
 /**
  * @author Tom Baeyens
@@ -124,7 +124,7 @@ public class ByteArrayEntity implements Serializable, PersistentObject, HasRevis
     public boolean equals(Object obj) {
       if (obj instanceof PersistentState) {
         PersistentState other = (PersistentState) obj;
-        return ObjectUtils.equals(this.name, other.name)
+        return Objects.equals(this.name, other.name)
             && Arrays.equals(this.bytes, other.bytes);
       }
       return false;

--- a/modules/flowable5-mule-test/src/test/java/org/activiti/mule/MuleHttpBasicAuthTest.java
+++ b/modules/flowable5-mule-test/src/test/java/org/activiti/mule/MuleHttpBasicAuthTest.java
@@ -50,7 +50,7 @@ public class MuleHttpBasicAuthTest extends AbstractMuleTest {
   }
 
   @Override
-  protected String getConfigResources() {
+  protected String getConfigFile() {
     return "mule-http-basicauth-config.xml";
   }
 }

--- a/modules/flowable5-mule-test/src/test/java/org/activiti/mule/MuleHttpTest.java
+++ b/modules/flowable5-mule-test/src/test/java/org/activiti/mule/MuleHttpTest.java
@@ -49,7 +49,7 @@ public class MuleHttpTest extends AbstractMuleTest {
   }
 
   @Override
-  protected String getConfigResources() {
+  protected String getConfigFile() {
     return "mule-http-config.xml";
   }
 }

--- a/modules/flowable5-mule-test/src/test/java/org/activiti/mule/MuleVMTest.java
+++ b/modules/flowable5-mule-test/src/test/java/org/activiti/mule/MuleVMTest.java
@@ -53,7 +53,7 @@ public class MuleVMTest extends AbstractMuleTest {
   }
 
   @Override
-  protected String getConfigResources() {
+  protected String getConfigFile() {
     return "mule-config.xml";
   }
 }


### PR DESCRIPTION
By using IntelliJ IDEA's code inspection, I find out all deprecated API usages, but still have [one](https://github.com/flowable/flowable-engine/blob/master/modules/flowable-cdi/src/main/java/org/flowable/cdi/impl/annotation/StartProcessInterceptor.java#L58) I don't know how to fix it, It calls [startProcessByName](https://github.com/flowable/flowable-engine/blob/master/modules/flowable-cdi/src/main/java/org/flowable/cdi/BusinessProcess.java#L222) has been annotated with deprecated.