### PR TITLE
Improvement to DynamicBpmnservice

### DIFF
--- a/modules/flowable-engine/src/main/java/org/activiti/engine/DynamicBpmnService.java
+++ b/modules/flowable-engine/src/main/java/org/activiti/engine/DynamicBpmnService.java
@@ -14,6 +14,9 @@
 package org.activiti.engine;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.activiti.engine.dynamic.DynamicProcessDefinitionSummary;
+
+import java.util.List;
 
 /** Service providing access to the repository of process definitions and deployments.
  * 
@@ -80,6 +83,60 @@ public interface DynamicBpmnService {
   ObjectNode changeUserTaskCandidateGroup(String id, String candidateGroup, boolean overwriteOtherChangedEntries);
   
   void changeUserTaskCandidateGroup(String id, String candidateGroup, boolean overwriteOtherChangedEntries, ObjectNode infoNode);
+
+  /**
+   * Creates a new processDefinitionInfo with {@link DynamicBpmnConstants#USER_TASK_CANDIDATE_USERS} for the given BPMN element.
+   *
+   * <p color="red">
+   *     Don't forget to call {@link DynamicBpmnService#saveProcessDefinitionInfo(String, ObjectNode)}
+   * </p>
+   *
+   * @param id the bpmn element id (ex. sid-3392FDEE-DD6F-484E-97FE-55F30BFEA77E)
+   * @param candidateUsers the candidate users.
+   * @return a new processDefinitionNode with the candidate users for the given bpmn element.
+   */
+  ObjectNode changeUserTaskCandidateUsers(String id, List<String> candidateUsers);
+
+  /**
+   * Updates a processDefinitionInfo's {@link DynamicBpmnConstants#USER_TASK_CANDIDATE_USERS} with the new list.
+   * Previous values for the BPMN Element with {@link DynamicBpmnConstants#USER_TASK_CANDIDATE_USERS} as key are ignored.
+   *
+   * <p color="red">
+   *     Don't forget to call {@link DynamicBpmnService#saveProcessDefinitionInfo(String, ObjectNode)}
+   * </p>
+   *
+   * @param id the bpmn element id (ex. sid-3392FDEE-DD6F-484E-97FE-55F30BFEA77E)
+   * @param candidateUsers the candidate users.
+   * @param infoNode the current processDefinitionInfo. This object will be modified.
+   */
+  void changeUserTaskCandidateUsers(String id, List<String> candidateUsers, ObjectNode infoNode);
+
+  /**
+   * Creates a new processDefinitionInfo with {@link DynamicBpmnConstants#USER_TASK_CANDIDATE_USERS} for the given BPMN element.
+   *
+   * <p color="red">
+   *     Don't forget to call {@link DynamicBpmnService#saveProcessDefinitionInfo(String, ObjectNode)}
+   * </p>
+   *
+   * @param id the bpmn element id (ex. sid-3392FDEE-DD6F-484E-97FE-55F30BFEA77E)
+   * @param candidateGroups the candidate groups.
+   * @return a new processDefinitionNode with the candidate users for the given bpmn element.
+   */
+  ObjectNode changeUserTaskCandidateGroups(String id, List<String> candidateGroups);
+
+  /**
+   * Updates a processDefinitionInfo's {@link DynamicBpmnConstants#USER_TASK_CANDIDATE_USERS} with the new list.
+   * Previous values for the BPMN Element with {@link DynamicBpmnConstants#USER_TASK_CANDIDATE_USERS} as key are ignored.
+   *
+   * <p color="red">
+   *     Don't forget to call {@link DynamicBpmnService#saveProcessDefinitionInfo(String, ObjectNode)}
+   * </p>
+   *
+   * @param id the bpmn element id (ex. sid-3392FDEE-DD6F-484E-97FE-55F30BFEA77E)
+   * @param candidateGroups the candidate groups.
+   * @param infoNode the current processDefinitionInfo. This object will be modified.
+   */
+  void changeUserTaskCandidateGroups(String id, List<String> candidateGroups, ObjectNode infoNode);
   
   ObjectNode changeSequenceFlowCondition(String id, String condition);
   
@@ -96,4 +153,29 @@ public interface DynamicBpmnService {
   void changeLocalizationDescription(String language, String id, String value, ObjectNode infoNode);
   
   ObjectNode getLocalizationElementProperties(String language, String id, ObjectNode infoNode);
+
+  /**
+   * <p>
+   *  Clears the field from the infoNode. So the engine uses the {@link org.activiti.bpmn.model.BpmnModel} value
+   *  On next instance.
+   * </p>
+   *
+   * <p color="red">
+   *     Don't forget to save the modified infoNode by calling {@link DynamicBpmnService#saveProcessDefinitionInfo(String, ObjectNode)}
+   * </p>
+   *
+   * @param elementId the flow elements id.
+   * @param property {@link DynamicBpmnConstants} property
+   * @param infoNode to modify
+   */
+  void resetProperty(String elementId, String property, ObjectNode infoNode);
+
+  /**
+   * Gives a summary between the {@link org.activiti.bpmn.model.BpmnModel} and {@link DynamicBpmnService#getProcessDefinitionInfo(String)}
+   *
+   * @param processDefinitionId the process definition id (key:version:sequence)
+   * @return DynamicProcessDefinitionSummary if the processdefinition exists
+   * @throws IllegalStateException if there is no processDefinition found for the provided processDefinitionId.
+   */
+  DynamicProcessDefinitionSummary getDynamicProcessDefinitionSummary(String processDefinitionId);
 }

--- a/modules/flowable-engine/src/main/java/org/activiti/engine/dynamic/BasePropertiesParser.java
+++ b/modules/flowable-engine/src/main/java/org/activiti/engine/dynamic/BasePropertiesParser.java
@@ -1,0 +1,56 @@
+package org.activiti.engine.dynamic;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.activiti.bpmn.model.FlowElement;
+import org.activiti.engine.DynamicBpmnConstants;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.List;
+
+/**
+ * Created by Pardo David on 5/12/2016.
+ */
+public abstract class BasePropertiesParser implements PropertiesParser, DynamicBpmnConstants, PropertiesParserConstants {
+
+	@Override
+	public ObjectNode parseElement(FlowElement flowElement, ObjectNode flowElementNode, ObjectMapper mapper) {
+		ObjectNode resultNode = mapper.createObjectNode();
+		resultNode.put(ELEMENT_ID,flowElement.getId());
+		resultNode.put(ELEMENT_TYPE, flowElement.getClass().getSimpleName());
+		if(supports(flowElement)){
+			resultNode.put(ELEMENT_PROPERTIES, createPropertiesNode(flowElement,flowElementNode,mapper));
+		}
+		return resultNode;
+	}
+
+	protected abstract ObjectNode createPropertiesNode(FlowElement flowElement, ObjectNode flowElementNode, ObjectMapper objectMapper);
+	public abstract boolean supports(FlowElement flowElement);
+
+	protected void putPropertyValue(String key, String value, ObjectNode propertiesNode){
+		if (StringUtils.isNotBlank(value)) {
+			propertiesNode.put(key,value);
+		}
+	}
+
+	protected void putPropertyValue(String key, List<String> values, ObjectNode propertiesNode){
+		//we don't set a node value if the collection is null.
+		//An empty collection is a indicator. if a task has candidate users you can only overrule it by putting an empty array as dynamic candidate users
+		if(values != null){
+			ArrayNode arrayNode = propertiesNode.putArray(key);
+			for(String value : values){
+				arrayNode.add(value);
+			}
+		}
+	}
+
+	protected void putPropertyValue(String key, JsonNode node, ObjectNode propertiesNode){
+		if(node != null){
+			if(!node.isMissingNode() && !node.isNull()){
+				propertiesNode.set(key,node);
+			}
+		}
+	}
+}

--- a/modules/flowable-engine/src/main/java/org/activiti/engine/dynamic/DefaultPropertiesParser.java
+++ b/modules/flowable-engine/src/main/java/org/activiti/engine/dynamic/DefaultPropertiesParser.java
@@ -1,0 +1,23 @@
+package org.activiti.engine.dynamic;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.activiti.bpmn.model.FlowElement;
+
+/**
+ * Used for {@link FlowElement} currently not supported by the {@link org.activiti.engine.DynamicBpmnService}
+ * and elements who are not parsed.
+ *
+ * Created by Pardo David on 5/12/2016.
+ */
+public class DefaultPropertiesParser extends BasePropertiesParser {
+	@Override
+	protected ObjectNode createPropertiesNode(FlowElement flowElement, ObjectNode flowElementNode, ObjectMapper objectMapper) {
+		return null;
+	}
+
+	@Override
+	public boolean supports(FlowElement flowElement) {
+		return false;
+	}
+}

--- a/modules/flowable-engine/src/main/java/org/activiti/engine/dynamic/DynamicProcessDefinitionSummary.java
+++ b/modules/flowable-engine/src/main/java/org/activiti/engine/dynamic/DynamicProcessDefinitionSummary.java
@@ -1,0 +1,112 @@
+package org.activiti.engine.dynamic;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.activiti.bpmn.model.*;
+import org.activiti.bpmn.model.Process;
+import org.activiti.engine.DynamicBpmnConstants;
+
+import java.util.HashMap;
+
+/**
+ * Pojo class who can be used to check information between {@link org.activiti.engine.DynamicBpmnService#getProcessDefinitionInfo(String)}
+ * and {@link org.activiti.bpmn.model.BpmnModel}. Without exposing the internal behavoir of activiti's logic.
+ *
+ * Created by Pardo David on 5/12/2016.
+ */
+public class DynamicProcessDefinitionSummary implements DynamicBpmnConstants {
+	private static final HashMap<String, PropertiesParser> summaryParsers = new HashMap<String,PropertiesParser>();
+	private static final PropertiesParser defaultParser = new DefaultPropertiesParser();
+	private BpmnModel bpmnModel;
+	private ObjectNode processInfo;
+	private ObjectMapper objectMapper;
+
+	static {
+		summaryParsers.put(UserTask.class.getSimpleName(),new UserTaskPropertiesParser());
+		summaryParsers.put(ScriptTask.class.getSimpleName(),new ScriptTaskPropertiesParser());
+	}
+
+	public DynamicProcessDefinitionSummary(BpmnModel bpmnModel, ObjectNode processInfo, ObjectMapper objectMapper) {
+		this.bpmnModel = bpmnModel;
+		this.processInfo = processInfo;
+		this.objectMapper = objectMapper;
+	}
+
+	/**
+	 * Returns the summary in the following structure:
+	 * <pre>
+	 * {
+	 *     "elementId": (the elements id)
+	 *     "elementType": (the elements type)
+	 *     "elementSummary": {
+	 *         "{@link org.activiti.engine.DynamicBpmnConstants} linked to the elementType": {
+	 *             bpmnmodel : (array of strings | string | not provided if empty / blank / null)
+	 *             dynamic: (array of strings or string or not provided if blank or empty)
+	 *         }
+	 *     }
+	 * }
+	 * </pre>
+	 *
+	 * <p>
+	 *     If no value is found for a given {@link org.activiti.engine.DynamicBpmnConstants} in the {@link BpmnModel} or
+	 *     ProcessDefinitionInfo. we don't store an key in the resulting {@link ObjectNode}. Null values should be avoided
+	 *     in JSON. Depending on the {@link ObjectMapper} configuration keys with a null value could even be removed when writting to json.
+	 * </p>
+	 *
+	 * <p color="red">
+	 *     Currently supported flow elements are:
+	 *     <li>
+	 *         <ul>UserTask</ul>
+	 *         <ul>ScriptTask</ul>
+	 *     </li>
+	 *     No summary will field will be created for other elements. ElementId, and elementType will be available.
+	 * </p>
+	 * @param elementId the id of the {@link org.activiti.bpmn.model.FlowElement}.
+	 * @return an {@link ObjectNode} with the provided structure.
+	 * @throws IllegalStateException if no {@link org.activiti.bpmn.model.FlowElement} is found for the provided id.
+	 */
+	public ObjectNode getElement(String elementId) throws IllegalStateException{
+
+		FlowElement flowElement = bpmnModel.getFlowElement(elementId);
+		if(flowElement == null){
+			throw new IllegalStateException("No flow element with id " + elementId + " found in bpmnmodel " + bpmnModel.getMainProcess().getId());
+		}
+
+		PropertiesParser propertiesParser = summaryParsers.get(flowElement.getClass().getSimpleName());
+		ObjectNode bpmnProperties = getBpmnProperties(elementId, processInfo);
+		if(propertiesParser != null){
+			return propertiesParser.parseElement(flowElement,bpmnProperties,objectMapper);
+		}else{
+			//if there is no parser for an element we have to use the default summary parser.
+			return defaultParser.parseElement(flowElement,bpmnProperties,objectMapper);
+		}
+	}
+
+
+	public ObjectNode getSummary() {
+		ObjectNode summary = objectMapper.createObjectNode();
+
+		for(Process process : bpmnModel.getProcesses()){
+			for(FlowElement flowElement : process.getFlowElements()){
+				summary.set(flowElement.getId(),getElement(flowElement.getId()));
+			}
+		}
+
+		return summary;
+	}
+
+	private ObjectNode getBpmnProperties(String elementId, ObjectNode processInfoNode){
+		JsonNode bpmnNode = processInfoNode.get(BPMN_NODE);
+		if(bpmnNode != null){
+			JsonNode elementNode = bpmnNode.get(elementId);
+			if(elementNode == null){
+				return objectMapper.createObjectNode();
+			}else{
+				return (ObjectNode) elementNode;
+			}
+		}else{
+			return objectMapper.createObjectNode();
+		}
+	}
+}

--- a/modules/flowable-engine/src/main/java/org/activiti/engine/dynamic/PropertiesParser.java
+++ b/modules/flowable-engine/src/main/java/org/activiti/engine/dynamic/PropertiesParser.java
@@ -1,0 +1,13 @@
+package org.activiti.engine.dynamic;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.activiti.bpmn.model.FlowElement;
+
+/**
+ * Created by Pardo David on 5/12/2016.
+ */
+public interface PropertiesParser {
+	ObjectNode parseElement(FlowElement flowElement, ObjectNode flowElementNode, ObjectMapper mapper);
+	boolean supports(FlowElement flowElement);
+}

--- a/modules/flowable-engine/src/main/java/org/activiti/engine/dynamic/PropertiesParserConstants.java
+++ b/modules/flowable-engine/src/main/java/org/activiti/engine/dynamic/PropertiesParserConstants.java
@@ -1,0 +1,12 @@
+package org.activiti.engine.dynamic;
+
+/**
+ * Created by Pardo David on 5/12/2016.
+ */
+public interface PropertiesParserConstants {
+	String ELEMENT_ID = "elementId";
+	String ELEMENT_TYPE = "elementType";
+	String ELEMENT_PROPERTIES = "elementProperties";
+	String BPMN_MODEL_VALUE = "bpmnmodel";
+	String DYNAMIC_VALUE = "dynamic";
+}

--- a/modules/flowable-engine/src/main/java/org/activiti/engine/dynamic/ScriptTaskPropertiesParser.java
+++ b/modules/flowable-engine/src/main/java/org/activiti/engine/dynamic/ScriptTaskPropertiesParser.java
@@ -1,0 +1,30 @@
+package org.activiti.engine.dynamic;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.activiti.bpmn.model.FlowElement;
+import org.activiti.bpmn.model.ScriptTask;
+
+/**
+ * Created by Pardo David on 5/12/2016.
+ */
+public class ScriptTaskPropertiesParser extends BasePropertiesParser {
+	@Override
+	protected ObjectNode createPropertiesNode(FlowElement flowElement, ObjectNode flowElementNode, ObjectMapper objectMapper) {
+		ScriptTask scriptTask = (ScriptTask) flowElement;
+
+		ObjectNode scriptTextNode = objectMapper.createObjectNode();
+		putPropertyValue(BPMN_MODEL_VALUE,scriptTask.getScript(),scriptTextNode);
+		putPropertyValue(DYNAMIC_VALUE,flowElementNode.path(SCRIPT_TASK_SCRIPT).textValue(),scriptTextNode);
+
+
+		ObjectNode propertiesNode = objectMapper.createObjectNode();
+		propertiesNode.put(SCRIPT_TASK_SCRIPT,scriptTextNode);
+		return propertiesNode;
+	}
+
+	@Override
+	public boolean supports(FlowElement flowElement) {
+		return flowElement instanceof ScriptTask;
+	}
+}

--- a/modules/flowable-engine/src/main/java/org/activiti/engine/dynamic/UserTaskPropertiesParser.java
+++ b/modules/flowable-engine/src/main/java/org/activiti/engine/dynamic/UserTaskPropertiesParser.java
@@ -1,0 +1,46 @@
+package org.activiti.engine.dynamic;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.activiti.bpmn.model.FlowElement;
+import org.activiti.bpmn.model.UserTask;
+
+/**
+ * Created by Pardo David on 5/12/2016.
+ */
+public class UserTaskPropertiesParser extends BasePropertiesParser {
+	@Override
+	protected ObjectNode createPropertiesNode(FlowElement flowElement, ObjectNode flowElementNode, ObjectMapper objectMapper) {
+		UserTask userTask = (UserTask) flowElement;
+
+
+		ObjectNode taskNameNode = objectMapper.createObjectNode();
+		putPropertyValue(BPMN_MODEL_VALUE,userTask.getName(),taskNameNode);
+		putPropertyValue(DYNAMIC_VALUE,flowElementNode.path(USER_TASK_NAME),taskNameNode);
+
+		ObjectNode assigneeNode = objectMapper.createObjectNode();
+		putPropertyValue(BPMN_MODEL_VALUE,userTask.getAssignee(),assigneeNode);
+		putPropertyValue(DYNAMIC_VALUE,flowElementNode.path(USER_TASK_ASSIGNEE),assigneeNode);
+
+		ObjectNode candidateUsersNode = objectMapper.createObjectNode();
+		putPropertyValue(BPMN_MODEL_VALUE,userTask.getCandidateUsers(),candidateUsersNode);
+		putPropertyValue(DYNAMIC_VALUE,flowElementNode.path(USER_TASK_CANDIDATE_USERS),candidateUsersNode);
+
+		ObjectNode candidateGroupsNode = objectMapper.createObjectNode();
+		putPropertyValue(BPMN_MODEL_VALUE,userTask.getCandidateGroups(),candidateGroupsNode);
+		putPropertyValue(DYNAMIC_VALUE,flowElementNode.path(USER_TASK_CANDIDATE_GROUPS),candidateGroupsNode);
+
+		ObjectNode propertiesNode = objectMapper.createObjectNode();
+		propertiesNode.set(USER_TASK_NAME,taskNameNode);
+		propertiesNode.set(USER_TASK_ASSIGNEE, assigneeNode);
+		propertiesNode.set(USER_TASK_CANDIDATE_USERS,candidateUsersNode);
+		propertiesNode.set(USER_TASK_CANDIDATE_GROUPS,candidateGroupsNode);
+
+		return propertiesNode;
+	}
+
+	@Override
+	public boolean supports(FlowElement flowElement) {
+		return flowElement instanceof UserTask;
+	}
+}

--- a/modules/flowable-engine/src/test/java/org/activiti/engine/test/bpmn/dynamic/DynamicCandidateGroupsTest.java
+++ b/modules/flowable-engine/src/test/java/org/activiti/engine/test/bpmn/dynamic/DynamicCandidateGroupsTest.java
@@ -1,0 +1,66 @@
+package org.activiti.engine.test.bpmn.dynamic;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.activiti.engine.DynamicBpmnConstants;
+import org.activiti.engine.impl.test.PluggableActivitiTestCase;
+import org.activiti.engine.runtime.ProcessInstance;
+import org.activiti.engine.test.Deployment;
+
+import java.util.ArrayList;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Created by Pardo David on 7/12/2016.
+ */
+public class DynamicCandidateGroupsTest extends PluggableActivitiTestCase implements DynamicBpmnConstants {
+	private final String TASK_ONE_SID = "sid-B94D5D22-E93E-4401-ADC5-C5C073E1EEB4";
+	private final String TASK_TWO_SID = "sid-B1C37EBE-A273-4DDE-B909-89302638526A";
+	private final String SCRIPT_TASK_SID = "sid-A403BAE0-E367-449A-90B2-48834FCAA2F9";
+
+	@Deployment(resources = {"org/activiti/engine/test/bpmn/dynamic/dynamic-bpmn-test-process.bpmn20.xml"})
+	public void testIsShouldBePossibleToChangeCandidateGroups(){
+		ProcessInstance instance = runtimeService.startProcessInstanceByKey("dynamicServiceTest");
+		ArrayList<String> candidateGroups = new ArrayList<String>(2);
+		candidateGroups.add("HR");
+		candidateGroups.add("SALES");
+
+		ObjectNode processInfo = dynamicBpmnService.changeUserTaskCandidateGroups(TASK_ONE_SID, candidateGroups);
+		dynamicBpmnService.saveProcessDefinitionInfo(instance.getProcessDefinitionId(),processInfo);
+
+		runtimeService.startProcessInstanceByKey("dynamicServiceTest");
+
+		long hrTaskCount = taskService.createTaskQuery().taskCandidateGroup("HR").count();
+		long salesTaskCount = taskService.createTaskQuery().taskCandidateGroup("SALES").count();
+
+		assertThat(hrTaskCount,is(1L));
+		assertThat(salesTaskCount,is(1L));
+	}
+
+	@Deployment(resources = {"org/activiti/engine/test/bpmn/dynamic/dynamic-bpmn-test-process.bpmn20.xml"})
+	public void testIsShouldBePossibleToResetChangeCandidateGroups(){
+		ProcessInstance instance = runtimeService.startProcessInstanceByKey("dynamicServiceTest");
+		ArrayList<String> candidateGroups = new ArrayList<String>(2);
+		candidateGroups.add("HR");
+		candidateGroups.add("SALES");
+
+		ObjectNode processInfo = dynamicBpmnService.changeUserTaskCandidateGroups(TASK_ONE_SID, candidateGroups);
+		dynamicBpmnService.saveProcessDefinitionInfo(instance.getProcessDefinitionId(),processInfo);
+
+		//reset
+		dynamicBpmnService.resetProperty(TASK_ONE_SID,USER_TASK_CANDIDATE_GROUPS,processInfo);
+		dynamicBpmnService.saveProcessDefinitionInfo(instance.getProcessDefinitionId(),processInfo);
+
+		runtimeService.startProcessInstanceByKey("dynamicServiceTest");
+
+		long hrTaskCount = taskService.createTaskQuery().taskCandidateGroup("HR").count();
+		long salesTaskCount = taskService.createTaskQuery().taskCandidateGroup("SALES").count();
+
+		assertThat(hrTaskCount,is(0L));
+		assertThat(salesTaskCount,is(0L));
+
+	}
+
+
+}

--- a/modules/flowable-engine/src/test/java/org/activiti/engine/test/bpmn/dynamic/DynamicProcessDefinitionSummaryTest.java
+++ b/modules/flowable-engine/src/test/java/org/activiti/engine/test/bpmn/dynamic/DynamicProcessDefinitionSummaryTest.java
@@ -1,0 +1,213 @@
+package org.activiti.engine.test.bpmn.dynamic;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.activiti.engine.DynamicBpmnConstants;
+import org.activiti.engine.dynamic.DynamicProcessDefinitionSummary;
+import org.activiti.engine.dynamic.PropertiesParserConstants;
+import org.activiti.engine.impl.test.PluggableActivitiTestCase;
+import org.activiti.engine.runtime.ProcessInstance;
+import org.activiti.engine.task.Task;
+import org.activiti.engine.test.Deployment;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Created by Pardo David on 1/12/2016.
+ */
+public class DynamicProcessDefinitionSummaryTest extends PluggableActivitiTestCase implements DynamicBpmnConstants, PropertiesParserConstants {
+	private final String TASK_ONE_SID = "sid-B94D5D22-E93E-4401-ADC5-C5C073E1EEB4";
+	private final String TASK_TWO_SID = "sid-B1C37EBE-A273-4DDE-B909-89302638526A";
+	private final String SCRIPT_TASK_SID = "sid-A403BAE0-E367-449A-90B2-48834FCAA2F9";
+
+
+	public void testProcessDefinitionInfoCacheIsEnabledWithPluggableActivitiTestCase() throws Exception{
+		assertThat(processEngineConfiguration.isEnableProcessDefinitionInfoCache(),is(true));
+	}
+
+	@Deployment(resources = {"org/activiti/engine/test/bpmn/dynamic/dynamic-bpmn-test-process.bpmn20.xml"})
+	public void testIfNoProcessInfoIsAvailableTheBpmnModelIsUsed() throws Exception{
+		//setup
+		ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("dynamicServiceTest");
+		DynamicProcessDefinitionSummary summary = dynamicBpmnService.getDynamicProcessDefinitionSummary(processInstance.getProcessDefinitionId());
+		ArrayNode candidateGroups = processEngineConfiguration.getObjectMapper().createArrayNode();
+		ArrayNode candidateUsers = processEngineConfiguration.getObjectMapper().createArrayNode();
+		candidateUsers.add("david");
+
+		//first task
+		JsonNode jsonNode = summary.getElement(TASK_ONE_SID).get(ELEMENT_PROPERTIES);
+		assertThat(jsonNode.get(USER_TASK_NAME).get(BPMN_MODEL_VALUE).asText(),is("Taak 1"));
+		assertThat(jsonNode.get(USER_TASK_NAME).get(DYNAMIC_VALUE),is(nullValue()));
+
+		assertThat(jsonNode.get(USER_TASK_ASSIGNEE).get(BPMN_MODEL_VALUE), is(nullValue()));
+		assertThat(jsonNode.get(USER_TASK_ASSIGNEE).get(DYNAMIC_VALUE), is(nullValue()));
+
+		assertThat((ArrayNode) jsonNode.get(USER_TASK_CANDIDATE_USERS).get(BPMN_MODEL_VALUE) , is(candidateUsers));
+		assertThat(jsonNode.get(USER_TASK_CANDIDATE_USERS).get(DYNAMIC_VALUE) , is(nullValue()));
+
+		assertThat((ArrayNode) jsonNode.get(USER_TASK_CANDIDATE_GROUPS).get(BPMN_MODEL_VALUE), is(candidateGroups));
+		assertThat(jsonNode.get(USER_TASK_CANDIDATE_GROUPS).get(DYNAMIC_VALUE), is(nullValue()));
+
+		//second tasks
+		candidateGroups = processEngineConfiguration.getObjectMapper().createArrayNode();
+		candidateGroups.add("HR");
+		candidateGroups.add("SALES");
+
+		jsonNode = summary.getElement(TASK_TWO_SID).get(ELEMENT_PROPERTIES);
+		assertThat(jsonNode.get(USER_TASK_ASSIGNEE).get(BPMN_MODEL_VALUE), is(nullValue()));
+		assertThat(jsonNode.get(USER_TASK_ASSIGNEE).get(DYNAMIC_VALUE), is(nullValue()));
+
+		assertThat((ArrayNode) jsonNode.get(USER_TASK_CANDIDATE_USERS).get(BPMN_MODEL_VALUE), is(candidateUsers));
+		assertThat((ArrayNode) jsonNode.get(USER_TASK_CANDIDATE_GROUPS).get(BPMN_MODEL_VALUE), is(candidateGroups));
+
+		//script tasks
+		jsonNode = summary.getElement(SCRIPT_TASK_SID).get(ELEMENT_PROPERTIES);
+		assertThat(jsonNode.get(SCRIPT_TASK_SCRIPT).get(BPMN_MODEL_VALUE).asText(),is("var test = \"hallo\";"));
+		assertThat(jsonNode.get(SCRIPT_TASK_SCRIPT).get(DYNAMIC_VALUE),is(nullValue()));
+	}
+
+	@Deployment(resources = {"org/activiti/engine/test/bpmn/dynamic/dynamic-bpmn-test-process.bpmn20.xml"})
+	public void testTheCandidateUserOfTheFirstTasksIsChanged() throws Exception{
+		ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("dynamicServiceTest");
+		String processDefinitionId = processInstance.getProcessDefinitionId();
+
+		ObjectNode processInfo = dynamicBpmnService.changeUserTaskCandidateUser(TASK_ONE_SID, "bob", false);
+		dynamicBpmnService.saveProcessDefinitionInfo(processDefinitionId,processInfo);
+
+		DynamicProcessDefinitionSummary summary = dynamicBpmnService.getDynamicProcessDefinitionSummary(processDefinitionId);
+
+		ArrayNode bpmnModelCandidateUsers = processEngineConfiguration.getObjectMapper().createArrayNode();
+		bpmnModelCandidateUsers.add("david");
+
+		ArrayNode dynamicCandidateUsers = processEngineConfiguration.getObjectMapper().createArrayNode();
+		dynamicCandidateUsers.add("bob");
+
+		JsonNode taskOneNode = summary.getElement(TASK_ONE_SID).get(ELEMENT_PROPERTIES);
+		assertThat((ArrayNode) taskOneNode.get(USER_TASK_CANDIDATE_USERS).get(BPMN_MODEL_VALUE), is(bpmnModelCandidateUsers));
+		assertThat((ArrayNode) taskOneNode.get(USER_TASK_CANDIDATE_USERS).get(DYNAMIC_VALUE), is(dynamicCandidateUsers));
+
+		//verify if runtime is up to date
+		runtimeService.startProcessInstanceById(processDefinitionId);
+		//bob and david both should have a single task.
+		Task bobTask = taskService.createTaskQuery().taskCandidateUser("bob").singleResult();
+		assertThat("Bob must have one task",bobTask , is(notNullValue()));
+
+		Task davidTask = taskService.createTaskQuery().taskCandidateUser("david").singleResult();
+		assertThat("David must have one task",davidTask,is(not(nullValue())));
+	}
+
+
+	@Deployment(resources = {"org/activiti/engine/test/bpmn/dynamic/dynamic-bpmn-test-process.bpmn20.xml"})
+	public void testTheCandidateUserOfTheFirstTasksIsChangedMultipleTimes() throws Exception {
+		ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("dynamicServiceTest");
+		String processDefinitionId = processInstance.getProcessDefinitionId();
+
+		ObjectNode processInfo = dynamicBpmnService.changeUserTaskCandidateUser(TASK_ONE_SID, "bob", false);
+		dynamicBpmnService.changeUserTaskCandidateUser(TASK_ONE_SID,"david",false,processInfo);
+		dynamicBpmnService.saveProcessDefinitionInfo(processDefinitionId,processInfo);
+
+		ArrayNode bpmnModelCandidateUsers = processEngineConfiguration.getObjectMapper().createArrayNode();
+		bpmnModelCandidateUsers.add("david");
+
+		ArrayNode dynamicCandidateUsers = processEngineConfiguration.getObjectMapper().createArrayNode();
+		dynamicCandidateUsers.add("bob");
+		dynamicCandidateUsers.add("david");
+
+		DynamicProcessDefinitionSummary summary = dynamicBpmnService.getDynamicProcessDefinitionSummary(processDefinitionId);
+
+		JsonNode taskOneNode = summary.getElement(TASK_ONE_SID).get(ELEMENT_PROPERTIES);
+		assertThat((ArrayNode) taskOneNode.get(USER_TASK_CANDIDATE_USERS).get(BPMN_MODEL_VALUE), is(bpmnModelCandidateUsers));
+		assertThat((ArrayNode) taskOneNode.get(USER_TASK_CANDIDATE_USERS).get(DYNAMIC_VALUE), is(dynamicCandidateUsers));
+
+		//verify if runtime is up to date
+		runtimeService.startProcessInstanceById(processDefinitionId);
+
+		Task bobTask = taskService.createTaskQuery().taskCandidateUser("bob").singleResult();
+		assertThat("Bob must have one task",bobTask , is(notNullValue()));
+
+		List<Task> davidTasks = taskService.createTaskQuery().taskCandidateUser("david").list();
+		assertThat("David must have two task",davidTasks.size(),is(2));
+	}
+
+	@Deployment(resources = {"org/activiti/engine/test/bpmn/dynamic/dynamic-bpmn-test-process.bpmn20.xml"})
+	public void testTheCandidateGroupOfTheFirstTasksIsChanged() throws Exception {
+		ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("dynamicServiceTest");
+		String processDefinitionId = processInstance.getProcessDefinitionId();
+
+		ObjectNode processInfo = dynamicBpmnService.changeUserTaskCandidateGroup(TASK_ONE_SID, "HR", false);
+		dynamicBpmnService.saveProcessDefinitionInfo(processDefinitionId,processInfo);
+
+		ArrayNode dynamicCandidateGroups = processEngineConfiguration.getObjectMapper().createArrayNode();
+		dynamicCandidateGroups.add("HR");
+
+		DynamicProcessDefinitionSummary summary = dynamicBpmnService.getDynamicProcessDefinitionSummary(processDefinitionId);
+
+		JsonNode taskOneNode = summary.getElement(TASK_ONE_SID).get(ELEMENT_PROPERTIES);
+		assertThat((ArrayNode) taskOneNode.get(USER_TASK_CANDIDATE_GROUPS).get(DYNAMIC_VALUE), is(dynamicCandidateGroups));
+	}
+
+	@Deployment(resources = {"org/activiti/engine/test/bpmn/dynamic/dynamic-bpmn-test-process.bpmn20.xml"})
+	public void testTheCandidateGroupOfTheFirstTasksIsChangedMultipleTimes() throws Exception {
+		ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("dynamicServiceTest");
+		String processDefinitionId = processInstance.getProcessDefinitionId();
+
+		ObjectNode processInfo = dynamicBpmnService.changeUserTaskCandidateGroup(TASK_ONE_SID, "HR", false);
+		dynamicBpmnService.changeUserTaskCandidateGroup(TASK_ONE_SID,"SALES",false,processInfo);
+		dynamicBpmnService.saveProcessDefinitionInfo(processDefinitionId,processInfo);
+
+		ArrayNode candidateGroups = processEngineConfiguration.getObjectMapper().createArrayNode();
+		candidateGroups.add("HR");
+		candidateGroups.add("SALES");
+
+		DynamicProcessDefinitionSummary summary = dynamicBpmnService.getDynamicProcessDefinitionSummary(processDefinitionId);
+		JsonNode taskOneNode = summary.getElement(TASK_ONE_SID).get(ELEMENT_PROPERTIES);
+
+		assertThat((ArrayNode) taskOneNode.get(USER_TASK_CANDIDATE_GROUPS).get(DYNAMIC_VALUE), is(candidateGroups));
+	}
+
+	@Deployment(resources = {"org/activiti/engine/test/bpmn/dynamic/dynamic-bpmn-test-process.bpmn20.xml"})
+	public void testTheScriptOfTheScriptTasksIsChanged() throws Exception {
+		ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("dynamicServiceTest");
+		String processDefinitionId = processInstance.getProcessDefinitionId();
+
+		ObjectNode jsonNodes = dynamicBpmnService.changeScriptTaskScript(SCRIPT_TASK_SID, "var x = \"hallo\";");
+		dynamicBpmnService.saveProcessDefinitionInfo(processDefinitionId,jsonNodes);
+
+		DynamicProcessDefinitionSummary summary = dynamicBpmnService.getDynamicProcessDefinitionSummary(processDefinitionId);
+		JsonNode scriptTaskNode = summary.getElement(SCRIPT_TASK_SID).get(ELEMENT_PROPERTIES);
+
+		assertThat(scriptTaskNode.get(SCRIPT_TASK_SCRIPT).get(DYNAMIC_VALUE).asText(),is("var x = \"hallo\";"));
+	}
+
+	@Deployment(resources = {"org/activiti/engine/test/bpmn/dynamic/dynamic-bpmn-test-process.bpmn20.xml"})
+	public void testItShouldBePossibleToResetDynamicCandidateUsers() throws Exception {
+		ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("dynamicServiceTest");
+		String processDefinitionId = processInstance.getProcessDefinitionId();
+
+		ObjectNode jsonNodes = dynamicBpmnService.changeUserTaskCandidateUser(TASK_ONE_SID, "bob",false);
+		dynamicBpmnService.saveProcessDefinitionInfo(processDefinitionId,jsonNodes);
+
+		//delete
+		jsonNodes = dynamicBpmnService.getProcessDefinitionInfo(processDefinitionId);
+		dynamicBpmnService.resetProperty(TASK_ONE_SID,USER_TASK_CANDIDATE_USERS,jsonNodes);
+		dynamicBpmnService.saveProcessDefinitionInfo(processDefinitionId,jsonNodes);
+
+		runtimeService.startProcessInstanceByKey("dynamicServiceTest");
+
+		long count = taskService.createTaskQuery().taskCandidateUser("david").count();
+		assertThat(count,is(2L));
+
+		//additional checks of summary
+		ArrayNode candidateUsersNode = processEngineConfiguration.getObjectMapper().createArrayNode();
+		candidateUsersNode.add("david");
+
+		DynamicProcessDefinitionSummary summary = dynamicBpmnService.getDynamicProcessDefinitionSummary(processDefinitionId);
+		JsonNode candidateUsers = summary.getElement(TASK_ONE_SID).get(ELEMENT_PROPERTIES).get(USER_TASK_CANDIDATE_USERS);
+		assertThat((ArrayNode) candidateUsers.get(BPMN_MODEL_VALUE), is(candidateUsersNode));
+		assertThat(candidateUsers.get(DYNAMIC_VALUE), is(nullValue()));
+	}
+}

--- a/modules/flowable-engine/src/test/resources/org/activiti/engine/test/bpmn/dynamic/dynamic-bpmn-test-process.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/activiti/engine/test/bpmn/dynamic/dynamic-bpmn-test-process.bpmn20.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://www.activiti.org/processdef">
+  <process id="dynamicServiceTest" name="dynamic-bpmn-test-process" isExecutable="true">
+    <startEvent id="sid-0B5FF4AC-12C5-4202-BBB5-BB54E866FE09"/>
+    <userTask id="sid-B94D5D22-E93E-4401-ADC5-C5C073E1EEB4" name="Taak 1" activiti:candidateUsers="david"/>
+    <sequenceFlow id="sid-CD26A84F-7A62-46CB-A6F4-58B264B71E52" sourceRef="sid-0B5FF4AC-12C5-4202-BBB5-BB54E866FE09" targetRef="sid-B94D5D22-E93E-4401-ADC5-C5C073E1EEB4"/>
+    <sequenceFlow id="sid-652E5401-70F4-4136-8BE5-40ECD02C7936" sourceRef="sid-B94D5D22-E93E-4401-ADC5-C5C073E1EEB4" targetRef="sid-A403BAE0-E367-449A-90B2-48834FCAA2F9"/>
+    <userTask id="sid-B1C37EBE-A273-4DDE-B909-89302638526A" name="Taak 2" activiti:candidateUsers="david" activiti:candidateGroups="HR,SALES"/>
+    <sequenceFlow id="sid-68FC6555-6D0A-4546-80CA-852F05E69B5D" sourceRef="sid-A403BAE0-E367-449A-90B2-48834FCAA2F9" targetRef="sid-B1C37EBE-A273-4DDE-B909-89302638526A"/>
+    <endEvent id="sid-1723AC22-2ABB-427A-82F5-01CAEB338783"/>
+    <sequenceFlow id="sid-6B2BCC2A-FA7B-4F68-8739-E7C3BE0DB4DB" sourceRef="sid-B1C37EBE-A273-4DDE-B909-89302638526A" targetRef="sid-1723AC22-2ABB-427A-82F5-01CAEB338783"/>
+    <scriptTask id="sid-A403BAE0-E367-449A-90B2-48834FCAA2F9" name="Service 1" activiti:autoStoreVariables="false">
+      <script><![CDATA[var test = "hallo";]]></script>
+    </scriptTask>
+  </process>
+</definitions>


### PR DESCRIPTION
* Helper method to reset an dynamic property to its original bpmn model value.
* Summary object to trace diffs between processDefinitionInfo and BpmnModel.
* Helper methods to set a Collection of Strings on candidategroups and candidateUsers.
* Unit / integration tests to check the newly added methods.