### PR TITLE
Fix mixture of append() and string concatenation

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/debug/ExecutionTreeNode.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/debug/ExecutionTreeNode.java
@@ -71,10 +71,10 @@ public class ExecutionTreeNode implements Iterable<ExecutionTreeNode> {
     StringBuilder strb = new StringBuilder();
     strb.append(getExecutionEntity().getId());
     if (getExecutionEntity().getActivityId() != null) {
-      strb.append(" : " + getExecutionEntity().getActivityId());
+      strb.append(" : ").append(getExecutionEntity().getActivityId());
     }
     if (getExecutionEntity().getParentId() != null) {
-      strb.append(", parent id " + getExecutionEntity().getParentId());
+      strb.append(", parent id ").append(getExecutionEntity().getParentId());
     }
     if (getExecutionEntity().isProcessInstanceType()) {
       strb.append(" (process instance)");
@@ -89,14 +89,14 @@ public class ExecutionTreeNode implements Iterable<ExecutionTreeNode> {
   }
 
   protected void internalToString(StringBuilder strb, String prefix, boolean isTail) {
-    strb.append(prefix + (isTail ? "└── " : "├── ") + getExecutionEntity().getId() + " : " 
-        + getCurrentFlowElementId()
-        + ", parent id " + getExecutionEntity().getParentId() 
-        + (getExecutionEntity().isActive() ? " (active)" : " (not active)")
-        + (getExecutionEntity().isScope() ? " (scope)" : "")
-        + (getExecutionEntity().isMultiInstanceRoot() ? " (multi instance root)" : "")
-        + (getExecutionEntity().isEnded() ? " (ended)" : "")
-        + System.lineSeparator());
+    strb.append(prefix).append(isTail ? "└── " : "├── ").append(getExecutionEntity().getId()).append(" : ")
+            .append(getCurrentFlowElementId()).append(", parent id ")
+            .append(getExecutionEntity().getParentId())
+            .append(getExecutionEntity().isActive() ? " (active)" : " (not active)")
+            .append(getExecutionEntity().isScope() ? " (scope)" : "")
+            .append(getExecutionEntity().isMultiInstanceRoot() ? " (multi instance root)" : "")
+            .append(getExecutionEntity().isEnded() ? " (ended)" : "")
+            .append(System.lineSeparator());
     if (children != null) {
       for (int i = 0; i < children.size() - 1; i++) {
         children.get(i).internalToString(strb, prefix + (isTail ? "    " : "│   "), false);

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/ExecutionEntityImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/ExecutionEntityImpl.java
@@ -935,17 +935,17 @@ public class ExecutionEntityImpl extends VariableScopeImpl implements ExecutionE
     } else {
       StringBuilder strb = new StringBuilder();
       if (isScope) {
-        strb.append("Scoped execution[ id '" + getId() + "' ]");
+        strb.append("Scoped execution[ id '").append(getId()).append("' ]");
       } else if(isMultiInstanceRoot) {
-        strb.append("Multi instance root execution[ id '" + getId() + "' ]");
+        strb.append("Multi instance root execution[ id '").append(getId()).append("' ]");
       } else {
-        strb.append("Execution[ id '" + getId() + "' ]");
+        strb.append("Execution[ id '").append(getId()).append("' ]");
       }
       if (activityId != null) {
-        strb.append(" - activity '" + activityId);
+        strb.append(" - activity '").append(activityId);
       }
       if (parentId != null) {
-        strb.append(" - parent '" + parentId + "'");
+        strb.append(" - parent '").append(parentId).append("'");
       }
       return strb.toString();
     }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/data/impl/util/ExecutionTreeStringBuilder.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/data/impl/util/ExecutionTreeStringBuilder.java
@@ -52,7 +52,7 @@ public class ExecutionTreeStringBuilder {
     strb.append(prefix)
         .append(isTail ? "└── " : "├── ")
         .append(execution.getId()).append(" : ")
-        .append("activityId=" + execution.getActivityId())
+        .append("activityId=").append(execution.getActivityId())
         .append(", parent id ")
         .append(execution.getParentId())
         .append(execution.isScope() ? " (scope)" : "")

--- a/modules/flowable-mule/src/test/java/org/flowable/mule/AbstractMuleTest.java
+++ b/modules/flowable-mule/src/test/java/org/flowable/mule/AbstractMuleTest.java
@@ -36,7 +36,7 @@ public abstract class AbstractMuleTest extends FunctionalTestCase {
       if (!TABLENAMES_EXCLUDED_FROM_DB_CLEAN_CHECK.contains(tableNameWithoutPrefix)) {
         Long count = tableCounts.get(tableName);
         if (count != 0L) {
-          outputMessage.append("  " + tableName + ": " + count + " record(s) ");
+          outputMessage.append("  ").append(tableName).append(": ").append(count.toString()).append(" record(s) ");
         }
       }
     }

--- a/modules/flowable-process-validation/src/main/java/org/flowable/validation/ValidationError.java
+++ b/modules/flowable-process-validation/src/main/java/org/flowable/validation/ValidationError.java
@@ -120,38 +120,38 @@ public class ValidationError {
   @Override
   public String toString() {
     StringBuilder strb = new StringBuilder();
-    strb.append("[Validation set: '" + validatorSetName + "' | Problem: '" + problem + "'] : ");
+    strb.append("[Validation set: '").append(validatorSetName).append("' | Problem: '").append(problem).append("'] : ");
     strb.append(defaultDescription);
     strb.append(" - [Extra info : ");
     boolean extraInfoAlreadyPresent = false;
     if (processDefinitionId != null) {
-      strb.append("processDefinitionId = " + processDefinitionId);
+      strb.append("processDefinitionId = ").append(processDefinitionId);
       extraInfoAlreadyPresent = true;
     }
     if (processDefinitionName != null) {
       if (extraInfoAlreadyPresent) {
         strb.append(" | ");
       }
-      strb.append("processDefinitionName = " + processDefinitionName + " | ");
+      strb.append("processDefinitionName = ").append(processDefinitionName).append(" | ");
       extraInfoAlreadyPresent = true;
     }
     if (activityId != null) {
       if (extraInfoAlreadyPresent) {
         strb.append(" | ");
       }
-      strb.append("id = " + activityId + " | ");
+      strb.append("id = ").append(activityId).append(" | ");
       extraInfoAlreadyPresent = true;
     }
     if (activityName != null) {
       if (extraInfoAlreadyPresent) {
         strb.append(" | ");
       }
-      strb.append("activityName = " + activityName + " | ");
+      strb.append("activityName = ").append(activityName).append(" | ");
       extraInfoAlreadyPresent = true;
     }
     strb.append("]");
     if (xmlLineNumber > 0 && xmlColumnNumber > 0) {
-      strb.append(" ( line: " + xmlLineNumber + ", column: " + xmlColumnNumber + ")");
+      strb.append(" ( line: ").append(Integer.toString(xmlLineNumber)).append(", column: ").append(Integer.toString(xmlColumnNumber)).append(")");
     }
     return strb.toString();
   }

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/api/jpa/BaseJPARestTestCase.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/api/jpa/BaseJPARestTestCase.java
@@ -281,7 +281,7 @@ public class BaseJPARestTestCase extends AbstractTestCase {
       if (!TABLENAMES_EXCLUDED_FROM_DB_CLEAN_CHECK.contains(tableNameWithoutPrefix)) {
         Long count = tableCounts.get(tableName);
         if (count != 0L) {
-          outputMessage.append("  " + tableName + ": " + count + " record(s) ");
+          outputMessage.append("  ").append(tableName).append(": ").append(count.toString()).append(" record(s) ");
         }
       }
     }

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/BaseSpringRestTestCase.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/BaseSpringRestTestCase.java
@@ -276,7 +276,7 @@ public class BaseSpringRestTestCase extends AbstractTestCase {
       if (!TABLENAMES_EXCLUDED_FROM_DB_CLEAN_CHECK.contains(tableNameWithoutPrefix)) {
         Long count = tableCounts.get(tableName);
         if (count != 0L) {
-          outputMessage.append("  " + tableName + ": " + count + " record(s) ");
+          outputMessage.append("  ").append(tableName).append(": ").append(count.toString()).append(" record(s) ");
         }
       }
     }


### PR DESCRIPTION
Fixes occurrences of string concatenation used as the argument to an existing StringBuffer.append() or StringBuilder.append().   Turned them into chained append calls saving the cost of an extra StringBuffer or StringBuilder allocation.

Besides it looks nicer too.