### PR TITLE
Add support for rescheduling a timer via a service task.

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/asyncexecutor/JobManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/asyncexecutor/JobManager.java
@@ -57,6 +57,11 @@ public interface JobManager {
   void scheduleTimerJob(TimerJobEntity timerJob);
 
   /**
+   *  Reschedules a timer by deleting the timer job and creating a new one.
+   */
+  void rescheduleTimerJob(TimerJobEntity timerJob);
+  
+  /**
    * Moves a {@link TimerJobEntity} to become an async {@link JobEntity}. 
    * 
    * This happens for example when the due date of a timer is reached, 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/RescheduleTimerJobActivityBehavior.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/RescheduleTimerJobActivityBehavior.java
@@ -1,0 +1,57 @@
+package org.flowable.engine.impl.bpmn.behavior;
+
+import java.util.List;
+
+import org.flowable.engine.delegate.DelegateExecution;
+import org.flowable.engine.delegate.Expression;
+import org.flowable.engine.impl.TimerJobQueryImpl;
+import org.flowable.engine.impl.asyncexecutor.JobManager;
+import org.flowable.engine.impl.context.Context;
+import org.flowable.engine.impl.jobexecutor.TimerEventHandler;
+import org.flowable.engine.impl.persistence.entity.TimerJobEntity;
+import org.flowable.engine.runtime.Job;
+
+
+public class RescheduleTimerJobActivityBehavior extends AbstractBpmnActivityBehavior {
+  private static final long serialVersionUID = 1L;
+  
+  protected Expression catchingEventId;
+
+  @Override
+  public void execute(DelegateExecution execution) {
+    String catchingEventIdStr = getStringFromField(catchingEventId, execution);
+    
+    JobManager jobManager = Context.getProcessEngineConfiguration().getJobManager();
+    
+    List<Job> jobs = new TimerJobQueryImpl().timers().processInstanceId(execution.getProcessInstanceId()).list();
+    for(Job job : jobs) {
+      String jobActivityId = TimerEventHandler.getActivityIdFromConfiguration(job.getJobHandlerConfiguration());
+      if(jobActivityId.equals(catchingEventIdStr) && Job.JOB_TYPE_TIMER.equals(job.getJobType())) {
+          jobManager.rescheduleTimerJob((TimerJobEntity) job);
+      }
+    }
+  }
+  
+  protected String getStringFromField(Expression expression, DelegateExecution execution) {
+    if (expression != null) {
+      Object value = expression.getValue(execution);
+      if (value != null) {
+        return value.toString();
+      }
+    }
+    return null;
+  } 
+  
+  protected boolean inSameScope(DelegateExecution rescheduleExecution, DelegateExecution jobExecution) {
+    DelegateExecution rescheduleScopeExecution = findScopeExecution(rescheduleExecution);
+    DelegateExecution jobScopeExecution = findScopeExecution(jobExecution);
+    return rescheduleScopeExecution.getId().equals(jobScopeExecution.getId());
+  }
+  
+  protected DelegateExecution findScopeExecution(DelegateExecution execution) {
+    while(!execution.isScope()) {
+      execution = execution.getParent();
+    }
+    return execution;
+  }
+}

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/parser/factory/ActivityBehaviorFactory.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/parser/factory/ActivityBehaviorFactory.java
@@ -71,6 +71,7 @@ import org.flowable.engine.impl.bpmn.behavior.NoneStartEventActivityBehavior;
 import org.flowable.engine.impl.bpmn.behavior.ParallelGatewayActivityBehavior;
 import org.flowable.engine.impl.bpmn.behavior.ParallelMultiInstanceBehavior;
 import org.flowable.engine.impl.bpmn.behavior.ReceiveTaskActivityBehavior;
+import org.flowable.engine.impl.bpmn.behavior.RescheduleTimerJobActivityBehavior;
 import org.flowable.engine.impl.bpmn.behavior.ScriptTaskActivityBehavior;
 import org.flowable.engine.impl.bpmn.behavior.SequentialMultiInstanceBehavior;
 import org.flowable.engine.impl.bpmn.behavior.ServiceTaskDelegateExpressionActivityBehavior;
@@ -212,4 +213,6 @@ public interface ActivityBehaviorFactory {
   public abstract BoundaryMessageEventActivityBehavior createBoundaryMessageEventActivityBehavior(BoundaryEvent boundaryEvent, MessageEventDefinition messageEventDefinition, boolean interrupting);
   
   public abstract BoundaryCompensateEventActivityBehavior createBoundaryCompensateEventActivityBehavior(BoundaryEvent boundaryEvent, CompensateEventDefinition compensateEventDefinition, boolean interrupting);
+  
+  public abstract RescheduleTimerJobActivityBehavior createRescheduleTimerJobActivityBehavior(ServiceTask serviceTask);
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/parser/factory/DefaultActivityBehaviorFactory.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/parser/factory/DefaultActivityBehaviorFactory.java
@@ -83,6 +83,7 @@ import org.flowable.engine.impl.bpmn.behavior.NoneStartEventActivityBehavior;
 import org.flowable.engine.impl.bpmn.behavior.ParallelGatewayActivityBehavior;
 import org.flowable.engine.impl.bpmn.behavior.ParallelMultiInstanceBehavior;
 import org.flowable.engine.impl.bpmn.behavior.ReceiveTaskActivityBehavior;
+import org.flowable.engine.impl.bpmn.behavior.RescheduleTimerJobActivityBehavior;
 import org.flowable.engine.impl.bpmn.behavior.ScriptTaskActivityBehavior;
 import org.flowable.engine.impl.bpmn.behavior.SequentialMultiInstanceBehavior;
 import org.flowable.engine.impl.bpmn.behavior.ServiceTaskDelegateExpressionActivityBehavior;
@@ -483,4 +484,13 @@ public class DefaultActivityBehaviorFactory extends AbstractBehaviorFactory impl
   public BoundaryMessageEventActivityBehavior createBoundaryMessageEventActivityBehavior(BoundaryEvent boundaryEvent, MessageEventDefinition messageEventDefinition, boolean interrupting) {
     return new BoundaryMessageEventActivityBehavior(messageEventDefinition, interrupting);
   }
+
+  @Override
+  public RescheduleTimerJobActivityBehavior createRescheduleTimerJobActivityBehavior(ServiceTask serviceTask) {
+    List<FieldDeclaration> fieldDeclarations = createFieldDeclarations(serviceTask.getFieldExtensions());
+    return (RescheduleTimerJobActivityBehavior) ClassDelegate.defaultInstantiateDelegate(
+            RescheduleTimerJobActivityBehavior.class, fieldDeclarations);
+  }
+  
+  
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/parser/handler/ServiceTaskParseHandler.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/parser/handler/ServiceTaskParseHandler.java
@@ -52,6 +52,9 @@ public class ServiceTaskParseHandler extends AbstractActivityBpmnParseHandler<Se
       } else if (serviceTask.getType().equalsIgnoreCase("dmn")) {
         serviceTask.setBehavior(bpmnParse.getActivityBehaviorFactory().createDmnActivityBehavior(serviceTask));
 
+      } else if(serviceTask.getType().equals("rescheduleTimer")) {
+        serviceTask.setBehavior(bpmnParse.getActivityBehaviorFactory().createRescheduleTimerJobActivityBehavior(serviceTask));
+      
       } else {
         logger.warn("Invalid service task type: '" + serviceTask.getType() + "' " + " for service task " + serviceTask.getId());
       }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/test/TestActivityBehaviorFactory.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/test/TestActivityBehaviorFactory.java
@@ -79,6 +79,7 @@ import org.flowable.engine.impl.bpmn.behavior.NoneStartEventActivityBehavior;
 import org.flowable.engine.impl.bpmn.behavior.ParallelGatewayActivityBehavior;
 import org.flowable.engine.impl.bpmn.behavior.ParallelMultiInstanceBehavior;
 import org.flowable.engine.impl.bpmn.behavior.ReceiveTaskActivityBehavior;
+import org.flowable.engine.impl.bpmn.behavior.RescheduleTimerJobActivityBehavior;
 import org.flowable.engine.impl.bpmn.behavior.ScriptTaskActivityBehavior;
 import org.flowable.engine.impl.bpmn.behavior.SequentialMultiInstanceBehavior;
 import org.flowable.engine.impl.bpmn.behavior.ServiceTaskDelegateExpressionActivityBehavior;
@@ -405,7 +406,11 @@ public class TestActivityBehaviorFactory extends AbstractBehaviorFactory impleme
     return wrappedActivityBehaviorFactory.createBoundaryCompensateEventActivityBehavior(boundaryEvent, compensateEventDefinition, interrupting);
   }
   
-
+  @Override
+  public RescheduleTimerJobActivityBehavior createRescheduleTimerJobActivityBehavior(ServiceTask serviceTask) {
+    return wrappedActivityBehaviorFactory.createRescheduleTimerJobActivityBehavior(serviceTask);
+  }
+  
   // Mock support //////////////////////////////////////////////////////
 
   public void addClassDelegateMock(String originalClassFqn, Class<?> mockClass) {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/IntermediateTimerEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/IntermediateTimerEventTest.java
@@ -18,8 +18,11 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import org.flowable.engine.impl.test.JobTestHelper;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
+import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.Job;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.runtime.TimerJobQuery;
@@ -154,4 +157,55 @@ public class IntermediateTimerEventTest extends PluggableFlowableTestCase {
     assertProcessEnded(processInstance.getId());
   }
 
+  @Deployment
+  public void testRescheduleTimer() {
+    // startDate variable set to one hour from now
+    Calendar calendar = Calendar.getInstance();
+    calendar.add(Calendar.HOUR, 1);
+    Map<String, Object> variables = new HashMap<String, Object>();
+    variables.put("startDate", calendar.getTime());
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("rescheduleTimer", variables);
+
+    List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+    assertEquals(0, tasks.size());
+    Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId())
+            .singleResult();
+    assertNotNull(timerJob);
+
+    // reschedule timer for two hours from now
+    calendar = Calendar.getInstance();
+    calendar.add(Calendar.HOUR, 2);
+    runtimeService.setVariable(processInstance.getId(), "startDate", calendar.getTime());
+    
+    Execution executionWithMessage = runtimeService.createExecutionQuery()
+            .messageEventSubscriptionName("rescheduleTimerMsg").singleResult();
+    assertNotNull(executionWithMessage);
+    
+    runtimeService.messageEventReceived("rescheduleTimerMsg", executionWithMessage.getId());
+    
+    // Move clock forward 1 hour from now
+    calendar = Calendar.getInstance();
+    calendar.add(Calendar.HOUR, 1);
+    processEngineConfiguration.getClock().setCurrentTime(calendar.getTime());
+    JobTestHelper.executeJobExecutorForTime(processEngineConfiguration, 1000, 100);
+    
+    // Confirm timer has not run
+    tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+    assertEquals(0, tasks.size());
+    timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId())
+            .singleResult();
+    assertNotNull(timerJob);
+    
+    // Move clock forward 2 hours from now
+    calendar = Calendar.getInstance();
+    calendar.add(Calendar.HOUR, 2);
+    processEngineConfiguration.getClock().setCurrentTime(calendar.getTime());
+    waitForJobExecutorToProcessAllJobs(2000, 100);
+    
+    // Confirm timer has run
+    tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+    assertEquals(1, tasks.size());
+    timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
+    assertNull(timerJob);
+  }
 }

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventTest.testRescheduleBoundaryTimerOnSubProcess.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventTest.testRescheduleBoundaryTimerOnSubProcess.bpmn20.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:flowable="http://flowable.org/bpmn"
+             targetNamespace="Examples">
+
+    <message id="reschedule" name="rescheduleTimerMsg" />
+    
+    <process id="rescheduleTimer" name="Reschedule intermediate timer event example">
+        <startEvent id="theStart"/>
+        <sequenceFlow id="flow1" sourceRef="theStart" targetRef="subprocess1"/>
+
+		<subProcess id="subprocess1" name="SubProcess">          
+            <startEvent id="startevent2" name="Start"></startEvent>
+            <endEvent id="endevent2" name="End"></endEvent>
+            <userTask id="usertask1" name="Task 1"/>
+            <sequenceFlow id="Start2" sourceRef="startevent2" targetRef="usertask1"/>
+            <sequenceFlow id="Done2" sourceRef="usertask1" targetRef="endevent2"/>
+        </subProcess>
+		
+		<boundaryEvent id="boundaryTimer" cancelActivity="true" attachedToRef="subprocess1">
+			<timerEventDefinition>
+				<timeDate>${startDate}</timeDate>
+			</timerEventDefinition>
+		</boundaryEvent>
+		
+		<boundaryEvent id="boundaryMessage" cancelActivity="false" attachedToRef="subprocess1">
+			<messageEventDefinition messageRef="reschedule" />
+		</boundaryEvent>
+				
+		<userTask id="usertask2" name="Task 2"/>
+		<userTask id="usertask3" name="Task 3"/>
+		
+		<sequenceFlow id="flow2" sourceRef="subprocess1" targetRef="usertask2"/>
+		<sequenceFlow id="flow3" sourceRef="boundaryTimer" targetRef="usertask3"/>
+		<sequenceFlow id="flow4" sourceRef="boundaryMessage" targetRef="rescheduleTimerTask"/>
+    
+    	<serviceTask id="rescheduleTimerTask" flowable:type="rescheduleTimer" name="Reschedule Timer Service Task">
+      		<extensionElements>
+        		<flowable:field name="catchingEventId" stringValue="boundaryTimer" />        
+      		</extensionElements>             
+    	</serviceTask>
+    
+        <sequenceFlow id="flow5" sourceRef="usertask2" targetRef="theEnd"/>
+        <sequenceFlow id="flow6" sourceRef="usertask3" targetRef="theEnd"/>
+
+        <endEvent id="theEnd"/>
+
+    </process>
+</definitions>

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventTest.testRescheduleBoundaryTimerOnUserTask.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventTest.testRescheduleBoundaryTimerOnUserTask.bpmn20.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:flowable="http://flowable.org/bpmn"
+             targetNamespace="Examples">
+
+    <message id="reschedule" name="rescheduleTimerMsg" />
+    
+    <process id="rescheduleTimer" name="Reschedule intermediate timer event example">
+        <startEvent id="theStart"/>
+        <sequenceFlow id="flow1" sourceRef="theStart" targetRef="usertask1"/>
+
+		<userTask id="usertask1" name="Task 1"/>
+		
+		<boundaryEvent id="boundaryTimer" cancelActivity="true" attachedToRef="usertask1">
+			<timerEventDefinition>
+				<timeDate>${startDate}</timeDate>
+			</timerEventDefinition>
+		</boundaryEvent>
+		
+		<boundaryEvent id="boundaryMessage" cancelActivity="false" attachedToRef="usertask1">
+			<messageEventDefinition messageRef="reschedule" />
+		</boundaryEvent>
+				
+		<userTask id="usertask2" name="Task 2"/>
+		<userTask id="usertask3" name="Task 3"/>
+		
+		<sequenceFlow id="flow2" sourceRef="usertask1" targetRef="usertask2"/>
+		<sequenceFlow id="flow3" sourceRef="boundaryTimer" targetRef="usertask3"/>
+		<sequenceFlow id="flow4" sourceRef="boundaryMessage" targetRef="rescheduleTimerTask"/>
+    
+    	<serviceTask id="rescheduleTimerTask" flowable:type="rescheduleTimer" name="Reschedule Timer Service Task">
+      		<extensionElements>
+        		<flowable:field name="catchingEventId" stringValue="boundaryTimer" />        
+      		</extensionElements>             
+    	</serviceTask>
+    
+        <sequenceFlow id="flow5" sourceRef="usertask2" targetRef="theEnd"/>
+        <sequenceFlow id="flow6" sourceRef="usertask3" targetRef="theEnd"/>
+
+        <endEvent id="theEnd"/>
+
+    </process>
+</definitions>

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/event/timer/IntermediateTimerEventTest.testRescheduleTimer.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/event/timer/IntermediateTimerEventTest.testRescheduleTimer.bpmn20.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:flowable="http://flowable.org/bpmn"
+             targetNamespace="Examples">
+
+    <message id="reschedule" name="rescheduleTimerMsg" />
+    
+    <process id="rescheduleTimer" name="Reschedule intermediate timer event example">
+        <startEvent id="theStart"/>
+        <sequenceFlow id="flow1" sourceRef="theStart" targetRef="timer"/>
+        <sequenceFlow id="flow2" sourceRef="theStart" targetRef="message"/>
+
+        <intermediateCatchEvent id="timer">
+            <timerEventDefinition>
+                <timeDate>${startDate}</timeDate>
+            </timerEventDefinition>
+        </intermediateCatchEvent>
+
+		<intermediateCatchEvent id="message" >
+        	<messageEventDefinition messageRef="reschedule" />
+    	</intermediateCatchEvent>
+
+		<sequenceFlow id="flow3" sourceRef="timer" targetRef="usertask"/>
+		<sequenceFlow id="flow4" sourceRef="message" targetRef="rescheduleTimerTask"/>
+		
+		<userTask id="usertask" name="Task 1"/>
+    
+    	<serviceTask id="rescheduleTimerTask" flowable:type="rescheduleTimer" name="Reschedule Timer Service Task">
+      		<extensionElements>
+        		<flowable:field name="catchingEventId" stringValue="timer" />        
+      		</extensionElements>             
+    	</serviceTask>
+    
+        <sequenceFlow id="flow5" sourceRef="usertask" targetRef="theEnd"/>
+
+        <endEvent id="theEnd"/>
+
+    </process>
+</definitions>

--- a/modules/flowable-process-validation/src/main/java/org/flowable/validation/validator/impl/ServiceTaskValidator.java
+++ b/modules/flowable-process-validation/src/main/java/org/flowable/validation/validator/impl/ServiceTaskValidator.java
@@ -55,7 +55,7 @@ public class ServiceTaskValidator extends ExternalInvocationTaskValidator {
     if (StringUtils.isNotEmpty(serviceTask.getType())) {
 
       if (!serviceTask.getType().equalsIgnoreCase("mail") && !serviceTask.getType().equalsIgnoreCase("mule") && !serviceTask.getType().equalsIgnoreCase("camel")
-          && !serviceTask.getType().equalsIgnoreCase("shell") && !serviceTask.getType().equalsIgnoreCase("dmn")) {
+          && !serviceTask.getType().equalsIgnoreCase("shell") && !serviceTask.getType().equalsIgnoreCase("dmn") && !serviceTask.getType().equalsIgnoreCase("rescheduleTimer")) {
         
         addError(errors, Problems.SERVICE_TASK_INVALID_TYPE, process, serviceTask, "Invalid or unsupported service task type");
       }


### PR DESCRIPTION
Here is the initial prototype support for rescheduling a boundary or intermediate timer using a message catching event that flows into the rescheduling service task. 

FYI, I'm not sure how to make this functionality work for the case of an intermediate timer in a multi-instance subprocess. For that case, I believe it will reschedule the timers (defined with the save intermediate catching event) across all of the subprocess instance while the client may want to be able to reschedule a timer in a single subprocess instance. Let me know if you have any thoughts on how this PR could be improved to support that. 

Thanks!
Rob 