### PR TITLE
Variable was assigned to itself

### DIFF
--- a/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/persistence/deploy/DecisionTableCacheEntry.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/persistence/deploy/DecisionTableCacheEntry.java
@@ -40,7 +40,7 @@ public class DecisionTableCacheEntry implements Serializable {
     }
 
     public void setDecisionTableEntity(DecisionTableEntity decisionTable) {
-        this.decisionTableEntity = decisionTableEntity;
+        this.decisionTableEntity = decisionTable;
     }
 
     public DmnDefinition getDmnDefinition() {


### PR DESCRIPTION
The variable `decisionTableEntity` was assigned to itself instead of using the method parameter `decisionTable`,