### PR TITLE
Remove redundant casts

### DIFF
--- a/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/CustomExtensionsConverterTest.java
+++ b/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/CustomExtensionsConverterTest.java
@@ -71,10 +71,10 @@ public class CustomExtensionsConverterTest extends AbstractConverterTest {
 
     List<FieldExtension> fields = serviceTask.getFieldExtensions();
     assertEquals(2, fields.size());
-    FieldExtension field = (FieldExtension) fields.get(0);
+    FieldExtension field = fields.get(0);
     assertEquals("testField", field.getFieldName());
     assertEquals("test", field.getStringValue());
-    field = (FieldExtension) fields.get(1);
+    field = fields.get(1);
     assertEquals("testField2", field.getFieldName());
     assertEquals("${test}", field.getExpression());
 
@@ -95,19 +95,19 @@ public class CustomExtensionsConverterTest extends AbstractConverterTest {
 
   protected void validateExecutionListeners(List<FlowableListener> listeners) {
     assertEquals(3, listeners.size());
-    FlowableListener listener = (FlowableListener) listeners.get(0);
+    FlowableListener listener = listeners.get(0);
     assertTrue(ImplementationType.IMPLEMENTATION_TYPE_CLASS.equals(listener.getImplementationType()));
     assertEquals("org.test.TestClass", listener.getImplementation());
     assertEquals("start", listener.getEvent());
     assertEquals("before-commit", listener.getOnTransaction());
     assertEquals("org.test.TestResolverClass", listener.getCustomPropertiesResolverImplementation());
-    listener = (FlowableListener) listeners.get(1);
+    listener = listeners.get(1);
     assertTrue(ImplementationType.IMPLEMENTATION_TYPE_EXPRESSION.equals(listener.getImplementationType()));
     assertEquals("${testExpression}", listener.getImplementation());
     assertEquals("end", listener.getEvent());
     assertEquals("committed", listener.getOnTransaction());
     assertEquals("${testResolverExpression}", listener.getCustomPropertiesResolverImplementation());
-    listener = (FlowableListener) listeners.get(2);
+    listener = listeners.get(2);
     assertTrue(ImplementationType.IMPLEMENTATION_TYPE_DELEGATEEXPRESSION.equals(listener.getImplementationType()));
     assertEquals("${delegateExpression}", listener.getImplementation());
     assertEquals("start", listener.getEvent());

--- a/modules/flowable-bpmn-layout/src/main/java/org/flowable/bpmn/BPMNLayout.java
+++ b/modules/flowable-bpmn-layout/src/main/java/org/flowable/bpmn/BPMNLayout.java
@@ -94,7 +94,7 @@ public class BPMNLayout extends mxGraphLayout {
   }
 
   public mxGraph getGraph() {
-    return (mxGraph) graph;
+    return graph;
   }
 
   /**

--- a/modules/flowable-cdi/src/main/java/org/flowable/cdi/impl/FlowableExtension.java
+++ b/modules/flowable-cdi/src/main/java/org/flowable/cdi/impl/FlowableExtension.java
@@ -77,7 +77,7 @@ public class FlowableExtension implements Extension {
     Iterator<ProcessEngineLookup> serviceIterator = processEngineServiceLoader.iterator();
     List<ProcessEngineLookup> discoveredLookups = new ArrayList<ProcessEngineLookup>();
     while (serviceIterator.hasNext()) {
-      ProcessEngineLookup serviceInstance = (ProcessEngineLookup) serviceIterator.next();
+      ProcessEngineLookup serviceInstance = serviceIterator.next();
       discoveredLookups.add(serviceInstance);
     }
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/agenda/ContinueProcessOperation.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/agenda/ContinueProcessOperation.java
@@ -207,11 +207,11 @@ public class ContinueProcessOperation extends AbstractOperation {
       FlowElement targetFlowElement = sequenceFlow.getTargetFlowElement();
       Context.getProcessEngineConfiguration().getEventDispatcher().dispatchEvent(
         FlowableEventBuilder.createSequenceFlowTakenEvent(
-            (ExecutionEntity) execution,
+            execution,
             FlowableEngineEventType.SEQUENCEFLOW_TAKEN, 
             sequenceFlow.getId(),
             sourceFlowElement != null ? sourceFlowElement.getId() : null, 
-            sourceFlowElement != null ? (String) sourceFlowElement.getName() : null, 
+            sourceFlowElement != null ? sourceFlowElement.getName() : null,
             sourceFlowElement != null ? sourceFlowElement.getClass().getName() : null,
             sourceFlowElement != null ? ((FlowNode) sourceFlowElement).getBehavior(): null,
             targetFlowElement != null ? targetFlowElement.getId() : null, 
@@ -238,7 +238,7 @@ public class ContinueProcessOperation extends AbstractOperation {
       }
 
       // A Child execution of the current execution is created to represent the boundary event being active 
-      ExecutionEntity childExecutionEntity = commandContext.getExecutionEntityManager().createChildExecution((ExecutionEntity) execution); 
+      ExecutionEntity childExecutionEntity = commandContext.getExecutionEntityManager().createChildExecution(execution);
       childExecutionEntity.setParentId(execution.getId());
       childExecutionEntity.setCurrentFlowElement(boundaryEvent);
       childExecutionEntity.setScope(false);

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/agenda/TakeOutgoingSequenceFlowsOperation.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/agenda/TakeOutgoingSequenceFlowsOperation.java
@@ -173,7 +173,7 @@ public class TakeOutgoingSequenceFlowsOperation extends AbstractOperation {
       // Reuse existing one
       execution.setCurrentFlowElement(sequenceFlow);
       execution.setActive(true);
-      outgoingExecutions.add((ExecutionEntity) execution);
+      outgoingExecutions.add(execution);
   
       // Executions for all the other one
       if (outgoingSequenceFlows.size() > 1) {

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/delegate/invocation/JavaDelegateInvocation.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/delegate/invocation/JavaDelegateInvocation.java
@@ -31,7 +31,7 @@ public class JavaDelegateInvocation extends DelegateInvocation {
   }
 
   protected void invoke() {
-    delegateInstance.execute((DelegateExecution) execution);
+    delegateInstance.execute(execution);
   }
 
   public Object getTarget() {

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/history/DefaultHistoryManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/history/DefaultHistoryManager.java
@@ -291,7 +291,7 @@ public class DefaultHistoryManager extends AbstractManager implements HistoryMan
     
     if (execution.getParentId() != null) {
       HistoricActivityInstanceEntity historicActivityInstanceFromParent 
-        = findActivityInstance((ExecutionEntity) execution.getParent(), activityId, false, endTimeMustBeNull); // always false for create, we only check if it can be found
+        = findActivityInstance(execution.getParent(), activityId, false, endTimeMustBeNull); // always false for create, we only check if it can be found
       if (historicActivityInstanceFromParent != null) {
         return historicActivityInstanceFromParent;
       }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/HistoricActivityInstanceEntityImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/HistoricActivityInstanceEntityImpl.java
@@ -42,7 +42,7 @@ public class HistoricActivityInstanceEntityImpl extends HistoricScopeInstanceEnt
   }
 
   public Object getPersistentState() {
-    Map<String, Object> persistentState = (Map<String, Object>) new HashMap<String, Object>();
+    Map<String, Object> persistentState = new HashMap<String, Object>();
     persistentState.put("endTime", endTime);
     persistentState.put("durationInMillis", durationInMillis);
     persistentState.put("deleteReason", deleteReason);

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/HistoricProcessInstanceEntityImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/HistoricProcessInstanceEntityImpl.java
@@ -72,7 +72,7 @@ public class HistoricProcessInstanceEntityImpl extends HistoricScopeInstanceEnti
   }
 
   public Object getPersistentState() {
-    Map<String, Object> persistentState = (Map<String, Object>) new HashMap<String, Object>();
+    Map<String, Object> persistentState = new HashMap<String, Object>();
     persistentState.put("endTime", endTime);
     persistentState.put("businessKey", businessKey);
     persistentState.put("name", name);

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/HistoricVariableInstanceEntityManagerImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/HistoricVariableInstanceEntityManagerImpl.java
@@ -119,7 +119,7 @@ public class HistoricVariableInstanceEntityManagerImpl extends AbstractEntityMan
     if (getHistoryManager().isHistoryLevelAtLeast(HistoryLevel.ACTIVITY)) {
       List<HistoricVariableInstanceEntity> historicProcessVariables = historicVariableInstanceDataManager.findHistoricVariableInstancesByTaskId(taskId);
       for (HistoricVariableInstanceEntity historicProcessVariable : historicProcessVariables) {
-        delete((HistoricVariableInstanceEntity) historicProcessVariable);
+        delete(historicProcessVariable);
       }
     }
   }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/ModelEntityManagerImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/ModelEntityManagerImpl.java
@@ -48,8 +48,8 @@ public class ModelEntityManagerImpl extends AbstractEntityManager<ModelEntity> i
 
   @Override
   public void insert(ModelEntity model) {
-    ((ModelEntity) model).setCreateTime(getClock().getCurrentTime());
-    ((ModelEntity) model).setLastUpdateTime(getClock().getCurrentTime());
+    model.setCreateTime(getClock().getCurrentTime());
+    model.setLastUpdateTime(getClock().getCurrentTime());
     
     super.insert(model);
   }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/CancelCallActivityTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/CancelCallActivityTest.java
@@ -105,7 +105,7 @@ public class CancelCallActivityTest extends PluggableFlowableTestCase {
     assertNotNull(executionEntity.getParentId());
     assertEquals(processExecutionId, executionEntity.getParentId());
 
-    FlowableEvent activitiEvent = (FlowableEvent) mylistener.getEventsReceived().get(2);
+    FlowableEvent activitiEvent = mylistener.getEventsReceived().get(2);
     assertEquals(FlowableEngineEventType.PROCESS_STARTED, activitiEvent.getType());
 
     
@@ -144,7 +144,7 @@ public class CancelCallActivityTest extends PluggableFlowableTestCase {
 
     
     // start event in external subprocess
-    activitiEvent = (FlowableEvent) mylistener.getEventsReceived().get(9);
+    activitiEvent = mylistener.getEventsReceived().get(9);
     assertEquals(FlowableEngineEventType.PROCESS_STARTED, activitiEvent.getType());   
     
     

--- a/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/cmd/GetVariablesFromFormSubmissionCmd.java
+++ b/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/cmd/GetVariablesFromFormSubmissionCmd.java
@@ -111,7 +111,7 @@ public class GetVariablesFromFormSubmissionCmd implements Command<Map<String, Ob
         result = Long.valueOf(strFieldValue);
         
       } else {
-        result = (Long) null;
+        result = null;
       }
 
     } else if (formField.getType().equals(FormFieldTypes.AMOUNT) && formFieldValue instanceof String) {

--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/UserTaskConverterTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/UserTaskConverterTest.java
@@ -74,18 +74,18 @@ public class UserTaskConverterTest extends AbstractConverterTest {
 
     List<FlowableListener> listeners = userTask.getTaskListeners();
     assertEquals(3, listeners.size());
-    FlowableListener listener = (FlowableListener) listeners.get(0);
+    FlowableListener listener = listeners.get(0);
     assertTrue(ImplementationType.IMPLEMENTATION_TYPE_CLASS.equals(listener.getImplementationType()));
     assertEquals("org.test.TestClass", listener.getImplementation());
     assertEquals("create", listener.getEvent());
     assertEquals(2, listener.getFieldExtensions().size());
     assertEquals("testField", listener.getFieldExtensions().get(0).getFieldName());
     assertEquals("test", listener.getFieldExtensions().get(0).getStringValue());
-    listener = (FlowableListener) listeners.get(1);
+    listener = listeners.get(1);
     assertTrue(ImplementationType.IMPLEMENTATION_TYPE_EXPRESSION.equals(listener.getImplementationType()));
     assertEquals("${someExpression}", listener.getImplementation());
     assertEquals("assignment", listener.getEvent());
-    listener = (FlowableListener) listeners.get(2);
+    listener = listeners.get(2);
     assertTrue(ImplementationType.IMPLEMENTATION_TYPE_DELEGATEEXPRESSION.equals(listener.getImplementationType()));
     assertEquals("${someDelegateExpression}", listener.getImplementation());
     assertEquals("complete", listener.getEvent());

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/deployer/BpmnDeployer.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/deployer/BpmnDeployer.java
@@ -656,7 +656,7 @@ public class BpmnDeployer implements Deployer {
     if (exprSet != null) {
       Iterator<Expression> iterator = exprSet.iterator();
       while (iterator.hasNext()) {
-        Expression expr = (Expression) iterator.next();
+        Expression expr = iterator.next();
         IdentityLinkEntity identityLink = new IdentityLinkEntity();
         identityLink.setProcessDef(processDefinition);
         if (exprType.equals(ExprType.USER)) {

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/helper/ScopeUtil.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/helper/ScopeUtil.java
@@ -174,7 +174,7 @@ public class ScopeUtil {
       eventScopeExecution.setActive(false);      
       eventScopeExecution.setConcurrent(false);
       eventScopeExecution.setEventScope(true);      
-      eventScopeExecution.setActivity((ActivityImpl) execution.getActivity());
+      eventScopeExecution.setActivity(execution.getActivity());
       
       execution.setConcurrent(false);
       

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/handler/ErrorEventDefinitionParseHandler.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/handler/ErrorEventDefinitionParseHandler.java
@@ -39,7 +39,7 @@ public class ErrorEventDefinitionParseHandler extends AbstractBpmnParseHandler<E
   
   protected void executeParse(BpmnParse bpmnParse, ErrorEventDefinition eventDefinition) {
 
-    ErrorEventDefinition modelErrorEvent = (ErrorEventDefinition) eventDefinition;
+    ErrorEventDefinition modelErrorEvent = eventDefinition;
     if (bpmnParse.getBpmnModel().containsErrorRef(modelErrorEvent.getErrorCode())) {
       String errorCode = bpmnParse.getBpmnModel().getErrors().get(modelErrorEvent.getErrorCode());
       modelErrorEvent.setErrorCode(errorCode);

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/delegate/JavaDelegateInvocation.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/delegate/JavaDelegateInvocation.java
@@ -31,7 +31,7 @@ public class JavaDelegateInvocation extends DelegateInvocation {
   }
 
   protected void invoke() {
-    delegateInstance.execute((DelegateExecution) execution);
+    delegateInstance.execute(execution);
   }
   
   public Object getTarget() {

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/history/DefaultHistoryManager.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/history/DefaultHistoryManager.java
@@ -183,7 +183,7 @@ public void recordProcessInstanceStart(ExecutionEntity processInstance) {
 public void recordSubProcessInstanceStart(ExecutionEntity parentExecution, ExecutionEntity subProcessInstance) {
     if(isHistoryLevelAtLeast(HistoryLevel.ACTIVITY)) {
       
-      HistoricProcessInstanceEntity historicProcessInstance = new HistoricProcessInstanceEntity((ExecutionEntity) subProcessInstance);
+      HistoricProcessInstanceEntity historicProcessInstance = new HistoricProcessInstanceEntity(subProcessInstance);
      
       ActivityImpl initialActivity = subProcessInstance.getActivity();
       // Fix for ACT-1728: startActivityId not initialized with subprocess-instance
@@ -363,7 +363,7 @@ public void recordActivityStart(ExecutionEntity executionEntity) {
     }
 
     if (execution.getParentId() != null) {
-      return findActivityInstance((ExecutionEntity) execution.getParent(), activityId, checkPersistentStore);
+      return findActivityInstance(execution.getParent(), activityId, checkPersistentStore);
     }
 
     return null;

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/EventSubscriptionEntityManager.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/EventSubscriptionEntityManager.java
@@ -117,7 +117,7 @@ public class EventSubscriptionEntityManager extends AbstractManager {
     // add events created in this command (not visible yet in query)
     for (SignalEventSubscriptionEntity entity : createdSignalSubscriptions) {
       if(executionId.equals(entity.getExecutionId())) {
-        selectList.add((SignalEventSubscriptionEntity) entity);        
+        selectList.add(entity);
       }
     }
     
@@ -136,7 +136,7 @@ public class EventSubscriptionEntityManager extends AbstractManager {
     for (SignalEventSubscriptionEntity entity : createdSignalSubscriptions) {
       if(executionId.equals(entity.getExecutionId())
          && name.equals(entity.getEventName())) {
-        selectList.add((SignalEventSubscriptionEntity) entity);        
+        selectList.add(entity);
       }
     }
     

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntity.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntity.java
@@ -924,7 +924,7 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
     }
     
     if (superExecution != null) {
-      this.superExecutionId = ((ExecutionEntity)superExecution).getId();
+      this.superExecutionId = superExecution.getId();
     } else {
       this.superExecutionId = null;
     }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/HistoricActivityInstanceEntity.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/HistoricActivityInstanceEntity.java
@@ -43,7 +43,7 @@ public class HistoricActivityInstanceEntity extends HistoricScopeInstanceEntity 
   }
   
   public Object getPersistentState() {
-    Map<String, Object> persistentState = (Map<String, Object>) new HashMap<String, Object>();
+    Map<String, Object> persistentState = new HashMap<String, Object>();
     persistentState.put("endTime", endTime);
     persistentState.put("durationInMillis", durationInMillis);
     persistentState.put("deleteReason", deleteReason);

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/HistoricProcessInstanceEntity.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/HistoricProcessInstanceEntity.java
@@ -70,7 +70,7 @@ public class HistoricProcessInstanceEntity extends HistoricScopeInstanceEntity i
 
   
   public Object getPersistentState() {
-    Map<String, Object> persistentState = (Map<String, Object>) new HashMap<String, Object>();
+    Map<String, Object> persistentState = new HashMap<String, Object>();
     persistentState.put("endTime", endTime);
     persistentState.put("businessKey", businessKey);
     persistentState.put("name", name);


### PR DESCRIPTION
Remove redundant and unneeded casts.  I am assuming that some of these are the product of renaming and rearranging of code.  

I was conservative in the changes primarily removing casts where the datatype was already declared to be the same or was defined as the type of a collection.

There are more removal possibilities but they were less obvious and may aid in code comprehension so I did not change them.

I ran the compile and test targets and they were clean.