### PR TITLE
Redundant String.toString() and String.format() calls removed

### DIFF
--- a/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/UserTaskXMLConverter.java
+++ b/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/UserTaskXMLConverter.java
@@ -136,7 +136,7 @@ public class UserTaskXMLConverter extends BaseBpmnXMLConverter {
     writeQualifiedAttribute(ATTRIBUTE_TASK_USER_CATEGORY, userTask.getCategory(), xtw);
     writeQualifiedAttribute(ATTRIBUTE_FORM_FORMKEY, userTask.getFormKey(), xtw);
     if (userTask.getPriority() != null) {
-      writeQualifiedAttribute(ATTRIBUTE_TASK_USER_PRIORITY, userTask.getPriority().toString(), xtw);
+      writeQualifiedAttribute(ATTRIBUTE_TASK_USER_PRIORITY, userTask.getPriority(), xtw);
     }
     if (StringUtils.isNotEmpty(userTask.getExtensionId())) {
       writeQualifiedAttribute(ATTRIBUTE_TASK_SERVICE_EXTENSIONID, userTask.getExtensionId(), xtw);

--- a/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/fs/FileSystemContentStorage.java
+++ b/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/fs/FileSystemContentStorage.java
@@ -160,7 +160,7 @@ public class FileSystemContentStorage implements ContentStorage {
       }
     }
 
-    return new FileSystemContentObject(contentFile, id.toString(), length);
+    return new FileSystemContentObject(contentFile, id, length);
   }
 
   public void deleteContentObject(String id) {

--- a/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/fs/SimpleFileSystemContentStorage.java
+++ b/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/fs/SimpleFileSystemContentStorage.java
@@ -173,7 +173,7 @@ public class SimpleFileSystemContentStorage implements ContentStorage {
       }
     }
 
-    return new FileSystemContentObject(contentFile, id.toString(), length);
+    return new FileSystemContentObject(contentFile, id, length);
   }
 
   @Override

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/ValidateExecutionRelatedEntityCountCfgCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/ValidateExecutionRelatedEntityCountCfgCmd.java
@@ -64,7 +64,7 @@ public class ValidateExecutionRelatedEntityCountCfgCmd implements Command<Void> 
       
     } else {
       
-      boolean propertyValue = Boolean.valueOf(propertyEntity.getValue().toString().toLowerCase());
+      boolean propertyValue = Boolean.valueOf(propertyEntity.getValue().toLowerCase());
       if (!configProperty && propertyValue) {
         if (logger.isInfoEnabled()) {
           logger.info("Configuration change: execution related entity counting feature was enabled before, but now disabled. "

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoryServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoryServiceTest.java
@@ -467,7 +467,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
     assertNull(tasks.get(0).getDescription());
     
     ObjectNode infoNode = dynamicBpmnService.changeLocalizationName("en-GB", "theTask", "My localized name");
-    dynamicBpmnService.changeLocalizationDescription("en-GB".toString(), "theTask", "My localized description", infoNode);
+    dynamicBpmnService.changeLocalizationDescription("en-GB", "theTask", "My localized description", infoNode);
     dynamicBpmnService.saveProcessDefinitionInfo(processInstance.getProcessDefinitionId(), infoNode);
     
     tasks = historyService.createHistoricTaskInstanceQuery().processDefinitionId(processInstance.getProcessDefinitionId()).list();

--- a/modules/flowable-json-converter/src/main/java/org/flowable/editor/language/json/converter/BpmnJsonConverterUtil.java
+++ b/modules/flowable-json-converter/src/main/java/org/flowable/editor/language/json/converter/BpmnJsonConverterUtil.java
@@ -587,7 +587,7 @@ public class BpmnJsonConverterUtil implements EditorJsonConstants, StencilConsta
         } else {
           value = new String(dObjValue.toString());
         }
-        propertyItemNode.put(PROPERTY_DATA_VALUE, value.toString());
+        propertyItemNode.put(PROPERTY_DATA_VALUE, value);
       }
 
       itemsNode.add(propertyItemNode);

--- a/modules/flowable-json-converter/src/main/java/org/flowable/editor/language/json/converter/UserTaskJsonConverter.java
+++ b/modules/flowable-json-converter/src/main/java/org/flowable/editor/language/json/converter/UserTaskJsonConverter.java
@@ -249,7 +249,7 @@ public class UserTaskJsonConverter extends BaseBpmnJsonConverter implements Form
     }
 
     if (userTask.getPriority() != null) {
-      setPropertyValue(PROPERTY_USERTASK_PRIORITY, userTask.getPriority().toString(), propertiesNode);
+      setPropertyValue(PROPERTY_USERTASK_PRIORITY, userTask.getPriority(), propertiesNode);
     }
 
     if (StringUtils.isNotEmpty(userTask.getFormKey())) {

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-starter-basic/src/main/java/org/flowable/spring/boot/AbstractProcessEngineConfiguration.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-starter-basic/src/main/java/org/flowable/spring/boot/AbstractProcessEngineConfiguration.java
@@ -85,7 +85,7 @@ public abstract class AbstractProcessEngineConfiguration {
     	}
     	
     	if (result.isEmpty()) {
-      	logger.info(String.format("No process definitions were found for autodeployment"));
+      	logger.info("No process definitions were found for autodeployment");
     	}
     	
       return result;


### PR DESCRIPTION
Remove calls 'toString()' on a String object and remove call to String.format() where there are no arguments thus only the string is required.