### PR TITLE
Remove redundant field initialization for class variables

### DIFF
--- a/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/IndentingXMLStreamWriter.java
+++ b/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/IndentingXMLStreamWriter.java
@@ -30,7 +30,7 @@ public class IndentingXMLStreamWriter extends DelegatingXMLStreamWriter {
   private Stack<Object> stateStack = new Stack<Object>();
 
   private String indentStep = "  ";
-  private int depth = 0;
+  private int depth;
 
   public IndentingXMLStreamWriter(XMLStreamWriter writer) {
     super(writer);

--- a/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/ValuedDataObjectXMLConverter.java
+++ b/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/ValuedDataObjectXMLConverter.java
@@ -29,7 +29,7 @@ public class ValuedDataObjectXMLConverter extends BaseBpmnXMLConverter {
 
   private final Pattern xmlChars = Pattern.compile("[<>&]");
   private SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-  protected boolean didWriteExtensionStartElement = false;
+  protected boolean didWriteExtensionStartElement;
 
   public Class<? extends BaseElement> getBpmnElementType() {
     return ValuedDataObject.class;

--- a/modules/flowable-bpmn-model/src/main/java/org/flowable/bpmn/model/ScriptTask.java
+++ b/modules/flowable-bpmn-model/src/main/java/org/flowable/bpmn/model/ScriptTask.java
@@ -21,8 +21,7 @@ public class ScriptTask extends Task {
   protected String scriptFormat;
   protected String script;
   protected String resultVariable;
-  protected boolean autoStoreVariables = false; // see
-                                                // https://activiti.atlassian.net/browse/ACT-1626
+  protected boolean autoStoreVariables; // see https://activiti.atlassian.net/browse/ACT-1626
 
   public String getScriptFormat() {
     return scriptFormat;

--- a/modules/flowable-camel/src/main/java/org/flowable/camel/CamelBehavior.java
+++ b/modules/flowable-camel/src/main/java/org/flowable/camel/CamelBehavior.java
@@ -72,7 +72,7 @@ public abstract class CamelBehavior extends AbstractBpmnActivityBehavior impleme
     BODY_AS_MAP, BODY, PROPERTIES
   }
 
-  protected TargetType toTargetType = null;
+  protected TargetType toTargetType;
 
   protected void updateTargetVariables(FlowableEndpoint endpoint) {
     toTargetType = null;

--- a/modules/flowable-camel/src/main/java/org/flowable/camel/FlowableProducer.java
+++ b/modules/flowable-camel/src/main/java/org/flowable/camel/FlowableProducer.java
@@ -50,9 +50,9 @@ public class FlowableProducer extends DefaultProducer {
 
   private final long timeResolution;
 
-  private String processKey = null;
+  private String processKey;
 
-  private String activity = null;
+  private String activity;
 
   public FlowableProducer(FlowableEndpoint endpoint, long timeout, long timeResolution) {
     super(endpoint);

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/exception/tools/ExceptionServiceMock.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/exception/tools/ExceptionServiceMock.java
@@ -4,7 +4,7 @@ import org.flowable.engine.delegate.DelegateExecution;
 import org.flowable.engine.delegate.JavaDelegate;
 
 public class ExceptionServiceMock implements JavaDelegate {
-  static boolean isCalled = false;
+  static boolean isCalled;
 
   @Override
   public void execute(DelegateExecution execution) {

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/exception/tools/NoExceptionServiceMock.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/exception/tools/NoExceptionServiceMock.java
@@ -5,7 +5,7 @@ import org.flowable.engine.delegate.JavaDelegate;
 
 public class NoExceptionServiceMock implements JavaDelegate {
 
-  static boolean isCalled = false;
+  static boolean isCalled;
 
   @Override
   public void execute(DelegateExecution execution) {

--- a/modules/flowable-cdi/src/test/java/org/flowable/cdi/test/CdiFlowableTestCase.java
+++ b/modules/flowable-cdi/src/test/java/org/flowable/cdi/test/CdiFlowableTestCase.java
@@ -166,7 +166,7 @@ public abstract class CdiFlowableTestCase {
   }
 
   private static class InteruptTask extends TimerTask {
-    protected boolean timeLimitExceeded = false;
+    protected boolean timeLimitExceeded;
     protected Thread thread;
 
     public InteruptTask(Thread thread) {

--- a/modules/flowable-cdi/src/test/java/org/flowable/cdi/test/impl/event/TestEventListener.java
+++ b/modules/flowable-cdi/src/test/java/org/flowable/cdi/test/impl/event/TestEventListener.java
@@ -81,24 +81,24 @@ public class TestEventListener {
 
   // ---------------------------------------------------------
   
-  private int startActivityService1WithLoopCounter = 0;
-  private int startActivityService1WithoutLoopCounter = 0;
-  private int endActivityService1WithLoopCounter = 0;
-  private int endActivityService1WithoutLoopCounter = 0;
-  private int startActivityService2WithLoopCounter = 0;
-  private int startActivityService2WithoutLoopCounter = 0;
-  private int endActivityService2WithLoopCounter = 0;
-  private int endActivityService2WithoutLoopCounter = 0;
-  private int takeTransitiont1 = 0;
-  private int takeTransitiont2 = 0;
-  private int takeTransitiont3 = 0;
-  private int assignTask1 = 0;
-  private int completeTask1 = 0;
-  private int completeTask2 = 0;
-  private int completeTask3 = 0;
-  private int createTask1 = 0;
-  private int createTask2 = 0;
-  private int deleteTask3 = 0;
+  private int startActivityService1WithLoopCounter;
+  private int startActivityService1WithoutLoopCounter;
+  private int endActivityService1WithLoopCounter;
+  private int endActivityService1WithoutLoopCounter;
+  private int startActivityService2WithLoopCounter;
+  private int startActivityService2WithoutLoopCounter;
+  private int endActivityService2WithLoopCounter;
+  private int endActivityService2WithoutLoopCounter;
+  private int takeTransitiont1;
+  private int takeTransitiont2;
+  private int takeTransitiont3;
+  private int assignTask1;
+  private int completeTask1;
+  private int completeTask2;
+  private int completeTask3;
+  private int createTask1;
+  private int createTask2;
+  private int deleteTask3;
     
   public void onStartActivityService1(@Observes @StartActivity("service1") BusinessProcessEvent businessProcessEvent) {    
   	Integer loopCounter = (Integer) businessProcessEvent.getVariableScope().getVariable("loopCounter");

--- a/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/fs/FileSystemContentStorage.java
+++ b/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/fs/FileSystemContentStorage.java
@@ -45,7 +45,7 @@ public class FileSystemContentStorage implements ContentStorage {
   private PathConverter converter;
 
   private Object idLock = new Object();
-  private int currentIndex = 0;
+  private int currentIndex;
 
   private static final Logger logger = LoggerFactory.getLogger(FileSystemContentStorage.class);
 

--- a/modules/flowable-content-spring/src/main/java/org/flowable/content/spring/SpringContentEngineConfiguration.java
+++ b/modules/flowable-content-spring/src/main/java/org/flowable/content/spring/SpringContentEngineConfiguration.java
@@ -37,7 +37,7 @@ public class SpringContentEngineConfiguration extends ContentEngineConfiguration
 
   protected PlatformTransactionManager transactionManager;
   protected ApplicationContext applicationContext;
-  protected Integer transactionSynchronizationAdapterOrder = null;
+  protected Integer transactionSynchronizationAdapterOrder;
 
   public SpringContentEngineConfiguration() {
     this.transactionsExternallyManaged = true;

--- a/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/SimpleSimulationRun.java
+++ b/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/SimpleSimulationRun.java
@@ -30,7 +30,7 @@ public class SimpleSimulationRun extends AbstractSimulationRun {
 
   /** simulation start date */
   protected Date simulationStartDate = new Date(0);
-  protected Date dueDate = null;
+  protected Date dueDate;
 
   protected SimpleSimulationRun(Builder builder) {
     super(builder.eventHandlers);

--- a/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/mvel/MvelExecutionContext.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/mvel/MvelExecutionContext.java
@@ -27,10 +27,10 @@ import org.mvel2.integration.PropertyHandler;
 public class MvelExecutionContext {
 
     protected Map<String, Object> resultVariables = new HashMap<String, Object>();
-    protected Map<String, Object> stackVariables = null;
-    protected ParserContext parserContext = null;
+    protected Map<String, Object> stackVariables;
+    protected ParserContext parserContext;
     protected Map<Class<?>, PropertyHandler> propertyHandlers = new HashMap<Class<?>, PropertyHandler>();
-    protected DecisionExecutionAuditContainer auditContainer = null;
+    protected DecisionExecutionAuditContainer auditContainer;
 
     public void checkExecutionContext(String variableId) {
 

--- a/modules/flowable-dmn-spring/src/main/java/org/flowable/dmn/spring/SpringDmnEngineConfiguration.java
+++ b/modules/flowable-dmn-spring/src/main/java/org/flowable/dmn/spring/SpringDmnEngineConfiguration.java
@@ -48,7 +48,7 @@ public class SpringDmnEngineConfiguration extends DmnEngineConfiguration impleme
   protected Resource[] deploymentResources = new Resource[0];
   protected String deploymentMode = "default";
   protected ApplicationContext applicationContext;
-  protected Integer transactionSynchronizationAdapterOrder = null;
+  protected Integer transactionSynchronizationAdapterOrder;
   protected Collection<AutoDeploymentStrategy> deploymentStrategies = new ArrayList<AutoDeploymentStrategy>();
 
   public SpringDmnEngineConfiguration() {

--- a/modules/flowable-dmn-xml-converter/src/main/java/org/flowable/dmn/xml/converter/IndentingXMLStreamWriter.java
+++ b/modules/flowable-dmn-xml-converter/src/main/java/org/flowable/dmn/xml/converter/IndentingXMLStreamWriter.java
@@ -30,7 +30,7 @@ public class IndentingXMLStreamWriter extends DelegatingXMLStreamWriter {
   private Stack<Object> stateStack = new Stack<Object>();
 
   private String indentStep = "  ";
-  private int depth = 0;
+  private int depth;
 
   public IndentingXMLStreamWriter(XMLStreamWriter writer) {
     super(writer);

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/ProcessEngineConfiguration.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/ProcessEngineConfiguration.java
@@ -128,7 +128,7 @@ public abstract class ProcessEngineConfiguration extends AbstractEngineConfigura
   
   protected ProcessEngineLifecycleListener processEngineLifecycleListener;
   
-  protected boolean enableProcessDefinitionInfoCache = false;
+  protected boolean enableProcessDefinitionInfoCache;
 
   /** use one of the static createXxxx methods instead */
   protected ProcessEngineConfiguration() {

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/HistoricProcessInstanceQueryImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/HistoricProcessInstanceQueryImpl.java
@@ -79,8 +79,8 @@ public class HistoricProcessInstanceQueryImpl extends AbstractVariableQueryImpl<
   protected String locale;
   protected boolean withLocalizationFallback;
   protected List<HistoricProcessInstanceQueryImpl> orQueryObjects = new ArrayList<HistoricProcessInstanceQueryImpl>();
-  protected HistoricProcessInstanceQueryImpl currentOrQueryObject = null;
-  protected boolean inOrStatement = false;
+  protected HistoricProcessInstanceQueryImpl currentOrQueryObject;
+  protected boolean inOrStatement;
   
   public HistoricProcessInstanceQueryImpl() {
   }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/HistoricTaskInstanceQueryImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/HistoricTaskInstanceQueryImpl.java
@@ -103,12 +103,12 @@ public class HistoricTaskInstanceQueryImpl extends AbstractVariableQueryImpl<His
   protected boolean withoutTenantId;
   protected String locale;
   protected boolean withLocalizationFallback;
-  protected boolean includeTaskLocalVariables = false;
-  protected boolean includeProcessVariables = false;
+  protected boolean includeTaskLocalVariables;
+  protected boolean includeProcessVariables;
   protected Integer taskVariablesLimit;
   protected List<HistoricTaskInstanceQueryImpl> orQueryObjects = new ArrayList<HistoricTaskInstanceQueryImpl>();
-  protected HistoricTaskInstanceQueryImpl currentOrQueryObject = null;
-  protected boolean inOrStatement = false;
+  protected HistoricTaskInstanceQueryImpl currentOrQueryObject;
+  protected boolean inOrStatement;
 
   public HistoricTaskInstanceQueryImpl() {
   }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/ProcessInstanceQueryImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/ProcessInstanceQueryImpl.java
@@ -78,8 +78,8 @@ public class ProcessInstanceQueryImpl extends AbstractVariableQueryImpl<ProcessI
   protected boolean withoutTenantId;
   
   protected List<ProcessInstanceQueryImpl> orQueryObjects = new ArrayList<ProcessInstanceQueryImpl>();
-  protected ProcessInstanceQueryImpl currentOrQueryObject = null;
-  protected boolean inOrStatement = false;
+  protected ProcessInstanceQueryImpl currentOrQueryObject;
+  protected boolean inOrStatement;
 
   protected Date startedBefore;
   protected Date startedAfter;

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/TaskQueryImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/TaskQueryImpl.java
@@ -109,7 +109,7 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
   protected boolean withLocalizationFallback;
   protected boolean orActive;
   protected List<TaskQueryImpl> orQueryObjects = new ArrayList<TaskQueryImpl>();
-  protected TaskQueryImpl currentOrQueryObject = null;
+  protected TaskQueryImpl currentOrQueryObject;
   
   private List<String> cachedCandidateGroups;
   

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/asyncexecutor/AbstractAsyncExecutor.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/asyncexecutor/AbstractAsyncExecutor.java
@@ -44,7 +44,7 @@ public abstract class AbstractAsyncExecutor implements AsyncExecutor {
   protected int maxAsyncJobsDuePerAcquisition = 1;
   protected int defaultTimerJobAcquireWaitTimeInMillis = 10 * 1000;
   protected int defaultAsyncJobAcquireWaitTimeInMillis = 10 * 1000;
-  protected int defaultQueueSizeFullWaitTime = 0;
+  protected int defaultQueueSizeFullWaitTime;
 
   protected String lockOwner = UUID.randomUUID().toString();
   protected int timerLockTimeInMillis = 5 * 60 * 1000;

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/asyncexecutor/DefaultAsyncJobExecutor.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/asyncexecutor/DefaultAsyncJobExecutor.java
@@ -59,7 +59,7 @@ public class DefaultAsyncJobExecutor extends AbstractAsyncExecutor {
   protected int queueSize = 100;
   
   /** Whether to unlock jobs that are owned by this executor (have the same lockOwner) at startup */
-  protected boolean unlockOwnedJobs = false;
+  protected boolean unlockOwnedJobs;
 
   /** The queue used for job execution work */
   protected BlockingQueue<Runnable> threadPoolQueue;

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/ScriptTaskActivityBehavior.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/ScriptTaskActivityBehavior.java
@@ -43,7 +43,7 @@ public class ScriptTaskActivityBehavior extends TaskActivityBehavior {
   protected String script;
   protected String language;
   protected String resultVariable;
-  protected boolean storeScriptVariables = false; // see https://activiti.atlassian.net/browse/ACT-1626
+  protected boolean storeScriptVariables; // see https://activiti.atlassian.net/browse/ACT-1626
 
   public ScriptTaskActivityBehavior(String script, String language, String resultVariable) {
     this.script = script;

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/helper/DelegateExpressionFlowableEventListener.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/helper/DelegateExpressionFlowableEventListener.java
@@ -29,7 +29,7 @@ import org.flowable.engine.impl.el.NoExecutionVariableScope;
 public class DelegateExpressionFlowableEventListener extends BaseDelegateEventListener {
 
   protected Expression expression;
-  protected boolean failOnException = false;
+  protected boolean failOnException;
 
   public DelegateExpressionFlowableEventListener(Expression expression, Class<?> entityClass) {
     this.expression = expression;

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/helper/DelegateFlowableEventListener.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/helper/DelegateFlowableEventListener.java
@@ -30,7 +30,7 @@ public class DelegateFlowableEventListener extends BaseDelegateEventListener {
 
   protected String className;
   protected FlowableEventListener delegateInstance;
-  protected boolean failOnException = false;
+  protected boolean failOnException;
 
   public DelegateFlowableEventListener(String className, Class<?> entityClass) {
     this.className = className;

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -640,7 +640,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
    * The time (in milliseconds) the async job (both timer and async continuations) acquisition thread will
    * wait when the queueu is full to execute the next query. By default set to 0 (for backwards compatibility)
    */
-  protected int asyncExecutorDefaultQueueSizeFullWaitTime = 0;
+  protected int asyncExecutorDefaultQueueSizeFullWaitTime;
 
   /**
    * When a job is acquired, it is locked so other async executors can't lock

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/AbstractSetProcessDefinitionStateCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/AbstractSetProcessDefinitionStateCmd.java
@@ -47,7 +47,7 @@ public abstract class AbstractSetProcessDefinitionStateCmd implements Command<Vo
   protected String processDefinitionId;
   protected String processDefinitionKey;
   protected ProcessDefinitionEntity processDefinitionEntity;
-  protected boolean includeProcessInstances = false;
+  protected boolean includeProcessInstances;
   protected Date executionDate;
   protected String tenantId;
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/test/profiler/CommandStats.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/test/profiler/CommandStats.java
@@ -10,7 +10,7 @@ import java.util.Map;
  */
 public class CommandStats {
 
-    protected long getTotalCommandTime = 0L;
+    protected long getTotalCommandTime;
     
     protected List<Long> commandExecutionTimings = new ArrayList<Long>();
     protected List<Long> databaseTimings = new ArrayList<Long>();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.java
@@ -45,7 +45,7 @@ import org.flowable.engine.test.Deployment;
  */
 public class TerminateEndEventTest extends PluggableFlowableTestCase {
 
-  public static int serviceTaskInvokedCount = 0;
+  public static int serviceTaskInvokedCount;
   
   @Override
   protected void setUp() throws Exception {
@@ -64,7 +64,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
     }
   }
 
-  public static int serviceTaskInvokedCount2 = 0;
+  public static int serviceTaskInvokedCount2;
 
   public static class CountDelegate2 implements JavaDelegate {
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/signal/FileExistsMock.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/signal/FileExistsMock.java
@@ -14,7 +14,7 @@ package org.flowable.engine.test.bpmn.event.signal;
 
 public class FileExistsMock {
 
-	private boolean exists = false;
+	private boolean exists;
 	
 	private static FileExistsMock instance;
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/StartTimerEventRepeatWithoutN.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/StartTimerEventRepeatWithoutN.java
@@ -27,7 +27,7 @@ import org.flowable.engine.test.Deployment;
 
 public class StartTimerEventRepeatWithoutN extends PluggableFlowableTestCase {
 
-	protected long counter = 0;
+	protected long counter;
 	protected StartEventListener startEventListener;
 	
 	class StartEventListener implements FlowableEventListener {

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/debugger/TestDebuggerImpl.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/debugger/TestDebuggerImpl.java
@@ -18,7 +18,7 @@ import org.flowable.engine.runtime.Debugger;
 public class TestDebuggerImpl implements Debugger {
 
     private final FlowableEngineAgendaFactory agendaFactoryBean;
-    private Predicate isBreakPointPredicate = null;
+    private Predicate isBreakPointPredicate;
     private Agenda agendaCopy;
 
     private static ThreadLocal<Boolean> suppressBreakPoints = new ThreadLocal<>();

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/jpa/HistoricJPAVariableTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/jpa/HistoricJPAVariableTest.java
@@ -31,7 +31,7 @@ public class HistoricJPAVariableTest extends AbstractFlowableTestCase {
 	private static EntityManagerFactory entityManagerFactory;
 	
 	private static FieldAccessJPAEntity simpleEntityFieldAccess;
-	private static boolean entitiesInitialized = false;
+	private static boolean entitiesInitialized;
 	
 	protected String processInstanceId;
 

--- a/modules/flowable-form-spring/src/main/java/org/flowable/form/spring/SpringFormEngineConfiguration.java
+++ b/modules/flowable-form-spring/src/main/java/org/flowable/form/spring/SpringFormEngineConfiguration.java
@@ -48,7 +48,7 @@ public class SpringFormEngineConfiguration extends FormEngineConfiguration imple
   protected Resource[] deploymentResources = new Resource[0];
   protected String deploymentMode = "default";
   protected ApplicationContext applicationContext;
-  protected Integer transactionSynchronizationAdapterOrder = null;
+  protected Integer transactionSynchronizationAdapterOrder;
   private Collection<AutoDeploymentStrategy> deploymentStrategies = new ArrayList<AutoDeploymentStrategy>();
 
   public SpringFormEngineConfiguration() {

--- a/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/UserEntityTest.java
+++ b/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/UserEntityTest.java
@@ -33,8 +33,8 @@ public class UserEntityTest {
   @SuppressWarnings("serial")
   class TestableUserEntity extends UserEntityImpl {
 
-    private boolean hasSavePictureBeenCalled = false;
-    private boolean hasDeletePictureBeenCalled = false;
+    private boolean hasSavePictureBeenCalled;
+    private boolean hasDeletePictureBeenCalled;
 
     @Override
     protected void savePicture(Picture picture) {

--- a/modules/flowable-idm-spring/src/main/java/org/flowable/idm/spring/SpringIdmEngineConfiguration.java
+++ b/modules/flowable-idm-spring/src/main/java/org/flowable/idm/spring/SpringIdmEngineConfiguration.java
@@ -35,7 +35,7 @@ public class SpringIdmEngineConfiguration extends IdmEngineConfiguration impleme
 
   protected PlatformTransactionManager transactionManager;
   protected ApplicationContext applicationContext;
-  protected Integer transactionSynchronizationAdapterOrder = null;
+  protected Integer transactionSynchronizationAdapterOrder;
 
   public SpringIdmEngineConfiguration() {
     this.transactionsExternallyManaged = true;

--- a/modules/flowable-image-generator/src/main/java/org/flowable/image/impl/DefaultProcessDiagramCanvas.java
+++ b/modules/flowable-image-generator/src/main/java/org/flowable/image/impl/DefaultProcessDiagramCanvas.java
@@ -94,8 +94,8 @@ public class DefaultProcessDiagramCanvas {
   protected static Color SUBPROCESS_BORDER_COLOR = new Color(0, 0, 0);
   
   // Fonts
-  protected static Font LABEL_FONT = null;
-  protected static Font ANNOTATION_FONT = null;
+  protected static Font LABEL_FONT;
+  protected static Font ANNOTATION_FONT;
   
   // Strokes
   protected static Stroke THICK_TASK_BORDER_STROKE = new BasicStroke(3.0f);

--- a/modules/flowable-jmx/src/main/java/org/flowable/management/jmx/JMXConfigurator.java
+++ b/modules/flowable-jmx/src/main/java/org/flowable/management/jmx/JMXConfigurator.java
@@ -55,7 +55,7 @@ public class JMXConfigurator extends AbstractProcessEngineConfigurator {
   private static final Logger LOG = LoggerFactory.getLogger(JMXConfigurator.class);
 
   // disable jmx
-  private boolean disabled = false;
+  private boolean disabled;
 
   public String getDomain() {
     return domain;

--- a/modules/flowable-ldap/src/test/java/org/flowable/test/ldap/LDAPTestCase.java
+++ b/modules/flowable-ldap/src/test/java/org/flowable/test/ldap/LDAPTestCase.java
@@ -29,9 +29,9 @@ import org.springframework.security.ldap.server.ApacheDSContainer;
  */
 public class LDAPTestCase extends SpringFlowableTestCase {
 
-  private static int testCount = 0;
+  private static int testCount;
   private static int totalTestCount = -1;
-  private static boolean disableAfterTestCase = false;
+  private static boolean disableAfterTestCase;
 
   @Resource(name = "org.springframework.security.apacheDirectoryServerContainer")
   private ApacheDSContainer apacheDSContainer;

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/identity/GroupRequest.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/identity/GroupRequest.java
@@ -18,8 +18,8 @@ package org.flowable.rest.service.api.identity;
  */
 public class GroupRequest extends GroupResponse {
 
-  protected boolean isNameChanged = false;
-  protected boolean isTypeChanged = false;
+  protected boolean isNameChanged;
+  protected boolean isTypeChanged;
 
   @Override
   public void setType(String type) {

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/identity/UserRequest.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/identity/UserRequest.java
@@ -20,10 +20,10 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
  */
 public class UserRequest extends UserResponse {
 
-  protected boolean firstNameChanged = false;
-  protected boolean lastNameChanged = false;
-  protected boolean passwordChanged = false;
-  protected boolean emailChanged = false;
+  protected boolean firstNameChanged;
+  protected boolean lastNameChanged;
+  protected boolean passwordChanged;
+  protected boolean emailChanged;
 
   @Override
   public void setEmail(String email) {

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/repository/ProcessDefinitionActionRequest.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/repository/ProcessDefinitionActionRequest.java
@@ -28,7 +28,7 @@ public class ProcessDefinitionActionRequest extends RestActionRequest {
   public static final String ACTION_SUSPEND = "suspend";
   public static final String ACTION_ACTIVATE = "activate";
 
-  private boolean includeProcessInstances = false;
+  private boolean includeProcessInstances;
   private Date date;
   private String category;
 

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/repository/ProcessDefinitionResponse.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/repository/ProcessDefinitionResponse.java
@@ -32,9 +32,9 @@ public class ProcessDefinitionResponse {
   private String resource;
   private String diagramResource;
   private String category;
-  private boolean graphicalNotationDefined = false;
-  private boolean suspended = false;
-  private boolean startFormDefined = false;
+  private boolean graphicalNotationDefined;
+  private boolean suspended;
+  private boolean startFormDefined;
 
   public String getId() {
     return id;

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/process/SignalEventReceivedRequest.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/process/SignalEventReceivedRequest.java
@@ -28,7 +28,7 @@ public class SignalEventReceivedRequest {
   private String signalName;
   private List<RestVariable> variables;
   private String tenantId;
-  private boolean async = false;
+  private boolean async;
 
   public void setTenantId(String tenantId) {
     this.tenantId = tenantId;

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/task/TaskRequest.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/task/TaskRequest.java
@@ -34,17 +34,17 @@ public class TaskRequest {
   private String tenantId;
   private String formKey;
 
-  private boolean ownerSet = false;
-  private boolean assigneeSet = false;
-  private boolean delegationStateSet = false;
-  private boolean nameSet = false;
-  private boolean descriptionSet = false;
-  private boolean duedateSet = false;
-  private boolean prioritySet = false;
-  private boolean parentTaskIdSet = false;
-  private boolean categorySet = false;
-  private boolean tenantIdSet = false;
-  private boolean formKeySet = false;
+  private boolean ownerSet;
+  private boolean assigneeSet;
+  private boolean delegationStateSet;
+  private boolean nameSet;
+  private boolean descriptionSet;
+  private boolean duedateSet;
+  private boolean prioritySet;
+  private boolean parentTaskIdSet;
+  private boolean categorySet;
+  private boolean tenantIdSet;
+  private boolean formKeySet;
 
   public String getOwner() {
     return owner;

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/api/jpa/BaseJPARestTestCase.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/api/jpa/BaseJPARestTestCase.java
@@ -392,7 +392,7 @@ public class BaseJPARestTestCase extends AbstractTestCase {
   }
 
   private static class InteruptTask extends TimerTask {
-    protected boolean timeLimitExceeded = false;
+    protected boolean timeLimitExceeded;
     protected Thread thread;
 
     public InteruptTask(Thread thread) {

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/BaseSpringRestTestCase.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/BaseSpringRestTestCase.java
@@ -400,7 +400,7 @@ public class BaseSpringRestTestCase extends AbstractTestCase {
   }
 
   private static class InteruptTask extends TimerTask {
-    protected boolean timeLimitExceeded = false;
+    protected boolean timeLimitExceeded;
     protected Thread thread;
 
     public InteruptTask(Thread thread) {

--- a/modules/flowable-spring/src/main/java/org/flowable/spring/SpringProcessEngineConfiguration.java
+++ b/modules/flowable-spring/src/main/java/org/flowable/spring/SpringProcessEngineConfiguration.java
@@ -52,7 +52,7 @@ public class SpringProcessEngineConfiguration extends ProcessEngineConfiguration
   protected Resource[] deploymentResources = new Resource[0];
   protected String deploymentMode = "default";
   protected ApplicationContext applicationContext;
-  protected Integer transactionSynchronizationAdapterOrder = null;
+  protected Integer transactionSynchronizationAdapterOrder;
   private Collection<AutoDeploymentStrategy> deploymentStrategies = new ArrayList<AutoDeploymentStrategy>();
 
   public SpringProcessEngineConfiguration() {

--- a/modules/flowable-spring/src/test/java/org/flowable/spring/test/components/scope/StatefulObject.java
+++ b/modules/flowable-spring/src/test/java/org/flowable/spring/test/components/scope/StatefulObject.java
@@ -21,7 +21,7 @@ public class StatefulObject implements Serializable, InitializingBean {
   public static final long serialVersionUID = 1L;
 
   private String name;
-  private int visitedCount = 0;
+  private int visitedCount;
 
   private long customerId;
 

--- a/modules/flowable-ui-idm/flowable-ui-idm-conf/src/main/java/org/flowable/app/web/CustomAntPathMatcher.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-conf/src/main/java/org/flowable/app/web/CustomAntPathMatcher.java
@@ -29,7 +29,7 @@ import javax.servlet.http.HttpServletRequest;
 public class CustomAntPathMatcher implements RequestMatcher {
 
     protected AntPathRequestMatcher wrapped;
-    protected boolean httpMethodUsed = false;
+    protected boolean httpMethodUsed;
 
     /**
      * Creates a matcher with the specific pattern which will match all HTTP

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/ProcessEngineConfiguration.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/ProcessEngineConfiguration.java
@@ -108,8 +108,8 @@ public abstract class ProcessEngineConfiguration {
   protected String mailServerUsername; // by default no name and password are provided, which 
   protected String mailServerPassword; // means no authentication for mail server
   protected int mailServerPort = 25;
-  protected boolean useSSL = false;
-  protected boolean useTLS = false;
+  protected boolean useSSL;
+  protected boolean useTLS;
   protected String mailServerDefaultFrom = "activiti@localhost";
   protected String mailSessionJndi;
   protected Map<String,MailServerInfo> mailServers = new HashMap<String,MailServerInfo>();
@@ -121,19 +121,19 @@ public abstract class ProcessEngineConfiguration {
   protected String jdbcUrl = "jdbc:h2:tcp://localhost/~/activiti";
   protected String jdbcUsername = "sa";
   protected String jdbcPassword = "";
-  protected String dataSourceJndiName = null;
+  protected String dataSourceJndiName;
   protected boolean isDbHistoryUsed = true;
   protected HistoryLevel historyLevel;
   protected int jdbcMaxActiveConnections;
   protected int jdbcMaxIdleConnections;
   protected int jdbcMaxCheckoutTime;
   protected int jdbcMaxWaitTime;
-  protected boolean jdbcPingEnabled = false;
-  protected String jdbcPingQuery = null;
+  protected boolean jdbcPingEnabled;
+  protected String jdbcPingQuery;
   protected int jdbcPingConnectionNotUsedFor;
   protected int jdbcDefaultTransactionIsolationLevel;
   protected DataSource dataSource;
-  protected boolean transactionsExternallyManaged = false;
+  protected boolean transactionsExternallyManaged;
   
   protected String jpaPersistenceUnitName;
   protected Object jpaEntityManagerFactory;
@@ -190,7 +190,7 @@ public abstract class ProcessEngineConfiguration {
    * doesn't return that correctly, see https://activiti.atlassian.net/browse/ACT-1220,
    * https://activiti.atlassian.net/browse/ACT-1062
    */
-  protected String databaseSchema = null;
+  protected String databaseSchema;
   
   /**
    * Set to true in case the defined databaseTablePrefix is a schema-name, instead of an actual table name
@@ -199,7 +199,7 @@ public abstract class ProcessEngineConfiguration {
    * 
    *  @since 5.15
    */
-  protected boolean tablePrefixIsSchema = false;
+  protected boolean tablePrefixIsSchema;
   
   protected boolean isCreateDiagramOnDeploy = true;
   
@@ -219,7 +219,7 @@ public abstract class ProcessEngineConfiguration {
   protected boolean useClassForNameClassLoading = true;
   protected ProcessEngineLifecycleListener processEngineLifecycleListener;
   
-  protected boolean enableProcessDefinitionInfoCache = false;
+  protected boolean enableProcessDefinitionInfoCache;
 
   /** use one of the static createXxxx methods instead */
   protected ProcessEngineConfiguration() {

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/ProcessEngines.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/ProcessEngines.java
@@ -64,7 +64,7 @@ public abstract class ProcessEngines {
   
   public static final String NAME_DEFAULT = "default";
   
-  protected static boolean isInitialized = false; 
+  protected static boolean isInitialized;
   protected static Map<String, ProcessEngine> processEngines = new HashMap<String, ProcessEngine>();
   protected static Map<String, ProcessEngineInfo> processEngineInfosByName = new HashMap<String, ProcessEngineInfo>();
   protected static Map<String, ProcessEngineInfo> processEngineInfosByResourceUrl = new HashMap<String, ProcessEngineInfo>();

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/AbstractNativeQuery.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/AbstractNativeQuery.java
@@ -44,7 +44,7 @@ public abstract class AbstractNativeQuery<T extends NativeQuery< ? , ? >, U> imp
   protected transient CommandContext commandContext;
 
   protected int maxResults = Integer.MAX_VALUE;
-  protected int firstResult = 0;
+  protected int firstResult;
   protected ResultType resultType;
 
   private Map<String, Object> parameters = new HashMap<String, Object>();

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/HistoricDetailQueryImpl.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/HistoricDetailQueryImpl.java
@@ -40,7 +40,7 @@ public class HistoricDetailQueryImpl extends AbstractQuery<HistoricDetailQuery, 
   protected String activityId;
   protected String activityInstanceId;
   protected String type;
-  protected boolean excludeTaskRelated = false;
+  protected boolean excludeTaskRelated;
 
   public HistoricDetailQueryImpl() {
   }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/HistoricProcessInstanceQueryImpl.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/HistoricProcessInstanceQueryImpl.java
@@ -47,10 +47,10 @@ public class HistoricProcessInstanceQueryImpl extends AbstractVariableQueryImpl<
   protected String businessKey;
   protected String deploymentId;
   protected List<String> deploymentIds;
-  protected boolean finished = false;
-  protected boolean unfinished = false;
-  protected boolean deleted = false;
-  protected boolean notDeleted = false;
+  protected boolean finished;
+  protected boolean unfinished;
+  protected boolean deleted;
+  protected boolean notDeleted;
   protected String startedBy;
   protected String superProcessInstanceId;
   protected boolean excludeSubprocesses;
@@ -78,8 +78,8 @@ public class HistoricProcessInstanceQueryImpl extends AbstractVariableQueryImpl<
   protected String locale;
   protected boolean withLocalizationFallback;
   protected List<HistoricProcessInstanceQueryImpl> orQueryObjects = new ArrayList<HistoricProcessInstanceQueryImpl>();
-  protected HistoricProcessInstanceQueryImpl currentOrQueryObject = null;
-  protected boolean inOrStatement = false;
+  protected HistoricProcessInstanceQueryImpl currentOrQueryObject;
+  protected boolean inOrStatement;
   
   public HistoricProcessInstanceQueryImpl() {
   }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/HistoricTaskInstanceQueryImpl.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/HistoricTaskInstanceQueryImpl.java
@@ -91,7 +91,7 @@ public class HistoricTaskInstanceQueryImpl extends AbstractVariableQueryImpl<His
   protected Date dueDate;
   protected Date dueAfter;
   protected Date dueBefore;
-  protected boolean withoutDueDate = false;
+  protected boolean withoutDueDate;
   protected Date creationDate;
   protected Date creationAfterDate;
   protected Date creationBeforeDate;
@@ -104,12 +104,12 @@ public class HistoricTaskInstanceQueryImpl extends AbstractVariableQueryImpl<His
   protected boolean withoutTenantId;
   protected String locale;
   protected boolean withLocalizationFallback;
-  protected boolean includeTaskLocalVariables = false;
-  protected boolean includeProcessVariables = false;
+  protected boolean includeTaskLocalVariables;
+  protected boolean includeProcessVariables;
   protected Integer taskVariablesLimit;
   protected List<HistoricTaskInstanceQueryImpl> orQueryObjects = new ArrayList<HistoricTaskInstanceQueryImpl>();
-  protected HistoricTaskInstanceQueryImpl currentOrQueryObject = null;
-  protected boolean inOrStatement = false;
+  protected HistoricTaskInstanceQueryImpl currentOrQueryObject;
+  protected boolean inOrStatement;
 
   public HistoricTaskInstanceQueryImpl() {
   }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/HistoricVariableInstanceQueryImpl.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/HistoricVariableInstanceQueryImpl.java
@@ -44,8 +44,8 @@ public class HistoricVariableInstanceQueryImpl extends AbstractQuery<HistoricVar
   protected String activityInstanceId;
   protected String variableName;
   protected String variableNameLike;
-  protected boolean excludeTaskRelated = false;
-  protected boolean excludeVariableInitialization = false;
+  protected boolean excludeTaskRelated;
+  protected boolean excludeVariableInitialization;
   protected QueryVariableValue queryVariableValue;
 
   public HistoricVariableInstanceQueryImpl() {

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/ProcessDefinitionQueryImpl.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/ProcessDefinitionQueryImpl.java
@@ -57,7 +57,7 @@ public class ProcessDefinitionQueryImpl extends AbstractQuery<ProcessDefinitionQ
   protected Integer versionGte;
   protected Integer versionLt;
   protected Integer versionLte;
-  protected boolean latest = false;
+  protected boolean latest;
   protected SuspensionState suspensionState;
   protected String authorizationUserId;
   protected String procDefId;

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/ProcessInstanceQueryImpl.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/ProcessInstanceQueryImpl.java
@@ -76,8 +76,8 @@ public class ProcessInstanceQueryImpl extends AbstractVariableQueryImpl<ProcessI
   protected boolean withoutTenantId;
   
   protected List<ProcessInstanceQueryImpl> orQueryObjects = new ArrayList<ProcessInstanceQueryImpl>();
-  protected ProcessInstanceQueryImpl currentOrQueryObject = null;
-  protected boolean inOrStatement = false;
+  protected ProcessInstanceQueryImpl currentOrQueryObject;
+  protected boolean inOrStatement;
   
   // Unused, see dynamic query
   protected String activityId;

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/TaskQueryImpl.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/TaskQueryImpl.java
@@ -63,8 +63,8 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
   protected String owner;
   protected String ownerLike;
   protected String ownerLikeIgnoreCase;
-  protected boolean unassigned = false;
-  protected boolean noDelegationState = false;
+  protected boolean unassigned;
+  protected boolean noDelegationState;
   protected DelegationState delegationState;
   protected String candidateUser;
   protected String candidateGroup;
@@ -98,19 +98,19 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
   protected Date dueDate;
   protected Date dueBefore;
   protected Date dueAfter;
-  protected boolean withoutDueDate = false;
+  protected boolean withoutDueDate;
   protected SuspensionState suspensionState;
-  protected boolean excludeSubtasks = false;
-  protected boolean includeTaskLocalVariables = false;
-  protected boolean includeProcessVariables = false;
+  protected boolean excludeSubtasks;
+  protected boolean includeTaskLocalVariables;
+  protected boolean includeProcessVariables;
   protected Integer taskVariablesLimit;
   protected String userIdForCandidateAndAssignee;
-  protected boolean bothCandidateAndAssigned = false;
+  protected boolean bothCandidateAndAssigned;
   protected String locale;
   protected boolean withLocalizationFallback;
   protected boolean orActive;
   protected List<TaskQueryImpl> orQueryObjects = new ArrayList<TaskQueryImpl>();
-  protected TaskQueryImpl currentOrQueryObject = null;
+  protected TaskQueryImpl currentOrQueryObject;
   
   public TaskQueryImpl() {
   }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/BusinessRuleTaskActivityBehavior.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/BusinessRuleTaskActivityBehavior.java
@@ -40,7 +40,7 @@ public class BusinessRuleTaskActivityBehavior extends TaskActivityBehavior imple
   
   protected Set<Expression> variablesInputExpressions = new HashSet<Expression>();
   protected Set<Expression> rulesExpressions = new HashSet<Expression>();
-  protected boolean exclude = false;
+  protected boolean exclude;
   protected String resultVariable;
 
   public BusinessRuleTaskActivityBehavior() {}

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/ScriptTaskActivityBehavior.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/ScriptTaskActivityBehavior.java
@@ -45,7 +45,7 @@ public class ScriptTaskActivityBehavior extends TaskActivityBehavior {
   protected String script;
   protected String language;
   protected String resultVariable;
-  protected boolean storeScriptVariables = false; // https://activiti.atlassian.net/browse/ACT-1626
+  protected boolean storeScriptVariables; // https://activiti.atlassian.net/browse/ACT-1626
 
   public ScriptTaskActivityBehavior(String script, String language, String resultVariable) {
     this.script = script;

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/listener/ScriptExecutionListener.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/listener/ScriptExecutionListener.java
@@ -25,11 +25,11 @@ public class ScriptExecutionListener implements ExecutionListener {
 
   private Expression script;
 
-	private Expression language = null;
+  private Expression language;
 
-	private Expression resultVariable = null;
+  private Expression resultVariable;
 
-	@Override
+  @Override
   public void notify(DelegateExecution execution) {
     
 		if (script == null) {

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/listener/ScriptTaskListener.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/listener/ScriptTaskListener.java
@@ -25,13 +25,13 @@ import org.flowable.engine.delegate.TaskListener;
  */
 public class ScriptTaskListener implements TaskListener {
 
-	private static final long serialVersionUID = -8915149072830499057L;
+  private static final long serialVersionUID = -8915149072830499057L;
 
   protected Expression script;
 
-  protected Expression language = null;
+  protected Expression language;
 
-  protected Expression resultVariable = null;
+  protected Expression resultVariable;
   
   protected boolean autoStoreVariables;
 

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -424,7 +424,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
    * The time (in milliseconds) the async job (both timer and async continuations) acquisition thread will 
    * wait when the queueu is full to execute the next query. By default set to 0 (for backwards compatibility)
    */
-  protected int asyncExecutorDefaultQueueSizeFullWaitTime = 0;
+  protected int asyncExecutorDefaultQueueSizeFullWaitTime;
 
   /**
    * When a job is acquired, it is locked so other async executors can't lock
@@ -551,7 +551,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
    * hence the reason why it is disabled by default. If your platform allows 
    * the use of StaxSource during XML parsing, do enable it.
    */
-  protected boolean enableSafeBpmnXml = false;
+  protected boolean enableSafeBpmnXml;
   
   /**
    * The following settings will determine the amount of entities loaded at once when the engine 
@@ -584,7 +584,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   protected FlowableEventDispatcher eventDispatcher;
   
   // Event logging to database
-  protected boolean enableDatabaseEventLogging = false;
+  protected boolean enableDatabaseEventLogging;
   
   /**
    * Using field injection together with a delegate expression for a service
@@ -604,7 +604,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
    */
   protected int maxLengthStringVariableType = 4000;
   
-  protected boolean enableProcessDefinitionInfoCache = false;
+  protected boolean enableProcessDefinitionInfoCache;
   
   // Flowable 5 backwards compatibility handler
   protected Flowable5CompatibilityHandler flowable5CompatibilityHandler;

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cfg/standalone/StandaloneMybatisTransactionContext.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cfg/standalone/StandaloneMybatisTransactionContext.java
@@ -39,7 +39,7 @@ public class StandaloneMybatisTransactionContext implements TransactionContext {
   private static Logger log = LoggerFactory.getLogger(StandaloneMybatisTransactionContext.class);
 
   protected CommandContext commandContext;
-  protected Map<TransactionState,List<TransactionListener>> stateTransactionListeners = null;
+  protected Map<TransactionState,List<TransactionListener>> stateTransactionListeners;
   
   public StandaloneMybatisTransactionContext(CommandContext commandContext) {
     this.commandContext = commandContext;

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cmd/AbstractSetProcessDefinitionStateCmd.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cmd/AbstractSetProcessDefinitionStateCmd.java
@@ -45,7 +45,7 @@ public abstract class AbstractSetProcessDefinitionStateCmd implements Command<Vo
   protected String processDefinitionId;
   protected String processDefinitionKey;
   protected ProcessDefinitionEntity processDefinitionEntity;
-  protected boolean includeProcessInstances = false;
+  protected boolean includeProcessInstances;
   protected Date executionDate;
   protected String tenantId;
 

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cmd/GetEventLogEntriesCmd.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cmd/GetEventLogEntriesCmd.java
@@ -23,9 +23,9 @@ import org.activiti.engine.impl.interceptor.CommandContext;
  */
 public class GetEventLogEntriesCmd implements Command<List<EventLogEntry>> {
 	
-  protected String processInstanceId = null;
-	protected Long startLogNr = null;
-	protected Long pageSize = null;
+  protected String processInstanceId;
+	protected Long startLogNr;
+	protected Long pageSize;
 	
 	public GetEventLogEntriesCmd() {
 		

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/db/DbIdGenerator.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/db/DbIdGenerator.java
@@ -25,7 +25,7 @@ import org.activiti.engine.impl.interceptor.CommandExecutor;
 public class DbIdGenerator implements IdGenerator {
 
   protected int idBlockSize;
-  protected long nextId = 0;
+  protected long nextId;
   protected long lastId = -1;
   
   protected CommandExecutor commandExecutor;

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/db/ListQueryParameterObject.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/db/ListQueryParameterObject.java
@@ -20,7 +20,7 @@ package org.activiti.engine.impl.db;
 public class ListQueryParameterObject {
   
   protected int maxResults = Integer.MAX_VALUE;
-  protected int firstResult = 0;
+  protected int firstResult;
   protected Object parameter;
   protected String databaseType;
   

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/interceptor/CommandContext.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/interceptor/CommandContext.java
@@ -74,7 +74,7 @@ public class CommandContext {
   protected TransactionContext transactionContext;
   protected Map<Class< ? >, SessionFactory> sessionFactories;
   protected Map<Class< ? >, Session> sessions = new HashMap<Class< ? >, Session>();
-  protected Throwable exception = null;
+  protected Throwable exception;
   protected LinkedList<AtomicOperation> nextOperations = new LinkedList<AtomicOperation>();
   protected ProcessEngineConfigurationImpl processEngineConfiguration;
   protected FailedJobCommandFactory failedJobCommandFactory;

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/jobexecutor/TimerDeclarationImpl.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/jobexecutor/TimerDeclarationImpl.java
@@ -41,7 +41,7 @@ public class TimerDeclarationImpl implements Serializable {
   protected Expression calendarNameExpression;
 
   protected String jobHandlerType;
-  protected String jobHandlerConfiguration = null;
+  protected String jobHandlerConfiguration;
   protected String repeat;
   protected boolean exclusive = TimerJobEntity.DEFAULT_EXCLUSIVE;
   protected int retries = TimerJobEntity.DEFAULT_RETRIES;

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/AbstractJobEntity.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/AbstractJobEntity.java
@@ -45,16 +45,16 @@ public abstract class AbstractJobEntity implements Job, PersistentObject, HasRev
 
   protected Date duedate;
 
-  protected String executionId = null;
-  protected String processInstanceId = null;
-  protected String processDefinitionId = null;
+  protected String executionId;
+  protected String processInstanceId;
+  protected String processDefinitionId;
 
   protected boolean isExclusive = DEFAULT_EXCLUSIVE;
 
   protected int retries = DEFAULT_RETRIES;
 
-  protected String jobHandlerType = null;
-  protected String jobHandlerConfiguration = null;
+  protected String jobHandlerType;
+  protected String jobHandlerConfiguration;
   protected int maxIterations;
   protected String repeat;
   protected Date endDate;

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ByteArrayRef.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ByteArrayRef.java
@@ -24,7 +24,7 @@ public final class ByteArrayRef implements Serializable {
   private String id;
   private String name;
   private ByteArrayEntity entity;
-  protected boolean deleted = false;
+  protected boolean deleted;
 
   public ByteArrayRef() {
   }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntity.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntity.java
@@ -95,10 +95,10 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
   protected FlowElement currentFlowElement;
   
   /** current transition.  is null when there is no transition being taken. */
-  protected TransitionImpl transition = null;
+  protected TransitionImpl transition;
   
   /** transition that will be taken.  is null when there is no transition being taken. */
-  protected TransitionImpl transitionBeingTaken = null;
+  protected TransitionImpl transitionBeingTaken;
 
   /** the process instance.  this is the root of the execution tree.  
    * the processInstance of a process instance is a self reference. */
@@ -139,15 +139,15 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
    * </ul>*/ 
   protected boolean isActive = true;
   protected boolean isScope = true;
-  protected boolean isConcurrent = false;
-  protected boolean isEnded = false;
-  protected boolean isEventScope = false;
+  protected boolean isConcurrent;
+  protected boolean isEnded;
+  protected boolean isEventScope;
   
   // events ///////////////////////////////////////////////////////////////////
   
   protected String eventName;
   protected PvmProcessElement eventSource;
-  protected int executionListenerIndex = 0;
+  protected int executionListenerIndex;
   
   // associated entities /////////////////////////////////////////////////////
   
@@ -179,7 +179,7 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
    * @see AtomicOperation
    * @see #performOperation(AtomicOperation) */
   protected AtomicOperation nextOperation;
-  protected boolean isOperating = false;
+  protected boolean isOperating;
 
   protected int revision = 1;
   protected int suspensionState = SuspensionState.ACTIVE.getStateCode();

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/JobEntity.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/JobEntity.java
@@ -31,8 +31,8 @@ public class JobEntity extends AbstractJobEntity {
 
   private static final long serialVersionUID = 1L;
 
-  protected String lockOwner = null;
-  protected Date lockExpirationTime = null;
+  protected String lockOwner;
+  protected Date lockExpirationTime;
   
   public JobEntity() {}
   

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ProcessDefinitionEntity.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ProcessDefinitionEntity.java
@@ -62,7 +62,7 @@ public class ProcessDefinitionEntity extends ProcessDefinitionImpl implements Pr
   protected Map<String, Object> variables;
   protected boolean hasStartFormKey;
   protected int suspensionState = SuspensionState.ACTIVE.getStateCode();
-  protected boolean isIdentityLinksInitialized = false;
+  protected boolean isIdentityLinksInitialized;
   protected List<IdentityLinkEntity> definitionIdentityLinkEntities = new ArrayList<IdentityLinkEntity>();
   protected Set<Expression> candidateStarterUserIdExpressions = new HashSet<Expression>();
   protected Set<Expression> candidateStarterGroupIdExpressions = new HashSet<Expression>();

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ResourceEntity.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ResourceEntity.java
@@ -29,7 +29,7 @@ public class ResourceEntity implements PersistentObject, Serializable {
   protected String name;
   protected byte[] bytes;
   protected String deploymentId;
-  protected boolean generated = false;
+  protected boolean generated;
   
   public String getId() {
     return id;

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/TaskEntity.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/TaskEntity.java
@@ -79,7 +79,7 @@ public class TaskEntity extends VariableScopeImpl implements Task, DelegateTask,
   protected int suspensionState = SuspensionState.ACTIVE.getStateCode();
   protected String category;
   
-  protected boolean isIdentityLinksInitialized = false;
+  protected boolean isIdentityLinksInitialized;
   protected List<IdentityLinkEntity> taskIdentityLinkEntities = new ArrayList<IdentityLinkEntity>(); 
   
   protected String executionId;

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/VariableInstanceEntity.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/VariableInstanceEntity.java
@@ -52,7 +52,7 @@ public class VariableInstanceEntity extends AbstractEntity implements VariableIn
 
   protected Object cachedValue;
   protected boolean forcedUpdate;
-  protected boolean deleted = false;
+  protected boolean deleted;
   
   // Default constructor for SQL mapping
   protected VariableInstanceEntity() {

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/VariableScopeImpl.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/VariableScopeImpl.java
@@ -54,7 +54,7 @@ public abstract class VariableScopeImpl implements Serializable, VariableScope {
   
   protected ELContext cachedElContext;
 
-  protected String id = null;
+  protected String id;
 
   protected abstract List<VariableInstanceEntity> loadVariableInstances();
   protected abstract VariableScopeImpl getParentVariableScope();

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/pvm/runtime/ExecutionImpl.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/pvm/runtime/ExecutionImpl.java
@@ -68,7 +68,7 @@ public class ExecutionImpl implements
   protected FlowElement currentFlowElement;
   
   /** current transition.  is null when there is no transition being taken. */
-  protected TransitionImpl transition = null;
+  protected TransitionImpl transition;
 
   /** the process instance.  this is the root of the execution tree.  
    * the processInstance of a process instance is a self reference. */
@@ -101,17 +101,17 @@ public class ExecutionImpl implements
    * </ul>*/ 
   protected boolean isActive = true;
   protected boolean isScope = true;
-  protected boolean isConcurrent = false;
-  protected boolean isEnded = false;
-  protected boolean isEventScope = false;
+  protected boolean isConcurrent;
+  protected boolean isEnded;
+  protected boolean isEventScope;
   
-  protected Map<String, Object> variables = null;
+  protected Map<String, Object> variables;
   
   // events ///////////////////////////////////////////////////////////////////
   
   protected String eventName;
   protected PvmProcessElement eventSource;
-  protected int executionListenerIndex = 0;
+  protected int executionListenerIndex;
     
   // cascade deletion ////////////////////////////////////////////////////////
   
@@ -133,7 +133,7 @@ public class ExecutionImpl implements
    * @see AtomicOperation
    * @see #performOperation(AtomicOperation) */
   protected AtomicOperation nextOperation;
-  protected boolean isOperating = false;
+  protected boolean isOperating;
 
   /* Default constructor for ibatis/jpa/etc. */
   public ExecutionImpl() {    

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/repository/DeploymentBuilderImpl.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/repository/DeploymentBuilderImpl.java
@@ -44,7 +44,7 @@ public class DeploymentBuilderImpl implements DeploymentBuilder, Serializable {
   protected DeploymentEntity deployment = new DeploymentEntity();
   protected boolean isBpmn20XsdValidationEnabled = true;
   protected boolean isProcessValidationEnabled = true;
-  protected boolean isDuplicateFilterEnabled = false;
+  protected boolean isDuplicateFilterEnabled;
   protected Date processDefinitionsActivationDate;
 
   public DeploymentBuilderImpl(RepositoryServiceImpl repositoryService) {

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/variable/EntityMetaData.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/variable/EntityMetaData.java
@@ -23,7 +23,7 @@ import java.lang.reflect.Method;
  */
 public class EntityMetaData {
 
-  private boolean isJPAEntity = false;
+  private boolean isJPAEntity;
   private Class< ? > entityClass;
   private Method idMethod;
   private Field idField;

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/variable/JPAEntityListVariableType.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/variable/JPAEntityListVariableType.java
@@ -28,7 +28,7 @@ public class JPAEntityListVariableType implements VariableType, CacheableVariabl
   
   protected JPAEntityMappings mappings;
   
-  protected boolean forceCachedValue = false;
+  protected boolean forceCachedValue;
   
   public JPAEntityListVariableType() {
     mappings = new JPAEntityMappings();

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/variable/JPAEntityVariableType.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/variable/JPAEntityVariableType.java
@@ -31,7 +31,7 @@ public class JPAEntityVariableType implements VariableType, CacheableVariable {
   
   private JPAEntityMappings mappings;
   
-  private boolean forceCacheable = false;
+  private boolean forceCacheable;
   
   public JPAEntityVariableType() {
     mappings = new JPAEntityMappings();

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/logging/LogMDC.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/logging/LogMDC.java
@@ -17,7 +17,7 @@ public class LogMDC {
   public static final String LOG_MDC_BUSINESS_KEY = "mdcBusinessKey";
   public static final String LOG_MDC_TASK_ID = "mdcTaskId";
 
-  static boolean enabled = false;
+  static boolean enabled;
 
   public static boolean isMDCEnabled() {
     return enabled;

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/repository/DiagramElement.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/repository/DiagramElement.java
@@ -24,7 +24,7 @@ public abstract class DiagramElement implements Serializable {
 
   private static final long serialVersionUID = 1L;
   
-  protected String id = null;
+  protected String id;
 
   public DiagramElement() {
   }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/repository/DiagramNode.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/repository/DiagramNode.java
@@ -22,10 +22,10 @@ public class DiagramNode extends DiagramElement {
 
   private static final long serialVersionUID = 1L;
 
-  private Double x = null;
-  private Double y = null;
-  private Double width = null;
-  private Double height = null;
+  private Double x;
+  private Double y;
+  private Double width;
+  private Double height;
 
   public DiagramNode() {
     super();

--- a/modules/flowable5-spring/src/main/java/org/activiti/spring/SpringProcessEngineConfiguration.java
+++ b/modules/flowable5-spring/src/main/java/org/activiti/spring/SpringProcessEngineConfiguration.java
@@ -49,7 +49,7 @@ public class SpringProcessEngineConfiguration extends ProcessEngineConfiguration
   protected Resource[] deploymentResources = new Resource[0];
   protected String deploymentMode = "default";
   protected ApplicationContext applicationContext;
-  protected Integer transactionSynchronizationAdapterOrder = null;
+  protected Integer transactionSynchronizationAdapterOrder;
   private Collection<AutoDeploymentStrategy> deploymentStrategies = new ArrayList<AutoDeploymentStrategy>();
 
   public SpringProcessEngineConfiguration() {


### PR DESCRIPTION
Addresses issue #5 from the [standards forum post](http://forum.flowable.org/t/coding-style-and-standards/154).  As per comment in the thread the change is only for class variables.