### PR TITLE
Fix misordered arguments to assertXXX()

### DIFF
--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/CustomConfigRuntimeTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/CustomConfigRuntimeTest.java
@@ -59,8 +59,8 @@ public class CustomConfigRuntimeTest {
         processVariablesInput.put("input1", localDate.toDate());
         RuleEngineExecutionResult result = ruleService.executeDecisionByKey("decision", processVariablesInput);
         Assert.assertNotNull(result);
-        Assert.assertSame(result.getResultVariables().get("output1").getClass(), String.class);
-        Assert.assertEquals(result.getResultVariables().get("output1"), "test2");
+        Assert.assertSame(String.class, result.getResultVariables().get("output1").getClass());
+        Assert.assertEquals("test2", result.getResultVariables().get("output1"));
     }
 
     @Test

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/RuntimeTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/RuntimeTest.java
@@ -34,10 +34,10 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
         processVariablesInput.put("input1", 10);
         RuleEngineExecutionResult result = ruleService.executeDecisionByKey("decision", processVariablesInput);
         Assert.assertNotNull(result);
-        Assert.assertSame(result.getResultVariables().get("output1").getClass(), String.class);
-        Assert.assertEquals(result.getResultVariables().get("output1"), "test3");
-        Assert.assertSame(result.getResultVariables().get("output2").getClass(), Double.class);
-        Assert.assertEquals(result.getResultVariables().get("output2"), 3D);
+        Assert.assertSame(String.class, result.getResultVariables().get("output1").getClass());
+        Assert.assertEquals("test3", result.getResultVariables().get("output1"));
+        Assert.assertSame(Double.class, result.getResultVariables().get("output2").getClass());
+        Assert.assertEquals(3D, result.getResultVariables().get("output2"));
     }
 
     @Test
@@ -51,8 +51,8 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
         processVariablesInput.put("input1", localDate.toDate());
         RuleEngineExecutionResult result = ruleService.executeDecisionByKey("decision", processVariablesInput);
         Assert.assertNotNull(result);
-        Assert.assertSame(result.getResultVariables().get("output1").getClass(), String.class);
-        Assert.assertEquals(result.getResultVariables().get("output1"), "test2");
+        Assert.assertSame(String.class, result.getResultVariables().get("output1").getClass());
+        Assert.assertEquals("test2", result.getResultVariables().get("output1"));
     }
 
     @Test
@@ -66,8 +66,8 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
         processVariablesInput.put("input1", localDate.toDate());
         RuleEngineExecutionResult result = ruleService.executeDecisionByKey("decision", processVariablesInput);
         Assert.assertNotNull(result);
-        Assert.assertSame(result.getResultVariables().get("output1").getClass(), String.class);
-        Assert.assertEquals(result.getResultVariables().get("output1"), "test2");
+        Assert.assertSame(String.class, result.getResultVariables().get("output1").getClass());
+        Assert.assertEquals("test2", result.getResultVariables().get("output1"));
     }
 
     @Test
@@ -81,8 +81,8 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
         processVariablesInput.put("input1", localDate.toDate());
         RuleEngineExecutionResult result = ruleService.executeDecisionByKey("decision", processVariablesInput);
         Assert.assertNotNull(result);
-        Assert.assertSame(result.getResultVariables().get("output1").getClass(), String.class);
-        Assert.assertEquals(result.getResultVariables().get("output1"), "test2");
+        Assert.assertSame(String.class, result.getResultVariables().get("output1").getClass());
+        Assert.assertEquals("test2", result.getResultVariables().get("output1"));
     }
 
     @Test
@@ -94,7 +94,7 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
         RuleEngineExecutionResult result = ruleService.executeDecisionByKey("decision", processVariablesInput);
         Assert.assertNotNull(result);
         Assert.assertSame(String.class, result.getResultVariables().get("output1").getClass());
-        Assert.assertEquals(result.getResultVariables().get("output1"), "test1");
+        Assert.assertEquals("test1", result.getResultVariables().get("output1"));
     }
 
     @Test
@@ -108,7 +108,7 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
         RuleEngineExecutionResult result = ruleService.executeDecisionByKey("decision", processVariablesInput);
         Assert.assertNotNull(result);
         Assert.assertSame(String.class, result.getResultVariables().get("output1").getClass());
-        Assert.assertEquals(result.getResultVariables().get("output1"), "test2");
+        Assert.assertEquals("test2", result.getResultVariables().get("output1"));
     }
 
     @Test
@@ -120,7 +120,7 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
         RuleEngineExecutionResult result = ruleService.executeDecisionByKey("decision", processVariablesInput);
         Assert.assertNotNull(result);
         Assert.assertSame(Double.class, result.getResultVariables().get("output1").getClass());
-        Assert.assertEquals(result.getResultVariables().get("output1"), 5D);
+        Assert.assertEquals(5D, result.getResultVariables().get("output1"));
     }
 
     @Test
@@ -194,8 +194,8 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
         processVariablesInput.put("input1", null);
         RuleEngineExecutionResult result = ruleService.executeDecisionByKey("decision", processVariablesInput);
         Assert.assertNotNull(result);
-        Assert.assertSame(result.getResultVariables().get("output1").getClass(), String.class);
-        Assert.assertEquals(result.getResultVariables().get("output1"), "test2");
+        Assert.assertSame(String.class, result.getResultVariables().get("output1").getClass());
+        Assert.assertEquals("test2", result.getResultVariables().get("output1"));
     }
 
     @Test
@@ -209,8 +209,8 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
         processVariablesInput.put("date", localDate.toDate());
         RuleEngineExecutionResult result = ruleService.executeDecisionByKey("decision", processVariablesInput);
         Assert.assertNotNull(result);
-        Assert.assertSame(result.getResultVariables().get("output1").getClass(), String.class);
-        Assert.assertEquals(result.getResultVariables().get("output1"), "test2");
+        Assert.assertSame(String.class, result.getResultVariables().get("output1").getClass());
+        Assert.assertEquals("test2", result.getResultVariables().get("output1"));
     }
 
     @Test
@@ -222,8 +222,8 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
         processVariablesInput.put("output1", 0);
         RuleEngineExecutionResult result = ruleService.executeDecisionByKey("decision", processVariablesInput);
         Assert.assertNotNull(result);
-        Assert.assertSame(result.getResultVariables().get("output1").getClass(), Double.class);
-        Assert.assertEquals(result.getResultVariables().get("output1"), 30D);
+        Assert.assertSame(Double.class, result.getResultVariables().get("output1").getClass());
+        Assert.assertEquals(30D, result.getResultVariables().get("output1"));
     }
 
     @Test
@@ -236,7 +236,7 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
         
         RuleEngineExecutionResult result = ruleService.executeDecisionByKey("OrderCalculation", processVariablesInput);
         Assert.assertNotNull(result);
-        Assert.assertEquals(result.getResultVariables().get("totalordersum"), 100000D);
+        Assert.assertEquals(100000D, result.getResultVariables().get("totalordersum"));
     }
 
     @Test
@@ -250,7 +250,7 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
         processVariablesInput.put("amountDue", null);
         RuleEngineExecutionResult result = ruleService.executeDecisionByKey("RiskAssessmentUpdated", processVariablesInput);
         Assert.assertNotNull(result);
-        Assert.assertEquals(result.getResultVariables().get("addedPerc"), 15D);
+        Assert.assertEquals(15D, result.getResultVariables().get("addedPerc"));
     }
 
     @Test

--- a/modules/flowable-dmn-json-converter/src/test/java/org/flowable/editor/dmn/converter/DmnJsonConverterTest.java
+++ b/modules/flowable-dmn-json-converter/src/test/java/org/flowable/editor/dmn/converter/DmnJsonConverterTest.java
@@ -255,12 +255,12 @@ public class DmnJsonConverterTest {
 
     List<DecisionRule> rules = dmnDefinition.getCurrentDecisionTable().getRules();
     Assert.assertNotNull(rules);
-    Assert.assertEquals(rules.size(), 1);
+    Assert.assertEquals(1, rules.size());
     Assert.assertNotNull(rules.get(0).getOutputEntries());
-    Assert.assertEquals(rules.get(0).getOutputEntries().size(), 3);
-    Assert.assertEquals(rules.get(0).getOutputEntries().get(0).getOutputClause().getId(), "outputExpression_14");
-    Assert.assertEquals(rules.get(0).getOutputEntries().get(1).getOutputClause().getId(), "outputExpression_13");
-    Assert.assertEquals(rules.get(0).getOutputEntries().get(2).getOutputClause().getId(), "outputExpression_15");
+    Assert.assertEquals(3, rules.get(0).getOutputEntries().size());
+    Assert.assertEquals("outputExpression_14", rules.get(0).getOutputEntries().get(0).getOutputClause().getId());
+    Assert.assertEquals("outputExpression_13", rules.get(0).getOutputEntries().get(1).getOutputClause().getId());
+    Assert.assertEquals("outputExpression_15", rules.get(0).getOutputEntries().get(2).getOutputClause().getId());
   }
 
   /* Helper methods */

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ProcessInstanceEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ProcessInstanceEventsTest.java
@@ -564,8 +564,8 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
     
     runtimeService.deleteProcessInstance(processInstance.getId(), "testing instance deletion");
     
-    assertEquals("Task cancelled event has to be fired.", this.listener.getEventsReceived().get(0).getType(), FlowableEngineEventType.ACTIVITY_CANCELLED);
-    assertEquals("SubProcess cancelled event has to be fired.", this.listener.getEventsReceived().get(2).getType(), FlowableEngineEventType.PROCESS_CANCELLED);
+    assertEquals("Task cancelled event has to be fired.", FlowableEngineEventType.ACTIVITY_CANCELLED, this.listener.getEventsReceived().get(0).getType());
+    assertEquals("SubProcess cancelled event has to be fired.", FlowableEngineEventType.PROCESS_CANCELLED, this.listener.getEventsReceived().get(2).getType());
     assertEquals(0, runtimeService.createProcessInstanceQuery().count());
     assertEquals(0, taskService.createTaskQuery().count());
   }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoryServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoryServiceTest.java
@@ -145,7 +145,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
     runtimeService.startProcessInstanceByKey("orderProcess");
     HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery().processDefinitionKey(processDefinitionKey).singleResult();
     assertNotNull(historicProcessInstance);
-    assertEquals(historicProcessInstance.getProcessDefinitionKey(), processDefinitionKey);
+    assertEquals(processDefinitionKey, historicProcessInstance.getProcessDefinitionKey());
     assertEquals("theStart", historicProcessInstance.getStartActivityId());
 
     // now complete the task to end the process instance

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/RuntimeServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/RuntimeServiceTest.java
@@ -426,7 +426,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
     runtimeService.trigger(execution.getId(), processVariables);
 
     Map<String, Object> variables = runtimeService.getVariables(processInstance.getId());
-    assertEquals(variables, processVariables);
+    assertEquals(processVariables, variables);
 
   }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/RuntimeVariablesTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/RuntimeVariablesTest.java
@@ -123,17 +123,17 @@ public class RuntimeVariablesTest extends PluggableFlowableTestCase {
     }
     
     List<VariableInstance> executionVariableInstances = runtimeService.getVariableInstancesByExecutionIds(executionIds);
-    assertEquals(executionVariableInstances.size(), 2);
-    assertEquals(executionVariableInstances.get(0).getName(), "executionVar");
-    assertEquals(executionVariableInstances.get(0).getValue() , "executionVar");
-    assertEquals(executionVariableInstances.get(1).getName(), "executionVar");
-    assertEquals(executionVariableInstances.get(1).getValue() , "executionVar");
+    assertEquals(2, executionVariableInstances.size());
+    assertEquals("executionVar", executionVariableInstances.get(0).getName());
+    assertEquals("executionVar", executionVariableInstances.get(0).getValue());
+    assertEquals("executionVar", executionVariableInstances.get(1).getName());
+    assertEquals("executionVar", executionVariableInstances.get(1).getValue());
     
     executionIds = new HashSet<String>();
     executionIds.add(processInstance.getId());
     executionVariableInstances = runtimeService.getVariableInstancesByExecutionIds(executionIds);
-    assertEquals(executionVariableInstances.size(), 1);
-    assertEquals(executionVariableInstances.get(0).getName(), "processVar");
-    assertEquals(executionVariableInstances.get(0).getValue() , "processVar");
+    assertEquals(1, executionVariableInstances.size());
+    assertEquals("processVar", executionVariableInstances.get(0).getName());
+    assertEquals("processVar", executionVariableInstances.get(0).getValue());
   }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskVariablesTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskVariablesTest.java
@@ -231,11 +231,11 @@ public class TaskVariablesTest extends PluggableFlowableTestCase {
     }
     
     List<VariableInstance> variableInstances = taskService.getVariableInstancesLocalByTaskIds(taskIds);
-    assertEquals(variableInstances.size(), 2);
-    assertEquals(variableInstances.get(0).getName(), "taskVar");
-    assertEquals(variableInstances.get(0).getValue() , "taskVar");
-    assertEquals(variableInstances.get(1).getName(), "taskVar");
-    assertEquals(variableInstances.get(1).getValue() , "taskVar");
+    assertEquals(2, variableInstances.size());
+    assertEquals("taskVar", variableInstances.get(0).getName());
+    assertEquals("taskVar", variableInstances.get(0).getValue());
+    assertEquals("taskVar", variableInstances.get(1).getName());
+    assertEquals("taskVar", variableInstances.get(1).getValue());
   }
 
   public static class MyVariable implements Serializable {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/TaskDueDateExtensionsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/TaskDueDateExtensionsTest.java
@@ -101,7 +101,7 @@ public class TaskDueDateExtensionsTest extends ResourceFlowableTestCase {
     Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
 
     assertNotNull(task.getDueDate());
-    assertEquals(task.getDueDate(), new Date(0));
+    assertEquals(new Date(0), task.getDueDate());
   }
 
   public static class CustomBusinessCalendar implements BusinessCalendar {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricVariableInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricVariableInstanceTest.java
@@ -334,16 +334,16 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
     Set<String> processInstanceIds = new HashSet<String>();
     processInstanceIds.add(processInstance.getId());
     List<HistoricVariableInstance> historicVariableInstances = historyService.createHistoricVariableInstanceQuery().executionIds(processInstanceIds).list();
-    assertEquals(historicVariableInstances.size(), 1);
-    assertEquals(historicVariableInstances.get(0).getVariableName(), "processVar");
-    assertEquals(historicVariableInstances.get(0).getValue() , "processVar");
+    assertEquals(1, historicVariableInstances.size());
+    assertEquals("processVar", historicVariableInstances.get(0).getVariableName());
+    assertEquals("processVar", historicVariableInstances.get(0).getValue());
     
     historicVariableInstances = historyService.createHistoricVariableInstanceQuery().executionIds(executionIds).excludeTaskVariables().list();
-    assertEquals(historicVariableInstances.size(), 2);
-    assertEquals(historicVariableInstances.get(0).getVariableName(), "executionVar");
-    assertEquals(historicVariableInstances.get(0).getValue() , "executionVar");
-    assertEquals(historicVariableInstances.get(1).getVariableName(), "executionVar");
-    assertEquals(historicVariableInstances.get(1).getValue() , "executionVar");
+    assertEquals(2, historicVariableInstances.size());
+    assertEquals("executionVar", historicVariableInstances.get(0).getVariableName());
+    assertEquals("executionVar", historicVariableInstances.get(0).getValue());
+    assertEquals("executionVar", historicVariableInstances.get(1).getVariableName());
+    assertEquals("executionVar", historicVariableInstances.get(1).getValue());
   }
 
   public void testHistoricVariableQueryByTaskIds() {
@@ -399,11 +399,11 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
     }
     
     List<HistoricVariableInstance> historicVariableInstances = historyService.createHistoricVariableInstanceQuery().taskIds(taskIds).list();
-    assertEquals(historicVariableInstances.size(), 2);
-    assertEquals(historicVariableInstances.get(0).getVariableName(), "taskVar");
-    assertEquals(historicVariableInstances.get(0).getValue() , "taskVar");
-    assertEquals(historicVariableInstances.get(1).getVariableName(), "taskVar");
-    assertEquals(historicVariableInstances.get(1).getValue() , "taskVar");
+    assertEquals(2, historicVariableInstances.size());
+    assertEquals("taskVar", historicVariableInstances.get(0).getVariableName());
+    assertEquals("taskVar", historicVariableInstances.get(0).getValue());
+    assertEquals("taskVar", historicVariableInstances.get(1).getVariableName());
+    assertEquals("taskVar", historicVariableInstances.get(1).getValue());
   }
 
   @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/impl/calendar/MapBusinessCalendarManagerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/impl/calendar/MapBusinessCalendarManagerTest.java
@@ -38,7 +38,7 @@ public class MapBusinessCalendarManagerTest extends TestCase {
     calendars.put("someKey", calendar);
     MapBusinessCalendarManager businessCalendarManager = new MapBusinessCalendarManager(calendars);
 
-    assertEquals(businessCalendarManager.getBusinessCalendar("someKey"), calendar);
+    assertEquals(calendar, businessCalendarManager.getBusinessCalendar("someKey"));
   }
 
   public void testInvalidCalendarNameRequest() {

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/shell/ShellTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/shell/ShellTaskTest.java
@@ -31,7 +31,7 @@ public class ShellTaskTest extends PluggableFlowableTestCase {
   }
 
   public void testOsDetection() throws Exception {
-    assertNotSame(osType, OsType.UNKOWN);
+    assertNotSame(OsType.UNKOWN, osType);
   }
 
   @Deployment

--- a/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-integration/src/test/java/org/flowable/test/spring/boot/IntegrationAutoConfigurationTest.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-integration/src/test/java/org/flowable/test/spring/boot/IntegrationAutoConfigurationTest.java
@@ -113,13 +113,13 @@ public class IntegrationAutoConfigurationTest {
                 .processDefinitionKey(integrationGatewayProcess)
                 .list();
         ProcessDefinition processDefinition = processDefinitionList.iterator().next();
-        Assert.assertEquals(processDefinition.getKey(), integrationGatewayProcess);
+        Assert.assertEquals(integrationGatewayProcess, processDefinition.getKey());
         Map<String, Object> vars = new HashMap<String, Object>();
         vars.put("customerId", 232);
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey(integrationGatewayProcess, vars);
         Assert.assertNotNull("the processInstance should not be null", processInstance);
-        Assert.assertEquals(applicationContext.getBean(InboundGatewayConfiguration.AnalysingService.class)
-                .getStringAtomicReference().get(), projectId);
+        Assert.assertEquals(projectId, applicationContext.getBean(InboundGatewayConfiguration.AnalysingService.class)
+                .getStringAtomicReference().get());
     }
 
     @Configuration


### PR DESCRIPTION
Addresses issue #49 from the [standards forum post](http://forum.flowable.org/t/coding-style-and-standards/154).