### PR TITLE
Fix spelling of eclipse perimeter argument

### DIFF
--- a/modules/flowable-bpmn-layout/src/main/java/org/flowable/bpmn/BpmnAutoLayout.java
+++ b/modules/flowable-bpmn-layout/src/main/java/org/flowable/bpmn/BpmnAutoLayout.java
@@ -236,7 +236,7 @@ public class BpmnAutoLayout {
       mxGeometry geometry = new mxGeometry(0.8, 1.0, eventSize, eventSize);
       geometry.setOffset(new mxPoint(-(eventSize / 2), -(eventSize / 2)));
       geometry.setRelative(true);
-      mxCell boundaryPort = new mxCell(null, geometry, "shape=ellipse;perimter=ellipsePerimeter");
+      mxCell boundaryPort = new mxCell(null, geometry, "shape=ellipse;perimeter=ellipsePerimeter");
       boundaryPort.setId("boundary-event-" + boundaryEvent.getId());
       boundaryPort.setVertex(true);
 


### PR DESCRIPTION
Change "shape=ellipse;perimter=ellipsePerimeter"  to "shape=ellipse;perimeter=ellipsePerimeter" based on  the fact the spelling of "perimter" looked wrong and the info on the web about mxgraph and [mxPerimeter](https://jgraph.github.io/mxgraph/docs/js-api/files/view/mxPerimeter-js.html).

Full disclosure: I did *not* test the change.