### PR TITLE
Fix serialization of rest QueryVariable class

### DIFF
--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/engine/variable/QueryVariable.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/engine/variable/QueryVariable.java
@@ -13,11 +13,14 @@
 
 package org.flowable.rest.service.api.engine.variable;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import org.flowable.engine.common.api.FlowableIllegalArgumentException;
 
 /**
  * @author Frederik Heremans
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class QueryVariable {
 
   private String name;
@@ -42,6 +45,10 @@ public class QueryVariable {
 
   public void setOperation(String operation) {
     this.operation = operation;
+  }
+
+  public String getOperation() {
+    return operation;
   }
 
   public Object getValue() {

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/api/engine/variable/QueryVariableTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/api/engine/variable/QueryVariableTest.java
@@ -1,0 +1,46 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.flowable.rest.api.engine.variable;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.flowable.rest.service.BaseSpringRestTestCase;
+import org.flowable.rest.service.api.engine.variable.QueryVariable;
+
+public class QueryVariableTest extends BaseSpringRestTestCase {
+
+    protected ObjectMapper objectMapper = new ObjectMapper();
+
+    public void testSerializeQueryVariable() throws Exception {
+        // Create a QueryVariable
+        QueryVariable origQueryVariable = new QueryVariable();
+        origQueryVariable.setName("name");
+        origQueryVariable.setOperation("notEquals");
+        origQueryVariable.setType("type");
+        origQueryVariable.setValue("value");
+        // Check that the "operation" is valid
+        assertEquals("notEquals", origQueryVariable.getOperation());
+        assertEquals(QueryVariable.QueryVariableOperation.NOT_EQUALS, origQueryVariable.getVariableOperation());
+
+        // Serialize
+        JsonNode jsonNode = objectMapper.convertValue(origQueryVariable, JsonNode.class);
+
+        // Reconstitute the QueryVariable
+        QueryVariable newQueryVariable = objectMapper.convertValue(jsonNode, QueryVariable.class);
+        // Recheck the "operation"
+        assertEquals(QueryVariable.QueryVariableOperation.NOT_EQUALS, origQueryVariable.getVariableOperation());
+        assertEquals("notEquals", origQueryVariable.getOperation());
+    }
+}


### PR DESCRIPTION
The class org.flowable.rest.service.api.engine.variable..QueryVariable.java has two problems.

First, the `setOperation()` method is missing so when serializing the `QueryRequest` object with
JSONNode  the operation property is not present and instead only the `variableOperation` property exists.  So before the change `getOperation()` returns null and after the change the appropriate value is returned.

Second, after adding `setOperation()`, the reconstituting the object throws an exception about the `variableOperation` property:

```java
java.lang.IllegalArgumentException: Unrecognized field "variableOperation" (class org.flowable.rest.service.api.engine.variable.QueryVariable), not marked as ignorable (4 known properties: "value", "type", "name", "operation"])
 at [Source: N/A; line: -1, column: -1] (through reference chain: org.flowable.rest.service.api.engine.variable.QueryVariable["variableOperation"])
```
Fixed this issue by adding `@JsonIgnoreProperties(ignoreUnknown = true)`.