### PR TITLE
Fix misused && with ||

### DIFF
--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/util/BitMaskUtil.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/util/BitMaskUtil.java
@@ -43,7 +43,7 @@ public class BitMaskUtil {
    * @param bitNumber number of the bit to set to '1' (right first bit starting at 1).
    */
   public static int setBitOn(int value, int bitNumber) {
-    if(bitNumber <= 0 && bitNumber > 8) {
+    if(bitNumber <= 0 || bitNumber > 8) {
       throw new IllegalArgumentException("Only bits 1 through 8 are supported");
     }
     
@@ -57,7 +57,7 @@ public class BitMaskUtil {
    * @param bitNumber number of the bit to set to '0' (right first bit starting at 1).
    */
   public static int setBitOff(int value, int bitNumber) {
-    if(bitNumber <= 0 && bitNumber > 8) {
+    if(bitNumber <= 0 || bitNumber > 8) {
       throw new IllegalArgumentException("Only bits 1 through 8 are supported");
     }
     
@@ -71,7 +71,7 @@ public class BitMaskUtil {
    * @param bitNumber of bit to check (right first bit starting at 1)
    */
   public static boolean isBitOn(int value, int bitNumber) {
-    if(bitNumber <= 0 && bitNumber > 8) {
+    if(bitNumber <= 0 || bitNumber > 8) {
       throw new IllegalArgumentException("Only bits 1 through 8 are supported");
     }
     


### PR DESCRIPTION
Port the same change made in org.flowable.engine.common.impl.util.BitMaskUtil in the Version 6 code to the flowable5-engine module.

Not a big deal because it looks like the routines are never used.