### PR TITLE
Remove useless if test

### DIFF
--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricTaskInstanceBaseResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricTaskInstanceBaseResource.java
@@ -264,11 +264,7 @@ public class HistoricTaskInstanceBaseResource {
       switch (variable.getVariableOperation()) {
 
       case EQUALS:
-        if (nameLess) {
-          taskInstanceQuery.taskVariableValueEquals(actualValue);
-        } else {
-          taskInstanceQuery.taskVariableValueEquals(variable.getName(), actualValue);
-        }
+        taskInstanceQuery.taskVariableValueEquals(variable.getName(), actualValue);
         break;
 
       case EQUALS_IGNORE_CASE:


### PR DESCRIPTION
Remove the if test as the same variable is tested above at line 260 making the **then** branch of the **if** unneeded:

<pre>
      if (nameLess) {
        throw new FlowableIllegalArgumentException("Value-only query (without a variable-name) is not supported.");
      }
</pre>