### PR TITLE
Ambiguous use of null in exception message

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/RescheduleTimerJobCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/RescheduleTimerJobCmd.java
@@ -35,7 +35,7 @@ public class RescheduleTimerJobCmd implements Command<Void>, Serializable {
 
   public RescheduleTimerJobCmd(String timerJobId, String timeDate, String timeDuration, String timeCycle, String endDate, String calendarName) {
     if (timerJobId == null) {
-      throw new FlowableIllegalArgumentException("The timer job id is mandatory, but '" + timerJobId + "' has been provided.");
+      throw new FlowableIllegalArgumentException("The timer job id is mandatory, but 'null' has been provided.");
     }
     
     int timeValues = Collections.frequency(Arrays.asList(timeDate, timeDuration, timeCycle), null);


### PR DESCRIPTION
The exception message concatenates a known null value so simplify the message but including it as part of the literal message text.

Another alternative would be to reword the text but that option was not chosen.