### PR TITLE
Fix double check locking pattern

### DIFF
--- a/modules/flowable-engine-common/src/main/java/org/flowable/engine/common/impl/persistence/StrongUuidGenerator.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/engine/common/impl/persistence/StrongUuidGenerator.java
@@ -15,7 +15,7 @@ import com.fasterxml.uuid.impl.TimeBasedGenerator;
 public class StrongUuidGenerator implements IdGenerator {
 
   // different ProcessEngines on the same classloader share one generator.
-  protected static TimeBasedGenerator timeBasedGenerator;
+  protected static volatile TimeBasedGenerator timeBasedGenerator;
 
   public StrongUuidGenerator() {
     ensureGeneratorInitialized();

--- a/modules/flowable-ui-common/src/main/java/org/flowable/app/repository/UuidIdGenerator.java
+++ b/modules/flowable-ui-common/src/main/java/org/flowable/app/repository/UuidIdGenerator.java
@@ -17,7 +17,7 @@ import com.fasterxml.uuid.impl.TimeBasedGenerator;
 public class UuidIdGenerator {
 
   // different ProcessEngines on the same classloader share one generator.
-  protected static TimeBasedGenerator timeBasedGenerator;
+  protected static volatile TimeBasedGenerator timeBasedGenerator;
 
   public UuidIdGenerator() {
     ensureGeneratorInitialized();

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/StrongUuidGenerator.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/StrongUuidGenerator.java
@@ -15,7 +15,7 @@ import com.fasterxml.uuid.impl.TimeBasedGenerator;
 public class StrongUuidGenerator implements IdGenerator {
 
   // different ProcessEngines on the same classloader share one generator.
-  protected static TimeBasedGenerator timeBasedGenerator;
+  protected static volatile TimeBasedGenerator timeBasedGenerator;
 
   public StrongUuidGenerator() {
     ensureGeneratorInitialized();


### PR DESCRIPTION
Partially created objects can be returned by the Double Checked Locking pattern when used in Java. An optimizing JRE may assign a reference to the baz variable before it calls the constructor of the object the reference points to.

The fix is to make the variable 'volatile'.

For more details refer to [this JavaWord article]( http://www.javaworld.com/javaworld/jw-02-2001/jw-0209-double.html) or this [discussion](http://www.cs.umd.edu/~pugh/java/memoryModel/DoubleCheckedLocking.html).

This is the same fix as PR  #56 