### PR TITLE
Correct test for null

### DIFF
--- a/modules/flowable-idm-engine/src/main/java/org/flowable/idm/engine/impl/persistence/entity/UserEntityImpl.java
+++ b/modules/flowable-idm-engine/src/main/java/org/flowable/idm/engine/impl/persistence/entity/UserEntityImpl.java
@@ -72,7 +72,7 @@ public class UserEntityImpl extends AbstractEntity implements UserEntity, Serial
   }
 
   protected void savePicture(Picture picture) {
-    if (pictureByteArrayRef != null) {
+    if (pictureByteArrayRef == null) {
       pictureByteArrayRef = new ByteArrayRef();
     }
     pictureByteArrayRef.setValue(picture.getMimeType(), picture.getBytes());


### PR DESCRIPTION
See the diff that now allocates `pictureByteArrayRef` if null.  The original code could generate a NPE.