### PR TITLE
Remove local variable in return statement

### DIFF
--- a/modules/flowable-dmn-xml-converter/src/main/java/org/flowable/dmn/converter/util/DmnXMLUtil.java
+++ b/modules/flowable-dmn-xml-converter/src/main/java/org/flowable/dmn/converter/util/DmnXMLUtil.java
@@ -173,7 +173,7 @@ public class DmnXMLUtil implements DmnXMLConstants {
     }
     
     public static boolean writeExtensionElements(DmnElement dmnElement, boolean didWriteExtensionStartElement, XMLStreamWriter xtw) throws Exception {
-        return didWriteExtensionStartElement = writeExtensionElements(dmnElement, didWriteExtensionStartElement, null, xtw);
+        return writeExtensionElements(dmnElement, didWriteExtensionStartElement, null, xtw);
     }
     
     public static boolean writeExtensionElements(DmnElement dmnElement, boolean didWriteExtensionStartElement, Map<String, String> namespaceMap, XMLStreamWriter xtw) throws Exception {


### PR DESCRIPTION
Remove the assignment to the local variable `didWriteExtensionStartElement` in the return statement.

This now matches the similar routine in `org.flowable.bpmn.converter.util.BpmnXMLUtil.java` (lines 203-204) from which this code appears to have been derived.

<pre>
  public static boolean writeExtensionElements(BaseElement baseElement, boolean didWriteExtensionStartElement, XMLStreamWriter xtw) throws Exception {
    return writeExtensionElements(baseElement, didWriteExtensionStartElement, null, xtw);
  }
</pre>