### PR TITLE
Unreachable

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/NeedsActiveProcessDefinitionCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/NeedsActiveProcessDefinitionCmd.java
@@ -38,10 +38,6 @@ public abstract class NeedsActiveProcessDefinitionCmd<T> implements Command<T>, 
   public T execute(CommandContext commandContext) {
     ProcessDefinitionEntity processDefinition = ProcessDefinitionUtil.getProcessDefinitionFromDatabase(processDefinitionId);
 
-    if (processDefinition == null) {
-      throw new FlowableObjectNotFoundException("No process definition found for id = '" + processDefinitionId + "'", ProcessDefinition.class);
-    }
-
     if (processDefinition.isSuspended()) {
       throw new FlowableException("Cannot execute operation because process definition '" + processDefinition.getName() + "' (id=" + processDefinition.getId() + ") is suspended");
     }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/util/ProcessDefinitionUtil.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/util/ProcessDefinitionUtil.java
@@ -14,7 +14,6 @@ package org.flowable.engine.impl.util;
 
 import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.bpmn.model.Process;
-import org.flowable.engine.common.api.FlowableException;
 import org.flowable.engine.common.api.FlowableObjectNotFoundException;
 import org.flowable.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.flowable.engine.impl.context.Context;

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/util/ProcessDefinitionUtil.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/util/ProcessDefinitionUtil.java
@@ -15,6 +15,7 @@ package org.flowable.engine.impl.util;
 import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.bpmn.model.Process;
 import org.flowable.engine.common.api.FlowableException;
+import org.flowable.engine.common.api.FlowableObjectNotFoundException;
 import org.flowable.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.flowable.engine.impl.context.Context;
 import org.flowable.engine.impl.persistence.deploy.DeploymentManager;
@@ -93,9 +94,9 @@ public class ProcessDefinitionUtil {
     ProcessDefinitionEntityManager processDefinitionEntityManager = Context.getProcessEngineConfiguration().getProcessDefinitionEntityManager();
     ProcessDefinitionEntity processDefinition = processDefinitionEntityManager.findById(processDefinitionId);
     if (processDefinition == null) {
-      throw new FlowableException("No process definition found with id " + processDefinitionId);
+      throw new FlowableObjectNotFoundException("No process definition found with id " + processDefinitionId);
     }
-    
+
     return processDefinition;
   }
 }


### PR DESCRIPTION
The null check is unreachable in `NeedsActiveProcessDefinitionCmd` because the call to `ProcessDefinitionUtil.getProcessDefinitionFromDatabase` does the same check.

Also changed the exception in `ProcessDefinitionUtil.getProcessDefinitionFromDatabase` to be the more specific version.