### PR TITLE
Fix for setting message references in modeler.

### DIFF
--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/editor-app/configuration/properties-message-scope-controller.js
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/editor-app/configuration/properties-message-scope-controller.js
@@ -16,8 +16,9 @@ angular.module('flowableModeler').controller('ActivitiMessageRefCtrl', [ '$scope
     var messageDefinitionsProperty = undefined;
     var parent = $scope.selectedShape;
     while (parent !== null && parent !== undefined && messageDefinitionsProperty === undefined) {
-        if (parent.properties && parent.properties['oryx-messagedefinitions']) {
-            messageDefinitionsProperty = parent.properties['oryx-messagedefinitions'];
+        var messageDefProp = parent.properties ? parent.properties.toObject()['oryx-messagedefinitions'] : undefined;
+        if(messageDefProp) {
+            messageDefinitionsProperty = messageDefProp;
         } else {
             parent = parent.parent;
         }


### PR DESCRIPTION
The modeler's client-side code isn't properly parsing the value that populates the selection dropdown. This commit fixes that.

Fix typo.