### PR TITLE
Remove or fix useless object creation

### DIFF
--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/history/HistoryServiceTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/history/HistoryServiceTest.java
@@ -13,6 +13,8 @@
 
 package org.activiti.engine.test.api.history;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -35,8 +37,6 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.task.Task;
 import org.flowable.engine.task.TaskQuery;
 import org.flowable.engine.test.Deployment;
-
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * @author Frederik Heremans
@@ -281,11 +281,10 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
   @Deployment(resources = { "org/activiti/engine/test/api/oneTaskProcess.bpmn20.xml", "org/activiti/engine/test/api/runtime/oneTaskProcess2.bpmn20.xml" })
   public void testHistoricProcessInstanceQueryByDeploymentId() {
     org.flowable.engine.repository.Deployment deployment = repositoryService.createDeploymentQuery().singleResult();
-    HashSet<String> processInstanceIds = new HashSet<String>();
     for (int i = 0; i < 4; i++) {
-      processInstanceIds.add(runtimeService.startProcessInstanceByKey("oneTaskProcess", String.valueOf(i)).getId());
+      runtimeService.startProcessInstanceByKey("oneTaskProcess", String.valueOf(i)).getId();
     }
-    processInstanceIds.add(runtimeService.startProcessInstanceByKey("oneTaskProcess2", "1").getId());
+    runtimeService.startProcessInstanceByKey("oneTaskProcess2", "1").getId();
 
     HistoricProcessInstanceQuery processInstanceQuery = historyService.createHistoricProcessInstanceQuery().deploymentId(deployment.getId());
     assertEquals(5, processInstanceQuery.count());
@@ -302,11 +301,10 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
   @Deployment(resources = { "org/activiti/engine/test/api/oneTaskProcess.bpmn20.xml", "org/activiti/engine/test/api/runtime/oneTaskProcess2.bpmn20.xml" })
   public void testHistoricProcessInstanceQueryByDeploymentIdIn() {
     org.flowable.engine.repository.Deployment deployment = repositoryService.createDeploymentQuery().singleResult();
-    HashSet<String> processInstanceIds = new HashSet<String>();
     for (int i = 0; i < 4; i++) {
-      processInstanceIds.add(runtimeService.startProcessInstanceByKey("oneTaskProcess", String.valueOf(i)).getId());
+      runtimeService.startProcessInstanceByKey("oneTaskProcess", String.valueOf(i)).getId();
     }
-    processInstanceIds.add(runtimeService.startProcessInstanceByKey("oneTaskProcess2", "1").getId());
+    runtimeService.startProcessInstanceByKey("oneTaskProcess2", "1").getId();
 
     List<String> deploymentIds = new ArrayList<String>();
     deploymentIds.add(deployment.getId());
@@ -327,11 +325,10 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
   @Deployment(resources = { "org/activiti/engine/test/api/oneTaskProcess.bpmn20.xml", "org/activiti/engine/test/api/runtime/oneTaskProcess2.bpmn20.xml" })
   public void testHistoricTaskInstanceQueryByDeploymentId() {
     org.flowable.engine.repository.Deployment deployment = repositoryService.createDeploymentQuery().singleResult();
-    HashSet<String> processInstanceIds = new HashSet<String>();
     for (int i = 0; i < 4; i++) {
-      processInstanceIds.add(runtimeService.startProcessInstanceByKey("oneTaskProcess", String.valueOf(i)).getId());
+      runtimeService.startProcessInstanceByKey("oneTaskProcess", String.valueOf(i)).getId();
     }
-    processInstanceIds.add(runtimeService.startProcessInstanceByKey("oneTaskProcess2", "1").getId());
+    runtimeService.startProcessInstanceByKey("oneTaskProcess2", "1").getId();
 
     HistoricTaskInstanceQuery taskInstanceQuery = historyService.createHistoricTaskInstanceQuery().deploymentId(deployment.getId());
     assertEquals(5, taskInstanceQuery.count());
@@ -347,11 +344,10 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
   @Deployment(resources = { "org/activiti/engine/test/api/oneTaskProcess.bpmn20.xml", "org/activiti/engine/test/api/runtime/oneTaskProcess2.bpmn20.xml" })
   public void testHistoricTaskInstanceQueryByDeploymentIdIn() {
     org.flowable.engine.repository.Deployment deployment = repositoryService.createDeploymentQuery().singleResult();
-    HashSet<String> processInstanceIds = new HashSet<String>();
     for (int i = 0; i < 4; i++) {
-      processInstanceIds.add(runtimeService.startProcessInstanceByKey("oneTaskProcess", String.valueOf(i)).getId());
+      runtimeService.startProcessInstanceByKey("oneTaskProcess", String.valueOf(i)).getId();
     }
-    processInstanceIds.add(runtimeService.startProcessInstanceByKey("oneTaskProcess2", "1").getId());
+    runtimeService.startProcessInstanceByKey("oneTaskProcess2", "1").getId();
 
     List<String> deploymentIds = new ArrayList<String>();
     deploymentIds.add(deployment.getId());
@@ -375,11 +371,10 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
   @Deployment(resources = { "org/activiti/engine/test/api/oneTaskProcess.bpmn20.xml", "org/activiti/engine/test/api/runtime/oneTaskProcess2.bpmn20.xml" })
   public void testHistoricTaskInstanceOrQueryByDeploymentId() {
     org.flowable.engine.repository.Deployment deployment = repositoryService.createDeploymentQuery().singleResult();
-    HashSet<String> processInstanceIds = new HashSet<String>();
     for (int i = 0; i < 4; i++) {
-      processInstanceIds.add(runtimeService.startProcessInstanceByKey("oneTaskProcess", String.valueOf(i)).getId());
+      runtimeService.startProcessInstanceByKey("oneTaskProcess", String.valueOf(i)).getId();
     }
-    processInstanceIds.add(runtimeService.startProcessInstanceByKey("oneTaskProcess2", "1").getId());
+    runtimeService.startProcessInstanceByKey("oneTaskProcess2", "1").getId();
 
     HistoricTaskInstanceQuery taskInstanceQuery = historyService.createHistoricTaskInstanceQuery().or().deploymentId(deployment.getId()).endOr();
     assertEquals(5, taskInstanceQuery.count());
@@ -459,11 +454,10 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
   @Deployment(resources = { "org/activiti/engine/test/api/oneTaskProcess.bpmn20.xml", "org/activiti/engine/test/api/runtime/oneTaskProcess2.bpmn20.xml" })
   public void testHistoricTaskInstanceOrQueryByDeploymentIdIn() {
     org.flowable.engine.repository.Deployment deployment = repositoryService.createDeploymentQuery().singleResult();
-    HashSet<String> processInstanceIds = new HashSet<String>();
     for (int i = 0; i < 4; i++) {
-      processInstanceIds.add(runtimeService.startProcessInstanceByKey("oneTaskProcess", String.valueOf(i)).getId());
+      runtimeService.startProcessInstanceByKey("oneTaskProcess", String.valueOf(i)).getId();
     }
-    processInstanceIds.add(runtimeService.startProcessInstanceByKey("oneTaskProcess2", "1").getId());
+    runtimeService.startProcessInstanceByKey("oneTaskProcess2", "1").getId();
 
     List<String> deploymentIds = new ArrayList<String>();
     deploymentIds.add(deployment.getId());

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/runtime/RuntimeVariablesTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/runtime/RuntimeVariablesTest.java
@@ -116,10 +116,8 @@ public class RuntimeVariablesTest extends PluggableFlowableTestCase {
     }
     
     List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-    Set<String> taskIds = new HashSet<String>();
     for (Task task : tasks){
       taskService.setVariableLocal(task.getId(), "taskVar", "taskVar");
-      taskIds.add(task.getId());
     }
     
     List<VariableInstance> executionVariableInstances = runtimeService.getVariableInstancesByExecutionIds(executionIds);

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/task/TaskVariablesTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/task/TaskVariablesTest.java
@@ -215,11 +215,9 @@ public class TaskVariablesTest extends PluggableFlowableTestCase {
     processVars.put("processVar", "processVar");
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("variableScopeProcess", processVars);
     
-    Set<String> executionIds = new HashSet<String>();
     List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
     for (Execution execution : executions){
       if (!processInstance.getId().equals(execution.getId())){
-        executionIds.add(execution.getId());
         runtimeService.setVariableLocal(execution.getId(), "executionVar", "executionVar");
       }
     }

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/history/HistoricVariableInstanceTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/history/HistoricVariableInstanceTest.java
@@ -390,11 +390,9 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
     processVars.put("processVar", "processVar");
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("variableScopeProcess", processVars);
     
-    Set<String> executionIds = new HashSet<String>();
     List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
     for (Execution execution : executions){
       if (!processInstance.getId().equals(execution.getId())){
-        executionIds.add(execution.getId());
         runtimeService.setVariableLocal(execution.getId(), "executionVar", "executionVar");
       }
     }

--- a/modules/flowable5-test/src/test/java/org/activiti/examples/bpmn/servicetask/ExpressionServiceTaskTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/examples/bpmn/servicetask/ExpressionServiceTaskTest.java
@@ -37,10 +37,10 @@ public class ExpressionServiceTaskTest extends PluggableFlowableTestCase {
     assertNull(runtimeService.getVariable(pi2.getId(), "result"));
     
     Map<String,Object> variables3 = new HashMap<String, Object>();
-    variables3.put("bean", new ValueBean("ok"));
-    variables3.put("_ACTIVITI_SKIP_EXPRESSION_ENABLED", true);
-    ProcessInstance pi3 = runtimeService.startProcessInstanceByKey("setServiceResultToProcessVariablesWithSkipExpression", variables2);
-    assertNull(runtimeService.getVariable(pi3.getId(), "result"));
+    variables3.put("bean", new ValueBean("okBean"));
+    variables3.put("_ACTIVITI_SKIP_EXPRESSION_ENABLED", false);
+    ProcessInstance pi3 = runtimeService.startProcessInstanceByKey("setServiceResultToProcessVariablesWithSkipExpression", variables3);
+    assertEquals("okBean", runtimeService.getVariable(pi3.getId(), "result"));
   }
   
   @Deployment


### PR DESCRIPTION
Remove objects created where the value is never used.

In the process found that there was a cut-n-paste error in the `flowable5-test` module in the `org.activiti.examples.bpmn.servicetask.ExpressionServiceTaskTest` class where a variable was defined but not used.  Ported the version 6 version of the test method back to `flowable5-test`.