### PR TITLE
Fix cut-n-paste error in recently added test

### DIFF
--- a/modules/flowable-rest/src/test/java/org/flowable/rest/api/engine/variable/QueryVariableTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/api/engine/variable/QueryVariableTest.java
@@ -39,8 +39,8 @@ public class QueryVariableTest extends BaseSpringRestTestCase {
 
         // Reconstitute the QueryVariable
         QueryVariable newQueryVariable = objectMapper.convertValue(jsonNode, QueryVariable.class);
-        // Recheck the "operation"
-        assertEquals(QueryVariable.QueryVariableOperation.NOT_EQUALS, origQueryVariable.getVariableOperation());
-        assertEquals("notEquals", origQueryVariable.getOperation());
+        // Recheck the "operation" with the "new" variable
+        assertEquals(QueryVariable.QueryVariableOperation.NOT_EQUALS, newQueryVariable.getVariableOperation());
+        assertEquals("notEquals", newQueryVariable.getOperation());
     }
 }


### PR DESCRIPTION
Reporting and fixing my own error (egg on my face) that resulting from cut-n-paste of the `assert` tests. The second set of checks should be on the new deserialized version and not the original variable.   