### PR TITLE
update groovy version to 2.4.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -521,7 +521,7 @@
 			<dependency>
 				<groupId>org.codehaus.groovy</groupId>
 				<artifactId>groovy-all</artifactId>
-				<version>2.4.5</version>
+				<version>2.4.8</version>
 			</dependency>
 			<dependency>
 				<groupId>org.drools</groupId>


### PR DESCRIPTION
Arguments for upgrading:

- versions below 2.4.8 are affected by CVE-2016-6814
- 2.4.8 improves java 9 compatiblity

Note that the poms contained in  `modules\flowable-spring-boot` still use groovy 1.7.5, but I could not build them locally, so I did not try updating them.
