### PR TITLE
Misc. cleanup

### DIFF
--- a/modules/flowable-common-rest/src/main/java/org/flowable/rest/variable/StringRestVariableConverter.java
+++ b/modules/flowable-common-rest/src/main/java/org/flowable/rest/variable/StringRestVariableConverter.java
@@ -36,7 +36,7 @@ public class StringRestVariableConverter implements RestVariableConverter {
       if (!(result.getValue() instanceof String)) {
         throw new FlowableIllegalArgumentException("Converter can only convert strings");
       }
-      return (String) result.getValue();
+      return result.getValue();
     }
     return null;
   }

--- a/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/SimulationEventComparatorTest.java
+++ b/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/SimulationEventComparatorTest.java
@@ -12,8 +12,6 @@
  */
 package org.flowable.crystalball.simulator;
 
-import org.flowable.crystalball.simulator.SimulationEvent;
-import org.flowable.crystalball.simulator.SimulationEventComparator;
 import org.junit.Test;
 
 import java.util.Comparator;

--- a/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/impl/playback/AbstractPlaybackTest.java
+++ b/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/impl/playback/AbstractPlaybackTest.java
@@ -30,8 +30,6 @@ import org.flowable.crystalball.simulator.impl.SimulationProcessEngineFactory;
 import org.flowable.crystalball.simulator.impl.StartProcessByIdEventHandler;
 import org.flowable.crystalball.simulator.impl.clock.DefaultClockFactory;
 import org.flowable.crystalball.simulator.impl.clock.ThreadLocalClock;
-import org.flowable.crystalball.simulator.impl.playback.CheckStatus;
-import org.flowable.crystalball.simulator.impl.playback.PlaybackUserTaskCompleteEventHandler;
 import org.flowable.engine.ProcessEngineConfiguration;
 import org.flowable.engine.ProcessEngines;
 import org.flowable.engine.common.api.delegate.event.FlowableEvent;

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/EventSubscriptionQueryImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/EventSubscriptionQueryImpl.java
@@ -167,7 +167,7 @@ public class EventSubscriptionQueryImpl extends AbstractQuery<EventSubscriptionQ
   @SuppressWarnings({ "unchecked" })
   public List<EventSubscription> executeList(CommandContext commandContext, Page page) {
     checkQueryOk();
-    return (List<EventSubscription>) commandContext.getEventSubscriptionEntityManager().findEventSubscriptionsByQueryCriteria(this, page);
+    return commandContext.getEventSubscriptionEntityManager().findEventSubscriptionsByQueryCriteria(this, page);
   }
 
   // getters //////////////////////////////////////////

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/GetDataObjectsCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/GetDataObjectsCmd.java
@@ -107,7 +107,7 @@ public class GetDataObjectsCmd implements Command<Map<String, DataObject>>, Seri
       
       for (Entry<String, VariableInstance> entry : variables.entrySet()) {
         String name = entry.getKey();
-        VariableInstance variableEntity = (VariableInstance) entry.getValue();
+        VariableInstance variableEntity = entry.getValue();
 
         ExecutionEntity executionEntity = commandContext.getExecutionEntityManager().findById(variableEntity.getExecutionId());
         while (!executionEntity.isScope()) {

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/NeedsActiveProcessDefinitionCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/NeedsActiveProcessDefinitionCmd.java
@@ -15,7 +15,6 @@ package org.flowable.engine.impl.cmd;
 import java.io.Serializable;
 
 import org.flowable.engine.common.api.FlowableException;
-import org.flowable.engine.common.api.FlowableObjectNotFoundException;
 import org.flowable.engine.impl.interceptor.Command;
 import org.flowable.engine.impl.interceptor.CommandContext;
 import org.flowable.engine.impl.persistence.entity.ProcessDefinitionEntity;

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/event/logger/handler/TaskCompletedEventHandler.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/event/logger/handler/TaskCompletedEventHandler.java
@@ -17,7 +17,6 @@ import java.util.Map;
 
 import org.flowable.engine.common.api.delegate.event.FlowableEntityEvent;
 import org.flowable.engine.delegate.event.FlowableEntityWithVariablesEvent;
-import org.flowable.engine.impl.event.logger.handler.Fields;
 import org.flowable.engine.impl.interceptor.CommandContext;
 import org.flowable.engine.impl.persistence.entity.EventLogEntryEntity;
 import org.flowable.engine.impl.persistence.entity.TaskEntity;

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/compatibility/IntermediateTimerEventRepeatCompatibilityTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/compatibility/IntermediateTimerEventRepeatCompatibilityTest.java
@@ -22,7 +22,6 @@ import org.flowable.engine.runtime.Job;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.task.Task;
 import org.flowable.engine.test.Deployment;
-import org.flowable.engine.test.bpmn.event.timer.compatibility.TimerEventCompatibilityTest;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;

--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/ServiceTaskConverterTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/ServiceTaskConverterTest.java
@@ -44,24 +44,24 @@ public class ServiceTaskConverterTest extends AbstractConverterTest {
 
     List<FieldExtension> fields = serviceTask.getFieldExtensions();
     assertEquals(2, fields.size());
-    FieldExtension field = (FieldExtension) fields.get(0);
+    FieldExtension field = fields.get(0);
     assertEquals("testField", field.getFieldName());
     assertEquals("test", field.getStringValue());
-    field = (FieldExtension) fields.get(1);
+    field = fields.get(1);
     assertEquals("testField2", field.getFieldName());
     assertEquals("${test}", field.getExpression());
 
     List<FlowableListener> listeners = serviceTask.getExecutionListeners();
     assertEquals(3, listeners.size());
-    FlowableListener listener = (FlowableListener) listeners.get(0);
+    FlowableListener listener = listeners.get(0);
     assertEquals(ImplementationType.IMPLEMENTATION_TYPE_CLASS, listener.getImplementationType());
     assertEquals("org.test.TestClass", listener.getImplementation());
     assertEquals("start", listener.getEvent());
-    listener = (FlowableListener) listeners.get(1);
+    listener = listeners.get(1);
     assertEquals(ImplementationType.IMPLEMENTATION_TYPE_EXPRESSION, listener.getImplementationType());
     assertEquals("${testExpression}", listener.getImplementation());
     assertEquals("end", listener.getEvent());
-    listener = (FlowableListener) listeners.get(2);
+    listener = listeners.get(2);
     assertEquals(ImplementationType.IMPLEMENTATION_TYPE_DELEGATEEXPRESSION, listener.getImplementationType());
     assertEquals("${delegateExpression}", listener.getImplementation());
     assertEquals("start", listener.getEvent());

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/service/editor/ModelServiceImpl.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/service/editor/ModelServiceImpl.java
@@ -579,7 +579,7 @@ public class ModelServiceImpl implements ModelService {
     for (ModelRelation persistedModelRelation : persistedModelRelations) {
       if (!idsReferencedInJson.contains(persistedModelRelation.getModelId())) {
         // model used to be referenced, but not anymore. Delete it.
-        modelRelationRepository.delete((ModelRelation) persistedModelRelation);
+        modelRelationRepository.delete(persistedModelRelation);
       } else {
         alreadyPersistedModelIds.add(persistedModelRelation.getModelId());
       }

--- a/modules/flowable-ui-task/flowable-ui-task-rest/src/main/java/org/flowable/app/rest/runtime/variable/StringRestVariableConverter.java
+++ b/modules/flowable-ui-task/flowable-ui-task-rest/src/main/java/org/flowable/app/rest/runtime/variable/StringRestVariableConverter.java
@@ -39,7 +39,7 @@ public class StringRestVariableConverter implements RestVariableConverter {
       if(!(result.getValue() instanceof String)) {
         throw new FlowableIllegalArgumentException("Converter can only convert strings");
       }
-      return (String) result.getValue();
+      return result.getValue();
     }
     return null;
   }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cmd/GetNextIdBlockCmd.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cmd/GetNextIdBlockCmd.java
@@ -31,7 +31,7 @@ public class GetNextIdBlockCmd implements Command<IdBlock> {
   }
 
   public IdBlock execute(CommandContext commandContext) {
-    PropertyEntity property = (PropertyEntity) commandContext
+    PropertyEntity property = commandContext
       .getPropertyEntityManager()
       .findPropertyById("next.dbid");
     long oldValue = Long.parseLong(property.getValue());

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntity.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntity.java
@@ -711,8 +711,8 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
 
   @SuppressWarnings({ "unchecked", "rawtypes" })
   protected void ensureExecutionsInitialized() {
-    if (executions==null) {
-      this.executions = (List) Context
+    if (executions == null) {
+      this.executions = Context
         .getCommandContext()
         .getExecutionEntityManager()
         .findChildExecutionsByParentExecutionId(id);
@@ -1171,7 +1171,7 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
       task.setExecution(this.replacedBy);         
       
       // update the related local task variables
-      List<VariableInstanceEntity> variables = (List) commandContext
+      List<VariableInstanceEntity> variables = commandContext
         .getVariableInstanceEntityManager()
         .findVariableInstancesByTaskId(task.getId());
       
@@ -1210,7 +1210,7 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
     }
     
     // update the related process variables
-    List<VariableInstanceEntity> variables = (List) commandContext
+    List<VariableInstanceEntity> variables = commandContext
       .getVariableInstanceEntityManager()
       .findVariableInstancesByExecutionId(id);
     
@@ -1463,7 +1463,7 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
   @SuppressWarnings({ "unchecked", "rawtypes" })
   protected void ensureJobsInitialized() {
     if (jobs == null) {    
-      jobs = (List) Context.getCommandContext()
+      jobs = Context.getCommandContext()
         .getJobEntityManager()
         .findJobsByExecutionId(id);
     }    
@@ -1489,7 +1489,7 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
   @SuppressWarnings({ "unchecked", "rawtypes" })
   protected void ensureTimerJobsInitialized() {
     if (timerJobs == null) {    
-      timerJobs = (List) Context.getCommandContext()
+      timerJobs = Context.getCommandContext()
         .getTimerJobEntityManager()
         .findTimerJobsByExecutionId(id);
     }    
@@ -1516,8 +1516,8 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
   
   @SuppressWarnings({ "unchecked", "rawtypes" })
   protected void ensureTasksInitialized() {
-    if(tasks == null) {    
-      tasks = (List)Context.getCommandContext()
+    if (tasks == null) {
+      tasks = Context.getCommandContext()
         .getTaskEntityManager()
         .findTasksByExecutionId(id);      
     }    

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/HistoricDetailEntityManager.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/HistoricDetailEntityManager.java
@@ -53,8 +53,7 @@ public class HistoricDetailEntityManager extends AbstractManager {
 
   public void deleteHistoricDetailsByTaskId(String taskId) {
     if (getHistoryManager().isHistoryLevelAtLeast(HistoryLevel.FULL)) {
-      HistoricDetailQueryImpl detailsQuery = 
-        (HistoricDetailQueryImpl) new HistoricDetailQueryImpl().taskId(taskId);
+      HistoricDetailQueryImpl detailsQuery = new HistoricDetailQueryImpl().taskId(taskId);
       List<HistoricDetail> details = detailsQuery.list();
       for(HistoricDetail detail : details) {
         ((HistoricDetailEntity) detail).delete();

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/event/JobEventsTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/event/JobEventsTest.java
@@ -239,7 +239,7 @@ public class JobEventsTest extends PluggableFlowableTestCase {
     int timerCancelledCount = 0;
     List<FlowableEvent> eventsReceived = listener.getEventsReceived();
     for (FlowableEvent eventReceived : eventsReceived) {
-      if (eventType.equals(eventReceived.getType())) {
+      if (eventType == eventReceived.getType()) {
         timerCancelledCount++;
       }
     }

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/event/ProcessInstanceEventsTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/event/ProcessInstanceEventsTest.java
@@ -532,7 +532,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
         // check whether entity in the event is initialized before adding to the list.
         assertNotNull(((ExecutionEntity) ((FlowableEntityEvent) event).getEntity()).getId());
         eventsReceived.add(event);
-      } else if (FlowableEngineEventType.PROCESS_CANCELLED.equals(event.getType()) || FlowableEngineEventType.ACTIVITY_CANCELLED.equals(event.getType())) {
+      } else if (FlowableEngineEventType.PROCESS_CANCELLED == event.getType() || FlowableEngineEventType.ACTIVITY_CANCELLED == event.getType()) {
         eventsReceived.add(event);
       }
     }
@@ -546,7 +546,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
       List<FlowableEvent> filteredEvents = new ArrayList<FlowableEvent>();
       List<FlowableEvent> eventsReceived = listener.getEventsReceived();
       for (FlowableEvent eventReceived : eventsReceived) {
-        if (eventType.equals(eventReceived.getType())) {
+        if (eventType == eventReceived.getType()) {
           filteredEvents.add(eventReceived);
         }
       }

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/event/timer/StartTimerEventRepeatWithEndExpressionTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/event/timer/StartTimerEventRepeatWithEndExpressionTest.java
@@ -139,7 +139,7 @@ public class StartTimerEventRepeatWithEndExpressionTest extends PluggableFlowabl
     int timerFiredCount = 0;
     List<FlowableEvent> eventsReceived = listener.getEventsReceived();
     for (FlowableEvent eventReceived : eventsReceived) {
-      if (FlowableEngineEventType.TIMER_FIRED.equals(eventReceived.getType())) {
+      if (FlowableEngineEventType.TIMER_FIRED == eventReceived.getType()) {
         timerFiredCount++;
       }
     }
@@ -147,7 +147,7 @@ public class StartTimerEventRepeatWithEndExpressionTest extends PluggableFlowabl
     //count "entity created" events
     int eventCreatedCount = 0;
     for (FlowableEvent eventReceived : eventsReceived) {
-      if (FlowableEngineEventType.ENTITY_CREATED.equals(eventReceived.getType())) {
+      if (FlowableEngineEventType.ENTITY_CREATED == eventReceived.getType()) {
         eventCreatedCount++;
       }
     }
@@ -155,7 +155,7 @@ public class StartTimerEventRepeatWithEndExpressionTest extends PluggableFlowabl
     // count "entity deleted" events
     int eventDeletedCount = 0;
     for (FlowableEvent eventReceived : eventsReceived) {
-      if (FlowableEngineEventType.ENTITY_DELETED.equals(eventReceived.getType())) {
+      if (FlowableEngineEventType.ENTITY_DELETED == eventReceived.getType()) {
         eventDeletedCount++;
       }
     }

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/event/timer/StartTimerEventRepeatWithEndTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/event/timer/StartTimerEventRepeatWithEndTest.java
@@ -136,7 +136,7 @@ public class StartTimerEventRepeatWithEndTest extends PluggableFlowableTestCase 
     int timerFiredCount = 0;
     List<FlowableEvent> eventsReceived = listener.getEventsReceived();
     for (FlowableEvent eventReceived : eventsReceived) {
-      if (FlowableEngineEventType.TIMER_FIRED.equals(eventReceived.getType())) {
+      if (FlowableEngineEventType.TIMER_FIRED == eventReceived.getType()) {
         timerFiredCount++;
       }
     }
@@ -144,7 +144,7 @@ public class StartTimerEventRepeatWithEndTest extends PluggableFlowableTestCase 
     //count "entity created" events
     int eventCreatedCount = 0;
     for (FlowableEvent eventReceived : eventsReceived) {
-      if (FlowableEngineEventType.ENTITY_CREATED.equals(eventReceived.getType())) {
+      if (FlowableEngineEventType.ENTITY_CREATED == eventReceived.getType()) {
         eventCreatedCount++;
       }
     }
@@ -152,7 +152,7 @@ public class StartTimerEventRepeatWithEndTest extends PluggableFlowableTestCase 
     // count "entity deleted" events
     int eventDeletedCount = 0;
     for (FlowableEvent eventReceived : eventsReceived) {
-      if (FlowableEngineEventType.ENTITY_DELETED.equals(eventReceived.getType())) {
+      if (FlowableEngineEventType.ENTITY_DELETED == eventReceived.getType()) {
         eventDeletedCount++;
       }
     }

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/event/timer/StartTimerEventRepeatWithoutEndDateTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/event/timer/StartTimerEventRepeatWithoutEndDateTest.java
@@ -139,7 +139,7 @@ public class StartTimerEventRepeatWithoutEndDateTest extends PluggableFlowableTe
     int timerFiredCount = 0;
     List<FlowableEvent> eventsReceived = listener.getEventsReceived();
     for (FlowableEvent eventReceived : eventsReceived) {
-      if (FlowableEngineEventType.TIMER_FIRED.equals(eventReceived.getType())) {
+      if (FlowableEngineEventType.TIMER_FIRED == eventReceived.getType()) {
         timerFiredCount++;
       }
     }
@@ -147,7 +147,7 @@ public class StartTimerEventRepeatWithoutEndDateTest extends PluggableFlowableTe
     //count "entity created" events
     int eventCreatedCount = 0;
     for (FlowableEvent eventReceived : eventsReceived) {
-      if (FlowableEngineEventType.ENTITY_CREATED.equals(eventReceived.getType())) {
+      if (FlowableEngineEventType.ENTITY_CREATED == eventReceived.getType()) {
         eventCreatedCount++;
       }
     }
@@ -155,7 +155,7 @@ public class StartTimerEventRepeatWithoutEndDateTest extends PluggableFlowableTe
     // count "entity deleted" events
     int eventDeletedCount = 0;
     for (FlowableEvent eventReceived : eventsReceived) {
-      if (FlowableEngineEventType.ENTITY_DELETED.equals(eventReceived.getType())) {
+      if (FlowableEngineEventType.ENTITY_DELETED == eventReceived.getType()) {
         eventDeletedCount++;
       }
     }

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/event/timer/compatibility/StartTimerEventRepeatCompatibilityTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/event/timer/compatibility/StartTimerEventRepeatCompatibilityTest.java
@@ -136,7 +136,7 @@ public class StartTimerEventRepeatCompatibilityTest extends TimerEventCompatibil
     int timerFiredCount = 0;
     List<FlowableEvent> eventsReceived = listener.getEventsReceived();
     for (FlowableEvent eventReceived : eventsReceived) {
-      if (FlowableEngineEventType.TIMER_FIRED.equals(eventReceived.getType())) {
+      if (FlowableEngineEventType.TIMER_FIRED == eventReceived.getType()) {
         timerFiredCount++;
       }
     }
@@ -144,7 +144,7 @@ public class StartTimerEventRepeatCompatibilityTest extends TimerEventCompatibil
     //count "entity created" events
     int eventCreatedCount = 0;
     for (FlowableEvent eventReceived : eventsReceived) {
-      if (FlowableEngineEventType.ENTITY_CREATED.equals(eventReceived.getType())) {
+      if (FlowableEngineEventType.ENTITY_CREATED == eventReceived.getType()) {
         eventCreatedCount++;
       }
     }
@@ -152,7 +152,7 @@ public class StartTimerEventRepeatCompatibilityTest extends TimerEventCompatibil
     // count "entity deleted" events
     int eventDeletedCount = 0;
     for (FlowableEvent eventReceived : eventsReceived) {
-      if (FlowableEngineEventType.ENTITY_DELETED.equals(eventReceived.getType())) {
+      if (FlowableEngineEventType.ENTITY_DELETED == eventReceived.getType()) {
         eventDeletedCount++;
       }
     }


### PR DESCRIPTION
Miscellaneous cleanup:
(1) Unused imports
(2) Imports from the same package
(3) Unnecessary casts
(4) Use == for enum comparisons instead of equals()
etc.