### PR TITLE
Fix resource package names for deployment resources

### DIFF
--- a/modules/flowable-cdi/src/test/java/org/flowable/cdi/test/api/BusinessProcessBeanTest.java
+++ b/modules/flowable-cdi/src/test/java/org/flowable/cdi/test/api/BusinessProcessBeanTest.java
@@ -75,7 +75,7 @@ public class BusinessProcessBeanTest extends CdiFlowableTestCase {
   }
 
   @Test
-  @Deployment(resources = "org/activiti/cdi/test/api/BusinessProcessBeanTest.test.bpmn20.xml")
+  @Deployment(resources = "org/flowable/cdi/test/api/BusinessProcessBeanTest.test.bpmn20.xml")
   public void testResolveProcessInstanceBean() {
     BusinessProcess businessProcess = getBeanInstance(BusinessProcess.class);
 
@@ -96,7 +96,7 @@ public class BusinessProcessBeanTest extends CdiFlowableTestCase {
   }
 
   @Test
-  @Deployment(resources = "org/activiti/cdi/test/api/BusinessProcessBeanTest.test.bpmn20.xml")
+  @Deployment(resources = "org/flowable/cdi/test/api/BusinessProcessBeanTest.test.bpmn20.xml")
   public void testResolveTaskBean() {
     BusinessProcess businessProcess = getBeanInstance(BusinessProcess.class);
 

--- a/modules/flowable-cdi/src/test/java/org/flowable/cdi/test/api/annotation/CompleteTaskTest.java
+++ b/modules/flowable-cdi/src/test/java/org/flowable/cdi/test/api/annotation/CompleteTaskTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 public class CompleteTaskTest extends CdiFlowableTestCase {
 
   @Test
-  @Deployment(resources = "org/activiti/cdi/test/api/annotation/CompleteTaskTest.bpmn20.xml")
+  @Deployment(resources = "org/flowable/cdi/test/api/annotation/CompleteTaskTest.bpmn20.xml")
   public void testCompleteTask() {
 
     BusinessProcess businessProcess = getBeanInstance(BusinessProcess.class);

--- a/modules/flowable-cdi/src/test/java/org/flowable/cdi/test/api/annotation/StartProcessTest.java
+++ b/modules/flowable-cdi/src/test/java/org/flowable/cdi/test/api/annotation/StartProcessTest.java
@@ -12,14 +12,16 @@
  */
 package org.flowable.cdi.test.api.annotation;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
 import org.flowable.cdi.BusinessProcess;
 import org.flowable.cdi.impl.annotation.StartProcessInterceptor;
 import org.flowable.cdi.test.CdiFlowableTestCase;
 import org.flowable.cdi.test.impl.beans.DeclarativeProcessController;
 import org.flowable.engine.test.Deployment;
 import org.junit.Test;
-
-import static org.junit.Assert.*;
 
 /**
  * Testcase for assuring that the {@link StartProcessInterceptor} behaves as expected.
@@ -29,7 +31,7 @@ import static org.junit.Assert.*;
 public class StartProcessTest extends CdiFlowableTestCase {
 
   @Test
-  @Deployment(resources = "org/activiti/cdi/test/api/annotation/StartProcessTest.bpmn20.xml")
+  @Deployment(resources = "org/flowable/cdi/test/api/annotation/StartProcessTest.bpmn20.xml")
   public void testStartProcessByKey() {
 
     assertNull(runtimeService.createProcessInstanceQuery().singleResult());
@@ -46,7 +48,7 @@ public class StartProcessTest extends CdiFlowableTestCase {
   }
 
   @Test
-  @Deployment(resources = "org/activiti/cdi/test/api/annotation/StartProcessTest.bpmn20.xml")
+  @Deployment(resources = "org/flowable/cdi/test/api/annotation/StartProcessTest.bpmn20.xml")
   public void testStartProcessByName() {
 
     assertNull(runtimeService.createProcessInstanceQuery().singleResult());


### PR DESCRIPTION
In the `flowable-cdi` module the package names for the resources changed from `org.activiti.cdi.test` to `org.flowable.cdi.test` but the java code annotations for the `@Deployment` annotation location did not change.  This request changes the names to match.  

I *did* not test the change but it looks correct.