### PR TITLE
Fix package name in log4j.properties file

### DIFF
--- a/modules/flowable-dmn-engine/src/test/resources/log4j.properties
+++ b/modules/flowable-dmn-engine/src/test/resources/log4j.properties
@@ -5,4 +5,4 @@ log4j.appender.CA=org.apache.log4j.ConsoleAppender
 log4j.appender.CA.layout=org.apache.log4j.PatternLayout
 log4j.appender.CA.layout.ConversionPattern= %d{hh:mm:ss,SSS} [%t] %-5p %c %x - %m%n
 
-log4j.logger.org.activiti.dmn.engine=DEBUG
+log4j.logger.org.flowable.dmn.engine=DEBUG


### PR DESCRIPTION
Found the same issue in `flowable-dmn-engine`: change package from `activiti` to `flowable`.