### PR TITLE
ISO8601 Zulu time updates

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/el/ExpressionManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/el/ExpressionManager.java
@@ -13,6 +13,7 @@
 package org.flowable.engine.impl.el;
 
 import java.util.Map;
+import java.util.Properties;
 
 import javax.el.ArrayELResolver;
 import javax.el.BeanELResolver;
@@ -68,7 +69,7 @@ public class ExpressionManager {
   public ExpressionManager(Map<Object, Object> beans, boolean initFactory) {
     // Use the ExpressionFactoryImpl in flowable build in version of juel,
     // with parametrised method expressions enabled
-    expressionFactory = new ExpressionFactoryImpl();
+    expressionFactory = new ExpressionFactoryImpl((Properties)null, new FlowableTypeConverter());
     this.beans = beans;
   }
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/el/FlowableTypeConverter.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/el/FlowableTypeConverter.java
@@ -1,0 +1,29 @@
+package org.flowable.engine.impl.el;
+
+import java.util.Date;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.ISODateTimeFormat;
+
+import de.odysseus.el.misc.TypeConverterImpl;
+
+public class FlowableTypeConverter extends TypeConverterImpl {
+
+    public FlowableTypeConverter() {}
+
+    private static final long serialVersionUID = 1L;
+
+    protected String coerceToString(Object value) {
+        String coercedValue = null;
+        if (value instanceof Date) {
+            Date date = (Date)value;
+            DateTimeFormatter fmt = ISODateTimeFormat.dateTime();
+            coercedValue =  fmt.print(new DateTime(date, DateTimeZone.UTC));
+        } else {
+            coercedValue = super.coerceToString(value);
+        }
+        return coercedValue;
+    }
+}

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/util/TimerUtil.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/util/TimerUtil.java
@@ -12,7 +12,6 @@
  */
 package org.flowable.engine.impl.util;
 
-import java.text.SimpleDateFormat;
 import java.util.Date;
 
 import org.apache.commons.lang3.StringUtils;
@@ -34,6 +33,9 @@ import org.flowable.engine.impl.persistence.entity.ExecutionEntity;
 import org.flowable.engine.impl.persistence.entity.JobEntity;
 import org.flowable.engine.impl.persistence.entity.TimerJobEntity;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.ISODateTimeFormat;
 
 /**
  * @author Joram Barrez
@@ -167,8 +169,9 @@ public class TimerUtil {
 
   public static String prepareRepeat(String dueDate) {
     if (dueDate.startsWith("R") && dueDate.split("/").length == 2) {
-      SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-      return dueDate.replace("/", "/" + sdf.format(Context.getProcessEngineConfiguration().getClock().getCurrentTime()) + "/");
+        DateTimeFormatter fmt = ISODateTimeFormat.dateTime();
+        Date now = Context.getProcessEngineConfiguration().getClock().getCurrentTime();
+        return dueDate.replace("/", "/" + fmt.print(new DateTime(now, DateTimeZone.UTC)) + "/");
     }
     return dueDate;
   }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventRepeatWithDurationAndEndTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventRepeatWithDurationAndEndTest.java
@@ -1,0 +1,126 @@
+
+package org.flowable.engine.test.bpmn.event.timer;
+
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+
+import org.flowable.engine.history.HistoricProcessInstance;
+import org.flowable.engine.impl.history.HistoryLevel;
+import org.flowable.engine.impl.persistence.entity.TimerJobEntity;
+import org.flowable.engine.impl.test.PluggableFlowableTestCase;
+import org.flowable.engine.runtime.Job;
+import org.flowable.engine.runtime.ProcessInstance;
+import org.flowable.engine.task.Task;
+import org.flowable.engine.test.Deployment;
+import org.joda.time.DateTime;
+import org.joda.time.format.ISODateTimeFormat;
+
+
+public class BoundaryTimerEventRepeatWithDurationAndEndTest extends PluggableFlowableTestCase {
+
+  @Deployment
+  public void testRepeatWithDurationAndEnd() throws Throwable {
+
+      // expect to stop boundary jobs after 20 minutes
+    Calendar calendar = Calendar.getInstance();
+    calendar.set(Calendar.MILLISECOND, 0);
+    calendar.add(Calendar.MINUTE, 20);
+    Date endTime = calendar.getTime();
+
+    // reset the timer
+    Calendar nextTimeCal = Calendar.getInstance();
+    processEngineConfiguration.getClock().setCurrentTime(nextTimeCal.getTime());
+
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("repeatWithDurationAndEnd");
+
+    runtimeService.setVariable(processInstance.getId(), "EndDateForBoundary", calendar.getTime());
+
+    List<Task> tasks = taskService.createTaskQuery().list();
+    assertEquals(1, tasks.size());
+
+    Task task = tasks.get(0);
+    assertEquals("Task A", task.getName());
+
+    // Test Boundary Events
+    // complete will cause timer to be created
+    taskService.complete(task.getId());
+
+    List<Job> jobs = managementService.createTimerJobQuery().list();
+    assertEquals(1, jobs.size());
+
+    // R/<duration>/${EndDateForBoundary} is persisted with end date in ISO 8601 Zulu time.
+    String repeatStr = ((TimerJobEntity)jobs.get(0)).getRepeat();
+    List<String> expression = Arrays.asList(repeatStr.split("/"));
+    String endDateStr = expression.get(2);
+
+    // Validate that repeat string is in ISO8601 Zulu time.
+    DateTime endDateTime = ISODateTimeFormat.dateTime().parseDateTime(endDateStr);
+    assertEquals(endDateTime, new DateTime(endTime));
+
+    // boundary events
+    Job executableJob = managementService.moveTimerToExecutableJob(jobs.get(0).getId());
+    managementService.executeJob(executableJob.getId());
+
+    assertEquals(0, managementService.createJobQuery().list().size());
+    jobs = managementService.createTimerJobQuery().list();
+    assertEquals(1, jobs.size());
+
+    nextTimeCal.add(Calendar.MINUTE, 15); // after 15 minutes
+    processEngineConfiguration.getClock().setCurrentTime(nextTimeCal.getTime());
+
+    executableJob = managementService.moveTimerToExecutableJob(jobs.get(0).getId());
+    managementService.executeJob(executableJob.getId());
+
+    assertEquals(0, managementService.createJobQuery().list().size());
+    jobs = managementService.createTimerJobQuery().list();
+    assertEquals(1, jobs.size());
+
+    nextTimeCal.add(Calendar.MINUTE, 5); // after another 5 minutes (20 minutes and 1 second from the baseTime) the BoundaryEndTime is reached
+    nextTimeCal.add(Calendar.SECOND, 1);
+    processEngineConfiguration.getClock().setCurrentTime(nextTimeCal.getTime());
+
+    executableJob = managementService.moveTimerToExecutableJob(jobs.get(0).getId());
+    managementService.executeJob(executableJob.getId());
+
+    jobs = managementService.createTimerJobQuery().list();
+    assertEquals(0, jobs.size());
+    jobs = managementService.createJobQuery().list();
+    assertEquals(0, jobs.size());
+
+    tasks = taskService.createTaskQuery().list();
+    task = tasks.get(0);
+    assertEquals("Task B", task.getName());
+    assertEquals(1, tasks.size());
+    taskService.complete(task.getId());
+
+    jobs = managementService.createTimerJobQuery().list();
+    assertEquals(0, jobs.size());
+    jobs = managementService.createJobQuery().list();
+    assertEquals(0, jobs.size());
+
+    if (processEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.ACTIVITY)) {
+      HistoricProcessInstance historicInstance = historyService.createHistoricProcessInstanceQuery()
+          .processInstanceId(processInstance.getId())
+          .singleResult();
+      assertNotNull(historicInstance.getEndTime());
+    }
+
+    // now all the process instances should be completed
+    List<ProcessInstance> processInstances = runtimeService.createProcessInstanceQuery().list();
+    assertEquals(0, processInstances.size());
+
+    // no jobs
+    jobs = managementService.createJobQuery().list();
+    assertEquals(0, jobs.size());
+
+    jobs = managementService.createTimerJobQuery().list();
+    assertEquals(0, jobs.size());
+
+    // no tasks
+    tasks = taskService.createTaskQuery().list();
+    assertEquals(0, tasks.size());
+  }
+
+}

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventRepeatWithDurationTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventRepeatWithDurationTest.java
@@ -1,0 +1,120 @@
+package org.flowable.engine.test.bpmn.event.timer;
+
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+
+import org.flowable.engine.history.HistoricProcessInstance;
+import org.flowable.engine.impl.history.HistoryLevel;
+import org.flowable.engine.impl.persistence.entity.TimerJobEntity;
+import org.flowable.engine.impl.test.PluggableFlowableTestCase;
+import org.flowable.engine.runtime.Job;
+import org.flowable.engine.runtime.ProcessInstance;
+import org.flowable.engine.task.Task;
+import org.flowable.engine.test.Deployment;
+import org.joda.time.DateTime;
+import org.joda.time.format.ISODateTimeFormat;
+
+public class BoundaryTimerEventRepeatWithDurationTest extends PluggableFlowableTestCase {
+
+  @Deployment
+  public void testRepeatWithDuration() throws Throwable {
+
+    Calendar calendar = Calendar.getInstance();
+    calendar.set(Calendar.MILLISECOND, 0);
+    Date baseTime = calendar.getTime();
+
+    // reset the timer
+    Calendar nextTimeCal = Calendar.getInstance();
+    nextTimeCal.setTime(baseTime);
+    processEngineConfiguration.getClock().setCurrentTime(nextTimeCal.getTime());
+
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("repeatWithDuration");
+
+    List<Task> tasks = taskService.createTaskQuery().list();
+    assertEquals(1, tasks.size());
+
+    Task task = tasks.get(0);
+    assertEquals("Task A", task.getName());
+
+    // Test Boundary Events
+    // complete will cause timer to be created
+    taskService.complete(task.getId());
+
+    List<Job> jobs = managementService.createTimerJobQuery().list();
+    assertEquals(1, jobs.size());
+
+    // R/<duration> is persisted with start date in ISO 8601 Zulu time.
+    String repeatStr = ((TimerJobEntity)jobs.get(0)).getRepeat();
+    List<String> expression = Arrays.asList(repeatStr.split("/"));
+    String startDateStr = expression.get(1);
+
+    // Validate that repeat string is in ISO8601 Zulu time.
+    DateTime startDateTime = ISODateTimeFormat.dateTime().parseDateTime(startDateStr);
+    assertEquals(startDateTime, new DateTime(baseTime));
+
+    // boundary events
+    Job executableJob = managementService.moveTimerToExecutableJob(jobs.get(0).getId());
+
+    managementService.executeJob(executableJob.getId());
+
+    assertEquals(0, managementService.createJobQuery().list().size());
+    jobs = managementService.createTimerJobQuery().list();
+    assertEquals(1, jobs.size());
+
+    nextTimeCal.add(Calendar.SECOND, 15);
+    processEngineConfiguration.getClock().setCurrentTime(nextTimeCal.getTime());
+
+    executableJob = managementService.moveTimerToExecutableJob(jobs.get(0).getId());
+    managementService.executeJob(executableJob.getId());
+
+    assertEquals(0, managementService.createJobQuery().list().size());
+    jobs = managementService.createTimerJobQuery().list();
+    assertEquals(1, jobs.size());
+
+    nextTimeCal.add(Calendar.SECOND, 15);
+    processEngineConfiguration.getClock().setCurrentTime(nextTimeCal.getTime());
+
+    executableJob = managementService.moveTimerToExecutableJob(jobs.get(0).getId());
+    managementService.executeJob(executableJob.getId());
+
+    jobs = managementService.createTimerJobQuery().list();
+    assertEquals(0, jobs.size());
+    jobs = managementService.createJobQuery().list();
+    assertEquals(0, jobs.size());
+
+    tasks = taskService.createTaskQuery().list();
+    task = tasks.get(0);
+    assertEquals("Task B", task.getName());
+    assertEquals(1, tasks.size());
+    taskService.complete(task.getId());
+
+    jobs = managementService.createTimerJobQuery().list();
+    assertEquals(0, jobs.size());
+    jobs = managementService.createJobQuery().list();
+    assertEquals(0, jobs.size());
+
+    if (processEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.ACTIVITY)) {
+      HistoricProcessInstance historicInstance = historyService.createHistoricProcessInstanceQuery()
+          .processInstanceId(processInstance.getId())
+          .singleResult();
+      assertNotNull(historicInstance.getEndTime());
+    }
+
+    // now all the process instances should be completed
+    List<ProcessInstance> processInstances = runtimeService.createProcessInstanceQuery().list();
+    assertEquals(0, processInstances.size());
+
+    // no jobs
+    jobs = managementService.createJobQuery().list();
+    assertEquals(0, jobs.size());
+
+    jobs = managementService.createTimerJobQuery().list();
+    assertEquals(0, jobs.size());
+
+    // no tasks
+    tasks = taskService.createTaskQuery().list();
+    assertEquals(0, tasks.size());
+  }
+}

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventRepeatWithStartAndDurationTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventRepeatWithStartAndDurationTest.java
@@ -1,0 +1,125 @@
+
+package org.flowable.engine.test.bpmn.event.timer;
+
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+
+import org.flowable.engine.history.HistoricProcessInstance;
+import org.flowable.engine.impl.history.HistoryLevel;
+import org.flowable.engine.impl.persistence.entity.TimerJobEntity;
+import org.flowable.engine.impl.test.PluggableFlowableTestCase;
+import org.flowable.engine.runtime.Job;
+import org.flowable.engine.runtime.ProcessInstance;
+import org.flowable.engine.task.Task;
+import org.flowable.engine.test.Deployment;
+import org.joda.time.DateTime;
+import org.joda.time.format.ISODateTimeFormat;
+
+public class BoundaryTimerEventRepeatWithStartAndDurationTest extends PluggableFlowableTestCase {
+
+  @Deployment
+  public void testRepeatWithStartAndDuration() throws Throwable {
+
+    Calendar calendar = Calendar.getInstance();
+    calendar.set(Calendar.MILLISECOND, 0);
+
+    Date baseTime = calendar.getTime();
+
+    // reset the timer
+    Calendar nextTimeCal = Calendar.getInstance();
+    nextTimeCal.setTime(baseTime);
+    processEngineConfiguration.getClock().setCurrentTime(nextTimeCal.getTime());
+
+    HashMap<String, Object> variables = new HashMap<String, Object>();
+    variables.put("StartDate", baseTime);
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("repeatWithStartAndDuration", variables);
+
+    List<Task> tasks = taskService.createTaskQuery().list();
+    assertEquals(1, tasks.size());
+
+    Task task = tasks.get(0);
+    assertEquals("Task A", task.getName());
+
+    // Test Boundary Events
+    // complete will cause timer to be created
+    taskService.complete(task.getId());
+
+    List<Job> jobs = managementService.createTimerJobQuery().list();
+    assertEquals(1, jobs.size());
+
+    // boundary events
+    Job executableJob = managementService.moveTimerToExecutableJob(jobs.get(0).getId());
+
+    // R/${StartDate}/<duration> is persisted with StartDate in ISO 8601 Zulu time.
+    String repeatStr = ((TimerJobEntity)jobs.get(0)).getRepeat();
+    List<String> expression = Arrays.asList(repeatStr.split("/"));
+    String startDateStr = expression.get(1);
+
+    // Validate that repeat string is in ISO8601 Zulu time.
+    DateTime startDateTime = ISODateTimeFormat.dateTime().parseDateTime(startDateStr);
+    assertEquals(startDateTime, new DateTime(baseTime));
+
+    managementService.executeJob(executableJob.getId());
+
+    assertEquals(0, managementService.createJobQuery().list().size());
+    jobs = managementService.createTimerJobQuery().list();
+    assertEquals(1, jobs.size());
+
+    nextTimeCal.add(Calendar.SECOND, 15);
+    processEngineConfiguration.getClock().setCurrentTime(nextTimeCal.getTime());
+
+    executableJob = managementService.moveTimerToExecutableJob(jobs.get(0).getId());
+    managementService.executeJob(executableJob.getId());
+
+    assertEquals(0, managementService.createJobQuery().list().size());
+    jobs = managementService.createTimerJobQuery().list();
+    assertEquals(1, jobs.size());
+
+    nextTimeCal.add(Calendar.SECOND, 15);
+    processEngineConfiguration.getClock().setCurrentTime(nextTimeCal.getTime());
+
+    executableJob = managementService.moveTimerToExecutableJob(jobs.get(0).getId());
+    managementService.executeJob(executableJob.getId());
+
+    jobs = managementService.createTimerJobQuery().list();
+    assertEquals(0, jobs.size());
+    jobs = managementService.createJobQuery().list();
+    assertEquals(0, jobs.size());
+
+    tasks = taskService.createTaskQuery().list();
+    task = tasks.get(0);
+    assertEquals("Task B", task.getName());
+    assertEquals(1, tasks.size());
+    taskService.complete(task.getId());
+
+    jobs = managementService.createTimerJobQuery().list();
+    assertEquals(0, jobs.size());
+    jobs = managementService.createJobQuery().list();
+    assertEquals(0, jobs.size());
+
+    if (processEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.ACTIVITY)) {
+      HistoricProcessInstance historicInstance = historyService.createHistoricProcessInstanceQuery()
+          .processInstanceId(processInstance.getId())
+          .singleResult();
+      assertNotNull(historicInstance.getEndTime());
+    }
+
+    // now all the process instances should be completed
+    List<ProcessInstance> processInstances = runtimeService.createProcessInstanceQuery().list();
+    assertEquals(0, processInstances.size());
+
+    // no jobs
+    jobs = managementService.createJobQuery().list();
+    assertEquals(0, jobs.size());
+
+    jobs = managementService.createTimerJobQuery().list();
+    assertEquals(0, jobs.size());
+
+    // no tasks
+    tasks = taskService.createTaskQuery().list();
+    assertEquals(0, tasks.size());
+  }
+}

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventRepeatWithDurationAndEndTest.testRepeatWithDurationAndEnd.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventRepeatWithDurationAndEndTest.testRepeatWithDurationAndEnd.bpmn20.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:activiti="http://activiti.org/bpmn"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			 targetNamespace="Examples">
+
+    <process id="repeatWithDurationAndEnd">
+
+        <startEvent id="theStart" />
+
+        <sequenceFlow id="a1" sourceRef="theStart" targetRef="processStartedScript"/>
+
+        <scriptTask id="processStartedScript" name="Execute script" scriptFormat="groovy">
+            <script>
+                System.out.println("Process started");
+            </script>
+        </scriptTask>
+
+        <sequenceFlow id="a2" sourceRef="processStartedScript" targetRef="task1"/>
+        <userTask id="task1" name="Task A" />
+        <sequenceFlow id="flow2" sourceRef="task1" targetRef="task2"/>
+        <userTask id="task2" name="Task B" />
+
+        <boundaryEvent id="timer" attachedToRef="task2" cancelActivity="false">
+            <timerEventDefinition>
+                <timeCycle>R5/PT10S/${EndDateForBoundary}</timeCycle>
+            </timerEventDefinition>
+        </boundaryEvent>
+        <sequenceFlow id="flow21" sourceRef="timer" targetRef="timerFiredTask"/>
+
+        <scriptTask id="timerFiredTask" name="Execute script" scriptFormat="groovy">
+            <script>
+                System.out.println("Boundary Event");
+            </script>
+        </scriptTask>
+
+        <sequenceFlow id="flow22" sourceRef="timerFiredTask" targetRef="nonInterruptingEnd"/>
+        <endEvent id="nonInterruptingEnd"/>
+
+        <sequenceFlow id="flow3" sourceRef="task2" targetRef="task2Completed"/>
+
+        <scriptTask id="task2Completed" name="Execute script" scriptFormat="groovy">
+            <script>
+                System.out.println("Process ended");
+            </script>
+        </scriptTask>
+
+        <sequenceFlow id="flow10" sourceRef="task2Completed" targetRef="end"/>
+
+        <endEvent id="end"/>
+
+
+    </process>
+
+
+</definitions>

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventRepeatWithDurationTest.testRepeatWithDuration.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventRepeatWithDurationTest.testRepeatWithDuration.bpmn20.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:activiti="http://activiti.org/bpmn"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+             xsi:schemaLocation="http://activiti.org/bpmn http://activiti.org/bpmn/flowable-bpmn-extensions-5.18.xsd"
+targetNamespace="Examples">
+
+    <process id="repeatWithDuration">
+
+        <startEvent id="theStart">
+        </startEvent>
+
+        <sequenceFlow id="a1" sourceRef="theStart" targetRef="processStartedScript"/>
+
+        <scriptTask id="processStartedScript" name="Execute script" scriptFormat="groovy">
+            <script>
+                System.out.println("Process started");
+            </script>
+        </scriptTask>
+
+        <sequenceFlow id="a2" sourceRef="processStartedScript" targetRef="task1"/>
+        <userTask id="task1" name="Task A"/>
+        <sequenceFlow id="flow2" sourceRef="task1" targetRef="task2"/>
+        <userTask id="task2" name="Task B"/>
+
+        <boundaryEvent id="timer" attachedToRef="task2" cancelActivity="false">
+            <timerEventDefinition>
+                <timeCycle>R3/PT10S</timeCycle>
+            </timerEventDefinition>
+        </boundaryEvent>
+        <sequenceFlow id="flow21" sourceRef="timer" targetRef="timerFiredTask"/>
+
+        <scriptTask id="timerFiredTask" name="Execute script" scriptFormat="groovy">
+            <script>
+                System.out.println("Boundary Event");
+            </script>
+        </scriptTask>
+
+        <sequenceFlow id="flow22" sourceRef="timerFiredTask" targetRef="nonInterruptingEnd"/>
+        <endEvent id="nonInterruptingEnd"/>
+
+
+
+        <sequenceFlow id="flow3" sourceRef="task2" targetRef="task2Completed"/>
+
+        <scriptTask id="task2Completed" name="Execute script" scriptFormat="groovy">
+            <script>
+                System.out.println("Process ended");
+            </script>
+        </scriptTask>
+
+        <sequenceFlow id="flow10" sourceRef="task2Completed" targetRef="end"/>
+
+        <endEvent id="end"/>
+
+
+    </process>
+
+
+</definitions>

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventRepeatWithStartAndDurationTest.testRepeatWithStartAndDuration.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventRepeatWithStartAndDurationTest.testRepeatWithStartAndDuration.bpmn20.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:activiti="http://activiti.org/bpmn"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+             xsi:schemaLocation="http://activiti.org/bpmn http://activiti.org/bpmn/flowable-bpmn-extensions-5.18.xsd"
+targetNamespace="Examples">
+
+    <process id="repeatWithStartAndDuration">
+
+        <startEvent id="theStart">
+        </startEvent>
+        <dataObject id="dObj1" itemSubjectRef="xsd:datetime" name="StartDate">
+           <extensionElements>
+              <activiti:value/>
+           </extensionElements>
+        </dataObject>
+
+        <sequenceFlow id="a1" sourceRef="theStart" targetRef="processStartedScript"/>
+
+        <scriptTask id="processStartedScript" name="Execute script" scriptFormat="groovy">
+            <script>
+                System.out.println("Process started");
+            </script>
+        </scriptTask>
+
+        <sequenceFlow id="a2" sourceRef="processStartedScript" targetRef="task1"/>
+        <userTask id="task1" name="Task A"/>
+        <sequenceFlow id="flow2" sourceRef="task1" targetRef="task2"/>
+        <userTask id="task2" name="Task B"/>
+
+        <boundaryEvent id="timer" attachedToRef="task2" cancelActivity="false">
+            <timerEventDefinition>
+                <timeCycle>R3/${StartDate}/PT2S</timeCycle>
+            </timerEventDefinition>
+        </boundaryEvent>
+        <sequenceFlow id="flow21" sourceRef="timer" targetRef="timerFiredTask"/>
+
+        <scriptTask id="timerFiredTask" name="Execute script" scriptFormat="groovy">
+            <script>
+                System.out.println("Boundary Event");
+            </script>
+        </scriptTask>
+
+        <sequenceFlow id="flow22" sourceRef="timerFiredTask" targetRef="nonInterruptingEnd"/>
+        <endEvent id="nonInterruptingEnd"/>
+
+
+
+        <sequenceFlow id="flow3" sourceRef="task2" targetRef="task2Completed"/>
+
+        <scriptTask id="task2Completed" name="Execute script" scriptFormat="groovy">
+            <script>
+                System.out.println("Process ended");
+            </script>
+        </scriptTask>
+
+        <sequenceFlow id="flow10" sourceRef="task2Completed" targetRef="end"/>
+
+        <endEvent id="end"/>
+
+
+    </process>
+
+
+</definitions>


### PR DESCRIPTION
Problem
Flowable persists the repeat timer string to the timer jobs table.   Datetime strings are either formatted in ISO8601 local time or non-ISO8601 string.

Fix
Datetime strings returned in the API (new the timer API) should be in ISO8601 Zulu time.  Zulu time should be used (not localtime) in case you have multiple clients running in different timezones.

Details
If the repeat is specified as R/<duration>, flowable determines the start time using the duration and persists the repeat field as R/’start datetime string’/<duration>
TimerUtil.prepareRepeat() is the method that formats the string.  It was formatting it in ISO8601 local time. It has been updated it to use ISO 8601 Zulu time.

If the repeat is specified with either a startDate or endDate datetime variable such as, R/${startDate}/<duration>  or R/<duration>/${endDate}, the JUEL expression is evaluated and Date.toString() is used to format the datetime string.  This is a NON-ISO8601 format.  I have added support for a custom type converter so that Date objects are converted into ISO8601 Zulu time.

Question
We did not add validation to the management service. Question is, should we require (validate) the repeat string only accepts datetime strings in Zulu time?  For example, a client could invoke the repeat() API and pass in a timeCycle that contains datetime string in their own locale, which happens to be different from the Flowable engine's locale.

