### PR TITLE
Update DefaultClockImpl to support specified timezone

### DIFF
--- a/modules/flowable-engine-common/src/main/java/org/flowable/engine/common/impl/util/DefaultClockImpl.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/engine/common/impl/util/DefaultClockImpl.java
@@ -21,15 +21,22 @@ import java.util.TimeZone;
  * @author Joram Barrez
  */
 public class DefaultClockImpl implements org.flowable.engine.common.runtime.Clock {
+    private TimeZone timeZone;
+    protected static volatile Calendar CURRENT_TIME;
 
-    private static volatile Calendar CURRENT_TIME;
+    public DefaultClockImpl() {
+    }
+
+    public DefaultClockImpl(TimeZone timeZone) {
+        this.timeZone = timeZone;
+    }
 
     @Override
     public void setCurrentTime(Date currentTime) {
         Calendar time = null;
 
         if (currentTime != null) {
-            time = new GregorianCalendar();
+            time = (null == timeZone ) ? new GregorianCalendar() : new GregorianCalendar(timeZone);
             time.setTime(currentTime);
         }
 
@@ -48,12 +55,16 @@ public class DefaultClockImpl implements org.flowable.engine.common.runtime.Cloc
 
     @Override
     public Date getCurrentTime() {
-        return CURRENT_TIME == null ? new Date() : CURRENT_TIME.getTime();
+        return null == CURRENT_TIME ? new Date() : CURRENT_TIME.getTime();
     }
 
     @Override
     public Calendar getCurrentCalendar() {
-        return CURRENT_TIME == null ? new GregorianCalendar() : (Calendar) CURRENT_TIME.clone();
+        if (null == CURRENT_TIME) {
+            return (null == timeZone) ? new GregorianCalendar() : new GregorianCalendar(timeZone);
+        }
+
+        return (Calendar) CURRENT_TIME.clone();
     }
 
     @Override


### PR DESCRIPTION
Update DeafultClockImpl to support specified TimeZone.  If not specified, it will continue to use the JVM's TimeZone.  The CURRENT_TIME variable changed to protected to make it easier to extend if needed.