### PR TITLE
More code cleanups

### DIFF
--- a/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/ValuedDataObjectConverterTest.java
+++ b/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/ValuedDataObjectConverterTest.java
@@ -70,7 +70,7 @@ public class ValuedDataObjectConverterTest extends AbstractConverterTest {
         assertEquals("BooleanTest", dataObj.getName());
         assertEquals("xsd:boolean", dataObj.getItemSubjectRef().getStructureRef());
         assertTrue(dataObj.getValue() instanceof Boolean);
-        assertEquals(new Boolean(true), dataObj.getValue());
+        assertEquals(Boolean.TRUE, dataObj.getValue());
 
         dataObj = objectMap.get("dObj3");
         assertEquals("dObj3", dataObj.getId());
@@ -85,21 +85,21 @@ public class ValuedDataObjectConverterTest extends AbstractConverterTest {
         assertEquals("DoubleTest", dataObj.getName());
         assertEquals("xsd:double", dataObj.getItemSubjectRef().getStructureRef());
         assertTrue(dataObj.getValue() instanceof Double);
-        assertEquals(new Double(123456789), dataObj.getValue());
+        assertEquals(123456789d, dataObj.getValue());
 
         dataObj = objectMap.get("dObj5");
         assertEquals("dObj5", dataObj.getId());
         assertEquals("IntegerTest", dataObj.getName());
         assertEquals("xsd:int", dataObj.getItemSubjectRef().getStructureRef());
         assertTrue(dataObj.getValue() instanceof Integer);
-        assertEquals(new Integer(123), dataObj.getValue());
+        assertEquals(123, dataObj.getValue());
 
         dataObj = objectMap.get("dObj6");
         assertEquals("dObj6", dataObj.getId());
         assertEquals("LongTest", dataObj.getName());
         assertEquals("xsd:long", dataObj.getItemSubjectRef().getStructureRef());
         assertTrue(dataObj.getValue() instanceof Long);
-        assertEquals(new Long(-123456), dataObj.getValue());
+        assertEquals((long) -123456, dataObj.getValue());
         assertEquals(1, dataObj.getExtensionElements().size());
         List<ExtensionElement> testValues = dataObj.getExtensionElements().get("testvalue");
         assertNotNull(testValues);
@@ -148,7 +148,7 @@ public class ValuedDataObjectConverterTest extends AbstractConverterTest {
         assertEquals("BooleanSubTest", dataObj.getName());
         assertEquals("xsd:boolean", dataObj.getItemSubjectRef().getStructureRef());
         assertTrue(dataObj.getValue() instanceof Boolean);
-        assertEquals(new Boolean(false), dataObj.getValue());
+        assertEquals(Boolean.FALSE, dataObj.getValue());
 
         dataObj = objectMap.get("dObj9");
         assertEquals("dObj9", dataObj.getId());
@@ -162,20 +162,20 @@ public class ValuedDataObjectConverterTest extends AbstractConverterTest {
         assertEquals("DoubleSubTest", dataObj.getName());
         assertEquals("xsd:double", dataObj.getItemSubjectRef().getStructureRef());
         assertTrue(dataObj.getValue() instanceof Double);
-        assertEquals(new Double(678912345), dataObj.getValue());
+        assertEquals(678912345d, dataObj.getValue());
 
         dataObj = objectMap.get("dObj11");
         assertEquals("dObj11", dataObj.getId());
         assertEquals("IntegerSubTest", dataObj.getName());
         assertEquals("xsd:int", dataObj.getItemSubjectRef().getStructureRef());
         assertTrue(dataObj.getValue() instanceof Integer);
-        assertEquals(new Integer(45), dataObj.getValue());
+        assertEquals(45, dataObj.getValue());
 
         dataObj = objectMap.get("dObj12");
         assertEquals("dObj12", dataObj.getId());
         assertEquals("LongSubTest", dataObj.getName());
         assertEquals("xsd:long", dataObj.getItemSubjectRef().getStructureRef());
         assertTrue(dataObj.getValue() instanceof Long);
-        assertEquals(new Long(456123), dataObj.getValue());
+        assertEquals(456123L, dataObj.getValue());
     }
 }

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/EmptyProcessTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/EmptyProcessTest.java
@@ -77,7 +77,7 @@ public class EmptyProcessTest extends SpringFlowableTestCase {
     public void testObjectAsVariable() throws Exception {
         CamelContext ctx = applicationContext.getBean(CamelContext.class);
         ProducerTemplate tpl = ctx.createProducerTemplate();
-        Object expectedObj = new Long(99);
+        Object expectedObj = 99L;
         Exchange exchange = ctx.getEndpoint("direct:startEmpty").createExchange();
         exchange.getIn().setBody(expectedObj);
         tpl.send("direct:startEmpty", exchange);
@@ -92,7 +92,7 @@ public class EmptyProcessTest extends SpringFlowableTestCase {
     public void testObjectAsStringVariable() throws Exception {
         CamelContext ctx = applicationContext.getBean(CamelContext.class);
         ProducerTemplate tpl = ctx.createProducerTemplate();
-        Object expectedObj = new Long(99);
+        Object expectedObj = 99L;
 
         Exchange exchange = ctx.getEndpoint("direct:startEmptyBodyAsString").createExchange();
         exchange.getIn().setBody(expectedObj);

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/util/json/XML.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/util/json/XML.java
@@ -35,31 +35,31 @@ import java.util.Iterator;
 public class XML {
 
     /** The Character '&'. */
-    public static final Character AMP = new Character('&');
+    public static final Character AMP = '&';
 
     /** The Character '''. */
-    public static final Character APOS = new Character('\'');
+    public static final Character APOS = '\'';
 
     /** The Character '!'. */
-    public static final Character BANG = new Character('!');
+    public static final Character BANG = '!';
 
     /** The Character '='. */
-    public static final Character EQ = new Character('=');
+    public static final Character EQ = '=';
 
     /** The Character '>'. */
-    public static final Character GT = new Character('>');
+    public static final Character GT = '>';
 
     /** The Character '<'. */
-    public static final Character LT = new Character('<');
+    public static final Character LT = '<';
 
     /** The Character '?'. */
-    public static final Character QUEST = new Character('?');
+    public static final Character QUEST = '?';
 
     /** The Character '"'. */
-    public static final Character QUOT = new Character('"');
+    public static final Character QUOT = '"';
 
     /** The Character '/'. */
-    public static final Character SLASH = new Character('/');
+    public static final Character SLASH = '/';
 
     /**
      * Replace special characters with XML escapes:

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricProcessInstanceAndVariablesQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricProcessInstanceAndVariablesQueryTest.java
@@ -28,11 +28,11 @@ import org.flowable.engine.task.Task;
  */
 public class HistoricProcessInstanceAndVariablesQueryTest extends PluggableFlowableTestCase {
 
-    private static String PROCESS_DEFINITION_KEY = "oneTaskProcess";
-    private static String PROCESS_DEFINITION_KEY_2 = "oneTaskProcess2";
-    private static String PROCESS_DEFINITION_NAME_2 = "oneTaskProcess2Name";
-    private static String PROCESS_DEFINITION_CATEGORY_2 = "org.flowable.enginge.test.api.runtime.2Category";
-    private static String PROCESS_DEFINITION_KEY_3 = "oneTaskProcess3";
+    private static final String PROCESS_DEFINITION_KEY = "oneTaskProcess";
+    private static final String PROCESS_DEFINITION_KEY_2 = "oneTaskProcess2";
+    private static final String PROCESS_DEFINITION_NAME_2 = "oneTaskProcess2Name";
+    private static final String PROCESS_DEFINITION_CATEGORY_2 = "org.flowable.enginge.test.api.runtime.2Category";
+    private static final String PROCESS_DEFINITION_KEY_3 = "oneTaskProcess3";
 
     private List<String> processInstanceIds;
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/NonCascadeDeleteTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/NonCascadeDeleteTest.java
@@ -7,7 +7,7 @@ import org.flowable.engine.task.Task;
 
 public class NonCascadeDeleteTest extends PluggableFlowableTestCase {
 
-    private static String PROCESS_DEFINITION_KEY = "oneTaskProcess";
+    private static final String PROCESS_DEFINITION_KEY = "oneTaskProcess";
 
     private String deploymentId;
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/repository/ProcessDefinitionQueryByLatestTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/repository/ProcessDefinitionQueryByLatestTest.java
@@ -10,7 +10,7 @@ import org.flowable.engine.repository.ProcessDefinitionQuery;
 
 public class ProcessDefinitionQueryByLatestTest extends PluggableFlowableTestCase {
 
-    private static String XML_FILE_PATH = "org/flowable/engine/test/repository/latest/";
+    private static final String XML_FILE_PATH = "org/flowable/engine/test/repository/latest/";
 
     @Override
     protected void setUp() throws Exception {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ExecutionQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ExecutionQueryTest.java
@@ -26,6 +26,8 @@
 
 package org.flowable.engine.test.api.runtime;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -47,20 +49,18 @@ import org.flowable.engine.runtime.ExecutionQuery;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 /**
  * @author Joram Barrez
  * @author Frederik Heremans
  */
 public class ExecutionQueryTest extends PluggableFlowableTestCase {
 
-    private static String CONCURRENT_PROCESS_KEY = "concurrent";
-    private static String SEQUENTIAL_PROCESS_KEY = "oneTaskProcess";
-    private static String CONCURRENT_PROCESS_NAME = "concurrentName";
-    private static String SEQUENTIAL_PROCESS_NAME = "oneTaskProcessName";
-    private static String CONCURRENT_PROCESS_CATEGORY = "org.flowable.enginge.test.api.runtime.concurrent.Category";
-    private static String SEQUENTIAL_PROCESS_CATEGORY = "org.flowable.enginge.test.api.runtime.Category";
+    private static final String CONCURRENT_PROCESS_KEY = "concurrent";
+    private static final String SEQUENTIAL_PROCESS_KEY = "oneTaskProcess";
+    private static final String CONCURRENT_PROCESS_NAME = "concurrentName";
+    private static final String SEQUENTIAL_PROCESS_NAME = "oneTaskProcessName";
+    private static final String CONCURRENT_PROCESS_CATEGORY = "org.flowable.enginge.test.api.runtime.concurrent.Category";
+    private static final String SEQUENTIAL_PROCESS_CATEGORY = "org.flowable.enginge.test.api.runtime.Category";
 
     private List<String> concurrentProcessInstanceIds;
     private List<String> sequentialProcessInstanceIds;

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ProcessInstanceAndVariablesQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ProcessInstanceAndVariablesQueryTest.java
@@ -26,9 +26,9 @@ import org.flowable.engine.runtime.ProcessInstanceQuery;
  */
 public class ProcessInstanceAndVariablesQueryTest extends PluggableFlowableTestCase {
 
-    private static String PROCESS_DEFINITION_KEY = "oneTaskProcess";
-    private static String PROCESS_DEFINITION_KEY_2 = "oneTaskProcess2";
-    private static String PROCESS_DEFINITION_KEY_3 = "oneTaskProcess3";
+    private static final String PROCESS_DEFINITION_KEY = "oneTaskProcess";
+    private static final String PROCESS_DEFINITION_KEY_2 = "oneTaskProcess2";
+    private static final String PROCESS_DEFINITION_KEY_3 = "oneTaskProcess3";
 
     private List<String> processInstanceIds;
 
@@ -43,10 +43,10 @@ public class ProcessInstanceAndVariablesQueryTest extends PluggableFlowableTestC
                 .addClasspathResource("org/flowable/engine/test/api/runtime/oneTaskProcess3.bpmn20.xml")
                 .deploy();
 
-        Map<String, Object> startMap = new HashMap<String, Object>();
+        Map<String, Object> startMap = new HashMap<>();
         startMap.put("test", "test");
         startMap.put("test2", "test2");
-        processInstanceIds = new ArrayList<String>();
+        processInstanceIds = new ArrayList<>();
         for (int i = 0; i < 4; i++) {
             processInstanceIds.add(runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY, String.valueOf(i), startMap).getId());
         }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskServiceTest.java
@@ -691,7 +691,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         assertNull(runtimeService.getVariable(processInstance.getId(), "b"));
 
         // verify script listener has done its job
-        assertEquals(new Integer(2), runtimeService.getVariable(processInstance.getId(), "sum"));
+        assertEquals(2, runtimeService.getVariable(processInstance.getId(), "sum"));
 
         // Fetch second task
         taskService.createTaskQuery().singleResult();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/v6/Flowable6Test.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/v6/Flowable6Test.java
@@ -114,11 +114,10 @@ public class Flowable6Test extends PluggableFlowableTestCase {
      */
     @org.flowable.engine.test.Deployment
     public void testLongServiceTaskLoop() {
-        int maxCount = 3210; // You can make this as big as you want (as long as
-                             // it still fits within transaction timeouts). Go
-                             // on, try it!
+        int maxCount = 3210; // You can make this as big as you want (as long as it still fits within transaction timeouts).
+                             // Go on, try it!
         Map<String, Object> vars = new HashMap<String, Object>();
-        vars.put("counter", new Integer(0));
+        vars.put("counter", 0);
         vars.put("maxCount", maxCount);
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testLongServiceTaskLoop", vars);
         assertNotNull(processInstance);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/variables/TransientVariablesTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/variables/TransientVariablesTest.java
@@ -276,7 +276,7 @@ public class TransientVariablesTest extends PluggableFlowableTestCase {
     public static class FetchDataServiceTask implements JavaDelegate {
         public void execute(DelegateExecution execution) {
             execution.setTransientVariable("response", "author=kermit;version=3;message=Hello World");
-            execution.setTransientVariable("status", new Integer(200));
+            execution.setTransientVariable("status", 200);
         }
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/dynamic/DynamicCandidateGroupsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/dynamic/DynamicCandidateGroupsTest.java
@@ -15,6 +15,8 @@ package org.flowable.engine.test.bpmn.dynamic;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import java.util.ArrayList;
 
 import org.flowable.engine.DynamicBpmnConstants;
@@ -22,16 +24,14 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 /**
  * Created by Pardo David on 7/12/2016.
  */
 public class DynamicCandidateGroupsTest extends PluggableFlowableTestCase implements DynamicBpmnConstants {
 
-    private final String TASK_ONE_SID = "sid-B94D5D22-E93E-4401-ADC5-C5C073E1EEB4";
-    private final String TASK_TWO_SID = "sid-B1C37EBE-A273-4DDE-B909-89302638526A";
-    private final String SCRIPT_TASK_SID = "sid-A403BAE0-E367-449A-90B2-48834FCAA2F9";
+    private static final String TASK_ONE_SID = "sid-B94D5D22-E93E-4401-ADC5-C5C073E1EEB4";
+    private static final String TASK_TWO_SID = "sid-B1C37EBE-A273-4DDE-B909-89302638526A";
+    private static final String SCRIPT_TASK_SID = "sid-A403BAE0-E367-449A-90B2-48834FCAA2F9";
 
     @Deployment(resources = { "org/flowable/engine/test/bpmn/dynamic/dynamic-bpmn-test-process.bpmn20.xml" })
     public void testIsShouldBePossibleToChangeCandidateGroups() {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/dynamic/DynamicProcessDefinitionSummaryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/dynamic/DynamicProcessDefinitionSummaryTest.java
@@ -18,6 +18,10 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import java.util.List;
 
 import org.flowable.engine.DynamicBpmnConstants;
@@ -28,18 +32,14 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.task.Task;
 import org.flowable.engine.test.Deployment;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 /**
  * Created by Pardo David on 1/12/2016.
  */
 public class DynamicProcessDefinitionSummaryTest extends PluggableFlowableTestCase implements DynamicBpmnConstants, PropertiesParserConstants {
 
-    private final String TASK_ONE_SID = "sid-B94D5D22-E93E-4401-ADC5-C5C073E1EEB4";
-    private final String TASK_TWO_SID = "sid-B1C37EBE-A273-4DDE-B909-89302638526A";
-    private final String SCRIPT_TASK_SID = "sid-A403BAE0-E367-449A-90B2-48834FCAA2F9";
+    private static final String TASK_ONE_SID = "sid-B94D5D22-E93E-4401-ADC5-C5C073E1EEB4";
+    private static final String TASK_TWO_SID = "sid-B1C37EBE-A273-4DDE-B909-89302638526A";
+    private static final String SCRIPT_TASK_SID = "sid-A403BAE0-E367-449A-90B2-48834FCAA2F9";
 
     public void testProcessDefinitionInfoCacheIsEnabledWithPluggableActivitiTestCase() throws Exception {
         assertThat(processEngineConfiguration.isEnableProcessDefinitionInfoCache(), is(true));

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/subprocess/CallActivityTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/subprocess/CallActivityTest.java
@@ -34,12 +34,12 @@ import org.flowable.engine.runtime.ProcessInstance;
 
 public class CallActivityTest extends ResourceFlowableTestCase {
 
-    private static String MAIN_PROCESS_RESOURCE = "org/flowable/engine/test/bpmn/subprocess/SubProcessTest.testSuspendedProcessCallActivity_mainProcess.bpmn.xml";
-    private static String CHILD_PROCESS_RESOURCE = "org/flowable/engine/test/bpmn/subprocess/SubProcessTest.testSuspendedProcessCallActivity_childProcess.bpmn.xml";
-    private static String MESSAGE_TRIGGERED_PROCESS_RESOURCE = "org/flowable/engine/test/bpmn/subprocess/SubProcessTest.testSuspendedProcessCallActivity_messageTriggeredProcess.bpmn.xml";
-    private static String INHERIT_VARIABLES_MAIN_PROCESS_RESOURCE = "org/flowable/engine/test/bpmn/subprocess/SubProcessTest.testInheritVariablesCallActivity_mainProcess.bpmn20.xml";
-    private static String INHERIT_VARIABLES_CHILD_PROCESS_RESOURCE = "org/flowable/engine/test/bpmn/subprocess/SubProcessTest.testInheritVariablesCallActivity_childProcess.bpmn20.xml";
-    private static String NOT_INHERIT_VARIABLES_MAIN_PROCESS_RESOURCE = "org/flowable/engine/test/bpmn/subprocess/SubProcessTest.testNotInheritVariablesCallActivity_mainProcess.bpmn20.xml";
+    private static final String MAIN_PROCESS_RESOURCE = "org/flowable/engine/test/bpmn/subprocess/SubProcessTest.testSuspendedProcessCallActivity_mainProcess.bpmn.xml";
+    private static final String CHILD_PROCESS_RESOURCE = "org/flowable/engine/test/bpmn/subprocess/SubProcessTest.testSuspendedProcessCallActivity_childProcess.bpmn.xml";
+    private static final String MESSAGE_TRIGGERED_PROCESS_RESOURCE = "org/flowable/engine/test/bpmn/subprocess/SubProcessTest.testSuspendedProcessCallActivity_messageTriggeredProcess.bpmn.xml";
+    private static final String INHERIT_VARIABLES_MAIN_PROCESS_RESOURCE = "org/flowable/engine/test/bpmn/subprocess/SubProcessTest.testInheritVariablesCallActivity_mainProcess.bpmn20.xml";
+    private static final String INHERIT_VARIABLES_CHILD_PROCESS_RESOURCE = "org/flowable/engine/test/bpmn/subprocess/SubProcessTest.testInheritVariablesCallActivity_childProcess.bpmn20.xml";
+    private static final String NOT_INHERIT_VARIABLES_MAIN_PROCESS_RESOURCE = "org/flowable/engine/test/bpmn/subprocess/SubProcessTest.testNotInheritVariablesCallActivity_mainProcess.bpmn20.xml";
 
     public CallActivityTest() {
         super("org/flowable/standalone/parsing/encoding.flowable.cfg.xml");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/ProcessInstanceLogQueryAndByteArrayTypeVariableTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/ProcessInstanceLogQueryAndByteArrayTypeVariableTest.java
@@ -32,12 +32,12 @@ public class ProcessInstanceLogQueryAndByteArrayTypeVariableTest extends Pluggab
 
     protected String processInstanceId;
 
-    private static String LARGE_STRING_VALUE;
+    private static final String LARGE_STRING_VALUE;
 
     static {
         StringBuilder sb = new StringBuilder("a");
         for (int i = 0; i < 4001; i++) {
-            sb.append("a");
+            sb.append('a');
         }
         LARGE_STRING_VALUE = sb.toString();
     }
@@ -50,7 +50,7 @@ public class ProcessInstanceLogQueryAndByteArrayTypeVariableTest extends Pluggab
         deployTwoTasksTestProcess();
 
         // Start process instance
-        Map<String, Object> vars = new HashMap<String, Object>();
+        Map<String, Object> vars = new HashMap<>();
         // ByteArrayType Variable
         vars.put("var", LARGE_STRING_VALUE);
         this.processInstanceId = runtimeService.startProcessInstanceByKey("twoTasksProcess", vars).getId();
@@ -76,7 +76,7 @@ public class ProcessInstanceLogQueryAndByteArrayTypeVariableTest extends Pluggab
 
             for (HistoricData event : events) {
                 assertTrue(event instanceof HistoricVariableInstance);
-                assertEquals(((HistoricVariableInstanceEntity) event).getValue(), LARGE_STRING_VALUE);
+                assertEquals(LARGE_STRING_VALUE, ((HistoricVariableInstanceEntity) event).getValue());
             }
         }
     }
@@ -86,7 +86,7 @@ public class ProcessInstanceLogQueryAndByteArrayTypeVariableTest extends Pluggab
 
             HistoricVariableInstance historicVariableInstance = historyService.createHistoricVariableInstanceQuery()
                     .processInstanceId(processInstanceId).variableName("var").singleResult();
-            assertEquals(historicVariableInstance.getValue(), LARGE_STRING_VALUE);
+            assertEquals(LARGE_STRING_VALUE, historicVariableInstance.getValue());
 
             ProcessInstanceHistoryLog log = historyService.createProcessInstanceHistoryLogQuery(processInstanceId)
                     .includeVariableUpdates()
@@ -96,7 +96,7 @@ public class ProcessInstanceLogQueryAndByteArrayTypeVariableTest extends Pluggab
 
             for (HistoricData event : events) {
                 assertTrue(event instanceof HistoricVariableUpdate);
-                assertEquals(((HistoricDetailVariableInstanceUpdateEntity) event).getValue(), LARGE_STRING_VALUE);
+                assertEquals(LARGE_STRING_VALUE, ((HistoricDetailVariableInstanceUpdateEntity) event).getValue());
             }
         }
     }

--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/EventSubprocessSequenceFlowTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/EventSubprocessSequenceFlowTest.java
@@ -26,8 +26,8 @@ import org.junit.Test;
  * Created by Pardo David on 21/02/2017.
  */
 public class EventSubprocessSequenceFlowTest extends AbstractConverterTest {
-    private final static String EVENT_SUBPROCESS_ID = "sid-3AE5DD30-CE0E-4660-871F-A515E39EECA6";
-    private final static String FROM_SE_TO_TASK = "sid-45B32336-D4E3-4576-8377-2D81C0EE02C4";
+    private static final String EVENT_SUBPROCESS_ID = "sid-3AE5DD30-CE0E-4660-871F-A515E39EECA6";
+    private static final String FROM_SE_TO_TASK = "sid-45B32336-D4E3-4576-8377-2D81C0EE02C4";
 
     @Test
     public void oneWay() throws Exception{

--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/ValuedDataObjectConverterTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/ValuedDataObjectConverterTest.java
@@ -74,7 +74,7 @@ public class ValuedDataObjectConverterTest extends AbstractConverterTest {
                 assertEquals("BooleanTest", dObj.getName());
                 assertEquals("xsd:boolean", dObj.getItemSubjectRef().getStructureRef());
                 assertTrue(dObj.getValue() instanceof Boolean);
-                assertEquals(new Boolean(true), dObj.getValue());
+                assertEquals(Boolean.TRUE, dObj.getValue());
             } else if ("dObj3".equals(dObj.getId())) {
                 assertEquals(DateDataObject.class, dObj.getClass());
                 assertEquals("DateTest", dObj.getName());
@@ -92,19 +92,19 @@ public class ValuedDataObjectConverterTest extends AbstractConverterTest {
                 assertEquals("DoubleTest", dObj.getName());
                 assertEquals("xsd:double", dObj.getItemSubjectRef().getStructureRef());
                 assertTrue(dObj.getValue() instanceof Double);
-                assertEquals(new Double(123456789), dObj.getValue());
+                assertEquals(123456789d, dObj.getValue());
             } else if ("dObj5".equals(dObj.getId())) {
                 assertEquals(IntegerDataObject.class, dObj.getClass());
                 assertEquals("IntegerTest", dObj.getName());
                 assertEquals("xsd:int", dObj.getItemSubjectRef().getStructureRef());
                 assertTrue(dObj.getValue() instanceof Integer);
-                assertEquals(new Integer(123), dObj.getValue());
+                assertEquals(123, dObj.getValue());
             } else if ("dObj6".equals(dObj.getId())) {
                 assertEquals(LongDataObject.class, dObj.getClass());
                 assertEquals("LongTest", dObj.getName());
                 assertEquals("xsd:long", dObj.getItemSubjectRef().getStructureRef());
                 assertTrue(dObj.getValue() instanceof Long);
-                assertEquals(new Long(-123456), dObj.getValue());
+                assertEquals((long) -123456, dObj.getValue());
             }
         }
 
@@ -130,7 +130,7 @@ public class ValuedDataObjectConverterTest extends AbstractConverterTest {
                 assertEquals("SubBooleanTest", dObj.getName());
                 assertEquals("xsd:boolean", dObj.getItemSubjectRef().getStructureRef());
                 assertTrue(dObj.getValue() instanceof Boolean);
-                assertEquals(new Boolean(false), dObj.getValue());
+                assertEquals(Boolean.FALSE, dObj.getValue());
             } else if ("dObj3".equals(dObj.getId())) {
                 assertEquals(DateDataObject.class, dObj.getClass());
                 assertEquals("SubDateTest", dObj.getName());
@@ -146,19 +146,19 @@ public class ValuedDataObjectConverterTest extends AbstractConverterTest {
                 assertEquals("SubDoubleTest", dObj.getName());
                 assertEquals("xsd:double", dObj.getItemSubjectRef().getStructureRef());
                 assertTrue(dObj.getValue() instanceof Double);
-                assertEquals(new Double(678912345), dObj.getValue());
+                assertEquals(678912345d, dObj.getValue());
             } else if ("dObj5".equals(dObj.getId())) {
                 assertEquals(IntegerDataObject.class, dObj.getClass());
                 assertEquals("SubIntegerTest", dObj.getName());
                 assertEquals("xsd:int", dObj.getItemSubjectRef().getStructureRef());
                 assertTrue(dObj.getValue() instanceof Integer);
-                assertEquals(new Integer(45), dObj.getValue());
+                assertEquals(45, dObj.getValue());
             } else if ("dObj6".equals(dObj.getId())) {
                 assertEquals(LongDataObject.class, dObj.getClass());
                 assertEquals("SubLongTest", dObj.getName());
                 assertEquals("xsd:long", dObj.getItemSubjectRef().getStructureRef());
                 assertTrue(dObj.getValue() instanceof Long);
-                assertEquals(new Long(456123), dObj.getValue());
+                assertEquals(456123L, dObj.getValue());
                 assertEquals(1, dObj.getExtensionElements().size());
             }
         }

--- a/modules/flowable-process-validation/src/main/java/org/flowable/validation/validator/impl/SequenceflowValidator.java
+++ b/modules/flowable-process-validation/src/main/java/org/flowable/validation/validator/impl/SequenceflowValidator.java
@@ -13,7 +13,6 @@
 package org.flowable.validation.validator.impl;
 
 import java.util.List;
-import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
 import org.flowable.bpmn.model.BpmnModel;

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/juel/NumberOperations.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/juel/NumberOperations.java
@@ -26,7 +26,7 @@ import org.activiti.engine.impl.javax.el.ELException;
  * @author Christoph Beck
  */
 public class NumberOperations {
-    private static final Long LONG_ZERO = Long.valueOf(0L);
+    private static final Long LONG_ZERO = 0L;
 
     private static final boolean isDotEe(String value) {
         int length = value.length();

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/util/json/XML.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/util/json/XML.java
@@ -35,31 +35,31 @@ import java.util.Iterator;
 public class XML {
 
     /** The Character '&'. */
-    public static final Character AMP = new Character('&');
+    public static final Character AMP = '&';
 
     /** The Character '''. */
-    public static final Character APOS = new Character('\'');
+    public static final Character APOS = '\'';
 
     /** The Character '!'. */
-    public static final Character BANG = new Character('!');
+    public static final Character BANG = '!';
 
     /** The Character '='. */
-    public static final Character EQ = new Character('=');
+    public static final Character EQ = '=';
 
     /** The Character '>'. */
-    public static final Character GT = new Character('>');
+    public static final Character GT = '>';
 
     /** The Character '<'. */
-    public static final Character LT = new Character('<');
+    public static final Character LT = '<';
 
     /** The Character '?'. */
-    public static final Character QUEST = new Character('?');
+    public static final Character QUEST = '?';
 
     /** The Character '"'. */
-    public static final Character QUOT = new Character('"');
+    public static final Character QUOT = '"';
 
     /** The Character '/'. */
-    public static final Character SLASH = new Character('/');
+    public static final Character SLASH = '/';
 
     /**
      * Replace special characters with XML escapes:

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/event/JobEventsTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/event/JobEventsTest.java
@@ -168,7 +168,7 @@ public class JobEventsTest extends PluggableFlowableTestCase {
         int timerFiredCount = 0;
         List<FlowableEvent> eventsReceived = listener.getEventsReceived();
         for (FlowableEvent eventReceived : eventsReceived) {
-            if (FlowableEngineEventType.TIMER_FIRED.equals(eventReceived.getType())) {
+            if (FlowableEngineEventType.TIMER_FIRED == eventReceived.getType()) {
                 timerFiredCount++;
             }
         }

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/history/HistoricProcessInstanceAndVariablesQueryTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/history/HistoricProcessInstanceAndVariablesQueryTest.java
@@ -28,11 +28,11 @@ import org.flowable.engine.task.Task;
  */
 public class HistoricProcessInstanceAndVariablesQueryTest extends PluggableFlowableTestCase {
 
-    private static String PROCESS_DEFINITION_KEY = "oneTaskProcess";
-    private static String PROCESS_DEFINITION_KEY_2 = "oneTaskProcess2";
-    private static String PROCESS_DEFINITION_NAME_2 = "oneTaskProcess2Name";
-    private static String PROCESS_DEFINITION_CATEGORY_2 = "org.activiti.enginge.test.api.runtime.2Category";
-    private static String PROCESS_DEFINITION_KEY_3 = "oneTaskProcess3";
+    private static final String PROCESS_DEFINITION_KEY = "oneTaskProcess";
+    private static final String PROCESS_DEFINITION_KEY_2 = "oneTaskProcess2";
+    private static final String PROCESS_DEFINITION_NAME_2 = "oneTaskProcess2Name";
+    private static final String PROCESS_DEFINITION_CATEGORY_2 = "org.activiti.enginge.test.api.runtime.2Category";
+    private static final String PROCESS_DEFINITION_KEY_3 = "oneTaskProcess3";
 
     private List<String> processInstanceIds;
 

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/history/NonCascadeDeleteTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/history/NonCascadeDeleteTest.java
@@ -7,7 +7,7 @@ import org.flowable.engine.task.Task;
 
 public class NonCascadeDeleteTest extends PluggableFlowableTestCase {
 
-    private static String PROCESS_DEFINITION_KEY = "oneTaskProcess";
+    private static final String PROCESS_DEFINITION_KEY = "oneTaskProcess";
 
     private String deploymentId;
 

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/history/ProcessInstanceLogQueryAndByteArrayTypeVariableTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/history/ProcessInstanceLogQueryAndByteArrayTypeVariableTest.java
@@ -32,12 +32,12 @@ public class ProcessInstanceLogQueryAndByteArrayTypeVariableTest extends Pluggab
 
     protected String processInstanceId;
 
-    private static String LARGE_STRING_VALUE;
+    private static final String LARGE_STRING_VALUE;
 
     static {
         StringBuilder sb = new StringBuilder("a");
         for (int i = 0; i < 4001; i++) {
-            sb.append("a");
+            sb.append('a');
         }
         LARGE_STRING_VALUE = sb.toString();
     }
@@ -50,7 +50,7 @@ public class ProcessInstanceLogQueryAndByteArrayTypeVariableTest extends Pluggab
         deployTwoTasksTestProcess();
 
         // Start process instance
-        Map<String, Object> vars = new HashMap<String, Object>();
+        Map<String, Object> vars = new HashMap<>();
         // ByteArrayType Variable
         vars.put("var", LARGE_STRING_VALUE);
         this.processInstanceId = runtimeService.startProcessInstanceByKey("twoTasksProcess", vars).getId();
@@ -76,7 +76,7 @@ public class ProcessInstanceLogQueryAndByteArrayTypeVariableTest extends Pluggab
 
             for (HistoricData event : events) {
                 assertTrue(event instanceof HistoricVariableInstance);
-                assertEquals(((HistoricVariableInstanceEntity) event).getValue(), LARGE_STRING_VALUE);
+                assertEquals(LARGE_STRING_VALUE, ((HistoricVariableInstanceEntity) event).getValue());
             }
         }
     }
@@ -86,7 +86,7 @@ public class ProcessInstanceLogQueryAndByteArrayTypeVariableTest extends Pluggab
 
             HistoricVariableInstance historicVariableInstance = historyService.createHistoricVariableInstanceQuery()
                     .processInstanceId(processInstanceId).variableName("var").singleResult();
-            assertEquals(historicVariableInstance.getValue(), LARGE_STRING_VALUE);
+            assertEquals(LARGE_STRING_VALUE, historicVariableInstance.getValue());
 
             ProcessInstanceHistoryLog log = historyService.createProcessInstanceHistoryLogQuery(processInstanceId)
                     .includeVariableUpdates()
@@ -96,7 +96,7 @@ public class ProcessInstanceLogQueryAndByteArrayTypeVariableTest extends Pluggab
 
             for (HistoricData event : events) {
                 assertTrue(event instanceof HistoricVariableUpdate);
-                assertEquals(((HistoricDetailVariableInstanceUpdateEntity) event).getValue(), LARGE_STRING_VALUE);
+                assertEquals(LARGE_STRING_VALUE, ((HistoricDetailVariableInstanceUpdateEntity) event).getValue());
             }
         }
     }

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/repository/ProcessDefinitionQueryByLatestTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/repository/ProcessDefinitionQueryByLatestTest.java
@@ -10,7 +10,7 @@ import org.flowable.engine.repository.ProcessDefinitionQuery;
 
 public class ProcessDefinitionQueryByLatestTest extends PluggableFlowableTestCase {
 
-    private static String XML_FILE_PATH = "org/activiti/engine/test/repository/latest/";
+    private static final String XML_FILE_PATH = "org/activiti/engine/test/repository/latest/";
 
     @Override
     protected void setUp() throws Exception {

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/runtime/ExecutionQueryTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/runtime/ExecutionQueryTest.java
@@ -26,6 +26,8 @@
 
 package org.activiti.engine.test.api.runtime;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -47,20 +49,18 @@ import org.flowable.engine.runtime.ExecutionQuery;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 /**
  * @author Joram Barrez
  * @author Frederik Heremans
  */
 public class ExecutionQueryTest extends PluggableFlowableTestCase {
 
-    private static String CONCURRENT_PROCESS_KEY = "concurrent";
-    private static String SEQUENTIAL_PROCESS_KEY = "oneTaskProcess";
-    private static String CONCURRENT_PROCESS_NAME = "concurrentName";
-    private static String SEQUENTIAL_PROCESS_NAME = "oneTaskProcessName";
-    private static String CONCURRENT_PROCESS_CATEGORY = "org.activiti.enginge.test.api.runtime.concurrent.Category";
-    private static String SEQUENTIAL_PROCESS_CATEGORY = "org.activiti.enginge.test.api.runtime.Category";
+    private static final String CONCURRENT_PROCESS_KEY = "concurrent";
+    private static final String SEQUENTIAL_PROCESS_KEY = "oneTaskProcess";
+    private static final String CONCURRENT_PROCESS_NAME = "concurrentName";
+    private static final String SEQUENTIAL_PROCESS_NAME = "oneTaskProcessName";
+    private static final String CONCURRENT_PROCESS_CATEGORY = "org.activiti.enginge.test.api.runtime.concurrent.Category";
+    private static final String SEQUENTIAL_PROCESS_CATEGORY = "org.activiti.enginge.test.api.runtime.Category";
 
     private List<String> concurrentProcessInstanceIds;
     private List<String> sequentialProcessInstanceIds;

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/runtime/ProcessInstanceAndVariablesQueryTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/runtime/ProcessInstanceAndVariablesQueryTest.java
@@ -27,9 +27,9 @@ import org.flowable.engine.runtime.ProcessInstanceQuery;
  */
 public class ProcessInstanceAndVariablesQueryTest extends PluggableFlowableTestCase {
 
-    private static String PROCESS_DEFINITION_KEY = "oneTaskProcess";
-    private static String PROCESS_DEFINITION_KEY_2 = "oneTaskProcess2";
-    private static String PROCESS_DEFINITION_KEY_3 = "oneTaskProcess3";
+    private static final String PROCESS_DEFINITION_KEY = "oneTaskProcess";
+    private static final String PROCESS_DEFINITION_KEY_2 = "oneTaskProcess2";
+    private static final String PROCESS_DEFINITION_KEY_3 = "oneTaskProcess3";
 
     private List<String> processInstanceIds;
 
@@ -45,10 +45,10 @@ public class ProcessInstanceAndVariablesQueryTest extends PluggableFlowableTestC
                 .deploymentProperty(DeploymentProperties.DEPLOY_AS_FLOWABLE5_PROCESS_DEFINITION, Boolean.TRUE)
                 .deploy();
 
-        Map<String, Object> startMap = new HashMap<String, Object>();
+        Map<String, Object> startMap = new HashMap<>();
         startMap.put("test", "test");
         startMap.put("test2", "test2");
-        processInstanceIds = new ArrayList<String>();
+        processInstanceIds = new ArrayList<>();
         for (int i = 0; i < 4; i++) {
             processInstanceIds.add(runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY, String.valueOf(i), startMap).getId());
         }

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/task/TaskServiceTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/task/TaskServiceTest.java
@@ -684,7 +684,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         assertNull(runtimeService.getVariable(processInstance.getId(), "b"));
 
         // verify script listener has done its job
-        assertEquals(new Integer(2), runtimeService.getVariable(processInstance.getId(), "sum"));
+        assertEquals(2, runtimeService.getVariable(processInstance.getId(), "sum"));
 
         // Fetch second task
         taskService.createTaskQuery().singleResult();

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/variables/TransientVariablesTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/variables/TransientVariablesTest.java
@@ -261,7 +261,7 @@ public class TransientVariablesTest extends PluggableFlowableTestCase {
     public static class FetchDataServiceTask implements JavaDelegate {
         public void execute(DelegateExecution execution) {
             execution.setTransientVariable("response", "author=kermit;version=3;message=Hello World");
-            execution.setTransientVariable("status", new Integer(200));
+            execution.setTransientVariable("status", 200);
         }
     }
 

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/dynamic/DynamicCandidateGroupsTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/dynamic/DynamicCandidateGroupsTest.java
@@ -15,6 +15,8 @@ package org.activiti.engine.test.bpmn.dynamic;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import java.util.ArrayList;
 
 import org.activiti.engine.impl.test.PluggableFlowableTestCase;
@@ -22,16 +24,14 @@ import org.flowable.engine.DynamicBpmnConstants;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 /**
  * Created by Pardo David on 7/12/2016.
  */
 public class DynamicCandidateGroupsTest extends PluggableFlowableTestCase implements DynamicBpmnConstants {
 
-    private final String TASK_ONE_SID = "sid-B94D5D22-E93E-4401-ADC5-C5C073E1EEB4";
-    private final String TASK_TWO_SID = "sid-B1C37EBE-A273-4DDE-B909-89302638526A";
-    private final String SCRIPT_TASK_SID = "sid-A403BAE0-E367-449A-90B2-48834FCAA2F9";
+    private static final String TASK_ONE_SID = "sid-B94D5D22-E93E-4401-ADC5-C5C073E1EEB4";
+    private static final String TASK_TWO_SID = "sid-B1C37EBE-A273-4DDE-B909-89302638526A";
+    private static final String SCRIPT_TASK_SID = "sid-A403BAE0-E367-449A-90B2-48834FCAA2F9";
 
     @Deployment(resources = { "org/activiti/engine/test/bpmn/dynamic/dynamic-bpmn-test-process.bpmn20.xml" })
     public void testIsShouldBePossibleToChangeCandidateGroups() {

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/dynamic/DynamicProcessDefinitionSummaryTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/dynamic/DynamicProcessDefinitionSummaryTest.java
@@ -18,6 +18,10 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import java.util.List;
 
 import org.activiti.engine.dynamic.PropertiesParserConstants;
@@ -28,18 +32,14 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.task.Task;
 import org.flowable.engine.test.Deployment;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 /**
  * Created by Pardo David on 1/12/2016.
  */
 public class DynamicProcessDefinitionSummaryTest extends PluggableFlowableTestCase implements DynamicBpmnConstants, PropertiesParserConstants {
 
-    private final String TASK_ONE_SID = "sid-B94D5D22-E93E-4401-ADC5-C5C073E1EEB4";
-    private final String TASK_TWO_SID = "sid-B1C37EBE-A273-4DDE-B909-89302638526A";
-    private final String SCRIPT_TASK_SID = "sid-A403BAE0-E367-449A-90B2-48834FCAA2F9";
+    private static final String TASK_ONE_SID = "sid-B94D5D22-E93E-4401-ADC5-C5C073E1EEB4";
+    private static final String TASK_TWO_SID = "sid-B1C37EBE-A273-4DDE-B909-89302638526A";
+    private static final String SCRIPT_TASK_SID = "sid-A403BAE0-E367-449A-90B2-48834FCAA2F9";
 
     public void testProcessDefinitionInfoCacheIsEnabledWithPluggableActivitiTestCase() throws Exception {
         assertThat(processEngineConfiguration.isEnableProcessDefinitionInfoCache(), is(true));

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/subprocess/CallActivityTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/subprocess/CallActivityTest.java
@@ -35,12 +35,12 @@ import org.flowable.engine.runtime.ProcessInstance;
 
 public class CallActivityTest extends ResourceFlowableTestCase {
 
-    private static String MAIN_PROCESS_RESOURCE = "org/activiti/engine/test/bpmn/subprocess/SubProcessTest.testSuspendedProcessCallActivity_mainProcess.bpmn.xml";
-    private static String CHILD_PROCESS_RESOURCE = "org/activiti/engine/test/bpmn/subprocess/SubProcessTest.testSuspendedProcessCallActivity_childProcess.bpmn.xml";
-    private static String MESSAGE_TRIGGERED_PROCESS_RESOURCE = "org/activiti/engine/test/bpmn/subprocess/SubProcessTest.testSuspendedProcessCallActivity_messageTriggeredProcess.bpmn.xml";
-    private static String INHERIT_VARIABLES_MAIN_PROCESS_RESOURCE = "org/activiti/engine/test/bpmn/subprocess/SubProcessTest.testInheritVariablesCallActivity_mainProcess.bpmn20.xml";
-    private static String INHERIT_VARIABLES_CHILD_PROCESS_RESOURCE = "org/activiti/engine/test/bpmn/subprocess/SubProcessTest.testInheritVariablesCallActivity_childProcess.bpmn20.xml";
-    private static String NOT_INHERIT_VARIABLES_MAIN_PROCESS_RESOURCE = "org/activiti/engine/test/bpmn/subprocess/SubProcessTest.testNotInheritVariablesCallActivity_mainProcess.bpmn20.xml";
+    private static final String  MAIN_PROCESS_RESOURCE = "org/activiti/engine/test/bpmn/subprocess/SubProcessTest.testSuspendedProcessCallActivity_mainProcess.bpmn.xml";
+    private static final String CHILD_PROCESS_RESOURCE = "org/activiti/engine/test/bpmn/subprocess/SubProcessTest.testSuspendedProcessCallActivity_childProcess.bpmn.xml";
+    private static final String MESSAGE_TRIGGERED_PROCESS_RESOURCE = "org/activiti/engine/test/bpmn/subprocess/SubProcessTest.testSuspendedProcessCallActivity_messageTriggeredProcess.bpmn.xml";
+    private static final String INHERIT_VARIABLES_MAIN_PROCESS_RESOURCE = "org/activiti/engine/test/bpmn/subprocess/SubProcessTest.testInheritVariablesCallActivity_mainProcess.bpmn20.xml";
+    private static final String INHERIT_VARIABLES_CHILD_PROCESS_RESOURCE = "org/activiti/engine/test/bpmn/subprocess/SubProcessTest.testInheritVariablesCallActivity_childProcess.bpmn20.xml";
+    private static final String NOT_INHERIT_VARIABLES_MAIN_PROCESS_RESOURCE = "org/activiti/engine/test/bpmn/subprocess/SubProcessTest.testNotInheritVariablesCallActivity_mainProcess.bpmn20.xml";
 
     public CallActivityTest() {
         super("org/activiti/standalone/parsing/encoding.flowable.cfg.xml");


### PR DESCRIPTION
Minor cleanups
* unused import
* misordered modifiers
* misordered assertEquals()
* explicit type can be replaced with <>
* update constant fields (static, final)
* remove unnecessary boxing (wrapping primitive values not needed post JDK5)
