### PR TITLE
Use JDK7 try/closeable and unwind the code

### DIFF
--- a/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/BpmnXMLConverter.java
+++ b/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/BpmnXMLConverter.java
@@ -265,7 +265,7 @@ public class BpmnXMLConverter implements BpmnXMLConstants {
                     validateModel(xif.createXMLStreamReader(in));
                 }
             } catch (UnsupportedEncodingException e) {
-                throw new XMLException("The bpmn 2.0 xml is not UTF8 encoded", e);
+                throw new XMLException("The bpmn 2.0 xml is not properly encoded", e);
             } catch(XMLStreamException e){
                 throw new XMLException("Error while reading the BPMN 2.0 XML", e);
             } catch(Exception e){
@@ -277,7 +277,7 @@ public class BpmnXMLConverter implements BpmnXMLConstants {
             // XML conversion
             return convertToBpmnModel(xif.createXMLStreamReader(in));
         } catch (UnsupportedEncodingException e) {
-            throw new XMLException("The bpmn 2.0 xml is not UTF8 encoded", e);
+            throw new XMLException("The bpmn 2.0 xml is not properly encoded", e);
         } catch (XMLStreamException e) {
             throw new XMLException("Error while reading the BPMN 2.0 XML", e);
         } catch (IOException e) {

--- a/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/BpmnXMLConverter.java
+++ b/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/BpmnXMLConverter.java
@@ -42,11 +42,11 @@ import org.flowable.bpmn.converter.alfresco.AlfrescoUserTaskXMLConverter;
 import org.flowable.bpmn.converter.child.DocumentationParser;
 import org.flowable.bpmn.converter.child.IOSpecificationParser;
 import org.flowable.bpmn.converter.child.MultiInstanceParser;
-import org.flowable.bpmn.converter.export.FlowableListenerExport;
 import org.flowable.bpmn.converter.export.BPMNDIExport;
 import org.flowable.bpmn.converter.export.CollaborationExport;
 import org.flowable.bpmn.converter.export.DataStoreExport;
 import org.flowable.bpmn.converter.export.DefinitionsRootExport;
+import org.flowable.bpmn.converter.export.FlowableListenerExport;
 import org.flowable.bpmn.converter.export.MultiInstanceExport;
 import org.flowable.bpmn.converter.export.ProcessExport;
 import org.flowable.bpmn.converter.export.SignalAndMessageDefinitionExport;
@@ -257,43 +257,31 @@ public class BpmnXMLConverter implements BpmnXMLConstants {
             xif.setProperty(XMLInputFactory.SUPPORT_DTD, false);
         }
 
-        InputStreamReader in = null;
-        try {
-            in = new InputStreamReader(inputStreamProvider.getInputStream(), encoding);
-            XMLStreamReader xtr = xif.createXMLStreamReader(in);
-
-            try {
-                if (validateSchema) {
-
-                    if (!enableSafeBpmnXml) {
-                        validateModel(inputStreamProvider);
-                    } else {
-                        validateModel(xtr);
-                    }
-
-                    // The input stream is closed after schema validation
-                    in = new InputStreamReader(inputStreamProvider.getInputStream(), encoding);
-                    xtr = xif.createXMLStreamReader(in);
+        if (validateSchema) {
+            try (InputStreamReader in = new InputStreamReader(inputStreamProvider.getInputStream(), encoding)) {
+                if (!enableSafeBpmnXml) {
+                    validateModel(inputStreamProvider);
+                } else {
+                    validateModel(xif.createXMLStreamReader(in));
                 }
-
-            } catch (Exception e) {
+            } catch (UnsupportedEncodingException e) {
+                throw new XMLException("The bpmn 2.0 xml is not UTF8 encoded", e);
+            } catch(XMLStreamException e){
+                throw new XMLException("Error while reading the BPMN 2.0 XML", e);
+            } catch(Exception e){
                 throw new XMLException(e.getMessage(), e);
             }
-
+        }
+        // The input stream is closed after schema validation
+        try (InputStreamReader in = new InputStreamReader(inputStreamProvider.getInputStream(), encoding)) {
             // XML conversion
-            return convertToBpmnModel(xtr);
+            return convertToBpmnModel(xif.createXMLStreamReader(in));
         } catch (UnsupportedEncodingException e) {
             throw new XMLException("The bpmn 2.0 xml is not UTF8 encoded", e);
         } catch (XMLStreamException e) {
             throw new XMLException("Error while reading the BPMN 2.0 XML", e);
-        } finally {
-            if (in != null) {
-                try {
-                    in.close();
-                } catch (IOException e) {
-                    LOGGER.debug("Problem closing BPMN input stream", e);
-                }
-            }
+        } catch (IOException e) {
+            throw new XMLException(e.getMessage(), e);
         }
     }
 

--- a/modules/flowable-dmn-xml-converter/src/main/java/org/flowable/dmn/xml/converter/DmnXMLConverter.java
+++ b/modules/flowable-dmn-xml-converter/src/main/java/org/flowable/dmn/xml/converter/DmnXMLConverter.java
@@ -138,44 +138,31 @@ public class DmnXMLConverter implements DmnXMLConstants {
             xif.setProperty(XMLInputFactory.SUPPORT_DTD, false);
         }
 
-        InputStreamReader in = null;
-        try {
-            in = new InputStreamReader(inputStreamProvider.getInputStream(), encoding);
-            XMLStreamReader xtr = xif.createXMLStreamReader(in);
-
-            try {
-                if (validateSchema) {
-
-                    if (!enableSafeBpmnXml) {
-                        validateModel(inputStreamProvider);
-                    } else {
-                        validateModel(xtr);
-                    }
-
-                    // The input stream is closed after schema validation
-                    in = new InputStreamReader(inputStreamProvider.getInputStream(), encoding);
-                    xtr = xif.createXMLStreamReader(in);
+        if (validateSchema) {
+            try (InputStreamReader in = new InputStreamReader(inputStreamProvider.getInputStream(), encoding)) {
+                if (!enableSafeBpmnXml) {
+                    validateModel(inputStreamProvider);
+                } else {
+                    validateModel(xif.createXMLStreamReader(in));
                 }
-
-            } catch (Exception e) {
+            } catch (UnsupportedEncodingException e) {
+                throw new DmnXMLException("The bpmn 2.0 xml is not UTF8 encoded", e);
+            } catch (XMLStreamException e) {
+                throw new DmnXMLException("Error while reading the BPMN 2.0 XML", e);
+            } catch(Exception e){
                 throw new DmnXMLException(e.getMessage(), e);
             }
-
+        }
+        // The input stream is closed after schema validation
+        try (InputStreamReader in = new InputStreamReader(inputStreamProvider.getInputStream(), encoding)) {
             // XML conversion
-            return convertToDmnModel(xtr);
-
+            return convertToDmnModel(xif.createXMLStreamReader(in));
         } catch (UnsupportedEncodingException e) {
-            throw new DmnXMLException("The dmn xml is not UTF8 encoded", e);
+            throw new DmnXMLException("The bpmn 2.0 xml is not UTF8 encoded", e);
         } catch (XMLStreamException e) {
             throw new DmnXMLException("Error while reading the BPMN 2.0 XML", e);
-        } finally {
-            if (in != null) {
-                try {
-                    in.close();
-                } catch (IOException e) {
-                    LOGGER.debug("Problem closing DMN input stream", e);
-                }
-            }
+        } catch (IOException e) {
+            throw new DmnXMLException(e.getMessage(), e);
         }
     }
 

--- a/modules/flowable-dmn-xml-converter/src/main/java/org/flowable/dmn/xml/converter/DmnXMLConverter.java
+++ b/modules/flowable-dmn-xml-converter/src/main/java/org/flowable/dmn/xml/converter/DmnXMLConverter.java
@@ -146,9 +146,9 @@ public class DmnXMLConverter implements DmnXMLConstants {
                     validateModel(xif.createXMLStreamReader(in));
                 }
             } catch (UnsupportedEncodingException e) {
-                throw new DmnXMLException("The bpmn 2.0 xml is not UTF8 encoded", e);
+                throw new DmnXMLException("The dmn xml is not properly encoded", e);
             } catch (XMLStreamException e) {
-                throw new DmnXMLException("Error while reading the BPMN 2.0 XML", e);
+                throw new DmnXMLException("Error while reading the dmn xml file", e);
             } catch(Exception e){
                 throw new DmnXMLException(e.getMessage(), e);
             }
@@ -158,9 +158,9 @@ public class DmnXMLConverter implements DmnXMLConstants {
             // XML conversion
             return convertToDmnModel(xif.createXMLStreamReader(in));
         } catch (UnsupportedEncodingException e) {
-            throw new DmnXMLException("The bpmn 2.0 xml is not UTF8 encoded", e);
+            throw new DmnXMLException("The dmn xml is not properly encoded", e);
         } catch (XMLStreamException e) {
-            throw new DmnXMLException("Error while reading the BPMN 2.0 XML", e);
+            throw new DmnXMLException("Error while reading the dmn xml file", e);
         } catch (IOException e) {
             throw new DmnXMLException(e.getMessage(), e);
         }


### PR DESCRIPTION
The same change in the Bpmn and Dmn converters to use the JDK7 try syntax (eliminating the finally block) and explicitly made it clear the opening and re-opening of the stream.