### PR TITLE
Remove unnecessary {@inheritDoc} comments

### DIFF
--- a/modules/flowable-cxf/src/main/java/org/flowable/engine/impl/webservice/CxfWebServiceClient.java
+++ b/modules/flowable-cxf/src/main/java/org/flowable/engine/impl/webservice/CxfWebServiceClient.java
@@ -63,9 +63,6 @@ public class CxfWebServiceClient implements SyncWebServiceClient {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public Object[] send(String methodName, Object[] arguments, ConcurrentMap<QName, URL> overridenEndpointAddresses) throws Exception {
         try {
             URL newEndpointAddress = null;

--- a/modules/flowable-cxf/src/main/java/org/flowable/engine/impl/webservice/CxfWebServiceClientFactory.java
+++ b/modules/flowable-cxf/src/main/java/org/flowable/engine/impl/webservice/CxfWebServiceClientFactory.java
@@ -19,9 +19,6 @@ package org.flowable.engine.impl.webservice;
  */
 public class CxfWebServiceClientFactory implements SyncWebServiceClientFactory {
 
-    /**
-     * {@inheritDoc}
-     */
     public SyncWebServiceClient create(String wsdl) {
         return new CxfWebServiceClient(wsdl);
     }

--- a/modules/flowable-cxf/src/test/java/org/flowable/engine/impl/webservice/WebServiceMockImpl.java
+++ b/modules/flowable-cxf/src/test/java/org/flowable/engine/impl/webservice/WebServiceMockImpl.java
@@ -33,16 +33,10 @@ public class WebServiceMockImpl implements WebServiceMock {
         this.dataStructure = new WebServiceDataStructure();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public int getCount() {
         return this.count;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public void inc() throws MaxValueReachedFault {
         if (this.count == 123456) {
             throw new RuntimeException("A runtime exception not expected in the processing of the web-service");
@@ -53,52 +47,31 @@ public class WebServiceMockImpl implements WebServiceMock {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public void reset() {
         this.setTo(0);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public void setTo(int value) {
         this.count = value;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public String prettyPrintCount(String prefix, String suffix) {
         return prefix + this.getCount() + suffix;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public void setDataStructure(String str, Date date) {
         this.dataStructure.eltString = str;
         this.dataStructure.eltDate = date;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public WebServiceDataStructure getDataStructure() {
         return this.dataStructure;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public String noNameResult(String prefix, String suffix) {
         return prefix + this.getCount() + suffix;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public String reservedWordAsName(String prefix, String suffix) {
         return prefix + this.getCount() + suffix;
     }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/transformer/AbstractTransformer.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/transformer/AbstractTransformer.java
@@ -21,9 +21,6 @@ import org.flowable.engine.common.api.FlowableException;
  */
 public abstract class AbstractTransformer implements Transformer {
 
-    /**
-     * {@inheritDoc}
-     */
     public Object transform(Object anObject) {
         try {
             return this.primTransform(anObject);

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/transformer/BigDecimalToString.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/transformer/BigDecimalToString.java
@@ -24,9 +24,6 @@ public class BigDecimalToString extends AbstractTransformer {
 
     protected DecimalFormat format = new DecimalFormat();
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected Object primTransform(Object anObject) throws Exception {
         return format.format((BigDecimal) anObject);

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/transformer/BooleanToString.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/transformer/BooleanToString.java
@@ -19,9 +19,6 @@ package org.flowable.engine.impl.transformer;
  */
 public class BooleanToString extends AbstractTransformer {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected Object primTransform(Object anObject) throws Exception {
         return ((Boolean) anObject).toString();

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/transformer/ComposedTransformer.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/transformer/ComposedTransformer.java
@@ -23,9 +23,6 @@ public class ComposedTransformer extends AbstractTransformer {
 
     protected List<Transformer> transformers;
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected Object primTransform(Object anObject) throws Exception {
         Object current = anObject;

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/transformer/DateToString.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/transformer/DateToString.java
@@ -26,9 +26,6 @@ public class DateToString extends AbstractTransformer {
 
     protected Format format = FastDateFormat.getInstance("dd/MM/yyyy");
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected Object primTransform(Object anObject) throws Exception {
         return format.format((Date) anObject);

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/transformer/Identity.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/transformer/Identity.java
@@ -32,9 +32,6 @@ public class Identity extends AbstractTransformer {
 
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected Object primTransform(Object anObject) throws Exception {
         return anObject;

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/transformer/IntegerToLong.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/transformer/IntegerToLong.java
@@ -19,9 +19,6 @@ package org.flowable.engine.impl.transformer;
  */
 public class IntegerToLong extends AbstractTransformer {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected Object primTransform(Object anObject) throws Exception {
         return Long.valueOf((Integer) anObject);

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/transformer/IntegerToString.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/transformer/IntegerToString.java
@@ -19,9 +19,6 @@ package org.flowable.engine.impl.transformer;
  */
 public class IntegerToString extends AbstractTransformer {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected Object primTransform(Object anObject) throws Exception {
         return ((Integer) anObject).toString();

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/transformer/LongToInteger.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/transformer/LongToInteger.java
@@ -19,9 +19,6 @@ package org.flowable.engine.impl.transformer;
  */
 public class LongToInteger extends AbstractTransformer {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected Object primTransform(Object anObject) throws Exception {
         return Integer.valueOf(((Long) anObject).toString());

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/transformer/LongToString.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/transformer/LongToString.java
@@ -19,9 +19,6 @@ package org.flowable.engine.impl.transformer;
  */
 public class LongToString extends AbstractTransformer {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected Object primTransform(Object anObject) throws Exception {
         return ((Long) anObject).toString();

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/webservice/WSOperation.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/webservice/WSOperation.java
@@ -45,23 +45,14 @@ public class WSOperation implements OperationImplementation {
         this.service = service;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public String getId() {
         return this.id;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public String getName() {
         return this.name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public MessageInstance sendFor(MessageInstance message, Operation operation, ConcurrentMap<QName, URL> overridenEndpointAddresses) throws Exception {
         Object[] arguments = this.getArguments(message);
         Object[] results = this.safeSend(arguments, overridenEndpointAddresses);

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/webservice/WSService.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/webservice/WSService.java
@@ -64,9 +64,6 @@ public class WSService implements BpmnInterfaceImplementation {
         return this.client;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public String getName() {
         return this.name;
     }

--- a/modules/flowable-osgi/src/main/java/org/flowable/osgi/blueprint/ClassLoaderWrapper.java
+++ b/modules/flowable-osgi/src/main/java/org/flowable/osgi/blueprint/ClassLoaderWrapper.java
@@ -33,9 +33,6 @@ public class ClassLoaderWrapper extends ClassLoader {
         this.parents = parents;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @SuppressWarnings({ "rawtypes", "unchecked" })
     protected synchronized Class loadClass(String name, boolean resolve) throws ClassNotFoundException {
         //
@@ -68,9 +65,6 @@ public class ClassLoaderWrapper extends ClassLoader {
         throw new ClassNotFoundException(name);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public URL getResource(String name) {
         //
         // Check parent class loaders
@@ -86,9 +80,6 @@ public class ClassLoaderWrapper extends ClassLoader {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public Enumeration findResources(String name) throws IOException {
         List resources = new ArrayList();

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/WebServiceActivityBehavior.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/WebServiceActivityBehavior.java
@@ -58,9 +58,6 @@ public class WebServiceActivityBehavior extends AbstractBpmnActivityBehavior {
         this.dataOutputAssociations.add(dataAssociation);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public void execute(ActivityExecution execution) throws Exception {
         MessageInstance message;
 

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/transformer/AbstractTransformer.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/transformer/AbstractTransformer.java
@@ -21,9 +21,6 @@ import org.activiti.engine.ActivitiException;
  */
 public abstract class AbstractTransformer implements Transformer {
 
-    /**
-     * {@inheritDoc}
-     */
     public Object transform(Object anObject) {
         try {
             return this.primTransform(anObject);

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/transformer/BigDecimalToString.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/transformer/BigDecimalToString.java
@@ -24,9 +24,6 @@ public class BigDecimalToString extends AbstractTransformer {
 
     protected DecimalFormat format = new DecimalFormat();
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected Object primTransform(Object anObject) throws Exception {
         return format.format((BigDecimal) anObject);

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/transformer/BooleanToString.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/transformer/BooleanToString.java
@@ -19,9 +19,6 @@ package org.activiti.engine.impl.transformer;
  */
 public class BooleanToString extends AbstractTransformer {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected Object primTransform(Object anObject) throws Exception {
         return ((Boolean) anObject).toString();

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/transformer/ComposedTransformer.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/transformer/ComposedTransformer.java
@@ -23,9 +23,6 @@ public class ComposedTransformer extends AbstractTransformer {
 
     protected List<Transformer> transformers;
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected Object primTransform(Object anObject) throws Exception {
         Object current = anObject;

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/transformer/DateToString.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/transformer/DateToString.java
@@ -26,9 +26,6 @@ public class DateToString extends AbstractTransformer {
 
     protected Format format = FastDateFormat.getInstance("dd/MM/yyyy");
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected Object primTransform(Object anObject) throws Exception {
         return format.format((Date) anObject);

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/transformer/Identity.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/transformer/Identity.java
@@ -32,9 +32,6 @@ public class Identity extends AbstractTransformer {
 
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected Object primTransform(Object anObject) throws Exception {
         return anObject;

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/transformer/IntegerToLong.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/transformer/IntegerToLong.java
@@ -19,9 +19,6 @@ package org.activiti.engine.impl.transformer;
  */
 public class IntegerToLong extends AbstractTransformer {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected Object primTransform(Object anObject) throws Exception {
         return Long.valueOf((Integer) anObject);

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/transformer/IntegerToString.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/transformer/IntegerToString.java
@@ -19,9 +19,6 @@ package org.activiti.engine.impl.transformer;
  */
 public class IntegerToString extends AbstractTransformer {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected Object primTransform(Object anObject) throws Exception {
         return ((Integer) anObject).toString();

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/transformer/LongToInteger.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/transformer/LongToInteger.java
@@ -19,9 +19,6 @@ package org.activiti.engine.impl.transformer;
  */
 public class LongToInteger extends AbstractTransformer {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected Object primTransform(Object anObject) throws Exception {
         return Integer.valueOf(((Long) anObject).toString());

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/transformer/LongToString.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/transformer/LongToString.java
@@ -19,9 +19,6 @@ package org.activiti.engine.impl.transformer;
  */
 public class LongToString extends AbstractTransformer {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected Object primTransform(Object anObject) throws Exception {
         return ((Long) anObject).toString();

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/webservice/WSOperation.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/webservice/WSOperation.java
@@ -45,23 +45,14 @@ public class WSOperation implements OperationImplementation {
         this.service = service;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public String getId() {
         return this.id;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public String getName() {
         return this.name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public MessageInstance sendFor(MessageInstance message, Operation operation, ConcurrentMap<QName, URL> overridenEndpointAddresses) throws Exception {
         Object[] arguments = this.getArguments(message);
         Object[] results = this.safeSend(arguments, overridenEndpointAddresses);

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/webservice/WSService.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/webservice/WSService.java
@@ -64,9 +64,6 @@ public class WSService implements BpmnInterfaceImplementation {
         return this.client;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public String getName() {
         return this.name;
     }


### PR DESCRIPTION
Remove the {@inheritDoc} tag since Javadoc copies the super class' comment if no comment is present, a comment containing only an {@inheritDoc} adds nothing. 