### PR TITLE
Fix 43 occurrences of incorrect spelling of "engine"

### DIFF
--- a/modules/flowable-cxf/src/test/resources/org/flowable/engine/impl/webservice/WebServiceImportTest.testImport.bpmn20.xml
+++ b/modules/flowable-cxf/src/test/resources/org/flowable/engine/impl/webservice/WebServiceImportTest.testImport.bpmn20.xml
@@ -2,8 +2,8 @@
 <definitions id="definitions"
   xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
   xmlns:activiti="http://activiti.org/bpmn"
-  targetNamespace="org.flowable.enginge.impl.webservice"
-  xmlns:tns="org.flowable.enginge.impl.webservice"
+  targetNamespace="org.flowable.engine.impl.webservice"
+  xmlns:tns="org.flowable.engine.impl.webservice"
   xmlns:counter="http://webservice.flowable.org/">
 
   <import importType="http://schemas.xmlsoap.org/wsdl/"

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricProcessInstanceAndVariablesQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricProcessInstanceAndVariablesQueryTest.java
@@ -31,7 +31,7 @@ public class HistoricProcessInstanceAndVariablesQueryTest extends PluggableFlowa
     private static final String PROCESS_DEFINITION_KEY = "oneTaskProcess";
     private static final String PROCESS_DEFINITION_KEY_2 = "oneTaskProcess2";
     private static final String PROCESS_DEFINITION_NAME_2 = "oneTaskProcess2Name";
-    private static final String PROCESS_DEFINITION_CATEGORY_2 = "org.flowable.enginge.test.api.runtime.2Category";
+    private static final String PROCESS_DEFINITION_CATEGORY_2 = "org.flowable.engine.test.api.runtime.2Category";
     private static final String PROCESS_DEFINITION_KEY_3 = "oneTaskProcess3";
 
     private List<String> processInstanceIds;

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ExecutionQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ExecutionQueryTest.java
@@ -59,8 +59,8 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
     private static final String SEQUENTIAL_PROCESS_KEY = "oneTaskProcess";
     private static final String CONCURRENT_PROCESS_NAME = "concurrentName";
     private static final String SEQUENTIAL_PROCESS_NAME = "oneTaskProcessName";
-    private static final String CONCURRENT_PROCESS_CATEGORY = "org.flowable.enginge.test.api.runtime.concurrent.Category";
-    private static final String SEQUENTIAL_PROCESS_CATEGORY = "org.flowable.enginge.test.api.runtime.Category";
+    private static final String CONCURRENT_PROCESS_CATEGORY = "org.flowable.engine.test.api.runtime.concurrent.Category";
+    private static final String SEQUENTIAL_PROCESS_CATEGORY = "org.flowable.engine.test.api.runtime.Category";
 
     private List<String> concurrentProcessInstanceIds;
     private List<String> sequentialProcessInstanceIds;

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ProcessInstanceQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ProcessInstanceQueryTest.java
@@ -52,8 +52,8 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
     private static final String PROCESS_DEFINITION_KEY_2 = "oneTaskProcess2";
     private static final String PROCESS_DEFINITION_NAME = "oneTaskProcessName";
     private static final String PROCESS_DEFINITION_NAME_2 = "oneTaskProcess2Name";
-    private static final String PROCESS_DEFINITION_CATEGORY = "org.flowable.enginge.test.api.runtime.Category";
-    private static final String PROCESS_DEFINITION_CATEGORY_2 = "org.flowable.enginge.test.api.runtime.2Category";
+    private static final String PROCESS_DEFINITION_CATEGORY = "org.flowable.engine.test.api.runtime.Category";
+    private static final String PROCESS_DEFINITION_CATEGORY_2 = "org.flowable.engine.test.api.runtime.2Category";
 
     private org.flowable.engine.repository.Deployment deployment;
     private List<String> processInstanceIds;

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/mgmt/ManagementServiceTest.testFailingAsyncJob.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/mgmt/ManagementServiceTest.testFailingAsyncJob.bpmn20.xml
@@ -2,7 +2,7 @@
 <definitions id="definitions"
 	xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" 
 	xmlns:activiti="http://activiti.org/bpmn" 
-	targetNamespace="org.flowable.enginge.test.api.mgmt">
+	targetNamespace="org.flowable.engine.test.api.mgmt">
 
 	<process id="exceptionInJobExecution">
 

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/mgmt/ManagementServiceTest.testGetJobExceptionStacktrace.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/mgmt/ManagementServiceTest.testGetJobExceptionStacktrace.bpmn20.xml
@@ -2,7 +2,7 @@
 <definitions id="definitions"
 	xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" 
 	xmlns:activiti="http://activiti.org/bpmn" 
-	targetNamespace="org.flowable.enginge.test.api.mgmt">
+	targetNamespace="org.flowable.engine.test.api.mgmt">
 
 	<process id="exceptionInJobExecution">
 

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/mgmt/timerOnTask.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/mgmt/timerOnTask.bpmn20.xml
@@ -2,7 +2,7 @@
 <definitions id="definitions"
 	xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
 	xmlns:activiti="http://activiti.org/bpmn" 
-	targetNamespace="org.flowable.enginge.test.api.mgmt">
+	targetNamespace="org.flowable.engine.test.api.mgmt">
 
 	<process id="timerOnTask">
 

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/runtime/RuntimeServiceTest.testSignalWithProcessVariables.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/runtime/RuntimeServiceTest.testSignalWithProcessVariables.bpmn20.xml
@@ -2,7 +2,7 @@
 <definitions
   xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
   xmlns:activiti="http://activiti.org/bpmn"
-  targetNamespace="org.flowable.enginge.test.api.runtime">
+  targetNamespace="org.flowable.engine.test.api.runtime">
 
   <process id="testSignalWithProcessVariables">
 

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/runtime/callActivity.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/runtime/callActivity.bpmn20.xml
@@ -3,7 +3,7 @@
   xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
   xmlns:activiti="http://activiti.org/bpmn"
   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-  targetNamespace="org.flowable.enginge.test.api.runtime.Category">
+  targetNamespace="org.flowable.engine.test.api.runtime.Category">
 
   <process id="callActivity" name="callActivity">
 	<documentation>oneTaskProcessDescription</documentation>

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/runtime/calledActivity.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/runtime/calledActivity.bpmn20.xml
@@ -3,7 +3,7 @@
   xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
   xmlns:activiti="http://activiti.org/bpmn"
   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-  targetNamespace="org.flowable.enginge.test.api.runtime.Category">
+  targetNamespace="org.flowable.engine.test.api.runtime.Category">
 
   <process id="calledActivity" name="calledActivity">
     

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/runtime/concurrentExecution.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/runtime/concurrentExecution.bpmn20.xml
@@ -2,7 +2,7 @@
 <definitions id="definitions" 
   xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
   xmlns:activiti="http://activiti.org/bpmn"
-  targetNamespace="org.flowable.enginge.test.api.runtime.concurrent.Category">
+  targetNamespace="org.flowable.engine.test.api.runtime.concurrent.Category">
   
   <process id="concurrent" name="concurrentName">
   

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/runtime/executionLocalization.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/runtime/executionLocalization.bpmn20.xml
@@ -2,7 +2,7 @@
 <definitions
   xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
   xmlns:activiti="http://activiti.org/bpmn"
-  targetNamespace="org.flowable.enginge.test.api.runtime">
+  targetNamespace="org.flowable.engine.test.api.runtime">
 
   <process id="executionLocalization" name="Process Name">
   	<documentation>Process Description</documentation>

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/runtime/multipleSubProcess.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/runtime/multipleSubProcess.bpmn20.xml
@@ -2,7 +2,7 @@
 <definitions id="definitions" 
   xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
   xmlns:activiti="http://activiti.org/bpmn"
-  targetNamespace="org.flowable.enginge.test.api.runtime">
+  targetNamespace="org.flowable.engine.test.api.runtime">
   
   <process id="multipleSubProcessTest">
   

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/runtime/nestedSubProcess.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/runtime/nestedSubProcess.bpmn20.xml
@@ -2,7 +2,7 @@
 <definitions id="definitions" 
   xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
   xmlns:activiti="http://activiti.org/bpmn"
-  targetNamespace="org.flowable.enginge.test.api.runtime">
+  targetNamespace="org.flowable.engine.test.api.runtime">
   
   <process id="nestedSimpleSubProcess">
   

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml
@@ -2,7 +2,7 @@
 <definitions
   xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
   xmlns:activiti="http://activiti.org/bpmn"
-  targetNamespace="org.flowable.enginge.test.api.runtime.Category">
+  targetNamespace="org.flowable.engine.test.api.runtime.Category">
 
   <process id="oneTaskProcess" name="oneTaskProcessName">
 	<documentation>oneTaskProcessDescription</documentation>

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/runtime/oneTaskProcess2.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/runtime/oneTaskProcess2.bpmn20.xml
@@ -2,7 +2,7 @@
 <definitions
   xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
   xmlns:activiti="http://activiti.org/bpmn"
-  targetNamespace="org.flowable.enginge.test.api.runtime.2Category">
+  targetNamespace="org.flowable.engine.test.api.runtime.2Category">
 
   <process id="oneTaskProcess2" name="oneTaskProcess2Name">
   

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/runtime/oneTaskProcess3.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/runtime/oneTaskProcess3.bpmn20.xml
@@ -2,7 +2,7 @@
 <definitions
   xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
   xmlns:activiti="http://activiti.org/bpmn"
-  targetNamespace="org.flowable.enginge.test.api.runtime">
+  targetNamespace="org.flowable.engine.test.api.runtime">
 
   <process id="oneTaskProcess3" name="oneTaskProcess3Name">
   

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/runtime/processVariableEvent.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/runtime/processVariableEvent.bpmn20.xml
@@ -3,7 +3,7 @@
   xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
   xmlns:activiti="http://activiti.org/bpmn"
   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-  targetNamespace="org.flowable.enginge.test.api.runtime.Category">
+  targetNamespace="org.flowable.engine.test.api.runtime.Category">
 
   <process id="processVariableEvent" name="processVariableEvent">
     

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/runtime/subProcess.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/runtime/subProcess.bpmn20.xml
@@ -2,7 +2,7 @@
 <definitions id="definitions" 
   xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
   xmlns:activiti="http://activiti.org/bpmn"
-  targetNamespace="org.flowable.enginge.test.api.runtime">
+  targetNamespace="org.flowable.engine.test.api.runtime">
   
   <process id="simpleSubProcess">
   

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/runtime/superProcess.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/runtime/superProcess.bpmn20.xml
@@ -2,7 +2,7 @@
 <definitions id="definitions" 
   xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
   xmlns:activiti="http://activiti.org/bpmn"
-  targetNamespace="org.flowable.enginge.test.api.runtime">
+  targetNamespace="org.flowable.engine.test.api.runtime">
   
   <process id="subProcessQueryTest">
   

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/runtime/superProcessWithMultipleNestedSubProcess.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/runtime/superProcessWithMultipleNestedSubProcess.bpmn20.xml
@@ -2,7 +2,7 @@
 <definitions id="definitions" 
   xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
   xmlns:activiti="http://activiti.org/bpmn"
-  targetNamespace="org.flowable.enginge.test.api.runtime">
+  targetNamespace="org.flowable.engine.test.api.runtime">
   
   <process id="nestedSubProcessQueryTest">
   

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/runtime/superProcessWithNestedSubProcess.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/runtime/superProcessWithNestedSubProcess.bpmn20.xml
@@ -2,7 +2,7 @@
 <definitions id="definitions" 
   xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
   xmlns:activiti="http://activiti.org/bpmn"
-  targetNamespace="org.flowable.enginge.test.api.runtime">
+  targetNamespace="org.flowable.engine.test.api.runtime">
   
   <process id="nestedSubProcessQueryTest">
   

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/runtime/threeParallelTasks.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/runtime/threeParallelTasks.bpmn20.xml
@@ -2,7 +2,7 @@
 <definitions id="definitions" 
   xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
   xmlns:activiti="http://activiti.org/bpmn"
-  targetNamespace="org.flowable.enginge.test.api.runtime">
+  targetNamespace="org.flowable.engine.test.api.runtime">
   
   <process id="threeParallelTasks">
   

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/runtime/variableScope.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/runtime/variableScope.bpmn20.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="org.flowable.enginge.test.api.runtime">
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="org.flowable.engine.test.api.runtime">
   <process id="variableScopeProcess" name="variableScopeProcess" isExecutable="true">
     <startEvent id="startevent1" name="Start"></startEvent>
     <parallelGateway id="parallelgateway1" name="Parallel Gateway"></parallelGateway>

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/db/oneJobProcess.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/db/oneJobProcess.bpmn20.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="org.flowable.enginge.test.api.runtime">
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="org.flowable.engine.test.api.runtime">
   <process id="oneTaskProcess" name="oneTaskProcess">
     <startEvent id="theStart" name="Start"></startEvent>
     <endEvent id="theEnd" name="End"></endEvent>

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/history/HistoricProcessInstanceAndVariablesQueryTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/history/HistoricProcessInstanceAndVariablesQueryTest.java
@@ -31,7 +31,7 @@ public class HistoricProcessInstanceAndVariablesQueryTest extends PluggableFlowa
     private static final String PROCESS_DEFINITION_KEY = "oneTaskProcess";
     private static final String PROCESS_DEFINITION_KEY_2 = "oneTaskProcess2";
     private static final String PROCESS_DEFINITION_NAME_2 = "oneTaskProcess2Name";
-    private static final String PROCESS_DEFINITION_CATEGORY_2 = "org.activiti.enginge.test.api.runtime.2Category";
+    private static final String PROCESS_DEFINITION_CATEGORY_2 = "org.activiti.engine.test.api.runtime.2Category";
     private static final String PROCESS_DEFINITION_KEY_3 = "oneTaskProcess3";
 
     private List<String> processInstanceIds;

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/runtime/ExecutionQueryTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/runtime/ExecutionQueryTest.java
@@ -59,8 +59,8 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
     private static final String SEQUENTIAL_PROCESS_KEY = "oneTaskProcess";
     private static final String CONCURRENT_PROCESS_NAME = "concurrentName";
     private static final String SEQUENTIAL_PROCESS_NAME = "oneTaskProcessName";
-    private static final String CONCURRENT_PROCESS_CATEGORY = "org.activiti.enginge.test.api.runtime.concurrent.Category";
-    private static final String SEQUENTIAL_PROCESS_CATEGORY = "org.activiti.enginge.test.api.runtime.Category";
+    private static final String CONCURRENT_PROCESS_CATEGORY = "org.activiti.engine.test.api.runtime.concurrent.Category";
+    private static final String SEQUENTIAL_PROCESS_CATEGORY = "org.activiti.engine.test.api.runtime.Category";
 
     private List<String> concurrentProcessInstanceIds;
     private List<String> sequentialProcessInstanceIds;

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/runtime/ProcessInstanceQueryTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/runtime/ProcessInstanceQueryTest.java
@@ -52,8 +52,8 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
     private static final String PROCESS_DEFINITION_KEY_2 = "oneTaskProcess2";
     private static final String PROCESS_DEFINITION_NAME = "oneTaskProcessName";
     private static final String PROCESS_DEFINITION_NAME_2 = "oneTaskProcess2Name";
-    private static final String PROCESS_DEFINITION_CATEGORY = "org.activiti.enginge.test.api.runtime.Category";
-    private static final String PROCESS_DEFINITION_CATEGORY_2 = "org.activiti.enginge.test.api.runtime.2Category";
+    private static final String PROCESS_DEFINITION_CATEGORY = "org.activiti.engine.test.api.runtime.Category";
+    private static final String PROCESS_DEFINITION_CATEGORY_2 = "org.activiti.engine.test.api.runtime.2Category";
 
     private org.flowable.engine.repository.Deployment deployment;
     private List<String> processInstanceIds;

--- a/modules/flowable5-test/src/test/resources/org/activiti/engine/test/api/mgmt/ManagementServiceTest.testGetJobExceptionStacktrace.bpmn20.xml
+++ b/modules/flowable5-test/src/test/resources/org/activiti/engine/test/api/mgmt/ManagementServiceTest.testGetJobExceptionStacktrace.bpmn20.xml
@@ -2,7 +2,7 @@
 <definitions id="definitions"
 	xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" 
 	xmlns:activiti="http://activiti.org/bpmn" 
-	targetNamespace="org.activiti.enginge.test.api.mgmt">
+	targetNamespace="org.activiti.engine.test.api.mgmt">
 
 	<process id="exceptionInJobExecution">
 

--- a/modules/flowable5-test/src/test/resources/org/activiti/engine/test/api/mgmt/timerOnTask.bpmn20.xml
+++ b/modules/flowable5-test/src/test/resources/org/activiti/engine/test/api/mgmt/timerOnTask.bpmn20.xml
@@ -2,7 +2,7 @@
 <definitions id="definitions"
 	xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
 	xmlns:activiti="http://activiti.org/bpmn" 
-	targetNamespace="org.activiti.enginge.test.api.mgmt">
+	targetNamespace="org.activiti.engine.test.api.mgmt">
 
 	<process id="timerOnTask">
 

--- a/modules/flowable5-test/src/test/resources/org/activiti/engine/test/api/runtime/RuntimeServiceTest.testSignalWithProcessVariables.bpmn20.xml
+++ b/modules/flowable5-test/src/test/resources/org/activiti/engine/test/api/runtime/RuntimeServiceTest.testSignalWithProcessVariables.bpmn20.xml
@@ -2,7 +2,7 @@
 <definitions
   xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
   xmlns:activiti="http://activiti.org/bpmn"
-  targetNamespace="org.activiti.enginge.test.api.runtime">
+  targetNamespace="org.activiti.engine.test.api.runtime">
 
   <process id="testSignalWithProcessVariables">
 

--- a/modules/flowable5-test/src/test/resources/org/activiti/engine/test/api/runtime/concurrentExecution.bpmn20.xml
+++ b/modules/flowable5-test/src/test/resources/org/activiti/engine/test/api/runtime/concurrentExecution.bpmn20.xml
@@ -2,7 +2,7 @@
 <definitions id="definitions" 
   xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
   xmlns:activiti="http://activiti.org/bpmn"
-  targetNamespace="org.activiti.enginge.test.api.runtime.concurrent.Category">
+  targetNamespace="org.activiti.engine.test.api.runtime.concurrent.Category">
   
   <process id="concurrent" name="concurrentName">
   

--- a/modules/flowable5-test/src/test/resources/org/activiti/engine/test/api/runtime/nestedSubProcess.bpmn20.xml
+++ b/modules/flowable5-test/src/test/resources/org/activiti/engine/test/api/runtime/nestedSubProcess.bpmn20.xml
@@ -2,7 +2,7 @@
 <definitions id="definitions" 
   xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
   xmlns:activiti="http://activiti.org/bpmn"
-  targetNamespace="org.activiti.enginge.test.api.runtime">
+  targetNamespace="org.activiti.engine.test.api.runtime">
   
   <process id="nestedSimpleSubProcess">
   

--- a/modules/flowable5-test/src/test/resources/org/activiti/engine/test/api/runtime/oneTaskProcess.bpmn20.xml
+++ b/modules/flowable5-test/src/test/resources/org/activiti/engine/test/api/runtime/oneTaskProcess.bpmn20.xml
@@ -2,7 +2,7 @@
 <definitions
   xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
   xmlns:activiti="http://activiti.org/bpmn"
-  targetNamespace="org.activiti.enginge.test.api.runtime.Category">
+  targetNamespace="org.activiti.engine.test.api.runtime.Category">
 
   <process id="oneTaskProcess" name="oneTaskProcessName">
   	<documentation>oneTaskProcessDescription</documentation>

--- a/modules/flowable5-test/src/test/resources/org/activiti/engine/test/api/runtime/oneTaskProcess2.bpmn20.xml
+++ b/modules/flowable5-test/src/test/resources/org/activiti/engine/test/api/runtime/oneTaskProcess2.bpmn20.xml
@@ -2,7 +2,7 @@
 <definitions
   xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
   xmlns:activiti="http://activiti.org/bpmn"
-  targetNamespace="org.activiti.enginge.test.api.runtime.2Category">
+  targetNamespace="org.activiti.engine.test.api.runtime.2Category">
 
   <process id="oneTaskProcess2" name="oneTaskProcess2Name">
   

--- a/modules/flowable5-test/src/test/resources/org/activiti/engine/test/api/runtime/oneTaskProcess3.bpmn20.xml
+++ b/modules/flowable5-test/src/test/resources/org/activiti/engine/test/api/runtime/oneTaskProcess3.bpmn20.xml
@@ -2,7 +2,7 @@
 <definitions
   xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
   xmlns:activiti="http://activiti.org/bpmn"
-  targetNamespace="org.activiti.enginge.test.api.runtime">
+  targetNamespace="org.activiti.engine.test.api.runtime">
 
   <process id="oneTaskProcess3" name="oneTaskProcess3Name">
   

--- a/modules/flowable5-test/src/test/resources/org/activiti/engine/test/api/runtime/subProcess.bpmn20.xml
+++ b/modules/flowable5-test/src/test/resources/org/activiti/engine/test/api/runtime/subProcess.bpmn20.xml
@@ -2,7 +2,7 @@
 <definitions id="definitions" 
   xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
   xmlns:activiti="http://activiti.org/bpmn"
-  targetNamespace="org.activiti.enginge.test.api.runtime">
+  targetNamespace="org.activiti.engine.test.api.runtime">
   
   <process id="simpleSubProcess">
   

--- a/modules/flowable5-test/src/test/resources/org/activiti/engine/test/api/runtime/superProcess.bpmn20.xml
+++ b/modules/flowable5-test/src/test/resources/org/activiti/engine/test/api/runtime/superProcess.bpmn20.xml
@@ -2,7 +2,7 @@
 <definitions id="definitions" 
   xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
   xmlns:activiti="http://activiti.org/bpmn"
-  targetNamespace="org.activiti.enginge.test.api.runtime">
+  targetNamespace="org.activiti.engine.test.api.runtime">
   
   <process id="subProcessQueryTest">
   

--- a/modules/flowable5-test/src/test/resources/org/activiti/engine/test/api/runtime/superProcessWithMultipleNestedSubProcess.bpmn20.xml
+++ b/modules/flowable5-test/src/test/resources/org/activiti/engine/test/api/runtime/superProcessWithMultipleNestedSubProcess.bpmn20.xml
@@ -2,7 +2,7 @@
 <definitions id="definitions" 
   xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
   xmlns:activiti="http://activiti.org/bpmn"
-  targetNamespace="org.activiti.enginge.test.api.runtime">
+  targetNamespace="org.activiti.engine.test.api.runtime">
   
   <process id="nestedSubProcessQueryTest">
   

--- a/modules/flowable5-test/src/test/resources/org/activiti/engine/test/api/runtime/superProcessWithNestedSubProcess.bpmn20.xml
+++ b/modules/flowable5-test/src/test/resources/org/activiti/engine/test/api/runtime/superProcessWithNestedSubProcess.bpmn20.xml
@@ -2,7 +2,7 @@
 <definitions id="definitions" 
   xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
   xmlns:activiti="http://activiti.org/bpmn"
-  targetNamespace="org.activiti.enginge.test.api.runtime">
+  targetNamespace="org.activiti.engine.test.api.runtime">
   
   <process id="nestedSubProcessQueryTest">
   

--- a/modules/flowable5-test/src/test/resources/org/activiti/engine/test/api/runtime/threeParallelTasks.bpmn20.xml
+++ b/modules/flowable5-test/src/test/resources/org/activiti/engine/test/api/runtime/threeParallelTasks.bpmn20.xml
@@ -2,7 +2,7 @@
 <definitions id="definitions" 
   xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
   xmlns:activiti="http://activiti.org/bpmn"
-  targetNamespace="org.activiti.enginge.test.api.runtime">
+  targetNamespace="org.activiti.engine.test.api.runtime">
   
   <process id="threeParallelTasks">
   

--- a/modules/flowable5-test/src/test/resources/org/activiti/engine/test/api/runtime/variableScope.bpmn20.xml
+++ b/modules/flowable5-test/src/test/resources/org/activiti/engine/test/api/runtime/variableScope.bpmn20.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="org.activiti.enginge.test.api.runtime">
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="org.activiti.engine.test.api.runtime">
   <process id="variableScopeProcess" name="variableScopeProcess" isExecutable="true">
     <startEvent id="startevent1" name="Start"></startEvent>
     <parallelGateway id="parallelgateway1" name="Parallel Gateway"></parallelGateway>

--- a/modules/flowable5-test/src/test/resources/org/activiti/engine/test/db/oneJobProcess.bpmn20.xml
+++ b/modules/flowable5-test/src/test/resources/org/activiti/engine/test/db/oneJobProcess.bpmn20.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="org.activiti.enginge.test.api.runtime">
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="org.activiti.engine.test.api.runtime">
   <process id="oneTaskProcess" name="oneTaskProcess">
     <startEvent id="theStart" name="Start"></startEvent>
     <endEvent id="theEnd" name="End"></endEvent>


### PR DESCRIPTION
Fixes 43 occurrences of ‘engine’ being spelled wrong. Here are a couple of examples:
 
In java files:
```java
private static final String PROCESS_DEFINITION_CATEGORY = "org.activiti.enginge.test.api.runtime.Category";
private static final String PROCESS_DEFINITION_CATEGORY_2 = "org.activiti.enginge.test.api.runtime.2Category";
``` 
in xml files:
```xml
targetNamespace="org.flowable.enginge.test.api.mgmt">
```

Ran the test suite with only expected errors.