### PR TITLE
Standardize date equality check; fixes MSSQL based test

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/JobEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/JobEventsTest.java
@@ -18,6 +18,7 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
 
+import org.apache.commons.lang.time.DateUtils;
 import org.flowable.engine.common.api.delegate.event.FlowableEntityEvent;
 import org.flowable.engine.common.api.delegate.event.FlowableEvent;
 import org.flowable.engine.common.impl.util.DefaultClockImpl;
@@ -171,7 +172,7 @@ public class JobEventsTest extends PluggableFlowableTestCase {
         Job newTimerJob = (Job) ((FlowableEntityEvent) event).getEntity();
         checkEventContext(event, rescheduledJob);
         assertEquals(rescheduledJob.getId(), newTimerJob.getId());
-        assertEquals(rescheduledJob.getDuedate(), newTimerJob.getDuedate());
+        assertEquals(DateUtils.truncate(rescheduledJob.getDuedate(), Calendar.SECOND), DateUtils.truncate(newTimerJob.getDuedate(), Calendar.SECOND));
 
         event = (FlowableEngineEvent) listener.getEventsReceived().get(4);
         assertEquals(FlowableEngineEventType.TIMER_SCHEDULED, event.getType());


### PR DESCRIPTION
If you look at the various Jenkins tests running that use MSSQL as the database, one particular test seemingly fails and passes randomly.  See for example this [test run](http://qa.flowable.org/job/Flowable6MSSQL/lastCompletedBuild/testReport/org.flowable.engine.test.api.event/JobEventsTest/testJobEntityEventsForRescheduleTimer/).  

The test is `org.flowable.engine.test.api.event.JobEventsTest.testJobEntityEventsForRescheduleTimer(JobEventsTest.java:174)`,   

The error message that is printed implies the dates are different but the `toString()` for each date looks exactly the same:

`expected:<Tue Mar 28 00:29:48 UTC 2017> but was:<Tue Mar 28 00:29:48 UTC 2017>`

To work around this problem the code was changed to ignore the milliseconds; thus instead of:

`assertEquals(rescheduledJob.getDuedate(), newTimerJob.getDuedate());`

the code is now: 

`assertEquals(DateUtils.truncate(rescheduledJob.getDuedate(), Calendar.SECOND), DateUtils.truncate(newTimerJob.getDuedate(), Calendar.SECOND));`