### PR TITLE
Fix mismatch query and update of collection

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricProcessInstanceQueryVersionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricProcessInstanceQueryVersionTest.java
@@ -1,8 +1,6 @@
 package org.flowable.engine.test.api.history;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import org.flowable.engine.history.HistoricProcessInstance;
@@ -16,7 +14,6 @@ public class HistoricProcessInstanceQueryVersionTest extends PluggableFlowableTe
 
     private org.flowable.engine.repository.Deployment oldDeployment;
     private org.flowable.engine.repository.Deployment newDeployment;
-    private List<String> processInstanceIds;
 
     protected void setUp() throws Exception {
         super.setUp();
@@ -24,11 +21,9 @@ public class HistoricProcessInstanceQueryVersionTest extends PluggableFlowableTe
                 .addClasspathResource(DEPLOYMENT_FILE_PATH)
                 .deploy();
 
-        processInstanceIds = new ArrayList<String>();
-
         Map<String, Object> startMap = new HashMap<String, Object>();
         startMap.put("test", 123);
-        processInstanceIds.add(runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY, startMap).getId());
+        runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY, startMap);
 
         newDeployment = repositoryService.createDeployment()
                 .addClasspathResource(DEPLOYMENT_FILE_PATH)
@@ -36,7 +31,7 @@ public class HistoricProcessInstanceQueryVersionTest extends PluggableFlowableTe
 
         startMap.clear();
         startMap.put("anothertest", 456);
-        processInstanceIds.add(runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY, startMap).getId());
+        runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY, startMap);
     }
 
     protected void tearDown() throws Exception {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoryServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoryServiceTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.engine.test.api.history;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -36,8 +38,6 @@ import org.flowable.engine.task.Task;
 import org.flowable.engine.task.TaskQuery;
 import org.flowable.engine.test.Deployment;
 import org.flowable.engine.test.api.runtime.ProcessInstanceQueryTest;
-
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * @author Frederik Heremans
@@ -248,11 +248,10 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml", "org/flowable/engine/test/api/runtime/oneTaskProcess2.bpmn20.xml" })
     public void testHistoricProcessInstanceQueryByDeploymentId() {
         org.flowable.engine.repository.Deployment deployment = repositoryService.createDeploymentQuery().singleResult();
-        HashSet<String> processInstanceIds = new HashSet<String>();
         for (int i = 0; i < 4; i++) {
-            processInstanceIds.add(runtimeService.startProcessInstanceByKey("oneTaskProcess", String.valueOf(i)).getId());
+            runtimeService.startProcessInstanceByKey("oneTaskProcess", String.valueOf(i));
         }
-        processInstanceIds.add(runtimeService.startProcessInstanceByKey("oneTaskProcess2", "1").getId());
+        runtimeService.startProcessInstanceByKey("oneTaskProcess2", "1");
 
         HistoricProcessInstanceQuery processInstanceQuery = historyService.createHistoricProcessInstanceQuery().deploymentId(deployment.getId());
         assertEquals(5, processInstanceQuery.count());
@@ -269,11 +268,10 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml", "org/flowable/engine/test/api/runtime/oneTaskProcess2.bpmn20.xml" })
     public void testHistoricProcessInstanceQueryByDeploymentIdIn() {
         org.flowable.engine.repository.Deployment deployment = repositoryService.createDeploymentQuery().singleResult();
-        HashSet<String> processInstanceIds = new HashSet<String>();
         for (int i = 0; i < 4; i++) {
-            processInstanceIds.add(runtimeService.startProcessInstanceByKey("oneTaskProcess", String.valueOf(i)).getId());
+            runtimeService.startProcessInstanceByKey("oneTaskProcess", String.valueOf(i));
         }
-        processInstanceIds.add(runtimeService.startProcessInstanceByKey("oneTaskProcess2", "1").getId());
+        runtimeService.startProcessInstanceByKey("oneTaskProcess2", "1");
 
         List<String> deploymentIds = new ArrayList<String>();
         deploymentIds.add(deployment.getId());
@@ -294,11 +292,10 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml", "org/flowable/engine/test/api/runtime/oneTaskProcess2.bpmn20.xml" })
     public void testHistoricTaskInstanceQueryByDeploymentId() {
         org.flowable.engine.repository.Deployment deployment = repositoryService.createDeploymentQuery().singleResult();
-        HashSet<String> processInstanceIds = new HashSet<String>();
         for (int i = 0; i < 4; i++) {
-            processInstanceIds.add(runtimeService.startProcessInstanceByKey("oneTaskProcess", String.valueOf(i)).getId());
+            runtimeService.startProcessInstanceByKey("oneTaskProcess", String.valueOf(i));
         }
-        processInstanceIds.add(runtimeService.startProcessInstanceByKey("oneTaskProcess2", "1").getId());
+        runtimeService.startProcessInstanceByKey("oneTaskProcess2", "1");
 
         HistoricTaskInstanceQuery taskInstanceQuery = historyService.createHistoricTaskInstanceQuery().deploymentId(deployment.getId());
         assertEquals(5, taskInstanceQuery.count());
@@ -314,11 +311,10 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml", "org/flowable/engine/test/api/runtime/oneTaskProcess2.bpmn20.xml" })
     public void testHistoricTaskInstanceQueryByDeploymentIdIn() {
         org.flowable.engine.repository.Deployment deployment = repositoryService.createDeploymentQuery().singleResult();
-        HashSet<String> processInstanceIds = new HashSet<String>();
         for (int i = 0; i < 4; i++) {
-            processInstanceIds.add(runtimeService.startProcessInstanceByKey("oneTaskProcess", String.valueOf(i)).getId());
+            runtimeService.startProcessInstanceByKey("oneTaskProcess", String.valueOf(i));
         }
-        processInstanceIds.add(runtimeService.startProcessInstanceByKey("oneTaskProcess2", "1").getId());
+        runtimeService.startProcessInstanceByKey("oneTaskProcess2", "1");
 
         List<String> deploymentIds = new ArrayList<String>();
         deploymentIds.add(deployment.getId());
@@ -342,11 +338,10 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml", "org/flowable/engine/test/api/runtime/oneTaskProcess2.bpmn20.xml" })
     public void testHistoricTaskInstanceOrQueryByDeploymentId() {
         org.flowable.engine.repository.Deployment deployment = repositoryService.createDeploymentQuery().singleResult();
-        HashSet<String> processInstanceIds = new HashSet<String>();
         for (int i = 0; i < 4; i++) {
-            processInstanceIds.add(runtimeService.startProcessInstanceByKey("oneTaskProcess", String.valueOf(i)).getId());
+            runtimeService.startProcessInstanceByKey("oneTaskProcess", String.valueOf(i));
         }
-        processInstanceIds.add(runtimeService.startProcessInstanceByKey("oneTaskProcess2", "1").getId());
+        runtimeService.startProcessInstanceByKey("oneTaskProcess2", "1");
 
         HistoricTaskInstanceQuery taskInstanceQuery = historyService.createHistoricTaskInstanceQuery().or().deploymentId(deployment.getId()).endOr();
         assertEquals(5, taskInstanceQuery.count());
@@ -426,11 +421,10 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml", "org/flowable/engine/test/api/runtime/oneTaskProcess2.bpmn20.xml" })
     public void testHistoricTaskInstanceOrQueryByDeploymentIdIn() {
         org.flowable.engine.repository.Deployment deployment = repositoryService.createDeploymentQuery().singleResult();
-        HashSet<String> processInstanceIds = new HashSet<String>();
         for (int i = 0; i < 4; i++) {
-            processInstanceIds.add(runtimeService.startProcessInstanceByKey("oneTaskProcess", String.valueOf(i)).getId());
+            runtimeService.startProcessInstanceByKey("oneTaskProcess", String.valueOf(i));
         }
-        processInstanceIds.add(runtimeService.startProcessInstanceByKey("oneTaskProcess2", "1").getId());
+        runtimeService.startProcessInstanceByKey("oneTaskProcess2", "1");
 
         List<String> deploymentIds = new ArrayList<String>();
         deploymentIds.add(deployment.getId());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ProcessInstanceAndVariablesQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ProcessInstanceAndVariablesQueryTest.java
@@ -12,7 +12,6 @@
  */
 package org.flowable.engine.test.api.runtime;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -30,8 +29,6 @@ public class ProcessInstanceAndVariablesQueryTest extends PluggableFlowableTestC
     private static final String PROCESS_DEFINITION_KEY_2 = "oneTaskProcess2";
     private static final String PROCESS_DEFINITION_KEY_3 = "oneTaskProcess3";
 
-    private List<String> processInstanceIds;
-
     /**
      * Setup starts 4 process instances of oneTaskProcess and 1 instance of oneTaskProcess2
      */
@@ -46,18 +43,17 @@ public class ProcessInstanceAndVariablesQueryTest extends PluggableFlowableTestC
         Map<String, Object> startMap = new HashMap<>();
         startMap.put("test", "test");
         startMap.put("test2", "test2");
-        processInstanceIds = new ArrayList<>();
         for (int i = 0; i < 4; i++) {
-            processInstanceIds.add(runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY, String.valueOf(i), startMap).getId());
+            runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY, String.valueOf(i), startMap);
         }
 
         startMap.clear();
         startMap.put("anothertest", 123);
-        processInstanceIds.add(runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY_2, "1", startMap).getId());
+        runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY_2, "1", startMap);
 
         startMap.clear();
         startMap.put("casetest", "MyCaseTest");
-        processInstanceIds.add(runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY_3, "1", startMap).getId());
+        runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY_3, "1", startMap);
     }
 
     protected void tearDown() throws Exception {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/RuntimeVariablesTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/RuntimeVariablesTest.java
@@ -116,10 +116,8 @@ public class RuntimeVariablesTest extends PluggableFlowableTestCase {
         }
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        Set<String> taskIds = new HashSet<String>();
         for (Task task : tasks) {
             taskService.setVariableLocal(task.getId(), "taskVar", "taskVar");
-            taskIds.add(task.getId());
         }
 
         List<VariableInstance> executionVariableInstances = runtimeService.getVariableInstancesByExecutionIds(executionIds);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskVariablesTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskVariablesTest.java
@@ -210,21 +210,19 @@ public class TaskVariablesTest extends PluggableFlowableTestCase {
             "org/flowable/engine/test/api/runtime/variableScope.bpmn20.xml"
     })
     public void testGetVariablesLocalByTaskIdsForScope() {
-        Map<String, Object> processVars = new HashMap<String, Object>();
+        Map<String, Object> processVars = new HashMap<>();
         processVars.put("processVar", "processVar");
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("variableScopeProcess", processVars);
 
-        Set<String> executionIds = new HashSet<String>();
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
         for (Execution execution : executions) {
             if (!processInstance.getId().equals(execution.getId())) {
-                executionIds.add(execution.getId());
                 runtimeService.setVariableLocal(execution.getId(), "executionVar", "executionVar");
             }
         }
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        Set<String> taskIds = new HashSet<String>();
+        Set<String> taskIds = new HashSet<>();
         for (Task task : tasks) {
             taskService.setVariableLocal(task.getId(), "taskVar", "taskVar");
             taskIds.add(task.getId());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/compensate/CompensateEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/compensate/CompensateEventTest.java
@@ -130,9 +130,9 @@ public class CompensateEventTest extends PluggableFlowableTestCase {
         // get task from first subprocess
         Task task = taskService.createTaskQuery().singleResult();
 
-        Map<String, String> taskFormVariables = new HashMap<String, String>();
+        Map<String, String> taskFormVariables = new HashMap<>();
         taskFormVariables.put("test", "begin");
-        formService.submitTaskFormData(task.getId(), new HashMap<String, String>());
+        formService.submitTaskFormData(task.getId(), taskFormVariables);
 
         // get task from second subprocess
         task = taskService.createTaskQuery().singleResult();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricVariableInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricVariableInstanceTest.java
@@ -382,11 +382,9 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
         processVars.put("processVar", "processVar");
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("variableScopeProcess", processVars);
 
-        Set<String> executionIds = new HashSet<String>();
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
         for (Execution execution : executions) {
             if (!processInstance.getId().equals(execution.getId())) {
-                executionIds.add(execution.getId());
                 runtimeService.setVariableLocal(execution.getId(), "executionVar", "executionVar");
             }
         }

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/history/HistoricProcessInstanceQueryVersionTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/history/HistoricProcessInstanceQueryVersionTest.java
@@ -1,8 +1,6 @@
 package org.activiti.engine.test.api.history;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import org.activiti.engine.impl.test.PluggableFlowableTestCase;
@@ -16,7 +14,6 @@ public class HistoricProcessInstanceQueryVersionTest extends PluggableFlowableTe
 
     private org.flowable.engine.repository.Deployment oldDeployment;
     private org.flowable.engine.repository.Deployment newDeployment;
-    private List<String> processInstanceIds;
 
     protected void setUp() throws Exception {
         super.setUp();
@@ -24,11 +21,9 @@ public class HistoricProcessInstanceQueryVersionTest extends PluggableFlowableTe
                 .addClasspathResource(DEPLOYMENT_FILE_PATH)
                 .deploy();
 
-        processInstanceIds = new ArrayList<String>();
-
-        Map<String, Object> startMap = new HashMap<String, Object>();
+        Map<String, Object> startMap = new HashMap<>();
         startMap.put("test", 123);
-        processInstanceIds.add(runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY, startMap).getId());
+        runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY, startMap);
 
         newDeployment = repositoryService.createDeployment()
                 .addClasspathResource(DEPLOYMENT_FILE_PATH)
@@ -36,7 +31,7 @@ public class HistoricProcessInstanceQueryVersionTest extends PluggableFlowableTe
 
         startMap.clear();
         startMap.put("anothertest", 456);
-        processInstanceIds.add(runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY, startMap).getId());
+        runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY, startMap);
     }
 
     protected void tearDown() throws Exception {

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/runtime/ProcessInstanceAndVariablesQueryTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/runtime/ProcessInstanceAndVariablesQueryTest.java
@@ -12,7 +12,6 @@
  */
 package org.activiti.engine.test.api.runtime;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -31,8 +30,6 @@ public class ProcessInstanceAndVariablesQueryTest extends PluggableFlowableTestC
     private static final String PROCESS_DEFINITION_KEY_2 = "oneTaskProcess2";
     private static final String PROCESS_DEFINITION_KEY_3 = "oneTaskProcess3";
 
-    private List<String> processInstanceIds;
-
     /**
      * Setup starts 4 process instances of oneTaskProcess and 1 instance of oneTaskProcess2
      */
@@ -48,17 +45,17 @@ public class ProcessInstanceAndVariablesQueryTest extends PluggableFlowableTestC
         Map<String, Object> startMap = new HashMap<>();
         startMap.put("test", "test");
         startMap.put("test2", "test2");
-        processInstanceIds = new ArrayList<>();
         for (int i = 0; i < 4; i++) {
-            processInstanceIds.add(runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY, String.valueOf(i), startMap).getId());
+            runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY, String.valueOf(i), startMap);
         }
+
         startMap.clear();
         startMap.put("anothertest", 123);
-        processInstanceIds.add(runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY_2, "1", startMap).getId());
+        runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY_2, "1", startMap);
 
         startMap.clear();
         startMap.put("casetest", "MyCaseTest");
-        processInstanceIds.add(runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY_3, "1", startMap).getId());
+        runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY_3, "1", startMap);
     }
 
     protected void tearDown() throws Exception {

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/event/compensate/CompensateEventTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/event/compensate/CompensateEventTest.java
@@ -79,9 +79,9 @@ public class CompensateEventTest extends PluggableFlowableTestCase {
         // get task from first subprocess
         Task task = taskService.createTaskQuery().singleResult();
 
-        Map<String, String> taskFormVariables = new HashMap<String, String>();
+        Map<String, String> taskFormVariables = new HashMap<>();
         taskFormVariables.put("test", "begin");
-        formService.submitTaskFormData(task.getId(), new HashMap<String, String>());
+        formService.submitTaskFormData(task.getId(), taskFormVariables);
 
         // get task from second subprocess
         task = taskService.createTaskQuery().singleResult();


### PR DESCRIPTION
Fix when collection fields or variables whose contents are either queried and not updated, or updated and not queried. Such mismatched queries and updates are pointless.