### PR TITLE
A circle with a clock inner icon is used to visualize a timer start e…

### DIFF
--- a/userguide/src/en/ch07b-BPMN-Constructs.adoc
+++ b/userguide/src/en/ch07b-BPMN-Constructs.adoc
@@ -484,7 +484,7 @@ _Note:_ when a new version of a process with a start timer event is deployed, th
 
 ===== Graphical notation
 
-A none start event is visualized as a circle with clock inner icon.
+A timer start event is visualized as a circle with clock inner icon.
 
 image::images/bpmn.clock.start.event.png[align="center"]
 


### PR DESCRIPTION
The documentation (user guide) has a small error. Refer to section "8.2.8. Timer Start Event". The last sentence in this section says "A **none** start event is visualized as a circle with clock inner icon."

However, the image that this sentence refers to is for "Timer Start Event." The sentence should be modified to - "A **timer** start event is visualized as a circle with clock inner icon."