### PR TITLE
Set source and target version for maven-compiler plugin in a single l…

### DIFF
--- a/modules/flowable-common-rest/pom.xml
+++ b/modules/flowable-common-rest/pom.xml
@@ -24,14 +24,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <archive>

--- a/modules/flowable-content-rest/pom.xml
+++ b/modules/flowable-content-rest/pom.xml
@@ -25,14 +25,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
-				</configuration>
-			</plugin>
-			<plugin>
 				<artifactId>maven-jar-plugin</artifactId>
 				<configuration>
 					<archive>

--- a/modules/flowable-content-spring/pom.xml
+++ b/modules/flowable-content-spring/pom.xml
@@ -25,14 +25,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <archive>

--- a/modules/flowable-cxf/pom.xml
+++ b/modules/flowable-cxf/pom.xml
@@ -31,14 +31,6 @@
     </resources>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
-        </configuration>
-      </plugin>
-      <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <archive>

--- a/modules/flowable-dmn-rest/pom.xml
+++ b/modules/flowable-dmn-rest/pom.xml
@@ -23,14 +23,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <archive>

--- a/modules/flowable-dmn-spring/pom.xml
+++ b/modules/flowable-dmn-spring/pom.xml
@@ -25,14 +25,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <archive>

--- a/modules/flowable-form-rest/pom.xml
+++ b/modules/flowable-form-rest/pom.xml
@@ -25,14 +25,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
-				</configuration>
-			</plugin>
-			<plugin>
 				<artifactId>maven-jar-plugin</artifactId>
 				<configuration>
 					<archive>

--- a/modules/flowable-form-spring/pom.xml
+++ b/modules/flowable-form-spring/pom.xml
@@ -25,14 +25,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <archive>

--- a/modules/flowable-idm-spring/pom.xml
+++ b/modules/flowable-idm-spring/pom.xml
@@ -25,14 +25,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <archive>

--- a/modules/flowable-jms-spring-executor/pom.xml
+++ b/modules/flowable-jms-spring-executor/pom.xml
@@ -19,14 +19,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
-				</configuration>
-			</plugin>
-			<plugin>
 				<artifactId>maven-jar-plugin</artifactId>
 				<configuration>
 					<archive>

--- a/modules/flowable-jmx/pom.xml
+++ b/modules/flowable-jmx/pom.xml
@@ -75,14 +75,6 @@
 
 	<build>
 		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
-				</configuration>
-			</plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>

--- a/modules/flowable-json-converter/pom.xml
+++ b/modules/flowable-json-converter/pom.xml
@@ -26,14 +26,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
-        </configuration>
-      </plugin>
-      <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <archive>

--- a/modules/flowable-ldap-configurator/pom.xml
+++ b/modules/flowable-ldap-configurator/pom.xml
@@ -175,14 +175,6 @@
 
 	<build>
 		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
-				</configuration>
-			</plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>

--- a/modules/flowable-ldap/pom.xml
+++ b/modules/flowable-ldap/pom.xml
@@ -61,14 +61,6 @@
 
 	<build>
 		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
-				</configuration>
-			</plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>

--- a/modules/flowable-mule/pom.xml
+++ b/modules/flowable-mule/pom.xml
@@ -45,14 +45,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
-        </configuration>
-      </plugin>
-      <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <archive>

--- a/modules/flowable-rest/pom.xml
+++ b/modules/flowable-rest/pom.xml
@@ -23,14 +23,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
-        </configuration>
-      </plugin>
-      <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <archive>

--- a/modules/flowable-spring-boot/flowable-spring-boot-samples/pom.xml
+++ b/modules/flowable-spring-boot/flowable-spring-boot-samples/pom.xml
@@ -37,14 +37,6 @@
     
      <build>
             <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <configuration>
-                        <source>1.7</source>
-                        <target>1.7</target>
-                    </configuration>
-                </plugin>
             </plugins>
         </build>
 </project>

--- a/modules/flowable-spring-boot/pom.xml
+++ b/modules/flowable-spring-boot/pom.xml
@@ -116,14 +116,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <archive>

--- a/modules/flowable-spring/pom.xml
+++ b/modules/flowable-spring/pom.xml
@@ -25,14 +25,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <archive>

--- a/modules/flowable-ui-admin/pom.xml
+++ b/modules/flowable-ui-admin/pom.xml
@@ -568,15 +568,6 @@
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.1</version>
-				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>
 				<version>1.3.1</version>
 				<executions>

--- a/modules/flowable5-compatibility-testdata/pom.xml
+++ b/modules/flowable5-compatibility-testdata/pom.xml
@@ -76,18 +76,6 @@
 			<plugins>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-compiler-plugin</artifactId>
-					<version>2.3.2</version>
-					<configuration>
-						<source>1.7</source>
-						<target>1.7</target>
-						<showDeprecation>true</showDeprecation>
-						<showWarnings>true</showWarnings>
-						<optimize>true</optimize>
-					</configuration>
-				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-shade-plugin</artifactId>
 					<version>2.3</version>
 					<configuration>

--- a/modules/flowable5-cxf-test/pom.xml
+++ b/modules/flowable5-cxf-test/pom.xml
@@ -24,14 +24,6 @@
     </resources>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
-        </configuration>
-      </plugin>
-      <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <archive>

--- a/modules/flowable5-mule-test/pom.xml
+++ b/modules/flowable5-mule-test/pom.xml
@@ -46,14 +46,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
-        </configuration>
-      </plugin>
-      <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <archive>

--- a/modules/flowable5-spring-test/pom.xml
+++ b/modules/flowable5-spring-test/pom.xml
@@ -15,14 +15,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <archive>

--- a/modules/flowable5-spring/pom.xml
+++ b/modules/flowable5-spring/pom.xml
@@ -25,14 +25,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <archive>

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
 	<version>6.0.1-SNAPSHOT</version>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<jdk.version>1.7</jdk.version>
 		<spring.framework.version>4.2.5.RELEASE</spring.framework.version>
 		<spring.security.version>4.0.4.RELEASE</spring.security.version>
 		<jackson.version>2.7.5</jackson.version>
@@ -870,8 +871,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>2.3.2</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>${jdk.version}</source>
+					<target>${jdk.version}</target>
 					<showDeprecation>true</showDeprecation>
 					<showWarnings>true</showWarnings>
 					<optimize>true</optimize>


### PR DESCRIPTION
…ocation.

This change makes it easier to build flowable at different JDK versions simply by making a change to the <jdk.version> property in the main pom.xml file. SubModules can also override the JDK version if needed simply be overriding the JDK.VERSION property in their respective pom.xml.

In addition the change ensures the showDeprecation, showWarnings, and optimize compiler options are set consistently across all modules.
