### PR TITLE
Add id field to DataObject

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/DataObjectImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/DataObjectImpl.java
@@ -15,6 +15,7 @@ package org.flowable.engine.impl;
 import org.flowable.engine.runtime.DataObject;
 
 public class DataObjectImpl implements DataObject {
+    protected String id;
     protected String processInstanceId;
     protected String executionId;
     protected String name;
@@ -26,9 +27,10 @@ public class DataObjectImpl implements DataObject {
 
     private String type;
 
-    public DataObjectImpl(String processInstanceId, String executionId, String name, Object value, String description, String type, String localizedName,
+    public DataObjectImpl(String id, String processInstanceId, String executionId, String name, Object value, String description, String type, String localizedName,
             String localizedDescription, String dataObjectDefinitionKey) {
 
+        this.id = id;
         this.processInstanceId = processInstanceId;
         this.executionId = executionId;
         this.name = name;
@@ -39,8 +41,25 @@ public class DataObjectImpl implements DataObject {
         this.localizedDescription = localizedDescription;
         this.dataObjectDefinitionKey = dataObjectDefinitionKey;
     }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setProcessInstanceId(String processInstanceId) {
+        this.processInstanceId = processInstanceId;
+    }
+
     public String getProcessInstanceId() {
         return processInstanceId;
+    }
+
+    public void setExecutionId(String executionId) {
+        this.executionId = executionId;
     }
 
     public String getExecutionId() {

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/GetDataObjectCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/GetDataObjectCmd.java
@@ -133,7 +133,7 @@ public class GetDataObjectCmd implements Command<DataObject>, Serializable {
             }
 
             if (foundDataObject != null) {
-                dataObject = new DataObjectImpl(variableEntity.getProcessInstanceId(), variableEntity.getExecutionId(),
+                dataObject = new DataObjectImpl(variableEntity.getId(), variableEntity.getProcessInstanceId(), variableEntity.getExecutionId(),
                         variableEntity.getName(), variableEntity.getValue(), foundDataObject.getDocumentation(),
                         foundDataObject.getType(), localizedName, localizedDescription, foundDataObject.getId());
             }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/GetDataObjectsCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/GetDataObjectsCmd.java
@@ -153,9 +153,10 @@ public class GetDataObjectsCmd implements Command<Map<String, DataObject>>, Seri
                 }
 
                 if (foundDataObject != null) {
-                    dataObjects.put(name, new DataObjectImpl(variableEntity.getProcessInstanceId(), variableEntity.getExecutionId(),
-                            variableEntity.getName(), variableEntity.getValue(), foundDataObject.getDocumentation(),
-                            foundDataObject.getType(), localizedName, localizedDescription, foundDataObject.getId()));
+                    dataObjects.put(name, new DataObjectImpl(variableEntity.getId(), variableEntity.getProcessInstanceId(),
+                            variableEntity.getExecutionId(), variableEntity.getName(), variableEntity.getValue(),
+                            foundDataObject.getDocumentation(), foundDataObject.getType(), localizedName,
+                            localizedDescription, foundDataObject.getId()));
                 }
             }
         }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/GetTaskDataObjectCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/GetTaskDataObjectCmd.java
@@ -117,7 +117,8 @@ public class GetTaskDataObjectCmd implements Command<DataObject>, Serializable {
             }
 
             if (foundDataObject != null) {
-                dataObject = new DataObjectImpl(variableEntity.getProcessInstanceId(), variableEntity.getExecutionId(),
+                dataObject = new DataObjectImpl(variableEntity.getId(), variableEntity.getProcessInstanceId(),
+                        variableEntity.getExecutionId(),
                         variableEntity.getName(), variableEntity.getValue(), foundDataObject.getDocumentation(),
                         foundDataObject.getType(), localizedName, localizedDescription, foundDataObject.getId());
             }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/GetTaskDataObjectsCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/GetTaskDataObjectsCmd.java
@@ -130,8 +130,8 @@ public class GetTaskDataObjectsCmd implements Command<Map<String, DataObject>>, 
 
                 if (foundDataObject != null) {
                     dataObjects.put(
-                            variableEntity.getName(), new DataObjectImpl(variableEntity.getProcessInstanceId(), variableEntity.getExecutionId(),
-                                    variableEntity.getName(), variableEntity.getValue(),
+                            variableEntity.getName(), new DataObjectImpl(variableEntity.getId(), variableEntity.getProcessInstanceId(),
+                                    variableEntity.getExecutionId(), variableEntity.getName(), variableEntity.getValue(),
                             foundDataObject.getDocumentation(), foundDataObject.getType(), localizedName, localizedDescription, foundDataObject.getId()));
                 }
             }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/runtime/DataObject.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/runtime/DataObject.java
@@ -19,6 +19,11 @@ package org.flowable.engine.runtime;
 public interface DataObject {
 
     /**
+     * The unique id of this Data Object.
+     */
+    public String getId();
+
+    /**
      /**
      * The id of the process instance that this Data Object is associated with.
      */

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/variables/VariablesTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/variables/VariablesTest.java
@@ -296,6 +296,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObjects.get("stringVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObjects = runtimeService.getDataObjects(processInstance.getId(), "it", false);
         assertEquals(1, dataObjects.size());
@@ -307,6 +308,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObjects.get("stringVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         // getDataObjects
         dataObjects = runtimeService.getDataObjects(processInstance.getId(), "en-US", false);
@@ -319,6 +321,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObjects.get("stringVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObjects = runtimeService.getDataObjects(processInstance.getId(), "en-AU", false);
         assertEquals(1, dataObjects.size());
@@ -330,6 +333,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObjects.get("stringVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObjects = runtimeService.getDataObjects(processInstance.getId(), "en-GB", true);
         assertEquals(1, dataObjects.size());
@@ -341,6 +345,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObjects.get("stringVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObjects = runtimeService.getDataObjects(processInstance.getId(), "en-GB", false);
         assertEquals(1, dataObjects.size());
@@ -352,6 +357,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObjects.get("stringVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         List<String> variableNames = new ArrayList<String>();
         variableNames.add("stringVar");
@@ -367,6 +373,8 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObjects.get("stringVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
+
 
         dataObjects = runtimeService.getDataObjects(processInstance.getId(), variableNames, "it", false);
         assertEquals(1, dataObjects.size());
@@ -378,6 +386,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObjects.get("stringVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObjects = runtimeService.getDataObjects(processInstance.getId(), variableNames, "en-US", false);
         assertEquals(1, dataObjects.size());
@@ -389,6 +398,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObjects.get("stringVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObjects = runtimeService.getDataObjects(processInstance.getId(), variableNames, "en-AU", false);
         assertEquals(1, dataObjects.size());
@@ -400,6 +410,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObjects.get("stringVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObjects = runtimeService.getDataObjects(processInstance.getId(), variableNames, "en-GB", true);
         assertEquals(1, dataObjects.size());
@@ -411,6 +422,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObjects.get("stringVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObjects = runtimeService.getDataObjects(processInstance.getId(), variableNames, "en-GB", false);
         assertEquals(1, dataObjects.size());
@@ -422,6 +434,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObjects.get("stringVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         // getDataObjectsLocal
         dataObjects = runtimeService.getDataObjectsLocal(processInstance.getId(), "es", false);
@@ -434,6 +447,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObjects.get("stringVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObjects = runtimeService.getDataObjectsLocal(processInstance.getId(), "it", false);
         assertEquals(1, dataObjects.size());
@@ -445,6 +459,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObjects.get("stringVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObjects = runtimeService.getDataObjectsLocal(processInstance.getId(), "en-US", false);
         assertEquals(1, dataObjects.size());
@@ -456,6 +471,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObjects.get("stringVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObjects = runtimeService.getDataObjectsLocal(processInstance.getId(), "en-AU", false);
         assertEquals(1, dataObjects.size());
@@ -467,6 +483,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObjects.get("stringVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObjects = runtimeService.getDataObjectsLocal(processInstance.getId(), "en-GB", true);
         assertEquals(1, dataObjects.size());
@@ -478,6 +495,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObjects.get("stringVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObjects = runtimeService.getDataObjectsLocal(processInstance.getId(), "en-GB", false);
         assertEquals(1, dataObjects.size());
@@ -489,6 +507,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObjects.get("stringVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObjects = runtimeService.getDataObjectsLocal(processInstance.getId(), "ja-JA", true);
         assertEquals(1, dataObjects.size());
@@ -500,6 +519,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObjects.get("stringVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         // getDataObjectsLocal via names
         dataObjects = runtimeService.getDataObjectsLocal(processInstance.getId(), variableNames, "es", false);
@@ -512,6 +532,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObjects.get("stringVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObjects = runtimeService.getDataObjectsLocal(processInstance.getId(), variableNames, "it", false);
         assertEquals(1, dataObjects.size());
@@ -523,6 +544,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObjects.get("stringVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObjects = runtimeService.getDataObjectsLocal(processInstance.getId(), variableNames, "en-US", false);
         assertEquals(1, dataObjects.size());
@@ -534,6 +556,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObjects.get("stringVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObjects = runtimeService.getDataObjectsLocal(processInstance.getId(), variableNames, "en-AU", false);
         assertEquals(1, dataObjects.size());
@@ -545,6 +568,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObjects.get("stringVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObjects = runtimeService.getDataObjectsLocal(processInstance.getId(), variableNames, "en-GB", true);
         assertEquals(1, dataObjects.size());
@@ -556,6 +580,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObjects.get("stringVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObjects = runtimeService.getDataObjectsLocal(processInstance.getId(), variableNames, "en-GB", false);
         assertEquals(1, dataObjects.size());
@@ -567,6 +592,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObjects.get("stringVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         // getDataObject
         DataObject dataObject = runtimeService.getDataObject(processInstance.getId(), "stringVar", "es", false);
@@ -579,6 +605,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObjects.get("stringVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObject = runtimeService.getDataObject(processInstance.getId(), "stringVar", "it", false);
         assertNotNull(dataObject);
@@ -590,6 +617,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObjects.get("stringVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObject = runtimeService.getDataObject(processInstance.getId(), "stringVar", "en-GB", false);
         assertNotNull(dataObject);
@@ -601,6 +629,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObjects.get("stringVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObject = runtimeService.getDataObject(processInstance.getId(), "stringVar", "en-US", false);
         assertNotNull(dataObject);
@@ -612,6 +641,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObjects.get("stringVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObject = runtimeService.getDataObject(processInstance.getId(), "stringVar", "en-AU", false);
         assertNotNull(dataObject);
@@ -623,6 +653,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObjects.get("stringVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObject = runtimeService.getDataObject(processInstance.getId(), "stringVar", "en-GB", true);
         assertNotNull(dataObject);
@@ -634,6 +665,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObjects.get("stringVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObject = runtimeService.getDataObject(processInstance.getId(), "stringVar", "en-GB", false);
         assertNotNull(dataObject);
@@ -645,6 +677,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObjects.get("stringVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         // getDataObjectLocal
         dataObject = runtimeService.getDataObjectLocal(processInstance.getId(), "stringVar", "es", false);
@@ -657,6 +690,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObjects.get("stringVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObject = runtimeService.getDataObjectLocal(processInstance.getId(), "stringVar", "it", false);
         assertNotNull(dataObject);
@@ -668,6 +702,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObjects.get("stringVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObject = runtimeService.getDataObjectLocal(processInstance.getId(), "stringVar", "en-US", false);
         assertNotNull(dataObject);
@@ -679,6 +714,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObjects.get("stringVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObject = runtimeService.getDataObjectLocal(processInstance.getId(), "stringVar", "en-AU", false);
         assertNotNull(dataObject);
@@ -690,6 +726,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObjects.get("stringVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObject = runtimeService.getDataObjectLocal(processInstance.getId(), "stringVar", "en-GB", true);
         assertNotNull(dataObject);
@@ -700,6 +737,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObject = runtimeService.getDataObjectLocal(processInstance.getId(), "stringVar", "en-GB", false);
         assertNotNull(dataObject);
@@ -711,6 +749,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObjects.get("stringVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         Execution subprocess = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("subprocess1").singleResult();
 
@@ -724,6 +763,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObjects.get("stringVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         // getDataObjects
         dataObjects = runtimeService.getDataObjects(subprocess.getId(), "es", false);
@@ -744,6 +784,8 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
+        assertNotNull(dataObjects.get("intVar").getId());
 
         dataObjects = runtimeService.getDataObjects(subprocess.getId(), "it", false);
         assertEquals(2, dataObjects.size());
@@ -763,6 +805,8 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
+        assertNotNull(dataObjects.get("intVar").getId());
 
         dataObjects = runtimeService.getDataObjects(subprocess.getId(), "en-US", false);
         assertEquals(2, dataObjects.size());
@@ -782,6 +826,8 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
+        assertNotNull(dataObjects.get("intVar").getId());
 
         dataObjects = runtimeService.getDataObjects(subprocess.getId(), "en-AU", false);
         assertEquals(2, dataObjects.size());
@@ -801,6 +847,8 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
+        assertNotNull(dataObjects.get("intVar").getId());
 
         dataObjects = runtimeService.getDataObjects(subprocess.getId(), "en-GB", true);
         assertEquals(2, dataObjects.size());
@@ -820,6 +868,8 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
+        assertNotNull(dataObjects.get("intVar").getId());
 
         dataObjects = runtimeService.getDataObjects(subprocess.getId(), "en-GB", false);
         assertEquals(2, dataObjects.size());
@@ -840,6 +890,8 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
+        assertNotNull(dataObjects.get("intVar").getId());
 
         // getDataObjects via names (from subprocess)
 
@@ -862,6 +914,8 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
+        assertNotNull(dataObjects.get("intVar").getId());
 
         dataObjects = runtimeService.getDataObjects(subprocess.getId(), variableNames, "it", false);
         assertEquals(2, dataObjects.size());
@@ -881,6 +935,8 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
+        assertNotNull(dataObjects.get("intVar").getId());
 
         dataObjects = runtimeService.getDataObjects(subprocess.getId(), variableNames, "en-US", false);
         assertEquals(2, dataObjects.size());
@@ -900,6 +956,8 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
+        assertNotNull(dataObjects.get("intVar").getId());
 
         dataObjects = runtimeService.getDataObjects(subprocess.getId(), variableNames, "en-AU", false);
         assertEquals(2, dataObjects.size());
@@ -919,6 +977,8 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
+        assertNotNull(dataObjects.get("intVar").getId());
 
         dataObjects = runtimeService.getDataObjects(subprocess.getId(), variableNames, "en-GB", true);
         assertEquals(2, dataObjects.size());
@@ -938,6 +998,8 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
+        assertNotNull(dataObjects.get("intVar").getId());
 
         dataObjects = runtimeService.getDataObjects(subprocess.getId(), variableNames, "en-GB", false);
         assertEquals(2, dataObjects.size());
@@ -957,6 +1019,8 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
+        assertNotNull(dataObjects.get("intVar").getId());
 
         // getDataObjectsLocal
         dataObjects = runtimeService.getDataObjectsLocal(subprocess.getId(), "es", false);
@@ -969,6 +1033,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("int", dataObjects.get("intVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("intVar").getId());
 
         dataObjects = runtimeService.getDataObjectsLocal(subprocess.getId(), "it", false);
         assertEquals(1, dataObjects.size());
@@ -980,6 +1045,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("int", dataObjects.get("intVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("intVar").getId());
 
         dataObjects = runtimeService.getDataObjectsLocal(subprocess.getId(), "en-US", false);
         assertEquals(1, dataObjects.size());
@@ -991,6 +1057,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("int", dataObjects.get("intVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("intVar").getId());
 
         dataObjects = runtimeService.getDataObjectsLocal(subprocess.getId(), "en-AU", false);
         assertEquals(1, dataObjects.size());
@@ -1002,6 +1069,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("int", dataObjects.get("intVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("intVar").getId());
 
         dataObjects = runtimeService.getDataObjectsLocal(subprocess.getId(), "en-GB", true);
         assertEquals(1, dataObjects.size());
@@ -1013,6 +1081,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("int", dataObjects.get("intVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("intVar").getId());
 
         dataObjects = runtimeService.getDataObjectsLocal(subprocess.getId(), "en-GB", false);
         assertEquals(1, dataObjects.size());
@@ -1024,6 +1093,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("int", dataObjects.get("intVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("intVar").getId());
 
         dataObjects = runtimeService.getDataObjectsLocal(subprocess.getId(), "ja-JA", true);
         assertEquals(1, dataObjects.size());
@@ -1035,6 +1105,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("int", dataObjects.get("intVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("intVar").getId());
 
         // getDataObjectsLocal via names
         dataObjects = runtimeService.getDataObjectsLocal(subprocess.getId(), variableNames, "es", false);
@@ -1047,6 +1118,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("int", dataObjects.get("intVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("intVar").getId());
 
         dataObjects = runtimeService.getDataObjectsLocal(subprocess.getId(), variableNames, "it", false);
         assertEquals(1, dataObjects.size());
@@ -1058,6 +1130,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("int", dataObjects.get("intVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("intVar").getId());
 
         dataObjects = runtimeService.getDataObjectsLocal(subprocess.getId(), variableNames, "en-US", false);
         assertEquals(1, dataObjects.size());
@@ -1069,6 +1142,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("int", dataObjects.get("intVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("intVar").getId());
 
         dataObjects = runtimeService.getDataObjectsLocal(subprocess.getId(), variableNames, "en-AU", false);
         assertEquals(1, dataObjects.size());
@@ -1080,6 +1154,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("int", dataObjects.get("intVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("intVar").getId());
 
         dataObjects = runtimeService.getDataObjectsLocal(subprocess.getId(), variableNames, "en-GB", true);
         assertEquals(1, dataObjects.size());
@@ -1091,6 +1166,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("int", dataObjects.get("intVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("intVar").getId());
 
         dataObjects = runtimeService.getDataObjectsLocal(subprocess.getId(), variableNames, "en-GB", false);
         assertEquals(1, dataObjects.size());
@@ -1102,6 +1178,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("int", dataObjects.get("intVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("intVar").getId());
 
         // getDataObject (in subprocess)
         dataObject = runtimeService.getDataObject(subprocess.getId(), "intVar", "es", false);
@@ -1114,6 +1191,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("int", dataObject.getType());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("intVar").getId());
 
         dataObject = runtimeService.getDataObject(subprocess.getId(), "intVar", "it", false);
         assertNotNull(dataObject);
@@ -1125,6 +1203,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("int", dataObject.getType());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("intVar").getId());
 
         dataObject = runtimeService.getDataObject(subprocess.getId(), "intVar", "en-GB", false);
         assertNotNull(dataObject);
@@ -1136,6 +1215,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("int", dataObject.getType());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("intVar").getId());
 
         dataObject = runtimeService.getDataObject(subprocess.getId(), "intVar", "en-US", false);
         assertNotNull(dataObject);
@@ -1147,6 +1227,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("int", dataObject.getType());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("intVar").getId());
 
         dataObject = runtimeService.getDataObject(subprocess.getId(), "intVar", "en-AU", false);
         assertNotNull(dataObject);
@@ -1158,6 +1239,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("int", dataObject.getType());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("intVar").getId());
 
         dataObject = runtimeService.getDataObject(subprocess.getId(), "intVar", "en-GB", true);
         assertNotNull(dataObject);
@@ -1169,6 +1251,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("int", dataObject.getType());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("intVar").getId());
 
         dataObject = runtimeService.getDataObject(subprocess.getId(), "intVar", "en-GB", false);
         assertNotNull(dataObject);
@@ -1180,6 +1263,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("int", dataObject.getType());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("intVar").getId());
 
         // getDataObjectLocal (in subprocess)
         dataObject = runtimeService.getDataObjectLocal(subprocess.getId(), "intVar", "es", false);
@@ -1192,6 +1276,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("int", dataObject.getType());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("intVar").getId());
 
         dataObject = runtimeService.getDataObjectLocal(subprocess.getId(), "intVar", "it", false);
         assertNotNull(dataObject);
@@ -1203,6 +1288,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("int", dataObject.getType());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("intVar").getId());
 
         dataObject = runtimeService.getDataObjectLocal(subprocess.getId(), "intVar", "en-US", false);
         assertNotNull(dataObject);
@@ -1214,6 +1300,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("int", dataObject.getType());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("intVar").getId());
 
         dataObject = runtimeService.getDataObjectLocal(subprocess.getId(), "intVar", "en-AU", false);
         assertNotNull(dataObject);
@@ -1225,6 +1312,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("int", dataObject.getType());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("intVar").getId());
 
         dataObject = runtimeService.getDataObjectLocal(subprocess.getId(), "intVar", "en-GB", true);
         assertNotNull(dataObject);
@@ -1236,6 +1324,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("int", dataObject.getType());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("intVar").getId());
 
         dataObject = runtimeService.getDataObjectLocal(subprocess.getId(), "intVar", "en-GB", false);
         assertNotNull(dataObject);
@@ -1247,6 +1336,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("int", dataObject.getType());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("intVar").getId());
 
         // Verify TaskService behavior
         dataObjects = taskService.getDataObjects(task.getId());
@@ -1266,6 +1356,8 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("intVar").getId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         // getDataObjects
         dataObjects = taskService.getDataObjects(task.getId());
@@ -1285,6 +1377,8 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("intVar").getId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObjects = taskService.getDataObjects(task.getId(), "es", false);
         assertEquals(2, dataObjects.size());
@@ -1303,6 +1397,8 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("intVar").getId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObjects = taskService.getDataObjects(task.getId(), "it", false);
         assertEquals(2, dataObjects.size());
@@ -1321,6 +1417,8 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("intVar").getId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObjects = taskService.getDataObjects(task.getId(), "en-US", false);
         assertEquals(2, dataObjects.size());
@@ -1339,6 +1437,8 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("intVar").getId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObjects = taskService.getDataObjects(task.getId(), "en-AU", false);
         assertEquals(2, dataObjects.size());
@@ -1357,6 +1457,8 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("intVar").getId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObjects = taskService.getDataObjects(task.getId(), "en-GB", true);
         assertEquals(2, dataObjects.size());
@@ -1375,6 +1477,8 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("intVar").getId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObjects = taskService.getDataObjects(task.getId(), "en-GB", false);
         assertEquals(2, dataObjects.size());
@@ -1393,6 +1497,8 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
         assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
         assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
+        assertNotNull(dataObjects.get("intVar").getId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         variableNames = new ArrayList<String>();
         variableNames.add("stringVar");
@@ -1408,6 +1514,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObjects.get("stringVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObjects = taskService.getDataObjects(task.getId(), variableNames, "it", false);
         assertEquals(1, dataObjects.size());
@@ -1419,6 +1526,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObjects.get("stringVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObjects = taskService.getDataObjects(task.getId(), variableNames, "en-US", false);
         assertEquals(1, dataObjects.size());
@@ -1430,6 +1538,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObjects.get("stringVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObjects = taskService.getDataObjects(task.getId(), variableNames, "en-AU", false);
         assertEquals(1, dataObjects.size());
@@ -1441,6 +1550,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObjects.get("stringVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObjects = taskService.getDataObjects(task.getId(), variableNames, "en-GB", true);
         assertEquals(1, dataObjects.size());
@@ -1452,6 +1562,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObjects.get("stringVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObjects = taskService.getDataObjects(task.getId(), variableNames, "en-GB", false);
         assertEquals(1, dataObjects.size());
@@ -1464,6 +1575,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObjects.get("stringVar").getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         // getDataObject
         dataObject = taskService.getDataObject(task.getId(), "stringVar");
@@ -1476,6 +1588,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObject.getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObject = taskService.getDataObject(task.getId(), "stringVar", "es", false);
         assertNotNull(dataObject);
@@ -1487,6 +1600,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObject.getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObject = taskService.getDataObject(task.getId(), "stringVar", "it", false);
         assertNotNull(dataObject);
@@ -1498,6 +1612,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObject.getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObject = taskService.getDataObject(task.getId(), "stringVar", "en-GB", false);
         assertNotNull(dataObject);
@@ -1509,6 +1624,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObject.getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObject = taskService.getDataObject(task.getId(), "stringVar", "en-US", false);
         assertNotNull(dataObject);
@@ -1520,6 +1636,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObject.getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObject = taskService.getDataObject(task.getId(), "stringVar", "en-AU", false);
         assertNotNull(dataObject);
@@ -1531,6 +1648,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObject.getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObject = taskService.getDataObject(task.getId(), "stringVar", "en-GB", true);
         assertNotNull(dataObject);
@@ -1542,6 +1660,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObject.getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
 
         dataObject = taskService.getDataObject(task.getId(), "stringVar", "en-GB", false);
         assertNotNull(dataObject);
@@ -1553,6 +1672,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("string", dataObject.getType());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
         assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
+        assertNotNull(dataObjects.get("stringVar").getId());
     }
 
     // Test case for ACT-1839


### PR DESCRIPTION
Expose the id of the DataObject to be consistent with the id being exposed via the VariableInstance class. Exposing the id is helpful in our REST API since our Variable representation exposes HATEOS style links. 