### PR TITLE
Initialization database type from main configurator.

### DIFF
--- a/modules/flowable-content-engine-configurator/src/main/java/org/flowable/content/engine/configurator/ContentEngineConfigurator.java
+++ b/modules/flowable-content-engine-configurator/src/main/java/org/flowable/content/engine/configurator/ContentEngineConfigurator.java
@@ -48,6 +48,7 @@ public class ContentEngineConfigurator extends AbstractProcessEngineConfigurator
                 throw new FlowableException("A datasource is required for initializing the Content engine ");
             }
 
+            contentEngineConfiguration.setDatabaseType(processEngineConfiguration.getDatabaseType());
             contentEngineConfiguration.setDatabaseCatalog(processEngineConfiguration.getDatabaseCatalog());
             contentEngineConfiguration.setDatabaseSchema(processEngineConfiguration.getDatabaseSchema());
             contentEngineConfiguration.setDatabaseSchemaUpdate(processEngineConfiguration.getDatabaseSchemaUpdate());

--- a/modules/flowable-content-spring-configurator/src/main/java/org/flowable/content/spring/configurator/SpringContentEngineConfigurator.java
+++ b/modules/flowable-content-spring-configurator/src/main/java/org/flowable/content/spring/configurator/SpringContentEngineConfigurator.java
@@ -45,7 +45,7 @@ public class SpringContentEngineConfigurator extends AbstractProcessEngineConfig
 
         contentEngineConfiguration.setTransactionManager(((SpringProcessEngineConfiguration) processEngineConfiguration).getTransactionManager());
 
-        contentEngineConfiguration.setDatabaseType(processEngineConfiguration.getDatabaseCatalog());
+        contentEngineConfiguration.setDatabaseType(processEngineConfiguration.getDatabaseType());
         contentEngineConfiguration.setDatabaseCatalog(processEngineConfiguration.getDatabaseCatalog());
         contentEngineConfiguration.setDatabaseSchema(processEngineConfiguration.getDatabaseSchema());
         contentEngineConfiguration.setDatabaseSchemaUpdate(processEngineConfiguration.getDatabaseSchemaUpdate());

--- a/modules/flowable-content-spring-configurator/src/main/java/org/flowable/content/spring/configurator/SpringContentEngineConfigurator.java
+++ b/modules/flowable-content-spring-configurator/src/main/java/org/flowable/content/spring/configurator/SpringContentEngineConfigurator.java
@@ -45,6 +45,7 @@ public class SpringContentEngineConfigurator extends AbstractProcessEngineConfig
 
         contentEngineConfiguration.setTransactionManager(((SpringProcessEngineConfiguration) processEngineConfiguration).getTransactionManager());
 
+        contentEngineConfiguration.setDatabaseType(processEngineConfiguration.getDatabaseCatalog());
         contentEngineConfiguration.setDatabaseCatalog(processEngineConfiguration.getDatabaseCatalog());
         contentEngineConfiguration.setDatabaseSchema(processEngineConfiguration.getDatabaseSchema());
         contentEngineConfiguration.setDatabaseSchemaUpdate(processEngineConfiguration.getDatabaseSchemaUpdate());

--- a/modules/flowable-dmn-engine-configurator/src/main/java/org/flowable/dmn/engine/configurator/DmnEngineConfigurator.java
+++ b/modules/flowable-dmn-engine-configurator/src/main/java/org/flowable/dmn/engine/configurator/DmnEngineConfigurator.java
@@ -66,6 +66,7 @@ public class DmnEngineConfigurator extends AbstractProcessEngineConfigurator {
                 throw new FlowableException("A datasource is required for initializing the DMN engine ");
             }
 
+            dmnEngineConfiguration.setDatabaseType(processEngineConfiguration.getDatabaseCatalog());
             dmnEngineConfiguration.setDatabaseCatalog(processEngineConfiguration.getDatabaseCatalog());
             dmnEngineConfiguration.setDatabaseSchema(processEngineConfiguration.getDatabaseSchema());
             dmnEngineConfiguration.setDatabaseSchemaUpdate(processEngineConfiguration.getDatabaseSchemaUpdate());

--- a/modules/flowable-dmn-engine-configurator/src/main/java/org/flowable/dmn/engine/configurator/DmnEngineConfigurator.java
+++ b/modules/flowable-dmn-engine-configurator/src/main/java/org/flowable/dmn/engine/configurator/DmnEngineConfigurator.java
@@ -66,7 +66,7 @@ public class DmnEngineConfigurator extends AbstractProcessEngineConfigurator {
                 throw new FlowableException("A datasource is required for initializing the DMN engine ");
             }
 
-            dmnEngineConfiguration.setDatabaseType(processEngineConfiguration.getDatabaseCatalog());
+            dmnEngineConfiguration.setDatabaseType(processEngineConfiguration.getDatabaseType());
             dmnEngineConfiguration.setDatabaseCatalog(processEngineConfiguration.getDatabaseCatalog());
             dmnEngineConfiguration.setDatabaseSchema(processEngineConfiguration.getDatabaseSchema());
             dmnEngineConfiguration.setDatabaseSchemaUpdate(processEngineConfiguration.getDatabaseSchemaUpdate());

--- a/modules/flowable-dmn-spring-configurator/src/main/java/org/flowable/dmn/spring/configurator/SpringDmnEngineConfigurator.java
+++ b/modules/flowable-dmn-spring-configurator/src/main/java/org/flowable/dmn/spring/configurator/SpringDmnEngineConfigurator.java
@@ -65,7 +65,7 @@ public class SpringDmnEngineConfigurator extends AbstractProcessEngineConfigurat
 
         dmnEngineConfiguration.setTransactionManager(((SpringProcessEngineConfiguration) processEngineConfiguration).getTransactionManager());
 
-        dmnEngineConfiguration.setDatabaseType(processEngineConfiguration.getDatabaseCatalog());
+        dmnEngineConfiguration.setDatabaseType(processEngineConfiguration.getDatabaseType());
         dmnEngineConfiguration.setDatabaseCatalog(processEngineConfiguration.getDatabaseCatalog());
         dmnEngineConfiguration.setDatabaseSchema(processEngineConfiguration.getDatabaseSchema());
         dmnEngineConfiguration.setDatabaseSchemaUpdate(processEngineConfiguration.getDatabaseSchemaUpdate());

--- a/modules/flowable-dmn-spring-configurator/src/main/java/org/flowable/dmn/spring/configurator/SpringDmnEngineConfigurator.java
+++ b/modules/flowable-dmn-spring-configurator/src/main/java/org/flowable/dmn/spring/configurator/SpringDmnEngineConfigurator.java
@@ -65,6 +65,7 @@ public class SpringDmnEngineConfigurator extends AbstractProcessEngineConfigurat
 
         dmnEngineConfiguration.setTransactionManager(((SpringProcessEngineConfiguration) processEngineConfiguration).getTransactionManager());
 
+        dmnEngineConfiguration.setDatabaseType(processEngineConfiguration.getDatabaseCatalog());
         dmnEngineConfiguration.setDatabaseCatalog(processEngineConfiguration.getDatabaseCatalog());
         dmnEngineConfiguration.setDatabaseSchema(processEngineConfiguration.getDatabaseSchema());
         dmnEngineConfiguration.setDatabaseSchemaUpdate(processEngineConfiguration.getDatabaseSchemaUpdate());

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/IdmEngineConfigurator.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/IdmEngineConfigurator.java
@@ -46,6 +46,7 @@ public class IdmEngineConfigurator extends AbstractProcessEngineConfigurator {
                 throw new FlowableException("A datasource is required for initializing the IDM engine ");
             }
 
+            idmEngineConfiguration.setDatabaseType(processEngineConfiguration.getDatabaseType());
             idmEngineConfiguration.setDatabaseCatalog(processEngineConfiguration.getDatabaseCatalog());
             idmEngineConfiguration.setDatabaseSchema(processEngineConfiguration.getDatabaseSchema());
             idmEngineConfiguration.setDatabaseSchemaUpdate(processEngineConfiguration.getDatabaseSchemaUpdate());

--- a/modules/flowable-form-engine-configurator/src/main/java/org/flowable/form/engine/configurator/FormEngineConfigurator.java
+++ b/modules/flowable-form-engine-configurator/src/main/java/org/flowable/form/engine/configurator/FormEngineConfigurator.java
@@ -68,7 +68,7 @@ public class FormEngineConfigurator extends AbstractProcessEngineConfigurator {
                 throw new FlowableException("A datasource is required for initializing the Form engine ");
             }
 
-            formEngineConfiguration.setDatabaseType(processEngineConfiguration.getDatabaseCatalog());
+            formEngineConfiguration.setDatabaseType(processEngineConfiguration.getDatabaseType());
             formEngineConfiguration.setDatabaseCatalog(processEngineConfiguration.getDatabaseCatalog());
             formEngineConfiguration.setDatabaseSchema(processEngineConfiguration.getDatabaseSchema());
             formEngineConfiguration.setDatabaseSchemaUpdate(processEngineConfiguration.getDatabaseSchemaUpdate());

--- a/modules/flowable-form-engine-configurator/src/main/java/org/flowable/form/engine/configurator/FormEngineConfigurator.java
+++ b/modules/flowable-form-engine-configurator/src/main/java/org/flowable/form/engine/configurator/FormEngineConfigurator.java
@@ -68,6 +68,7 @@ public class FormEngineConfigurator extends AbstractProcessEngineConfigurator {
                 throw new FlowableException("A datasource is required for initializing the Form engine ");
             }
 
+            formEngineConfiguration.setDatabaseType(processEngineConfiguration.getDatabaseCatalog());
             formEngineConfiguration.setDatabaseCatalog(processEngineConfiguration.getDatabaseCatalog());
             formEngineConfiguration.setDatabaseSchema(processEngineConfiguration.getDatabaseSchema());
             formEngineConfiguration.setDatabaseSchemaUpdate(processEngineConfiguration.getDatabaseSchemaUpdate());

--- a/modules/flowable-form-spring-configurator/src/main/java/org/flowable/form/spring/configurator/SpringFormEngineConfigurator.java
+++ b/modules/flowable-form-spring-configurator/src/main/java/org/flowable/form/spring/configurator/SpringFormEngineConfigurator.java
@@ -65,7 +65,7 @@ public class SpringFormEngineConfigurator extends AbstractProcessEngineConfigura
 
         formEngineConfiguration.setTransactionManager(((SpringProcessEngineConfiguration) processEngineConfiguration).getTransactionManager());
 
-        formEngineConfiguration.setDatabaseType(processEngineConfiguration.getDatabaseCatalog());
+        formEngineConfiguration.setDatabaseType(processEngineConfiguration.getDatabaseType());
         formEngineConfiguration.setDatabaseCatalog(processEngineConfiguration.getDatabaseCatalog());
         formEngineConfiguration.setDatabaseSchema(processEngineConfiguration.getDatabaseSchema());
         formEngineConfiguration.setDatabaseSchemaUpdate(processEngineConfiguration.getDatabaseSchemaUpdate());

--- a/modules/flowable-form-spring-configurator/src/main/java/org/flowable/form/spring/configurator/SpringFormEngineConfigurator.java
+++ b/modules/flowable-form-spring-configurator/src/main/java/org/flowable/form/spring/configurator/SpringFormEngineConfigurator.java
@@ -65,6 +65,7 @@ public class SpringFormEngineConfigurator extends AbstractProcessEngineConfigura
 
         formEngineConfiguration.setTransactionManager(((SpringProcessEngineConfiguration) processEngineConfiguration).getTransactionManager());
 
+        formEngineConfiguration.setDatabaseType(processEngineConfiguration.getDatabaseCatalog());
         formEngineConfiguration.setDatabaseCatalog(processEngineConfiguration.getDatabaseCatalog());
         formEngineConfiguration.setDatabaseSchema(processEngineConfiguration.getDatabaseSchema());
         formEngineConfiguration.setDatabaseSchemaUpdate(processEngineConfiguration.getDatabaseSchemaUpdate());

--- a/modules/flowable-spring/src/main/java/org/flowable/spring/configurator/SpringIdmEngineConfigurator.java
+++ b/modules/flowable-spring/src/main/java/org/flowable/spring/configurator/SpringIdmEngineConfigurator.java
@@ -43,6 +43,7 @@ public class SpringIdmEngineConfigurator extends AbstractProcessEngineConfigurat
             throw new FlowableException("A datasource is required for initializing the IDM engine ");
         }
 
+        idmEngineConfiguration.setDatabaseType(processEngineConfiguration.getDatabaseCatalog());
         idmEngineConfiguration.setDatabaseCatalog(processEngineConfiguration.getDatabaseCatalog());
         idmEngineConfiguration.setDatabaseSchema(processEngineConfiguration.getDatabaseSchema());
         idmEngineConfiguration.setDatabaseSchemaUpdate(processEngineConfiguration.getDatabaseSchemaUpdate());

--- a/modules/flowable-spring/src/main/java/org/flowable/spring/configurator/SpringIdmEngineConfigurator.java
+++ b/modules/flowable-spring/src/main/java/org/flowable/spring/configurator/SpringIdmEngineConfigurator.java
@@ -43,7 +43,7 @@ public class SpringIdmEngineConfigurator extends AbstractProcessEngineConfigurat
             throw new FlowableException("A datasource is required for initializing the IDM engine ");
         }
 
-        idmEngineConfiguration.setDatabaseType(processEngineConfiguration.getDatabaseCatalog());
+        idmEngineConfiguration.setDatabaseType(processEngineConfiguration.getDatabaseType());
         idmEngineConfiguration.setDatabaseCatalog(processEngineConfiguration.getDatabaseCatalog());
         idmEngineConfiguration.setDatabaseSchema(processEngineConfiguration.getDatabaseSchema());
         idmEngineConfiguration.setDatabaseSchemaUpdate(processEngineConfiguration.getDatabaseSchemaUpdate());


### PR DESCRIPTION
Hello!
I submitted an issue #337 yesterday. I wrote that they are no possibility to set the database type manually. But I was wrong. There was a bug: database type was not initialised in method "configure" children of the class
```java
org.flowable.engine.cfg.AbstractProcessEngineConfigurator
```
 After I added initialisation it works when I creating process engine like this:
```java
		ProcessEngineConfiguration cfg = new StandaloneProcessEngineConfiguration()
				.setDatabaseType(ProcessEngineConfiguration.DATABASE_TYPE_DB2)
				.setDataSourceJndiName("java:jboss/datasources/AS400DS")
				.setDatabaseSchemaUpdate(ProcessEngineConfiguration.DB_SCHEMA_UPDATE_TRUE);
		ProcessEngine processEngine = cfg.buildProcessEngine();

```