### PR TITLE
Improve exception message to match other uses in class

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/DeadLetterJobQueryImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/DeadLetterJobQueryImpl.java
@@ -177,7 +177,7 @@ public class DeadLetterJobQueryImpl extends AbstractQuery<DeadLetterJobQuery, Jo
 
     public DeadLetterJobQueryImpl jobTenantId(String tenantId) {
         if (tenantId == null) {
-            throw new FlowableIllegalArgumentException("job is null");
+            throw new FlowableIllegalArgumentException("Provided tentant id is null");
         }
         this.tenantId = tenantId;
         return this;
@@ -185,7 +185,7 @@ public class DeadLetterJobQueryImpl extends AbstractQuery<DeadLetterJobQuery, Jo
 
     public DeadLetterJobQueryImpl jobTenantIdLike(String tenantIdLike) {
         if (tenantIdLike == null) {
-            throw new FlowableIllegalArgumentException("job is null");
+            throw new FlowableIllegalArgumentException("Provided tentant id is null");
         }
         this.tenantIdLike = tenantIdLike;
         return this;

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/JobQueryImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/JobQueryImpl.java
@@ -193,7 +193,7 @@ public class JobQueryImpl extends AbstractQuery<JobQuery, Job> implements JobQue
 
     public JobQuery jobTenantId(String tenantId) {
         if (tenantId == null) {
-            throw new FlowableIllegalArgumentException("job is null");
+            throw new FlowableIllegalArgumentException("Provided tenant id is null");
         }
         this.tenantId = tenantId;
         return this;
@@ -201,7 +201,7 @@ public class JobQueryImpl extends AbstractQuery<JobQuery, Job> implements JobQue
 
     public JobQuery jobTenantIdLike(String tenantIdLike) {
         if (tenantIdLike == null) {
-            throw new FlowableIllegalArgumentException("job is null");
+            throw new FlowableIllegalArgumentException("Provided tenant id is null");
         }
         this.tenantIdLike = tenantIdLike;
         return this;

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/SuspendedJobQueryImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/SuspendedJobQueryImpl.java
@@ -189,7 +189,7 @@ public class SuspendedJobQueryImpl extends AbstractQuery<SuspendedJobQuery, Job>
 
     public SuspendedJobQueryImpl jobTenantId(String tenantId) {
         if (tenantId == null) {
-            throw new FlowableIllegalArgumentException("job is null");
+            throw new FlowableIllegalArgumentException("Provided tenant id is null");
         }
         this.tenantId = tenantId;
         return this;
@@ -197,7 +197,7 @@ public class SuspendedJobQueryImpl extends AbstractQuery<SuspendedJobQuery, Job>
 
     public SuspendedJobQueryImpl jobTenantIdLike(String tenantIdLike) {
         if (tenantIdLike == null) {
-            throw new FlowableIllegalArgumentException("job is null");
+            throw new FlowableIllegalArgumentException("Provided tenant id is null");
         }
         this.tenantIdLike = tenantIdLike;
         return this;

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/TimerJobQueryImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/TimerJobQueryImpl.java
@@ -189,7 +189,7 @@ public class TimerJobQueryImpl extends AbstractQuery<TimerJobQuery, Job> impleme
 
     public TimerJobQueryImpl jobTenantId(String tenantId) {
         if (tenantId == null) {
-            throw new FlowableIllegalArgumentException("job is null");
+            throw new FlowableIllegalArgumentException("Provided tentant id is null");
         }
         this.tenantId = tenantId;
         return this;
@@ -197,7 +197,7 @@ public class TimerJobQueryImpl extends AbstractQuery<TimerJobQuery, Job> impleme
 
     public TimerJobQueryImpl jobTenantIdLike(String tenantIdLike) {
         if (tenantIdLike == null) {
-            throw new FlowableIllegalArgumentException("job is null");
+            throw new FlowableIllegalArgumentException("Provided tentant id is null");
         }
         this.tenantIdLike = tenantIdLike;
         return this;

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/JobQueryImpl.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/JobQueryImpl.java
@@ -189,7 +189,7 @@ public class JobQueryImpl extends AbstractQuery<JobQuery, Job> implements JobQue
 
     public JobQuery jobTenantId(String tenantId) {
         if (tenantId == null) {
-            throw new ActivitiIllegalArgumentException("job is null");
+            throw new ActivitiIllegalArgumentException("Provided tentant id is null");
         }
         this.tenantId = tenantId;
         return this;
@@ -197,7 +197,7 @@ public class JobQueryImpl extends AbstractQuery<JobQuery, Job> implements JobQue
 
     public JobQuery jobTenantIdLike(String tenantIdLike) {
         if (tenantIdLike == null) {
-            throw new ActivitiIllegalArgumentException("job is null");
+            throw new ActivitiIllegalArgumentException("Provided tentant id is null");
         }
         this.tenantIdLike = tenantIdLike;
         return this;

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/TimerJobQueryImpl.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/TimerJobQueryImpl.java
@@ -168,7 +168,7 @@ public class TimerJobQueryImpl extends AbstractQuery<TimerJobQuery, Job> impleme
 
     public TimerJobQuery jobTenantId(String tenantId) {
         if (tenantId == null) {
-            throw new ActivitiIllegalArgumentException("job is null");
+            throw new ActivitiIllegalArgumentException("Provided tentant id is null");
         }
         this.tenantId = tenantId;
         return this;
@@ -176,7 +176,7 @@ public class TimerJobQueryImpl extends AbstractQuery<TimerJobQuery, Job> impleme
 
     public TimerJobQuery jobTenantIdLike(String tenantIdLike) {
         if (tenantIdLike == null) {
-            throw new ActivitiIllegalArgumentException("job is null");
+            throw new ActivitiIllegalArgumentException("Provided tentant id is null");
         }
         this.tenantIdLike = tenantIdLike;
         return this;


### PR DESCRIPTION
It appears that the cut-n-paste of adding tenant support left the exception message referring to a job and not the tenant id.  Made changes to the exception messages to better match the form used in other messages in the same class.