### PR TITLE
Fix Tomcat 8 startup warnings

### DIFF
--- a/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/webapp/META-INF/context.xml
+++ b/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/webapp/META-INF/context.xml
@@ -16,5 +16,5 @@
 	limitations under the License.
 
 -->
-<Context path="/" debug="100" privileged="true" reloadable="true" crossContext="true">
+<Context path="" privileged="true" reloadable="true" crossContext="true">
 </Context>

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/META-INF/context.xml
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/META-INF/context.xml
@@ -16,5 +16,5 @@
 	limitations under the License.
 
 -->
-<Context path="/" debug="100" privileged="true" reloadable="true" crossContext="true">
+<Context path="" privileged="true" reloadable="true" crossContext="true">
 </Context>

--- a/modules/flowable-ui-task/flowable-ui-task-app/src/main/webapp/META-INF/context.xml
+++ b/modules/flowable-ui-task/flowable-ui-task-app/src/main/webapp/META-INF/context.xml
@@ -16,5 +16,5 @@
 	limitations under the License.
 
 -->
-<Context path="/" debug="100" privileged="true" reloadable="true" crossContext="true">
+<Context path="" privileged="true" reloadable="true" crossContext="true">
 </Context>


### PR DESCRIPTION
This patch fixes two Tomcat 8 startup warnings:
- org.apache.catalina.core.StandardContext.setPath A context path must
  either be an empty string or start with a '/' and do not end with a '/'.
  The path [/] does not meet these criteria and has been changed to []
- org.apache.catalina.startup.SetContextPropertiesRule.begin
  [SetContextPropertiesRule]{Context} Setting property 'debug' to '100'
  did not find a matching property."