### PR TITLE
Add read-only property in form fields in formfield-edit-popover.html

### DIFF
--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/i18n/en.json
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/i18n/en.json
@@ -477,6 +477,7 @@
             "DROPDOWN-DEFAULT-EMPTY-SELECTION": "Please choose one...",
             "DROPDOWN-EMPTY-VALUE-HELP": "This is the 'empty value' option. Selecting this at runtime is the taken to mean 'no value' or 'empty'.  This is allowed for optional fields, but not allowed for required fields.",
             "REQUIRED": "Required",
+	    "READONLY": "Read-only",
             "EXPRESSION": "Expression",
             "ADD-OPTION": "+ Add a new option",
             "UPLOAD-ALLOW-MULTIPLE": "Allow uploading multiple files",

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/i18n/pt-BR.json
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/i18n/pt-BR.json
@@ -451,6 +451,7 @@
       "DROPDOWN-DEFAULT-EMPTY-SELECTION":"Por favor, escolha uma...",
       "DROPDOWN-EMPTY-VALUE-HELP":"Esta é a opção 'valor vazio'. Selecionar isto em tempo de execução significa dizer 'sem valor' ou 'vazio'.  Isto é permitido para campos opcionais, mas não permitido para campos obrigatórios.",
       "REQUIRED":"Obrigatório",
+      "READONLY":"Somente leitura",
       "EXPRESSION":"Expressão",
       "ADD-OPTION":"+ Adicionar uma nova opção",
       "UPLOAD-ALLOW-MULTIPLE":"Permitir o upload de vários arquivos"

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/views/popover/formfield-edit-popover.html
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/views/popover/formfield-edit-popover.html
@@ -40,14 +40,24 @@
                         <input type="text" class="form-control" ng-model="formElement.id" ng-disabled="!formElement.overrideId" editor-input-check>
                     </div>
 
-                    <div ng-show="formElement.type !== 'expression'">
-                        <div class="form-group">
-                            <div class="checkbox">
-                                <label>
-                                    <input type="checkbox" ng-model="formElement.required">
-                                    {{'FORM-BUILDER.COMPONENT.REQUIRED' | translate}}
-                                </label>
+                    <div ng-show="formElement.type !== 'expression' && formElement.type !== 'hyperlink'">
+                        <div class="row">
+                           <div class="form-group col-md-2">
+                               <div class="checkbox">
+                                   <label>
+                                       <input type="checkbox" ng-model="formElement.required">
+                                       {{'FORM-BUILDER.COMPONENT.REQUIRED' | translate}}
+                                   </label>
+                               </div>
                             </div>
+                            <div class="form-group col-md-10">
+                               <div class="checkbox">
+                                   <label>
+                                       <input type="checkbox" ng-model="formElement.readOnly">
+                                       {{'FORM-BUILDER.COMPONENT.READONLY' | translate}}
+                                   </label>
+                               </div>                               
+                           </div>
                         </div>
                     </div>
 


### PR DESCRIPTION
Add read-only property in form fields except to type expression and hyperlink.
This feature is required to reuse form fields in parsing / validation activities and so that the attachment type field can view the attached file and does not allow the user to delete the file.