### PR TITLE
Fix some incorrect comparisons with NaN.

### DIFF
--- a/modules/flowable-ui-admin/src/main/webapp/scripts/process-instances-controllers.js
+++ b/modules/flowable-ui-admin/src/main/webapp/scripts/process-instances-controllers.js
@@ -121,7 +121,7 @@ flowableAdminApp.controller('ProcessInstancesController', ['$rootScope', '$scope
 
 	              if (variable.type.id == 'long' || variable.type.id == 'short' || variable.type.id == 'double' || variable.type.id == 'integer') {
 	                  varPayload.value = parseFloat(varPayload.value);
-	                  if (varPayload.value != NaN) {
+	                  if (!isNaN(varPayload.value)) {
 	                      // Return valid value for number
 	                      actualValue.push(varPayload);
 	                  }

--- a/modules/flowable-ui-admin/src/main/webapp/scripts/tasks-controllers.js
+++ b/modules/flowable-ui-admin/src/main/webapp/scripts/tasks-controllers.js
@@ -122,7 +122,7 @@ flowableAdminApp.controller('TasksController', ['$scope', '$rootScope', '$http',
               
               if(variable.type.id == 'long' || variable.type.id == 'short' || variable.type.id == 'double' || variable.type.id == 'integer') {
                 varPayload.value = parseFloat(varPayload.value);
-                if(varPayload.value != NaN) {
+                if(!isNaN(varPayload.value)) {
                   // Return valid value for number
                   actualValue.push(varPayload);
                 }

--- a/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/webapp/scripts/common/directives.js
+++ b/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/webapp/scripts/common/directives.js
@@ -112,7 +112,7 @@ flowableModule
                     var offset = 0;
                     if($attrs['offset']) {
                         offset = parseInt($attrs['offset']);
-                        if(offset == NaN || offset == undefined) {
+                        if(isNaN(offset) || offset == undefined) {
                             offset = 0;
                         }
                     }
@@ -188,7 +188,7 @@ flowableModule
                             var offsetTop = $attrs['offsetTop'];
                             if(offsetTop) {
                                 offsetTop = parseInt(offsetTop);
-                                if(offsetTop == NaN) {
+                                if(isNaN(offsetTop)) {
                                     offsetTop = 0;
                                 }
                             }

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/common/directives.js
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/common/directives.js
@@ -112,7 +112,7 @@ flowableModule
                     var offset = 0;
                     if($attrs['offset']) {
                         offset = parseInt($attrs['offset']);
-                        if(offset == NaN || offset == undefined) {
+                        if(isNaN(offset) || offset == undefined) {
                             offset = 0;
                         }
                     }
@@ -188,7 +188,7 @@ flowableModule
                             var offsetTop = $attrs['offsetTop'];
                             if(offsetTop) {
                                 offsetTop = parseInt(offsetTop);
-                                if(offsetTop == NaN) {
+                                if(isNaN(offsetTop)) {
                                     offsetTop = 0;
                                 }
                             }

--- a/modules/flowable-ui-task/flowable-ui-task-app/src/main/webapp/scripts/common/directives.js
+++ b/modules/flowable-ui-task/flowable-ui-task-app/src/main/webapp/scripts/common/directives.js
@@ -112,7 +112,7 @@ flowableModule
                     var offset = 0;
                     if($attrs['offset']) {
                         offset = parseInt($attrs['offset']);
-                        if(offset == NaN || offset == undefined) {
+                        if(isNaN(offset) || offset == undefined) {
                             offset = 0;
                         }
                     }
@@ -188,7 +188,7 @@ flowableModule
                             var offsetTop = $attrs['offsetTop'];
                             if(offsetTop) {
                                 offsetTop = parseInt(offsetTop);
-                                if(offsetTop == NaN) {
+                                if(isNaN(offsetTop)) {
                                     offsetTop = 0;
                                 }
                             }


### PR DESCRIPTION
I spotted these checks of numbers against `NaN` that don't seem to be correct. In JavaScript `NaN` is not equal to anything, not even itself. I've fixed these to use the built in `isNaN` function instead which should correctly check if they are `NaN`.

---

I found these issues through [lgtm.com](https://lgtm.com/projects/g/flowable/flowable-engine/alerts/), a service that analyzes open-source code to look for potential problems. (Full disclosure: I work for the company that operates it.)