### PR TITLE
Fixed upload form-field to allow readOnly

### DIFF
--- a/modules/flowable-ui-task/flowable-ui-task-app/src/main/webapp/workflow/scripts/controllers/render-form.js
+++ b/modules/flowable-ui-task/flowable-ui-task-app/src/main/webapp/workflow/scripts/controllers/render-form.js
@@ -316,6 +316,7 @@ angular.module('flowableApp')
                             }
                             newUploadValue += field.value[j].id;
                         }
+                        field.value = newUploadValue;
 					}
                 }
             };

--- a/modules/flowable-ui-task/flowable-ui-task-app/src/main/webapp/workflow/views/templates/form-element-template.html
+++ b/modules/flowable-ui-task/flowable-ui-task-app/src/main/webapp/workflow/views/templates/form-element-template.html
@@ -170,7 +170,7 @@
         <label class="control-label">{{field.name}}</label>
         <span ng-if="!field.value || field.value.length == 0" translate="FORM.MESSAGE.EMPTY"></span>
         <ul class="simple-list selectable content-list">
-            <li ng-repeat="content in field.value" title="{{content.name}}">
+            <li ng-repeat="content in model.uploads[field.id]" title="{{content.name}}">
                 <document-preview content="content" editable="field.params.documentsEditable" read-only="true"></document-preview>
             </li>
         </ul>


### PR DESCRIPTION
Fixed upload form-field to allow the same field ID to be used in multiple forms and when used as a readOnly field.
This fixes how the content-id(s) of the attached files is handled in flowable-task app.

See the discussion at https://forum.flowable.org/t/error-when-you-reuse-the-form-field-of-the-attachment-upload-type/522
