### PR TITLE
Added ability to save forms in flowable-task and support for multiple…

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/CompleteTaskWithFormCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/CompleteTaskWithFormCmd.java
@@ -79,7 +79,7 @@ public class CompleteTaskWithFormCmd extends NeedsActiveTaskCmd<Void> {
             FormService formService = processEngineConfiguration.getFormEngineFormService();
             Map<String, Object> formVariables = formService.getVariablesFromFormSubmission(formModel, variables, outcome);
 
-            formService.createFormInstance(formVariables, formModel, task.getId(), task.getProcessInstanceId());
+            formService.saveFormInstance(formVariables, formModel, task.getId(), task.getProcessInstanceId());
 
             processUploadFieldsIfNeeded(formModel, task, commandContext);
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/GetTaskFormModelCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/GetTaskFormModelCmd.java
@@ -87,7 +87,7 @@ public class GetTaskFormModelCmd implements Command<FormModel>, Serializable {
         } else {
             formModel = processEngineConfiguration.getFormEngineFormService()
                     .getFormModelWithVariablesByKeyAndParentDeploymentId(task.getFormKey(), parentDeploymentId,
-                            task.getProcessInstanceId(), variables, task.getTenantId());
+                            task.getProcessInstanceId(), taskId, variables, task.getTenantId());
         }
 
         // If form does not exists, we don't want to leak out this info to just anyone

--- a/modules/flowable-form-api/src/main/java/org/flowable/form/api/FormService.java
+++ b/modules/flowable-form-api/src/main/java/org/flowable/form/api/FormService.java
@@ -48,20 +48,39 @@ public interface FormService {
      */
     FormInstance createFormInstance(Map<String, Object> values, FormModel formModel, String taskId, String processInstanceId);
 
+    FormInstance saveFormInstance(Map<String, Object> values, FormModel formModel, String taskId, String processInstanceId);
+
+    FormInstance saveFormInstanceByFormModelId(Map<String, Object> variables, String formModelId, String taskId, String processInstanceId);
+
     FormModel getFormModelWithVariablesById(String formDefinitionId, String processInstanceId, Map<String, Object> variables);
 
     FormModel getFormModelWithVariablesById(String formDefinitionId, String processInstanceId, Map<String, Object> variables, String tenantId);
+
+    FormModel getFormModelWithVariablesById(String formDefinitionId, String processInstanceId, String taskId, Map<String, Object> variables);
+
+    FormModel getFormModelWithVariablesById(String formDefinitionId, String processInstanceId, String taskId, Map<String, Object> variables, String tenantId);
 
     FormModel getFormModelWithVariablesByKey(String formDefinitionKey, String processInstanceId, Map<String, Object> variables);
 
     FormModel getFormModelWithVariablesByKey(String formDefinitionKey, String processInstanceId,
             Map<String, Object> variables, String tenantId);
 
+    FormModel getFormModelWithVariablesByKey(String formDefinitionKey, String processInstanceId, String taskId, Map<String, Object> variables);
+
+    FormModel getFormModelWithVariablesByKey(String formDefinitionKey, String processInstanceId, String taskId,
+                                             Map<String, Object> variables, String tenantId);
+
     FormModel getFormModelWithVariablesByKeyAndParentDeploymentId(String formDefinitionKey, String parentDeploymentId,
             String processInstanceId, Map<String, Object> variables);
 
     FormModel getFormModelWithVariablesByKeyAndParentDeploymentId(String formDefinitionKey, String parentDeploymentId, String processInstanceId,
             Map<String, Object> variables, String tenantId);
+
+    FormModel getFormModelWithVariablesByKeyAndParentDeploymentId(String formDefinitionKey, String parentDeploymentId, String processInstanceId,
+                                                                  String taskId, Map<String, Object> variables);
+
+    FormModel getFormModelWithVariablesByKeyAndParentDeploymentId(String formDefinitionKey, String parentDeploymentId, String processInstanceId,
+                                                                  String taskId, Map<String, Object> variables, String tenantId);
 
     FormInstanceModel getFormInstanceModelById(String formInstanceId, Map<String, Object> variables);
 

--- a/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/FormServiceImpl.java
+++ b/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/FormServiceImpl.java
@@ -21,6 +21,7 @@ import org.flowable.form.engine.impl.cmd.CreateFormInstanceCmd;
 import org.flowable.form.engine.impl.cmd.GetFormInstanceModelCmd;
 import org.flowable.form.engine.impl.cmd.GetFormModelWithVariablesCmd;
 import org.flowable.form.engine.impl.cmd.GetVariablesFromFormSubmissionCmd;
+import org.flowable.form.engine.impl.cmd.SaveFormInstanceCmd;
 import org.flowable.form.model.FormInstanceModel;
 import org.flowable.form.model.FormModel;
 
@@ -41,35 +42,74 @@ public class FormServiceImpl extends ServiceImpl implements FormService {
         return commandExecutor.execute(new CreateFormInstanceCmd(formModel, variables, taskId, processInstanceId));
     }
 
+    public FormInstance saveFormInstance(Map<String, Object> variables, FormModel formModel, String taskId, String processInstanceId) {
+        return commandExecutor.execute(new SaveFormInstanceCmd(formModel, variables, taskId, processInstanceId));
+    }
+
+    public FormInstance saveFormInstanceByFormModelId(Map<String, Object> variables, String formModelId, String taskId, String processInstanceId) {
+        return commandExecutor.execute(new SaveFormInstanceCmd(formModelId, variables, taskId, processInstanceId));
+    }
+
     public FormModel getFormModelWithVariablesById(String formDefinitionId, String processInstanceId, Map<String, Object> variables) {
-        return commandExecutor.execute(new GetFormModelWithVariablesCmd(null, formDefinitionId, processInstanceId, variables));
+        return commandExecutor.execute(new GetFormModelWithVariablesCmd(null, formDefinitionId, processInstanceId, null, variables));
     }
 
     public FormModel getFormModelWithVariablesById(String formId, String processInstanceId,
             Map<String, Object> variables, String tenantId) {
-        return commandExecutor.execute(new GetFormModelWithVariablesCmd(null, formId, processInstanceId, tenantId, variables));
+        return commandExecutor.execute(new GetFormModelWithVariablesCmd(null, formId, null, processInstanceId, null, tenantId, variables));
+    }
+
+    public FormModel getFormModelWithVariablesById(String formDefinitionId, String processInstanceId, String taskId, Map<String, Object> variables) {
+        return commandExecutor.execute(new GetFormModelWithVariablesCmd(null, formDefinitionId, processInstanceId, taskId, variables));
+    }
+
+    public FormModel getFormModelWithVariablesById(String formId, String processInstanceId, String taskId,
+                                                   Map<String, Object> variables, String tenantId) {
+        return commandExecutor.execute(new GetFormModelWithVariablesCmd(null, formId, null, processInstanceId, taskId, tenantId, variables));
     }
 
     public FormModel getFormModelWithVariablesByKey(String formDefinitionKey, String processInstanceId, Map<String, Object> variables) {
-        return commandExecutor.execute(new GetFormModelWithVariablesCmd(formDefinitionKey, null, processInstanceId, variables));
+        return commandExecutor.execute(new GetFormModelWithVariablesCmd(formDefinitionKey, null, processInstanceId, null, variables));
     }
 
     public FormModel getFormModelWithVariablesByKey(String formDefinitionKey, String processInstanceId,
             Map<String, Object> variables, String tenantId) {
 
-        return commandExecutor.execute(new GetFormModelWithVariablesCmd(formDefinitionKey, null, null, processInstanceId, tenantId, variables));
+        return commandExecutor.execute(new GetFormModelWithVariablesCmd(formDefinitionKey, null, null, processInstanceId, null, tenantId, variables));
+    }
+
+    public FormModel getFormModelWithVariablesByKey(String formDefinitionKey, String processInstanceId, String taskId, Map<String, Object> variables) {
+        return commandExecutor.execute(new GetFormModelWithVariablesCmd(formDefinitionKey, null, processInstanceId, taskId, variables));
+    }
+
+    public FormModel getFormModelWithVariablesByKey(String formDefinitionKey, String processInstanceId, String taskId,
+                                                    Map<String, Object> variables, String tenantId) {
+
+        return commandExecutor.execute(new GetFormModelWithVariablesCmd(formDefinitionKey, null, null, processInstanceId, taskId, tenantId, variables));
     }
 
     public FormModel getFormModelWithVariablesByKeyAndParentDeploymentId(String formDefinitionKey, String parentDeploymentId,
             String processInstanceId, Map<String, Object> variables) {
 
-        return commandExecutor.execute(new GetFormModelWithVariablesCmd(formDefinitionKey, parentDeploymentId, null, processInstanceId, variables));
+        return commandExecutor.execute(new GetFormModelWithVariablesCmd(formDefinitionKey, parentDeploymentId, null, processInstanceId, null, variables));
     }
 
     public FormModel getFormModelWithVariablesByKeyAndParentDeploymentId(String formDefinitionKey, String parentDeploymentId, String processInstanceId,
             Map<String, Object> variables, String tenantId) {
 
-        return commandExecutor.execute(new GetFormModelWithVariablesCmd(formDefinitionKey, parentDeploymentId, null, processInstanceId, tenantId, variables));
+        return commandExecutor.execute(new GetFormModelWithVariablesCmd(formDefinitionKey, parentDeploymentId, null, processInstanceId, null, tenantId, variables));
+    }
+
+    public FormModel getFormModelWithVariablesByKeyAndParentDeploymentId(String formDefinitionKey, String parentDeploymentId,
+                                                                         String processInstanceId, String taskId, Map<String, Object> variables) {
+
+        return commandExecutor.execute(new GetFormModelWithVariablesCmd(formDefinitionKey, parentDeploymentId, null, processInstanceId, taskId, variables));
+    }
+
+    public FormModel getFormModelWithVariablesByKeyAndParentDeploymentId(String formDefinitionKey, String parentDeploymentId, String processInstanceId, String taskId,
+                                                                         Map<String, Object> variables, String tenantId) {
+
+        return commandExecutor.execute(new GetFormModelWithVariablesCmd(formDefinitionKey, parentDeploymentId, null, processInstanceId, taskId, tenantId, variables));
     }
 
     public FormInstanceModel getFormInstanceModelById(String formInstanceId, Map<String, Object> variables) {

--- a/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/cmd/CreateFormInstanceCmd.java
+++ b/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/cmd/CreateFormInstanceCmd.java
@@ -13,107 +13,27 @@
 package org.flowable.form.engine.impl.cmd;
 
 import java.io.Serializable;
-import java.util.Date;
 import java.util.Map;
 
-import org.flowable.engine.common.api.FlowableException;
-import org.flowable.form.api.FormInstance;
-import org.flowable.form.engine.impl.interceptor.Command;
-import org.flowable.form.engine.impl.interceptor.CommandContext;
+import org.flowable.form.engine.FormEngineConfiguration;
 import org.flowable.form.engine.impl.persistence.entity.FormInstanceEntity;
-import org.flowable.form.engine.impl.persistence.entity.FormInstanceEntityManager;
-import org.flowable.form.model.FormField;
-import org.flowable.form.model.FormFieldTypes;
 import org.flowable.form.model.FormModel;
-import org.joda.time.LocalDate;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * @author Tijs Rademakers
  */
-public class CreateFormInstanceCmd implements Command<FormInstance>, Serializable {
+public class CreateFormInstanceCmd extends SaveFormInstanceCmd implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    protected FormModel formModel;
-    protected Map<String, Object> variables;
-    protected String taskId;
-    protected String processInstanceId;
-
     public CreateFormInstanceCmd(FormModel formModel, Map<String, Object> variables, String taskId, String processInstanceId) {
-        this.formModel = formModel;
-        this.variables = variables;
-        this.taskId = taskId;
-        this.processInstanceId = processInstanceId;
+        super(formModel, variables, taskId, processInstanceId);
     }
 
-    public FormInstance execute(CommandContext commandContext) {
-
-        if (formModel == null || formModel.getId() == null) {
-            throw new FlowableException("Invalid form model provided");
-        }
-
-        ObjectMapper objectMapper = commandContext.getFormEngineConfiguration().getObjectMapper();
-        ObjectNode submittedFormValuesJson = objectMapper.createObjectNode();
-
-        ObjectNode valuesNode = submittedFormValuesJson.putObject("values");
-
-        // Loop over all form fields and see if a value was provided
-        Map<String, FormField> fieldMap = formModel.allFieldsAsMap();
-        for (String fieldId : fieldMap.keySet()) {
-            FormField formField = fieldMap.get(fieldId);
-
-            if (FormFieldTypes.EXPRESSION.equals(formField.getType()) || FormFieldTypes.CONTAINER.equals(formField.getType())) {
-                continue;
-            }
-
-            if (variables.containsKey(fieldId)) {
-                Object variableValue = variables.get(fieldId);
-                if (variableValue == null) {
-                    valuesNode.putNull(fieldId);
-                } else if (variableValue instanceof Long) {
-                    valuesNode.put(fieldId, (Long) variables.get(fieldId));
-
-                } else if (variableValue instanceof Double) {
-                    valuesNode.put(fieldId, (Double) variables.get(fieldId));
-
-                } else if (variableValue instanceof LocalDate) {
-                    valuesNode.put(fieldId, ((LocalDate) variableValue).toString());
-
-                } else {
-                    valuesNode.put(fieldId, variableValue.toString());
-                }
-            }
-        }
-
-        // Handle outcome
-        String outcomeVariable = null;
-        if (formModel.getOutcomeVariableName() != null) {
-            outcomeVariable = formModel.getOutcomeVariableName();
-        } else {
-            outcomeVariable = "form_" + formModel.getKey() + "_outcome";
-        }
-
-        if (variables.containsKey(outcomeVariable) && variables.get(outcomeVariable) != null) {
-            submittedFormValuesJson.put("flowable_form_outcome", variables.get(outcomeVariable).toString());
-        }
-
-        FormInstanceEntityManager formInstanceEntityManager = commandContext.getFormInstanceEntityManager();
-        FormInstanceEntity formInstanceEntity = formInstanceEntityManager.create();
-        formInstanceEntity.setFormDefinitionId(formModel.getId());
-        formInstanceEntity.setTaskId(taskId);
-        formInstanceEntity.setProcessInstanceId(processInstanceId);
-        formInstanceEntity.setSubmittedDate(new Date());
-        try {
-            formInstanceEntity.setFormValueBytes(objectMapper.writeValueAsBytes(submittedFormValuesJson));
-        } catch (Exception e) {
-            throw new FlowableException("Error setting form values JSON", e);
-        }
-
-        formInstanceEntityManager.insert(formInstanceEntity);
-
-        return formInstanceEntity;
+    @Override
+    protected FormInstanceEntity findExistingFormInstance(FormEngineConfiguration formEngineConfiguration) {
+        // We always want to create a formInstance.
+        return null;
     }
+
 }

--- a/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/cmd/SaveFormInstanceCmd.java
+++ b/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/cmd/SaveFormInstanceCmd.java
@@ -1,0 +1,162 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.form.engine.impl.cmd;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.flowable.engine.common.api.FlowableException;
+import org.flowable.form.api.FormInstance;
+import org.flowable.form.api.FormInstanceQuery;
+import org.flowable.form.engine.FormEngineConfiguration;
+import org.flowable.form.engine.impl.interceptor.Command;
+import org.flowable.form.engine.impl.interceptor.CommandContext;
+import org.flowable.form.engine.impl.persistence.entity.FormInstanceEntity;
+import org.flowable.form.engine.impl.persistence.entity.FormInstanceEntityManager;
+import org.flowable.form.model.FormField;
+import org.flowable.form.model.FormFieldTypes;
+import org.flowable.form.model.FormModel;
+import org.joda.time.LocalDate;
+
+import java.io.Serializable;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+public class SaveFormInstanceCmd implements Command<FormInstance>, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    protected String formModelId;
+    protected FormModel formModel;
+    protected Map<String, Object> variables;
+    protected String taskId;
+    protected String processInstanceId;
+
+
+    public SaveFormInstanceCmd(FormModel formModel, Map<String, Object> variables, String taskId, String processInstanceId) {
+        this.formModel = formModel;
+        this.variables = variables;
+        this.taskId = taskId;
+        this.processInstanceId = processInstanceId;
+    }
+
+    public SaveFormInstanceCmd(String formModelId, Map<String, Object> variables, String taskId, String processInstanceId) {
+        this.formModelId = formModelId;
+        this.variables = variables;
+        this.taskId = taskId;
+        this.processInstanceId = processInstanceId;
+    }
+
+    public FormInstance execute(CommandContext commandContext) {
+
+        if(formModel == null) {
+            if(formModelId == null) {
+                throw new FlowableException("Invalid form model and no form model Id provided");
+            }
+            formModel = commandContext.getFormEngineConfiguration().getFormRepositoryService().getFormModelById(formModelId);
+        }
+
+        if (formModel == null || formModel.getId() == null) {
+            throw new FlowableException("Invalid form model provided");
+        }
+
+        ObjectMapper objectMapper = commandContext.getFormEngineConfiguration().getObjectMapper();
+        ObjectNode submittedFormValuesJson = objectMapper.createObjectNode();
+
+        ObjectNode valuesNode = submittedFormValuesJson.putObject("values");
+
+        // Loop over all form fields and see if a value was provided
+        Map<String, FormField> fieldMap = formModel.allFieldsAsMap();
+        for (String fieldId : fieldMap.keySet()) {
+            FormField formField = fieldMap.get(fieldId);
+
+            if (FormFieldTypes.EXPRESSION.equals(formField.getType()) || FormFieldTypes.CONTAINER.equals(formField.getType())) {
+                continue;
+            }
+
+            if (variables.containsKey(fieldId)) {
+                Object variableValue = variables.get(fieldId);
+                if (variableValue == null) {
+                    valuesNode.putNull(fieldId);
+                } else if (variableValue instanceof Long) {
+                    valuesNode.put(fieldId, (Long) variables.get(fieldId));
+
+                } else if (variableValue instanceof Double) {
+                    valuesNode.put(fieldId, (Double) variables.get(fieldId));
+
+                } else if (variableValue instanceof LocalDate) {
+                    valuesNode.put(fieldId, ((LocalDate) variableValue).toString());
+
+                } else {
+                    valuesNode.put(fieldId, variableValue.toString());
+                }
+            }
+        }
+
+        // Handle outcome
+        String outcomeVariable = null;
+        if (formModel.getOutcomeVariableName() != null) {
+            outcomeVariable = formModel.getOutcomeVariableName();
+        } else {
+            outcomeVariable = "form_" + formModel.getKey() + "_outcome";
+        }
+
+        if (variables.containsKey(outcomeVariable) && variables.get(outcomeVariable) != null) {
+            submittedFormValuesJson.put("flowable_form_outcome", variables.get(outcomeVariable).toString());
+        }
+
+        FormInstanceEntityManager formInstanceEntityManager = commandContext.getFormInstanceEntityManager();
+        FormInstanceEntity formInstanceEntity = findExistingFormInstance(commandContext.getFormEngineConfiguration());
+
+        if(formInstanceEntity == null) {
+            formInstanceEntity = formInstanceEntityManager.create();
+        }
+
+        formInstanceEntity.setFormDefinitionId(formModel.getId());
+        formInstanceEntity.setTaskId(taskId);
+        formInstanceEntity.setProcessInstanceId(processInstanceId);
+        formInstanceEntity.setSubmittedDate(new Date());
+        try {
+            formInstanceEntity.setFormValueBytes(objectMapper.writeValueAsBytes(submittedFormValuesJson));
+        } catch (Exception e) {
+            throw new FlowableException("Error setting form values JSON", e);
+        }
+
+        if(formInstanceEntity.getId() == null) {
+            formInstanceEntityManager.insert(formInstanceEntity);
+        } else {
+            formInstanceEntityManager.update(formInstanceEntity);
+        }
+
+
+        return formInstanceEntity;
+    }
+
+    protected FormInstanceEntity findExistingFormInstance(FormEngineConfiguration formEngineConfiguration) {
+
+        if(taskId == null) {
+            // Only update formInstances related to a task - cannot save a process start form as no processInstance exists
+            return null;
+        }
+
+        FormInstanceQuery formInstanceQuery =
+                formEngineConfiguration.getFormService().createFormInstanceQuery().formDefinitionId(formModel.getId()).taskId(taskId);
+
+        List<FormInstance> formInstances = formInstanceQuery.orderBySubmittedDate().desc().list();
+
+        if(formInstances.size() > 0 && formInstances.get(0) instanceof FormInstanceEntity) {
+            return (FormInstanceEntity) formInstances.get(0);
+        }
+        return null;
+    }
+}

--- a/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/persistence/entity/ResourceRef.java
+++ b/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/persistence/entity/ResourceRef.java
@@ -60,6 +60,7 @@ public class ResourceRef implements Serializable {
         } else {
             ensureInitialized();
             entity.setBytes(bytes);
+            Context.getCommandContext().getResourceEntityManager().update(entity);
         }
     }
 

--- a/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/persistence/entity/data/impl/MybatisFormInstanceDataManager.java
+++ b/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/persistence/entity/data/impl/MybatisFormInstanceDataManager.java
@@ -44,7 +44,7 @@ public class MybatisFormInstanceDataManager extends AbstractDataManager<FormInst
 
     @Override
     public long findFormInstanceCountByQueryCriteria(FormInstanceQueryImpl formInstanceQuery) {
-        return (Long) getDbSqlSession().selectOne("selectFormInstanceCountByQueryCriteria", formInstanceQuery);
+        return (Long) getDbSqlSession().selectOne("selectFormInstancesCountByQueryCriteria", formInstanceQuery);
     }
 
     @Override

--- a/modules/flowable-form-engine/src/main/resources/org/flowable/form/db/mapping/entity/FormInstance.xml
+++ b/modules/flowable-form-engine/src/main/resources/org/flowable/form/db/mapping/entity/FormInstance.xml
@@ -19,6 +19,21 @@
             #{tenantId, jdbcType=VARCHAR})
   </insert>
 
+  <update id="updateFormInstance" parameterType="org.flowable.form.engine.impl.persistence.entity.FormInstanceEntityImpl">
+    update ${prefix}ACT_FO_FORM_INSTANCE
+    set
+      FORM_DEFINITION_ID_ = #{formDefinitionId, jdbcType=VARCHAR},
+      TASK_ID_ = #{taskId, jdbcType=VARCHAR},
+      PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR},
+      PROC_DEF_ID_ = #{processDefinitionId, jdbcType=VARCHAR},
+      SUBMITTED_DATE_ = #{submittedDate, jdbcType=TIMESTAMP},
+      SUBMITTED_BY_ = #{submittedBy, jdbcType=VARCHAR},
+      FORM_VALUES_ID_ = #{resourceRef, typeHandler=ResourceRefTypeHandler},
+      TENANT_ID_ = #{tenantId, jdbcType=VARCHAR}
+    where
+      ID_ = #{id, jdbcType=VARCHAR}
+  </update>
+
   <!-- FORM INSTANCE DELETE -->
 
   <delete id="deleteFormInstancesByProcessDefinitionId" parameterType="string">
@@ -135,7 +150,7 @@
   </select>
 
   <!-- mysql specific sql -->
-  <select id="selectFormInstanceCountByQueryCriteria" databaseId="mysql" parameterType="org.flowable.form.engine.impl.FormInstanceQueryImpl" resultType="long">
+  <select id="selectFormInstancesCountByQueryCriteria" databaseId="mysql" parameterType="org.flowable.form.engine.impl.FormInstanceQueryImpl" resultType="long">
     select distinct count(RES.ID_)
     <include refid="selectFormInstancesByQueryCriteriaSql"/>
   </select>

--- a/modules/flowable-form-engine/src/main/resources/org/flowable/form/db/mapping/entity/Resource.xml
+++ b/modules/flowable-form-engine/src/main/resources/org/flowable/form/db/mapping/entity/Resource.xml
@@ -37,6 +37,13 @@
   
   <!-- RESOURCE UPDATE -->
 
+  <update id="updateResource" parameterType="org.flowable.form.engine.impl.persistence.entity.ResourceEntityImpl">
+    update ${prefix}ACT_FO_FORM_RESOURCE
+    set
+      RESOURCE_BYTES_ = #{bytes, jdbcType=${blobType}}
+    where ID_ = #{id, jdbcType=VARCHAR}
+  </update>
+
   <!-- RESOURCE DELETE -->
 
   <delete id="deleteResourcesByDeploymentId" parameterType="string">

--- a/modules/flowable-ui-task/flowable-ui-task-app/src/main/webapp/workflow/scripts/controllers/render-form.js
+++ b/modules/flowable-ui-task/flowable-ui-task-app/src/main/webapp/workflow/scripts/controllers/render-form.js
@@ -524,6 +524,31 @@ angular.module('flowableApp')
                 }
             };
 
+            $scope.saveForm = function () {
+
+                $scope.model.loading = true;
+                $scope.model.completeButtonDisabled = true;
+
+                // Prep data
+                var postData = $scope.createPostData();
+                postData.formId = $scope.formData.id;
+
+                 FormService.saveTaskForm($scope.taskId, postData).then(
+                     function (data) {
+                         $rootScope.addAlertPromise($translate('TASK.ALERT.SAVED'));
+                         $scope.model.completeButtonDisabled = false;
+                         $scope.model.loading = false;
+                     },
+                     function (errorResponse) {
+                         $scope.model.completeButtonDisabled = false;
+                         $scope.model.loading = false;
+                         $scope.$emit('task-save-error', {
+                             taskId: $scope.taskId,
+                             error: errorResponse
+                         });
+                     });
+            };
+
             $scope.completeForm = function (outcome) {
 
                 $scope.model.loading = true;

--- a/modules/flowable-ui-task/flowable-ui-task-app/src/main/webapp/workflow/views/templates/form-template.html
+++ b/modules/flowable-ui-task/flowable-ui-task-app/src/main/webapp/workflow/views/templates/form-template.html
@@ -15,6 +15,8 @@
         
         <div ng-if="!formData.outcomes || formData.outcomes.length === 0" class="clearfix form-actions">
             <div class="pull-right" ng-if="(hideButtons == undefined || hideButtons == null || hideButtons == false) && (disableForm == undefined || disableForm == null || disableForm == false)">
+                <button id="form_save_button" class="btn btn-default" ng-disabled="model.completeButtonDisabled || !model.valid || (disableOutcomes != undefined && disableOutcomes != null && disableOutcomes) || model.uploadInProgress"
+                        ng-click="saveForm()" ng-show="!processDefinitionId" translate="FORM.ACTION.SAVE"></button>
                 <button id="form_complete_button" class="btn btn-default" ng-disabled="model.completeButtonDisabled || !model.valid || (disableOutcomes != undefined && disableOutcomes != null && disableOutcomes) || model.uploadInProgress"
                         ng-click="completeForm('complete')">{{getDefaultCompleteButtonText()}}</button>
             </div>
@@ -22,6 +24,9 @@
 
         <div ng-if="formData.outcomes && formData.outcomes.length > 0" class="clearfix form-actions">
             <div class="pull-right" ng-if="(hideButtons == undefined || hideButtons == null || hideButtons == false) && (disableForm == undefined || disableForm == null || disableForm == false)">
+                <button id="form_save_button" class="btn btn-default"
+                        ng-disabled="!model.valid || model.completeButtonDisabled || model.uploadInProgress"
+                        ng-click="saveForm()" ng-show="!processDefinitionId" translate="FORM.ACTION.SAVE"></button>
                 <button id="form_complete_button" class="btn btn-default"
                         ng-disabled="!model.valid || model.completeButtonDisabled || model.uploadInProgress"
                         ng-repeat="outcome in formData.outcomes"

--- a/modules/flowable-ui-task/flowable-ui-task-logic/src/main/java/org/flowable/app/model/runtime/SaveFormRepresentation.java
+++ b/modules/flowable-ui-task/flowable-ui-task-logic/src/main/java/org/flowable/app/model/runtime/SaveFormRepresentation.java
@@ -12,20 +12,27 @@
  */
 package org.flowable.app.model.runtime;
 
-/**
- * @author Joram Barrez
- * @author Tijs Rademakers
- */
-public class CompleteFormRepresentation extends SaveFormRepresentation {
+import java.util.Map;
 
-    protected String outcome;
+public class SaveFormRepresentation {
 
-    public String getOutcome() {
-        return outcome;
+    protected String formId;
+    protected Map<String, Object> values;
+
+    public String getFormId() {
+        return formId;
     }
 
-    public void setOutcome(String outcome) {
-        this.outcome = outcome;
+    public void setFormId(String formId) {
+        this.formId = formId;
+    }
+
+    public Map<String, Object> getValues() {
+        return values;
+    }
+
+    public void setValues(Map<String, Object> values) {
+        this.values = values;
     }
 
 }

--- a/modules/flowable-ui-task/flowable-ui-task-rest/src/main/java/org/flowable/app/rest/runtime/TaskFormResource.java
+++ b/modules/flowable-ui-task/flowable-ui-task-rest/src/main/java/org/flowable/app/rest/runtime/TaskFormResource.java
@@ -12,20 +12,16 @@
  */
 package org.flowable.app.rest.runtime;
 
-import java.util.List;
-
 import org.flowable.app.model.runtime.CompleteFormRepresentation;
 import org.flowable.app.model.runtime.ProcessInstanceVariableRepresentation;
+import org.flowable.app.model.runtime.SaveFormRepresentation;
 import org.flowable.app.service.runtime.FlowableTaskFormService;
 import org.flowable.form.model.FormModel;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 /**
  * @author Joram Barrez
@@ -46,6 +42,12 @@ public class TaskFormResource {
     @RequestMapping(value = "/{taskId}", method = RequestMethod.POST, produces = "application/json")
     public void completeTaskForm(@PathVariable String taskId, @RequestBody CompleteFormRepresentation completeTaskFormRepresentation) {
         taskFormService.completeTaskForm(taskId, completeTaskFormRepresentation);
+    }
+
+    @ResponseStatus(value = HttpStatus.OK)
+    @RequestMapping(value = "/{taskId}/save-form", method = RequestMethod.POST, produces = "application/json")
+    public void saveTaskForm(@PathVariable String taskId, @RequestBody SaveFormRepresentation saveFormRepresentation) {
+        taskFormService.saveTaskForm(taskId, saveFormRepresentation);
     }
 
     @RequestMapping(value = "/{taskId}/variables", method = RequestMethod.GET, produces = "application/json")


### PR DESCRIPTION
… form instances on the same task

See in the forum - https://forum.flowable.org/t/ability-to-save-without-completing-forms-in-flowable-task/538/2

I have added the ability to save forms using the flowable-task app. I have made a number of comments in the commit as well to explain my decisions.

This has required a few changes in the form Engine. In particular I have changed so that its possible to save multiple formInstances for a task and that the latest submitted is treated as the last saved for ongoing tasks or completed values for completed tasks. Previously this caused an error when creating the formInstanceModel for a task.

I have not looked in depth at the form rest API but I Believe it should work with my solution.

As far as I can see none of the classes I have modified contain unit tests and I haven't had time to add these.
I suspect there will be improvements needed so please let me know your comments/feedback.