### PR TITLE
Variables not set, extra event when CallActivity defined with terminate end event

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/CallActivityTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/CallActivityTest.java
@@ -1,0 +1,496 @@
+package org.flowable.engine.test.api.event;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.flowable.engine.common.api.delegate.event.FlowableEntityEvent;
+import org.flowable.engine.common.api.delegate.event.FlowableEvent;
+import org.flowable.engine.common.api.delegate.event.FlowableEventListener;
+import org.flowable.engine.delegate.event.FlowableActivityEvent;
+import org.flowable.engine.delegate.event.FlowableEngineEventType;
+import org.flowable.engine.event.EventLogEntry;
+import org.flowable.engine.impl.delegate.event.FlowableEngineEntityEvent;
+import org.flowable.engine.impl.event.logger.EventLogger;
+import org.flowable.engine.impl.persistence.entity.ExecutionEntity;
+import org.flowable.engine.impl.persistence.entity.TaskEntity;
+import org.flowable.engine.impl.test.PluggableFlowableTestCase;
+import org.flowable.engine.runtime.ProcessInstance;
+import org.flowable.engine.task.Task;
+import org.flowable.engine.test.Deployment;
+
+public class CallActivityTest extends PluggableFlowableTestCase {
+
+    private CallActivityEventListener listener;
+
+    protected EventLogger databaseEventLogger;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+
+        // Database event logger setup
+        databaseEventLogger = new EventLogger(processEngineConfiguration.getClock(),
+                processEngineConfiguration.getObjectMapper());
+        runtimeService.addEventListener(databaseEventLogger);
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+
+        if (listener != null) {
+            listener.clearEventsReceived();
+            processEngineConfiguration.getEventDispatcher().removeEventListener(listener);
+        }
+
+        // Remove entries
+        for (EventLogEntry eventLogEntry : managementService.getEventLogEntries(null, null)) {
+            managementService.deleteEventLogEntry(eventLogEntry.getLogNumber());
+        }
+
+        // Database event logger teardown
+        runtimeService.removeEventListener(databaseEventLogger);
+
+        super.tearDown();
+    }
+
+    @Override
+    protected void initializeServices() {
+        super.initializeServices();
+
+        listener = new CallActivityEventListener();
+        processEngineConfiguration.getEventDispatcher().addEventListener(listener);
+    }
+
+    @Deployment(resources = {
+            "org/flowable/engine/test/api/event/CallActivityTest.testCallActivity.bpmn20.xml",
+            "org/flowable/engine/test/api/event/CallActivityTest.testCalledActivity.bpmn20.xml" })
+    public void testCallActivityCalledHasNoneEndEvent() throws Exception {
+
+        CallActivityEventListener mylistener = new CallActivityEventListener();
+        processEngineConfiguration.getEventDispatcher().addEventListener(mylistener);
+
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("callActivity");
+        assertNotNull(processInstance);
+
+        // no task should be active in parent process
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertNull(task);
+
+        // only active task should be the one defined in the external subprocess
+        task = taskService.createTaskQuery().active().singleResult();
+        assertNotNull(task);
+        assertEquals("User Task2 in External", task.getName());
+
+        ExecutionEntity subprocessInstance = (ExecutionEntity) runtimeService.createExecutionQuery()
+                .rootProcessInstanceId(processInstance.getId())
+                .onlySubProcessExecutions()
+                .singleResult();
+        assertNotNull(subprocessInstance);
+
+        assertEquals("Default name", runtimeService.getVariable(processInstance.getId(), "Name"));
+        assertEquals("Default name", runtimeService.getVariable(subprocessInstance.getId(), "FullName"));
+
+        // set the variable in the subprocess to validate that the new value is returned from callActivity
+        runtimeService.setVariable(subprocessInstance.getId(), "FullName", "Mary Smith");
+        assertEquals("Default name", runtimeService.getVariable(processInstance.getId(), "Name"));
+        assertEquals("Mary Smith", runtimeService.getVariable(subprocessInstance.getId(), "FullName"));
+
+        // complete user task so that external subprocess will flow to terminate end
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertNotNull(task);
+        assertEquals("User Task1", task.getName());
+
+        // validate that the variable was copied back when Call Activity finished
+        assertEquals("Mary Smith", runtimeService.getVariable(processInstance.getId(), "Name"));
+
+        // complete user task so that parent process will terminate normally
+        taskService.complete(task.getId());
+
+        FlowableEntityEvent entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(0);
+        assertEquals(FlowableEngineEventType.ENTITY_CREATED, entityEvent.getType());
+        ExecutionEntity executionEntity = (ExecutionEntity) entityEvent.getEntity();
+
+        // this is the root process so parent null
+        assertNull(executionEntity.getParentId());
+        String processExecutionId = executionEntity.getId();
+
+        entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(1);
+        assertEquals(FlowableEngineEventType.ENTITY_CREATED, entityEvent.getType());
+        executionEntity = (ExecutionEntity) entityEvent.getEntity();
+        assertNotNull(executionEntity.getParentId());
+        assertEquals(processExecutionId, executionEntity.getParentId());
+
+        FlowableEvent activitiEvent = mylistener.getEventsReceived().get(2);
+        assertEquals(FlowableEngineEventType.PROCESS_STARTED, activitiEvent.getType());
+
+        FlowableActivityEvent activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(3);
+        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
+        assertEquals("startEvent", activityEvent.getActivityType());
+
+        activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(4);
+        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
+        assertEquals("startEvent", activityEvent.getActivityType());
+
+        activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(5);
+        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
+        assertEquals("callActivity1", activityEvent.getActivityId());
+
+        entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(6);
+        assertEquals(FlowableEngineEventType.ENTITY_CREATED, entityEvent.getType());
+        executionEntity = (ExecutionEntity) entityEvent.getEntity();
+        assertNull(executionEntity.getParentId());
+        assertEquals(executionEntity.getId(), executionEntity.getProcessInstanceId());
+
+        // user task within the external subprocess
+        entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(7);
+        assertEquals(FlowableEngineEventType.ENTITY_CREATED, entityEvent.getType());
+        executionEntity = (ExecutionEntity) entityEvent.getEntity();
+        assertEquals("calledtask1", executionEntity.getActivityId());
+
+        // external subprocess
+        activitiEvent = mylistener.getEventsReceived().get(8);
+        assertEquals(FlowableEngineEventType.PROCESS_STARTED, activitiEvent.getType());
+
+        // start event in external subprocess
+        activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(9);
+        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
+        assertEquals("startEvent", activityEvent.getActivityType());
+        assertEquals("startevent2", activityEvent.getActivityId());
+
+        activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(10);
+        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
+        assertEquals("startEvent", activityEvent.getActivityType());
+        assertEquals("startevent2", activityEvent.getActivityId());
+
+        // user task within external subprocess
+        activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(11);
+        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
+        assertEquals("calledtask1", activityEvent.getActivityId());
+        assertEquals("userTask", activityEvent.getActivityType());
+
+        entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(12);
+        assertEquals(FlowableEngineEventType.TASK_CREATED, entityEvent.getType());
+        TaskEntity taskEntity = (TaskEntity) entityEvent.getEntity();
+        assertEquals("User Task2 in External", taskEntity.getName());
+
+        entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(13);
+        assertEquals(FlowableEngineEventType.TASK_COMPLETED, entityEvent.getType());
+        taskEntity = (TaskEntity) entityEvent.getEntity();
+        assertEquals("User Task2 in External", taskEntity.getName());
+
+        // user task within external subprocess
+        activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(14);
+        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
+        assertEquals("calledtask1", activityEvent.getActivityId());
+        assertEquals("userTask", activityEvent.getActivityType());
+
+        // None event in external subprocess
+        activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(15);
+        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
+        assertEquals("noneevent2", activityEvent.getActivityId());
+        assertEquals("endEvent", activityEvent.getActivityType());
+
+        activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(16);
+        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
+        assertEquals("noneevent2", activityEvent.getActivityId());
+        assertEquals("endEvent", activityEvent.getActivityType());
+
+        // the external subprocess
+        entityEvent = (FlowableEntityEvent)mylistener.getEventsReceived().get(17);
+        assertEquals(FlowableEngineEventType.PROCESS_COMPLETED, entityEvent.getType());
+
+        // callActivity
+        activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(18);
+        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
+        assertEquals("callActivity", activityEvent.getActivityType());
+
+        // user task within parent process
+        activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(19);
+        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
+        assertEquals("task1", activityEvent.getActivityId());
+        assertEquals("userTask", activityEvent.getActivityType());
+
+        entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(20);
+        assertEquals(FlowableEngineEventType.TASK_CREATED, entityEvent.getType());
+        taskEntity = (TaskEntity) entityEvent.getEntity();
+        assertEquals("User Task1", taskEntity.getName());
+
+        entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(21);
+        assertEquals(FlowableEngineEventType.TASK_COMPLETED, entityEvent.getType());
+        taskEntity = (TaskEntity) entityEvent.getEntity();
+        assertEquals("User Task1", taskEntity.getName());
+
+        activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(22);
+        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
+        assertEquals("task1", activityEvent.getActivityId());
+        assertEquals("userTask", activityEvent.getActivityType());
+
+        activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(23);
+        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
+        assertEquals("noneevent1", activityEvent.getActivityId());
+        assertEquals("endEvent", activityEvent.getActivityType());
+
+        activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(24);
+        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
+        assertEquals("noneevent1", activityEvent.getActivityId());
+        assertEquals("endEvent", activityEvent.getActivityType());
+
+        // the parent process
+        entityEvent = (FlowableEntityEvent)mylistener.getEventsReceived().get(25);
+        assertEquals(FlowableEngineEventType.PROCESS_COMPLETED, entityEvent.getType());
+
+        assertEquals(26, mylistener.getEventsReceived().size());
+    }
+
+    @Deployment(resources = {
+            "org/flowable/engine/test/api/event/CallActivityTest.testCallActivityTerminateEnd.bpmn20.xml",
+            "org/flowable/engine/test/api/event/CallActivityTest.testCalledActivityTerminateEnd.bpmn20.xml" })
+    public void  testCallActivityCalledHasTerminateEndEvent() throws Exception {
+
+        CallActivityEventListener mylistener = new CallActivityEventListener();
+        processEngineConfiguration.getEventDispatcher().addEventListener(mylistener);
+
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("callActivityTerminateEnd");
+        assertNotNull(processInstance);
+
+        // no task should be active in parent process
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertNull(task);
+
+        // only active task should be the one defined in the external subprocess
+        task = taskService.createTaskQuery().active().singleResult();
+        assertNotNull(task);
+        assertEquals("User Task2 in External with Terminate End Event", task.getName());
+
+        ExecutionEntity subprocessInstance = (ExecutionEntity) runtimeService.createExecutionQuery()
+                .rootProcessInstanceId(processInstance.getId())
+                .onlySubProcessExecutions()
+                .singleResult();
+        assertNotNull(subprocessInstance);
+
+        assertEquals("Default name", runtimeService.getVariable(processInstance.getId(), "Name"));
+        assertEquals("Default name", runtimeService.getVariable(subprocessInstance.getId(), "FullName"));
+
+        // set the variable in the subprocess to validate that the new value is returned from callActivity
+        runtimeService.setVariable(subprocessInstance.getId(), "FullName", "Mary Smith");
+        assertEquals("Default name", runtimeService.getVariable(processInstance.getId(), "Name"));
+        assertEquals("Mary Smith", runtimeService.getVariable(subprocessInstance.getId(), "FullName"));
+
+        // complete user task so that external subprocess will flow to terminate end
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertNotNull(task);
+        assertEquals("User Task1 in Parent", task.getName());
+
+        // PROBLEM:
+        // Test failure because variables are not copied back when external subprocess
+        // is defined with a terminateEnd event. We are expecting the variable to be
+        // copied in this scenario.
+
+        // validate that the variable was copied back when Call Activity finished
+        assertEquals("Mary Smith", runtimeService.getVariable(processInstance.getId(), "Name"));
+
+        // complete user task so that parent process will terminate normally
+        taskService.complete(task.getId());
+
+        FlowableEntityEvent entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(0);
+        assertEquals(FlowableEngineEventType.ENTITY_CREATED, entityEvent.getType());
+        ExecutionEntity executionEntity = (ExecutionEntity) entityEvent.getEntity();
+
+        // this is the root process so parent null
+        assertNull(executionEntity.getParentId());
+        String processExecutionId = executionEntity.getId();
+
+        int idx=1;
+        entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(idx++);
+        assertEquals(FlowableEngineEventType.ENTITY_CREATED, entityEvent.getType());
+        executionEntity = (ExecutionEntity) entityEvent.getEntity();
+        assertNotNull(executionEntity.getParentId());
+        assertEquals(processExecutionId, executionEntity.getParentId());
+
+        FlowableEvent activitiEvent = mylistener.getEventsReceived().get(idx++);
+        assertEquals(FlowableEngineEventType.PROCESS_STARTED, activitiEvent.getType());
+
+        FlowableActivityEvent activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(idx++);
+        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
+        assertEquals("startEvent", activityEvent.getActivityType());
+
+        activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(idx++);
+        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
+        assertEquals("startEvent", activityEvent.getActivityType());
+
+        activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(idx++);
+        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
+        assertEquals("callActivityId1", activityEvent.getActivityId());
+
+        entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(idx++);
+        assertEquals(FlowableEngineEventType.ENTITY_CREATED, entityEvent.getType());
+        executionEntity = (ExecutionEntity) entityEvent.getEntity();
+        assertNull(executionEntity.getParentId());
+        assertEquals(executionEntity.getId(), executionEntity.getProcessInstanceId());
+
+        // user task within the external subprocess
+        entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(idx++);
+        assertEquals(FlowableEngineEventType.ENTITY_CREATED, entityEvent.getType());
+        executionEntity = (ExecutionEntity) entityEvent.getEntity();
+        assertEquals("calledtask1", executionEntity.getActivityId());
+
+        // external subprocess
+        activitiEvent = mylistener.getEventsReceived().get(idx++);
+        assertEquals(FlowableEngineEventType.PROCESS_STARTED, activitiEvent.getType());
+
+        // start event in external subprocess
+        activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(idx++);
+        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
+        assertEquals("startEvent", activityEvent.getActivityType());
+        assertEquals("startevent2", activityEvent.getActivityId());
+
+        activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(idx++);
+        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
+        assertEquals("startEvent", activityEvent.getActivityType());
+        assertEquals("startevent2", activityEvent.getActivityId());
+
+        // user task within external subprocess
+        activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(idx++);
+        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
+        assertEquals("calledtask1", activityEvent.getActivityId());
+        assertEquals("userTask", activityEvent.getActivityType());
+
+        entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(idx++);
+        assertEquals(FlowableEngineEventType.TASK_CREATED, entityEvent.getType());
+        TaskEntity taskEntity = (TaskEntity) entityEvent.getEntity();
+        assertEquals("User Task2 in External with Terminate End Event", taskEntity.getName());
+
+        entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(idx++);
+        assertEquals(FlowableEngineEventType.TASK_COMPLETED, entityEvent.getType());
+        taskEntity = (TaskEntity) entityEvent.getEntity();
+        assertEquals("User Task2 in External with Terminate End Event", taskEntity.getName());
+
+        // user task within external subprocess
+        activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(idx++);
+        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
+        assertEquals("calledtask1", activityEvent.getActivityId());
+        assertEquals("userTask", activityEvent.getActivityType());
+
+        // None event in external subprocess
+        activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(idx++);
+        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
+        assertEquals("terminateEnd2", activityEvent.getActivityId());
+        assertEquals("endEvent", activityEvent.getActivityType());
+
+        // PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT instead of PROCESS_COMPLETED
+        // because external subprocess defined with terminate end event
+        entityEvent = (FlowableEntityEvent)mylistener.getEventsReceived().get(idx++);
+        assertEquals(subprocessInstance.getId(), ((FlowableEngineEntityEvent)entityEvent).getExecutionId());
+        assertEquals(FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT, entityEvent.getType());
+
+        // ACTIVITY_CANCELLED instead of ACTIVITY_COMPLETED due to terminate end event
+        activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(idx++);
+        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, activityEvent.getType());
+        assertEquals("terminateEnd2", activityEvent.getActivityId());
+        assertEquals("endEvent", activityEvent.getActivityType());
+
+        // PROBLEM:
+        // Test fails because unexpected PROCESS_COMPLETED event received. We already received
+        // the PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT for the external subprocess
+        // so we should not be getting a PROCESS_COMPLETED event here.
+        FlowableEvent flowableEvent = mylistener.getEventsReceived().get(idx++);
+        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, flowableEvent.getType());
+
+        // the external subprocess (callActivity)
+        activityEvent = (FlowableActivityEvent) flowableEvent;
+        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
+        assertEquals("callActivity", activityEvent.getActivityType());
+
+        // user task within parent process
+        activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(idx++);
+        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
+        assertEquals("task1", activityEvent.getActivityId());
+        assertEquals("userTask", activityEvent.getActivityType());
+
+        entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(idx++);
+        assertEquals(FlowableEngineEventType.TASK_CREATED, entityEvent.getType());
+        taskEntity = (TaskEntity) entityEvent.getEntity();
+        assertEquals("User Task1 in Parent", taskEntity.getName());
+
+        entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(idx++);
+        assertEquals(FlowableEngineEventType.TASK_COMPLETED, entityEvent.getType());
+        taskEntity = (TaskEntity) entityEvent.getEntity();
+        assertEquals("User Task1 in Parent", taskEntity.getName());
+
+        activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(idx++);
+        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
+        assertEquals("task1", activityEvent.getActivityId());
+        assertEquals("userTask", activityEvent.getActivityType());
+
+        activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(idx++);
+        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
+        assertEquals("noneevent1", activityEvent.getActivityId());
+        assertEquals("endEvent", activityEvent.getActivityType());
+
+        activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(idx++);
+        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
+        assertEquals("noneevent1", activityEvent.getActivityId());
+        assertEquals("endEvent", activityEvent.getActivityType());
+
+        // the parent process
+        entityEvent = (FlowableEntityEvent)mylistener.getEventsReceived().get(idx++);
+        assertEquals(FlowableEngineEventType.PROCESS_COMPLETED, entityEvent.getType());
+
+        assertEquals(idx, mylistener.getEventsReceived().size());
+    }
+
+    class CallActivityEventListener implements FlowableEventListener {
+
+        private List<FlowableEvent> eventsReceived;
+
+        public CallActivityEventListener() {
+            eventsReceived = new ArrayList<FlowableEvent>();
+
+        }
+
+        public List<FlowableEvent> getEventsReceived() {
+            return eventsReceived;
+        }
+
+        public void clearEventsReceived() {
+            eventsReceived.clear();
+        }
+
+        @Override
+        public void onEvent(FlowableEvent event) {
+            FlowableEngineEventType engineEventType = (FlowableEngineEventType) event.getType();
+            switch (engineEventType) {
+            case ENTITY_CREATED:
+                FlowableEntityEvent entityEvent = (FlowableEntityEvent) event;
+                if (entityEvent.getEntity() instanceof ExecutionEntity) {
+                    eventsReceived.add(event);
+                }
+                break;
+            case ACTIVITY_STARTED:
+            case ACTIVITY_COMPLETED:
+            case ACTIVITY_CANCELLED:
+            case TASK_CREATED:
+            case TASK_COMPLETED:
+            case PROCESS_STARTED:
+            case PROCESS_COMPLETED:
+            case PROCESS_CANCELLED:
+            case PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT:
+                eventsReceived.add(event);
+                break;
+            default:
+                break;
+
+            }
+        }
+
+        @Override
+        public boolean isFailOnException() {
+            return false;
+        }
+    }
+
+}

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/event/CallActivityTest.testCallActivity.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/event/CallActivityTest.testCallActivity.bpmn20.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+             xmlns:flowable="http://flowable.org/bpmn"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" exporter="edoras vis" exporterVersion="DEVELOPER"
+             targetNamespace="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://www.omg.org/spec/BPMN/2.0/20100501/BPMN20.xsd">
+  <process id="callActivity" isExecutable="true" name="call activity">
+    <startEvent id="startevent1"/>
+    <dataObject id="dataObject1" name="Name" itemSubjectRef="xsd:string">
+      <extensionElements>
+        <flowable:value>Default name</flowable:value>
+      </extensionElements>
+    </dataObject>
+
+    <callActivity id="callActivity1" calledElement="calledProcessId">
+      <extensionElements>
+        <flowable:in source="Name" target="FullName" />
+        <flowable:out source="FullName" target="Name" />
+      </extensionElements>
+    </callActivity>
+
+    <endEvent id="noneevent1"/>
+
+    <userTask id="task1" name="User Task1">
+    </userTask>
+
+    <sequenceFlow id="flow1" sourceRef="startevent1" targetRef="callActivity1"/>
+
+    <sequenceFlow id="flow3" sourceRef="task1" targetRef="noneevent1"/>
+
+    <sequenceFlow id="flow4" sourceRef="callActivity1" targetRef="task1"/>
+
+  </process>
+</definitions>

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/event/CallActivityTest.testCallActivityTerminateEnd.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/event/CallActivityTest.testCallActivityTerminateEnd.bpmn20.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:flowable="http://flowable.org/bpmn"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" exporter="edoras vis" exporterVersion="DEVELOPER"
+             targetNamespace="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://www.omg.org/spec/BPMN/2.0/20100501/BPMN20.xsd">
+  <process id="callActivityTerminateEnd" isExecutable="true" name="call activity">
+    <startEvent id="startevent1"/>
+
+    <callActivity id="callActivityId1" calledElement="calledProcessIdTerminateEnd">
+      <extensionElements>
+        <flowable:in source="Name" target="FullName" />
+        <flowable:out source="FullName" target="Name" />
+      </extensionElements>
+    </callActivity>
+    <dataObject id="dataObject1" name="Name" itemSubjectRef="xsd:string">
+      <extensionElements>
+        <flowable:value>Default name</flowable:value>
+      </extensionElements>
+    </dataObject>
+
+    <endEvent id="noneevent1"/>
+    <userTask id="task1" name="User Task1 in Parent">
+    </userTask>
+
+    <sequenceFlow id="flow1" sourceRef="startevent1" targetRef="callActivityId1"/>
+
+    <sequenceFlow id="flow3" sourceRef="task1" targetRef="noneevent1"/>
+
+    <sequenceFlow id="flow4" sourceRef="callActivityId1" targetRef="task1"/>
+
+  </process>
+</definitions>

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/event/CallActivityTest.testCalledActivity.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/event/CallActivityTest.testCalledActivity.bpmn20.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+             xmlns:flowable="http://flowable.org/bpmn"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" exporter="edoras vis" exporterVersion="DEVELOPER"
+             targetNamespace="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://www.omg.org/spec/BPMN/2.0/20100501/BPMN20.xsd">
+  <process id="calledProcessId" isExecutable="true" name="External process">
+      <startEvent id="startevent2"/>
+      <dataObject id="dataObject1" name="FullName" itemSubjectRef="xsd:string">
+        <extensionElements>
+          <flowable:value>Joe Smith</flowable:value>
+        </extensionElements>
+      </dataObject>
+      <sequenceFlow id="flow5"  sourceRef="startevent2" targetRef="calledtask1"/>
+      <userTask id="calledtask1" name="User Task2 in External"/>
+      <sequenceFlow id="flow6" sourceRef="calledtask1" targetRef="noneevent2"/>
+      <endEvent id="noneevent2"/>
+  </process>
+</definitions>

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/event/CallActivityTest.testCalledActivityTerminateEnd.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/event/CallActivityTest.testCalledActivityTerminateEnd.bpmn20.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:flowable="http://flowable.org/bpmn"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" exporter="edoras vis" exporterVersion="DEVELOPER"
+             targetNamespace="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://www.omg.org/spec/BPMN/2.0/20100501/BPMN20.xsd">
+  <process id="calledProcessIdTerminateEnd" isExecutable="true" name="External process">
+      <startEvent id="startevent2"/>
+      <dataObject id="dataObject1" name="FullName" itemSubjectRef="xsd:string">
+        <extensionElements>
+          <flowable:value>Joe Smith</flowable:value>
+        </extensionElements>
+      </dataObject>
+      <sequenceFlow id="flow5"  sourceRef="startevent2" targetRef="calledtask1"/>
+      <userTask id="calledtask1" name="User Task2 in External with Terminate End Event"/>
+      <sequenceFlow id="flow6" sourceRef="calledtask1" targetRef="terminateEnd2"/>
+      <endEvent id="terminateEnd2">
+        <terminateEventDefinition></terminateEventDefinition>
+      </endEvent>
+  </process>
+</definitions>


### PR DESCRIPTION

Seeing two potential issues when Called Activity (External subprocess) is
defined with terminate end event. First, the process variables are not
returned to the calling process. Second, we are seeing an unexpected
PROCESS_COMPLETED event as we already received a
PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT event. Included test recreates the
issues.