### PR TITLE
Fixed NullPointerException when retreiving processInstances in flowab…

### DIFF
--- a/modules/flowable-ui-task/flowable-ui-task-app/src/main/webapp/workflow/views/process-detail.html
+++ b/modules/flowable-ui-task/flowable-ui-task-app/src/main/webapp/workflow/views/process-detail.html
@@ -52,8 +52,8 @@
             model.processInstance.processDefinitionName}}</h2>
 
         <div class="detail">
-            <span class="label" ng-show="model.processInstance.startedBy">{{'PROCESS.FIELD.STARTED-BY' | translate}}: </span>
-            <span user-name="model.processInstance.startedBy" ng-show="model.processInstance.startedBy"></span>
+            <span class="label" ng-if="model.processInstance.startedBy">{{'PROCESS.FIELD.STARTED-BY' | translate}}: </span>
+            <span user-name="model.processInstance.startedBy" ng-if="model.processInstance.startedBy"></span>
             <span class="label">{{'PROCESS.FIELD.STARTED' | translate}}: </span>
             <span title="{{model.processInstance.started | dateformat}}">{{model.processInstance.started | dateformat:'fromNow'}}</span>
             <span class="label" ng-show="model.processInstance.ended">{{'PROCESS.FIELD.ENDED' | translate}}: </span>

--- a/modules/flowable-ui-task/flowable-ui-task-logic/src/main/java/org/flowable/app/model/runtime/ProcessInstanceRepresentation.java
+++ b/modules/flowable-ui-task/flowable-ui-task-logic/src/main/java/org/flowable/app/model/runtime/ProcessInstanceRepresentation.java
@@ -61,7 +61,7 @@ public class ProcessInstanceRepresentation extends AbstractRepresentation {
         this.processDefinitionId = processInstance.getProcessDefinitionId();
         this.tenantId = processInstance.getTenantId();
         this.graphicalNotationDefined = graphicalNotation;
-        this.startedBy = new UserRepresentation(startedBy);
+        this.startedBy = startedBy != null ? new UserRepresentation(startedBy) : null;
     }
 
     public ProcessInstanceRepresentation(HistoricProcessInstance processInstance, ProcessDefinition processDefinition, boolean graphicalNotation, User startedBy) {
@@ -78,7 +78,7 @@ public class ProcessInstanceRepresentation extends AbstractRepresentation {
         this.graphicalNotationDefined = graphicalNotation;
         this.started = processInstance.getStartTime();
         this.ended = processInstance.getEndTime();
-        this.startedBy = new UserRepresentation(startedBy);
+        this.startedBy = startedBy != null ? new UserRepresentation(startedBy) : null;
     }
 
     protected void mapProcessDefinition(ProcessDefinition processDefinition) {


### PR DESCRIPTION
…le-task and no process starter is set

Hi,

I have encountered a NullpointerException in flowable-task app when retreiving a list of the process instances and one of the process instances does not have a starter set.
This can occur when a callactivity is started from an asynchronous scriptTask/serviceTask. In this case the authorized user is not set as it occurs from the Job executor, and thus the newley created subprocess has no value to set the process starter to.

I have added a simple null check and modified a little in the flowable-task front end so that if the started-by user is not displayed the padding is correctly set.

Stacktrace:

```
11:35:47,103 [http-nio-8080-exec-10] ERROR org.flowable.rest.exception.BaseExceptionHandlerAdvice  - Unhandled exception
java.lang.NullPointerException
        at org.flowable.app.model.common.UserRepresentation.<init>(UserRepresentation.java:38)
        at org.flowable.app.model.runtime.ProcessInstanceRepresentation.<init>(ProcessInstanceRepresentation.java:81)
        at org.flowable.app.model.runtime.ProcessInstanceRepresentation.<init>(ProcessInstanceRepresentation.java:68)
        at org.flowable.app.service.runtime.FlowableProcessInstanceQueryService.convertInstanceList(FlowableProcessInstanceQueryService.java:160)
        at org.flowable.app.service.runtime.FlowableProcessInstanceQueryService.getProcessInstances(FlowableProcessInstanceQueryService.java:135)
        at org.flowable.app.service.runtime.FlowableProcessInstanceQueryService$$FastClassBySpringCGLIB$$937f0791.invoke(<generated>)
        at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:204)
        at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:720)
        at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:157)
        at org.springframework.transaction.interceptor.TransactionInterceptor$1.proceedWithInvocation(TransactionInterceptor.java:99)
        at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:281)
        at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:96)
        at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:179)
        at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:655)
        at org.flowable.app.service.runtime.FlowableProcessInstanceQueryService$$EnhancerBySpringCGLIB$$2a00b017.getProcessInstances(<generated>)
        at org.flowable.app.rest.runtime.ProcessInstanceQueryResource.getProcessInstances(ProcessInstanceQueryResource.java:33)
```

Regards,
Paul