### PR TITLE
Remove local overrides of library versions

### DIFF
--- a/modules/flowable-ui-admin/pom.xml
+++ b/modules/flowable-ui-admin/pom.xml
@@ -20,10 +20,6 @@
 
   		<!-- Libraries versions -->
   		<flowable.version>6.1.0-SNAPSHOT</flowable.version>
-  	    <spring.version>4.1.6.RELEASE</spring.version>
-  		<spring.security.version>4.0.1.RELEASE</spring.security.version>
-  		<jackson.version>2.3.3</jackson.version>
-  		<batik.version>1.7</batik.version>
   		<jetty.version>9.1.3.v20140225</jetty.version>
 
   		<!-- Web container version -->


### PR DESCRIPTION
Remove local overrides of library versions in admin ui application.  Appears to build locally but I have no ready way to test the application.

This was discussed briefly in the forum [post 616](https://forum.flowable.org/t/versions-of-jars-in-admin-war/616).