### PR TITLE
Remove override of maven-surefire-plugin version

### DIFF
--- a/modules/flowable-http/pom.xml
+++ b/modules/flowable-http/pom.xml
@@ -35,7 +35,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.6</version>
                 <configuration>
                     <workingDirectory>${project.build.directory}</workingDirectory>
                     <systemPropertyVariables>

--- a/modules/flowable-mule/pom.xml
+++ b/modules/flowable-mule/pom.xml
@@ -34,7 +34,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.6</version>
         <configuration>
           <workingDirectory>${project.build.directory}</workingDirectory>
           <systemPropertyVariables>

--- a/modules/flowable5-mule-test/pom.xml
+++ b/modules/flowable5-mule-test/pom.xml
@@ -35,7 +35,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.6</version>
         <configuration>
           <workingDirectory>${project.build.directory}</workingDirectory>
           <systemPropertyVariables>


### PR DESCRIPTION
I noticed in some POMs that the surefire plugin [runOrder](http://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#runOrder) parameter was set.  In three POMs (the attached changed files), the version of the surefire-plugin was overridden to a version prior to the version that supported the option.

The parent POM specifies version 2.7.1 which does support the option so removing the local overrides removes the error.

In addition it should be noted that other POMs specify a version *after* the one defined in the parent/root POM file. Specifically, `ui-admin`, `ui-idm`, `ui-modeler`, and `ui-task` specify version 2.16.