### PR TITLE
Fixed bug where content-disposition header was not quoted/encoded cor…

### DIFF
--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/service/editor/AppDefinitionExportService.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/service/editor/AppDefinitionExportService.java
@@ -31,6 +31,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.springframework.web.util.UriUtils;
 
 @Service
 @Transactional
@@ -65,8 +66,9 @@ public class AppDefinitionExportService extends BaseAppDefinitionService {
     }
 
     protected void createAppDefinitionZip(HttpServletResponse response, Model appModel, AppDefinitionRepresentation appDefinition) {
-        response.setHeader("Content-Disposition", "attachment; filename=" + appDefinition.getName() + ".zip");
         try {
+            response.setHeader("Content-Disposition", "attachment; filename=\"" + appDefinition.getName() + ".zip\"; filename*=utf-8''" + UriUtils.encode(appDefinition.getName() + ".zip", "utf-8"));
+
             ServletOutputStream servletOutputStream = response.getOutputStream();
             response.setContentType("application/zip");
 
@@ -139,9 +141,10 @@ public class AppDefinitionExportService extends BaseAppDefinitionService {
     }
 
     public void createAppDefinitionBar(HttpServletResponse response, Model appModel, AppDefinitionRepresentation appDefinition) {
-        response.setHeader("Content-Disposition", "attachment; filename=" + appDefinition.getName() + ".bar");
 
         try {
+            response.setHeader("Content-Disposition", "attachment; filename=\"" + appDefinition.getName() + ".bar\"; filename*=utf-8''" + UriUtils.encode(appDefinition.getName() + ".bar", "utf-8"));
+
             byte[] deployZipArtifact = createDeployableZipArtifact(appModel, appDefinition.getDefinition());
 
             ServletOutputStream servletOutputStream = response.getOutputStream();


### PR DESCRIPTION
…rectly for application definitions with a space or non US-ASCII characters

I had a App definition containing a space in the name. When I exported this as a .zip or .bar file from the modeler then the download dialog was showing the name only up to the first space. See screenshot. The file would then be saved without a file extension or the correct name.

<img width="606" alt="download-box" src="https://user-images.githubusercontent.com/592501/27028537-572207aa-4f65-11e7-8e69-3ea7f3cc8211.png">

The HTTP header Content-Disposition filename was not being quoted so that the filename was only taken as the text up to the first space.
Additionally I added a filename* key to the Content-Disposition header to allow for modern browsers to handle non US-ASCII characters in a better, more predictable way.

Further information is found in stackoverflow - https://stackoverflow.com/questions/93551/how-to-encode-the-filename-parameter-of-content-disposition-header-in-http