### PR TITLE
Cleanup after async history merge

### DIFF
--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/RuntimeTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/RuntimeTest.java
@@ -16,7 +16,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.flowable.dmn.api.DmnDeployment;
 import org.flowable.dmn.api.RuleEngineExecutionSingleResult;
 import org.flowable.dmn.engine.test.AbstractFlowableDmnTest;
 import org.flowable.dmn.engine.test.DmnDeploymentAnnotation;
@@ -25,8 +24,6 @@ import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 import org.junit.Assert;
 import org.junit.Test;
-
-import static org.junit.Assert.assertNotNull;
 
 /**
  * @author Yvo Swillens

--- a/modules/flowable-dmn-xml-converter/src/main/java/org/flowable/dmn/converter/util/DmnXMLUtil.java
+++ b/modules/flowable-dmn-xml-converter/src/main/java/org/flowable/dmn/converter/util/DmnXMLUtil.java
@@ -16,7 +16,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.xml.stream.Location;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
 

--- a/modules/flowable-engine-common/src/main/java/org/flowable/engine/common/impl/de/odysseus/el/misc/BooleanOperations.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/engine/common/impl/de/odysseus/el/misc/BooleanOperations.java
@@ -25,8 +25,8 @@ import java.util.Set;
 import org.flowable.engine.common.impl.javax.el.ELException;
 
 public class BooleanOperations {
-	private final static Set<Class<? extends Number>> SIMPLE_INTEGER_TYPES = new HashSet<Class<? extends Number>>();
-	private final static Set<Class<? extends Number>> SIMPLE_FLOAT_TYPES = new HashSet<Class<? extends Number>>();
+	private static final Set<Class<? extends Number>> SIMPLE_INTEGER_TYPES = new HashSet<Class<? extends Number>>();
+	private static final Set<Class<? extends Number>> SIMPLE_FLOAT_TYPES = new HashSet<Class<? extends Number>>();
 	
 	static {
 		SIMPLE_INTEGER_TYPES.add(Byte.class);

--- a/modules/flowable-engine-common/src/main/java/org/flowable/engine/common/impl/de/odysseus/el/misc/NumberOperations.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/engine/common/impl/de/odysseus/el/misc/NumberOperations.java
@@ -26,9 +26,9 @@ import org.flowable.engine.common.impl.javax.el.ELException;
  * @author Christoph Beck
  */
 public class NumberOperations {
-	private final static Long LONG_ZERO = Long.valueOf(0L);
+	private static final Long LONG_ZERO = Long.valueOf(0L);
 
-	private final static boolean isDotEe(String value) {
+	private static final boolean isDotEe(String value) {
 		int length = value.length();
 		for (int i = 0; i < length; i++) {
 			switch (value.charAt(i)) {
@@ -40,7 +40,7 @@ public class NumberOperations {
 		return false;
 	}
 
-	private final static boolean isDotEe(Object value) {
+	private static final boolean isDotEe(Object value) {
 		return value instanceof String && isDotEe((String)value);
 	}
 

--- a/modules/flowable-engine-common/src/main/java/org/flowable/engine/common/impl/de/odysseus/el/tree/impl/Parser.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/engine/common/impl/de/odysseus/el/tree/impl/Parser.java
@@ -123,7 +123,7 @@ public class Parser {
 	/**
 	 * Provide limited support for syntax extensions.
 	 */
-	public static abstract class ExtensionHandler {
+    public abstract static class ExtensionHandler {
 		private final ExtensionPoint point;
 		
 		public ExtensionHandler(ExtensionPoint point) {

--- a/modules/flowable-engine-common/src/main/java/org/flowable/engine/common/impl/de/odysseus/el/tree/impl/ast/AstBinary.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/engine/common/impl/de/odysseus/el/tree/impl/ast/AstBinary.java
@@ -25,7 +25,7 @@ public class AstBinary extends AstRightValue {
 	public interface Operator {
 		public Object eval(Bindings bindings, ELContext context, AstNode left, AstNode right);		
 	}
-	public static abstract class SimpleOperator implements Operator {
+	public abstract static class SimpleOperator implements Operator {
 		public Object eval(Bindings bindings, ELContext context, AstNode left, AstNode right) {
 			return apply(bindings, left.eval(bindings, context), right.eval(bindings, context));
 		}

--- a/modules/flowable-engine-common/src/main/java/org/flowable/engine/common/impl/de/odysseus/el/tree/impl/ast/AstUnary.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/engine/common/impl/de/odysseus/el/tree/impl/ast/AstUnary.java
@@ -26,7 +26,7 @@ public class AstUnary extends AstRightValue {
 	public interface Operator {
 		public Object eval(Bindings bindings, ELContext context, AstNode node);		
 	}
-	public static abstract class SimpleOperator implements Operator {
+	public abstract static class SimpleOperator implements Operator {
 		public Object eval(Bindings bindings, ELContext context, AstNode node) {
 			return apply(bindings, node.eval(bindings, context));
 		}

--- a/modules/flowable-engine-common/src/main/java/org/flowable/engine/common/impl/de/odysseus/el/util/SimpleResolver.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/engine/common/impl/de/odysseus/el/util/SimpleResolver.java
@@ -133,5 +133,5 @@ public class SimpleResolver extends ELResolver {
 	@Override
 	public Object invoke(ELContext context, Object base, Object method, Class<?>[] paramTypes, Object[] params) {
 		return delegate.invoke(context, base, method, paramTypes, params);
-	};
+	}
 }

--- a/modules/flowable-engine-common/src/main/java/org/flowable/engine/common/impl/javax/el/BeanELResolver.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/engine/common/impl/javax/el/BeanELResolver.java
@@ -506,9 +506,9 @@ public class BeanELResolver extends ELResolver {
 			context.setPropertyResolved(true);
 		}
 		return result;
-	};
+	}
 
-	private Method findMethod(Object base, String name, Class<?>[] types, int paramCount) {
+    private Method findMethod(Object base, String name, Class<?>[] types, int paramCount) {
 		if (types != null) {
 			try {
 				return findAccessibleMethod(base.getClass().getMethod(name, types));

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/AcquireJobsCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/AcquireJobsCmd.java
@@ -19,8 +19,6 @@ import java.util.List;
 import org.flowable.engine.common.impl.Page;
 import org.flowable.engine.impl.asyncexecutor.AcquiredJobEntities;
 import org.flowable.engine.impl.asyncexecutor.AsyncExecutor;
-import org.flowable.engine.impl.cfg.ProcessEngineConfigurationImpl;
-import org.flowable.engine.impl.context.Context;
 import org.flowable.engine.impl.interceptor.Command;
 import org.flowable.engine.impl.interceptor.CommandContext;
 import org.flowable.engine.impl.persistence.entity.JobInfoEntity;

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/history/async/AsyncHistoryJobHandler.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/history/async/AsyncHistoryJobHandler.java
@@ -12,6 +12,9 @@
  */
 package org.flowable.engine.impl.history.async;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -44,9 +47,6 @@ import org.flowable.engine.impl.interceptor.CommandContext;
 import org.flowable.engine.impl.persistence.entity.HistoryJobEntity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 public class AsyncHistoryJobHandler extends AbstractAsyncHistoryJobHandler {
 
@@ -117,8 +117,7 @@ public class AsyncHistoryJobHandler extends AbstractAsyncHistoryJobHandler {
 
                 } else {
                     if (logger.isDebugEnabled()) {
-                        logger.debug("Could not handle history job (id={}) for transformer {}. as it is not applicable. Unacquiring. " + historicalJsonData, 
-                                job.getId(), transformer.getType());
+                        logger.debug("Could not handle history job (id={}) for transformer {}. as it is not applicable. Unacquiring. {}", job.getId(), transformer.getType(), historicalJsonData);
                     }
                     throw new AsyncHistoryJobNotApplicableException();
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/history/async/json/transformer/TaskEndedHistoryJsonTransformer.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/history/async/json/transformer/TaskEndedHistoryJsonTransformer.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.impl.history.async.json.transformer;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import java.util.Date;
 
 import org.apache.commons.lang3.StringUtils;
@@ -23,8 +25,6 @@ import org.flowable.engine.impl.persistence.entity.HistoricTaskInstanceEntityMan
 import org.flowable.engine.impl.persistence.entity.HistoryJobEntity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 public class TaskEndedHistoryJsonTransformer extends AbstractHistoryJsonTransformer {
     
@@ -76,7 +76,7 @@ public class TaskEndedHistoryJsonTransformer extends AbstractHistoryJsonTransfor
                 
             } else {
                 if (logger.isDebugEnabled()) {
-                    logger.debug("History job (id={}) has expired and will be ignored." + historicTaskInstance.getLastUpdateTime() + " " + lastUpdateTime, job.getId());
+                    logger.debug("History job (id={}) has expired and will be ignored.{} {}", job.getId(), historicTaskInstance.getLastUpdateTime(), lastUpdateTime);
                 }
             }
             

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/test/HistoryTestHelper.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/test/HistoryTestHelper.java
@@ -13,7 +13,6 @@
 
 package org.flowable.engine.impl.test;
 
-import java.util.List;
 import java.util.Timer;
 import java.util.TimerTask;
 
@@ -23,10 +22,6 @@ import org.flowable.engine.common.api.FlowableException;
 import org.flowable.engine.impl.asyncexecutor.AsyncExecutor;
 import org.flowable.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.flowable.engine.impl.history.HistoryLevel;
-import org.flowable.engine.impl.interceptor.Command;
-import org.flowable.engine.impl.interceptor.CommandContext;
-import org.flowable.engine.impl.persistence.entity.HistoryJobEntityImpl;
-import org.flowable.engine.runtime.HistoryJob;
 import org.flowable.engine.test.FlowableRule;
 
 /**

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/HistoricActivityEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/HistoricActivityEventsTest.java
@@ -90,10 +90,10 @@ public class HistoricActivityEventsTest extends PluggableFlowableTestCase {
 
             // Process instance start
             for (FlowableEvent flowableEvent : events) {
-                if (FlowableEngineEventType.HISTORIC_PROCESS_INSTANCE_CREATED.equals(flowableEvent.getType())) {
+                if (FlowableEngineEventType.HISTORIC_PROCESS_INSTANCE_CREATED == flowableEvent.getType()) {
                     processInstanceCreated++;
                 
-                } else if (FlowableEngineEventType.HISTORIC_ACTIVITY_INSTANCE_CREATED.equals(flowableEvent.getType())) {
+                } else if (FlowableEngineEventType.HISTORIC_ACTIVITY_INSTANCE_CREATED == flowableEvent.getType()) {
                     FlowableEntityEvent flowableEntityEvent = (FlowableEntityEvent) flowableEvent;
                     HistoricActivityInstance historicActivityInstance = (HistoricActivityInstance) flowableEntityEvent.getEntity();
                     if ("mainStart".equals(historicActivityInstance.getActivityId())) {
@@ -118,7 +118,7 @@ public class HistoricActivityEventsTest extends PluggableFlowableTestCase {
                         mainEndActivityStarted++;
                     }
                     
-                } else if (FlowableEngineEventType.HISTORIC_ACTIVITY_INSTANCE_ENDED.equals(flowableEvent.getType())) {
+                } else if (FlowableEngineEventType.HISTORIC_ACTIVITY_INSTANCE_ENDED == flowableEvent.getType()) {
                     FlowableEntityEvent flowableEntityEvent = (FlowableEntityEvent) flowableEvent;
                     HistoricActivityInstance historicActivityInstance = (HistoricActivityInstance) flowableEntityEvent.getEntity();
                     if ("mainStart".equals(historicActivityInstance.getActivityId())) {
@@ -150,7 +150,7 @@ public class HistoricActivityEventsTest extends PluggableFlowableTestCase {
                         mainEndActivityEnded++;
                     }
                     
-                } else if (FlowableEngineEventType.HISTORIC_PROCESS_INSTANCE_ENDED.equals(flowableEvent.getType())) {
+                } else if (FlowableEngineEventType.HISTORIC_PROCESS_INSTANCE_ENDED == flowableEvent.getType()) {
                     processInstanceEnded++;
                 }
             }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/compensate/CompensateEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/compensate/CompensateEventTest.java
@@ -27,7 +27,6 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.task.Task;
 import org.flowable.engine.test.Deployment;
 import org.flowable.engine.test.EnableVerboseExecutionTreeLogging;
-import org.flowable.engine.test.bpmn.event.compensate.helper.SetVariablesDelegate;
 
 /**
  * @author Tijs Rademakers

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventTest.java
@@ -22,7 +22,6 @@ import java.util.Map;
 
 import org.flowable.engine.delegate.DelegateExecution;
 import org.flowable.engine.delegate.ExecutionListener;
-import org.flowable.engine.history.DeleteReason;
 import org.flowable.engine.impl.history.HistoryLevel;
 import org.flowable.engine.impl.test.HistoryTestHelper;
 import org.flowable.engine.impl.test.JobTestHelper;

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/AsyncExecutorTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/AsyncExecutorTest.java
@@ -24,7 +24,6 @@ import org.flowable.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.flowable.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration;
 import org.flowable.engine.impl.test.JobTestHelper;
 import org.flowable.engine.runtime.JobInfo;
-import org.flowable.engine.runtime.Job;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.junit.Assert;
 import org.junit.Test;

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/groovy/GroovyScriptTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/groovy/GroovyScriptTest.java
@@ -13,7 +13,6 @@
 
 package org.flowable.examples.groovy;
 
-import java.util.Date;
 import java.util.List;
 
 import org.flowable.engine.common.impl.util.CollectionUtil;

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/mgmt/ManagementServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/mgmt/ManagementServiceTest.java
@@ -42,7 +42,7 @@ public class ManagementServiceTest extends PluggableFlowableTestCase {
             public Void execute(CommandContext commandContext) {
                 List<PropertyEntity> properties = commandContext.getProcessEngineConfiguration().getPropertyEntityManager().findAll();
                 for (PropertyEntity propertyEntity : properties) {
-                    log.info("!!!Property " + propertyEntity.getName() + " " + propertyEntity.getValue());
+                    log.info("!!!Property {} {}", propertyEntity.getName(), propertyEntity.getValue());
                 }
                 return null;
             }

--- a/modules/flowable-spring/src/main/java/org/flowable/spring/SpringAsyncExecutor.java
+++ b/modules/flowable-spring/src/main/java/org/flowable/spring/SpringAsyncExecutor.java
@@ -16,9 +16,7 @@ import java.util.concurrent.RejectedExecutionException;
 
 import org.flowable.engine.impl.asyncexecutor.DefaultAsyncJobExecutor;
 import org.flowable.engine.impl.asyncexecutor.ExecuteAsyncRunnable;
-import org.flowable.engine.impl.persistence.entity.JobEntity;
 import org.flowable.engine.runtime.JobInfo;
-import org.flowable.engine.runtime.Job;
 import org.springframework.core.task.TaskExecutor;
 
 /**


### PR DESCRIPTION
* Replace equals() on Enum compares as Enum constants are equal only when they have the same identity
* Fix missorted modifiers
* Remove unnecessary semicolon
* Remove unused imports
* Replace concatenations in log statements with parameterized log messages
