### PR TITLE
First pass at standardizing on private static final Logger LOGGER

### DIFF
--- a/eclipse/Preferences-Java-Editor-Templates.xml
+++ b/eclipse/Preferences-Java-Editor-Templates.xml
@@ -1,1 +1,1 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><templates><template autoinsert="true" context="java" deleted="false" description="flowable logger" enabled="true" name="log">private static Logger log = Logger.getLogger(${enclosing_type}.class.getName());</template></templates>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><templates><template autoinsert="true" context="java" deleted="false" description="flowable logger" enabled="true" name="log">private static final Logger LOGGER = Logger.getLogger(${enclosing_type}.class.getName());</template></templates>

--- a/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/child/ExecutionListenerParser.java
+++ b/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/child/ExecutionListenerParser.java
@@ -13,19 +13,15 @@
 package org.flowable.bpmn.converter.child;
 
 import org.apache.commons.lang3.StringUtils;
-import org.flowable.bpmn.model.FlowableListener;
 import org.flowable.bpmn.model.BaseElement;
+import org.flowable.bpmn.model.FlowableListener;
 import org.flowable.bpmn.model.HasExecutionListeners;
 import org.flowable.bpmn.model.SequenceFlow;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * @author Tijs Rademakers
  */
 public class ExecutionListenerParser extends FlowableListenerParser {
-
-    private static Logger logger = LoggerFactory.getLogger(ExecutionListenerParser.class);
 
     public String getElementName() {
         return ELEMENT_EXECUTION_LISTENER;

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/exception/tools/ThrowBpmnExceptionBean.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/exception/tools/ThrowBpmnExceptionBean.java
@@ -21,11 +21,11 @@ public class ThrowBpmnExceptionBean {
         ThrowBpmnExceptionBean.exceptionType = exceptionType;
     }
 
-    private static final Logger LOG = LoggerFactory.getLogger(ThrowBpmnExceptionBean.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ThrowBpmnExceptionBean.class);
 
     @Handler
     public void throwNonBpmnException() throws Exception {
-        LOG.debug("throwing non bpmn bug");
+        LOGGER.debug("throwing non bpmn bug");
 
         switch (getExceptionType()) {
         case NO_EXCEPTION:

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/util/BrokenService.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/util/BrokenService.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
  */
 public class BrokenService {
 
-    private static final Logger LOG = LoggerFactory.getLogger(BrokenService.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(BrokenService.class);
 
     /**
      * Always throws an exception.
@@ -33,7 +33,7 @@ public class BrokenService {
      * @throws BrokenServiceException
      */
     public void alwaysFails() throws BrokenServiceException {
-        LOG.info("{} called", this.getClass().getSimpleName());
+        LOGGER.info("{} called", this.getClass().getSimpleName());
         throw new BrokenServiceException("Provoked failure");
     }
 

--- a/modules/flowable-cdi/src/main/java/org/flowable/cdi/impl/FlowableExtension.java
+++ b/modules/flowable-cdi/src/main/java/org/flowable/cdi/impl/FlowableExtension.java
@@ -47,7 +47,7 @@ import org.slf4j.LoggerFactory;
  */
 public class FlowableExtension implements Extension {
 
-    private static Logger logger = LoggerFactory.getLogger(FlowableExtension.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(FlowableExtension.class);
     private ProcessEngineLookup processEngineLookup;
 
     public void beforeBeanDiscovery(@Observes final BeforeBeanDiscovery event) {
@@ -61,7 +61,7 @@ public class FlowableExtension implements Extension {
 
     public void afterDeploymentValidation(@Observes AfterDeploymentValidation event, BeanManager beanManager) {
         try {
-            logger.info("Initializing flowable-cdi.");
+            LOGGER.info("Initializing flowable-cdi.");
             // initialize the process engine
             ProcessEngine processEngine = lookupProcessEngine(beanManager);
             // deploy the processes if engine was set up correctly
@@ -93,10 +93,10 @@ public class FlowableExtension implements Extension {
             processEngine = processEngineLookup.getProcessEngine();
             if (processEngine != null) {
                 this.processEngineLookup = processEngineLookup;
-                logger.debug("ProcessEngineLookup service {} returned process engine.", processEngineLookup.getClass());
+                LOGGER.debug("ProcessEngineLookup service {} returned process engine.", processEngineLookup.getClass());
                 break;
             } else {
-                logger.debug("ProcessEngineLookup service {} returned 'null' value.", processEngineLookup.getClass());
+                LOGGER.debug("ProcessEngineLookup service {} returned 'null' value.", processEngineLookup.getClass());
             }
         }
 
@@ -119,7 +119,7 @@ public class FlowableExtension implements Extension {
             processEngineLookup.ungetProcessEngine();
             processEngineLookup = null;
         }
-        logger.info("Shutting down flowable-cdi");
+        LOGGER.info("Shutting down flowable-cdi");
     }
 
 }

--- a/modules/flowable-cdi/src/main/java/org/flowable/cdi/impl/ProcessDeployer.java
+++ b/modules/flowable-cdi/src/main/java/org/flowable/cdi/impl/ProcessDeployer.java
@@ -41,7 +41,7 @@ public class ProcessDeployer {
     public static final String PROCESS_ELEMENT_NAME = "process";
     public static final String PROCESS_ATTR_RESOURCE = "resource";
 
-    private static Logger logger = LoggerFactory.getLogger(ProcessDeployer.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProcessDeployer.class);
 
     protected final ProcessEngine processEngine;
 
@@ -55,13 +55,13 @@ public class ProcessDeployer {
      * @return the processDefinitionId of the deployed process as returned by {@link ProcessDefinition#getId()}
      */
     public String deployProcess(String resourceName) {
-        logger.debug("Start deploying single process.");
+        LOGGER.debug("Start deploying single process.");
         // deploy processes as one deployment
         DeploymentBuilder deploymentBuilder = processEngine.getRepositoryService().createDeployment();
         deploymentBuilder.addClasspathResource(resourceName);
         // deploy the processes
         Deployment deployment = deploymentBuilder.deploy();
-        logger.debug("Process deployed");
+        LOGGER.debug("Process deployed");
         // retrieve the processDefinitionId for this process
         return processEngine.getRepositoryService().createProcessDefinitionQuery().deploymentId(deployment.getId()).singleResult().getId();
     }
@@ -73,25 +73,25 @@ public class ProcessDeployer {
         // build a single deployment containing all discovered processes
         Set<String> resourceNames = getResourceNames();
         if (resourceNames.isEmpty()) {
-            logger.debug("Not creating a deployment");
+            LOGGER.debug("Not creating a deployment");
             return;
         }
-        logger.debug("Start deploying processes.");
+        LOGGER.debug("Start deploying processes.");
         DeploymentBuilder deploymentBuilder = processEngine.getRepositoryService().createDeployment();
         for (String string : resourceNames) {
-            logger.info("Adding '{}' to deployment.", string);
+            LOGGER.info("Adding '{}' to deployment.", string);
             deploymentBuilder.addClasspathResource(string);
         }
         // deploy the processes
         deploymentBuilder.deploy();
-        logger.debug("Done deploying processes.");
+        LOGGER.debug("Done deploying processes.");
     }
 
     public Set<String> getResourceNames() {
         Set<String> result = new HashSet<String>();
         URL processFileUrl = getClass().getClassLoader().getResource(PROCESSES_FILE_NAME);
         if (processFileUrl == null) {
-            logger.debug("No '{}'-file provided.", PROCESSES_FILE_NAME);
+            LOGGER.debug("No '{}'-file provided.", PROCESSES_FILE_NAME);
             // return empty set
             return result;
         }
@@ -111,7 +111,7 @@ public class ProcessDeployer {
                 result.add(resourceName);
             }
         } catch (Exception e) {
-            logger.error("could not parse file '{}'. {}", PROCESSES_FILE_NAME, e.getMessage(), e);
+            LOGGER.error("could not parse file '{}'. {}", PROCESSES_FILE_NAME, e.getMessage(), e);
         }
         return result;
     }

--- a/modules/flowable-cdi/src/main/java/org/flowable/cdi/impl/context/DefaultContextAssociationManager.java
+++ b/modules/flowable-cdi/src/main/java/org/flowable/cdi/impl/context/DefaultContextAssociationManager.java
@@ -48,7 +48,7 @@ import org.slf4j.LoggerFactory;
 @SuppressWarnings("serial")
 public class DefaultContextAssociationManager implements ContextAssociationManager, Serializable {
 
-    private static final Logger log = LoggerFactory.getLogger(DefaultContextAssociationManager.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultContextAssociationManager.class);
 
     protected static class ScopedAssociation {
 
@@ -117,7 +117,7 @@ public class DefaultContextAssociationManager implements ContextAssociationManag
                 beanManager.getContext(scopeAnnotation.annotationType());
                 return scopeType;
             } catch (ContextNotActiveException e) {
-                log.trace("Context {} not active.", scopeAnnotation.annotationType());
+                LOGGER.trace("Context {} not active.", scopeAnnotation.annotationType());
             }
         }
         throw new FlowableException("Could not determine an active context to associate the current process instance / task instance with.");
@@ -155,8 +155,8 @@ public class DefaultContextAssociationManager implements ContextAssociationManag
             throw new FlowableCdiException("Cannot associate " + execution + ", already associated with " + associatedExecution + ". Disassociate first!");
         }
 
-        if (log.isTraceEnabled()) {
-            log.trace("Associating {} (@{})", execution, scopedAssociation.getClass().getAnnotations()[0].annotationType().getSimpleName());
+        if (LOGGER.isTraceEnabled()) {
+            LOGGER.trace("Associating {} (@{})", execution, scopedAssociation.getClass().getAnnotations()[0].annotationType().getSimpleName());
         }
         scopedAssociation.setExecution(execution);
     }
@@ -170,8 +170,8 @@ public class DefaultContextAssociationManager implements ContextAssociationManag
         if (scopedAssociation.getExecution() == null) {
             throw new FlowableException("Cannot disassociate execution, no " + scopedAssociation.getClass().getAnnotations()[0].annotationType().getSimpleName() + " execution associated. ");
         }
-        if (log.isTraceEnabled()) {
-            log.trace("Disassociating");
+        if (LOGGER.isTraceEnabled()) {
+            LOGGER.trace("Disassociating");
         }
         scopedAssociation.setExecution(null);
         scopedAssociation.setTask(null);

--- a/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/ContentEngines.java
+++ b/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/ContentEngines.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
 
 public abstract class ContentEngines {
 
-    private static Logger log = LoggerFactory.getLogger(ContentEngines.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ContentEngines.class);
 
     public static final String NAME_DEFAULT = "default";
 
@@ -73,7 +73,7 @@ public abstract class ContentEngines {
             }
             for (Iterator<URL> iterator = configUrls.iterator(); iterator.hasNext();) {
                 URL resource = iterator.next();
-                log.info("Initializing content engine using configuration '{}'", resource.toString());
+                LOGGER.info("Initializing content engine using configuration '{}'", resource.toString());
                 initContentEngineFromResource(resource);
             }
 
@@ -85,13 +85,13 @@ public abstract class ContentEngines {
 
             while (resources.hasMoreElements()) {
                 URL resource = resources.nextElement();
-                log.info("Initializing content engine using Spring configuration '{}'", resource.toString());
+                LOGGER.info("Initializing content engine using Spring configuration '{}'", resource.toString());
                 initContentEngineFromSpringResource(resource);
             }
 
             setInitialized(true);
         } else {
-            log.info("Content engines already initialized");
+            LOGGER.info("Content engines already initialized");
         }
     }
 
@@ -142,16 +142,16 @@ public abstract class ContentEngines {
 
         String resourceUrlString = resourceUrl.toString();
         try {
-            log.info("initializing content engine for resource {}", resourceUrl);
+            LOGGER.info("initializing content engine for resource {}", resourceUrl);
             ContentEngine contentEngine = buildFormEngine(resourceUrl);
             String contentEngineName = contentEngine.getName();
-            log.info("initialised content engine {}", contentEngineName);
+            LOGGER.info("initialised content engine {}", contentEngineName);
             contentEngineInfo = new EngineInfo(contentEngineName, resourceUrlString, null);
             contentEngines.put(contentEngineName, contentEngine);
             contentEngineInfosByName.put(contentEngineName, contentEngineInfo);
 
         } catch (Throwable e) {
-            log.error("Exception while initializing content engine: {}", e.getMessage(), e);
+            LOGGER.error("Exception while initializing content engine: {}", e.getMessage(), e);
             contentEngineInfo = new EngineInfo(null, resourceUrlString, getExceptionString(e));
         }
         contentEngineInfosByResourceUrl.put(resourceUrlString, contentEngineInfo);
@@ -214,7 +214,7 @@ public abstract class ContentEngines {
      * Retries to initialize a content engine that previously failed.
      */
     public static EngineInfo retry(String resourceUrl) {
-        log.debug("retying initializing of resource {}", resourceUrl);
+        LOGGER.debug("retying initializing of resource {}", resourceUrl);
         try {
             return initContentEngineFromResource(new URL(resourceUrl));
         } catch (MalformedURLException e) {
@@ -242,7 +242,7 @@ public abstract class ContentEngines {
                 try {
                     contentEngine.close();
                 } catch (Exception e) {
-                    log.error("exception while closing {}", (contentEngineName == null ? "the default content engine" : "content engine " + contentEngineName), e);
+                    LOGGER.error("exception while closing {}", (contentEngineName == null ? "the default content engine" : "content engine " + contentEngineName), e);
                 }
             }
 

--- a/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/ContentEngineImpl.java
+++ b/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/ContentEngineImpl.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ContentEngineImpl implements ContentEngine {
 
-    private static Logger log = LoggerFactory.getLogger(ContentEngineImpl.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ContentEngineImpl.class);
 
     protected String name;
     protected ContentManagementService managementService;
@@ -39,9 +39,9 @@ public class ContentEngineImpl implements ContentEngine {
         this.contentService = engineConfiguration.getContentService();
 
         if (name == null) {
-            log.info("default flowable ContentEngine created");
+            LOGGER.info("default flowable ContentEngine created");
         } else {
-            log.info("ContentEngine {} created", name);
+            LOGGER.info("ContentEngine {} created", name);
         }
 
         ContentEngines.registerContentEngine(this);

--- a/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/cfg/standalone/StandaloneMybatisTransactionContext.java
+++ b/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/cfg/standalone/StandaloneMybatisTransactionContext.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  */
 public class StandaloneMybatisTransactionContext implements TransactionContext {
 
-    private static Logger log = LoggerFactory.getLogger(StandaloneMybatisTransactionContext.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(StandaloneMybatisTransactionContext.class);
 
     protected CommandContext commandContext;
     protected Map<TransactionState, List<TransactionListener>> stateTransactionListeners;
@@ -58,12 +58,12 @@ public class StandaloneMybatisTransactionContext implements TransactionContext {
 
     public void commit() {
 
-        log.debug("firing event committing...");
+        LOGGER.debug("firing event committing...");
         fireTransactionEvent(TransactionState.COMMITTING, false);
 
-        log.debug("committing the ibatis sql session...");
+        LOGGER.debug("committing the ibatis sql session...");
         getDbSqlSession().commit();
-        log.debug("firing event committed...");
+        LOGGER.debug("firing event committed...");
         fireTransactionEvent(TransactionState.COMMITTED, true);
 
     }
@@ -115,23 +115,23 @@ public class StandaloneMybatisTransactionContext implements TransactionContext {
     public void rollback() {
         try {
             try {
-                log.debug("firing event rolling back...");
+                LOGGER.debug("firing event rolling back...");
                 fireTransactionEvent(TransactionState.ROLLINGBACK, false);
 
             } catch (Throwable exception) {
-                log.info("Exception during transaction: {}", exception.getMessage());
+                LOGGER.info("Exception during transaction: {}", exception.getMessage());
                 commandContext.exception(exception);
             } finally {
-                log.debug("rolling back ibatis sql session...");
+                LOGGER.debug("rolling back ibatis sql session...");
                 getDbSqlSession().rollback();
             }
 
         } catch (Throwable exception) {
-            log.info("Exception during transaction: {}", exception.getMessage());
+            LOGGER.info("Exception during transaction: {}", exception.getMessage());
             commandContext.exception(exception);
 
         } finally {
-            log.debug("firing event rolled back...");
+            LOGGER.debug("firing event rolled back...");
             fireTransactionEvent(TransactionState.ROLLED_BACK, true);
         }
     }

--- a/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/db/DbSqlSession.java
+++ b/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/db/DbSqlSession.java
@@ -34,7 +34,7 @@ import liquibase.resource.ClassLoaderResourceAccessor;
  */
 public class DbSqlSession extends AbstractNonCachingDbSqlSession {
 
-    private static final Logger log = LoggerFactory.getLogger(DbSqlSession.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DbSqlSession.class);
 
     public DbSqlSession(DbSqlSessionFactory dbSqlSessionFactory) {
         super(dbSqlSessionFactory);
@@ -48,7 +48,7 @@ public class DbSqlSession extends AbstractNonCachingDbSqlSession {
     // ////////////////////////////////////////////////////////
 
     public void dbSchemaCheckVersion() {
-        log.debug("flowable content db schema check successful");
+        LOGGER.debug("flowable content db schema check successful");
     }
 
     public void dbSchemaCreate() {

--- a/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/fs/SimpleFileSystemContentStorage.java
+++ b/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/fs/SimpleFileSystemContentStorage.java
@@ -12,6 +12,10 @@
  */
 package org.flowable.content.engine.impl.fs;
 
+import com.fasterxml.uuid.EthernetAddress;
+import com.fasterxml.uuid.Generators;
+import com.fasterxml.uuid.impl.TimeBasedGenerator;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -28,10 +32,6 @@ import org.flowable.engine.common.api.FlowableObjectNotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.uuid.EthernetAddress;
-import com.fasterxml.uuid.Generators;
-import com.fasterxml.uuid.impl.TimeBasedGenerator;
-
 /**
  * (Very) simple implementation of the {@link ContentStorage} that relies on the passed metadata to store content.
  * 
@@ -43,7 +43,7 @@ import com.fasterxml.uuid.impl.TimeBasedGenerator;
  */
 public class SimpleFileSystemContentStorage implements ContentStorage {
 
-    private static final Logger LOG = LoggerFactory.getLogger(SimpleFileSystemContentStorage.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SimpleFileSystemContentStorage.class);
 
     private static TimeBasedGenerator UUID_GENERATOR = Generators.timeBasedGenerator(EthernetAddress.fromInterface());
 
@@ -79,9 +79,9 @@ public class SimpleFileSystemContentStorage implements ContentStorage {
         if (!subFolder.exists()) {
             boolean created = subFolder.mkdir();
             if (created) {
-                LOG.info("Created content folder in {}", subFolder.getAbsolutePath());
+                LOGGER.info("Created content folder in {}", subFolder.getAbsolutePath());
             } else {
-                LOG.warn("Could not create content folder. This might impact the storage of related content");
+                LOGGER.warn("Could not create content folder. This might impact the storage of related content");
             }
         }
         return subFolder;

--- a/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/interceptor/CommandContext.java
+++ b/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/interceptor/CommandContext.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
  */
 public class CommandContext extends AbstractCommandContext {
 
-    private static Logger log = LoggerFactory.getLogger(CommandContext.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(CommandContext.class);
 
     protected ContentEngineConfiguration contentEngineConfiguration;
 

--- a/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/interceptor/CommandContextInterceptor.java
+++ b/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/interceptor/CommandContextInterceptor.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
  * @author Tijs Rademakers
  */
 public class CommandContextInterceptor extends AbstractCommandInterceptor {
-    private static final Logger log = LoggerFactory.getLogger(CommandContextInterceptor.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(CommandContextInterceptor.class);
 
     protected CommandContextFactory commandContextFactory;
     protected ContentEngineConfiguration contentEngineConfiguration;
@@ -45,7 +45,7 @@ public class CommandContextInterceptor extends AbstractCommandInterceptor {
         if (!config.isContextReusePossible() || context == null || context.getException() != null) {
             context = commandContextFactory.createCommandContext(command);
         } else {
-            log.debug("Valid context found. Reusing it for the current command '{}'", command.getClass().getCanonicalName());
+            LOGGER.debug("Valid context found. Reusing it for the current command '{}'", command.getClass().getCanonicalName());
             contextReused = true;
         }
 

--- a/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/interceptor/LogInterceptor.java
+++ b/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/interceptor/LogInterceptor.java
@@ -22,22 +22,22 @@ import org.slf4j.LoggerFactory;
  */
 public class LogInterceptor extends AbstractCommandInterceptor {
 
-    private static Logger log = LoggerFactory.getLogger(LogInterceptor.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(LogInterceptor.class);
 
     public <T> T execute(CommandConfig config, Command<T> command) {
-        if (!log.isDebugEnabled()) {
+        if (!LOGGER.isDebugEnabled()) {
             // do nothing here if we cannot log
             return next.execute(config, command);
         }
-        log.debug("\n");
-        log.debug("--- starting {} --------------------------------------------------------", command.getClass().getSimpleName());
+        LOGGER.debug("\n");
+        LOGGER.debug("--- starting {} --------------------------------------------------------", command.getClass().getSimpleName());
         try {
 
             return next.execute(config, command);
 
         } finally {
-            log.debug("--- {} finished --------------------------------------------------------", command.getClass().getSimpleName());
-            log.debug("\n");
+            LOGGER.debug("--- {} finished --------------------------------------------------------", command.getClass().getSimpleName());
+            LOGGER.debug("\n");
         }
     }
 }

--- a/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/persistence/entity/TableDataManagerImpl.java
+++ b/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/persistence/entity/TableDataManagerImpl.java
@@ -44,7 +44,7 @@ public class TableDataManagerImpl extends AbstractManager implements TableDataMa
         super(formEngineConfiguration);
     }
 
-    private static Logger log = LoggerFactory.getLogger(TableDataManagerImpl.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TableDataManagerImpl.class);
 
     public static Map<Class<?>, String> apiTypeToTableNameMap = new HashMap<Class<?>, String>();
     public static Map<Class<? extends Entity>, String> entityToTableNameMap = new HashMap<Class<? extends Entity>, String>();
@@ -65,7 +65,7 @@ public class TableDataManagerImpl extends AbstractManager implements TableDataMa
             for (String tableName : getTablesPresentInDatabase()) {
                 tableCount.put(tableName, getTableCount(tableName));
             }
-            log.debug("Number of rows per flowable table: {}", tableCount);
+            LOGGER.debug("Number of rows per flowable table: {}", tableCount);
         } catch (Exception e) {
             throw new FlowableException("couldn't get table counts", e);
         }
@@ -81,7 +81,7 @@ public class TableDataManagerImpl extends AbstractManager implements TableDataMa
             DatabaseMetaData databaseMetaData = connection.getMetaData();
             ResultSet tables = null;
             try {
-                log.debug("retrieving flowable tables from jdbc metadata");
+                LOGGER.debug("retrieving flowable tables from jdbc metadata");
                 String databaseTablePrefix = getDbSqlSession().getDbSqlSessionFactory().getDatabaseTablePrefix();
                 String tableNameFilter = databaseTablePrefix + "ACT_%";
                 if ("postgres".equals(getDbSqlSession().getDbSqlSessionFactory().getDatabaseType())) {
@@ -110,7 +110,7 @@ public class TableDataManagerImpl extends AbstractManager implements TableDataMa
                     String tableName = tables.getString("TABLE_NAME");
                     tableName = tableName.toUpperCase();
                     tableNames.add(tableName);
-                    log.debug("  retrieved flowable table name {}", tableName);
+                    LOGGER.debug("  retrieved flowable table name {}", tableName);
                 }
             } finally {
                 tables.close();
@@ -122,7 +122,7 @@ public class TableDataManagerImpl extends AbstractManager implements TableDataMa
     }
 
     protected long getTableCount(String tableName) {
-        log.debug("selecting table count for {}", tableName);
+        LOGGER.debug("selecting table count for {}", tableName);
         Long count = (Long) getDbSqlSession().selectOne("org.flowable.form.engine.impl.TablePageMap.selectTableCount", Collections.singletonMap("tableName", tableName));
         return count;
     }

--- a/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/util/ReflectUtil.java
+++ b/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/util/ReflectUtil.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class ReflectUtil {
 
-    private static final Logger LOG = LoggerFactory.getLogger(ReflectUtil.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ReflectUtil.class);
 
     private static final Pattern GETTER_PATTERN = Pattern.compile("(get|is)[A-Z].*");
     private static final Pattern SETTER_PATTERN = Pattern.compile("set[A-Z].*");
@@ -56,7 +56,7 @@ public abstract class ReflectUtil {
 
         if (classLoader != null) {
             try {
-                LOG.trace("Trying to load class with custom classloader: {}", className);
+                LOGGER.trace("Trying to load class with custom classloader: {}", className);
                 clazz = loadClass(classLoader, className);
             } catch (Throwable t) {
                 throwable = t;
@@ -64,7 +64,7 @@ public abstract class ReflectUtil {
         }
         if (clazz == null) {
             try {
-                LOG.trace("Trying to load class with current thread context classloader: {}", className);
+                LOGGER.trace("Trying to load class with current thread context classloader: {}", className);
                 clazz = loadClass(Thread.currentThread().getContextClassLoader(), className);
             } catch (Throwable t) {
                 if (throwable == null) {
@@ -73,7 +73,7 @@ public abstract class ReflectUtil {
             }
             if (clazz == null) {
                 try {
-                    LOG.trace("Trying to load class with local classloader: {}", className);
+                    LOGGER.trace("Trying to load class with local classloader: {}", className);
                     clazz = loadClass(ReflectUtil.class.getClassLoader(), className);
                 } catch (Throwable t) {
                     if (throwable == null) {

--- a/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/test/ContentTestHelper.java
+++ b/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/test/ContentTestHelper.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class ContentTestHelper {
 
-    private static Logger log = LoggerFactory.getLogger(ContentTestHelper.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ContentTestHelper.class);
 
     public static final String EMPTY_LINE = "\n";
 
@@ -41,11 +41,11 @@ public abstract class ContentTestHelper {
     public static ContentEngine getContentEngine(String configurationResource) {
         ContentEngine contentEngine = contentEngines.get(configurationResource);
         if (contentEngine == null) {
-            log.debug("==== BUILDING CONTENT ENGINE ========================================================================");
+            LOGGER.debug("==== BUILDING CONTENT ENGINE ========================================================================");
             contentEngine = ContentEngineConfiguration.createContentEngineConfigurationFromResource(configurationResource)
                     .setDatabaseSchemaUpdate(ContentEngineConfiguration.DB_SCHEMA_UPDATE_DROP_CREATE)
                     .buildContentEngine();
-            log.debug("==== CONTENT ENGINE CREATED =========================================================================");
+            LOGGER.debug("==== CONTENT ENGINE CREATED =========================================================================");
             contentEngines.put(configurationResource, contentEngine);
         }
         return contentEngine;
@@ -63,7 +63,7 @@ public abstract class ContentTestHelper {
      * the DB is not clean. If the DB is not clean, it is cleaned by performing a create a drop.
      */
     public static void assertAndEnsureCleanDb(ContentEngine contentEngine) {
-        log.debug("verifying that db is clean after test");
+        LOGGER.debug("verifying that db is clean after test");
         ContentService contentService = contentEngine.getContentEngineConfiguration().getContentService();
         List<ContentItem> items = contentService.createContentItemQuery().list();
         if (items != null && !items.isEmpty()) {

--- a/modules/flowable-content-rest/src/test/java/org/flowable/rest/content/service/api/BaseSpringContentRestTestCase.java
+++ b/modules/flowable-content-rest/src/test/java/org/flowable/rest/content/service/api/BaseSpringContentRestTestCase.java
@@ -12,6 +12,12 @@
  */
 package org.flowable.rest.content.service.api;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
@@ -59,17 +65,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
-
 import junit.framework.AssertionFailedError;
 
 public abstract class BaseSpringContentRestTestCase extends AbstractContentTestCase {
 
-    private static Logger log = LoggerFactory.getLogger(BaseSpringContentRestTestCase.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(BaseSpringContentRestTestCase.class);
 
     protected static String SERVER_URL_PREFIX;
     protected static ContentRestUrlBuilder URL_BUILDER;
@@ -119,7 +119,7 @@ public abstract class BaseSpringContentRestTestCase extends AbstractContentTestC
                     try {
                         client.close();
                     } catch (IOException e) {
-                        log.error("Could not close http client", e);
+                        LOGGER.error("Could not close http client", e);
                     }
                 }
 
@@ -127,7 +127,7 @@ public abstract class BaseSpringContentRestTestCase extends AbstractContentTestC
                     try {
                         server.stop();
                     } catch (Exception e) {
-                        log.error("Error stopping server", e);
+                        LOGGER.error("Error stopping server", e);
                     }
                 }
             }
@@ -140,14 +140,14 @@ public abstract class BaseSpringContentRestTestCase extends AbstractContentTestC
             super.runBare();
 
         } catch (AssertionFailedError e) {
-            log.error(EMPTY_LINE);
-            log.error("ASSERTION FAILED: {}", e, e);
+            LOGGER.error(EMPTY_LINE);
+            LOGGER.error("ASSERTION FAILED: {}", e, e);
             exception = e;
             throw e;
 
         } catch (Throwable e) {
-            log.error(EMPTY_LINE);
-            log.error("EXCEPTION: {}", e, e);
+            LOGGER.error(EMPTY_LINE);
+            LOGGER.error("EXCEPTION: {}", e, e);
             exception = e;
             throw e;
 
@@ -184,8 +184,8 @@ public abstract class BaseSpringContentRestTestCase extends AbstractContentTestC
 
             int responseStatusCode = response.getStatusLine().getStatusCode();
             if (expectedStatusCode != responseStatusCode) {
-                log.info("Wrong status code : {}, but should be {}", responseStatusCode, expectedStatusCode);
-                log.info("Response body: {}", IOUtils.toString(response.getEntity().getContent()));
+                LOGGER.info("Wrong status code : {}, but should be {}", responseStatusCode, expectedStatusCode);
+                LOGGER.info("Response body: {}", IOUtils.toString(response.getEntity().getContent()));
             }
 
             Assert.assertEquals(expectedStatusCode, responseStatusCode);
@@ -216,7 +216,7 @@ public abstract class BaseSpringContentRestTestCase extends AbstractContentTestC
                 try {
                     response.close();
                 } catch (IOException e) {
-                    log.error("Could not close http connection", e);
+                    LOGGER.error("Could not close http connection", e);
                 }
             }
         }

--- a/modules/flowable-content-rest/src/test/java/org/flowable/rest/content/util/TestServerUtil.java
+++ b/modules/flowable-content-rest/src/test/java/org/flowable/rest/content/util/TestServerUtil.java
@@ -31,7 +31,7 @@ import org.springframework.web.context.support.AnnotationConfigWebApplicationCon
  */
 public class TestServerUtil {
 
-    private static final Logger log = LoggerFactory.getLogger(TestServerUtil.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestServerUtil.class);
 
     protected static final int START_PORT = 9696;
     private static AtomicInteger NEXT_PORT = new AtomicInteger(9696);
@@ -51,7 +51,7 @@ public class TestServerUtil {
             server.setHandler(getServletContextHandler(applicationContext));
             server.start();
         } catch (Exception e) {
-            log.error("Error starting server", e);
+            LOGGER.error("Error starting server", e);
         }
 
         return new TestServer(server, applicationContext, port);

--- a/modules/flowable-content-spring/src/main/java/org/flowable/content/spring/SpringContentConfigurationHelper.java
+++ b/modules/flowable-content-spring/src/main/java/org/flowable/content/spring/SpringContentConfigurationHelper.java
@@ -29,10 +29,10 @@ import org.springframework.core.io.UrlResource;
  */
 public class SpringContentConfigurationHelper {
 
-    private static Logger log = LoggerFactory.getLogger(SpringContentConfigurationHelper.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SpringContentConfigurationHelper.class);
 
     public static ContentEngine buildContentEngine(URL resource) {
-        log.debug("==== BUILDING SPRING APPLICATION CONTEXT AND CONTENT ENGINE =========================================");
+        LOGGER.debug("==== BUILDING SPRING APPLICATION CONTEXT AND CONTENT ENGINE =========================================");
 
         ApplicationContext applicationContext = new GenericXmlApplicationContext(new UrlResource(resource));
         Map<String, ContentEngine> beansOfType = applicationContext.getBeansOfType(ContentEngine.class);
@@ -42,7 +42,7 @@ public class SpringContentConfigurationHelper {
 
         ContentEngine contentEngine = beansOfType.values().iterator().next();
 
-        log.debug("==== SPRING CONTENT ENGINE CREATED ==================================================================");
+        LOGGER.debug("==== SPRING CONTENT ENGINE CREATED ==================================================================");
         return contentEngine;
     }
 

--- a/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/AbstractSimulationRun.java
+++ b/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/AbstractSimulationRun.java
@@ -12,14 +12,14 @@
  */
 package org.flowable.crystalball.simulator;
 
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.flowable.engine.ProcessEngine;
 import org.flowable.engine.delegate.VariableScope;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * This class implements all methods for Simulation run
@@ -28,7 +28,7 @@ import java.util.Map;
  */
 public abstract class AbstractSimulationRun implements SimulationRun, SimulationDebugger {
 
-    private static Logger log = LoggerFactory.getLogger(AbstractSimulationRun.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractSimulationRun.class);
 
     protected String id;
     /**
@@ -69,11 +69,11 @@ public abstract class AbstractSimulationRun implements SimulationRun, Simulation
     public void step() {
         SimulationEvent event = removeSimulationEvent();
         if (!simulationEnd(event)) {
-            log.debug("executing simulation event {}", event);
+            LOGGER.debug("executing simulation event {}", event);
             executeEvent(event);
-            log.debug("simulation event {} execution done", event);
+            LOGGER.debug("simulation event {} execution done", event);
         } else {
-            log.info("Simulation run has ended.");
+            LOGGER.info("Simulation run has ended.");
         }
     }
 
@@ -124,14 +124,14 @@ public abstract class AbstractSimulationRun implements SimulationRun, Simulation
 
     protected void executeEvent(SimulationEvent event) {
         // set simulation time to the next event for process engine too
-        log.debug("Simulation time: {}", this.processEngine.getProcessEngineConfiguration().getClock().getCurrentTime());
+        LOGGER.debug("Simulation time: {}", this.processEngine.getProcessEngineConfiguration().getClock().getCurrentTime());
 
         SimulationEventHandler handler = eventHandlerMap.get(event.getType());
         if (handler != null) {
-            log.debug("Handling event of type[{}]", event.getType());
+            LOGGER.debug("Handling event of type[{}]", event.getType());
             handler.handle(event);
         } else {
-            log.warn("Event type[{}] does not have any handler assigned.", event.getType());
+            LOGGER.warn("Event type[{}] does not have any handler assigned.", event.getType());
         }
     }
 

--- a/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/SimpleEventCalendar.java
+++ b/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/SimpleEventCalendar.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
  */
 public class SimpleEventCalendar implements EventCalendar {
 
-    private static Logger log = LoggerFactory.getLogger(SimpleEventCalendar.class.getName());
+    private static final Logger LOGGER = LoggerFactory.getLogger(SimpleEventCalendar.class.getName());
 
     private static final int NULL = -1;
 
@@ -87,7 +87,7 @@ public class SimpleEventCalendar implements EventCalendar {
 
     @Override
     public void addEvent(SimulationEvent event) {
-        log.debug("Scheduling new event [{}]", event);
+        LOGGER.debug("Scheduling new event [{}]", event);
         if (event != null && isMinimal(event))
             minIndex = eventList.size();
         eventList.add(event);

--- a/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/impl/DeployClasspathResourcesEventHandler.java
+++ b/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/impl/DeployClasspathResourcesEventHandler.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.crystalball.simulator.impl;
 
+import java.util.List;
+
 import org.flowable.crystalball.simulator.SimulationEvent;
 import org.flowable.crystalball.simulator.SimulationEventHandler;
 import org.flowable.crystalball.simulator.SimulationRunContext;
@@ -19,14 +21,12 @@ import org.flowable.engine.repository.DeploymentBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.List;
-
 /**
  * This class deploys resources from classpath
  */
 public class DeployClasspathResourcesEventHandler implements SimulationEventHandler {
 
-    private static Logger log = LoggerFactory.getLogger(DeployClasspathResourcesEventHandler.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DeployClasspathResourcesEventHandler.class);
 
     /**
      * process to start key
@@ -50,7 +50,7 @@ public class DeployClasspathResourcesEventHandler implements SimulationEventHand
         DeploymentBuilder deploymentBuilder = SimulationRunContext.getRepositoryService().createDeployment();
 
         for (String resource : resources) {
-            log.debug("adding resource [{}] to repository {}", resource, SimulationRunContext.getRepositoryService());
+            LOGGER.debug("adding resource [{}] to repository {}", resource, SimulationRunContext.getRepositoryService());
             deploymentBuilder.addClasspathResource(resource);
         }
 

--- a/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/impl/DeployResourcesEventHandler.java
+++ b/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/impl/DeployResourcesEventHandler.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
  */
 public class DeployResourcesEventHandler implements SimulationEventHandler {
 
-    private static Logger log = LoggerFactory.getLogger(DeployResourcesEventHandler.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DeployResourcesEventHandler.class);
 
     /** process to start key */
     protected String resourcesKey;
@@ -59,7 +59,7 @@ public class DeployResourcesEventHandler implements SimulationEventHandler {
             DeploymentBuilder deploymentBuilder = SimulationRunContext.getRepositoryService().createDeployment();
 
             for (ResourceEntity resource : resources.values()) {
-                log.debug("adding resource [{}] to deployment", resource.getName());
+                LOGGER.debug("adding resource [{}] to deployment", resource.getName());
                 InputStream is = new ByteArrayInputStream(resource.getBytes());
                 deploymentBuilder.addInputStream(resource.getName(), is);
                 inputStreams.add(is);
@@ -71,7 +71,7 @@ public class DeployResourcesEventHandler implements SimulationEventHandler {
                 try {
                     is.close();
                 } catch (IOException e) {
-                    log.error("Unable to close resource input stream {}", is);
+                    LOGGER.error("Unable to close resource input stream {}", is);
                 }
             }
         }

--- a/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/impl/ScriptEventHandler.java
+++ b/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/impl/ScriptEventHandler.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ScriptEventHandler implements SimulationEventHandler {
 
-    private static Logger log = LoggerFactory.getLogger(ScriptEventHandler.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ScriptEventHandler.class);
 
     protected String scriptPropertyName;
     protected String language;
@@ -53,7 +53,7 @@ public class ScriptEventHandler implements SimulationEventHandler {
             scriptingEngines.evaluate((String) event.getProperty(this.scriptPropertyName), language, execution, false);
 
         } catch (FlowableException e) {
-            log.warn("Exception while executing simulation event {} scriptPropertyName :{}\n script: {}\n exception is:{}", event, this.scriptPropertyName, event.getProperty(this.scriptPropertyName), e.getMessage());
+            LOGGER.warn("Exception while executing simulation event {} scriptPropertyName :{}\n script: {}\n exception is:{}", event, this.scriptPropertyName, event.getProperty(this.scriptPropertyName), e.getMessage());
             throw e;
         }
     }

--- a/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/impl/StartProcessByIdEventHandler.java
+++ b/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/impl/StartProcessByIdEventHandler.java
@@ -12,13 +12,13 @@
  */
 package org.flowable.crystalball.simulator.impl;
 
+import java.util.Map;
+
 import org.flowable.crystalball.simulator.SimulationEvent;
 import org.flowable.crystalball.simulator.SimulationEventHandler;
 import org.flowable.crystalball.simulator.SimulationRunContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Map;
 
 /**
  * Start new process event handler for playback purposes
@@ -27,7 +27,7 @@ import java.util.Map;
  */
 public class StartProcessByIdEventHandler implements SimulationEventHandler {
 
-    private static Logger log = LoggerFactory.getLogger(StartProcessByIdEventHandler.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(StartProcessByIdEventHandler.class);
 
     /** process to start key */
     protected String processToStartIdKey;
@@ -52,7 +52,7 @@ public class StartProcessByIdEventHandler implements SimulationEventHandler {
         @SuppressWarnings("unchecked")
         Map<String, Object> variables = (Map<String, Object>) event.getProperty(variablesKey);
 
-        log.debug("Starting new processDefId[{}] businessKey[{}] with variables[{}]", processDefinitionId, businessKey, variables);
+        LOGGER.debug("Starting new processDefId[{}] businessKey[{}] with variables[{}]", processDefinitionId, businessKey, variables);
         SimulationRunContext.getRuntimeService().startProcessInstanceById(processDefinitionId, businessKey, variables);
     }
 

--- a/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/impl/StartProcessByKeyEventHandler.java
+++ b/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/impl/StartProcessByKeyEventHandler.java
@@ -12,13 +12,13 @@
  */
 package org.flowable.crystalball.simulator.impl;
 
+import java.util.Map;
+
 import org.flowable.crystalball.simulator.SimulationEvent;
 import org.flowable.crystalball.simulator.SimulationEventHandler;
 import org.flowable.crystalball.simulator.SimulationRunContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Map;
 
 /**
  * Start new process event handler for playback purposes
@@ -27,7 +27,7 @@ import java.util.Map;
  */
 public class StartProcessByKeyEventHandler implements SimulationEventHandler {
 
-    private static Logger log = LoggerFactory.getLogger(StartProcessByKeyEventHandler.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(StartProcessByKeyEventHandler.class);
 
     /** process to start key */
     protected String processToStartKey;
@@ -52,7 +52,7 @@ public class StartProcessByKeyEventHandler implements SimulationEventHandler {
         @SuppressWarnings("unchecked")
         Map<String, Object> variables = (Map<String, Object>) event.getProperty(variablesKey);
 
-        log.debug("Starting new processDefKey[{}] businessKey[{}] with variables[{}]", processDefinitionKey, businessKey, variables);
+        LOGGER.debug("Starting new processDefKey[{}] businessKey[{}] with variables[{}]", processDefinitionKey, businessKey, variables);
         SimulationRunContext.getRuntimeService().startProcessInstanceByKey(processDefinitionKey, businessKey, variables);
     }
 

--- a/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/impl/StartReplayLogEventHandler.java
+++ b/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/impl/StartReplayLogEventHandler.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
  */
 public class StartReplayLogEventHandler implements SimulationEventHandler {
 
-    private static Logger log = LoggerFactory.getLogger(StartReplayLogEventHandler.class.getName());
+    private static final Logger LOGGER = LoggerFactory.getLogger(StartReplayLogEventHandler.class.getName());
 
     /** variable name where original process instance ID is stored - only for internal replay purposes */
     public static final String PROCESS_INSTANCE_ID = "_replay.processInstanceId";
@@ -71,7 +71,7 @@ public class StartReplayLogEventHandler implements SimulationEventHandler {
         } else {
             startBusinessKey = this.businessKey;
         }
-        log.debug("Starting new processDefId[{}] businessKey[{}] with variables[{}]", processDefinitionId, startBusinessKey, variables);
+        LOGGER.debug("Starting new processDefId[{}] businessKey[{}] with variables[{}]", processDefinitionId, startBusinessKey, variables);
         SimulationRunContext.getRuntimeService().startProcessInstanceById(processDefinitionId, startBusinessKey, variables);
     }
 }

--- a/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/impl/StartReplayProcessEventHandler.java
+++ b/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/impl/StartReplayProcessEventHandler.java
@@ -12,6 +12,9 @@
  */
 package org.flowable.crystalball.simulator.impl;
 
+import java.util.Collection;
+import java.util.Map;
+
 import org.flowable.crystalball.simulator.CrystalballException;
 import org.flowable.crystalball.simulator.SimulationEvent;
 import org.flowable.crystalball.simulator.SimulationEventHandler;
@@ -20,9 +23,6 @@ import org.flowable.crystalball.simulator.delegate.event.impl.ProcessInstanceCre
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collection;
-import java.util.Map;
-
 /**
  * This class schedules replay start simulation event and takes care about process start and next event schedule
  * 
@@ -30,7 +30,7 @@ import java.util.Map;
  */
 public class StartReplayProcessEventHandler implements SimulationEventHandler {
 
-    private static Logger log = LoggerFactory.getLogger(StartReplayProcessEventHandler.class.getName());
+    private static final Logger LOGGER = LoggerFactory.getLogger(StartReplayProcessEventHandler.class.getName());
 
     /** variable name where original process instance ID is stored - only for internal replay purposes */
     public static final String PROCESS_INSTANCE_ID = "_replay.processInstanceId";
@@ -80,7 +80,7 @@ public class StartReplayProcessEventHandler implements SimulationEventHandler {
         Map<String, Object> variables = (Map<String, Object>) event.getProperty(variablesKey);
         variables.put(PROCESS_INSTANCE_ID, processInstanceId);
 
-        log.debug("Starting new processDefId[{}] businessKey[{}] with variables[{}]", processDefinitionId, businessKey, variables);
+        LOGGER.debug("Starting new processDefId[{}] businessKey[{}] with variables[{}]", processDefinitionId, businessKey, variables);
         SimulationRunContext.getRuntimeService().startProcessInstanceById(processDefinitionId, businessKey, variables);
     }
 }

--- a/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/impl/bpmn/parser/handler/SimulatorParserUtils.java
+++ b/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/impl/bpmn/parser/handler/SimulatorParserUtils.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
  * @author martin.grofcik
  */
 final class SimulatorParserUtils {
-    private static Logger LOG = LoggerFactory.getLogger(SimulatorParserUtils.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SimulatorParserUtils.class);
 
     /**
      * The namespace of the simulator custom BPMN extensions.
@@ -43,14 +43,14 @@ final class SimulatorParserUtils {
     // ProcessDefinitionImpl processDefinition = scope.getProcessDefinition();
     // ActivityImpl activity = processDefinition.findActivity(baseElement.getId());
     //
-    // LOG.debug("Scripting task [" + activity.getId() + "] setting behavior to [" + behaviorClassName + "]");
+    // LOGGER.debug("Scripting task [" + activity.getId() + "] setting behavior to [" + behaviorClassName + "]");
     // try {
     // @SuppressWarnings("unchecked")
     // Class<AbstractSimulationActivityBehavior> behaviorClass = (Class<AbstractSimulationActivityBehavior>) Class.forName(behaviorClassName);
     // Constructor<AbstractSimulationActivityBehavior> constructor = behaviorClass.getDeclaredConstructor(ScopeImpl.class, ActivityImpl.class);
     // activity.setActivityBehavior(constructor.newInstance(scope, activity));
     // } catch (Throwable t) {
-    // LOG.error("unable to set simulation behavior class[" + behaviorClassName + "]", t);
+    // LOGGER.error("unable to set simulation behavior class[" + behaviorClassName + "]", t);
     // throw new FlowableException("unable to set simulation behavior class[" + behaviorClassName + "]");
     // }
     // }

--- a/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/impl/playback/PlaybackUserTaskCompleteEventHandler.java
+++ b/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/impl/playback/PlaybackUserTaskCompleteEventHandler.java
@@ -12,14 +12,14 @@
  */
 package org.flowable.crystalball.simulator.impl.playback;
 
+import java.util.Map;
+
 import org.flowable.crystalball.simulator.SimulationEvent;
 import org.flowable.crystalball.simulator.SimulationEventHandler;
 import org.flowable.crystalball.simulator.SimulationRunContext;
 import org.flowable.engine.task.Task;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Map;
 
 /**
  * complete user task handler for playback purposes
@@ -28,7 +28,7 @@ import java.util.Map;
  */
 public class PlaybackUserTaskCompleteEventHandler implements SimulationEventHandler {
 
-    private static Logger log = LoggerFactory.getLogger(PlaybackUserTaskCompleteEventHandler.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(PlaybackUserTaskCompleteEventHandler.class);
 
     @Override
     public void handle(SimulationEvent event) {
@@ -40,7 +40,7 @@ public class PlaybackUserTaskCompleteEventHandler implements SimulationEventHand
         Map<String, Object> variables = (Map<String, Object>) event.getProperty("variables");
 
         SimulationRunContext.getTaskService().complete(taskId, variables);
-        log.debug("completed {}, {}, {}, {}", task, task.getName(), assignee, variables);
+        LOGGER.debug("completed {}, {}, {}, {}", task, task.getName(), assignee, variables);
     }
 
     @Override

--- a/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/impl/replay/ReplayUserTaskCompleteEventHandler.java
+++ b/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/impl/replay/ReplayUserTaskCompleteEventHandler.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ReplayUserTaskCompleteEventHandler implements SimulationEventHandler {
 
-    private static Logger log = LoggerFactory.getLogger(ReplayUserTaskCompleteEventHandler.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ReplayUserTaskCompleteEventHandler.class);
 
     @Override
     public void handle(SimulationEvent event) {
@@ -54,10 +54,10 @@ public class ReplayUserTaskCompleteEventHandler implements SimulationEventHandle
             } else {
                 SimulationRunContext.getTaskService().complete(task.getId(), variables);
             }
-            log.debug("completed {}, {}, {}", task, task.getName(), variables);
+            LOGGER.debug("completed {}, {}, {}", task, task.getName(), variables);
         } else {
             SimulationRunContext.getTaskService().complete(task.getId());
-            log.debug("completed {}, {}", task, task.getName());
+            LOGGER.debug("completed {}, {}", task, task.getName());
         }
     }
 

--- a/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/impl/playback/AbstractPlaybackTest.java
+++ b/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/impl/playback/AbstractPlaybackTest.java
@@ -12,7 +12,13 @@
  */
 package org.flowable.crystalball.simulator.impl.playback;
 
-import junit.framework.AssertionFailedError;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.flowable.crystalball.simulator.SimpleEventCalendarFactory;
 import org.flowable.crystalball.simulator.SimpleSimulationRun;
 import org.flowable.crystalball.simulator.SimulationDebugger;
@@ -44,12 +50,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.FactoryBean;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import junit.framework.AssertionFailedError;
 
 /**
  * This class is supper class for all Playback tests
@@ -66,7 +67,7 @@ public abstract class AbstractPlaybackTest extends AbstractFlowableTestCase {
 
     private static final String BUSINESS_KEY = "testBusinessKey";
 
-    private static Logger log = LoggerFactory.getLogger(AbstractPlaybackTest.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractPlaybackTest.class);
 
     protected InMemoryRecordFlowableEventListener listener = new InMemoryRecordFlowableEventListener(getTransformers());
 
@@ -84,16 +85,16 @@ public abstract class AbstractPlaybackTest extends AbstractFlowableTestCase {
     @Override
     public void runBare() throws Throwable {
 
-        log.info("Running test {} to record events", getName());
+        LOGGER.info("Running test {} to record events", getName());
 
         recordEvents();
 
-        log.info("Events for {} recorded successfully", getName());
-        log.info("Running playback simulation for {}", getName());
+        LOGGER.info("Events for {} recorded successfully", getName());
+        LOGGER.info("Running playback simulation for {}", getName());
 
         runPlayback();
 
-        log.info("Playback simulation for {} finished successfully.", getName());
+        LOGGER.info("Playback simulation for {} finished successfully.", getName());
 
     }
 
@@ -121,16 +122,16 @@ public abstract class AbstractPlaybackTest extends AbstractFlowableTestCase {
 
             _checkStatus();
         } catch (AssertionFailedError e) {
-            log.warn("Playback simulation {} has failed", getName());
-            log.error(EMPTY_LINE);
-            log.error("ASSERTION FAILED: {}", e, e);
+            LOGGER.warn("Playback simulation {} has failed", getName());
+            LOGGER.error(EMPTY_LINE);
+            LOGGER.error("ASSERTION FAILED: {}", e, e);
             exception = e;
             throw e;
 
         } catch (Throwable e) {
-            log.warn("Playback simulation {} has failed", getName());
-            log.error(EMPTY_LINE);
-            log.error("EXCEPTION: {}", e, e);
+            LOGGER.warn("Playback simulation {} has failed", getName());
+            LOGGER.error(EMPTY_LINE);
+            LOGGER.error("EXCEPTION: {}", e, e);
             exception = e;
             throw e;
 
@@ -152,12 +153,12 @@ public abstract class AbstractPlaybackTest extends AbstractFlowableTestCase {
         try {
             method = getClass().getMethod(getName(), (Class<?>[]) null);
         } catch (Exception e) {
-            log.warn("Could not get method by reflection. This could happen if you are using @Parameters in combination with annotations.", e);
+            LOGGER.warn("Could not get method by reflection. This could happen if you are using @Parameters in combination with annotations.", e);
             return;
         }
         CheckStatus checkStatusAnnotation = method.getAnnotation(CheckStatus.class);
         if (checkStatusAnnotation != null) {
-            log.debug("annotation @CheckStatus checks status for {}.{}", getClass().getSimpleName(), getName());
+            LOGGER.debug("annotation @CheckStatus checks status for {}.{}", getClass().getSimpleName(), getName());
             String checkStatusMethodName = checkStatusAnnotation.methodName();
             if (checkStatusMethodName.isEmpty()) {
                 String name = method.getName();
@@ -167,12 +168,12 @@ public abstract class AbstractPlaybackTest extends AbstractFlowableTestCase {
             try {
                 method = getClass().getMethod(checkStatusMethodName);
             } catch (Exception e) {
-                log.error("Could not get CheckStatus method: {} by reflection. This could happen if you are using @Parameters in combination with annotations.", checkStatusMethodName, e);
+                LOGGER.error("Could not get CheckStatus method: {} by reflection. This could happen if you are using @Parameters in combination with annotations.", checkStatusMethodName, e);
                 throw new RuntimeException("Could not get CheckStatus method by reflection");
             }
             method.invoke(this);
         } else {
-            log.warn("Check status annotation is not present - nothing is checked");
+            LOGGER.warn("Check status annotation is not present - nothing is checked");
         }
     }
 
@@ -206,22 +207,22 @@ public abstract class AbstractPlaybackTest extends AbstractFlowableTestCase {
 
             _checkStatus();
         } catch (AssertionFailedError e) {
-            log.error(EMPTY_LINE);
-            log.error("ASSERTION FAILED: {}", e, e);
+            LOGGER.error(EMPTY_LINE);
+            LOGGER.error("ASSERTION FAILED: {}", e, e);
             exception = e;
             throw e;
 
         } catch (Throwable e) {
-            log.warn("Record events {} has failed", getName());
-            log.error(EMPTY_LINE);
-            log.error("EXCEPTION: {}", e, e);
+            LOGGER.warn("Record events {} has failed", getName());
+            LOGGER.error(EMPTY_LINE);
+            LOGGER.error("EXCEPTION: {}", e, e);
             exception = e;
             throw e;
 
         } finally {
             TestHelper.annotationDeploymentTearDown(processEngine, deploymentIdFromDeploymentAnnotation, getClass(), getName());
             assertAndEnsureCleanDb();
-            log.info("dropping and recreating db");
+            LOGGER.info("dropping and recreating db");
 
             this.processEngineConfiguration.getClock().reset();
 

--- a/modules/flowable-dmn-engine-configurator/src/main/java/org/flowable/dmn/engine/deployer/DmnDeployer.java
+++ b/modules/flowable-dmn-engine-configurator/src/main/java/org/flowable/dmn/engine/deployer/DmnDeployer.java
@@ -28,21 +28,21 @@ import org.slf4j.LoggerFactory;
  */
 public class DmnDeployer implements Deployer {
 
-    private static final Logger log = LoggerFactory.getLogger(DmnDeployer.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DmnDeployer.class);
 
     @Override
     public void deploy(DeploymentEntity deployment, Map<String, Object> deploymentSettings) {
         if (!deployment.isNew())
             return;
 
-        log.debug("DmnDeployer: processing deployment {}", deployment.getName());
+        LOGGER.debug("DmnDeployer: processing deployment {}", deployment.getName());
 
         DmnDeploymentBuilder dmnDeploymentBuilder = null;
 
         Map<String, ResourceEntity> resources = deployment.getResources();
         for (String resourceName : resources.keySet()) {
             if (resourceName.endsWith(".dmn")) {
-                log.info("DmnDeployer: processing resource {}", resourceName);
+                LOGGER.info("DmnDeployer: processing resource {}", resourceName);
                 if (dmnDeploymentBuilder == null) {
                     DmnRepositoryService dmnRepositoryService = Context.getProcessEngineConfiguration().getDmnEngineRepositoryService();
                     dmnDeploymentBuilder = dmnRepositoryService.createDeployment();

--- a/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/DmnEngines.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/DmnEngines.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
 
 public abstract class DmnEngines {
 
-    private static Logger log = LoggerFactory.getLogger(DmnEngines.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DmnEngines.class);
 
     public static final String NAME_DEFAULT = "default";
 
@@ -73,7 +73,7 @@ public abstract class DmnEngines {
             }
             for (Iterator<URL> iterator = configUrls.iterator(); iterator.hasNext();) {
                 URL resource = iterator.next();
-                log.info("Initializing dmn engine using configuration '{}'", resource.toString());
+                LOGGER.info("Initializing dmn engine using configuration '{}'", resource.toString());
                 initDmnEngineFromResource(resource);
             }
 
@@ -85,13 +85,13 @@ public abstract class DmnEngines {
 
             while (resources.hasMoreElements()) {
                 URL resource = resources.nextElement();
-                log.info("Initializing dmn engine using Spring configuration '{}'", resource.toString());
+                LOGGER.info("Initializing dmn engine using Spring configuration '{}'", resource.toString());
                 initDmnEngineFromSpringResource(resource);
             }
 
             setInitialized(true);
         } else {
-            log.info("DMN engines already initialized");
+            LOGGER.info("DMN engines already initialized");
         }
     }
 
@@ -141,15 +141,15 @@ public abstract class DmnEngines {
 
         String resourceUrlString = resourceUrl.toString();
         try {
-            log.info("initializing dmn engine for resource {}", resourceUrl);
+            LOGGER.info("initializing dmn engine for resource {}", resourceUrl);
             DmnEngine dmnEngine = buildDmnEngine(resourceUrl);
             String dmnEngineName = dmnEngine.getName();
-            log.info("initialised dmn engine {}", dmnEngineName);
+            LOGGER.info("initialised dmn engine {}", dmnEngineName);
             dmnEngineInfo = new EngineInfo(dmnEngineName, resourceUrlString, null);
             dmnEngines.put(dmnEngineName, dmnEngine);
             dmnEngineInfosByName.put(dmnEngineName, dmnEngineInfo);
         } catch (Throwable e) {
-            log.error("Exception while initializing dmn engine: {}", e.getMessage(), e);
+            LOGGER.error("Exception while initializing dmn engine: {}", e.getMessage(), e);
             dmnEngineInfo = new EngineInfo(null, resourceUrlString, getExceptionString(e));
         }
         dmnEngineInfosByResourceUrl.put(resourceUrlString, dmnEngineInfo);
@@ -212,7 +212,7 @@ public abstract class DmnEngines {
      * retries to initialize a dmn engine that previously failed.
      */
     public static EngineInfo retry(String resourceUrl) {
-        log.debug("retying initializing of resource {}", resourceUrl);
+        LOGGER.debug("retying initializing of resource {}", resourceUrl);
         try {
             return initDmnEngineFromResource(new URL(resourceUrl));
         } catch (MalformedURLException e) {
@@ -240,7 +240,7 @@ public abstract class DmnEngines {
                 try {
                     dmnEngine.close();
                 } catch (Exception e) {
-                    log.error("exception while closing {}", (dmnEngineName == null ? "the default dmn engine" : "dmn engine " + dmnEngineName), e);
+                    LOGGER.error("exception while closing {}", (dmnEngineName == null ? "the default dmn engine" : "dmn engine " + dmnEngineName), e);
                 }
             }
 

--- a/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/DmnEngineImpl.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/DmnEngineImpl.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
  */
 public class DmnEngineImpl implements DmnEngine {
 
-    private static Logger log = LoggerFactory.getLogger(DmnEngineImpl.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DmnEngineImpl.class);
 
     protected String name;
     protected DmnManagementService dmnManagementService;
@@ -42,9 +42,9 @@ public class DmnEngineImpl implements DmnEngine {
         this.dmnRuleService = dmnEngineConfiguration.getDmnRuleService();
 
         if (name == null) {
-            log.info("default flowable DmnEngine created");
+            LOGGER.info("default flowable DmnEngine created");
         } else {
-            log.info("DmnEngine {} created", name);
+            LOGGER.info("DmnEngine {} created", name);
         }
 
         DmnEngines.registerDmnEngine(this);

--- a/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/cfg/standalone/StandaloneMybatisTransactionContext.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/cfg/standalone/StandaloneMybatisTransactionContext.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  */
 public class StandaloneMybatisTransactionContext implements TransactionContext {
 
-    private static Logger log = LoggerFactory.getLogger(StandaloneMybatisTransactionContext.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(StandaloneMybatisTransactionContext.class);
 
     protected CommandContext commandContext;
     protected Map<TransactionState, List<TransactionListener>> stateTransactionListeners;
@@ -58,12 +58,12 @@ public class StandaloneMybatisTransactionContext implements TransactionContext {
 
     public void commit() {
 
-        log.debug("firing event committing...");
+        LOGGER.debug("firing event committing...");
         fireTransactionEvent(TransactionState.COMMITTING, false);
 
-        log.debug("committing the ibatis sql session...");
+        LOGGER.debug("committing the ibatis sql session...");
         getDbSqlSession().commit();
-        log.debug("firing event committed...");
+        LOGGER.debug("firing event committed...");
         fireTransactionEvent(TransactionState.COMMITTED, true);
 
     }
@@ -115,23 +115,23 @@ public class StandaloneMybatisTransactionContext implements TransactionContext {
     public void rollback() {
         try {
             try {
-                log.debug("firing event rolling back...");
+                LOGGER.debug("firing event rolling back...");
                 fireTransactionEvent(TransactionState.ROLLINGBACK, false);
 
             } catch (Throwable exception) {
-                log.info("Exception during transaction: {}", exception.getMessage());
+                LOGGER.info("Exception during transaction: {}", exception.getMessage());
                 commandContext.exception(exception);
             } finally {
-                log.debug("rolling back ibatis sql session...");
+                LOGGER.debug("rolling back ibatis sql session...");
                 getDbSqlSession().rollback();
             }
 
         } catch (Throwable exception) {
-            log.info("Exception during transaction: {}", exception.getMessage());
+            LOGGER.info("Exception during transaction: {}", exception.getMessage());
             commandContext.exception(exception);
 
         } finally {
-            log.debug("firing event rolled back...");
+            LOGGER.debug("firing event rolled back...");
             fireTransactionEvent(TransactionState.ROLLED_BACK, true);
         }
     }

--- a/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/db/DbSqlSession.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/db/DbSqlSession.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
  */
 public class DbSqlSession extends AbstractNonCachingDbSqlSession {
 
-    private static final Logger log = LoggerFactory.getLogger(DbSqlSession.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DbSqlSession.class);
 
     public DbSqlSession(DbSqlSessionFactory dbSqlSessionFactory) {
         super(dbSqlSessionFactory);
@@ -39,7 +39,7 @@ public class DbSqlSession extends AbstractNonCachingDbSqlSession {
     // ////////////////////////////////////////////////////////
 
     public void dbSchemaCheckVersion() {
-        log.debug("flowable dmn db schema check successful");
+        LOGGER.debug("flowable dmn db schema check successful");
     }
 
     public void dbSchemaCreate() {

--- a/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/deployer/DmnDeployer.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/deployer/DmnDeployer.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  */
 public class DmnDeployer implements Deployer {
 
-    private static final Logger log = LoggerFactory.getLogger(DmnDeployer.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DmnDeployer.class);
 
     protected IdGenerator idGenerator;
     protected ParsedDeploymentBuilderFactory parsedDeploymentBuilderFactory;
@@ -39,7 +39,7 @@ public class DmnDeployer implements Deployer {
     protected CachingAndArtifactsManager cachingAndArtifactsManager;
 
     public void deploy(DmnDeploymentEntity deployment, Map<String, Object> deploymentSettings) {
-        log.debug("Processing deployment {}", deployment.getName());
+        LOGGER.debug("Processing deployment {}", deployment.getName());
 
         // The ParsedDeployment represents the deployment, the decision tables, and the DMN
         // resource, parse, and model associated with each decision table.

--- a/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/deployer/ParsedDeploymentBuilder.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/deployer/ParsedDeploymentBuilder.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
 
 public class ParsedDeploymentBuilder {
 
-    private static final Logger log = LoggerFactory.getLogger(ParsedDeploymentBuilder.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ParsedDeploymentBuilder.class);
 
     public static final String[] DMN_RESOURCE_SUFFIXES = new String[] { "dmn" };
 
@@ -51,7 +51,7 @@ public class ParsedDeploymentBuilder {
 
         for (ResourceEntity resource : deployment.getResources().values()) {
             if (isDmnResource(resource.getName())) {
-                log.debug("Processing DMN resource {}", resource.getName());
+                LOGGER.debug("Processing DMN resource {}", resource.getName());
                 DmnParse parse = createDmnParseFromResource(resource);
                 for (DecisionTableEntity decisionTable : parse.getDecisionTables()) {
                     decisionTables.add(decisionTable);

--- a/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/interceptor/CommandContext.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/interceptor/CommandContext.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  */
 public class CommandContext extends AbstractCommandContext {
 
-    private static Logger log = LoggerFactory.getLogger(CommandContext.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(CommandContext.class);
 
     protected DmnEngineConfiguration dmnEngineConfiguration;
 

--- a/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/interceptor/CommandContextInterceptor.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/interceptor/CommandContextInterceptor.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
  * @author Tijs Rademakers
  */
 public class CommandContextInterceptor extends AbstractCommandInterceptor {
-    private static final Logger log = LoggerFactory.getLogger(CommandContextInterceptor.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(CommandContextInterceptor.class);
 
     protected CommandContextFactory commandContextFactory;
     protected DmnEngineConfiguration dmnEngineConfiguration;
@@ -45,7 +45,7 @@ public class CommandContextInterceptor extends AbstractCommandInterceptor {
         if (!config.isContextReusePossible() || context == null || context.getException() != null) {
             context = commandContextFactory.createCommandContext(command);
         } else {
-            log.debug("Valid context found. Reusing it for the current command '{}'", command.getClass().getCanonicalName());
+            LOGGER.debug("Valid context found. Reusing it for the current command '{}'", command.getClass().getCanonicalName());
             contextReused = true;
             context.setReused(true);
         }

--- a/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/interceptor/LogInterceptor.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/interceptor/LogInterceptor.java
@@ -22,22 +22,22 @@ import org.slf4j.LoggerFactory;
  */
 public class LogInterceptor extends AbstractCommandInterceptor {
 
-    private static Logger log = LoggerFactory.getLogger(LogInterceptor.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(LogInterceptor.class);
 
     public <T> T execute(CommandConfig config, Command<T> command) {
-        if (!log.isDebugEnabled()) {
+        if (!LOGGER.isDebugEnabled()) {
             // do nothing here if we cannot log
             return next.execute(config, command);
         }
-        log.debug("\n");
-        log.debug("--- starting {} --------------------------------------------------------", command.getClass().getSimpleName());
+        LOGGER.debug("\n");
+        LOGGER.debug("--- starting {} --------------------------------------------------------", command.getClass().getSimpleName());
         try {
 
             return next.execute(config, command);
 
         } finally {
-            log.debug("--- {} finished --------------------------------------------------------", command.getClass().getSimpleName());
-            log.debug("\n");
+            LOGGER.debug("--- {} finished --------------------------------------------------------", command.getClass().getSimpleName());
+            LOGGER.debug("\n");
         }
     }
 }

--- a/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/persistence/entity/TableDataManagerImpl.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/persistence/entity/TableDataManagerImpl.java
@@ -44,7 +44,7 @@ public class TableDataManagerImpl extends AbstractManager implements TableDataMa
         super(dmnEngineConfiguration);
     }
 
-    private static Logger log = LoggerFactory.getLogger(TableDataManagerImpl.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TableDataManagerImpl.class);
 
     public static Map<Class<?>, String> apiTypeToTableNameMap = new HashMap<Class<?>, String>();
     public static Map<Class<? extends Entity>, String> entityToTableNameMap = new HashMap<Class<? extends Entity>, String>();
@@ -68,7 +68,7 @@ public class TableDataManagerImpl extends AbstractManager implements TableDataMa
             for (String tableName : getTablesPresentInDatabase()) {
                 tableCount.put(tableName, getTableCount(tableName));
             }
-            log.debug("Number of rows per flowable table: {}", tableCount);
+            LOGGER.debug("Number of rows per flowable table: {}", tableCount);
         } catch (Exception e) {
             throw new FlowableException("couldn't get table counts", e);
         }
@@ -84,7 +84,7 @@ public class TableDataManagerImpl extends AbstractManager implements TableDataMa
             DatabaseMetaData databaseMetaData = connection.getMetaData();
             ResultSet tables = null;
             try {
-                log.debug("retrieving flowable tables from jdbc metadata");
+                LOGGER.debug("retrieving flowable tables from jdbc metadata");
                 String databaseTablePrefix = getDbSqlSession().getDbSqlSessionFactory().getDatabaseTablePrefix();
                 String tableNameFilter = databaseTablePrefix + "ACT_%";
                 if ("postgres".equals(getDbSqlSession().getDbSqlSessionFactory().getDatabaseType())) {
@@ -113,7 +113,7 @@ public class TableDataManagerImpl extends AbstractManager implements TableDataMa
                     String tableName = tables.getString("TABLE_NAME");
                     tableName = tableName.toUpperCase();
                     tableNames.add(tableName);
-                    log.debug("  retrieved flowable table name {}", tableName);
+                    LOGGER.debug("  retrieved flowable table name {}", tableName);
                 }
             } finally {
                 tables.close();
@@ -125,7 +125,7 @@ public class TableDataManagerImpl extends AbstractManager implements TableDataMa
     }
 
     protected long getTableCount(String tableName) {
-        log.debug("selecting table count for {}", tableName);
+        LOGGER.debug("selecting table count for {}", tableName);
         Long count = (Long) getDbSqlSession().selectOne("org.flowable.dmn.engine.impl.TablePageMap.selectTableCount", Collections.singletonMap("tableName", tableName));
         return count;
     }

--- a/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/util/ReflectUtil.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/util/ReflectUtil.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class ReflectUtil {
 
-    private static final Logger LOG = LoggerFactory.getLogger(ReflectUtil.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ReflectUtil.class);
 
     private static final Pattern GETTER_PATTERN = Pattern.compile("(get|is)[A-Z].*");
     private static final Pattern SETTER_PATTERN = Pattern.compile("set[A-Z].*");
@@ -56,7 +56,7 @@ public abstract class ReflectUtil {
 
         if (classLoader != null) {
             try {
-                LOG.trace("Trying to load class with custom classloader: {}", className);
+                LOGGER.trace("Trying to load class with custom classloader: {}", className);
                 clazz = loadClass(classLoader, className);
             } catch (Throwable t) {
                 throwable = t;
@@ -64,7 +64,7 @@ public abstract class ReflectUtil {
         }
         if (clazz == null) {
             try {
-                LOG.trace("Trying to load class with current thread context classloader: {}", className);
+                LOGGER.trace("Trying to load class with current thread context classloader: {}", className);
                 clazz = loadClass(Thread.currentThread().getContextClassLoader(), className);
             } catch (Throwable t) {
                 if (throwable == null) {
@@ -73,7 +73,7 @@ public abstract class ReflectUtil {
             }
             if (clazz == null) {
                 try {
-                    LOG.trace("Trying to load class with local classloader: {}", className);
+                    LOGGER.trace("Trying to load class with local classloader: {}", className);
                     clazz = loadClass(ReflectUtil.class.getClassLoader(), className);
                 } catch (Throwable t) {
                     if (throwable == null) {

--- a/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/test/DmnTestHelper.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/test/DmnTestHelper.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class DmnTestHelper {
 
-    private static Logger log = LoggerFactory.getLogger(DmnTestHelper.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DmnTestHelper.class);
 
     public static final String EMPTY_LINE = "\n";
 
@@ -48,12 +48,12 @@ public abstract class DmnTestHelper {
         try {
             method = testClass.getMethod(methodName, (Class<?>[]) null);
         } catch (Exception e) {
-            log.warn("Could not get method by reflection. This could happen if you are using @Parameters in combination with annotations.", e);
+            LOGGER.warn("Could not get method by reflection. This could happen if you are using @Parameters in combination with annotations.", e);
             return null;
         }
         DmnDeploymentAnnotation deploymentAnnotation = method.getAnnotation(DmnDeploymentAnnotation.class);
         if (deploymentAnnotation != null) {
-            log.debug("annotation @Deployment creates deployment for {}.{}", testClass.getSimpleName(), methodName);
+            LOGGER.debug("annotation @Deployment creates deployment for {}.{}", testClass.getSimpleName(), methodName);
             String[] resources = deploymentAnnotation.resources();
             if (resources.length == 0) {
                 String name = method.getName();
@@ -74,7 +74,7 @@ public abstract class DmnTestHelper {
     }
 
     public static void annotationDeploymentTearDown(DmnEngine dmnEngine, String deploymentId, Class<?> testClass, String methodName) {
-        log.debug("annotation @Deployment deletes deployment for {}.{}", testClass.getSimpleName(), methodName);
+        LOGGER.debug("annotation @Deployment deletes deployment for {}.{}", testClass.getSimpleName(), methodName);
         if (deploymentId != null) {
             try {
                 dmnEngine.getDmnRepositoryService().deleteDeployment(deploymentId);
@@ -107,9 +107,9 @@ public abstract class DmnTestHelper {
     public static DmnEngine getDmnEngine(String configurationResource) {
         DmnEngine dmnEngine = dmnEngines.get(configurationResource);
         if (dmnEngine == null) {
-            log.debug("==== BUILDING DMN ENGINE ========================================================================");
+            LOGGER.debug("==== BUILDING DMN ENGINE ========================================================================");
             dmnEngine = DmnEngineConfiguration.createDmnEngineConfigurationFromResource(configurationResource).setDatabaseSchemaUpdate(DmnEngineConfiguration.DB_SCHEMA_UPDATE_DROP_CREATE).buildDmnEngine();
-            log.debug("==== DMN ENGINE CREATED =========================================================================");
+            LOGGER.debug("==== DMN ENGINE CREATED =========================================================================");
             dmnEngines.put(configurationResource, dmnEngine);
         }
         return dmnEngine;
@@ -127,7 +127,7 @@ public abstract class DmnTestHelper {
      * the DB is not clean. If the DB is not clean, it is cleaned by performing a create a drop.
      */
     public static void assertAndEnsureCleanDb(DmnEngine dmnEngine) {
-        log.debug("verifying that db is clean after test");
+        LOGGER.debug("verifying that db is clean after test");
         DmnRepositoryService repositoryService = dmnEngine.getDmnEngineConfiguration().getDmnRepositoryService();
         List<DmnDeployment> deployments = repositoryService.createDeploymentQuery().list();
         if (deployments != null && !deployments.isEmpty()) {

--- a/modules/flowable-dmn-rest/src/test/java/org/flowable/rest/dmn/service/api/BaseSpringDmnRestTestCase.java
+++ b/modules/flowable-dmn-rest/src/test/java/org/flowable/rest/dmn/service/api/BaseSpringDmnRestTestCase.java
@@ -12,6 +12,11 @@
  */
 package org.flowable.rest.dmn.service.api;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -55,16 +60,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import junit.framework.AssertionFailedError;
 
 public abstract class BaseSpringDmnRestTestCase extends AbstractDmnTestCase {
 
-    private static Logger log = LoggerFactory.getLogger(BaseSpringDmnRestTestCase.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(BaseSpringDmnRestTestCase.class);
 
     protected static String SERVER_URL_PREFIX;
     protected static DmnRestUrlBuilder URL_BUILDER;
@@ -115,7 +115,7 @@ public abstract class BaseSpringDmnRestTestCase extends AbstractDmnTestCase {
                     try {
                         client.close();
                     } catch (IOException e) {
-                        log.error("Could not close http client", e);
+                        LOGGER.error("Could not close http client", e);
                     }
                 }
 
@@ -123,7 +123,7 @@ public abstract class BaseSpringDmnRestTestCase extends AbstractDmnTestCase {
                     try {
                         server.stop();
                     } catch (Exception e) {
-                        log.error("Error stopping server", e);
+                        LOGGER.error("Error stopping server", e);
                     }
                 }
             }
@@ -137,14 +137,14 @@ public abstract class BaseSpringDmnRestTestCase extends AbstractDmnTestCase {
 
             super.runBare();
         } catch (AssertionFailedError e) {
-            log.error(EMPTY_LINE);
-            log.error("ASSERTION FAILED: {}", e, e);
+            LOGGER.error(EMPTY_LINE);
+            LOGGER.error("ASSERTION FAILED: {}", e, e);
             exception = e;
             throw e;
 
         } catch (Throwable e) {
-            log.error(EMPTY_LINE);
-            log.error("EXCEPTION: {}", e, e);
+            LOGGER.error(EMPTY_LINE);
+            LOGGER.error("EXCEPTION: {}", e, e);
             exception = e;
             throw e;
 
@@ -182,8 +182,8 @@ public abstract class BaseSpringDmnRestTestCase extends AbstractDmnTestCase {
 
             int responseStatusCode = response.getStatusLine().getStatusCode();
             if (expectedStatusCode != responseStatusCode) {
-                log.info("Wrong status code : {}, but should be {}", responseStatusCode, expectedStatusCode);
-                log.info("Response body: {}", IOUtils.toString(response.getEntity().getContent()));
+                LOGGER.info("Wrong status code : {}, but should be {}", responseStatusCode, expectedStatusCode);
+                LOGGER.info("Response body: {}", IOUtils.toString(response.getEntity().getContent()));
             }
 
             Assert.assertEquals(expectedStatusCode, responseStatusCode);
@@ -214,7 +214,7 @@ public abstract class BaseSpringDmnRestTestCase extends AbstractDmnTestCase {
                 try {
                     response.close();
                 } catch (IOException e) {
-                    log.error("Could not close http connection", e);
+                    LOGGER.error("Could not close http connection", e);
                 }
             }
         }

--- a/modules/flowable-dmn-rest/src/test/java/org/flowable/rest/dmn/util/TestServerUtil.java
+++ b/modules/flowable-dmn-rest/src/test/java/org/flowable/rest/dmn/util/TestServerUtil.java
@@ -12,6 +12,9 @@
  */
 package org.flowable.rest.dmn.util;
 
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.session.HashSessionIdManager;
 import org.eclipse.jetty.server.session.HashSessionManager;
@@ -20,19 +23,15 @@ import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.flowable.rest.dmn.WebConfigurer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.springframework.context.ApplicationContext;
 import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
-
-import java.io.IOException;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * @author Joram Barrez
  */
 public class TestServerUtil {
 
-    private static final Logger log = LoggerFactory.getLogger(TestServerUtil.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestServerUtil.class);
 
     protected static final int START_PORT = 9797;
     private static AtomicInteger NEXT_PORT = new AtomicInteger(9797);
@@ -52,7 +51,7 @@ public class TestServerUtil {
             server.setHandler(getServletContextHandler(applicationContext));
             server.start();
         } catch (Exception e) {
-            log.error("Error starting server", e);
+            LOGGER.error("Error starting server", e);
         }
 
         return new TestServer(server, applicationContext, port);

--- a/modules/flowable-dmn-spring/src/main/java/org/flowable/dmn/spring/SpringDmnConfigurationHelper.java
+++ b/modules/flowable-dmn-spring/src/main/java/org/flowable/dmn/spring/SpringDmnConfigurationHelper.java
@@ -29,10 +29,10 @@ import org.springframework.core.io.UrlResource;
  */
 public class SpringDmnConfigurationHelper {
 
-    private static Logger log = LoggerFactory.getLogger(SpringDmnConfigurationHelper.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SpringDmnConfigurationHelper.class);
 
     public static DmnEngine buildDmnEngine(URL resource) {
-        log.debug("==== BUILDING SPRING APPLICATION CONTEXT AND DMN ENGINE =========================================");
+        LOGGER.debug("==== BUILDING SPRING APPLICATION CONTEXT AND DMN ENGINE =========================================");
 
         ApplicationContext applicationContext = new GenericXmlApplicationContext(new UrlResource(resource));
         Map<String, DmnEngine> beansOfType = applicationContext.getBeansOfType(DmnEngine.class);
@@ -42,7 +42,7 @@ public class SpringDmnConfigurationHelper {
 
         DmnEngine dmnEngine = beansOfType.values().iterator().next();
 
-        log.debug("==== SPRING DMN ENGINE CREATED ==================================================================");
+        LOGGER.debug("==== SPRING DMN ENGINE CREATED ==================================================================");
         return dmnEngine;
     }
 

--- a/modules/flowable-engine-common/src/main/java/org/flowable/engine/common/impl/interceptor/AbstractCommandContext.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/engine/common/impl/interceptor/AbstractCommandContext.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
  */
 public class AbstractCommandContext {
 
-    private static Logger log = LoggerFactory.getLogger(AbstractCommandContext.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractCommandContext.class);
 
     protected BaseCommand<?, ? extends AbstractCommandContext> command;
     protected Map<Class<?>, SessionFactory> sessionFactories;
@@ -99,9 +99,9 @@ public class AbstractCommandContext {
         
         if (exception instanceof FlowableOptimisticLockingException) {
             // reduce log level, as normally we're not interested in logging this exception
-            log.debug("Optimistic locking exception : {}", exception.getMessage(), exception);
+            LOGGER.debug("Optimistic locking exception : {}", exception.getMessage(), exception);
         } else {
-            log.error("Error while closing command context", exception);
+            LOGGER.error("Error while closing command context", exception);
         }
     }
 
@@ -200,7 +200,7 @@ public class AbstractCommandContext {
             this.exception = exception;
 
         } else {
-            log.error("masked exception in command context. for root cause, see below as it will be rethrown later.", exception);
+            LOGGER.error("masked exception in command context. for root cause, see below as it will be rethrown later.", exception);
         }
     }
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/ProcessEngines.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/ProcessEngines.java
@@ -54,7 +54,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class ProcessEngines {
 
-    private static Logger log = LoggerFactory.getLogger(ProcessEngines.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProcessEngines.class);
 
     public static final String NAME_DEFAULT = "default";
 
@@ -92,7 +92,7 @@ public abstract class ProcessEngines {
             }
             for (Iterator<URL> iterator = configUrls.iterator(); iterator.hasNext();) {
                 URL resource = iterator.next();
-                log.info("Initializing process engine using configuration '{}'", resource.toString());
+                LOGGER.info("Initializing process engine using configuration '{}'", resource.toString());
                 initProcessEngineFromResource(resource);
             }
 
@@ -103,13 +103,13 @@ public abstract class ProcessEngines {
             }
             while (resources.hasMoreElements()) {
                 URL resource = resources.nextElement();
-                log.info("Initializing process engine using Spring configuration '{}'", resource.toString());
+                LOGGER.info("Initializing process engine using Spring configuration '{}'", resource.toString());
                 initProcessEngineFromSpringResource(resource);
             }
 
             setInitialized(true);
         } else {
-            log.info("Process engines already initialized");
+            LOGGER.info("Process engines already initialized");
         }
     }
 
@@ -160,15 +160,15 @@ public abstract class ProcessEngines {
 
         String resourceUrlString = resourceUrl.toString();
         try {
-            log.info("initializing process engine for resource {}", resourceUrl);
+            LOGGER.info("initializing process engine for resource {}", resourceUrl);
             ProcessEngine processEngine = buildProcessEngine(resourceUrl);
             String processEngineName = processEngine.getName();
-            log.info("initialised process engine {}", processEngineName);
+            LOGGER.info("initialised process engine {}", processEngineName);
             processEngineInfo = new EngineInfo(processEngineName, resourceUrlString, null);
             processEngines.put(processEngineName, processEngine);
             processEngineInfosByName.put(processEngineName, processEngineInfo);
         } catch (Throwable e) {
-            log.error("Exception while initializing process engine: {}", e.getMessage(), e);
+            LOGGER.error("Exception while initializing process engine: {}", e.getMessage(), e);
             processEngineInfo = new EngineInfo(null, resourceUrlString, getExceptionString(e));
         }
         processEngineInfosByResourceUrl.put(resourceUrlString, processEngineInfo);
@@ -231,7 +231,7 @@ public abstract class ProcessEngines {
      * retries to initialize a process engine that previously failed.
      */
     public static EngineInfo retry(String resourceUrl) {
-        log.debug("retying initializing of resource {}", resourceUrl);
+        LOGGER.debug("retying initializing of resource {}", resourceUrl);
         try {
             return initProcessEngineFromResource(new URL(resourceUrl));
         } catch (MalformedURLException e) {
@@ -259,7 +259,7 @@ public abstract class ProcessEngines {
                 try {
                     processEngine.close();
                 } catch (Exception e) {
-                    log.error("exception while closing {}", (processEngineName == null ? "the default process engine" : "process engine " + processEngineName), e);
+                    LOGGER.error("exception while closing {}", (processEngineName == null ? "the default process engine" : "process engine " + processEngineName), e);
                 }
             }
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/impl/FlowableEventSupport.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/impl/FlowableEventSupport.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
  */
 public class FlowableEventSupport {
 
-    private static final Logger LOG = LoggerFactory.getLogger(FlowableEventSupport.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(FlowableEventSupport.class);
 
     protected List<FlowableEventListener> eventListeners;
     protected Map<FlowableEventType, List<FlowableEventListener>> typedListeners;
@@ -108,7 +108,7 @@ public class FlowableEventSupport {
             } else {
                 // Ignore the exception and continue notifying remaining listeners. The listener
                 // explicitly states that the exception should not bubble up
-                LOG.warn("Exception while executing event-listener, which was ignored", t);
+                LOGGER.warn("Exception while executing event-listener, which was ignored", t);
             }
         }
     }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/ProcessEngineImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/ProcessEngineImpl.java
@@ -46,7 +46,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ProcessEngineImpl implements ProcessEngine {
 
-    private static Logger log = LoggerFactory.getLogger(ProcessEngineImpl.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProcessEngineImpl.class);
 
     protected String name;
     protected RepositoryService repositoryService;
@@ -98,9 +98,9 @@ public class ProcessEngineImpl implements ProcessEngine {
         }
 
         if (name == null) {
-            log.info("default ProcessEngine created");
+            LOGGER.info("default ProcessEngine created");
         } else {
-            log.info("ProcessEngine {} created", name);
+            LOGGER.info("ProcessEngine {} created", name);
         }
 
         ProcessEngines.registerProcessEngine(this);

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/agenda/ContinueMultiInstanceOperation.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/agenda/ContinueMultiInstanceOperation.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ContinueMultiInstanceOperation extends AbstractOperation {
 
-    private static Logger logger = LoggerFactory.getLogger(ContinueMultiInstanceOperation.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ContinueMultiInstanceOperation.class);
     
     protected int loopCounter;
 
@@ -78,7 +78,7 @@ public class ContinueMultiInstanceOperation extends AbstractOperation {
         
         // Execute actual behavior
         ActivityBehavior activityBehavior = (ActivityBehavior) flowNode.getBehavior();
-        logger.debug("Executing activityBehavior {} on activity '{}' with execution {}", activityBehavior.getClass(), flowNode.getId(), execution.getId());
+        LOGGER.debug("Executing activityBehavior {} on activity '{}' with execution {}", activityBehavior.getClass(), flowNode.getId(), execution.getId());
 
         if (Context.getProcessEngineConfiguration() != null && Context.getProcessEngineConfiguration().getEventDispatcher().isEnabled()) {
             Context.getProcessEngineConfiguration().getEventDispatcher().dispatchEvent(

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/agenda/ContinueProcessOperation.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/agenda/ContinueProcessOperation.java
@@ -49,7 +49,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ContinueProcessOperation extends AbstractOperation {
 
-    private static Logger logger = LoggerFactory.getLogger(ContinueProcessOperation.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ContinueProcessOperation.class);
 
     protected boolean forceSynchronousOperation;
     protected boolean inCompensation;
@@ -152,7 +152,7 @@ public class ContinueProcessOperation extends AbstractOperation {
             executeActivityBehavior(activityBehavior, flowNode);
 
         } else {
-            logger.debug("No activityBehavior on activity '{}' with execution {}", flowNode.getId(), execution.getId());
+            LOGGER.debug("No activityBehavior on activity '{}' with execution {}", flowNode.getId(), execution.getId());
             Context.getAgenda().planTakeOutgoingSequenceFlowsOperation(execution, true);
         }
     }
@@ -219,7 +219,7 @@ public class ContinueProcessOperation extends AbstractOperation {
     }
 
     protected void executeActivityBehavior(ActivityBehavior activityBehavior, FlowNode flowNode) {
-        logger.debug("Executing activityBehavior {} on activity '{}' with execution {}", activityBehavior.getClass(), flowNode.getId(), execution.getId());
+        LOGGER.debug("Executing activityBehavior {} on activity '{}' with execution {}", activityBehavior.getClass(), flowNode.getId(), execution.getId());
 
         if (Context.getProcessEngineConfiguration() != null && Context.getProcessEngineConfiguration().getEventDispatcher().isEnabled()) {
             Context.getProcessEngineConfiguration().getEventDispatcher().dispatchEvent(
@@ -268,7 +268,7 @@ public class ContinueProcessOperation extends AbstractOperation {
         FlowElement targetFlowElement = sequenceFlow.getTargetFlowElement();
         execution.setCurrentFlowElement(targetFlowElement);
 
-        logger.debug("Sequence flow '{}' encountered. Continuing process by following it using execution {}", sequenceFlow.getId(), execution.getId());
+        LOGGER.debug("Sequence flow '{}' encountered. Continuing process by following it using execution {}", sequenceFlow.getId(), execution.getId());
         
         execution.setActive(false);
         //agenda.planContinueProcessOperation(execution);
@@ -297,7 +297,7 @@ public class ContinueProcessOperation extends AbstractOperation {
             childExecutionEntity.setScope(false);
 
             ActivityBehavior boundaryEventBehavior = ((ActivityBehavior) boundaryEvent.getBehavior());
-            logger.debug("Executing boundary event activityBehavior {} with execution {}", boundaryEventBehavior.getClass(), childExecutionEntity.getId());
+            LOGGER.debug("Executing boundary event activityBehavior {} with execution {}", boundaryEventBehavior.getClass(), childExecutionEntity.getId());
             boundaryEventBehavior.execute(childExecutionEntity);
         }
     }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/app/AppDeployer.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/app/AppDeployer.java
@@ -29,10 +29,10 @@ import org.slf4j.LoggerFactory;
  */
 public class AppDeployer implements Deployer {
 
-    private static final Logger log = LoggerFactory.getLogger(AppDeployer.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AppDeployer.class);
 
     public void deploy(DeploymentEntity deployment, Map<String, Object> deploymentSettings) {
-        log.debug("Processing app deployment {}", deployment.getName());
+        LOGGER.debug("Processing app deployment {}", deployment.getName());
 
         ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
         DeploymentManager deploymentManager = processEngineConfiguration.getDeploymentManager();
@@ -41,7 +41,7 @@ public class AppDeployer implements Deployer {
         Map<String, ResourceEntity> resources = deployment.getResources();
         for (String resourceName : resources.keySet()) {
             if (resourceName.endsWith(".app")) {
-                log.info("Processing app resource {}", resourceName);
+                LOGGER.info("Processing app resource {}", resourceName);
 
                 ResourceEntity resourceEntity = resources.get(resourceName);
                 byte[] resourceBytes = resourceEntity.getBytes();

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/asyncexecutor/AbstractAsyncExecutor.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/asyncexecutor/AbstractAsyncExecutor.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class AbstractAsyncExecutor implements AsyncExecutor {
 
-    private static Logger log = LoggerFactory.getLogger(AbstractAsyncExecutor.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractAsyncExecutor.class);
 
     protected boolean timerRunnableNeeded = true; // default true for backwards compatibility (History Async executor came later)
     protected AcquireTimerJobsRunnable timerJobRunnable;
@@ -110,7 +110,7 @@ public abstract class AbstractAsyncExecutor implements AsyncExecutor {
 
         isActive = true;
 
-        log.info("Starting up the async job executor [{}].", getClass().getName());
+        LOGGER.info("Starting up the async job executor [{}].", getClass().getName());
 
         initializeJobEntityManager();
         initializeRunnables();
@@ -157,7 +157,7 @@ public abstract class AbstractAsyncExecutor implements AsyncExecutor {
         if (!isActive) {
             return;
         }
-        log.info("Shutting down the async job executor [{}].", getClass().getName());
+        LOGGER.info("Shutting down the async job executor [{}].", getClass().getName());
 
         stopRunnables();
         shutdownAdditionalComponents();

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/asyncexecutor/AcquireAsyncJobsDueRunnable.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/asyncexecutor/AcquireAsyncJobsDueRunnable.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
  */
 public class AcquireAsyncJobsDueRunnable implements Runnable {
 
-    private static Logger log = LoggerFactory.getLogger(AcquireAsyncJobsDueRunnable.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AcquireAsyncJobsDueRunnable.class);
 
     protected String name;
     protected final AsyncExecutor asyncExecutor;
@@ -48,7 +48,7 @@ public class AcquireAsyncJobsDueRunnable implements Runnable {
     }
 
     public synchronized void run() {
-        log.info("starting to acquire async jobs due");
+        LOGGER.info("starting to acquire async jobs due");
         Thread.currentThread().setName(name);
 
         CommandExecutor commandExecutor = asyncExecutor.getProcessEngineConfiguration().getCommandExecutor();
@@ -60,14 +60,14 @@ public class AcquireAsyncJobsDueRunnable implements Runnable {
             if (remainingCapacity > 0) {
                 millisToWait = acquireAndExecuteJobs(commandExecutor, remainingCapacity);
 
-                if (log.isDebugEnabled()) {
-                    log.debug("acquired and queued new jobs; sleeping for {} ms", millisToWait);
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("acquired and queued new jobs; sleeping for {} ms", millisToWait);
                 }
             } else {
                 millisToWait = asyncExecutor.getDefaultAsyncJobAcquireWaitTimeInMillis();
 
-                if (log.isDebugEnabled()) {
-                    log.debug("queue is full; sleeping for {} ms", millisToWait);
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("queue is full; sleeping for {} ms", millisToWait);
                 }
             }
 
@@ -75,7 +75,7 @@ public class AcquireAsyncJobsDueRunnable implements Runnable {
                 sleep(millisToWait);
             }
         }
-        log.info("stopped async job due acquisition");
+        LOGGER.info("stopped async job due acquisition");
     }
 
     protected long acquireAndExecuteJobs(CommandExecutor commandExecutor, int remainingCapacity) {
@@ -84,7 +84,7 @@ public class AcquireAsyncJobsDueRunnable implements Runnable {
 
             List<JobInfoEntity> rejectedJobs = offerJobs(acquiredJobs);
 
-            log.debug("Jobs acquired: {}, rejected: {}", acquiredJobs.size(), rejectedJobs.size());
+            LOGGER.debug("Jobs acquired: {}, rejected: {}", acquiredJobs.size(), rejectedJobs.size());
             if (rejectedJobs.size() > 0) {
                 // some jobs were rejected, so the queue was full; wait until attempting to acquire more.
                 return asyncExecutor.getDefaultQueueSizeFullWaitTimeInMillis();
@@ -95,15 +95,15 @@ public class AcquireAsyncJobsDueRunnable implements Runnable {
             }
 
         } catch (FlowableOptimisticLockingException optimisticLockingException) {
-            if (log.isDebugEnabled()) {
-                log.debug("Optimistic locking exception during async job acquisition. If you have multiple async executors running against the same database, "
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Optimistic locking exception during async job acquisition. If you have multiple async executors running against the same database, "
                         + "this exception means that this thread tried to acquire a due async job, which already was acquired by another async executor acquisition thread."
                         + "This is expected behavior in a clustered environment. "
                         + "You can ignore this message if you indeed have multiple async executor acquisition threads running against the same database. " + "Exception message: {}",
                         optimisticLockingException.getMessage());
             }
         } catch (Throwable e) {
-            log.error("exception during async job acquisition: {}", e.getMessage(), e);
+            LOGGER.error("exception during async job acquisition: {}", e.getMessage(), e);
         }
 
         return asyncExecutor.getDefaultAsyncJobAcquireWaitTimeInMillis();
@@ -132,8 +132,8 @@ public class AcquireAsyncJobsDueRunnable implements Runnable {
     protected void sleep(long millisToWait) {
         if (millisToWait > 0) {
             try {
-                if (log.isDebugEnabled()) {
-                    log.debug("async job acquisition thread sleeping for {} millis", millisToWait);
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("async job acquisition thread sleeping for {} millis", millisToWait);
                 }
                 synchronized (MONITOR) {
                     if (!isInterrupted) {
@@ -142,12 +142,12 @@ public class AcquireAsyncJobsDueRunnable implements Runnable {
                     }
                 }
 
-                if (log.isDebugEnabled()) {
-                    log.debug("async job acquisition thread woke up");
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("async job acquisition thread woke up");
                 }
             } catch (InterruptedException e) {
-                if (log.isDebugEnabled()) {
-                    log.debug("async job acquisition wait interrupted");
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("async job acquisition wait interrupted");
                 }
             } finally {
                 isWaiting.set(false);

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/asyncexecutor/AcquireTimerJobsRunnable.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/asyncexecutor/AcquireTimerJobsRunnable.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
  */
 public class AcquireTimerJobsRunnable implements Runnable {
 
-    private static Logger log = LoggerFactory.getLogger(AcquireTimerJobsRunnable.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AcquireTimerJobsRunnable.class);
 
     protected final AsyncExecutor asyncExecutor;
     protected final JobManager jobManager;
@@ -46,7 +46,7 @@ public class AcquireTimerJobsRunnable implements Runnable {
     }
 
     public synchronized void run() {
-        log.info("starting to acquire async jobs due");
+        LOGGER.info("starting to acquire async jobs due");
         Thread.currentThread().setName("flowable-acquire-timer-jobs");
 
         final CommandExecutor commandExecutor = asyncExecutor.getProcessEngineConfiguration().getCommandExecutor();
@@ -75,22 +75,22 @@ public class AcquireTimerJobsRunnable implements Runnable {
                 }
 
             } catch (FlowableOptimisticLockingException optimisticLockingException) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Optimistic locking exception during timer job acquisition. If you have multiple timer executors running against the same database, "
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("Optimistic locking exception during timer job acquisition. If you have multiple timer executors running against the same database, "
                             + "this exception means that this thread tried to acquire a timer job, which already was acquired by another timer executor acquisition thread."
                             + "This is expected behavior in a clustered environment. "
                             + "You can ignore this message if you indeed have multiple timer executor acquisition threads running against the same database. " + "Exception message: {}",
                             optimisticLockingException.getMessage());
                 }
             } catch (Throwable e) {
-                log.error("exception during timer job acquisition: {}", e.getMessage(), e);
+                LOGGER.error("exception during timer job acquisition: {}", e.getMessage(), e);
                 millisToWait = asyncExecutor.getDefaultTimerJobAcquireWaitTimeInMillis();
             }
 
             if (millisToWait > 0) {
                 try {
-                    if (log.isDebugEnabled()) {
-                        log.debug("timer job acquisition thread sleeping for {} millis", millisToWait);
+                    if (LOGGER.isDebugEnabled()) {
+                        LOGGER.debug("timer job acquisition thread sleeping for {} millis", millisToWait);
                     }
                     synchronized (MONITOR) {
                         if (!isInterrupted) {
@@ -99,12 +99,12 @@ public class AcquireTimerJobsRunnable implements Runnable {
                         }
                     }
 
-                    if (log.isDebugEnabled()) {
-                        log.debug("timer job acquisition thread woke up");
+                    if (LOGGER.isDebugEnabled()) {
+                        LOGGER.debug("timer job acquisition thread woke up");
                     }
                 } catch (InterruptedException e) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("timer job acquisition wait interrupted");
+                    if (LOGGER.isDebugEnabled()) {
+                        LOGGER.debug("timer job acquisition wait interrupted");
                     }
                 } finally {
                     isWaiting.set(false);
@@ -112,7 +112,7 @@ public class AcquireTimerJobsRunnable implements Runnable {
             }
         }
 
-        log.info("stopped async job due acquisition");
+        LOGGER.info("stopped async job due acquisition");
     }
 
     public void stop() {

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/asyncexecutor/DefaultAsyncJobExecutor.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/asyncexecutor/DefaultAsyncJobExecutor.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
  */
 public class DefaultAsyncJobExecutor extends AbstractAsyncExecutor {
 
-    private static Logger log = LoggerFactory.getLogger(DefaultAsyncJobExecutor.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultAsyncJobExecutor.class);
 
     protected Thread timerJobAcquisitionThread;
     protected Thread asyncJobAcquisitionThread;
@@ -133,12 +133,12 @@ public class DefaultAsyncJobExecutor extends AbstractAsyncExecutor {
 
     protected void initAsyncJobExecutionThreadPool() {
         if (threadPoolQueue == null) {
-            log.info("Creating thread pool queue of size {}", queueSize);
+            LOGGER.info("Creating thread pool queue of size {}", queueSize);
             threadPoolQueue = new ArrayBlockingQueue<Runnable>(queueSize);
         }
 
         if (executorService == null) {
-            log.info("Creating executor service with corePoolSize {}, maxPoolSize {} and keepAliveTime {}", corePoolSize, maxPoolSize, keepAliveTime);
+            LOGGER.info("Creating executor service with corePoolSize {}, maxPoolSize {} and keepAliveTime {}", corePoolSize, maxPoolSize, keepAliveTime);
 
             BasicThreadFactory threadFactory = new BasicThreadFactory.Builder().namingPattern("flowable-async-job-executor-thread-%d").build();
             executorService = new ThreadPoolExecutor(corePoolSize, maxPoolSize, keepAliveTime, TimeUnit.MILLISECONDS, threadPoolQueue, threadFactory);
@@ -154,10 +154,10 @@ public class DefaultAsyncJobExecutor extends AbstractAsyncExecutor {
             // Waits for 1 minute to finish all currently executing jobs
             try {
                 if (!executorService.awaitTermination(secondsToWaitOnShutdown, TimeUnit.SECONDS)) {
-                    log.warn("Timeout during shutdown of async job executor. The current running jobs could not end within {} seconds after shutdown operation.", secondsToWaitOnShutdown);
+                    LOGGER.warn("Timeout during shutdown of async job executor. The current running jobs could not end within {} seconds after shutdown operation.", secondsToWaitOnShutdown);
                 }
             } catch (InterruptedException e) {
-                log.warn("Interrupted while shutting down the async job executor. ", e);
+                LOGGER.warn("Interrupted while shutting down the async job executor. ", e);
             }
 
             executorService = null;
@@ -185,7 +185,7 @@ public class DefaultAsyncJobExecutor extends AbstractAsyncExecutor {
             try {
                 asyncJobAcquisitionThread.join();
             } catch (InterruptedException e) {
-                log.warn("Interrupted while waiting for the async job acquisition thread to terminate", e);
+                LOGGER.warn("Interrupted while waiting for the async job acquisition thread to terminate", e);
             }
             asyncJobAcquisitionThread = null;
         }
@@ -196,7 +196,7 @@ public class DefaultAsyncJobExecutor extends AbstractAsyncExecutor {
             try {
                 timerJobAcquisitionThread.join();
             } catch (InterruptedException e) {
-                log.warn("Interrupted while waiting for the timer job acquisition thread to terminate", e);
+                LOGGER.warn("Interrupted while waiting for the timer job acquisition thread to terminate", e);
             }
             timerJobAcquisitionThread = null;
         }
@@ -216,7 +216,7 @@ public class DefaultAsyncJobExecutor extends AbstractAsyncExecutor {
             try {
                 resetExpiredJobThread.join();
             } catch (InterruptedException e) {
-                log.warn("Interrupted while waiting for the reset expired jobs thread to terminate", e);
+                LOGGER.warn("Interrupted while waiting for the reset expired jobs thread to terminate", e);
             }
 
             resetExpiredJobThread = null;

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/asyncexecutor/DefaultJobManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/asyncexecutor/DefaultJobManager.java
@@ -68,7 +68,7 @@ import org.slf4j.LoggerFactory;
 
 public class DefaultJobManager implements JobManager {
 
-    private static Logger logger = LoggerFactory.getLogger(DefaultJobManager.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultJobManager.class);
 
     protected ProcessEngineConfigurationImpl processEngineConfiguration;
 
@@ -403,8 +403,8 @@ public class DefaultJobManager implements JobManager {
         restoreExtraData(timerEntity, variableScope);
 
         if (timerEntity.getDuedate() != null && !isValidTime(timerEntity, timerEntity.getDuedate(), variableScope)) {
-            if (logger.isDebugEnabled()) {
-                logger.debug("Timer {} fired. but the dueDate is after the endDate.  Deleting timer.", timerEntity.getId());
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Timer {} fired. but the dueDate is after the endDate.  Deleting timer.", timerEntity.getId());
             }
             processEngineConfiguration.getJobEntityManager().delete(timerEntity);
             return;
@@ -413,8 +413,8 @@ public class DefaultJobManager implements JobManager {
         executeJobHandler(timerEntity);
         processEngineConfiguration.getJobEntityManager().delete(timerEntity);
 
-        if (logger.isDebugEnabled()) {
-            logger.debug("Timer {} fired. Deleting timer.", timerEntity.getId());
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Timer {} fired. Deleting timer.", timerEntity.getId());
         }
 
         if (timerEntity.getRepeat() != null) {

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/asyncexecutor/ExecuteAsyncRunnable.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/asyncexecutor/ExecuteAsyncRunnable.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ExecuteAsyncRunnable implements Runnable {
 
-    private static Logger log = LoggerFactory.getLogger(ExecuteAsyncRunnable.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExecuteAsyncRunnable.class);
 
     protected String jobId;
     protected JobInfo job;
@@ -123,8 +123,8 @@ public class ExecuteAsyncRunnable implements Runnable {
 
             handleFailedJob(e);
 
-            if (log.isDebugEnabled()) {
-                log.debug("Optimistic locking exception during job execution. If you have multiple async executors running against the same database, "
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Optimistic locking exception during job execution. If you have multiple async executors running against the same database, "
                         + "this exception means that this thread tried to acquire an exclusive job, which already was changed by another async executor thread."
                         + "This is expected behavior in a clustered environment. " + "You can ignore this message if you indeed have multiple job executor threads running against the same database. "
                         + "Exception message: {}", e.getMessage());
@@ -143,15 +143,15 @@ public class ExecuteAsyncRunnable implements Runnable {
             }
 
         } catch (FlowableOptimisticLockingException optimisticLockingException) {
-            if (log.isDebugEnabled()) {
-                log.debug("Optimistic locking exception while unlocking the job. If you have multiple async executors running against the same database, "
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Optimistic locking exception while unlocking the job. If you have multiple async executors running against the same database, "
                         + "this exception means that this thread tried to acquire an exclusive job, which already was changed by another async executor thread."
                         + "This is expected behavior in a clustered environment. " + "You can ignore this message if you indeed have multiple job executor acquisition threads running against the same database. "
                         + "Exception message: {}", optimisticLockingException.getMessage());
             }
 
         } catch (Throwable t) {
-            log.error("Error while unlocking exclusive job {}", job.getId(), t);
+            LOGGER.error("Error while unlocking exclusive job {}", job.getId(), t);
         }
     }
 
@@ -166,8 +166,8 @@ public class ExecuteAsyncRunnable implements Runnable {
             }
 
         } catch (Throwable lockException) {
-            if (log.isDebugEnabled()) {
-                log.debug("Could not lock exclusive job. Unlocking job so it can be acquired again. Caught exception: {}", lockException.getMessage());
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Could not lock exclusive job. Unlocking job so it can be acquired again. Caught exception: {}", lockException.getMessage());
             }
 
             // Release the job again so it can be acquired later or by another node
@@ -215,7 +215,7 @@ public class ExecuteAsyncRunnable implements Runnable {
                 
                 // Finally, Throw the exception to indicate the ExecuteAsyncJobCmd failed
                 String message = "Job " + jobId + " failed";
-                log.error(message, exception);
+                LOGGER.error(message, exception);
                 
                 if (job instanceof AbstractRuntimeJobEntity) {
                     AbstractRuntimeJobEntity runtimeJob = (AbstractRuntimeJobEntity) job;
@@ -230,7 +230,7 @@ public class ExecuteAsyncRunnable implements Runnable {
                 FailedJobCommandFactory failedJobCommandFactory = commandContext.getFailedJobCommandFactory();
                 Command<Object> cmd = failedJobCommandFactory.getCommand(job.getId(), exception);
 
-                log.trace("Using FailedJobCommandFactory '{}' and command of type '{}'", failedJobCommandFactory.getClass(), cmd.getClass());
+                LOGGER.trace("Using FailedJobCommandFactory '{}' and command of type '{}'", failedJobCommandFactory.getClass(), cmd.getClass());
                 processEngineConfiguration.getCommandExecutor().execute(commandConfig, cmd);
 
                 // Dispatch an event, indicating job execution failed in a
@@ -239,7 +239,7 @@ public class ExecuteAsyncRunnable implements Runnable {
                     try {
                         commandContext.getEventDispatcher().dispatchEvent(FlowableEventBuilder.createEntityExceptionEvent(FlowableEngineEventType.JOB_EXECUTION_FAILURE, job, exception));
                     } catch (Throwable ignore) {
-                        log.warn("Exception occurred while dispatching job failure event, ignoring.", ignore);
+                        LOGGER.warn("Exception occurred while dispatching job failure event, ignoring.", ignore);
                     }
                 }
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/asyncexecutor/ManagedAsyncJobExecutor.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/asyncexecutor/ManagedAsyncJobExecutor.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ManagedAsyncJobExecutor extends DefaultAsyncJobExecutor {
 
-    private static Logger log = LoggerFactory.getLogger(ManagedAsyncJobExecutor.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ManagedAsyncJobExecutor.class);
 
     protected ManagedThreadFactory threadFactory;
 
@@ -44,16 +44,16 @@ public class ManagedAsyncJobExecutor extends DefaultAsyncJobExecutor {
 
     protected void initAsyncJobExecutionThreadPool() {
         if (threadFactory == null) {
-            log.warn("A managed thread factory was not found, falling back to self-managed threads");
+            LOGGER.warn("A managed thread factory was not found, falling back to self-managed threads");
             super.initAsyncJobExecutionThreadPool();
         } else {
             if (threadPoolQueue == null) {
-                log.info("Creating thread pool queue of size {}", queueSize);
+                LOGGER.info("Creating thread pool queue of size {}", queueSize);
                 threadPoolQueue = new ArrayBlockingQueue<Runnable>(queueSize);
             }
 
             if (executorService == null) {
-                log.info("Creating executor service with corePoolSize {}, maxPoolSize {} and keepAliveTime {}", corePoolSize, maxPoolSize, keepAliveTime);
+                LOGGER.info("Creating executor service with corePoolSize {}, maxPoolSize {} and keepAliveTime {}", corePoolSize, maxPoolSize, keepAliveTime);
 
                 ThreadPoolExecutor threadPoolExecutor = new ThreadPoolExecutor(corePoolSize, maxPoolSize, keepAliveTime, TimeUnit.MILLISECONDS, threadPoolQueue, threadFactory);
                 threadPoolExecutor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/asyncexecutor/ResetExpiredJobsRunnable.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/asyncexecutor/ResetExpiredJobsRunnable.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ResetExpiredJobsRunnable implements Runnable {
 
-    private static Logger log = LoggerFactory.getLogger(ResetExpiredJobsRunnable.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ResetExpiredJobsRunnable.class);
 
     protected final String name;
     protected final AsyncExecutor asyncExecutor;
@@ -52,7 +52,7 @@ public class ResetExpiredJobsRunnable implements Runnable {
     }
 
     public synchronized void run() {
-        log.info("starting to reset expired jobs");
+        LOGGER.info("starting to reset expired jobs");
         Thread.currentThread().setName(name);
 
         while (!isInterrupted) {
@@ -74,9 +74,9 @@ public class ResetExpiredJobsRunnable implements Runnable {
 
             } catch (Throwable e) {
                 if (e instanceof FlowableOptimisticLockingException) {
-                    log.debug("Optimistic lock exception while resetting locked jobs", e);
+                    LOGGER.debug("Optimistic lock exception while resetting locked jobs", e);
                 } else {
-                    log.error("exception during resetting expired jobs: {}", e.getMessage(), e);
+                    LOGGER.error("exception during resetting expired jobs: {}", e.getMessage(), e);
                 }
             }
 
@@ -91,8 +91,8 @@ public class ResetExpiredJobsRunnable implements Runnable {
                 }
 
             } catch (InterruptedException e) {
-                if (log.isDebugEnabled()) {
-                    log.debug("async reset expired jobs wait interrupted");
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("async reset expired jobs wait interrupted");
                 }
             } finally {
                 isWaiting.set(false);
@@ -100,7 +100,7 @@ public class ResetExpiredJobsRunnable implements Runnable {
 
         }
 
-        log.info("stopped resetting expired jobs");
+        LOGGER.info("stopped resetting expired jobs");
     }
 
     public void stop() {

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/BpmnActivityBehavior.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/BpmnActivityBehavior.java
@@ -37,7 +37,7 @@ public class BpmnActivityBehavior implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private static Logger log = LoggerFactory.getLogger(BpmnActivityBehavior.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(BpmnActivityBehavior.class);
 
     /**
      * Performs the default outgoing BPMN 2.0 behavior, which is having parallel paths of executions for the outgoing sequence flow.

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/ExclusiveGatewayActivityBehavior.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/ExclusiveGatewayActivityBehavior.java
@@ -35,7 +35,7 @@ public class ExclusiveGatewayActivityBehavior extends GatewayActivityBehavior {
 
     private static final long serialVersionUID = 1L;
 
-    private static Logger log = LoggerFactory.getLogger(ExclusiveGatewayActivityBehavior.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExclusiveGatewayActivityBehavior.class);
 
     /**
      * The default behaviour of BPMN, taking every outgoing sequence flow (where the condition evaluates to true), is not valid for an exclusive gateway.
@@ -48,8 +48,8 @@ public class ExclusiveGatewayActivityBehavior extends GatewayActivityBehavior {
     @Override
     public void leave(DelegateExecution execution) {
 
-        if (log.isDebugEnabled()) {
-            log.debug("Leaving exclusive gateway '{}'", execution.getCurrentActivityId());
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Leaving exclusive gateway '{}'", execution.getCurrentActivityId());
         }
 
         ExclusiveGateway exclusiveGateway = (ExclusiveGateway) execution.getCurrentFlowElement();
@@ -73,8 +73,8 @@ public class ExclusiveGatewayActivityBehavior extends GatewayActivityBehavior {
             if (!SkipExpressionUtil.isSkipExpressionEnabled(execution, skipExpressionString)) {
                 boolean conditionEvaluatesToTrue = ConditionUtil.hasTrueCondition(sequenceFlow, execution);
                 if (conditionEvaluatesToTrue && (defaultSequenceFlowId == null || !defaultSequenceFlowId.equals(sequenceFlow.getId()))) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Sequence flow '{}'selected as outgoing sequence flow.", sequenceFlow.getId());
+                    if (LOGGER.isDebugEnabled()) {
+                        LOGGER.debug("Sequence flow '{}'selected as outgoing sequence flow.", sequenceFlow.getId());
                     }
                     outgoingSequenceFlow = sequenceFlow;
                 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/InclusiveGatewayActivityBehavior.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/InclusiveGatewayActivityBehavior.java
@@ -36,7 +36,7 @@ public class InclusiveGatewayActivityBehavior extends GatewayActivityBehavior im
 
     private static final long serialVersionUID = 1L;
 
-    private static Logger logger = LoggerFactory.getLogger(InclusiveGatewayActivityBehavior.class.getName());
+    private static final Logger LOGGER = LoggerFactory.getLogger(InclusiveGatewayActivityBehavior.class.getName());
 
     @Override
     public void execute(DelegateExecution execution) {
@@ -82,7 +82,7 @@ public class InclusiveGatewayActivityBehavior extends GatewayActivityBehavior im
         // If no execution can reach the gateway, the gateway activates and executes fork behavior
         if (!oneExecutionCanReachGateway) {
 
-            logger.debug("Inclusive gateway cannot be reached by any execution and is activated");
+            LOGGER.debug("Inclusive gateway cannot be reached by any execution and is activated");
 
             // Kill all executions here (except the incoming)
             Collection<ExecutionEntity> executionsInGateway = executionEntityManager

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/MailActivityBehavior.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/MailActivityBehavior.java
@@ -47,7 +47,7 @@ public class MailActivityBehavior extends AbstractBpmnActivityBehavior {
 
     private static final long serialVersionUID = 1L;
 
-    private static final Logger LOG = LoggerFactory.getLogger(MailActivityBehavior.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(MailActivityBehavior.class);
 
     private static final Class<?>[] ALLOWED_ATT_TYPES = new Class<?>[] { File.class, File[].class, String.class, String[].class, DataSource.class, DataSource[].class };
 
@@ -395,7 +395,7 @@ public class MailActivityBehavior extends AbstractBpmnActivityBehavior {
 
     protected void handleException(DelegateExecution execution, String msg, Exception e, boolean doIgnoreException, String exceptionVariable) {
         if (doIgnoreException) {
-            LOG.info("Ignoring email send error: {}", msg, e);
+            LOGGER.info("Ignoring email send error: {}", msg, e);
             if (exceptionVariable != null && exceptionVariable.length() > 0) {
                 execution.setVariable(exceptionVariable, msg);
             }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/ParallelGatewayActivityBehavior.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/ParallelGatewayActivityBehavior.java
@@ -50,7 +50,7 @@ public class ParallelGatewayActivityBehavior extends GatewayActivityBehavior {
 
     private static final long serialVersionUID = 1840892471343975524L;
 
-    private static Logger log = LoggerFactory.getLogger(ParallelGatewayActivityBehavior.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ParallelGatewayActivityBehavior.class);
 
     public void execute(DelegateExecution execution) {
 
@@ -90,8 +90,8 @@ public class ParallelGatewayActivityBehavior extends GatewayActivityBehavior {
         if (nbrOfExecutionsCurrentlyJoined == nbrOfExecutionsToJoin) {
 
             // Fork
-            if (log.isDebugEnabled()) {
-                log.debug("parallel gateway '{}' activates: {} of {} joined", execution.getCurrentActivityId(), nbrOfExecutionsCurrentlyJoined, nbrOfExecutionsToJoin);
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("parallel gateway '{}' activates: {} of {} joined", execution.getCurrentActivityId(), nbrOfExecutionsCurrentlyJoined, nbrOfExecutionsToJoin);
             }
 
             if (parallelGateway.getIncomingFlows().size() > 1) {
@@ -111,8 +111,8 @@ public class ParallelGatewayActivityBehavior extends GatewayActivityBehavior {
             // TODO: potential optimization here: reuse more then 1 execution, only 1 currently
             Context.getAgenda().planTakeOutgoingSequenceFlowsOperation((ExecutionEntity) execution, false); // false -> ignoring conditions on parallel gw
 
-        } else if (log.isDebugEnabled()) {
-            log.debug("parallel gateway '{}' does not activate: {} of {} joined", execution.getCurrentActivityId(), nbrOfExecutionsCurrentlyJoined, nbrOfExecutionsToJoin);
+        } else if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("parallel gateway '{}' does not activate: {} of {} joined", execution.getCurrentActivityId(), nbrOfExecutionsCurrentlyJoined, nbrOfExecutionsToJoin);
         }
 
     }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/deployer/BpmnDeployer.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/deployer/BpmnDeployer.java
@@ -12,6 +12,9 @@
  */
 package org.flowable.engine.impl.bpmn.deployer;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -44,16 +47,13 @@ import org.flowable.engine.impl.persistence.entity.ResourceEntityManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 /**
  * @author Joram Barrez
  * @author Tijs Rademakers
  */
 public class BpmnDeployer implements Deployer {
 
-    private static final Logger log = LoggerFactory.getLogger(BpmnDeployer.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(BpmnDeployer.class);
 
     protected IdGenerator idGenerator;
     protected ParsedDeploymentBuilderFactory parsedDeploymentBuilderFactory;
@@ -63,7 +63,7 @@ public class BpmnDeployer implements Deployer {
 
     @Override
     public void deploy(DeploymentEntity deployment, Map<String, Object> deploymentSettings) {
-        log.debug("Processing deployment {}", deployment.getName());
+        LOGGER.debug("Processing deployment {}", deployment.getName());
 
         // The ParsedDeployment represents the deployment, the process definitions, and the BPMN
         // resource, parse, and model associated with each process definition.

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/deployer/ParsedDeploymentBuilder.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/deployer/ParsedDeploymentBuilder.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
 
 public class ParsedDeploymentBuilder {
 
-    private static final Logger log = LoggerFactory.getLogger(ParsedDeploymentBuilder.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ParsedDeploymentBuilder.class);
 
     protected DeploymentEntity deployment;
     protected BpmnParser bpmnParser;
@@ -49,7 +49,7 @@ public class ParsedDeploymentBuilder {
 
         for (ResourceEntity resource : deployment.getResources().values()) {
             if (isBpmnResource(resource.getName())) {
-                log.debug("Processing BPMN resource {}", resource.getName());
+                LOGGER.debug("Processing BPMN resource {}", resource.getName());
                 BpmnParse parse = createBpmnParseFromResource(resource);
                 for (ProcessDefinitionEntity processDefinition : parse.getProcessDefinitions()) {
                     processDefinitions.add(processDefinition);

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/deployer/ProcessDefinitionDiagramHelper.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/deployer/ProcessDefinitionDiagramHelper.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ProcessDefinitionDiagramHelper {
 
-    private static final Logger log = LoggerFactory.getLogger(ProcessDefinitionDiagramHelper.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProcessDefinitionDiagramHelper.class);
 
     /**
      * Generates a diagram resource for a ProcessDefinitionEntity and associated BpmnParse. The returned resource has not yet been persisted, nor attached to the ProcessDefinitionEntity. This requires
@@ -63,7 +63,7 @@ public class ProcessDefinitionDiagramHelper {
             resource.setGenerated(true);
 
         } catch (Throwable t) { // if anything goes wrong, we don't store the image (the process will still be executable).
-            log.warn("Error while generating process diagram, image will not be stored in repository", t);
+            LOGGER.warn("Error while generating process diagram, image will not be stored in repository", t);
             resource = null;
         }
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/parser/handler/HttpServiceTaskParseHandler.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/parser/handler/HttpServiceTaskParseHandler.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
  */
 public class HttpServiceTaskParseHandler extends AbstractActivityBpmnParseHandler<ServiceTask> {
 
-    private static Logger logger = LoggerFactory.getLogger(HttpServiceTaskParseHandler.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(HttpServiceTaskParseHandler.class);
 
     public Class<? extends BaseElement> getHandledType() {
         return HttpServiceTask.class;

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/parser/handler/ServiceTaskParseHandler.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/parser/handler/ServiceTaskParseHandler.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ServiceTaskParseHandler extends AbstractActivityBpmnParseHandler<ServiceTask> {
 
-    private static Logger logger = LoggerFactory.getLogger(ServiceTaskParseHandler.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ServiceTaskParseHandler.class);
 
     public Class<? extends BaseElement> getHandledType() {
         return ServiceTask.class;
@@ -56,7 +56,7 @@ public class ServiceTaskParseHandler extends AbstractActivityBpmnParseHandler<Se
                 serviceTask.setBehavior(bpmnParse.getActivityBehaviorFactory().createHttpActivityBehavior(serviceTask));
 
             } else {
-                logger.warn("Invalid service task type: '{}'  for service task {}", serviceTask.getType(), serviceTask.getId());
+                LOGGER.warn("Invalid service task type: '{}'  for service task {}", serviceTask.getType(), serviceTask.getId());
             }
 
             // activiti:class
@@ -81,7 +81,7 @@ public class ServiceTaskParseHandler extends AbstractActivityBpmnParseHandler<Se
             serviceTask.setBehavior(webServiceActivityBehavior);
 
         } else {
-            logger.warn("One of the attributes 'class', 'delegateExpression', 'type', 'operation', or 'expression' is mandatory on serviceTask {}", serviceTask.getId());
+            LOGGER.warn("One of the attributes 'class', 'delegateExpression', 'type', 'operation', or 'expression' is mandatory on serviceTask {}", serviceTask.getId());
         }
 
     }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -367,7 +367,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfiguration {
 
-    private static Logger log = LoggerFactory.getLogger(ProcessEngineConfigurationImpl.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProcessEngineConfigurationImpl.class);
 
     public static final String DEFAULT_WS_SYNC_FACTORY = "org.flowable.engine.impl.webservice.CxfWebServiceClientFactory";
 
@@ -1378,7 +1378,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
             }
 
             if (nrOfServiceLoadedConfigurators > 0) {
-                log.info("Found {} auto-discoverable Process Engine Configurator{}", nrOfServiceLoadedConfigurators++, nrOfServiceLoadedConfigurators > 1 ? "s" : "");
+                LOGGER.info("Found {} auto-discoverable Process Engine Configurator{}", nrOfServiceLoadedConfigurators++, nrOfServiceLoadedConfigurators > 1 ? "s" : "");
             }
 
             if (!allConfigurators.isEmpty()) {
@@ -1401,9 +1401,9 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
                 });
 
                 // Execute the configurators
-                log.info("Found {} Process Engine Configurators in total:", allConfigurators.size());
+                LOGGER.info("Found {} Process Engine Configurators in total:", allConfigurators.size());
                 for (ProcessEngineConfigurator configurator : allConfigurators) {
-                    log.info("{} (priority:{})", configurator.getClass(), configurator.getPriority());
+                    LOGGER.info("{} (priority:{})", configurator.getClass(), configurator.getPriority());
                 }
 
             }
@@ -1413,14 +1413,14 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     public void configuratorsBeforeInit() {
         for (ProcessEngineConfigurator configurator : allConfigurators) {
-            log.info("Executing beforeInit() of {} (priority:{})", configurator.getClass(), configurator.getPriority());
+            LOGGER.info("Executing beforeInit() of {} (priority:{})", configurator.getClass(), configurator.getPriority());
             configurator.beforeInit(this);
         }
     }
 
     public void configuratorsAfterInit() {
         for (ProcessEngineConfigurator configurator : allConfigurators) {
-            log.info("Executing configure() of {} (priority:{})", configurator.getClass(), configurator.getPriority());
+            LOGGER.info("Executing configure() of {} (priority:{})", configurator.getClass(), configurator.getPriority());
             configurator.configure(this);
         }
     }
@@ -1667,7 +1667,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
                     Class<?> handledType = defaultBpmnParseHandler.getHandledTypes().iterator().next();
                     if (customParseHandlerMap.containsKey(handledType)) {
                         BpmnParseHandler newBpmnParseHandler = customParseHandlerMap.get(handledType);
-                        log.info("Replacing default BpmnParseHandler {} with {}", defaultBpmnParseHandler.getClass().getName(), newBpmnParseHandler.getClass().getName());
+                        LOGGER.info("Replacing default BpmnParseHandler {} with {}", defaultBpmnParseHandler.getClass().getName(), newBpmnParseHandler.getClass().getName());
                         bpmnParserHandlers.set(i, newBpmnParseHandler);
                     }
                 }
@@ -2123,7 +2123,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
             flowable5CompatibilityHandler = flowable5CompatibilityHandlerFactory.createFlowable5CompatibilityHandler();
 
             if (flowable5CompatibilityHandler != null) {
-                log.info("Found compatibility handler instance : {}", flowable5CompatibilityHandler.getClass());
+                LOGGER.info("Found compatibility handler instance : {}", flowable5CompatibilityHandler.getClass());
                 
                 flowable5CompatibilityHandler.setFlowable6ProcessEngineConfiguration(this);
             }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/standalone/StandaloneMybatisTransactionContext.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/standalone/StandaloneMybatisTransactionContext.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
  */
 public class StandaloneMybatisTransactionContext implements TransactionContext {
 
-    private static Logger log = LoggerFactory.getLogger(StandaloneMybatisTransactionContext.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(StandaloneMybatisTransactionContext.class);
 
     protected CommandContext commandContext;
     protected DbSqlSession dbSqlSession;
@@ -62,12 +62,12 @@ public class StandaloneMybatisTransactionContext implements TransactionContext {
 
     public void commit() {
 
-        log.debug("firing event committing...");
+        LOGGER.debug("firing event committing...");
         fireTransactionEvent(TransactionState.COMMITTING, false);
 
-        log.debug("committing the ibatis sql session...");
+        LOGGER.debug("committing the ibatis sql session...");
         dbSqlSession.commit();
-        log.debug("firing event committed...");
+        LOGGER.debug("firing event committed...");
         fireTransactionEvent(TransactionState.COMMITTED, true);
 
     }
@@ -115,23 +115,23 @@ public class StandaloneMybatisTransactionContext implements TransactionContext {
     public void rollback() {
         try {
             try {
-                log.debug("firing event rolling back...");
+                LOGGER.debug("firing event rolling back...");
                 fireTransactionEvent(TransactionState.ROLLINGBACK, false);
 
             } catch (Throwable exception) {
-                log.info("Exception during transaction: {}", exception.getMessage());
+                LOGGER.info("Exception during transaction: {}", exception.getMessage());
                 commandContext.exception(exception);
             } finally {
-                log.debug("rolling back ibatis sql session...");
+                LOGGER.debug("rolling back ibatis sql session...");
                 dbSqlSession.rollback();
             }
 
         } catch (Throwable exception) {
-            log.info("Exception during transaction: {}", exception.getMessage());
+            LOGGER.info("Exception during transaction: {}", exception.getMessage());
             commandContext.exception(exception);
 
         } finally {
-            log.debug("firing event rolled back...");
+            LOGGER.debug("firing event rolled back...");
             fireTransactionEvent(TransactionState.ROLLED_BACK, true);
         }
     }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/DeleteDeadLetterJobCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/DeleteDeadLetterJobCmd.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
 
 public class DeleteDeadLetterJobCmd implements Command<Object>, Serializable {
 
-    private static final Logger log = LoggerFactory.getLogger(DeleteDeadLetterJobCmd.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DeleteDeadLetterJobCmd.class);
     private static final long serialVersionUID = 1L;
 
     protected String timerJobId;
@@ -60,8 +60,8 @@ public class DeleteDeadLetterJobCmd implements Command<Object>, Serializable {
         if (timerJobId == null) {
             throw new FlowableIllegalArgumentException("jobId is null");
         }
-        if (log.isDebugEnabled()) {
-            log.debug("Deleting job {}", timerJobId);
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Deleting job {}", timerJobId);
         }
 
         DeadLetterJobEntity job = commandContext.getDeadLetterJobEntityManager().findById(timerJobId);

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/DeleteHistoryJobCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/DeleteHistoryJobCmd.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
 
 public class DeleteHistoryJobCmd implements Command<Object>, Serializable {
 
-    private static final Logger log = LoggerFactory.getLogger(DeleteHistoryJobCmd.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DeleteHistoryJobCmd.class);
     private static final long serialVersionUID = 1L;
 
     protected String historyJobId;
@@ -60,8 +60,8 @@ public class DeleteHistoryJobCmd implements Command<Object>, Serializable {
         if (historyJobId == null) {
             throw new FlowableIllegalArgumentException("jobId is null");
         }
-        if (log.isDebugEnabled()) {
-            log.debug("Deleting job {}", historyJobId);
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Deleting job {}", historyJobId);
         }
 
         HistoryJobEntity job = commandContext.getHistoryJobEntityManager().findById(historyJobId);

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/DeleteJobCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/DeleteJobCmd.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
 
 public class DeleteJobCmd implements Command<Object>, Serializable {
 
-    private static final Logger log = LoggerFactory.getLogger(DeleteJobCmd.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DeleteJobCmd.class);
     private static final long serialVersionUID = 1L;
 
     protected String jobId;
@@ -70,8 +70,8 @@ public class DeleteJobCmd implements Command<Object>, Serializable {
         if (jobId == null) {
             throw new FlowableIllegalArgumentException("jobId is null");
         }
-        if (log.isDebugEnabled()) {
-            log.debug("Deleting job {}", jobId);
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Deleting job {}", jobId);
         }
 
         JobEntity job = commandContext.getJobEntityManager().findById(jobId);

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/DeleteSuspendedJobCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/DeleteSuspendedJobCmd.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
 
 public class DeleteSuspendedJobCmd implements Command<Object>, Serializable {
 
-    private static final Logger log = LoggerFactory.getLogger(DeleteSuspendedJobCmd.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DeleteSuspendedJobCmd.class);
     private static final long serialVersionUID = 1L;
 
     protected String suspendedJobId;
@@ -60,8 +60,8 @@ public class DeleteSuspendedJobCmd implements Command<Object>, Serializable {
         if (suspendedJobId == null) {
             throw new FlowableIllegalArgumentException("jobId is null");
         }
-        if (log.isDebugEnabled()) {
-            log.debug("Deleting job {}", suspendedJobId);
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Deleting job {}", suspendedJobId);
         }
 
         SuspendedJobEntity job = commandContext.getSuspendedJobEntityManager().findById(suspendedJobId);

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/DeleteTimerJobCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/DeleteTimerJobCmd.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
 
 public class DeleteTimerJobCmd implements Command<Object>, Serializable {
 
-    private static final Logger log = LoggerFactory.getLogger(DeleteTimerJobCmd.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DeleteTimerJobCmd.class);
     private static final long serialVersionUID = 1L;
 
     protected String timerJobId;
@@ -61,8 +61,8 @@ public class DeleteTimerJobCmd implements Command<Object>, Serializable {
         if (timerJobId == null) {
             throw new FlowableIllegalArgumentException("jobId is null");
         }
-        if (log.isDebugEnabled()) {
-            log.debug("Deleting job {}", timerJobId);
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Deleting job {}", timerJobId);
         }
 
         TimerJobEntity job = commandContext.getTimerJobEntityManager().findById(timerJobId);

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/ExecuteAsyncJobCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/ExecuteAsyncJobCmd.java
@@ -32,7 +32,7 @@ public class ExecuteAsyncJobCmd implements Command<Object>, Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private static Logger log = LoggerFactory.getLogger(ExecuteAsyncJobCmd.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExecuteAsyncJobCmd.class);
 
     protected String jobId;
     protected JobInfoEntityManager<? extends JobInfoEntity> jobEntityManager;
@@ -64,13 +64,13 @@ public class ExecuteAsyncJobCmd implements Command<Object>, Serializable {
 
         JobInfoEntity job = jobEntityManager.findById(jobId);
         if (job == null) {
-            log.debug("Job does not exist anymore and will not be executed. It has most likely been deleted "
+            LOGGER.debug("Job does not exist anymore and will not be executed. It has most likely been deleted "
                     + "as part of another concurrent part of the process instance.");
             return null;
         }
 
-        if (log.isDebugEnabled()) {
-            log.debug("Executing async job {}", job.getId());
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Executing async job {}", job.getId());
         }
 
         commandContext.getJobManager().execute(job);

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/ExecuteJobCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/ExecuteJobCmd.java
@@ -34,7 +34,7 @@ public class ExecuteJobCmd implements Command<Object>, Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private static Logger log = LoggerFactory.getLogger(ExecuteJobCmd.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExecuteJobCmd.class);
 
     protected String jobId;
 
@@ -54,8 +54,8 @@ public class ExecuteJobCmd implements Command<Object>, Serializable {
             throw new JobNotFoundException(jobId);
         }
 
-        if (log.isDebugEnabled()) {
-            log.debug("Executing job {}", job.getId());
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Executing job {}", job.getId());
         }
 
         if (job.getProcessDefinitionId() != null && Flowable5Util.isFlowable5ProcessDefinitionId(commandContext, job.getProcessDefinitionId())) {

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/GetDeploymentProcessDiagramCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/GetDeploymentProcessDiagramCmd.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
 public class GetDeploymentProcessDiagramCmd implements Command<InputStream>, Serializable {
 
     private static final long serialVersionUID = 1L;
-    private static Logger log = LoggerFactory.getLogger(GetDeploymentProcessDiagramCmd.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(GetDeploymentProcessDiagramCmd.class);
 
     protected String processDefinitionId;
 
@@ -47,7 +47,7 @@ public class GetDeploymentProcessDiagramCmd implements Command<InputStream>, Ser
         String deploymentId = processDefinition.getDeploymentId();
         String resourceName = processDefinition.getDiagramResourceName();
         if (resourceName == null) {
-            log.info("Resource name is null! No process diagram stream exists.");
+            LOGGER.info("Resource name is null! No process diagram stream exists.");
             return null;
         } else {
             InputStream processDiagramStream = new GetDeploymentResourceCmd(deploymentId, resourceName).execute(commandContext);

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/JobRetryCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/JobRetryCmd.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
 
 public class JobRetryCmd implements Command<Object> {
 
-    private static final Logger log = LoggerFactory.getLogger(JobRetryCmd.class.getName());
+    private static final Logger LOGGER = LoggerFactory.getLogger(JobRetryCmd.class.getName());
 
     protected String jobId;
     protected Throwable exception;
@@ -73,7 +73,7 @@ public class JobRetryCmd implements Command<Object> {
         AbstractRuntimeJobEntity newJobEntity = null;
         if (currentFlowElement == null || failedJobRetryTimeCycleValue == null) {
 
-            log.debug("activity or FailedJobRetryTimerCycleValue is null in job {}. Only decrementing retries.", jobId);
+            LOGGER.debug("activity or FailedJobRetryTimerCycleValue is null in job {}. Only decrementing retries.", jobId);
 
             if (job.getRetries() <= 1) {
                 newJobEntity = commandContext.getJobManager().moveJobToDeadLetterJob(job);
@@ -108,10 +108,10 @@ public class JobRetryCmd implements Command<Object> {
                 newJobEntity.setDuedate(durationHelper.getDateAfter());
 
                 if (job.getExceptionMessage() == null) { // is it the first exception
-                    log.debug("Applying JobRetryStrategy '{}' the first time for job {} with {} retries", failedJobRetryTimeCycleValue, job.getId(), durationHelper.getTimes());
+                    LOGGER.debug("Applying JobRetryStrategy '{}' the first time for job {} with {} retries", failedJobRetryTimeCycleValue, job.getId(), durationHelper.getTimes());
 
                 } else {
-                    log.debug("Decrementing retries of JobRetryStrategy '{}' for job {}", failedJobRetryTimeCycleValue, job.getId());
+                    LOGGER.debug("Decrementing retries of JobRetryStrategy '{}' for job {}", failedJobRetryTimeCycleValue, job.getId());
                 }
 
                 newJobEntity.setRetries(jobRetries - 1);

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/LockExclusiveJobCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/LockExclusiveJobCmd.java
@@ -29,7 +29,7 @@ public class LockExclusiveJobCmd implements Command<Object>, Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private static Logger log = LoggerFactory.getLogger(LockExclusiveJobCmd.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(LockExclusiveJobCmd.class);
 
     protected Job job;
 
@@ -43,8 +43,8 @@ public class LockExclusiveJobCmd implements Command<Object>, Serializable {
             throw new FlowableIllegalArgumentException("job is null");
         }
 
-        if (log.isDebugEnabled()) {
-            log.debug("Executing lock exclusive job {} {}", job.getId(), job.getExecutionId());
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Executing lock exclusive job {} {}", job.getId(), job.getExecutionId());
         }
 
         if (job.isExclusive()) {

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/MoveDeadLetterJobToExecutableJobCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/MoveDeadLetterJobToExecutableJobCmd.java
@@ -30,7 +30,7 @@ public class MoveDeadLetterJobToExecutableJobCmd implements Command<JobEntity>, 
 
     private static final long serialVersionUID = 1L;
 
-    private static Logger log = LoggerFactory.getLogger(MoveDeadLetterJobToExecutableJobCmd.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(MoveDeadLetterJobToExecutableJobCmd.class);
 
     protected String jobId;
     protected int retries;
@@ -51,8 +51,8 @@ public class MoveDeadLetterJobToExecutableJobCmd implements Command<JobEntity>, 
             throw new JobNotFoundException(jobId);
         }
 
-        if (log.isDebugEnabled()) {
-            log.debug("Moving deadletter job to executable job table {}", job.getId());
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Moving deadletter job to executable job table {}", job.getId());
         }
 
         return commandContext.getJobManager().moveDeadLetterJobToExecutableJob(job, retries);

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/MoveJobToDeadLetterJobCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/MoveJobToDeadLetterJobCmd.java
@@ -30,7 +30,7 @@ public class MoveJobToDeadLetterJobCmd implements Command<DeadLetterJobEntity>, 
 
     private static final long serialVersionUID = 1L;
 
-    private static Logger log = LoggerFactory.getLogger(MoveJobToDeadLetterJobCmd.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(MoveJobToDeadLetterJobCmd.class);
 
     protected String jobId;
 
@@ -53,8 +53,8 @@ public class MoveJobToDeadLetterJobCmd implements Command<DeadLetterJobEntity>, 
             throw new JobNotFoundException(jobId);
         }
 
-        if (log.isDebugEnabled()) {
-            log.debug("Moving job to deadletter job table {}", job.getId());
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Moving job to deadletter job table {}", job.getId());
         }
 
         DeadLetterJobEntity deadLetterJob = commandContext.getJobManager().moveJobToDeadLetterJob(job);

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/MoveTimerToExecutableJobCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/MoveTimerToExecutableJobCmd.java
@@ -30,7 +30,7 @@ public class MoveTimerToExecutableJobCmd implements Command<JobEntity>, Serializ
 
     private static final long serialVersionUID = 1L;
 
-    private static Logger log = LoggerFactory.getLogger(MoveTimerToExecutableJobCmd.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(MoveTimerToExecutableJobCmd.class);
 
     protected String jobId;
 
@@ -50,8 +50,8 @@ public class MoveTimerToExecutableJobCmd implements Command<JobEntity>, Serializ
             throw new JobNotFoundException(jobId);
         }
 
-        if (log.isDebugEnabled()) {
-            log.debug("Executing timer job {}", timerJob.getId());
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Executing timer job {}", timerJob.getId());
         }
 
         return commandContext.getJobManager().moveTimerJobToExecutableJob(timerJob);

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/UnlockExclusiveJobCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/UnlockExclusiveJobCmd.java
@@ -30,7 +30,7 @@ public class UnlockExclusiveJobCmd implements Command<Object>, Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private static Logger log = LoggerFactory.getLogger(UnlockExclusiveJobCmd.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(UnlockExclusiveJobCmd.class);
 
     protected Job job;
 
@@ -44,8 +44,8 @@ public class UnlockExclusiveJobCmd implements Command<Object>, Serializable {
             throw new FlowableIllegalArgumentException("job is null");
         }
 
-        if (log.isDebugEnabled()) {
-            log.debug("Unlocking exclusive job {}", job.getId());
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Unlocking exclusive job {}", job.getId());
         }
 
         if (job.isExclusive()) {

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/db/DbSqlSession.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/db/DbSqlSession.java
@@ -61,7 +61,7 @@ import org.slf4j.LoggerFactory;
  */
 public class DbSqlSession extends AbstractDbSqlSession {
 
-    private static final Logger log = LoggerFactory.getLogger(DbSqlSession.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DbSqlSession.class);
 
     protected static final String LAST_V5_VERSION = "5.99.0.0";
 
@@ -331,7 +331,7 @@ public class DbSqlSession extends AbstractDbSqlSession {
         determineUpdatedObjects(); // Needs to be done before the removeUnnecessaryOperations, as removeUnnecessaryOperations will remove stuff from the cache
         removeUnnecessaryOperations();
 
-        if (log.isDebugEnabled()) {
+        if (LOGGER.isDebugEnabled()) {
             debugFlush();
         }
 
@@ -397,34 +397,34 @@ public class DbSqlSession extends AbstractDbSqlSession {
     }
 
     protected void debugFlush() {
-        log.debug("Flushing dbSqlSession");
+        LOGGER.debug("Flushing dbSqlSession");
         int nrOfInserts = 0;
         int nrOfUpdates = 0;
         int nrOfDeletes = 0;
         for (Map<String, Entity> insertedObjectMap : insertedObjects.values()) {
             for (Entity insertedObject : insertedObjectMap.values()) {
-                log.debug("  insert {}", insertedObject);
+                LOGGER.debug("  insert {}", insertedObject);
                 nrOfInserts++;
             }
         }
         for (Entity updatedObject : updatedObjects) {
-            log.debug("  update {}", updatedObject);
+            LOGGER.debug("  update {}", updatedObject);
             nrOfUpdates++;
         }
         for (Map<String, Entity> deletedObjectMap : deletedObjects.values()) {
             for (Entity deletedObject : deletedObjectMap.values()) {
-                log.debug("  delete {} with id {}", deletedObject, deletedObject.getId());
+                LOGGER.debug("  delete {} with id {}", deletedObject, deletedObject.getId());
                 nrOfDeletes++;
             }
         }
         for (Collection<BulkDeleteOperation> bulkDeleteOperationList : bulkDeleteOperations.values()) {
             for (BulkDeleteOperation bulkDeleteOperation : bulkDeleteOperationList) {
-                log.debug("  {}", bulkDeleteOperation);
+                LOGGER.debug("  {}", bulkDeleteOperation);
                 nrOfDeletes++;
             }
         }
-        log.debug("flush summary: {} insert, {} update, {} delete.", nrOfInserts, nrOfUpdates, nrOfDeletes);
-        log.debug("now executing flush...");
+        LOGGER.debug("flush summary: {} insert, {} update, {} delete.", nrOfInserts, nrOfUpdates, nrOfDeletes);
+        LOGGER.debug("now executing flush...");
     }
 
     public boolean isEntityInserted(Entity entity) {
@@ -567,7 +567,7 @@ public class DbSqlSession extends AbstractDbSqlSession {
             throw new FlowableException("no insert statement for " + entity.getClass() + " in the ibatis mapping files");
         }
 
-        log.debug("inserting: {}", entity);
+        LOGGER.debug("inserting: {}", entity);
         sqlSession.insert(insertStatement, entity);
 
         // See https://activiti.atlassian.net/browse/ACT-1290
@@ -627,7 +627,7 @@ public class DbSqlSession extends AbstractDbSqlSession {
                 throw new FlowableException("no update statement for " + updatedObject.getClass() + " in the ibatis mapping files");
             }
 
-            log.debug("updating: {}", updatedObject);
+            LOGGER.debug("updating: {}", updatedObject);
             
             int updatedRecords = sqlSession.update(updateStatement, updatedObject);
             if (updatedRecords == 0) {
@@ -735,7 +735,7 @@ public class DbSqlSession extends AbstractDbSqlSession {
             }
         }
 
-        log.debug("flowable db schema check successful");
+        LOGGER.debug("flowable db schema check successful");
     }
 
     protected String addMissingComponent(String missingComponents, String component) {
@@ -923,7 +923,7 @@ public class DbSqlSession extends AbstractDbSqlSession {
                 try {
                     tables.close();
                 } catch (Exception e) {
-                    log.error("Error closing meta data tables", e);
+                    LOGGER.error("Error closing meta data tables", e);
                 }
             }
 
@@ -951,7 +951,7 @@ public class DbSqlSession extends AbstractDbSqlSession {
             throw new FlowableException("Version of flowable database (" + versionInDatabase + ") is more recent than the engine (" + ProcessEngine.VERSION + ")");
         } else if (cleanDbVersion.compareTo(cleanEngineVersion) == 0) {
             // Versions don't match exactly, possibly snapshot is being used
-            log.warn("Engine-version is the same, but not an exact match: {} vs. {}. Not performing database-upgrade.", versionInDatabase, ProcessEngine.VERSION);
+            LOGGER.warn("Engine-version is the same, but not an exact match: {} vs. {}. Not performing database-upgrade.", versionInDatabase, ProcessEngine.VERSION);
             return false;
         }
         return true;
@@ -980,7 +980,7 @@ public class DbSqlSession extends AbstractDbSqlSession {
     protected void dbSchemaUpgrade(final String component, final int currentDatabaseVersionsIndex) {
         FlowableVersion version = FLOWABLE_VERSIONS.get(currentDatabaseVersionsIndex);
         String dbVersion = version.getMainVersion();
-        log.info("upgrading flowable {} schema from {} to {}", component, dbVersion, ProcessEngine.VERSION);
+        LOGGER.info("upgrading flowable {} schema from {} to {}", component, dbVersion, ProcessEngine.VERSION);
 
         // Actual execution of schema DDL SQL
         for (int i = currentDatabaseVersionsIndex + 1; i < FLOWABLE_VERSIONS.size(); i++) {
@@ -993,7 +993,7 @@ public class DbSqlSession extends AbstractDbSqlSession {
 
             dbVersion = dbVersion.replace(".", "");
             nextVersion = nextVersion.replace(".", "");
-            log.info("Upgrade needed: {} -> {}. Looking for schema update resource for component '{}'", dbVersion, nextVersion, component);
+            LOGGER.info("Upgrade needed: {} -> {}. Looking for schema update resource for component '{}'", dbVersion, nextVersion, component);
             executeSchemaResource("upgrade", component, getResourceForDbOperation("upgrade", "upgradestep." + dbVersion + ".to." + nextVersion, component), true);
             dbVersion = nextVersion;
         }
@@ -1010,7 +1010,7 @@ public class DbSqlSession extends AbstractDbSqlSession {
             inputStream = ReflectUtil.getResourceAsStream(resourceName);
             if (inputStream == null) {
                 if (isOptional) {
-                    log.info("no schema resource {} for {}", resourceName, operation);
+                    LOGGER.info("no schema resource {} for {}", resourceName, operation);
                 } else {
                     throw new FlowableException("resource '" + resourceName + "' is not available");
                 }
@@ -1024,7 +1024,7 @@ public class DbSqlSession extends AbstractDbSqlSession {
     }
 
     private void executeSchemaResource(String operation, String component, String resourceName, InputStream inputStream) {
-        log.info("performing {} on {} with resource {}", operation, component, resourceName);
+        LOGGER.info("performing {} on {} with resource {}", operation, component, resourceName);
         String sqlStatement = null;
         String exceptionSqlStatement = null;
         try {
@@ -1039,7 +1039,7 @@ public class DbSqlSession extends AbstractDbSqlSession {
                     DatabaseMetaData databaseMetaData = connection.getMetaData();
                     int majorVersion = databaseMetaData.getDatabaseMajorVersion();
                     int minorVersion = databaseMetaData.getDatabaseMinorVersion();
-                    log.info("Found MySQL: majorVersion={} minorVersion={}", majorVersion, minorVersion);
+                    LOGGER.info("Found MySQL: majorVersion={} minorVersion={}", majorVersion, minorVersion);
 
                     // Special care for MySQL < 5.6
                     if (majorVersion <= 5 && minorVersion < 6) {
@@ -1047,7 +1047,7 @@ public class DbSqlSession extends AbstractDbSqlSession {
                     }
                 }
             } catch (Exception e) {
-                log.info("Could not get database metadata", e);
+                LOGGER.info("Could not get database metadata", e);
             }
 
             BufferedReader reader = new BufferedReader(new StringReader(ddlStatements));
@@ -1055,10 +1055,10 @@ public class DbSqlSession extends AbstractDbSqlSession {
             boolean inOraclePlsqlBlock = false;
             while (line != null) {
                 if (line.startsWith("# ")) {
-                    log.debug(line.substring(2));
+                    LOGGER.debug(line.substring(2));
 
                 } else if (line.startsWith("-- ")) {
-                    log.debug(line.substring(3));
+                    LOGGER.debug(line.substring(3));
 
                 } else if (line.startsWith("execute java ")) {
                     String upgradestepClassName = line.substring(13).trim();
@@ -1069,7 +1069,7 @@ public class DbSqlSession extends AbstractDbSqlSession {
                         throw new FlowableException("database update java class '" + upgradestepClassName + "' can't be instantiated: " + e.getMessage(), e);
                     }
                     try {
-                        log.debug("executing upgrade step java class {}", upgradestepClassName);
+                        LOGGER.debug("executing upgrade step java class {}", upgradestepClassName);
                         dbUpgradeStep.execute(this);
                     } catch (Exception e) {
                         throw new FlowableException("error while executing database update java class '" + upgradestepClassName + "': " + e.getMessage(), e);
@@ -1092,7 +1092,7 @@ public class DbSqlSession extends AbstractDbSqlSession {
                         Statement jdbcStatement = connection.createStatement();
                         try {
                             // no logging needed as the connection will log it
-                            log.debug("SQL: {}", sqlStatement);
+                            LOGGER.debug("SQL: {}", sqlStatement);
                             jdbcStatement.execute(sqlStatement);
                             jdbcStatement.close();
                             
@@ -1101,7 +1101,7 @@ public class DbSqlSession extends AbstractDbSqlSession {
                                 exception = e;
                                 exceptionSqlStatement = sqlStatement;
                             }
-                            log.error("problem during schema {}, statement {}", operation, sqlStatement, e);
+                            LOGGER.error("problem during schema {}, statement {}", operation, sqlStatement, e);
                             
                         } finally {
                             sqlStatement = null;
@@ -1119,7 +1119,7 @@ public class DbSqlSession extends AbstractDbSqlSession {
                 throw exception;
             }
 
-            log.debug("flowable db schema {} for component {} successful", operation, component);
+            LOGGER.debug("flowable db schema {} for component {} successful", operation, component);
 
         } catch (Exception e) {
             throw new FlowableException("couldn't " + operation + " db schema: " + exceptionSqlStatement, e);
@@ -1182,7 +1182,7 @@ public class DbSqlSession extends AbstractDbSqlSession {
 
     public void performSchemaOperationsProcessEngineBuild() {
         String databaseSchemaUpdate = Context.getProcessEngineConfiguration().getDatabaseSchemaUpdate();
-        log.debug("Executing performSchemaOperationsProcessEngineBuild with setting {}", databaseSchemaUpdate);
+        LOGGER.debug("Executing performSchemaOperationsProcessEngineBuild with setting {}", databaseSchemaUpdate);
         if (ProcessEngineConfigurationImpl.DB_SCHEMA_UPDATE_DROP_CREATE.equals(databaseSchemaUpdate)) {
             try {
                 dbSchemaDrop();

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/history/AbstractHistoryManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/history/AbstractHistoryManager.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
 
 public abstract class AbstractHistoryManager extends AbstractManager implements HistoryManager {
 
-    private static Logger log = LoggerFactory.getLogger(AbstractHistoryManager.class.getName());
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractHistoryManager.class.getName());
 
     protected HistoryLevel historyLevel;
 
@@ -43,8 +43,8 @@ public abstract class AbstractHistoryManager extends AbstractManager implements 
 
     @Override
     public boolean isHistoryLevelAtLeast(HistoryLevel level) {
-        if (log.isDebugEnabled()) {
-            log.debug("Current history level: {}, level required: {}", historyLevel, level);
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Current history level: {}, level required: {}", historyLevel, level);
         }
         // Comparing enums actually compares the location of values declared in the enum
         return historyLevel.isAtLeast(level);
@@ -52,8 +52,8 @@ public abstract class AbstractHistoryManager extends AbstractManager implements 
 
     @Override
     public boolean isHistoryEnabled() {
-        if (log.isDebugEnabled()) {
-            log.debug("Current history level: {}", historyLevel);
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Current history level: {}", historyLevel);
         }
         return historyLevel != HistoryLevel.NONE;
     }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/history/DefaultHistoryManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/history/DefaultHistoryManager.java
@@ -45,7 +45,7 @@ import org.slf4j.LoggerFactory;
  */
 public class DefaultHistoryManager extends AbstractHistoryManager {
 
-    private static Logger log = LoggerFactory.getLogger(DefaultHistoryManager.class.getName());
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultHistoryManager.class.getName());
 
     public DefaultHistoryManager(ProcessEngineConfigurationImpl processEngineConfiguration, HistoryLevel historyLevel) {
         super(processEngineConfiguration, historyLevel);
@@ -385,8 +385,8 @@ public class DefaultHistoryManager extends AbstractHistoryManager {
     @Override
     public void updateProcessBusinessKeyInHistory(ExecutionEntity processInstance) {
         if (isHistoryEnabled()) {
-            if (log.isDebugEnabled()) {
-                log.debug("updateProcessBusinessKeyInHistory : {}", processInstance.getId());
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("updateProcessBusinessKeyInHistory : {}", processInstance.getId());
             }
             if (processInstance != null) {
                 HistoricProcessInstanceEntity historicProcessInstance = getHistoricProcessInstanceEntityManager().findById(processInstance.getId());

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/interceptor/CommandContext.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/interceptor/CommandContext.java
@@ -68,7 +68,7 @@ import org.slf4j.LoggerFactory;
  */
 public class CommandContext extends AbstractCommandContext {
 
-    private static Logger log = LoggerFactory.getLogger(CommandContext.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(CommandContext.class);
 
     protected ProcessEngineConfigurationImpl processEngineConfiguration;
     protected FailedJobCommandFactory failedJobCommandFactory;
@@ -89,7 +89,7 @@ public class CommandContext extends AbstractCommandContext {
     protected void logException() {
         if (exception instanceof JobNotFoundException || exception instanceof FlowableTaskAlreadyClaimedException) {
             // reduce log level, because this may have been caused because of job deletion due to cancelActiviti="true"
-            log.info("Error while closing command context", exception);
+            LOGGER.info("Error while closing command context", exception);
         } else {
             if (hideAsyncHistoryExceptions) {
                 return;

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/interceptor/CommandContextInterceptor.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/interceptor/CommandContextInterceptor.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
  */
 public class CommandContextInterceptor extends AbstractCommandInterceptor {
 
-    private static final Logger log = LoggerFactory.getLogger(CommandContextInterceptor.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(CommandContextInterceptor.class);
 
     protected CommandContextFactory commandContextFactory;
     protected ProcessEngineConfigurationImpl processEngineConfiguration;
@@ -47,7 +47,7 @@ public class CommandContextInterceptor extends AbstractCommandInterceptor {
         if (!config.isContextReusePossible() || context == null || context.getException() != null) {
             context = commandContextFactory.createCommandContext(command);
         } else {
-            log.debug("Valid context found. Reusing it for the current command '{}'", command.getClass().getCanonicalName());
+            LOGGER.debug("Valid context found. Reusing it for the current command '{}'", command.getClass().getCanonicalName());
             contextReused = true;
             context.setReused(true);
         }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/interceptor/LogInterceptor.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/interceptor/LogInterceptor.java
@@ -22,22 +22,22 @@ import org.slf4j.LoggerFactory;
  */
 public class LogInterceptor extends AbstractCommandInterceptor {
 
-    private static Logger log = LoggerFactory.getLogger(LogInterceptor.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(LogInterceptor.class);
 
     public <T> T execute(CommandConfig config, Command<T> command) {
-        if (!log.isDebugEnabled()) {
+        if (!LOGGER.isDebugEnabled()) {
             // do nothing here if we cannot log
             return next.execute(config, command);
         }
-        log.debug("\n");
-        log.debug("--- starting {} --------------------------------------------------------", command.getClass().getSimpleName());
+        LOGGER.debug("\n");
+        LOGGER.debug("--- starting {} --------------------------------------------------------", command.getClass().getSimpleName());
         try {
 
             return next.execute(config, command);
 
         } finally {
-            log.debug("--- {} finished --------------------------------------------------------", command.getClass().getSimpleName());
-            log.debug("\n");
+            LOGGER.debug("--- {} finished --------------------------------------------------------", command.getClass().getSimpleName());
+            LOGGER.debug("\n");
         }
     }
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/interceptor/RetryInterceptor.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/interceptor/RetryInterceptor.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
  */
 public class RetryInterceptor extends AbstractCommandInterceptor {
 
-    private static Logger log = LoggerFactory.getLogger(RetryInterceptor.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(RetryInterceptor.class);
 
     protected int numOfRetries = 3;
     protected int waitTimeInMs = 50;
@@ -37,7 +37,7 @@ public class RetryInterceptor extends AbstractCommandInterceptor {
 
         do {
             if (failedAttempts > 0) {
-                log.info("Waiting for {}ms before retrying the command.", waitTime);
+                LOGGER.info("Waiting for {}ms before retrying the command.", waitTime);
                 waitBeforeRetry(waitTime);
                 waitTime *= waitIncreaseFactor;
             }
@@ -48,7 +48,7 @@ public class RetryInterceptor extends AbstractCommandInterceptor {
                 return next.execute(config, command);
 
             } catch (FlowableOptimisticLockingException e) {
-                log.info("Caught optimistic locking exception: {}", e.getMessage(), e);
+                LOGGER.info("Caught optimistic locking exception: {}", e.getMessage(), e);
             }
 
             failedAttempts++;
@@ -61,7 +61,7 @@ public class RetryInterceptor extends AbstractCommandInterceptor {
         try {
             Thread.sleep(waitTime);
         } catch (InterruptedException e) {
-            log.debug("I am interrupted while waiting for a retry.");
+            LOGGER.debug("I am interrupted while waiting for a retry.");
         }
     }
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/jobexecutor/AsyncJobAddedNotification.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/jobexecutor/AsyncJobAddedNotification.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
  */
 public class AsyncJobAddedNotification implements CommandContextCloseListener {
 
-    private static Logger log = LoggerFactory.getLogger(AsyncJobAddedNotification.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AsyncJobAddedNotification.class);
 
     protected JobEntity job;
     protected AsyncExecutor asyncExecutor;
@@ -44,8 +44,8 @@ public class AsyncJobAddedNotification implements CommandContextCloseListener {
         CommandConfig commandConfig = new CommandConfig(false, TransactionPropagation.REQUIRES_NEW);
         commandExecutor.execute(commandConfig, new Command<Void>() {
             public Void execute(CommandContext commandContext) {
-                if (log.isTraceEnabled()) {
-                    log.trace("notifying job executor of new job");
+                if (LOGGER.isTraceEnabled()) {
+                    LOGGER.trace("notifying job executor of new job");
                 }
                 asyncExecutor.executeAsyncJob(job);
                 return null;

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/jobexecutor/FailedJobListener.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/jobexecutor/FailedJobListener.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  */
 public class FailedJobListener implements CommandContextCloseListener {
 
-    private static final Logger log = LoggerFactory.getLogger(FailedJobListener.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(FailedJobListener.class);
 
     protected CommandExecutor commandExecutor;
     protected Job job;
@@ -68,7 +68,7 @@ public class FailedJobListener implements CommandContextCloseListener {
         FailedJobCommandFactory failedJobCommandFactory = commandContext.getFailedJobCommandFactory();
         Command<Object> cmd = failedJobCommandFactory.getCommand(job.getId(), commandContext.getException());
 
-        log.trace("Using FailedJobCommandFactory '{}' and command of type '{}'", failedJobCommandFactory.getClass(), cmd.getClass());
+        LOGGER.trace("Using FailedJobCommandFactory '{}' and command of type '{}'", failedJobCommandFactory.getClass(), cmd.getClass());
         commandExecutor.execute(commandConfig, cmd);
     }
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/jobexecutor/JobAddedTransactionListener.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/jobexecutor/JobAddedTransactionListener.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
  */
 public class JobAddedTransactionListener implements TransactionListener {
 
-    private static Logger log = LoggerFactory.getLogger(JobAddedTransactionListener.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(JobAddedTransactionListener.class);
 
     protected JobEntity job;
     protected AsyncExecutor asyncExecutor;
@@ -44,8 +44,8 @@ public class JobAddedTransactionListener implements TransactionListener {
         CommandConfig commandConfig = new CommandConfig(false, TransactionPropagation.REQUIRES_NEW);
         commandExecutor.execute(commandConfig, new Command<Void>() {
             public Void execute(CommandContext commandContext) {
-                if (log.isTraceEnabled()) {
-                    log.trace("notifying job executor of new job");
+                if (LOGGER.isTraceEnabled()) {
+                    LOGGER.trace("notifying job executor of new job");
                 }
                 asyncExecutor.executeAsyncJob(job);
                 return null;

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/jobexecutor/TimerStartEventJobHandler.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/jobexecutor/TimerStartEventJobHandler.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
 
 public class TimerStartEventJobHandler extends TimerEventHandler implements JobHandler {
 
-    private static Logger log = LoggerFactory.getLogger(TimerStartEventJobHandler.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TimerStartEventJobHandler.class);
 
     public static final String TYPE = "timer-start-event";
 
@@ -66,13 +66,13 @@ public class TimerStartEventJobHandler extends TimerEventHandler implements JobH
                 }
 
             } else {
-                log.debug("ignoring timer of suspended process definition {}", processDefinitionEntity.getName());
+                LOGGER.debug("ignoring timer of suspended process definition {}", processDefinitionEntity.getName());
             }
         } catch (RuntimeException e) {
-            log.error("exception during timer execution", e);
+            LOGGER.error("exception during timer execution", e);
             throw e;
         } catch (Exception e) {
-            log.error("exception during timer execution", e);
+            LOGGER.error("exception during timer execution", e);
             throw new FlowableException("exception during timer execution: " + e.getMessage(), e);
         }
     }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/TableDataManagerImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/TableDataManagerImpl.java
@@ -58,7 +58,7 @@ public class TableDataManagerImpl extends AbstractManager implements TableDataMa
         super(processEngineConfiguration);
     }
 
-    private static Logger log = LoggerFactory.getLogger(TableDataManagerImpl.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TableDataManagerImpl.class);
 
     public static Map<Class<?>, String> apiTypeToTableNameMap = new HashMap<Class<?>, String>();
     public static Map<Class<? extends Entity>, String> entityToTableNameMap = new HashMap<Class<? extends Entity>, String>();
@@ -143,7 +143,7 @@ public class TableDataManagerImpl extends AbstractManager implements TableDataMa
             for (String tableName : getTablesPresentInDatabase()) {
                 tableCount.put(tableName, getTableCount(tableName));
             }
-            log.debug("Number of rows per flowable table: {}", tableCount);
+            LOGGER.debug("Number of rows per flowable table: {}", tableCount);
         } catch (Exception e) {
             throw new FlowableException("couldn't get table counts", e);
         }
@@ -159,7 +159,7 @@ public class TableDataManagerImpl extends AbstractManager implements TableDataMa
             DatabaseMetaData databaseMetaData = connection.getMetaData();
             ResultSet tables = null;
             try {
-                log.debug("retrieving flowable tables from jdbc metadata");
+                LOGGER.debug("retrieving flowable tables from jdbc metadata");
                 String databaseTablePrefix = getDbSqlSession().getDbSqlSessionFactory().getDatabaseTablePrefix();
                 String tableNameFilter = databaseTablePrefix + "ACT_%";
                 if ("postgres".equals(getDbSqlSession().getDbSqlSessionFactory().getDatabaseType())) {
@@ -188,7 +188,7 @@ public class TableDataManagerImpl extends AbstractManager implements TableDataMa
                     String tableName = tables.getString("TABLE_NAME");
                     tableName = tableName.toUpperCase();
                     tableNames.add(tableName);
-                    log.debug("  retrieved flowable table name {}", tableName);
+                    LOGGER.debug("  retrieved flowable table name {}", tableName);
                 }
             } finally {
                 tables.close();
@@ -200,7 +200,7 @@ public class TableDataManagerImpl extends AbstractManager implements TableDataMa
     }
 
     protected long getTableCount(String tableName) {
-        log.debug("selecting table count for {}", tableName);
+        LOGGER.debug("selecting table count for {}", tableName);
         Long count = (Long) getDbSqlSession().selectOne("org.flowable.engine.impl.TablePageMap.selectTableCount", Collections.singletonMap("tableName", tableName));
         return count;
     }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/rules/RulesDeployer.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/rules/RulesDeployer.java
@@ -34,10 +34,10 @@ import org.slf4j.LoggerFactory;
  */
 public class RulesDeployer implements Deployer {
 
-    private static final Logger log = LoggerFactory.getLogger(RulesDeployer.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(RulesDeployer.class);
 
     public void deploy(DeploymentEntity deployment, Map<String, Object> deploymentSettings) {
-        log.debug("Processing rules deployment {}", deployment.getName());
+        LOGGER.debug("Processing rules deployment {}", deployment.getName());
 
         KnowledgeBuilder knowledgeBuilder = null;
 
@@ -46,7 +46,7 @@ public class RulesDeployer implements Deployer {
         Map<String, ResourceEntity> resources = deployment.getResources();
         for (String resourceName : resources.keySet()) {
             if (resourceName.endsWith(".drl")) { // is only parsing .drls sufficient? what about other rule dsl's? (@see ResourceType)
-                log.info("Processing rules resource {}", resourceName);
+                LOGGER.info("Processing rules resource {}", resourceName);
                 if (knowledgeBuilder == null) {
                     knowledgeBuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
                 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/test/TestHelper.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/test/TestHelper.java
@@ -49,7 +49,7 @@ import junit.framework.AssertionFailedError;
  */
 public abstract class TestHelper {
 
-    private static Logger log = LoggerFactory.getLogger(TestHelper.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestHelper.class);
 
     public static final String EMPTY_LINE = "\n";
 
@@ -75,12 +75,12 @@ public abstract class TestHelper {
         try {
             method = testClass.getMethod(methodName, (Class<?>[]) null);
         } catch (Exception e) {
-            log.warn("Could not get method by reflection. This could happen if you are using @Parameters in combination with annotations.", e);
+            LOGGER.warn("Could not get method by reflection. This could happen if you are using @Parameters in combination with annotations.", e);
             return null;
         }
         Deployment deploymentAnnotation = method.getAnnotation(Deployment.class);
         if (deploymentAnnotation != null) {
-            log.debug("annotation @Deployment creates deployment for {}.{}", testClass.getSimpleName(), methodName);
+            LOGGER.debug("annotation @Deployment creates deployment for {}.{}", testClass.getSimpleName(), methodName);
             String[] resources = deploymentAnnotation.resources();
             if (resources.length == 0) {
                 String name = method.getName();
@@ -106,7 +106,7 @@ public abstract class TestHelper {
     }
 
     public static void annotationDeploymentTearDown(ProcessEngine processEngine, String deploymentId, Class<?> testClass, String methodName) {
-        log.debug("annotation @Deployment deletes deployment for {}.{}", testClass.getSimpleName(), methodName);
+        LOGGER.debug("annotation @Deployment deletes deployment for {}.{}", testClass.getSimpleName(), methodName);
         if (deploymentId != null) {
             try {
                 processEngine.getRepositoryService().deleteDeployment(deploymentId, true);
@@ -124,7 +124,7 @@ public abstract class TestHelper {
         try {
             method = testClass.getMethod(methodName, (Class<?>[]) null);
         } catch (Exception e) {
-            log.warn("Could not get method by reflection. This could happen if you are using @Parameters in combination with annotations.", e);
+            LOGGER.warn("Could not get method by reflection. This could happen if you are using @Parameters in combination with annotations.", e);
             return;
         }
 
@@ -215,9 +215,9 @@ public abstract class TestHelper {
     public static ProcessEngine getProcessEngine(String configurationResource) {
         ProcessEngine processEngine = processEngines.get(configurationResource);
         if (processEngine == null) {
-            log.debug("==== BUILDING PROCESS ENGINE ========================================================================");
+            LOGGER.debug("==== BUILDING PROCESS ENGINE ========================================================================");
             processEngine = ProcessEngineConfiguration.createProcessEngineConfigurationFromResource(configurationResource).buildProcessEngine();
-            log.debug("==== PROCESS ENGINE CREATED =========================================================================");
+            LOGGER.debug("==== PROCESS ENGINE CREATED =========================================================================");
             processEngines.put(configurationResource, processEngine);
         }
         return processEngine;
@@ -235,7 +235,7 @@ public abstract class TestHelper {
      * the DB is not clean. If the DB is not clean, it is cleaned by performing a create a drop.
      */
     public static void assertAndEnsureCleanDb(ProcessEngine processEngine) {
-        log.debug("verifying that db is clean after test");
+        LOGGER.debug("verifying that db is clean after test");
         Map<String, Long> tableCounts = processEngine.getManagementService().getTableCount();
         StringBuilder outputMessage = new StringBuilder();
         for (String tableName : tableCounts.keySet()) {
@@ -248,8 +248,8 @@ public abstract class TestHelper {
         }
         if (outputMessage.length() > 0) {
             outputMessage.insert(0, "DB NOT CLEAN: \n");
-            log.error(EMPTY_LINE);
-            log.error(outputMessage.toString());
+            LOGGER.error(EMPTY_LINE);
+            LOGGER.error(outputMessage.toString());
 
             ((ProcessEngineImpl) processEngine).getProcessEngineConfiguration().getCommandExecutor().execute(new Command<Object>() {
                 public Object execute(CommandContext commandContext) {

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/util/ReflectUtil.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/util/ReflectUtil.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class ReflectUtil {
 
-    private static final Logger LOG = LoggerFactory.getLogger(ReflectUtil.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ReflectUtil.class);
 
     private static final Pattern GETTER_PATTERN = Pattern.compile("(get|is)[A-Z].*");
     private static final Pattern SETTER_PATTERN = Pattern.compile("set[A-Z].*");
@@ -58,7 +58,7 @@ public abstract class ReflectUtil {
 
         if (classLoader != null) {
             try {
-                LOG.trace("Trying to load class with custom classloader: {}", className);
+                LOGGER.trace("Trying to load class with custom classloader: {}", className);
                 clazz = loadClass(classLoader, className);
             } catch (Throwable t) {
                 throwable = t;
@@ -66,7 +66,7 @@ public abstract class ReflectUtil {
         }
         if (clazz == null) {
             try {
-                LOG.trace("Trying to load class with current thread context classloader: {}", className);
+                LOGGER.trace("Trying to load class with current thread context classloader: {}", className);
                 clazz = loadClass(Thread.currentThread().getContextClassLoader(), className);
             } catch (Throwable t) {
                 if (throwable == null) {
@@ -75,7 +75,7 @@ public abstract class ReflectUtil {
             }
             if (clazz == null) {
                 try {
-                    LOG.trace("Trying to load class with local classloader: {}", className);
+                    LOGGER.trace("Trying to load class with local classloader: {}", className);
                     clazz = loadClass(ReflectUtil.class.getClassLoader(), className);
                 } catch (Throwable t) {
                     if (throwable == null) {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/end/DummyServiceTask.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/end/DummyServiceTask.java
@@ -19,7 +19,7 @@ import org.flowable.engine.impl.bpmn.behavior.TaskActivityBehavior;
 
 public class DummyServiceTask extends TaskActivityBehavior {
 
-    private static final Logger log = Logger.getLogger("DummyServiceTask");
+    private static final Logger LOGGER = Logger.getLogger("DummyServiceTask");
 
     public DummyServiceTask() {
         super();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/concurrency/ConcurrentEngineUsageTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/concurrency/ConcurrentEngineUsageTest.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ConcurrentEngineUsageTest extends PluggableFlowableTestCase {
 
-    private static Logger log = LoggerFactory.getLogger(ConcurrentEngineUsageTest.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConcurrentEngineUsageTest.class);
     private static final int MAX_RETRIES = 5;
 
     @Deployment
@@ -58,7 +58,7 @@ public class ConcurrentEngineUsageTest extends PluggableFlowableTestCase {
             executor.shutdown();
             boolean isEnded = executor.awaitTermination(20000, TimeUnit.MILLISECONDS);
             if (!isEnded) {
-                log.error("Executor was not shut down after timeout, not al tasks have been executed");
+                LOGGER.error("Executor was not shut down after timeout, not al tasks have been executed");
                 executor.shutdownNow();
 
             }
@@ -85,7 +85,7 @@ public class ConcurrentEngineUsageTest extends PluggableFlowableTestCase {
                 success = true;
             } catch (PersistenceException pe) {
                 retries = retries - 1;
-                log.debug("Retrying process start - {}", (MAX_RETRIES - retries));
+                LOGGER.debug("Retrying process start - {}", (MAX_RETRIES - retries));
                 try {
                     Thread.sleep(timeout);
                 } catch (InterruptedException ignore) {
@@ -94,7 +94,7 @@ public class ConcurrentEngineUsageTest extends PluggableFlowableTestCase {
             }
         }
         if (!success) {
-            log.debug("Retrying process start FAILED {} times", MAX_RETRIES);
+            LOGGER.debug("Retrying process start FAILED {} times", MAX_RETRIES);
         }
     }
 
@@ -108,7 +108,7 @@ public class ConcurrentEngineUsageTest extends PluggableFlowableTestCase {
                 success = true;
             } catch (PersistenceException pe) {
                 retries = retries - 1;
-                log.debug("Retrying task completion - {}", (MAX_RETRIES - retries));
+                LOGGER.debug("Retrying task completion - {}", (MAX_RETRIES - retries));
                 try {
                     Thread.sleep(timeout);
                 } catch (InterruptedException ignore) {
@@ -118,7 +118,7 @@ public class ConcurrentEngineUsageTest extends PluggableFlowableTestCase {
         }
 
         if (!success) {
-            log.debug("Retrying task completion FAILED {} times", MAX_RETRIES);
+            LOGGER.debug("Retrying task completion FAILED {} times", MAX_RETRIES);
         }
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/db/MetaDataTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/db/MetaDataTest.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
  */
 public class MetaDataTest extends PluggableFlowableTestCase {
 
-    private static Logger log = LoggerFactory.getLogger(MetaDataTest.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(MetaDataTest.class);
 
     public void testMetaData() {
         ((ProcessEngineImpl) processEngine).getProcessEngineConfiguration().getCommandExecutor().execute(new Command<Object>() {
@@ -45,9 +45,9 @@ public class MetaDataTest extends PluggableFlowableTestCase {
                         ResultSetMetaData resultSetMetaData = tables.getMetaData();
                         int columnCount = resultSetMetaData.getColumnCount();
                         for (int i = 1; i <= columnCount; i++) {
-                            log.info("result set column {}|{}|{}|{}", i, resultSetMetaData.getColumnName(i), resultSetMetaData.getColumnLabel(i), tables.getString(i));
+                            LOGGER.info("result set column {}|{}|{}|{}", i, resultSetMetaData.getColumnName(i), resultSetMetaData.getColumnLabel(i), tables.getString(i));
                         }
-                        log.info("-------------------------------------------------------");
+                        LOGGER.info("-------------------------------------------------------");
                     }
                 } catch (Exception e) {
                     e.printStackTrace();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/TweetExceptionHandler.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/TweetExceptionHandler.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
  */
 public class TweetExceptionHandler implements JobHandler {
 
-    private static Logger log = LoggerFactory.getLogger(TweetExceptionHandler.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TweetExceptionHandler.class);
 
     protected int exceptionsRemaining = 2;
 
@@ -37,7 +37,7 @@ public class TweetExceptionHandler implements JobHandler {
             exceptionsRemaining--;
             throw new RuntimeException("exception remaining: " + exceptionsRemaining);
         }
-        log.info("no more exceptions to throw.");
+        LOGGER.info("no more exceptions to throw.");
     }
 
     public int getExceptionsRemaining() {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/regression/DeleteProcessInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/regression/DeleteProcessInstanceTest.java
@@ -33,13 +33,13 @@ import org.slf4j.LoggerFactory;
  */
 public class DeleteProcessInstanceTest extends PluggableFlowableTestCase {
 
-    private static Logger log = LoggerFactory.getLogger(DeleteProcessInstanceTest.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DeleteProcessInstanceTest.class);
 
     @Deployment
     public void testNoEndTimeSet() {
 
         // Note that the instance with a Task Type of "user" is being started.
-        log.info("Starting an instance of \"Demo Partial Deletion\" with a Task Type of \"user\".");
+        LOGGER.info("Starting an instance of \"Demo Partial Deletion\" with a Task Type of \"user\".");
 
         // Set the inputs for the first process instance, which we will be able
         // to completely delete.
@@ -49,7 +49,7 @@ public class DeleteProcessInstanceTest extends PluggableFlowableTestCase {
         // Start the process instance & ensure it's started.
         ProcessInstance instanceUser = runtimeService.startProcessInstanceByKey("DemoPartialDeletion", inputParamsUser);
         assertNotNull(instanceUser);
-        log.info("Process instance (of process model {}) started with id: {}.", instanceUser.getProcessDefinitionId(), instanceUser.getId());
+        LOGGER.info("Process instance (of process model {}) started with id: {}.", instanceUser.getProcessDefinitionId(), instanceUser.getId());
 
         // Assert that the process instance is active.
         Execution executionUser = runtimeService.createExecutionQuery().processInstanceId(instanceUser.getProcessInstanceId()).onlyChildExecutions().singleResult();
@@ -67,12 +67,12 @@ public class DeleteProcessInstanceTest extends PluggableFlowableTestCase {
             // end time.
             HistoricProcessInstance hInstanceUser = historyService.createHistoricProcessInstanceQuery().processInstanceId(instanceUser.getId()).singleResult();
             assertNotNull(hInstanceUser.getEndTime());
-            log.info("End time for the deleted instance of \"Demo Partial Deletion\" that was started with a Task Type of \"user\": {}.", hInstanceUser.getEndTime());
-            log.info("Successfully deleted the instance of \"Demo Partial Deletion\" that was started with a Task Type of \"user\".");
+            LOGGER.info("End time for the deleted instance of \"Demo Partial Deletion\" that was started with a Task Type of \"user\": {}.", hInstanceUser.getEndTime());
+            LOGGER.info("Successfully deleted the instance of \"Demo Partial Deletion\" that was started with a Task Type of \"user\".");
         }
 
         // Note that the instance with a Task Type of "java" is being started.
-        log.info("Starting an instance of \"Demo Partial Deletion\" with a Task Type of \"java\".");
+        LOGGER.info("Starting an instance of \"Demo Partial Deletion\" with a Task Type of \"java\".");
 
         // Set the inputs for the second process instance, which we will NOT be
         // able to completely delete.
@@ -82,7 +82,7 @@ public class DeleteProcessInstanceTest extends PluggableFlowableTestCase {
         // Start the process instance & ensure it's started.
         ProcessInstance instanceJava = runtimeService.startProcessInstanceByKey("DemoPartialDeletion", inputParamsJava);
         assertNotNull(instanceJava);
-        log.info("Process instance (of process model {}) started with id: {}.", instanceJava.getProcessDefinitionId(), instanceJava.getId());
+        LOGGER.info("Process instance (of process model {}) started with id: {}.", instanceJava.getProcessDefinitionId(), instanceJava.getId());
 
         // Assert that the process instance is active.
         Execution executionJava = runtimeService.createExecutionQuery().processInstanceId(instanceJava.getProcessInstanceId()).onlyChildExecutions().singleResult();

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/jta/BitronixDataSourceFactoryBean.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/jta/BitronixDataSourceFactoryBean.java
@@ -26,7 +26,7 @@ import bitronix.tm.resource.jdbc.PoolingDataSource;
  * @author Marcus Klimstra (CGI)
  */
 public class BitronixDataSourceFactoryBean extends ResourceBean implements FactoryBean<PoolingDataSource>, DisposableBean {
-    private static final Logger LOG = LoggerFactory.getLogger(BitronixDataSourceFactoryBean.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(BitronixDataSourceFactoryBean.class);
 
     private PoolingDataSource ds;
 
@@ -61,7 +61,7 @@ public class BitronixDataSourceFactoryBean extends ResourceBean implements Facto
             ds.setIgnoreRecoveryFailures(getIgnoreRecoveryFailures());
             ds.setDriverProperties(getDriverProperties());
 
-            LOG.debug("Initializing PoolingDataSource with id {}", ds.getUniqueName());
+            LOGGER.debug("Initializing PoolingDataSource with id {}", ds.getUniqueName());
             ds.init();
         }
         return ds;
@@ -69,7 +69,7 @@ public class BitronixDataSourceFactoryBean extends ResourceBean implements Facto
 
     @Override
     public void destroy() throws Exception {
-        LOG.debug("Closing PoolingDataSource with id {}", ds.getUniqueName());
+        LOGGER.debug("Closing PoolingDataSource with id {}", ds.getUniqueName());
         ds.close();
         ds = null;
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/jta/CloseXADataSourceLifecycleListener.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/jta/CloseXADataSourceLifecycleListener.java
@@ -31,18 +31,18 @@ public class CloseXADataSourceLifecycleListener implements ProcessEngineLifecycl
     private PoolingDataSource dataSource;
     private BitronixTransactionManager transactionManager;
 
-    private static final Logger LOG = LoggerFactory.getLogger(CloseXADataSourceLifecycleListener.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(CloseXADataSourceLifecycleListener.class);
 
     @Override
     public void onProcessEngineBuilt(ProcessEngine processEngine) {
-        LOG.info("--------------------- Callback for engine start");
+        LOGGER.info("--------------------- Callback for engine start");
     }
 
     @Override
     public void onProcessEngineClosed(ProcessEngine processEngine) {
-        LOG.info("--------------------- Callback for engine end");
+        LOGGER.info("--------------------- Callback for engine end");
         if (dataSource != null) {
-            LOG.info("--------------------- Closing datasource");
+            LOGGER.info("--------------------- Closing datasource");
             dataSource.close();
         }
 

--- a/modules/flowable-form-engine-configurator/src/main/java/org/flowable/form/engine/deployer/FormDeployer.java
+++ b/modules/flowable-form-engine-configurator/src/main/java/org/flowable/form/engine/deployer/FormDeployer.java
@@ -28,21 +28,21 @@ import org.slf4j.LoggerFactory;
  */
 public class FormDeployer implements Deployer {
 
-    private static final Logger log = LoggerFactory.getLogger(FormDeployer.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(FormDeployer.class);
 
     @Override
     public void deploy(DeploymentEntity deployment, Map<String, Object> deploymentSettings) {
         if (!deployment.isNew())
             return;
 
-        log.debug("FormDeployer: processing deployment {}", deployment.getName());
+        LOGGER.debug("FormDeployer: processing deployment {}", deployment.getName());
 
         FormDeploymentBuilder formDeploymentBuilder = null;
 
         Map<String, ResourceEntity> resources = deployment.getResources();
         for (String resourceName : resources.keySet()) {
             if (resourceName.endsWith(".form")) {
-                log.info("FormDeployer: processing resource {}", resourceName);
+                LOGGER.info("FormDeployer: processing resource {}", resourceName);
                 if (formDeploymentBuilder == null) {
                     FormRepositoryService formRepositoryService = Context.getProcessEngineConfiguration().getFormEngineRepositoryService();
                     formDeploymentBuilder = formRepositoryService.createDeployment();

--- a/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/FormEngines.java
+++ b/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/FormEngines.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
 
 public abstract class FormEngines {
 
-    private static Logger log = LoggerFactory.getLogger(FormEngines.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(FormEngines.class);
 
     public static final String NAME_DEFAULT = "default";
 
@@ -73,7 +73,7 @@ public abstract class FormEngines {
             }
             for (Iterator<URL> iterator = configUrls.iterator(); iterator.hasNext();) {
                 URL resource = iterator.next();
-                log.info("Initializing form engine using configuration '{}'", resource.toString());
+                LOGGER.info("Initializing form engine using configuration '{}'", resource.toString());
                 initFormEngineFromResource(resource);
             }
 
@@ -85,13 +85,13 @@ public abstract class FormEngines {
 
             while (resources.hasMoreElements()) {
                 URL resource = resources.nextElement();
-                log.info("Initializing form engine using Spring configuration '{}'", resource.toString());
+                LOGGER.info("Initializing form engine using Spring configuration '{}'", resource.toString());
                 initFormEngineFromSpringResource(resource);
             }
 
             setInitialized(true);
         } else {
-            log.info("Form engines already initialized");
+            LOGGER.info("Form engines already initialized");
         }
     }
 
@@ -141,15 +141,15 @@ public abstract class FormEngines {
 
         String resourceUrlString = resourceUrl.toString();
         try {
-            log.info("initializing dmn engine for resource {}", resourceUrl);
+            LOGGER.info("initializing dmn engine for resource {}", resourceUrl);
             FormEngine formEngine = buildFormEngine(resourceUrl);
             String formEngineName = formEngine.getName();
-            log.info("initialised form engine {}", formEngineName);
+            LOGGER.info("initialised form engine {}", formEngineName);
             formEngineInfo = new EngineInfo(formEngineName, resourceUrlString, null);
             formEngines.put(formEngineName, formEngine);
             formEngineInfosByName.put(formEngineName, formEngineInfo);
         } catch (Throwable e) {
-            log.error("Exception while initializing form engine: {}", e.getMessage(), e);
+            LOGGER.error("Exception while initializing form engine: {}", e.getMessage(), e);
             formEngineInfo = new EngineInfo(null, resourceUrlString, getExceptionString(e));
         }
         formEngineInfosByResourceUrl.put(resourceUrlString, formEngineInfo);
@@ -212,7 +212,7 @@ public abstract class FormEngines {
      * retries to initialize a form engine that previously failed.
      */
     public static EngineInfo retry(String resourceUrl) {
-        log.debug("retying initializing of resource {}", resourceUrl);
+        LOGGER.debug("retying initializing of resource {}", resourceUrl);
         try {
             return initFormEngineFromResource(new URL(resourceUrl));
         } catch (MalformedURLException e) {
@@ -240,7 +240,7 @@ public abstract class FormEngines {
                 try {
                     formEngine.close();
                 } catch (Exception e) {
-                    log.error("exception while closing {}", (formEngineName == null ? "the default form engine" : "form engine " + formEngineName), e);
+                    LOGGER.error("exception while closing {}", (formEngineName == null ? "the default form engine" : "form engine " + formEngineName), e);
                 }
             }
 

--- a/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/FormEngineImpl.java
+++ b/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/FormEngineImpl.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
  */
 public class FormEngineImpl implements FormEngine {
 
-    private static Logger log = LoggerFactory.getLogger(FormEngineImpl.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(FormEngineImpl.class);
 
     protected String name;
     protected FormManagementService managementService;
@@ -42,9 +42,9 @@ public class FormEngineImpl implements FormEngine {
         this.formService = engineConfiguration.getFormService();
 
         if (name == null) {
-            log.info("default flowable FormEngine created");
+            LOGGER.info("default flowable FormEngine created");
         } else {
-            log.info("FormEngine {} created", name);
+            LOGGER.info("FormEngine {} created", name);
         }
 
         FormEngines.registerFormEngine(this);

--- a/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/cfg/standalone/StandaloneMybatisTransactionContext.java
+++ b/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/cfg/standalone/StandaloneMybatisTransactionContext.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  */
 public class StandaloneMybatisTransactionContext implements TransactionContext {
 
-    private static Logger log = LoggerFactory.getLogger(StandaloneMybatisTransactionContext.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(StandaloneMybatisTransactionContext.class);
 
     protected CommandContext commandContext;
     protected Map<TransactionState, List<TransactionListener>> stateTransactionListeners;
@@ -58,12 +58,12 @@ public class StandaloneMybatisTransactionContext implements TransactionContext {
 
     public void commit() {
 
-        log.debug("firing event committing...");
+        LOGGER.debug("firing event committing...");
         fireTransactionEvent(TransactionState.COMMITTING, false);
 
-        log.debug("committing the ibatis sql session...");
+        LOGGER.debug("committing the ibatis sql session...");
         getDbSqlSession().commit();
-        log.debug("firing event committed...");
+        LOGGER.debug("firing event committed...");
         fireTransactionEvent(TransactionState.COMMITTED, true);
 
     }
@@ -115,23 +115,23 @@ public class StandaloneMybatisTransactionContext implements TransactionContext {
     public void rollback() {
         try {
             try {
-                log.debug("firing event rolling back...");
+                LOGGER.debug("firing event rolling back...");
                 fireTransactionEvent(TransactionState.ROLLINGBACK, false);
 
             } catch (Throwable exception) {
-                log.info("Exception during transaction: {}", exception.getMessage());
+                LOGGER.info("Exception during transaction: {}", exception.getMessage());
                 commandContext.exception(exception);
             } finally {
-                log.debug("rolling back ibatis sql session...");
+                LOGGER.debug("rolling back ibatis sql session...");
                 getDbSqlSession().rollback();
             }
 
         } catch (Throwable exception) {
-            log.info("Exception during transaction: {}", exception.getMessage());
+            LOGGER.info("Exception during transaction: {}", exception.getMessage());
             commandContext.exception(exception);
 
         } finally {
-            log.debug("firing event rolled back...");
+            LOGGER.debug("firing event rolled back...");
             fireTransactionEvent(TransactionState.ROLLED_BACK, true);
         }
     }

--- a/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/cmd/GetFormInstanceModelCmd.java
+++ b/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/cmd/GetFormInstanceModelCmd.java
@@ -12,6 +12,9 @@
  */
 package org.flowable.form.engine.impl.cmd;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import java.io.Serializable;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -45,15 +48,12 @@ import org.joda.time.LocalDate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 /**
  * @author Tijs Rademakers
  */
 public class GetFormInstanceModelCmd implements Command<FormInstanceModel>, Serializable {
 
-    private static Logger logger = LoggerFactory.getLogger(GetFormInstanceModelCmd.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(GetFormInstanceModelCmd.class);
 
     private static final long serialVersionUID = 1L;
     
@@ -138,7 +138,7 @@ public class GetFormInstanceModelCmd implements Command<FormInstanceModel>, Seri
                     try {
                         field.setValue(formExpression.getValue(variables));
                     } catch (Exception e) {
-                        logger.error("Error getting value for expression {} {}", expressionField.getExpression(), e.getMessage());
+                        LOGGER.error("Error getting value for expression {} {}", expressionField.getExpression(), e.getMessage());
                     }
 
                 } else if (FormFieldTypes.UPLOAD.equals(field.getType())) {
@@ -311,7 +311,7 @@ public class GetFormInstanceModelCmd implements Command<FormInstanceModel>, Seri
                         variables.put(field.getId(), dateValue.toString("d-M-yyyy"));
                     }
                 } catch (Exception e) {
-                    logger.error("Error parsing form date value for process instance {} and task {} with value {}", processInstanceId, taskId, fieldValue, e);
+                    LOGGER.error("Error parsing form date value for process instance {} and task {} with value {}", processInstanceId, taskId, fieldValue, e);
                 }
 
             } else {

--- a/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/cmd/GetFormModelWithVariablesCmd.java
+++ b/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/cmd/GetFormModelWithVariablesCmd.java
@@ -12,6 +12,9 @@
  */
 package org.flowable.form.engine.impl.cmd;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import java.io.Serializable;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -40,15 +43,12 @@ import org.joda.time.LocalDate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 /**
  * @author Tijs Rademakers
  */
 public class GetFormModelWithVariablesCmd implements Command<FormModel>, Serializable {
 
-    private static Logger logger = LoggerFactory.getLogger(GetFormModelWithVariablesCmd.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(GetFormModelWithVariablesCmd.class);
 
     private static final long serialVersionUID = 1L;
     
@@ -121,7 +121,7 @@ public class GetFormModelWithVariablesCmd implements Command<FormModel>, Seriali
                     try {
                         field.setValue(formExpression.getValue(variables));
                     } catch (Exception e) {
-                        logger.error("Error getting value for expression {} {}", expressionField.getExpression(), e.getMessage(), e);
+                        LOGGER.error("Error getting value for expression {} {}", expressionField.getExpression(), e.getMessage(), e);
                     }
 
                 } else {
@@ -244,7 +244,7 @@ public class GetFormModelWithVariablesCmd implements Command<FormModel>, Seriali
                     }
                     
                 } catch (Exception e) {
-                    logger.error("Error parsing form date value for process instance {} with value {}", processInstanceId, fieldValue, e);
+                    LOGGER.error("Error parsing form date value for process instance {} with value {}", processInstanceId, fieldValue, e);
                 }
 
             } else {

--- a/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/db/DbSqlSession.java
+++ b/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/db/DbSqlSession.java
@@ -35,7 +35,7 @@ import liquibase.resource.ClassLoaderResourceAccessor;
  */
 public class DbSqlSession extends AbstractNonCachingDbSqlSession {
 
-    private static final Logger log = LoggerFactory.getLogger(DbSqlSession.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DbSqlSession.class);
 
     public DbSqlSession(DbSqlSessionFactory dbSqlSessionFactory) {
         super(dbSqlSessionFactory);
@@ -49,7 +49,7 @@ public class DbSqlSession extends AbstractNonCachingDbSqlSession {
     // ////////////////////////////////////////////////////////
 
     public void dbSchemaCheckVersion() {
-        log.debug("flowable form db schema check successful");
+        LOGGER.debug("flowable form db schema check successful");
     }
 
     public void dbSchemaCreate() {

--- a/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/deployer/FormDefinitionDeployer.java
+++ b/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/deployer/FormDefinitionDeployer.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  */
 public class FormDefinitionDeployer implements Deployer {
 
-    private static final Logger log = LoggerFactory.getLogger(FormDefinitionDeployer.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(FormDefinitionDeployer.class);
 
     protected IdGenerator idGenerator;
     protected ParsedDeploymentBuilderFactory parsedDeploymentBuilderFactory;
@@ -39,7 +39,7 @@ public class FormDefinitionDeployer implements Deployer {
     protected CachingAndArtifactsManager cachingAndArtifactsManager;
 
     public void deploy(FormDeploymentEntity deployment) {
-        log.debug("Processing deployment {}", deployment.getName());
+        LOGGER.debug("Processing deployment {}", deployment.getName());
 
         // The ParsedDeployment represents the deployment, the forms, and the form
         // resource, parse, and model associated with each form.

--- a/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/deployer/ParsedDeploymentBuilder.java
+++ b/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/deployer/ParsedDeploymentBuilder.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
 
 public class ParsedDeploymentBuilder {
 
-    private static final Logger log = LoggerFactory.getLogger(ParsedDeploymentBuilder.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ParsedDeploymentBuilder.class);
 
     public static final String[] FORM_RESOURCE_SUFFIXES = new String[] { "form" };
 
@@ -48,7 +48,7 @@ public class ParsedDeploymentBuilder {
 
         for (ResourceEntity resource : deployment.getResources().values()) {
             if (isFormResource(resource.getName())) {
-                log.debug("Processing Form definition resource {}", resource.getName());
+                LOGGER.debug("Processing Form definition resource {}", resource.getName());
                 FormDefinitionParse parse = createFormParseFromResource(resource);
                 for (FormDefinitionEntity formDefinition : parse.getFormDefinitions()) {
                     formDefinitions.add(formDefinition);

--- a/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/interceptor/CommandContext.java
+++ b/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/interceptor/CommandContext.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
  */
 public class CommandContext extends AbstractCommandContext {
 
-    private static Logger log = LoggerFactory.getLogger(CommandContext.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(CommandContext.class);
 
     protected FormEngineConfiguration formEngineConfiguration;
 

--- a/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/interceptor/CommandContextInterceptor.java
+++ b/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/interceptor/CommandContextInterceptor.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
  * @author Tijs Rademakers
  */
 public class CommandContextInterceptor extends AbstractCommandInterceptor {
-    private static final Logger log = LoggerFactory.getLogger(CommandContextInterceptor.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(CommandContextInterceptor.class);
 
     protected CommandContextFactory commandContextFactory;
     protected FormEngineConfiguration formEngineConfiguration;
@@ -45,7 +45,7 @@ public class CommandContextInterceptor extends AbstractCommandInterceptor {
         if (!config.isContextReusePossible() || context == null || context.getException() != null) {
             context = commandContextFactory.createCommandContext(command);
         } else {
-            log.debug("Valid context found. Reusing it for the current command '{}'", command.getClass().getCanonicalName());
+            LOGGER.debug("Valid context found. Reusing it for the current command '{}'", command.getClass().getCanonicalName());
             contextReused = true;
         }
 

--- a/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/interceptor/LogInterceptor.java
+++ b/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/interceptor/LogInterceptor.java
@@ -22,22 +22,22 @@ import org.slf4j.LoggerFactory;
  */
 public class LogInterceptor extends AbstractCommandInterceptor {
 
-    private static Logger log = LoggerFactory.getLogger(LogInterceptor.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(LogInterceptor.class);
 
     public <T> T execute(CommandConfig config, Command<T> command) {
-        if (!log.isDebugEnabled()) {
+        if (!LOGGER.isDebugEnabled()) {
             // do nothing here if we cannot log
             return next.execute(config, command);
         }
-        log.debug("\n");
-        log.debug("--- starting {} --------------------------------------------------------", command.getClass().getSimpleName());
+        LOGGER.debug("\n");
+        LOGGER.debug("--- starting {} --------------------------------------------------------", command.getClass().getSimpleName());
         try {
 
             return next.execute(config, command);
 
         } finally {
-            log.debug("--- {} finished --------------------------------------------------------", command.getClass().getSimpleName());
-            log.debug("\n");
+            LOGGER.debug("--- {} finished --------------------------------------------------------", command.getClass().getSimpleName());
+            LOGGER.debug("\n");
         }
     }
 }

--- a/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/persistence/entity/TableDataManagerImpl.java
+++ b/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/persistence/entity/TableDataManagerImpl.java
@@ -44,7 +44,7 @@ public class TableDataManagerImpl extends AbstractManager implements TableDataMa
         super(formEngineConfiguration);
     }
 
-    private static Logger log = LoggerFactory.getLogger(TableDataManagerImpl.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TableDataManagerImpl.class);
 
     public static Map<Class<?>, String> apiTypeToTableNameMap = new HashMap<Class<?>, String>();
     public static Map<Class<? extends Entity>, String> entityToTableNameMap = new HashMap<Class<? extends Entity>, String>();
@@ -69,7 +69,7 @@ public class TableDataManagerImpl extends AbstractManager implements TableDataMa
             for (String tableName : getTablesPresentInDatabase()) {
                 tableCount.put(tableName, getTableCount(tableName));
             }
-            log.debug("Number of rows per flowable table: {}", tableCount);
+            LOGGER.debug("Number of rows per flowable table: {}", tableCount);
         } catch (Exception e) {
             throw new FlowableException("couldn't get table counts", e);
         }
@@ -85,7 +85,7 @@ public class TableDataManagerImpl extends AbstractManager implements TableDataMa
             DatabaseMetaData databaseMetaData = connection.getMetaData();
             ResultSet tables = null;
             try {
-                log.debug("retrieving flowable tables from jdbc metadata");
+                LOGGER.debug("retrieving flowable tables from jdbc metadata");
                 String databaseTablePrefix = getDbSqlSession().getDbSqlSessionFactory().getDatabaseTablePrefix();
                 String tableNameFilter = databaseTablePrefix + "ACT_%";
                 if ("postgres".equals(getDbSqlSession().getDbSqlSessionFactory().getDatabaseType())) {
@@ -114,7 +114,7 @@ public class TableDataManagerImpl extends AbstractManager implements TableDataMa
                     String tableName = tables.getString("TABLE_NAME");
                     tableName = tableName.toUpperCase();
                     tableNames.add(tableName);
-                    log.debug("  retrieved flowable table name {}", tableName);
+                    LOGGER.debug("  retrieved flowable table name {}", tableName);
                 }
             } finally {
                 tables.close();
@@ -126,7 +126,7 @@ public class TableDataManagerImpl extends AbstractManager implements TableDataMa
     }
 
     protected long getTableCount(String tableName) {
-        log.debug("selecting table count for {}", tableName);
+        LOGGER.debug("selecting table count for {}", tableName);
         Long count = (Long) getDbSqlSession().selectOne("org.flowable.form.engine.impl.TablePageMap.selectTableCount", Collections.singletonMap("tableName", tableName));
         return count;
     }

--- a/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/util/ReflectUtil.java
+++ b/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/util/ReflectUtil.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class ReflectUtil {
 
-    private static final Logger LOG = LoggerFactory.getLogger(ReflectUtil.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ReflectUtil.class);
 
     private static final Pattern GETTER_PATTERN = Pattern.compile("(get|is)[A-Z].*");
     private static final Pattern SETTER_PATTERN = Pattern.compile("set[A-Z].*");
@@ -56,7 +56,7 @@ public abstract class ReflectUtil {
 
         if (classLoader != null) {
             try {
-                LOG.trace("Trying to load class with custom classloader: {}", className);
+                LOGGER.trace("Trying to load class with custom classloader: {}", className);
                 clazz = loadClass(classLoader, className);
             } catch (Throwable t) {
                 throwable = t;
@@ -64,7 +64,7 @@ public abstract class ReflectUtil {
         }
         if (clazz == null) {
             try {
-                LOG.trace("Trying to load class with current thread context classloader: {}", className);
+                LOGGER.trace("Trying to load class with current thread context classloader: {}", className);
                 clazz = loadClass(Thread.currentThread().getContextClassLoader(), className);
             } catch (Throwable t) {
                 if (throwable == null) {
@@ -73,7 +73,7 @@ public abstract class ReflectUtil {
             }
             if (clazz == null) {
                 try {
-                    LOG.trace("Trying to load class with local classloader: {}", className);
+                    LOGGER.trace("Trying to load class with local classloader: {}", className);
                     clazz = loadClass(ReflectUtil.class.getClassLoader(), className);
                 } catch (Throwable t) {
                     if (throwable == null) {

--- a/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/test/FormTestHelper.java
+++ b/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/test/FormTestHelper.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class FormTestHelper {
 
-    private static Logger log = LoggerFactory.getLogger(FormTestHelper.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(FormTestHelper.class);
 
     public static final String EMPTY_LINE = "\n";
 
@@ -48,12 +48,12 @@ public abstract class FormTestHelper {
         try {
             method = testClass.getMethod(methodName, (Class<?>[]) null);
         } catch (Exception e) {
-            log.warn("Could not get method by reflection. This could happen if you are using @Parameters in combination with annotations.", e);
+            LOGGER.warn("Could not get method by reflection. This could happen if you are using @Parameters in combination with annotations.", e);
             return null;
         }
         FormDeploymentAnnotation deploymentAnnotation = method.getAnnotation(FormDeploymentAnnotation.class);
         if (deploymentAnnotation != null) {
-            log.debug("annotation @Deployment creates deployment for {}.{}", testClass.getSimpleName(), methodName);
+            LOGGER.debug("annotation @Deployment creates deployment for {}.{}", testClass.getSimpleName(), methodName);
             String[] resources = deploymentAnnotation.resources();
             if (resources.length == 0) {
                 String name = method.getName();
@@ -74,7 +74,7 @@ public abstract class FormTestHelper {
     }
 
     public static void annotationDeploymentTearDown(FormEngine formEngine, String deploymentId, Class<?> testClass, String methodName) {
-        log.debug("annotation @Deployment deletes deployment for {}.{}", testClass.getSimpleName(), methodName);
+        LOGGER.debug("annotation @Deployment deletes deployment for {}.{}", testClass.getSimpleName(), methodName);
         if (deploymentId != null) {
             try {
                 formEngine.getFormRepositoryService().deleteDeployment(deploymentId);
@@ -107,11 +107,11 @@ public abstract class FormTestHelper {
     public static FormEngine getFormEngine(String configurationResource) {
         FormEngine formEngine = formEngines.get(configurationResource);
         if (formEngine == null) {
-            log.debug("==== BUILDING FORM ENGINE ========================================================================");
+            LOGGER.debug("==== BUILDING FORM ENGINE ========================================================================");
             formEngine = FormEngineConfiguration.createFormEngineConfigurationFromResource(configurationResource)
                     .setDatabaseSchemaUpdate(FormEngineConfiguration.DB_SCHEMA_UPDATE_DROP_CREATE)
                     .buildFormEngine();
-            log.debug("==== FORM ENGINE CREATED =========================================================================");
+            LOGGER.debug("==== FORM ENGINE CREATED =========================================================================");
             formEngines.put(configurationResource, formEngine);
         }
         return formEngine;
@@ -129,7 +129,7 @@ public abstract class FormTestHelper {
      * the DB is not clean. If the DB is not clean, it is cleaned by performing a create a drop.
      */
     public static void assertAndEnsureCleanDb(FormEngine formEngine) {
-        log.debug("verifying that db is clean after test");
+        LOGGER.debug("verifying that db is clean after test");
         FormRepositoryService repositoryService = formEngine.getFormEngineConfiguration().getFormRepositoryService();
         List<FormDeployment> deployments = repositoryService.createDeploymentQuery().list();
         if (deployments != null && !deployments.isEmpty()) {

--- a/modules/flowable-form-spring/src/main/java/org/flowable/form/spring/SpringFormConfigurationHelper.java
+++ b/modules/flowable-form-spring/src/main/java/org/flowable/form/spring/SpringFormConfigurationHelper.java
@@ -29,10 +29,10 @@ import org.springframework.core.io.UrlResource;
  */
 public class SpringFormConfigurationHelper {
 
-    private static Logger log = LoggerFactory.getLogger(SpringFormConfigurationHelper.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SpringFormConfigurationHelper.class);
 
     public static FormEngine buildFormEngine(URL resource) {
-        log.debug("==== BUILDING SPRING APPLICATION CONTEXT AND FORM ENGINE =========================================");
+        LOGGER.debug("==== BUILDING SPRING APPLICATION CONTEXT AND FORM ENGINE =========================================");
 
         ApplicationContext applicationContext = new GenericXmlApplicationContext(new UrlResource(resource));
         Map<String, FormEngine> beansOfType = applicationContext.getBeansOfType(FormEngine.class);
@@ -42,7 +42,7 @@ public class SpringFormConfigurationHelper {
 
         FormEngine formEngine = beansOfType.values().iterator().next();
 
-        log.debug("==== SPRING FORM ENGINE CREATED ==================================================================");
+        LOGGER.debug("==== SPRING FORM ENGINE CREATED ==================================================================");
         return formEngine;
     }
 

--- a/modules/flowable-http/src/main/java/org/flowable/http/HttpActivityBehavior.java
+++ b/modules/flowable-http/src/main/java/org/flowable/http/HttpActivityBehavior.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class HttpActivityBehavior extends AbstractBpmnActivityBehavior {
 
-    private static final Logger log = LoggerFactory.getLogger(HttpActivityBehavior.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(HttpActivityBehavior.class);
     
     private static final long serialVersionUID = 1L;
     
@@ -186,7 +186,7 @@ public abstract class HttpActivityBehavior extends AbstractBpmnActivityBehavior 
             
         } catch (Exception e) {
             if (request.isIgnoreErrors()) {
-                log.info("Error ignored while processing http task in execution {}", execution.getId(), e);
+                LOGGER.info("Error ignored while processing http task in execution {}", execution.getId(), e);
                 execution.setVariable(request.getPrefix() + ".errorMessage", e.getMessage());
                 
             } else {

--- a/modules/flowable-http/src/main/java/org/flowable/http/impl/HttpActivityBehaviorImpl.java
+++ b/modules/flowable-http/src/main/java/org/flowable/http/impl/HttpActivityBehaviorImpl.java
@@ -76,7 +76,7 @@ import org.slf4j.LoggerFactory;
 public class HttpActivityBehaviorImpl extends HttpActivityBehavior {
 
     private static final long serialVersionUID = 1L;
-    private static final Logger log = LoggerFactory.getLogger(HttpActivityBehaviorImpl.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(HttpActivityBehaviorImpl.class);
     
     protected HttpServiceTask httpServiceTask;
 
@@ -100,7 +100,7 @@ public class HttpActivityBehaviorImpl extends HttpActivityBehavior {
                         }));
                 
             } catch (Exception e) {
-                log.error("Could not configure HTTP client SSL self signed strategy", e);
+                LOGGER.error("Could not configure HTTP client SSL self signed strategy", e);
             }
         }
 
@@ -113,7 +113,7 @@ public class HttpActivityBehaviorImpl extends HttpActivityBehavior {
 
         // Build http client
         client = httpClientBuilder.build();
-        log.info("HTTP client is initialized");
+        LOGGER.info("HTTP client is initialized");
 
         // Shutdown hook to close the http client
         Runtime.getRuntime().addShutdownHook(new Thread() {
@@ -122,9 +122,9 @@ public class HttpActivityBehaviorImpl extends HttpActivityBehavior {
                 if (client != null) {
                     try {
                         client.close();
-                        log.info("HTTP client is closed");
+                        LOGGER.info("HTTP client is closed");
                     } catch (Throwable e) {
-                        log.error("Could not close http client", e);
+                        LOGGER.error("Could not close http client", e);
                     }
                 }
             }
@@ -229,7 +229,7 @@ public class HttpActivityBehaviorImpl extends HttpActivityBehavior {
                 try {
                     response.close();
                 } catch (Throwable e) {
-                    log.error("Could not close http response", e);
+                    LOGGER.error("Could not close http response", e);
                 }
             }
         }

--- a/modules/flowable-http/src/test/java/org/flowable/http/HttpExecutionListener.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/HttpExecutionListener.java
@@ -22,16 +22,16 @@ import org.slf4j.LoggerFactory;
 public class HttpExecutionListener implements ExecutionListener {
 
     private static final long serialVersionUID = 1L;
-    private static final Logger log = LoggerFactory.getLogger(HttpExecutionListener.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(HttpExecutionListener.class);
 
     public static int runs;
 
     public void notify(DelegateExecution execution) {
         execution.setVariable("runs", ++runs);
         for (Map.Entry e : execution.getVariables().entrySet()) {
-            log.info("key: {}", e.getKey());
+            LOGGER.info("key: {}", e.getKey());
             if (e.getValue() != null) {
-                log.info("Value: {}", e.getValue());
+                LOGGER.info("Value: {}", e.getValue());
             }
         }
     }

--- a/modules/flowable-http/src/test/java/org/flowable/http/HttpServiceTaskTest.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/HttpServiceTaskTest.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  */
 public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
 
-    private static Logger log = LoggerFactory.getLogger(HttpServiceTaskTest.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(HttpServiceTaskTest.class);
 
     private ObjectMapper mapper = new ObjectMapper();
 

--- a/modules/flowable-http/src/test/java/org/flowable/http/HttpServiceTaskTestCase.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/HttpServiceTaskTestCase.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class HttpServiceTaskTestCase extends PluggableFlowableTestCase {
 
-    private static Logger log = LoggerFactory.getLogger(HttpServiceTaskTestCase.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(HttpServiceTaskTestCase.class);
 
     @Override
     protected void setUp() throws Exception {

--- a/modules/flowable-http/src/test/java/org/flowable/http/HttpServiceTaskTestServer.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/HttpServiceTaskTestServer.java
@@ -48,7 +48,7 @@ import org.slf4j.LoggerFactory;
  */
 public class HttpServiceTaskTestServer {
 
-    private static Logger log = LoggerFactory.getLogger(HttpServiceTaskTestServer.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(HttpServiceTaskTestServer.class);
     // These should be fixed and known as we use it in test process templates
     protected static final int HTTP_PORT = 9798;
     protected static final int HTTPS_PORT = 9799;
@@ -88,7 +88,7 @@ public class HttpServiceTaskTestServer {
             server.setHandler(contextHandler);
             server.start();
         } catch (Exception e) {
-            log.error("Error starting server", e);
+            LOGGER.error("Error starting server", e);
         }
 
         // Shutdown hook to close the http server
@@ -98,9 +98,9 @@ public class HttpServiceTaskTestServer {
                 if (server != null && server.isRunning()) {
                     try {
                         server.stop();
-                        log.info("HTTP server stopped");
+                        LOGGER.info("HTTP server stopped");
                     } catch (Exception e) {
-                        log.error("Could not close http server", e);
+                        LOGGER.error("Could not close http server", e);
                     }
                 }
             }

--- a/modules/flowable-http/src/test/java/org/flowable/http/cfg/HttpServiceTaskCfgTest.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/cfg/HttpServiceTaskCfgTest.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
  * @author Harsha Teja Kanna
  */
 public class HttpServiceTaskCfgTest extends HttpServiceTaskCfgTestCase {
-    private static Logger log = LoggerFactory.getLogger(HttpServiceTaskCfgTest.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(HttpServiceTaskCfgTest.class);
 
     public HttpServiceTaskCfgTest() {
         super("flowable.cfg.xml");
@@ -32,7 +32,7 @@ public class HttpServiceTaskCfgTest extends HttpServiceTaskCfgTestCase {
 
     @Override
     protected void additionalConfiguration(ProcessEngineConfiguration processEngineConfiguration) {
-        log.info("Set Http client config");
+        LOGGER.info("Set Http client config");
         processEngineConfiguration
                 .getHttpClientConfig()
                 .setDisableCertVerify(false);

--- a/modules/flowable-http/src/test/java/org/flowable/http/cfg/HttpServiceTaskCfgTestCase.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/cfg/HttpServiceTaskCfgTestCase.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class HttpServiceTaskCfgTestCase extends ResourceFlowableTestCase {
 
-    private static Logger log = LoggerFactory.getLogger(HttpServiceTaskCfgTestCase.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(HttpServiceTaskCfgTestCase.class);
 
     public HttpServiceTaskCfgTestCase(String configPath) {
         super(configPath);

--- a/modules/flowable-http/src/test/java/org/flowable/http/custom/HttpActivityBehaviorCustomTestImpl.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/custom/HttpActivityBehaviorCustomTestImpl.java
@@ -28,7 +28,7 @@ public class HttpActivityBehaviorCustomTestImpl extends HttpActivityBehavior {
 
     private static final long serialVersionUID = 1L;
 
-    private static final Logger log = LoggerFactory.getLogger(HttpActivityBehaviorCustomTestImpl.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(HttpActivityBehaviorCustomTestImpl.class);
 
     @Override
     protected HttpResponse perform(DelegateExecution execution, HttpRequest request) {

--- a/modules/flowable-idm-engine/src/main/java/org/flowable/idm/engine/IdmEngines.java
+++ b/modules/flowable-idm-engine/src/main/java/org/flowable/idm/engine/IdmEngines.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
 
 public abstract class IdmEngines {
 
-    private static Logger log = LoggerFactory.getLogger(IdmEngines.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(IdmEngines.class);
 
     public static final String NAME_DEFAULT = "default";
 
@@ -73,7 +73,7 @@ public abstract class IdmEngines {
             }
             for (Iterator<URL> iterator = configUrls.iterator(); iterator.hasNext();) {
                 URL resource = iterator.next();
-                log.info("Initializing idm engine using configuration '{}'", resource.toString());
+                LOGGER.info("Initializing idm engine using configuration '{}'", resource.toString());
                 initIdmEngineFromResource(resource);
             }
 
@@ -85,13 +85,13 @@ public abstract class IdmEngines {
 
             while (resources.hasMoreElements()) {
                 URL resource = resources.nextElement();
-                log.info("Initializing idm engine using Spring configuration '{}'", resource.toString());
+                LOGGER.info("Initializing idm engine using Spring configuration '{}'", resource.toString());
                 initIdmEngineFromSpringResource(resource);
             }
 
             setInitialized(true);
         } else {
-            log.info("Idm engines already initialized");
+            LOGGER.info("Idm engines already initialized");
         }
     }
 
@@ -141,15 +141,15 @@ public abstract class IdmEngines {
 
         String resourceUrlString = resourceUrl.toString();
         try {
-            log.info("initializing idm engine for resource {}", resourceUrl);
+            LOGGER.info("initializing idm engine for resource {}", resourceUrl);
             IdmEngine idmEngine = buildIdmEngine(resourceUrl);
             String idmEngineName = idmEngine.getName();
-            log.info("initialised idm engine {}", idmEngineName);
+            LOGGER.info("initialised idm engine {}", idmEngineName);
             idmEngineInfo = new EngineInfo(idmEngineName, resourceUrlString, null);
             idmEngines.put(idmEngineName, idmEngine);
             idmEngineInfosByName.put(idmEngineName, idmEngineInfo);
         } catch (Throwable e) {
-            log.error("Exception while initializing idm engine: {}", e.getMessage(), e);
+            LOGGER.error("Exception while initializing idm engine: {}", e.getMessage(), e);
             idmEngineInfo = new EngineInfo(null, resourceUrlString, getExceptionString(e));
         }
         idmEngineInfosByResourceUrl.put(resourceUrlString, idmEngineInfo);
@@ -212,7 +212,7 @@ public abstract class IdmEngines {
      * retries to initialize a idm engine that previously failed.
      */
     public static EngineInfo retry(String resourceUrl) {
-        log.debug("retying initializing of resource {}", resourceUrl);
+        LOGGER.debug("retying initializing of resource {}", resourceUrl);
         try {
             return initIdmEngineFromResource(new URL(resourceUrl));
         } catch (MalformedURLException e) {
@@ -240,7 +240,7 @@ public abstract class IdmEngines {
                 try {
                     idmEngine.close();
                 } catch (Exception e) {
-                    log.error("exception while closing {}", (idmEngineName == null ? "the default idm engine" : "idm engine " + idmEngineName), e);
+                    LOGGER.error("exception while closing {}", (idmEngineName == null ? "the default idm engine" : "idm engine " + idmEngineName), e);
                 }
             }
 

--- a/modules/flowable-idm-engine/src/main/java/org/flowable/idm/engine/delegate/event/impl/FlowableIdmEventSupport.java
+++ b/modules/flowable-idm-engine/src/main/java/org/flowable/idm/engine/delegate/event/impl/FlowableIdmEventSupport.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
  */
 public class FlowableIdmEventSupport {
 
-    private static final Logger LOG = LoggerFactory.getLogger(FlowableIdmEventSupport.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(FlowableIdmEventSupport.class);
 
     protected List<FlowableEventListener> eventListeners;
     protected Map<FlowableEventType, List<FlowableEventListener>> typedListeners;
@@ -108,7 +108,7 @@ public class FlowableIdmEventSupport {
             } else {
                 // Ignore the exception and continue notifying remaining listeners. The listener
                 // explicitly states that the exception should not bubble up
-                LOG.warn("Exception while executing event-listener, which was ignored", t);
+                LOGGER.warn("Exception while executing event-listener, which was ignored", t);
             }
         }
     }

--- a/modules/flowable-idm-engine/src/main/java/org/flowable/idm/engine/impl/IdmEngineImpl.java
+++ b/modules/flowable-idm-engine/src/main/java/org/flowable/idm/engine/impl/IdmEngineImpl.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
  */
 public class IdmEngineImpl implements IdmEngine {
 
-    private static Logger log = LoggerFactory.getLogger(IdmEngineImpl.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(IdmEngineImpl.class);
 
     protected String name;
     protected IdmIdentityService identityService;
@@ -46,9 +46,9 @@ public class IdmEngineImpl implements IdmEngine {
         }
 
         if (name == null) {
-            log.info("default flowable IdmEngine created");
+            LOGGER.info("default flowable IdmEngine created");
         } else {
-            log.info("IdmEngine {} created", name);
+            LOGGER.info("IdmEngine {} created", name);
         }
 
         IdmEngines.registerIdmEngine(this);

--- a/modules/flowable-idm-engine/src/main/java/org/flowable/idm/engine/impl/cfg/standalone/StandaloneMybatisTransactionContext.java
+++ b/modules/flowable-idm-engine/src/main/java/org/flowable/idm/engine/impl/cfg/standalone/StandaloneMybatisTransactionContext.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  */
 public class StandaloneMybatisTransactionContext implements TransactionContext {
 
-    private static Logger log = LoggerFactory.getLogger(StandaloneMybatisTransactionContext.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(StandaloneMybatisTransactionContext.class);
 
     protected CommandContext commandContext;
     protected Map<TransactionState, List<TransactionListener>> stateTransactionListeners;
@@ -58,12 +58,12 @@ public class StandaloneMybatisTransactionContext implements TransactionContext {
 
     public void commit() {
 
-        log.debug("firing event committing...");
+        LOGGER.debug("firing event committing...");
         fireTransactionEvent(TransactionState.COMMITTING, false);
 
-        log.debug("committing the ibatis sql session...");
+        LOGGER.debug("committing the ibatis sql session...");
         getDbSqlSession().commit();
-        log.debug("firing event committed...");
+        LOGGER.debug("firing event committed...");
         fireTransactionEvent(TransactionState.COMMITTED, true);
 
     }
@@ -115,23 +115,23 @@ public class StandaloneMybatisTransactionContext implements TransactionContext {
     public void rollback() {
         try {
             try {
-                log.debug("firing event rolling back...");
+                LOGGER.debug("firing event rolling back...");
                 fireTransactionEvent(TransactionState.ROLLINGBACK, false);
 
             } catch (Throwable exception) {
-                log.info("Exception during transaction: {}", exception.getMessage());
+                LOGGER.info("Exception during transaction: {}", exception.getMessage());
                 commandContext.exception(exception);
             } finally {
-                log.debug("rolling back ibatis sql session...");
+                LOGGER.debug("rolling back ibatis sql session...");
                 getDbSqlSession().rollback();
             }
 
         } catch (Throwable exception) {
-            log.info("Exception during transaction: {}", exception.getMessage());
+            LOGGER.info("Exception during transaction: {}", exception.getMessage());
             commandContext.exception(exception);
 
         } finally {
-            log.debug("firing event rolled back...");
+            LOGGER.debug("firing event rolled back...");
             fireTransactionEvent(TransactionState.ROLLED_BACK, true);
         }
     }

--- a/modules/flowable-idm-engine/src/main/java/org/flowable/idm/engine/impl/interceptor/CommandContext.java
+++ b/modules/flowable-idm-engine/src/main/java/org/flowable/idm/engine/impl/interceptor/CommandContext.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
  */
 public class CommandContext extends AbstractCommandContext {
 
-    private static Logger log = LoggerFactory.getLogger(CommandContext.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(CommandContext.class);
 
     protected IdmEngineConfiguration idmEngineConfiguration;
 

--- a/modules/flowable-idm-engine/src/main/java/org/flowable/idm/engine/impl/interceptor/CommandContextInterceptor.java
+++ b/modules/flowable-idm-engine/src/main/java/org/flowable/idm/engine/impl/interceptor/CommandContextInterceptor.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
  * @author Tijs Rademakers
  */
 public class CommandContextInterceptor extends AbstractCommandInterceptor {
-    private static final Logger log = LoggerFactory.getLogger(CommandContextInterceptor.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(CommandContextInterceptor.class);
 
     protected CommandContextFactory commandContextFactory;
     protected IdmEngineConfiguration idmEngineConfiguration;
@@ -45,7 +45,7 @@ public class CommandContextInterceptor extends AbstractCommandInterceptor {
         if (!config.isContextReusePossible() || context == null || context.getException() != null) {
             context = commandContextFactory.createCommandContext(command);
         } else {
-            log.debug("Valid context found. Reusing it for the current command '{}'", command.getClass().getCanonicalName());
+            LOGGER.debug("Valid context found. Reusing it for the current command '{}'", command.getClass().getCanonicalName());
             contextReused = true;
             context.setReused(true);
         }

--- a/modules/flowable-idm-engine/src/main/java/org/flowable/idm/engine/impl/interceptor/LogInterceptor.java
+++ b/modules/flowable-idm-engine/src/main/java/org/flowable/idm/engine/impl/interceptor/LogInterceptor.java
@@ -22,22 +22,22 @@ import org.slf4j.LoggerFactory;
  */
 public class LogInterceptor extends AbstractCommandInterceptor {
 
-    private static Logger log = LoggerFactory.getLogger(LogInterceptor.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(LogInterceptor.class);
 
     public <T> T execute(CommandConfig config, Command<T> command) {
-        if (!log.isDebugEnabled()) {
+        if (!LOGGER.isDebugEnabled()) {
             // do nothing here if we cannot log
             return next.execute(config, command);
         }
-        log.debug("\n");
-        log.debug("--- starting {} --------------------------------------------------------", command.getClass().getSimpleName());
+        LOGGER.debug("\n");
+        LOGGER.debug("--- starting {} --------------------------------------------------------", command.getClass().getSimpleName());
         try {
 
             return next.execute(config, command);
 
         } finally {
-            log.debug("--- {} finished --------------------------------------------------------", command.getClass().getSimpleName());
-            log.debug("\n");
+            LOGGER.debug("--- {} finished --------------------------------------------------------", command.getClass().getSimpleName());
+            LOGGER.debug("\n");
         }
     }
 }

--- a/modules/flowable-idm-engine/src/main/java/org/flowable/idm/engine/impl/persistence/entity/TableDataManagerImpl.java
+++ b/modules/flowable-idm-engine/src/main/java/org/flowable/idm/engine/impl/persistence/entity/TableDataManagerImpl.java
@@ -48,7 +48,7 @@ public class TableDataManagerImpl extends AbstractManager implements TableDataMa
         super(idmEngineConfiguration);
     }
 
-    private static Logger log = LoggerFactory.getLogger(TableDataManagerImpl.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TableDataManagerImpl.class);
 
     public static Map<Class<?>, String> apiTypeToTableNameMap = new HashMap<Class<?>, String>();
     public static Map<Class<? extends Entity>, String> entityToTableNameMap = new HashMap<Class<? extends Entity>, String>();
@@ -84,7 +84,7 @@ public class TableDataManagerImpl extends AbstractManager implements TableDataMa
             for (String tableName : getTablesPresentInDatabase()) {
                 tableCount.put(tableName, getTableCount(tableName));
             }
-            log.debug("Number of rows per flowable table: {}", tableCount);
+            LOGGER.debug("Number of rows per flowable table: {}", tableCount);
         } catch (Exception e) {
             throw new FlowableException("couldn't get table counts", e);
         }
@@ -100,7 +100,7 @@ public class TableDataManagerImpl extends AbstractManager implements TableDataMa
             DatabaseMetaData databaseMetaData = connection.getMetaData();
             ResultSet tables = null;
             try {
-                log.debug("retrieving flowable tables from jdbc metadata");
+                LOGGER.debug("retrieving flowable tables from jdbc metadata");
                 String databaseTablePrefix = getDbSqlSession().getDbSqlSessionFactory().getDatabaseTablePrefix();
                 String tableNameFilter = databaseTablePrefix + "ACT_%";
                 if ("postgres".equals(getDbSqlSession().getDbSqlSessionFactory().getDatabaseType())) {
@@ -129,7 +129,7 @@ public class TableDataManagerImpl extends AbstractManager implements TableDataMa
                     String tableName = tables.getString("TABLE_NAME");
                     tableName = tableName.toUpperCase();
                     tableNames.add(tableName);
-                    log.debug("  retrieved flowable table name {}", tableName);
+                    LOGGER.debug("  retrieved flowable table name {}", tableName);
                 }
             } finally {
                 tables.close();
@@ -141,7 +141,7 @@ public class TableDataManagerImpl extends AbstractManager implements TableDataMa
     }
 
     protected long getTableCount(String tableName) {
-        log.debug("selecting table count for {}", tableName);
+        LOGGER.debug("selecting table count for {}", tableName);
         Long count = (Long) getDbSqlSession().selectOne("org.flowable.idm.engine.impl.TablePageMap.selectTableCount", Collections.singletonMap("tableName", tableName));
         return count;
     }

--- a/modules/flowable-idm-engine/src/main/java/org/flowable/idm/engine/impl/util/ReflectUtil.java
+++ b/modules/flowable-idm-engine/src/main/java/org/flowable/idm/engine/impl/util/ReflectUtil.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class ReflectUtil {
 
-    private static final Logger LOG = LoggerFactory.getLogger(ReflectUtil.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ReflectUtil.class);
 
     private static final Pattern GETTER_PATTERN = Pattern.compile("(get|is)[A-Z].*");
     private static final Pattern SETTER_PATTERN = Pattern.compile("set[A-Z].*");
@@ -56,7 +56,7 @@ public abstract class ReflectUtil {
 
         if (classLoader != null) {
             try {
-                LOG.trace("Trying to load class with custom classloader: {}", className);
+                LOGGER.trace("Trying to load class with custom classloader: {}", className);
                 clazz = loadClass(classLoader, className);
             } catch (Throwable t) {
                 throwable = t;
@@ -64,7 +64,7 @@ public abstract class ReflectUtil {
         }
         if (clazz == null) {
             try {
-                LOG.trace("Trying to load class with current thread context classloader: {}", className);
+                LOGGER.trace("Trying to load class with current thread context classloader: {}", className);
                 clazz = loadClass(Thread.currentThread().getContextClassLoader(), className);
             } catch (Throwable t) {
                 if (throwable == null) {
@@ -73,7 +73,7 @@ public abstract class ReflectUtil {
             }
             if (clazz == null) {
                 try {
-                    LOG.trace("Trying to load class with local classloader: {}", className);
+                    LOGGER.trace("Trying to load class with local classloader: {}", className);
                     clazz = loadClass(ReflectUtil.class.getClassLoader(), className);
                 } catch (Throwable t) {
                     if (throwable == null) {

--- a/modules/flowable-idm-engine/src/main/java/org/flowable/idm/engine/test/IdmTestHelper.java
+++ b/modules/flowable-idm-engine/src/main/java/org/flowable/idm/engine/test/IdmTestHelper.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class IdmTestHelper {
 
-    private static Logger log = LoggerFactory.getLogger(IdmTestHelper.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(IdmTestHelper.class);
 
     public static final String EMPTY_LINE = "\n";
 
@@ -35,11 +35,11 @@ public abstract class IdmTestHelper {
     public static IdmEngine getIdmEngine(String configurationResource) {
         IdmEngine idmEngine = idmEngines.get(configurationResource);
         if (idmEngine == null) {
-            log.debug("==== BUILDING IDM ENGINE ========================================================================");
+            LOGGER.debug("==== BUILDING IDM ENGINE ========================================================================");
             idmEngine = IdmEngineConfiguration.createIdmEngineConfigurationFromResource(configurationResource)
                     .setDatabaseSchemaUpdate(IdmEngineConfiguration.DB_SCHEMA_UPDATE_DROP_CREATE)
                     .buildIdmEngine();
-            log.debug("==== IDM ENGINE CREATED =========================================================================");
+            LOGGER.debug("==== IDM ENGINE CREATED =========================================================================");
             idmEngines.put(configurationResource, idmEngine);
         }
         return idmEngine;

--- a/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/PasswordEncoderTest.java
+++ b/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/PasswordEncoderTest.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
  */
 public class PasswordEncoderTest extends PluggableFlowableIdmTestCase {
 
-    private static Logger log = LoggerFactory.getLogger(PasswordEncoderTest.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(PasswordEncoderTest.class);
 
     private void validatePassword() {
         User user = idmIdentityService.newUser("johndoe");
@@ -26,7 +26,7 @@ public class PasswordEncoderTest extends PluggableFlowableIdmTestCase {
         idmIdentityService.saveUser(user);
 
         User johndoe = idmIdentityService.createUserQuery().userId("johndoe").list().get(0);
-        log.info("Hash Password = {} ", johndoe.getPassword());
+        LOGGER.info("Hash Password = {} ", johndoe.getPassword());
 
         assertFalse("xxx".equals(johndoe.getPassword()));
         assertTrue(idmIdentityService.checkPassword("johndoe", "xxx"));

--- a/modules/flowable-idm-spring/src/main/java/org/flowable/idm/spring/SpringIdmConfigurationHelper.java
+++ b/modules/flowable-idm-spring/src/main/java/org/flowable/idm/spring/SpringIdmConfigurationHelper.java
@@ -29,10 +29,10 @@ import org.springframework.core.io.UrlResource;
  */
 public class SpringIdmConfigurationHelper {
 
-    private static Logger log = LoggerFactory.getLogger(SpringIdmConfigurationHelper.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SpringIdmConfigurationHelper.class);
 
     public static IdmEngine buildIdmEngine(URL resource) {
-        log.debug("==== BUILDING SPRING APPLICATION CONTEXT AND IDM ENGINE =========================================");
+        LOGGER.debug("==== BUILDING SPRING APPLICATION CONTEXT AND IDM ENGINE =========================================");
 
         ApplicationContext applicationContext = new GenericXmlApplicationContext(new UrlResource(resource));
         Map<String, IdmEngine> beansOfType = applicationContext.getBeansOfType(IdmEngine.class);
@@ -42,7 +42,7 @@ public class SpringIdmConfigurationHelper {
 
         IdmEngine idmEngine = beansOfType.values().iterator().next();
 
-        log.debug("==== SPRING IDM ENGINE CREATED ==================================================================");
+        LOGGER.debug("==== SPRING IDM ENGINE CREATED ==================================================================");
         return idmEngine;
     }
 

--- a/modules/flowable-idm-spring/src/test/java/org/flowable/spring/test/authentication/SpringPasswordEncoderTest.java
+++ b/modules/flowable-idm-spring/src/test/java/org/flowable/spring/test/authentication/SpringPasswordEncoderTest.java
@@ -44,7 +44,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 @ContextConfiguration("classpath:org/flowable/spring/test/engine/springIdmEngineWithPasswordEncoder-context.xml")
 public class SpringPasswordEncoderTest {
 
-    private static Logger log = LoggerFactory.getLogger(SpringPasswordEncoderTest.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SpringPasswordEncoderTest.class);
 
     @Autowired
     private IdmEngineConfiguration autoWiredIdmIdmEngineConfiguration;
@@ -116,7 +116,7 @@ public class SpringPasswordEncoderTest {
         autoWiredIdmIdentityService.saveUser(user);
 
         User johndoe = autoWiredIdmIdentityService.createUserQuery().userId("johndoe").list().get(0);
-        log.info("Hash Password = {} ", johndoe.getPassword());
+        LOGGER.info("Hash Password = {} ", johndoe.getPassword());
 
         assertFalse("xxx".equals(johndoe.getPassword()));
         assertTrue(autoWiredIdmIdentityService.checkPassword("johndoe", "xxx"));

--- a/modules/flowable-jmx/src/main/java/org/flowable/management/jmx/DefaultManagementAgent.java
+++ b/modules/flowable-jmx/src/main/java/org/flowable/management/jmx/DefaultManagementAgent.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
 
 public class DefaultManagementAgent implements ManagementAgent {
 
-    private static final Logger LOG = LoggerFactory.getLogger(DefaultManagementAgent.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultManagementAgent.class);
 
     protected MBeanServer server;
     protected final ConcurrentMap<ObjectName, ObjectName> mbeansRegistered = new ConcurrentHashMap<ObjectName, ObjectName>();
@@ -72,7 +72,7 @@ public class DefaultManagementAgent implements ManagementAgent {
                 registerMBeanWithServer(obj, name, forceRegistration);
 
         } catch (NotCompliantMBeanException e) {
-            LOG.error("Mbean {} is not compliant MBean.", name, e);
+            LOGGER.error("Mbean {} is not compliant MBean.", name, e);
             registerMBeanWithServer(obj, name, forceRegistration);
 
         }
@@ -84,20 +84,20 @@ public class DefaultManagementAgent implements ManagementAgent {
         boolean exists = isRegistered(name);
         if (exists) {
             if (forceRegistration) {
-                LOG.info("ForceRegistration enabled, unregistering existing MBean with ObjectName: {}", name);
+                LOGGER.info("ForceRegistration enabled, unregistering existing MBean with ObjectName: {}", name);
                 server.unregisterMBean(name);
             } else {
                 // okay ignore we do not want to force it and it could be a
                 // shared
                 // instance
-                LOG.debug("MBean already registered with ObjectName: {}", name);
+                LOGGER.debug("MBean already registered with ObjectName: {}", name);
             }
         }
 
         // register bean if by force or not exists
         ObjectInstance instance = null;
         if (forceRegistration || !exists) {
-            LOG.trace("Registering MBean with ObjectName: {}", name);
+            LOGGER.trace("Registering MBean with ObjectName: {}", name);
             instance = server.registerMBean(obj, name);
         }
 
@@ -105,7 +105,7 @@ public class DefaultManagementAgent implements ManagementAgent {
         // modify the name
         if (instance != null) {
             ObjectName registeredName = instance.getObjectName();
-            LOG.debug("Registered MBean with ObjectName: {}", registeredName);
+            LOGGER.debug("Registered MBean with ObjectName: {}", registeredName);
             mbeansRegistered.put(name, registeredName);
         }
     }
@@ -119,7 +119,7 @@ public class DefaultManagementAgent implements ManagementAgent {
         if (isRegistered(name)) {
             ObjectName on = mbeansRegistered.remove(name);
             server.unregisterMBean(on);
-            LOG.debug("Unregistered MBean with ObjectName: {}", name);
+            LOGGER.debug("Unregistered MBean with ObjectName: {}", name);
         } else {
             mbeansRegistered.remove(name);
         }
@@ -148,7 +148,7 @@ public class DefaultManagementAgent implements ManagementAgent {
                 createJmxConnector(Utils.getHostName());
             }
         } catch (IOException ioe) {
-            LOG.warn("Could not create and start JMX connector.", ioe);
+            LOGGER.warn("Could not create and start JMX connector.", ioe);
         }
 
     }
@@ -162,7 +162,7 @@ public class DefaultManagementAgent implements ManagementAgent {
         List<MBeanServer> servers = MBeanServerFactory.findMBeanServer(null);
 
         for (MBeanServer server : servers) {
-            LOG.debug("Found MBeanServer with default domain {}", server.getDefaultDomain());
+            LOGGER.debug("Found MBeanServer with default domain {}", server.getDefaultDomain());
 
             if (jmxConfigurator.getMbeanDomain().equals(server.getDefaultDomain())) {
                 return server;
@@ -186,17 +186,17 @@ public class DefaultManagementAgent implements ManagementAgent {
         Integer registryPort = jmxConfigurator.getRegistryPort();
         Integer connectorPort = jmxConfigurator.getConnectorPort();
         if (serviceUrlPath == null) {
-            LOG.warn("Service url path is null. JMX connector creation skipped");
+            LOGGER.warn("Service url path is null. JMX connector creation skipped");
             return;
         }
         if (registryPort == null) {
-            LOG.warn("Registery port is null. JMX connector creation skipped.");
+            LOGGER.warn("Registery port is null. JMX connector creation skipped.");
             return;
         }
 
         try {
             registry = LocateRegistry.createRegistry(registryPort);
-            LOG.debug("Created JMXConnector RMI registry on port {}", registryPort);
+            LOGGER.debug("Created JMXConnector RMI registry on port {}", registryPort);
         } catch (RemoteException ex) {
             // The registry may had been created, we could get the registry
             // instead
@@ -221,14 +221,14 @@ public class DefaultManagementAgent implements ManagementAgent {
 
             public void run() {
                 try {
-                    LOG.debug("Staring JMX Connector thread to listen at: {}", url);
+                    LOGGER.debug("Staring JMX Connector thread to listen at: {}", url);
                     cs.start();
-                    LOG.info("JMX Connector thread started and listening at: {}", url);
+                    LOGGER.info("JMX Connector thread started and listening at: {}", url);
                 } catch (IOException ioe) {
                     if (ioe.getCause() instanceof javax.naming.NameAlreadyBoundException) {
-                        LOG.warn("JMX connection:{} already exists.", url);
+                        LOGGER.warn("JMX connection:{} already exists.", url);
                     } else {
-                        LOG.warn("Could not start JMXConnector thread at: {}. JMX Connector not in use.", url, ioe);
+                        LOGGER.warn("Could not start JMXConnector thread at: {}. JMX Connector not in use.", url, ioe);
                     }
                 }
             }

--- a/modules/flowable-jmx/src/main/java/org/flowable/management/jmx/DefaultManagementMBeanAssembler.java
+++ b/modules/flowable-jmx/src/main/java/org/flowable/management/jmx/DefaultManagementMBeanAssembler.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
  */
 public class DefaultManagementMBeanAssembler implements ManagementMBeanAssembler {
 
-    private static final Logger LOG = LoggerFactory.getLogger(DefaultManagementMBeanAssembler.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultManagementMBeanAssembler.class);
 
     protected final MBeanInfoAssembler assembler;
 
@@ -41,7 +41,7 @@ public class DefaultManagementMBeanAssembler implements ManagementMBeanAssembler
 
         // use the default provided mbean which has been annotated with JMX
         // annotations
-        LOG.trace("Assembling MBeanInfo for: {} from @ManagedResource object: {}", name, obj);
+        LOGGER.trace("Assembling MBeanInfo for: {} from @ManagedResource object: {}", name, obj);
         mbi = assembler.getMBeanInfo(obj, null, name.toString());
 
         if (mbi == null) {

--- a/modules/flowable-jmx/src/main/java/org/flowable/management/jmx/JMXConfigurator.java
+++ b/modules/flowable-jmx/src/main/java/org/flowable/management/jmx/JMXConfigurator.java
@@ -52,7 +52,7 @@ public class JMXConfigurator extends AbstractProcessEngineConfigurator {
         this.processEngineConfig = processEngineConfig;
     }
 
-    private static final Logger LOG = LoggerFactory.getLogger(JMXConfigurator.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(JMXConfigurator.class);
 
     // disable jmx
     private boolean disabled;
@@ -124,7 +124,7 @@ public class JMXConfigurator extends AbstractProcessEngineConfigurator {
                 managementAgent.findAndRegisterMbeans();
             }
         } catch (Exception e) {
-            LOG.warn("error in initializing jmx. Continue with partial or no JMX configuration", e);
+            LOGGER.warn("error in initializing jmx. Continue with partial or no JMX configuration", e);
         }
 
     }

--- a/modules/flowable-jmx/src/main/java/org/flowable/management/jmx/MBeanInfoAssembler.java
+++ b/modules/flowable-jmx/src/main/java/org/flowable/management/jmx/MBeanInfoAssembler.java
@@ -45,7 +45,7 @@ import org.slf4j.LoggerFactory;
 
 public class MBeanInfoAssembler {
 
-    private static final Logger LOG = LoggerFactory.getLogger(MBeanInfoAssembler.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(MBeanInfoAssembler.class);
 
     protected final WeakHashMap<Class<?>, MBeanAttributesAndOperations> cache = new WeakHashMap<Class<?>, MBeanAttributesAndOperations>(10);
 
@@ -58,7 +58,7 @@ public class MBeanInfoAssembler {
             return null;
         // skip proxy classes
         if (defaultManagedBean != null && Proxy.isProxyClass(defaultManagedBean.getClass())) {
-            LOG.trace("Skip creating ModelMBeanInfo due proxy class {}", defaultManagedBean.getClass());
+            LOGGER.trace("Skip creating ModelMBeanInfo due proxy class {}", defaultManagedBean.getClass());
             return null;
         }
 
@@ -93,7 +93,7 @@ public class MBeanInfoAssembler {
         ModelMBeanNotificationInfo[] arrayNotifications = mBeanNotifications.toArray(new ModelMBeanNotificationInfo[mBeanNotifications.size()]);
 
         ModelMBeanInfo info = new ModelMBeanInfoSupport(name, description, arrayAttributes, null, arrayOperations, arrayNotifications);
-        LOG.trace("Created ModelMBeanInfo {}", info);
+        LOGGER.trace("Created ModelMBeanInfo {}", info);
         return info;
     }
 
@@ -126,7 +126,7 @@ public class MBeanInfoAssembler {
             Class<?> clazz = managedClass.getSuperclass();
             // skip any JDK classes
             if (!clazz.getName().startsWith("java")) {
-                LOG.trace("Extracting attributes and operations from sub class: {}", clazz);
+                LOGGER.trace("Extracting attributes and operations from sub class: {}", clazz);
                 doExtractAttributesAndOperations(clazz, attributes, operations);
             }
         }
@@ -140,7 +140,7 @@ public class MBeanInfoAssembler {
                     // skip any JDK classes
                     continue;
                 }
-                LOG.trace("Extracting attributes and operations from implemented interface: {}", clazz);
+                LOGGER.trace("Extracting attributes and operations from implemented interface: {}", clazz);
                 doExtractAttributesAndOperations(clazz, attributes, operations);
             }
         }
@@ -162,7 +162,7 @@ public class MBeanInfoAssembler {
     }
 
     private void doDoExtractAttributesAndOperations(Class<?> managedClass, Map<String, ManagedAttributeInfo> attributes, Set<ManagedOperationInfo> operations) {
-        LOG.trace("Extracting attributes and operations from class: {}", managedClass);
+        LOGGER.trace("Extracting attributes and operations from class: {}", managedClass);
 
         for (Method method : managedClass.getMethods()) {
             // must be from declaring class
@@ -170,7 +170,7 @@ public class MBeanInfoAssembler {
                 continue;
             }
 
-            LOG.trace("Extracting attributes and operations from method: {}", method);
+            LOGGER.trace("Extracting attributes and operations from method: {}", method);
             ManagedAttribute ma = method.getAnnotation(ManagedAttribute.class);
             if (ma != null) {
                 String key;
@@ -244,7 +244,7 @@ public class MBeanInfoAssembler {
             mbeanAttribute.setDescriptor(desc);
 
             mBeanAttributes.add(mbeanAttribute);
-            LOG.trace("Assembled attribute: {}", mbeanAttribute);
+            LOGGER.trace("Assembled attribute: {}", mbeanAttribute);
         }
     }
 
@@ -254,7 +254,7 @@ public class MBeanInfoAssembler {
             Descriptor opDesc = mbean.getDescriptor();
             mbean.setDescriptor(opDesc);
             mBeanOperations.add(mbean);
-            LOG.trace("Assembled operation: {}", mbean);
+            LOGGER.trace("Assembled operation: {}", mbean);
         }
     }
 
@@ -264,7 +264,7 @@ public class MBeanInfoAssembler {
             for (ManagedNotification notification : notifications.value()) {
                 ModelMBeanNotificationInfo info = new ModelMBeanNotificationInfo(notification.notificationTypes(), notification.name(), notification.description());
                 mBeanNotifications.add(info);
-                LOG.trace("Assembled notification: {}", info);
+                LOGGER.trace("Assembled notification: {}", info);
             }
         }
     }

--- a/modules/flowable-jmx/src/main/java/org/flowable/management/jmx/Utils.java
+++ b/modules/flowable-jmx/src/main/java/org/flowable/management/jmx/Utils.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
 
 public class Utils {
 
-    private static final Logger LOG = LoggerFactory.getLogger(Utils.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(Utils.class);
 
     public static String getHostName() {
 
@@ -48,7 +48,7 @@ public class Utils {
             try {
                 hostName = InetAddress.getLocalHost().getHostName();
             } catch (UnknownHostException uhe) {
-                LOG.info("Cannot determine localhost name. Fallback to: " + DEFAULT_HOST, uhe);
+                LOGGER.info("Cannot determine localhost name. Fallback to: " + DEFAULT_HOST, uhe);
                 hostName = DEFAULT_HOST;
             }
         } else {

--- a/modules/flowable-ldap/src/main/java/org/flowable/ldap/LDAPIdentityServiceImpl.java
+++ b/modules/flowable-ldap/src/main/java/org/flowable/ldap/LDAPIdentityServiceImpl.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
 
 public class LDAPIdentityServiceImpl extends IdmIdentityServiceImpl {
 
-    private static Logger logger = LoggerFactory.getLogger(LDAPIdentityServiceImpl.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(LDAPIdentityServiceImpl.class);
 
     protected LDAPConfiguration ldapConfigurator;
     protected LDAPGroupCache ldapGroupCache;
@@ -167,7 +167,7 @@ public class LDAPIdentityServiceImpl extends IdmIdentityServiceImpl {
                         namingEnum.close();
 
                     } catch (NamingException ne) {
-                        logger.info("Could not authenticate user {} : {}", userId, ne.getMessage(), ne);
+                        LOGGER.info("Could not authenticate user {} : {}", userId, ne.getMessage(), ne);
                         return false;
                     }
 
@@ -192,7 +192,7 @@ public class LDAPIdentityServiceImpl extends IdmIdentityServiceImpl {
             });
 
         } catch (FlowableException e) {
-            logger.info("Could not authenticate user : {}", userId, e);
+            LOGGER.info("Could not authenticate user : {}", userId, e);
             return false;
         }
     }

--- a/modules/flowable-ldap/src/main/java/org/flowable/ldap/impl/LDAPUserQueryImpl.java
+++ b/modules/flowable-ldap/src/main/java/org/flowable/ldap/impl/LDAPUserQueryImpl.java
@@ -36,7 +36,7 @@ public class LDAPUserQueryImpl extends UserQueryImpl {
 
     private static final long serialVersionUID = 1L;
 
-    private static Logger logger = LoggerFactory.getLogger(LDAPUserQueryImpl.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(LDAPUserQueryImpl.class);
 
     protected LDAPConfiguration ldapConfigurator;
 
@@ -108,7 +108,7 @@ public class LDAPUserQueryImpl extends UserQueryImpl {
                     return user;
 
                 } catch (NamingException ne) {
-                    logger.debug("Could not find user {} : {}", userId, ne.getMessage(), ne);
+                    LOGGER.debug("Could not find user {} : {}", userId, ne.getMessage(), ne);
                     return null;
                 }
             }
@@ -137,7 +137,7 @@ public class LDAPUserQueryImpl extends UserQueryImpl {
                     namingEnum.close();
 
                 } catch (NamingException ne) {
-                    logger.debug("Could not execute LDAP query: {}", ne.getMessage(), ne);
+                    LOGGER.debug("Could not execute LDAP query: {}", ne.getMessage(), ne);
                     return null;
                 }
                 return result;

--- a/modules/flowable-osgi/src/main/java/org/flowable/osgi/BpmnURLHandler.java
+++ b/modules/flowable-osgi/src/main/java/org/flowable/osgi/BpmnURLHandler.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  */
 public class BpmnURLHandler extends AbstractURLStreamHandlerService {
 
-    private static Logger logger = LoggerFactory.getLogger(BpmnURLHandler.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(BpmnURLHandler.class);
 
     private static String SYNTAX = "bpmn: bpmn-xml-uri";
 
@@ -53,7 +53,7 @@ public class BpmnURLHandler extends AbstractURLStreamHandlerService {
         }
         bpmnXmlURL = new URL(url.getPath());
 
-        logger.debug("BPMN xml URL is: [{}]", bpmnXmlURL);
+        LOGGER.debug("BPMN xml URL is: [{}]", bpmnXmlURL);
         return new Connection(url);
     }
 
@@ -79,7 +79,7 @@ public class BpmnURLHandler extends AbstractURLStreamHandlerService {
                 os.close();
                 return new ByteArrayInputStream(os.toByteArray());
             } catch (Exception e) {
-                logger.error("Error opening spring xml url", e);
+                LOGGER.error("Error opening spring xml url", e);
                 throw (IOException) new IOException("Error opening spring xml url").initCause(e);
             }
         }

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/api/jpa/BaseJPARestTestCase.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/api/jpa/BaseJPARestTestCase.java
@@ -76,7 +76,7 @@ import junit.framework.AssertionFailedError;
 
 public class BaseJPARestTestCase extends AbstractTestCase {
 
-    private static Logger log = LoggerFactory.getLogger(BaseJPARestTestCase.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(BaseJPARestTestCase.class);
 
     protected static final int HTTP_SERVER_PORT = 7979;
     protected static final String SERVER_URL_PREFIX = "http://localhost:7979/service/";
@@ -130,7 +130,7 @@ public class BaseJPARestTestCase extends AbstractTestCase {
                     try {
                         server.stop();
                     } catch (Exception e) {
-                        log.error("Error stopping server", e);
+                        LOGGER.error("Error stopping server", e);
                     }
                 }
             }
@@ -141,7 +141,7 @@ public class BaseJPARestTestCase extends AbstractTestCase {
     public void runBare() throws Throwable {
         createUsers();
 
-        log.error(EMPTY_LINE);
+        LOGGER.error(EMPTY_LINE);
 
         try {
 
@@ -150,14 +150,14 @@ public class BaseJPARestTestCase extends AbstractTestCase {
             super.runBare();
 
         } catch (AssertionFailedError e) {
-            log.error(EMPTY_LINE);
-            log.error("ASSERTION FAILED: {}", e, e);
+            LOGGER.error(EMPTY_LINE);
+            LOGGER.error("ASSERTION FAILED: {}", e, e);
             exception = e;
             throw e;
 
         } catch (Throwable e) {
-            log.error(EMPTY_LINE);
-            log.error("EXCEPTION: {}", e, e);
+            LOGGER.error(EMPTY_LINE);
+            LOGGER.error("EXCEPTION: {}", e, e);
             exception = e;
             throw e;
 
@@ -199,7 +199,7 @@ public class BaseJPARestTestCase extends AbstractTestCase {
             server.setHandler(getServletContextHandler(applicationContext));
             server.start();
         } catch (Exception e) {
-            log.error("Error starting server", e);
+            LOGGER.error("Error starting server", e);
         }
     }
 
@@ -272,7 +272,7 @@ public class BaseJPARestTestCase extends AbstractTestCase {
      * the DB is not clean. If the DB is not clean, it is cleaned by performing a create a drop.
      */
     protected void assertAndEnsureCleanDb() throws Throwable {
-        log.debug("verifying that db is clean after test");
+        LOGGER.debug("verifying that db is clean after test");
         Map<String, Long> tableCounts = managementService.getTableCount();
         StringBuilder outputMessage = new StringBuilder();
         for (String tableName : tableCounts.keySet()) {
@@ -286,10 +286,10 @@ public class BaseJPARestTestCase extends AbstractTestCase {
         }
         if (outputMessage.length() > 0) {
             outputMessage.insert(0, "DB NOT CLEAN: \n");
-            log.error(EMPTY_LINE);
-            log.error(outputMessage.toString());
+            LOGGER.error(EMPTY_LINE);
+            LOGGER.error(outputMessage.toString());
 
-            log.info("dropping and recreating db");
+            LOGGER.info("dropping and recreating db");
 
             CommandExecutor commandExecutor = ((ProcessEngineImpl) processEngine).getProcessEngineConfiguration().getCommandExecutor();
             commandExecutor.execute(new Command<Object>() {
@@ -307,7 +307,7 @@ public class BaseJPARestTestCase extends AbstractTestCase {
                 Assert.fail(outputMessage.toString());
             }
         } else {
-            log.info("database was clean");
+            LOGGER.info("database was clean");
         }
     }
 

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/BaseSpringRestTestCase.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/BaseSpringRestTestCase.java
@@ -75,7 +75,7 @@ import junit.framework.AssertionFailedError;
 
 public class BaseSpringRestTestCase extends AbstractTestCase {
 
-    private static Logger log = LoggerFactory.getLogger(BaseSpringRestTestCase.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(BaseSpringRestTestCase.class);
 
     protected static final List<String> TABLENAMES_EXCLUDED_FROM_DB_CLEAN_CHECK = Arrays.asList(
             "ACT_GE_PROPERTY",
@@ -142,7 +142,7 @@ public class BaseSpringRestTestCase extends AbstractTestCase {
                     try {
                         client.close();
                     } catch (IOException e) {
-                        log.error("Could not close http client", e);
+                        LOGGER.error("Could not close http client", e);
                     }
                 }
 
@@ -150,7 +150,7 @@ public class BaseSpringRestTestCase extends AbstractTestCase {
                     try {
                         server.stop();
                     } catch (Exception e) {
-                        log.error("Error stopping server", e);
+                        LOGGER.error("Error stopping server", e);
                     }
                 }
             }
@@ -168,14 +168,14 @@ public class BaseSpringRestTestCase extends AbstractTestCase {
             super.runBare();
 
         } catch (AssertionFailedError e) {
-            log.error(EMPTY_LINE);
-            log.error("ASSERTION FAILED: {}", e, e);
+            LOGGER.error(EMPTY_LINE);
+            LOGGER.error("ASSERTION FAILED: {}", e, e);
             exception = e;
             throw e;
 
         } catch (Throwable e) {
-            log.error(EMPTY_LINE);
-            log.error("EXCEPTION: {}", e, e);
+            LOGGER.error(EMPTY_LINE);
+            LOGGER.error("EXCEPTION: {}", e, e);
             exception = e;
             throw e;
 
@@ -228,8 +228,8 @@ public class BaseSpringRestTestCase extends AbstractTestCase {
 
             int responseStatusCode = response.getStatusLine().getStatusCode();
             if (expectedStatusCode != responseStatusCode) {
-                log.info("Wrong status code : {}, but should be {}", responseStatusCode, expectedStatusCode);
-                log.info("Response body: {}", IOUtils.toString(response.getEntity().getContent()));
+                LOGGER.info("Wrong status code : {}, but should be {}", responseStatusCode, expectedStatusCode);
+                LOGGER.info("Response body: {}", IOUtils.toString(response.getEntity().getContent()));
             }
 
             Assert.assertEquals(expectedStatusCode, responseStatusCode);
@@ -267,7 +267,7 @@ public class BaseSpringRestTestCase extends AbstractTestCase {
      * the DB is not clean. If the DB is not clean, it is cleaned by performing a create a drop.
      */
     protected void assertAndEnsureCleanDb() throws Throwable {
-        log.debug("verifying that db is clean after test");
+        LOGGER.debug("verifying that db is clean after test");
         Map<String, Long> tableCounts = managementService.getTableCount();
         StringBuilder outputMessage = new StringBuilder();
         for (String tableName : tableCounts.keySet()) {
@@ -281,10 +281,10 @@ public class BaseSpringRestTestCase extends AbstractTestCase {
         }
         if (outputMessage.length() > 0) {
             outputMessage.insert(0, "DB NOT CLEAN: \n");
-            log.error(EMPTY_LINE);
-            log.error(outputMessage.toString());
+            LOGGER.error(EMPTY_LINE);
+            LOGGER.error(outputMessage.toString());
 
-            log.info("dropping and recreating db");
+            LOGGER.info("dropping and recreating db");
 
             CommandExecutor commandExecutor = ((ProcessEngineImpl) processEngine).getProcessEngineConfiguration().getCommandExecutor();
             commandExecutor.execute(new Command<Object>() {
@@ -302,7 +302,7 @@ public class BaseSpringRestTestCase extends AbstractTestCase {
                 Assert.fail(outputMessage.toString());
             }
         } else {
-            log.info("database was clean");
+            LOGGER.info("database was clean");
         }
     }
 
@@ -312,7 +312,7 @@ public class BaseSpringRestTestCase extends AbstractTestCase {
                 try {
                     response.close();
                 } catch (IOException e) {
-                    log.error("Could not close http connection", e);
+                    LOGGER.error("Could not close http connection", e);
                 }
             }
         }

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/util/TestServerUtil.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/util/TestServerUtil.java
@@ -31,7 +31,7 @@ import org.springframework.web.context.support.AnnotationConfigWebApplicationCon
  */
 public class TestServerUtil {
 
-    private static final Logger log = LoggerFactory.getLogger(TestServerUtil.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestServerUtil.class);
 
     protected static final int START_PORT = 9797;
     private static AtomicInteger NEXT_PORT = new AtomicInteger(9797);
@@ -51,7 +51,7 @@ public class TestServerUtil {
             server.setHandler(getServletContextHandler(applicationContext));
             server.start();
         } catch (Exception e) {
-            log.error("Error starting server", e);
+            LOGGER.error("Error starting server", e);
         }
 
         return new TestServer(server, applicationContext, port);

--- a/modules/flowable-spring/src/main/java/org/flowable/spring/SpringCallerRunsRejectedJobsHandler.java
+++ b/modules/flowable-spring/src/main/java/org/flowable/spring/SpringCallerRunsRejectedJobsHandler.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
  */
 public class SpringCallerRunsRejectedJobsHandler implements SpringRejectedJobsHandler {
 
-    private static Logger log = LoggerFactory.getLogger(SpringCallerRunsRejectedJobsHandler.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SpringCallerRunsRejectedJobsHandler.class);
 
     public void jobRejected(AsyncExecutor asyncExecutor, JobInfo job) {
         try {
@@ -34,7 +34,7 @@ public class SpringCallerRunsRejectedJobsHandler implements SpringRejectedJobsHa
             new ExecuteAsyncRunnable(job, asyncExecutor.getProcessEngineConfiguration(), 
                     asyncExecutor.getProcessEngineConfiguration().getJobEntityManager(), null).run();
         } catch (Exception e) {
-            log.error("Failed to execute rejected job {}", job.getId(), e);
+            LOGGER.error("Failed to execute rejected job {}", job.getId(), e);
         }
     }
 

--- a/modules/flowable-spring/src/main/java/org/flowable/spring/SpringConfigurationHelper.java
+++ b/modules/flowable-spring/src/main/java/org/flowable/spring/SpringConfigurationHelper.java
@@ -29,10 +29,10 @@ import org.springframework.core.io.UrlResource;
  */
 public class SpringConfigurationHelper {
 
-    private static Logger log = LoggerFactory.getLogger(SpringConfigurationHelper.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SpringConfigurationHelper.class);
 
     public static ProcessEngine buildProcessEngine(URL resource) {
-        log.debug("==== BUILDING SPRING APPLICATION CONTEXT AND PROCESS ENGINE =========================================");
+        LOGGER.debug("==== BUILDING SPRING APPLICATION CONTEXT AND PROCESS ENGINE =========================================");
 
         ApplicationContext applicationContext = new GenericXmlApplicationContext(new UrlResource(resource));
         Map<String, ProcessEngine> beansOfType = applicationContext.getBeansOfType(ProcessEngine.class);
@@ -42,7 +42,7 @@ public class SpringConfigurationHelper {
 
         ProcessEngine processEngine = beansOfType.values().iterator().next();
 
-        log.debug("==== SPRING PROCESS ENGINE CREATED ==================================================================");
+        LOGGER.debug("==== SPRING PROCESS ENGINE CREATED ==================================================================");
         return processEngine;
     }
 

--- a/modules/flowable-spring/src/test/java/org/flowable/spring/test/email/JndiEmailTest.java
+++ b/modules/flowable-spring/src/test/java/org/flowable/spring/test/email/JndiEmailTest.java
@@ -22,7 +22,7 @@ import org.springframework.test.context.ContextConfiguration;
 @ContextConfiguration("classpath:org/flowable/spring/test/email/jndiEmailConfiguaration-context.xml")
 public class JndiEmailTest extends SpringFlowableTestCase {
 
-    private static Logger logger = LoggerFactory.getLogger(JndiEmailTest.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(JndiEmailTest.class);
 
     @BeforeClass
     public void setUp() {
@@ -41,9 +41,9 @@ public class JndiEmailTest extends SpringFlowableTestCase {
             builder = SimpleNamingContextBuilder.emptyActivatedContextBuilder();
             builder.bind("java:comp/env/Session", mailSession);
         } catch (NamingException e) {
-            logger.error("Naming error in email setup", e);
+            LOGGER.error("Naming error in email setup", e);
         } catch (NoSuchProviderException e) {
-            logger.error("provider error in email setup", e);
+            LOGGER.error("provider error in email setup", e);
         }
     }
 

--- a/modules/flowable-spring/src/test/java/org/flowable/spring/test/email/MockEmailTransport.java
+++ b/modules/flowable-spring/src/test/java/org/flowable/spring/test/email/MockEmailTransport.java
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory;
  */
 public class MockEmailTransport extends Transport {
 
-    private static Logger logger = LoggerFactory.getLogger(MockEmailTransport.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(MockEmailTransport.class);
 
     public MockEmailTransport(Session smtpSession, URLName urlName) {
         super(smtpSession, urlName);
@@ -26,9 +26,9 @@ public class MockEmailTransport extends Transport {
     @Override
     public void sendMessage(Message message, Address[] addresses) throws MessagingException {
         try {
-            logger.info(message.getContent().toString());
+            LOGGER.info(message.getContent().toString());
         } catch (IOException ex) {
-            logger.error("Error occurred while sending email", ex);
+            LOGGER.error("Error occurred while sending email", ex);
         }
     }
 

--- a/modules/flowable-spring/src/test/java/org/flowable/spring/test/servicetask/DelegateExpressionBean.java
+++ b/modules/flowable-spring/src/test/java/org/flowable/spring/test/servicetask/DelegateExpressionBean.java
@@ -24,13 +24,13 @@ import org.slf4j.LoggerFactory;
  */
 public class DelegateExpressionBean implements JavaDelegate {
 
-    private static final Logger log = LoggerFactory.getLogger(DelegateExpressionBean.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DelegateExpressionBean.class);
     private SentenceGenerator sentenceGenerator;
 
     private FixedValue someField;
 
     public void execute(DelegateExecution execution) {
-        log.info("Entering DelegateExpressionBean.execute()");
+        LOGGER.info("Entering DelegateExpressionBean.execute()");
         if (sentenceGenerator != null) {
             execution.setVariable("myVar", sentenceGenerator.getSentence());
         } else {
@@ -41,7 +41,7 @@ public class DelegateExpressionBean implements JavaDelegate {
         } else {
             execution.setVariable("fieldInjection", "Field injection not working");
         }
-        log.info("Leaving DelegateExpressionBean.execute()");
+        LOGGER.info("Leaving DelegateExpressionBean.execute()");
     }
 
     public void setSentenceGenerator(SentenceGenerator sentenceGenerator) {

--- a/modules/flowable-ui-admin/src/main/java/org/flowable/admin/service/engine/FlowableClientService.java
+++ b/modules/flowable-ui-admin/src/main/java/org/flowable/admin/service/engine/FlowableClientService.java
@@ -58,7 +58,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 @Service
 public class FlowableClientService {
 
-    private static final Logger log = LoggerFactory.getLogger(FlowableClientService.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(FlowableClientService.class);
 
     protected static final String[] PAGING_AND_SORTING_PARAMETER_NAMES = new String[] { "sort", "order", "size" };
 
@@ -86,7 +86,7 @@ public class FlowableClientService {
             builder.loadTrustMaterial(null, new TrustSelfSignedStrategy());
             sslsf = new SSLConnectionSocketFactory(builder.build(), SSLConnectionSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER);
         } catch (Exception e) {
-            log.warn("Could not configure HTTP client to use SSL", e);
+            LOGGER.warn("Could not configure HTTP client to use SSL", e);
         }
 
         HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
@@ -138,22 +138,22 @@ public class FlowableClientService {
                     try {
                         bodyNode = objectMapper.readTree(strResponse);
                     } catch (Exception e) {
-                        log.debug("Error parsing error message", e);
+                        LOGGER.debug("Error parsing error message", e);
                     }
                     exception = new FlowableServiceException(extractError(bodyNode, "An error occurred while calling Flowable: " + response.getStatusLine()));
                 }
             } catch (Exception e) {
-                log.warn("Error consuming response from uri {}", request.getURI(), e);
+                LOGGER.warn("Error consuming response from uri {}", request.getURI(), e);
                 exception = wrapException(e, request);
             }
         } catch (Exception e) {
-            log.error("Error executing request to uri {}", request.getURI(), e);
+            LOGGER.error("Error executing request to uri {}", request.getURI(), e);
             exception = wrapException(e, request);
         } finally {
             try {
                 client.close();
             } catch (Exception e) {
-                log.warn("Error closing http client instance", e);
+                LOGGER.warn("Error closing http client instance", e);
             }
         }
 
@@ -190,22 +190,22 @@ public class FlowableClientService {
                     try {
                         bodyNode = objectMapper.readTree(strResponse);
                     } catch (Exception e) {
-                        log.debug("Error parsing error message", e);
+                        LOGGER.debug("Error parsing error message", e);
                     }
                     exception = new FlowableServiceException(extractError(bodyNode, "An error occurred while calling Flowable: " + response.getStatusLine()));
                 }
             } catch (Exception e) {
-                log.warn("Error consuming response from uri {}", request.getURI(), e);
+                LOGGER.warn("Error consuming response from uri {}", request.getURI(), e);
                 exception = wrapException(e, request);
             }
         } catch (Exception e) {
-            log.error("Error executing request to uri {}", request.getURI(), e);
+            LOGGER.error("Error executing request to uri {}", request.getURI(), e);
             exception = wrapException(e, request);
         } finally {
             try {
                 client.close();
             } catch (Exception e) {
-                log.warn("Error closing http client instance", e);
+                LOGGER.warn("Error closing http client instance", e);
             }
         }
 
@@ -251,17 +251,17 @@ public class FlowableClientService {
                     exception = new FlowableServiceException(extractError(readJsonContent(response.getEntity().getContent()), "An error occurred while calling Flowable: " + response.getStatusLine()));
                 }
             } catch (Exception e) {
-                log.warn("Error consuming response from uri {}", request.getURI(), e);
+                LOGGER.warn("Error consuming response from uri {}", request.getURI(), e);
                 exception = wrapException(e, request);
             }
         } catch (Exception e) {
-            log.error("Error executing request to uri {}", request.getURI(), e);
+            LOGGER.error("Error executing request to uri {}", request.getURI(), e);
             exception = wrapException(e, request);
         } finally {
             try {
                 client.close();
             } catch (Exception e) {
-                log.warn("Error closing http client instance", e);
+                LOGGER.warn("Error closing http client instance", e);
             }
         }
 
@@ -301,17 +301,17 @@ public class FlowableClientService {
                     exception = new FlowableServiceException(extractError(readJsonContent(response.getEntity().getContent()), "An error occurred while calling Flowable: " + response.getStatusLine()));
                 }
             } catch (Exception e) {
-                log.warn("Error consuming response from uri {}", request.getURI(), e);
+                LOGGER.warn("Error consuming response from uri {}", request.getURI(), e);
                 exception = wrapException(e, request);
             }
         } catch (Exception e) {
-            log.error("Error executing request to uri {}", request.getURI(), e);
+            LOGGER.error("Error executing request to uri {}", request.getURI(), e);
             exception = wrapException(e, request);
         } finally {
             try {
                 client.close();
             } catch (Exception e) {
-                log.warn("Error closing http client instance", e);
+                LOGGER.warn("Error closing http client instance", e);
             }
         }
 
@@ -342,17 +342,17 @@ public class FlowableClientService {
                     exception = new FlowableServiceException(extractError(readJsonContent(response.getEntity().getContent()), "An error occurred while calling Flowable: " + response.getStatusLine()));
                 }
             } catch (Exception e) {
-                log.warn("Error consuming response from uri {}", request.getURI(), e);
+                LOGGER.warn("Error consuming response from uri {}", request.getURI(), e);
                 exception = wrapException(e, request);
             }
         } catch (Exception e) {
-            log.error("Error executing request to uri {}", request.getURI(), e);
+            LOGGER.error("Error executing request to uri {}", request.getURI(), e);
             exception = wrapException(e, request);
         } finally {
             try {
                 client.close();
             } catch (Exception e) {
-                log.warn("Error closing http client instance", e);
+                LOGGER.warn("Error closing http client instance", e);
             }
         }
 
@@ -383,7 +383,7 @@ public class FlowableClientService {
                         errorMessage = "An error was returned when calling the Flowable server";
                     }
                 } catch (Exception e) {
-                    log.warn("Error consuming response from uri {}", request.getURI(), e);
+                    LOGGER.warn("Error consuming response from uri {}", request.getURI(), e);
                     exception = wrapException(e, request);
 
                 } finally {
@@ -392,7 +392,7 @@ public class FlowableClientService {
                 exception = new FlowableServiceException(errorMessage);
             }
         } catch (Exception e) {
-            log.error("Error executing request to uri {}", request.getURI(), e);
+            LOGGER.error("Error executing request to uri {}", request.getURI(), e);
             exception = wrapException(e, request);
 
         } finally {
@@ -400,7 +400,7 @@ public class FlowableClientService {
                 client.close();
             } catch (Exception e) {
                 // No need to throw upwards, as this may hide exceptions/valid result
-                log.warn("Error closing http client instance", e);
+                LOGGER.warn("Error closing http client instance", e);
             }
         }
 
@@ -447,7 +447,7 @@ public class FlowableClientService {
                         errorMessage = "An error was returned when calling the Flowable server";
                     }
                 } catch (Exception e) {
-                    log.warn("Error consuming response from uri {}", request.getURI(), e);
+                    LOGGER.warn("Error consuming response from uri {}", request.getURI(), e);
                     exception = wrapException(e, request);
                 } finally {
                     response.close();
@@ -455,7 +455,7 @@ public class FlowableClientService {
                 exception = new FlowableServiceException(errorMessage);
             }
         } catch (Exception e) {
-            log.error("Error executing request to uri {}", request.getURI(), e);
+            LOGGER.error("Error executing request to uri {}", request.getURI(), e);
             exception = wrapException(e, request);
 
         } finally {
@@ -463,7 +463,7 @@ public class FlowableClientService {
                 client.close();
             } catch (Exception e) {
                 // No need to throw upwards, as this may hide exceptions/valid result
-                log.warn("Error closing http client instance", e);
+                LOGGER.warn("Error closing http client instance", e);
             }
         }
 
@@ -521,7 +521,7 @@ public class FlowableClientService {
         try {
             return new StringEntity(json.toString());
         } catch (Exception e) {
-            log.warn("Error translation json to http client entity {}", json, e);
+            LOGGER.warn("Error translation json to http client entity {}", json, e);
         }
         return null;
     }
@@ -530,7 +530,7 @@ public class FlowableClientService {
         try {
             return new StringEntity(json);
         } catch (Exception e) {
-            log.warn("Error translation json to http client entity {}", json, e);
+            LOGGER.warn("Error translation json to http client entity {}", json, e);
         }
         return null;
     }
@@ -624,7 +624,7 @@ public class FlowableClientService {
         try {
             return objectMapper.readTree(IOUtils.toString(requestContent));
         } catch (Exception e) {
-            log.debug("Error parsing error message", e);
+            LOGGER.debug("Error parsing error message", e);
         }
         return null;
     }

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-rest/src/main/java/org/flowable/app/rest/api/ApiModelResource.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-rest/src/main/java/org/flowable/app/rest/api/ApiModelResource.java
@@ -47,7 +47,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 @RestController
 public class ApiModelResource {
 
-    private static final Logger log = LoggerFactory.getLogger(ApiModelResource.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ApiModelResource.class);
 
     private static final String RESOLVE_ACTION_OVERWRITE = "overwrite";
     private static final String RESOLVE_ACTION_SAVE_AS = "saveAs";
@@ -122,7 +122,7 @@ public class ApiModelResource {
             modelService.deleteModel(model.getId());
 
         } catch (Exception e) {
-            log.error("Error while deleting: ", e);
+            LOGGER.error("Error while deleting: ", e);
             throw new BadRequestException("Model cannot be deleted: " + modelId);
         }
     }
@@ -146,7 +146,7 @@ public class ApiModelResource {
                 editorJsonNode.put("modelType", "model");
                 modelNode.set("model", editorJsonNode);
             } catch (Exception e) {
-                log.error("Error reading editor json {}", modelId, e);
+                LOGGER.error("Error reading editor json {}", modelId, e);
                 throw new InternalServerErrorException("Error reading editor json " + modelId);
             }
 
@@ -254,7 +254,7 @@ public class ApiModelResource {
             return new ModelRepresentation(model);
 
         } catch (Exception e) {
-            log.error("Error saving model {}", model.getId(), e);
+            LOGGER.error("Error saving model {}", model.getId(), e);
             throw new BadRequestException("Process model could not be saved " + model.getId());
         }
     }

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-rest/src/main/java/org/flowable/app/rest/editor/ModelResource.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-rest/src/main/java/org/flowable/app/rest/editor/ModelResource.java
@@ -50,7 +50,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 @RestController
 public class ModelResource {
 
-    private static final Logger log = LoggerFactory.getLogger(ModelResource.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ModelResource.class);
 
     private static final String RESOLVE_ACTION_OVERWRITE = "overwrite";
     private static final String RESOLVE_ACTION_SAVE_AS = "saveAs";
@@ -125,7 +125,7 @@ public class ModelResource {
             modelService.deleteModel(model.getId());
 
         } catch (Exception e) {
-            log.error("Error while deleting: ", e);
+            LOGGER.error("Error while deleting: ", e);
             throw new BadRequestException("Model cannot be deleted: " + modelId);
         }
     }
@@ -149,7 +149,7 @@ public class ModelResource {
                 editorJsonNode.put("modelType", "model");
                 modelNode.set("model", editorJsonNode);
             } catch (Exception e) {
-                log.error("Error reading editor json {}", modelId, e);
+                LOGGER.error("Error reading editor json {}", modelId, e);
                 throw new InternalServerErrorException("Error reading editor json " + modelId);
             }
 
@@ -272,7 +272,7 @@ public class ModelResource {
             return new ModelRepresentation(model);
 
         } catch (Exception e) {
-            log.error("Error saving model {}", model.getId(), e);
+            LOGGER.error("Error saving model {}", model.getId(), e);
             throw new BadRequestException("Process model could not be saved " + model.getId());
         }
     }

--- a/modules/flowable5-camel-test/src/test/java/org/activiti/camel/exception/tools/ThrowBpmnExceptionBean.java
+++ b/modules/flowable5-camel-test/src/test/java/org/activiti/camel/exception/tools/ThrowBpmnExceptionBean.java
@@ -33,11 +33,11 @@ public class ThrowBpmnExceptionBean {
         ThrowBpmnExceptionBean.exceptionType = exceptionType;
     }
 
-    private static final Logger LOG = LoggerFactory.getLogger(ThrowBpmnExceptionBean.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ThrowBpmnExceptionBean.class);
 
     @Handler
     public void throwNonBpmnException() throws Exception {
-        LOG.debug("throwing non bpmn bug");
+        LOGGER.debug("throwing non bpmn bug");
 
         switch (getExceptionType()) {
         case NO_EXCEPTION:

--- a/modules/flowable5-camel-test/src/test/java/org/activiti/camel/util/BrokenService.java
+++ b/modules/flowable5-camel-test/src/test/java/org/activiti/camel/util/BrokenService.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
  */
 public class BrokenService {
 
-    private static final Logger LOG = LoggerFactory.getLogger(BrokenService.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(BrokenService.class);
 
     /**
      * Always throws an exception.
@@ -33,7 +33,7 @@ public class BrokenService {
      * @throws BrokenServiceException
      */
     public void alwaysFails() throws BrokenServiceException {
-        LOG.info("{} called", this.getClass().getSimpleName());
+        LOGGER.info("{} called", this.getClass().getSimpleName());
         throw new BrokenServiceException("Provoked failure");
     }
 

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/ProcessEngines.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/ProcessEngines.java
@@ -52,7 +52,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class ProcessEngines {
 
-    private static Logger log = LoggerFactory.getLogger(ProcessEngines.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProcessEngines.class);
 
     public static final String NAME_DEFAULT = "default";
 
@@ -87,7 +87,7 @@ public abstract class ProcessEngines {
             }
             for (Iterator<URL> iterator = configUrls.iterator(); iterator.hasNext();) {
                 URL resource = iterator.next();
-                log.info("Initializing process engine using configuration '{}'", resource.toString());
+                LOGGER.info("Initializing process engine using configuration '{}'", resource.toString());
                 initProcessEngineFromResource(resource);
             }
 
@@ -98,13 +98,13 @@ public abstract class ProcessEngines {
             }
             while (resources.hasMoreElements()) {
                 URL resource = resources.nextElement();
-                log.info("Initializing process engine using Spring configuration '{}'", resource.toString());
+                LOGGER.info("Initializing process engine using Spring configuration '{}'", resource.toString());
                 initProcessEngineFromSpringResource(resource);
             }
 
             setInitialized(true);
         } else {
-            log.info("Process engines already initialized");
+            LOGGER.info("Process engines already initialized");
         }
     }
 
@@ -155,15 +155,15 @@ public abstract class ProcessEngines {
 
         String resourceUrlString = resourceUrl.toString();
         try {
-            log.info("initializing process engine for resource {}", resourceUrl);
+            LOGGER.info("initializing process engine for resource {}", resourceUrl);
             ProcessEngine processEngine = buildProcessEngine(resourceUrl);
             String processEngineName = processEngine.getName();
-            log.info("initialised process engine {}", processEngineName);
+            LOGGER.info("initialised process engine {}", processEngineName);
             processEngineInfo = new ProcessEngineInfoImpl(processEngineName, resourceUrlString, null);
             processEngines.put(processEngineName, processEngine);
             processEngineInfosByName.put(processEngineName, processEngineInfo);
         } catch (Throwable e) {
-            log.error("Exception while initializing process engine: {}", e.getMessage(), e);
+            LOGGER.error("Exception while initializing process engine: {}", e.getMessage(), e);
             processEngineInfo = new ProcessEngineInfoImpl(null, resourceUrlString, getExceptionString(e));
         }
         processEngineInfosByResourceUrl.put(resourceUrlString, processEngineInfo);
@@ -226,7 +226,7 @@ public abstract class ProcessEngines {
      * retries to initialize a process engine that previously failed.
      */
     public static ProcessEngineInfo retry(String resourceUrl) {
-        log.debug("retying initializing of resource {}", resourceUrl);
+        LOGGER.debug("retying initializing of resource {}", resourceUrl);
         try {
             return initProcessEngineFromResource(new URL(resourceUrl));
         } catch (MalformedURLException e) {
@@ -252,7 +252,7 @@ public abstract class ProcessEngines {
                 try {
                     processEngine.close();
                 } catch (Exception e) {
-                    log.error("exception while closing {}", (processEngineName == null ? "the default process engine" : "process engine " + processEngineName), e);
+                    LOGGER.error("exception while closing {}", (processEngineName == null ? "the default process engine" : "process engine " + processEngineName), e);
                 }
             }
 

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/ProcessEngineImpl.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/ProcessEngineImpl.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ProcessEngineImpl implements ProcessEngine {
 
-    private static Logger log = LoggerFactory.getLogger(ProcessEngineImpl.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProcessEngineImpl.class);
 
     protected String name;
     protected RepositoryService repositoryService;
@@ -73,9 +73,9 @@ public class ProcessEngineImpl implements ProcessEngine {
         this.transactionContextFactory = processEngineConfiguration.getTransactionContextFactory();
 
         if (name == null) {
-            log.info("default activiti ProcessEngine created");
+            LOGGER.info("default activiti ProcessEngine created");
         } else {
-            log.info("ProcessEngine {} created", name);
+            LOGGER.info("ProcessEngine {} created", name);
         }
 
         ProcessEngines.registerProcessEngine(this);

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/asyncexecutor/AsyncJobUtil.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/asyncexecutor/AsyncJobUtil.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
 
 public class AsyncJobUtil {
 
-    private static Logger log = LoggerFactory.getLogger(AsyncJobUtil.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AsyncJobUtil.class);
 
     public static void executeJob(final JobEntity job, final CommandExecutor commandExecutor) {
         try {
@@ -39,8 +39,8 @@ public class AsyncJobUtil {
             }
 
         } catch (Throwable lockException) {
-            if (log.isDebugEnabled()) {
-                log.debug("Could not lock exclusive job. Unlocking job so it can be acquired again. Caught exception: {}", lockException.getMessage());
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Could not lock exclusive job. Unlocking job so it can be acquired again. Caught exception: {}", lockException.getMessage());
             }
 
             unacquireJob(commandExecutor, job);
@@ -55,8 +55,8 @@ public class AsyncJobUtil {
 
             handleFailedJob(job, e, commandExecutor);
 
-            if (log.isDebugEnabled()) {
-                log.debug("Optimistic locking exception during job execution. If you have multiple async executors running against the same database, " +
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Optimistic locking exception during job execution. If you have multiple async executors running against the same database, " +
                         "this exception means that this thread tried to acquire an exclusive job, which already was changed by another async executor thread." +
                         "This is expected behavior in a clustered environment. " +
                         "You can ignore this message if you indeed have multiple job executor threads running against the same database. " +
@@ -68,7 +68,7 @@ public class AsyncJobUtil {
 
             // Finally, Throw the exception to indicate the ExecuteAsyncJobCmd failed
             String message = "Job " + job.getId() + " failed";
-            log.error(message, exception);
+            LOGGER.error(message, exception);
         }
 
         try {
@@ -77,15 +77,15 @@ public class AsyncJobUtil {
             }
 
         } catch (ActivitiOptimisticLockingException optimisticLockingException) {
-            if (log.isDebugEnabled()) {
-                log.debug("Optimistic locking exception while unlocking the job. If you have multiple async executors running against the same database, " +
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Optimistic locking exception while unlocking the job. If you have multiple async executors running against the same database, " +
                         "this exception means that this thread tried to acquire an exclusive job, which already was changed by another async executor thread." +
                         "This is expected behavior in a clustered environment. " +
                         "You can ignore this message if you indeed have multiple job executor acquisition threads running against the same database. " +
                         "Exception message: {}", optimisticLockingException.getMessage());
             }
         } catch (Throwable t) {
-            log.error("Error while unlocking exclusive job {}", job.getId(), t);
+            LOGGER.error("Error while unlocking exclusive job {}", job.getId(), t);
         }
     }
 
@@ -112,7 +112,7 @@ public class AsyncJobUtil {
                 FailedJobCommandFactory failedJobCommandFactory = commandContext.getFailedJobCommandFactory();
                 Command<Object> cmd = failedJobCommandFactory.getCommand(job.getId(), exception);
 
-                log.trace("Using FailedJobCommandFactory '{}' and command of type '{}'", failedJobCommandFactory.getClass(), cmd.getClass());
+                LOGGER.trace("Using FailedJobCommandFactory '{}' and command of type '{}'", failedJobCommandFactory.getClass(), cmd.getClass());
                 commandExecutor.execute(commandConfig, cmd);
 
                 // Dispatch an event, indicating job execution failed in a try-catch block, to prevent the original
@@ -122,7 +122,7 @@ public class AsyncJobUtil {
                         commandContext.getEventDispatcher().dispatchEvent(ActivitiEventBuilder.createEntityExceptionEvent(
                                 FlowableEngineEventType.JOB_EXECUTION_FAILURE, job, exception));
                     } catch (Throwable ignore) {
-                        log.warn("Exception occurred while dispatching job failure event, ignoring.", ignore);
+                        LOGGER.warn("Exception occurred while dispatching job failure event, ignoring.", ignore);
                     }
                 }
 

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/BpmnActivityBehavior.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/BpmnActivityBehavior.java
@@ -47,7 +47,7 @@ public class BpmnActivityBehavior implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private static Logger log = LoggerFactory.getLogger(BpmnActivityBehavior.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(BpmnActivityBehavior.class);
 
     /**
      * Performs the default outgoing BPMN 2.0 behavior, which is having parallel paths of executions for the outgoing sequence flow.
@@ -110,8 +110,8 @@ public class BpmnActivityBehavior implements Serializable {
     protected void performOutgoingBehavior(ActivityExecution execution,
             boolean checkConditions, boolean throwExceptionIfExecutionStuck, List<ActivityExecution> reusableExecutions) {
 
-        if (log.isDebugEnabled()) {
-            log.debug("Leaving activity '{}'", execution.getActivity().getId());
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Leaving activity '{}'", execution.getActivity().getId());
         }
 
         String defaultSequenceFlow = (String) execution.getActivity().getProperty("default");
@@ -169,8 +169,8 @@ public class BpmnActivityBehavior implements Serializable {
 
                 } else {
 
-                    if (log.isDebugEnabled()) {
-                        log.debug("No outgoing sequence flow found for {}. Ending execution.", execution.getActivity().getId());
+                    if (LOGGER.isDebugEnabled()) {
+                        LOGGER.debug("No outgoing sequence flow found for {}. Ending execution.", execution.getActivity().getId());
                     }
                     execution.end();
 

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/ExclusiveGatewayActivityBehavior.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/ExclusiveGatewayActivityBehavior.java
@@ -33,7 +33,7 @@ public class ExclusiveGatewayActivityBehavior extends GatewayActivityBehavior {
 
     private static final long serialVersionUID = 1L;
 
-    private static Logger log = LoggerFactory.getLogger(ExclusiveGatewayActivityBehavior.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExclusiveGatewayActivityBehavior.class);
 
     /**
      * The default behaviour of BPMN, taking every outgoing sequence flow (where the condition evaluates to true), is not valid for an exclusive gateway.
@@ -46,8 +46,8 @@ public class ExclusiveGatewayActivityBehavior extends GatewayActivityBehavior {
     @Override
     protected void leave(ActivityExecution execution) {
 
-        if (log.isDebugEnabled()) {
-            log.debug("Leaving activity '{}'", execution.getActivity().getId());
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Leaving activity '{}'", execution.getActivity().getId());
         }
 
         PvmTransition outgoingSeqFlow = null;
@@ -61,8 +61,8 @@ public class ExclusiveGatewayActivityBehavior extends GatewayActivityBehavior {
                 Condition condition = (Condition) seqFlow.getProperty(BpmnParse.PROPERTYNAME_CONDITION);
                 if ((condition == null && (defaultSequenceFlow == null || !defaultSequenceFlow.equals(seqFlow.getId())))
                         || (condition != null && condition.evaluate(seqFlow.getId(), execution))) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Sequence flow '{}'selected as outgoing sequence flow.", seqFlow.getId());
+                    if (LOGGER.isDebugEnabled()) {
+                        LOGGER.debug("Sequence flow '{}'selected as outgoing sequence flow.", seqFlow.getId());
                     }
                     outgoingSeqFlow = seqFlow;
                 }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/InclusiveGatewayActivityBehavior.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/InclusiveGatewayActivityBehavior.java
@@ -41,7 +41,7 @@ public class InclusiveGatewayActivityBehavior extends GatewayActivityBehavior {
 
     private static final long serialVersionUID = 1L;
 
-    private static Logger log = LoggerFactory.getLogger(InclusiveGatewayActivityBehavior.class.getName());
+    private static final Logger LOGGER = LoggerFactory.getLogger(InclusiveGatewayActivityBehavior.class.getName());
 
     public void execute(DelegateExecution execution) {
         ActivityExecution activityExecution = (ActivityExecution) execution;
@@ -51,8 +51,8 @@ public class InclusiveGatewayActivityBehavior extends GatewayActivityBehavior {
         PvmActivity activity = activityExecution.getActivity();
         if (!activeConcurrentExecutionsExist(activityExecution)) {
 
-            if (log.isDebugEnabled()) {
-                log.debug("inclusive gateway '{}' activates", activity.getId());
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("inclusive gateway '{}' activates", activity.getId());
             }
 
             List<ActivityExecution> joinedExecutions = activityExecution.findInactiveConcurrentExecutions(activity);
@@ -97,8 +97,8 @@ public class InclusiveGatewayActivityBehavior extends GatewayActivityBehavior {
             }
 
         } else {
-            if (log.isDebugEnabled()) {
-                log.debug("Inclusive gateway '{}' does not activate", activity.getId());
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Inclusive gateway '{}' does not activate", activity.getId());
             }
         }
     }
@@ -131,16 +131,16 @@ public class InclusiveGatewayActivityBehavior extends GatewayActivityBehavior {
                     }
 
                     if (reachable) {
-                        if (log.isDebugEnabled()) {
-                            log.debug("an active concurrent execution found: '{}'", concurrentExecution.getActivity());
+                        if (LOGGER.isDebugEnabled()) {
+                            LOGGER.debug("an active concurrent execution found: '{}'", concurrentExecution.getActivity());
                         }
                         return true;
                     }
                 }
             }
         } else if (execution.isActive()) { // is this ever true?
-            if (log.isDebugEnabled()) {
-                log.debug("an active concurrent execution found: '{}'", execution.getActivity());
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("an active concurrent execution found: '{}'", execution.getActivity());
             }
             return true;
         }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/MailActivityBehavior.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/MailActivityBehavior.java
@@ -48,7 +48,7 @@ public class MailActivityBehavior extends AbstractBpmnActivityBehavior {
 
     private static final long serialVersionUID = 1L;
 
-    private static final Logger LOG = LoggerFactory.getLogger(MailActivityBehavior.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(MailActivityBehavior.class);
 
     private static final Class<?>[] ALLOWED_ATT_TYPES = new Class<?>[] {
             File.class, File[].class, String.class, String[].class, DataSource.class, DataSource[].class
@@ -400,7 +400,7 @@ public class MailActivityBehavior extends AbstractBpmnActivityBehavior {
 
     protected void handleException(DelegateExecution execution, String msg, Exception e, boolean doIgnoreException, String exceptionVariable) {
         if (doIgnoreException) {
-            LOG.info("Ignoring email send error: {}", msg, e);
+            LOGGER.info("Ignoring email send error: {}", msg, e);
             if (exceptionVariable != null && exceptionVariable.length() > 0) {
                 execution.setVariable(exceptionVariable, msg);
             }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/ParallelGatewayActivityBehavior.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/ParallelGatewayActivityBehavior.java
@@ -45,7 +45,7 @@ public class ParallelGatewayActivityBehavior extends GatewayActivityBehavior {
 
     private static final long serialVersionUID = 1L;
 
-    private static Logger log = LoggerFactory.getLogger(ParallelGatewayActivityBehavior.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ParallelGatewayActivityBehavior.class);
 
     public void execute(DelegateExecution execution) {
         ActivityExecution activityExecution = (ActivityExecution) execution;
@@ -62,13 +62,13 @@ public class ParallelGatewayActivityBehavior extends GatewayActivityBehavior {
         if (nbrOfExecutionsJoined == nbrOfExecutionsToJoin) {
 
             // Fork
-            if (log.isDebugEnabled()) {
-                log.debug("parallel gateway '{}' activates: {} of {} joined", activity.getId(), nbrOfExecutionsJoined, nbrOfExecutionsToJoin);
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("parallel gateway '{}' activates: {} of {} joined", activity.getId(), nbrOfExecutionsJoined, nbrOfExecutionsToJoin);
             }
             activityExecution.takeAll(outgoingTransitions, joinedExecutions);
 
-        } else if (log.isDebugEnabled()) {
-            log.debug("parallel gateway '{}' does not activate: {} of {} joined", activity.getId(), nbrOfExecutionsJoined, nbrOfExecutionsToJoin);
+        } else if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("parallel gateway '{}' does not activate: {} of {} joined", activity.getId(), nbrOfExecutionsJoined, nbrOfExecutionsToJoin);
         }
     }
 

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/deployer/BpmnDeployer.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/deployer/BpmnDeployer.java
@@ -12,6 +12,10 @@
  */
 package org.activiti.engine.impl.bpmn.deployer;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -74,17 +78,13 @@ import org.flowable.engine.runtime.Job;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 /**
  * @author Tom Baeyens
  * @author Joram Barrez
  */
 public class BpmnDeployer implements Deployer {
 
-    private static final Logger log = LoggerFactory.getLogger(BpmnDeployer.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(BpmnDeployer.class);
 
     public static final String[] BPMN_RESOURCE_SUFFIXES = new String[] { "bpmn20.xml", "bpmn" };
     public static final String[] DIAGRAM_SUFFIXES = new String[] { "png", "jpg", "gif", "svg" };
@@ -94,7 +94,7 @@ public class BpmnDeployer implements Deployer {
     protected IdGenerator idGenerator;
 
     public void deploy(DeploymentEntity deployment, Map<String, Object> deploymentSettings) {
-        log.debug("Processing deployment {}", deployment.getName());
+        LOGGER.debug("Processing deployment {}", deployment.getName());
 
         List<ProcessDefinitionEntity> processDefinitions = new ArrayList<ProcessDefinitionEntity>();
         Map<String, ResourceEntity> resources = deployment.getResources();
@@ -103,7 +103,7 @@ public class BpmnDeployer implements Deployer {
         final ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
         for (String resourceName : resources.keySet()) {
 
-            log.info("Processing resource {}", resourceName);
+            LOGGER.info("Processing resource {}", resourceName);
             if (isBpmnResource(resourceName)) {
                 ResourceEntity resource = resources.get(resourceName);
                 byte[] bytes = resource.getBytes();
@@ -160,7 +160,7 @@ public class BpmnDeployer implements Deployer {
                                 createResource(diagramResourceName, diagramBytes, deployment);
 
                             } catch (Throwable t) { // if anything goes wrong, we don't store the image (the process will still be executable).
-                                log.warn("Error while generating process diagram, image will not be stored in repository", t);
+                                LOGGER.warn("Error while generating process diagram, image will not be stored in repository", t);
                             }
                         }
                     }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/helper/ErrorPropagation.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/helper/ErrorPropagation.java
@@ -51,7 +51,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ErrorPropagation {
 
-    private static final Logger LOG = LoggerFactory.getLogger(ErrorPropagation.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ErrorPropagation.class);
 
     public static void propagateError(BpmnError error, ActivityExecution execution) {
         propagateError(error.getErrorCode(), execution);

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/handler/ServiceTaskParseHandler.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/handler/ServiceTaskParseHandler.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ServiceTaskParseHandler extends AbstractExternalInvocationBpmnParseHandler<ServiceTask> {
 
-    private static Logger logger = LoggerFactory.getLogger(ServiceTaskParseHandler.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ServiceTaskParseHandler.class);
 
     public Class<? extends BaseElement> getHandledType() {
         return ServiceTask.class;
@@ -60,7 +60,7 @@ public class ServiceTaskParseHandler extends AbstractExternalInvocationBpmnParse
                 activity.setActivityBehavior(bpmnParse.getActivityBehaviorFactory().createShellActivityBehavior(serviceTask));
 
             } else {
-                logger.warn("Invalid service task type: '{}'  for service task {}", serviceTask.getType(), serviceTask.getId());
+                LOGGER.warn("Invalid service task type: '{}'  for service task {}", serviceTask.getType(), serviceTask.getId());
             }
 
             // activiti:class
@@ -80,7 +80,7 @@ public class ServiceTaskParseHandler extends AbstractExternalInvocationBpmnParse
                 StringUtils.isNotEmpty(serviceTask.getOperationRef())) {
 
             if (!bpmnParse.getOperations().containsKey(serviceTask.getOperationRef())) {
-                logger.warn("{} does not exist for service task {}", serviceTask.getOperationRef(), serviceTask.getId());
+                LOGGER.warn("{} does not exist for service task {}", serviceTask.getOperationRef(), serviceTask.getId());
             } else {
 
                 WebServiceActivityBehavior webServiceActivityBehavior = bpmnParse.getActivityBehaviorFactory().createWebServiceActivityBehavior(serviceTask);
@@ -104,7 +104,7 @@ public class ServiceTaskParseHandler extends AbstractExternalInvocationBpmnParse
                 activity.setActivityBehavior(webServiceActivityBehavior);
             }
         } else {
-            logger.warn("One of the attributes 'class', 'delegateExpression', 'type', 'operation', or 'expression' is mandatory on serviceTask {}", serviceTask.getId());
+            LOGGER.warn("One of the attributes 'class', 'delegateExpression', 'type', 'operation', or 'expression' is mandatory on serviceTask {}", serviceTask.getId());
         }
 
     }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/handler/StartEventParseHandler.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/handler/StartEventParseHandler.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
  */
 public class StartEventParseHandler extends AbstractActivityBpmnParseHandler<StartEvent> {
 
-    private static Logger logger = LoggerFactory.getLogger(StartEventParseHandler.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(StartEventParseHandler.class);
 
     public static final String PROPERTYNAME_INITIATOR_VARIABLE_NAME = "initiatorVariableName";
     public static final String PROPERTYNAME_INITIAL = "initial";
@@ -102,7 +102,7 @@ public class StartEventParseHandler extends AbstractActivityBpmnParseHandler<Sta
                     || eventDefinition instanceof SignalEventDefinition) {
                 bpmnParse.getBpmnParserHandlers().parseElement(bpmnParse, eventDefinition);
             } else {
-                logger.warn("Unsupported event definition on start event {}", eventDefinition);
+                LOGGER.warn("Unsupported event definition on start event {}", eventDefinition);
             }
         }
     }
@@ -127,20 +127,20 @@ public class StartEventParseHandler extends AbstractActivityBpmnParseHandler<Sta
                         || eventDefinition instanceof SignalEventDefinition) {
                     bpmnParse.getBpmnParserHandlers().parseElement(bpmnParse, eventDefinition);
                 } else {
-                    logger.warn("start event of event subprocess must be of type 'error', 'message' or 'signal' for start event {}", startEvent.getId());
+                    LOGGER.warn("start event of event subprocess must be of type 'error', 'message' or 'signal' for start event {}", startEvent.getId());
                 }
             }
 
         } else { // "regular" subprocess
 
             if (!startEvent.getEventDefinitions().isEmpty()) {
-                logger.warn("event definitions only allowed on start event if subprocess is an event subprocess {}", bpmnParse.getCurrentSubProcess().getId());
+                LOGGER.warn("event definitions only allowed on start event if subprocess is an event subprocess {}", bpmnParse.getCurrentSubProcess().getId());
             }
             if (scope.getProperty(PROPERTYNAME_INITIAL) == null) {
                 scope.setProperty(PROPERTYNAME_INITIAL, startEventActivity);
                 startEventActivity.setActivityBehavior(bpmnParse.getActivityBehaviorFactory().createNoneStartEventActivityBehavior(startEvent));
             } else {
-                logger.warn("multiple start events not supported for subprocess {}", bpmnParse.getCurrentSubProcess().getId());
+                LOGGER.warn("multiple start events not supported for subprocess {}", bpmnParse.getCurrentSubProcess().getId());
             }
         }
 

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -246,7 +246,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfiguration {
 
-    private static Logger log = LoggerFactory.getLogger(ProcessEngineConfigurationImpl.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProcessEngineConfigurationImpl.class);
 
     public static final String DB_SCHEMA_UPDATE_CREATE = "create";
     public static final String DB_SCHEMA_UPDATE_DROP_CREATE = "drop-create";
@@ -716,7 +716,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
                     throw new ActivitiException("DataSource or JDBC properties have to be specified in a process engine configuration");
                 }
 
-                log.debug("initializing datasource to db: {}", jdbcUrl);
+                LOGGER.debug("initializing datasource to db: {}", jdbcUrl);
 
                 PooledDataSource pooledDataSource = new PooledDataSource(ReflectUtil.getClassLoader(), jdbcDriver, jdbcUrl, jdbcUsername, jdbcPassword);
 
@@ -805,22 +805,22 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
             connection = dataSource.getConnection();
             DatabaseMetaData databaseMetaData = connection.getMetaData();
             String databaseProductName = databaseMetaData.getDatabaseProductName();
-            log.debug("database product name: '{}'", databaseProductName);
+            LOGGER.debug("database product name: '{}'", databaseProductName);
             databaseType = databaseTypeMappings.getProperty(databaseProductName);
             if (databaseType == null) {
                 throw new ActivitiException("couldn't deduct database type from database product name '" + databaseProductName + "'");
             }
-            log.debug("using database type: {}", databaseType);
+            LOGGER.debug("using database type: {}", databaseType);
 
         } catch (SQLException e) {
-            log.error("Exception while initializing Database connection", e);
+            LOGGER.error("Exception while initializing Database connection", e);
         } finally {
             try {
                 if (connection != null) {
                     connection.close();
                 }
             } catch (SQLException e) {
-                log.error("Exception while closing the Database connection", e);
+                LOGGER.error("Exception while closing the Database connection", e);
             }
         }
     }
@@ -1024,7 +1024,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
             }
 
             if (nrOfServiceLoadedConfigurators > 0) {
-                log.info("Found {} auto-discoverable Process Engine Configurator{}", nrOfServiceLoadedConfigurators++, nrOfServiceLoadedConfigurators > 1 ? "s" : "");
+                LOGGER.info("Found {} auto-discoverable Process Engine Configurator{}", nrOfServiceLoadedConfigurators++, nrOfServiceLoadedConfigurators > 1 ? "s" : "");
             }
 
             if (!allConfigurators.isEmpty()) {
@@ -1046,9 +1046,9 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
                 });
 
                 // Execute the configurators
-                log.info("Found {} Process Engine Configurators in total:", allConfigurators.size());
+                LOGGER.info("Found {} Process Engine Configurators in total:", allConfigurators.size());
                 for (ProcessEngineConfigurator configurator : allConfigurators) {
-                    log.info("{} (priority:{})", configurator.getClass(), configurator.getPriority());
+                    LOGGER.info("{} (priority:{})", configurator.getClass(), configurator.getPriority());
                 }
 
             }
@@ -1058,14 +1058,14 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     protected void configuratorsBeforeInit() {
         for (ProcessEngineConfigurator configurator : allConfigurators) {
-            log.info("Executing beforeInit() of {} (priority:{})", configurator.getClass(), configurator.getPriority());
+            LOGGER.info("Executing beforeInit() of {} (priority:{})", configurator.getClass(), configurator.getPriority());
             configurator.beforeInit(this);
         }
     }
 
     protected void configuratorsAfterInit() {
         for (ProcessEngineConfigurator configurator : allConfigurators) {
-            log.info("Executing configure() of {} (priority:{})", configurator.getClass(), configurator.getPriority());
+            LOGGER.info("Executing configure() of {} (priority:{})", configurator.getClass(), configurator.getPriority());
             configurator.configure(this);
         }
     }
@@ -1238,7 +1238,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
                     Class<?> handledType = defaultBpmnParseHandler.getHandledTypes().iterator().next();
                     if (customParseHandlerMap.containsKey(handledType)) {
                         BpmnParseHandler newBpmnParseHandler = customParseHandlerMap.get(handledType);
-                        log.info("Replacing default BpmnParseHandler {} with {}", defaultBpmnParseHandler.getClass().getName(), newBpmnParseHandler.getClass()
+                        LOGGER.info("Replacing default BpmnParseHandler {} with {}", defaultBpmnParseHandler.getClass().getName(), newBpmnParseHandler.getClass()
                                 .getName());
                         bpmnParserHandlers.set(i, newBpmnParseHandler);
                     }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cfg/standalone/StandaloneMybatisTransactionContext.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cfg/standalone/StandaloneMybatisTransactionContext.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  */
 public class StandaloneMybatisTransactionContext implements TransactionContext {
 
-    private static Logger log = LoggerFactory.getLogger(StandaloneMybatisTransactionContext.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(StandaloneMybatisTransactionContext.class);
 
     protected CommandContext commandContext;
     protected Map<TransactionState, List<TransactionListener>> stateTransactionListeners;
@@ -58,12 +58,12 @@ public class StandaloneMybatisTransactionContext implements TransactionContext {
 
     public void commit() {
 
-        log.debug("firing event committing...");
+        LOGGER.debug("firing event committing...");
         fireTransactionEvent(TransactionState.COMMITTING, false);
 
-        log.debug("committing the ibatis sql session...");
+        LOGGER.debug("committing the ibatis sql session...");
         getDbSqlSession().commit();
-        log.debug("firing event committed...");
+        LOGGER.debug("firing event committed...");
         fireTransactionEvent(TransactionState.COMMITTED, true);
 
     }
@@ -115,23 +115,23 @@ public class StandaloneMybatisTransactionContext implements TransactionContext {
     public void rollback() {
         try {
             try {
-                log.debug("firing event rolling back...");
+                LOGGER.debug("firing event rolling back...");
                 fireTransactionEvent(TransactionState.ROLLINGBACK, false);
 
             } catch (Throwable exception) {
-                log.info("Exception during transaction: {}", exception.getMessage());
+                LOGGER.info("Exception during transaction: {}", exception.getMessage());
                 commandContext.exception(exception);
             } finally {
-                log.debug("rolling back ibatis sql session...");
+                LOGGER.debug("rolling back ibatis sql session...");
                 getDbSqlSession().rollback();
             }
 
         } catch (Throwable exception) {
-            log.info("Exception during transaction: {}", exception.getMessage());
+            LOGGER.info("Exception during transaction: {}", exception.getMessage());
             commandContext.exception(exception);
 
         } finally {
-            log.debug("firing event rolled back...");
+            LOGGER.debug("firing event rolled back...");
             fireTransactionEvent(TransactionState.ROLLED_BACK, true);
         }
     }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cmd/DeleteJobCmd.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cmd/DeleteJobCmd.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
 
 public class DeleteJobCmd implements Command<Object>, Serializable {
 
-    private static final Logger log = LoggerFactory.getLogger(DeleteJobCmd.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DeleteJobCmd.class);
     private static final long serialVersionUID = 1L;
 
     protected String jobId;
@@ -51,8 +51,8 @@ public class DeleteJobCmd implements Command<Object>, Serializable {
         if (jobId == null) {
             throw new ActivitiIllegalArgumentException("jobId is null");
         }
-        if (log.isDebugEnabled()) {
-            log.debug("Deleting job {}", jobId);
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Deleting job {}", jobId);
         }
 
         JobEntity job = commandContext.getJobEntityManager().findJobById(jobId);

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cmd/ExecuteAsyncJobCmd.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cmd/ExecuteAsyncJobCmd.java
@@ -30,7 +30,7 @@ public class ExecuteAsyncJobCmd implements Command<Object>, Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private static Logger log = LoggerFactory.getLogger(ExecuteAsyncJobCmd.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExecuteAsyncJobCmd.class);
 
     protected JobEntity job;
 
@@ -52,13 +52,13 @@ public class ExecuteAsyncJobCmd implements Command<Object>, Serializable {
 
         JobEntity refetchedJob = commandContext.getJobEntityManager().findJobById(job.getId());
         if (refetchedJob == null) {
-            log.debug("Job does not exist anymore and will not be executed. It has most likely been deleted "
+            LOGGER.debug("Job does not exist anymore and will not be executed. It has most likely been deleted "
                     + "as part of another concurrent part of the process instance.");
             return null;
         }
 
-        if (log.isDebugEnabled()) {
-            log.debug("Executing async job {}", refetchedJob.getId());
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Executing async job {}", refetchedJob.getId());
         }
 
         refetchedJob.execute(commandContext);

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cmd/ExecuteJobsCmd.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cmd/ExecuteJobsCmd.java
@@ -37,7 +37,7 @@ public class ExecuteJobsCmd implements Command<Object>, Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private static Logger log = LoggerFactory.getLogger(ExecuteJobsCmd.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExecuteJobsCmd.class);
 
     protected String jobId;
     protected JobEntity job;
@@ -66,8 +66,8 @@ public class ExecuteJobsCmd implements Command<Object>, Serializable {
             throw new JobNotFoundException(jobId);
         }
 
-        if (log.isDebugEnabled()) {
-            log.debug("Executing job {}", job.getId());
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Executing job {}", job.getId());
         }
 
         JobExecutorContext jobExecutorContext = Context.getJobExecutorContext();
@@ -100,7 +100,7 @@ public class ExecuteJobsCmd implements Command<Object>, Serializable {
                     commandContext.getEventDispatcher().dispatchEvent(ActivitiEventBuilder.createEntityExceptionEvent(
                             FlowableEngineEventType.JOB_EXECUTION_FAILURE, job, exception));
                 } catch (Throwable ignore) {
-                    log.warn("Exception occurred while dispatching job failure event, ignoring.", ignore);
+                    LOGGER.warn("Exception occurred while dispatching job failure event, ignoring.", ignore);
                 }
             }
 

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cmd/GetDeploymentProcessDiagramCmd.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cmd/GetDeploymentProcessDiagramCmd.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
 public class GetDeploymentProcessDiagramCmd implements Command<InputStream>, Serializable {
 
     private static final long serialVersionUID = 1L;
-    private static Logger log = LoggerFactory.getLogger(GetDeploymentProcessDiagramCmd.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(GetDeploymentProcessDiagramCmd.class);
 
     protected String processDefinitionId;
 
@@ -50,7 +50,7 @@ public class GetDeploymentProcessDiagramCmd implements Command<InputStream>, Ser
         String deploymentId = processDefinition.getDeploymentId();
         String resourceName = processDefinition.getDiagramResourceName();
         if (resourceName == null) {
-            log.info("Resource name is null! No process diagram stream exists.");
+            LOGGER.info("Resource name is null! No process diagram stream exists.");
             return null;
         } else {
             InputStream processDiagramStream = new GetDeploymentResourceCmd(deploymentId, resourceName)

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cmd/JobRetryCmd.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cmd/JobRetryCmd.java
@@ -50,7 +50,7 @@ import org.slf4j.LoggerFactory;
 
 public class JobRetryCmd implements Command<Object> {
 
-    private static final Logger log = LoggerFactory.getLogger(JobRetryCmd.class.getName());
+    private static final Logger LOGGER = LoggerFactory.getLogger(JobRetryCmd.class.getName());
 
     protected String jobId;
     protected Throwable exception;
@@ -71,7 +71,7 @@ public class JobRetryCmd implements Command<Object> {
 
         AbstractJobEntity newJobEntity = null;
         if (activity == null || activity.getFailedJobRetryTimeCycleValue() == null) {
-            log.debug("activity or FailedJobRetryTimerCycleValue is null in job '{}'. Only decrementing retries.", jobId);
+            LOGGER.debug("activity or FailedJobRetryTimerCycleValue is null in job '{}'. Only decrementing retries.", jobId);
 
             if (job.getRetries() <= 1) {
                 DeadLetterJobEntity deadLetterJob = new DeadLetterJobEntity(job);
@@ -115,10 +115,10 @@ public class JobRetryCmd implements Command<Object> {
                 newJobEntity.setDuedate(durationHelper.getDateAfter());
 
                 if (job.getExceptionMessage() == null) { // is it the first exception
-                    log.debug("Applying JobRetryStrategy '{}' the first time for job {} with {} retries", failedJobRetryTimeCycle, job.getId(), durationHelper.getTimes());
+                    LOGGER.debug("Applying JobRetryStrategy '{}' the first time for job {} with {} retries", failedJobRetryTimeCycle, job.getId(), durationHelper.getTimes());
 
                 } else {
-                    log.debug("Decrementing retries of JobRetryStrategy '{}' for job {}", failedJobRetryTimeCycle, job.getId());
+                    LOGGER.debug("Decrementing retries of JobRetryStrategy '{}' for job {}", failedJobRetryTimeCycle, job.getId());
                 }
                 newJobEntity.setRetries(jobRetries - 1);
 

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cmd/LockExclusiveJobCmd.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cmd/LockExclusiveJobCmd.java
@@ -29,7 +29,7 @@ public class LockExclusiveJobCmd implements Command<Object>, Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private static Logger log = LoggerFactory.getLogger(LockExclusiveJobCmd.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(LockExclusiveJobCmd.class);
 
     protected JobEntity job;
 
@@ -43,8 +43,8 @@ public class LockExclusiveJobCmd implements Command<Object>, Serializable {
             throw new ActivitiIllegalArgumentException("job is null");
         }
 
-        if (log.isDebugEnabled()) {
-            log.debug("Executing lock exclusive job {} {}", job.getId(), job.getExecutionId());
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Executing lock exclusive job {} {}", job.getId(), job.getExecutionId());
         }
 
         if (job.isExclusive()) {

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cmd/UnlockExclusiveJobCmd.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cmd/UnlockExclusiveJobCmd.java
@@ -30,7 +30,7 @@ public class UnlockExclusiveJobCmd implements Command<Object>, Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private static Logger log = LoggerFactory.getLogger(UnlockExclusiveJobCmd.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(UnlockExclusiveJobCmd.class);
 
     protected JobEntity job;
 
@@ -44,8 +44,8 @@ public class UnlockExclusiveJobCmd implements Command<Object>, Serializable {
             throw new ActivitiIllegalArgumentException("job is null");
         }
 
-        if (log.isDebugEnabled()) {
-            log.debug("Unlocking exclusive job {}", job.getId());
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Unlocking exclusive job {}", job.getId());
         }
 
         if (job.isExclusive()) {

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/db/DbSqlSession.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/db/DbSqlSession.java
@@ -65,7 +65,7 @@ import org.slf4j.LoggerFactory;
  */
 public class DbSqlSession implements Session {
 
-    private static final Logger log = LoggerFactory.getLogger(DbSqlSession.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DbSqlSession.class);
 
     protected static final Pattern CLEAN_VERSION_REGEX = Pattern.compile("\\d\\.\\d*");
 
@@ -131,7 +131,7 @@ public class DbSqlSession implements Session {
     public void delete(PersistentObject persistentObject) {
         for (DeleteOperation deleteOperation : deleteOperations) {
             if (deleteOperation.sameIdentity(persistentObject)) {
-                log.debug("skipping redundant delete: {}", persistentObject);
+                LOGGER.debug("skipping redundant delete: {}", persistentObject);
                 return; // Skip this delete. It was already added.
             }
         }
@@ -535,27 +535,27 @@ public class DbSqlSession implements Session {
         flushDeserializedObjects();
         List<PersistentObject> updatedObjects = getUpdatedObjects();
 
-        if (log.isDebugEnabled()) {
+        if (LOGGER.isDebugEnabled()) {
             Collection<List<PersistentObject>> insertedObjectLists = insertedObjects.values();
             int nrOfInserts = 0;
             int nrOfUpdates = 0;
             int nrOfDeletes = 0;
             for (List<PersistentObject> insertedObjectList : insertedObjectLists) {
                 for (PersistentObject insertedObject : insertedObjectList) {
-                    log.debug("  insert {}", insertedObject);
+                    LOGGER.debug("  insert {}", insertedObject);
                     nrOfInserts++;
                 }
             }
             for (PersistentObject updatedObject : updatedObjects) {
-                log.debug("  update {}", updatedObject);
+                LOGGER.debug("  update {}", updatedObject);
                 nrOfUpdates++;
             }
             for (DeleteOperation deleteOperation : deleteOperations) {
-                log.debug("  {}", deleteOperation);
+                LOGGER.debug("  {}", deleteOperation);
                 nrOfDeletes++;
             }
-            log.debug("flush summary: {} insert, {} update, {} delete.", nrOfInserts, nrOfUpdates, nrOfDeletes);
-            log.debug("now executing flush...");
+            LOGGER.debug("flush summary: {} insert, {} update, {} delete.", nrOfInserts, nrOfUpdates, nrOfDeletes);
+            LOGGER.debug("now executing flush...");
         }
 
         flushInserts();
@@ -699,7 +699,7 @@ public class DbSqlSession implements Session {
 
                         updatedObjects.add(persistentObject);
                     } else {
-                        log.trace("loaded object '{}' was not updated", persistentObject);
+                        LOGGER.trace("loaded object '{}' was not updated", persistentObject);
                     }
                 }
 
@@ -772,7 +772,7 @@ public class DbSqlSession implements Session {
             throw new ActivitiException("no insert statement for " + persistentObject.getClass() + " in the ibatis mapping files");
         }
 
-        log.debug("inserting: {}", persistentObject);
+        LOGGER.debug("inserting: {}", persistentObject);
         sqlSession.insert(insertStatement, persistentObject);
 
         // See https://activiti.atlassian.net/browse/ACT-1290
@@ -823,7 +823,7 @@ public class DbSqlSession implements Session {
                 throw new ActivitiException("no update statement for " + updatedObject.getClass() + " in the ibatis mapping files");
             }
 
-            log.debug("updating: {}", updatedObject);
+            LOGGER.debug("updating: {}", updatedObject);
             int updatedRecords = sqlSession.update(updateStatement, updatedObject);
             if (updatedRecords != 1) {
                 throw new ActivitiOptimisticLockingException(updatedObject + " was updated by another transaction concurrently");
@@ -876,7 +876,7 @@ public class DbSqlSession implements Session {
 
     protected void flushRegularDeletes(boolean dispatchEvent) {
         for (DeleteOperation delete : deleteOperations) {
-            log.debug("executing: {}", delete);
+            LOGGER.debug("executing: {}", delete);
 
             delete.execute();
 
@@ -953,7 +953,7 @@ public class DbSqlSession implements Session {
             }
         }
 
-        log.debug("activiti db schema check successful");
+        LOGGER.debug("activiti db schema check successful");
     }
 
     protected String addMissingComponent(String missingComponents, String component) {
@@ -1014,7 +1014,7 @@ public class DbSqlSession implements Session {
                 try {
                     tables.close();
                 } catch (Exception e) {
-                    log.error("Error closing meta data tables", e);
+                    LOGGER.error("Error closing meta data tables", e);
                 }
             }
 

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/history/DefaultHistoryManager.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/history/DefaultHistoryManager.java
@@ -54,7 +54,7 @@ import org.slf4j.LoggerFactory;
  */
 public class DefaultHistoryManager extends AbstractManager implements HistoryManager {
 
-    private static Logger log = LoggerFactory.getLogger(DefaultHistoryManager.class.getName());
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultHistoryManager.class.getName());
 
     private HistoryLevel historyLevel;
 
@@ -69,8 +69,8 @@ public class DefaultHistoryManager extends AbstractManager implements HistoryMan
      */
     @Override
     public boolean isHistoryLevelAtLeast(HistoryLevel level) {
-        if (log.isDebugEnabled()) {
-            log.debug("Current history level: {}, level required: {}", historyLevel, level);
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Current history level: {}, level required: {}", historyLevel, level);
         }
         // Comparing enums actually compares the location of values declared in the enum
         return historyLevel.isAtLeast(level);
@@ -83,8 +83,8 @@ public class DefaultHistoryManager extends AbstractManager implements HistoryMan
      */
     @Override
     public boolean isHistoryEnabled() {
-        if (log.isDebugEnabled()) {
-            log.debug("Current history level: {}", historyLevel);
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Current history level: {}", historyLevel);
         }
         return historyLevel != HistoryLevel.NONE;
     }
@@ -942,8 +942,8 @@ public class DefaultHistoryManager extends AbstractManager implements HistoryMan
     @Override
     public void updateProcessBusinessKeyInHistory(ExecutionEntity processInstance) {
         if (isHistoryEnabled()) {
-            if (log.isDebugEnabled()) {
-                log.debug("updateProcessBusinessKeyInHistory : {}", processInstance.getId());
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("updateProcessBusinessKeyInHistory : {}", processInstance.getId());
             }
             if (processInstance != null) {
                 HistoricProcessInstanceEntity historicProcessInstance = getDbSqlSession().selectById(HistoricProcessInstanceEntity.class, processInstance.getId());

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/interceptor/CommandContext.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/interceptor/CommandContext.java
@@ -68,7 +68,7 @@ import org.slf4j.LoggerFactory;
  */
 public class CommandContext {
 
-    private static Logger log = LoggerFactory.getLogger(CommandContext.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(CommandContext.class);
 
     protected Command<?> command;
     protected TransactionContext transactionContext;
@@ -88,8 +88,8 @@ public class CommandContext {
                 Context.setExecutionContext(execution);
                 while (!nextOperations.isEmpty()) {
                     AtomicOperation currentOperation = nextOperations.removeFirst();
-                    if (log.isTraceEnabled()) {
-                        log.trace("AtomicOperation: {} on {}", currentOperation, this);
+                    if (LOGGER.isTraceEnabled()) {
+                        LOGGER.trace("AtomicOperation: {} on {}", currentOperation, this);
                     }
                     if (execution.getReplacedBy() == null) {
                         currentOperation.execute(execution);
@@ -161,12 +161,12 @@ public class CommandContext {
                     if (exception != null) {
                         if (exception instanceof JobNotFoundException || exception instanceof ActivitiTaskAlreadyClaimedException) {
                             // reduce log level, because this may have been caused because of job deletion due to cancelActiviti="true"
-                            log.info("Error while closing command context", exception);
+                            LOGGER.info("Error while closing command context", exception);
                         } else if (exception instanceof ActivitiOptimisticLockingException) {
                             // reduce log level, as normally we're not interested in logging this exception
-                            log.debug("Optimistic locking exception : {}", exception.getMessage(), exception);
+                            LOGGER.debug("Optimistic locking exception : {}", exception.getMessage(), exception);
                         } else {
-                            log.error("Error while closing command context", exception);
+                            LOGGER.error("Error while closing command context", exception);
                         }
 
                         transactionContext.rollback();
@@ -228,7 +228,7 @@ public class CommandContext {
             if (Context.isExecutionContextActive()) {
                 LogMDC.putMDCExecution(Context.getExecutionContext().getExecution());
             }
-            log.error("masked exception in command context. for root cause, see below as it will be rethrown later.", exception);
+            LOGGER.error("masked exception in command context. for root cause, see below as it will be rethrown later.", exception);
             LogMDC.clear();
         }
     }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/interceptor/CommandContextInterceptor.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/interceptor/CommandContextInterceptor.java
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory;
  * @author Tom Baeyens
  */
 public class CommandContextInterceptor extends AbstractCommandInterceptor {
-    private static final Logger log = LoggerFactory.getLogger(CommandContextInterceptor.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(CommandContextInterceptor.class);
 
     protected CommandContextFactory commandContextFactory;
     protected ProcessEngineConfigurationImpl processEngineConfiguration;
@@ -44,7 +44,7 @@ public class CommandContextInterceptor extends AbstractCommandInterceptor {
         if (!config.isContextReusePossible() || context == null || context.getException() != null) {
             context = commandContextFactory.createCommandContext(command);
         } else {
-            log.debug("Valid context found. Reusing it for the current command '{}'", command.getClass().getCanonicalName());
+            LOGGER.debug("Valid context found. Reusing it for the current command '{}'", command.getClass().getCanonicalName());
             contextReused = true;
         }
 

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/interceptor/LogInterceptor.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/interceptor/LogInterceptor.java
@@ -21,22 +21,22 @@ import org.slf4j.LoggerFactory;
  */
 public class LogInterceptor extends AbstractCommandInterceptor {
 
-    private static Logger log = LoggerFactory.getLogger(LogInterceptor.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(LogInterceptor.class);
 
     public <T> T execute(CommandConfig config, Command<T> command) {
-        if (!log.isDebugEnabled()) {
+        if (!LOGGER.isDebugEnabled()) {
             // do nothing here if we cannot log
             return next.execute(config, command);
         }
-        log.debug("\n");
-        log.debug("--- starting {} --------------------------------------------------------", command.getClass().getSimpleName());
+        LOGGER.debug("\n");
+        LOGGER.debug("--- starting {} --------------------------------------------------------", command.getClass().getSimpleName());
         try {
 
             return next.execute(config, command);
 
         } finally {
-            log.debug("--- {} finished --------------------------------------------------------", command.getClass().getSimpleName());
-            log.debug("\n");
+            LOGGER.debug("--- {} finished --------------------------------------------------------", command.getClass().getSimpleName());
+            LOGGER.debug("\n");
         }
     }
 }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/interceptor/RetryInterceptor.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/interceptor/RetryInterceptor.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
  */
 public class RetryInterceptor extends AbstractCommandInterceptor {
 
-    private static Logger log = LoggerFactory.getLogger(RetryInterceptor.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(RetryInterceptor.class);
 
     protected int numOfRetries = 3;
     protected int waitTimeInMs = 50;
@@ -36,7 +36,7 @@ public class RetryInterceptor extends AbstractCommandInterceptor {
 
         do {
             if (failedAttempts > 0) {
-                log.info("Waiting for {}ms before retrying the command.", waitTime);
+                LOGGER.info("Waiting for {}ms before retrying the command.", waitTime);
                 waitBeforeRetry(waitTime);
                 waitTime *= waitIncreaseFactor;
             }
@@ -47,7 +47,7 @@ public class RetryInterceptor extends AbstractCommandInterceptor {
                 return next.execute(config, command);
 
             } catch (ActivitiOptimisticLockingException e) {
-                log.info("Caught optimistic locking exception: {}", e.getMessage(), e);
+                LOGGER.info("Caught optimistic locking exception: {}", e.getMessage(), e);
             }
 
             failedAttempts++;
@@ -60,7 +60,7 @@ public class RetryInterceptor extends AbstractCommandInterceptor {
         try {
             Thread.sleep(waitTime);
         } catch (InterruptedException e) {
-            log.debug("I am interrupted while waiting for a retry.");
+            LOGGER.debug("I am interrupted while waiting for a retry.");
         }
     }
 

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/jobexecutor/AsyncJobAddedNotification.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/jobexecutor/AsyncJobAddedNotification.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
  */
 public class AsyncJobAddedNotification implements CommandContextCloseListener {
 
-    private static Logger log = LoggerFactory.getLogger(AsyncJobAddedNotification.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AsyncJobAddedNotification.class);
 
     protected Job job;
     protected AsyncExecutor asyncExecutor;
@@ -44,7 +44,7 @@ public class AsyncJobAddedNotification implements CommandContextCloseListener {
         CommandConfig commandConfig = new CommandConfig(false, TransactionPropagation.REQUIRES_NEW);
         commandExecutor.execute(commandConfig, new Command<Void>() {
             public Void execute(CommandContext commandContext) {
-                log.debug("notifying job executor of new job");
+                LOGGER.debug("notifying job executor of new job");
                 asyncExecutor.executeAsyncJob(job);
                 return null;
             }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/jobexecutor/FailedJobListener.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/jobexecutor/FailedJobListener.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
  * @author Saeid Mirzaei
  */
 public class FailedJobListener implements TransactionListener {
-    private static final Logger log = LoggerFactory.getLogger(FailedJobListener.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(FailedJobListener.class);
 
     protected CommandExecutor commandExecutor;
     protected String jobId;
@@ -42,7 +42,7 @@ public class FailedJobListener implements TransactionListener {
         FailedJobCommandFactory failedJobCommandFactory = commandContext.getFailedJobCommandFactory();
         Command<Object> cmd = failedJobCommandFactory.getCommand(jobId, exception);
 
-        log.trace("Using FailedJobCommandFactory '{}' and command of type '{}'", failedJobCommandFactory.getClass(), cmd.getClass());
+        LOGGER.trace("Using FailedJobCommandFactory '{}' and command of type '{}'", failedJobCommandFactory.getClass(), cmd.getClass());
         commandExecutor.execute(commandConfig, cmd);
     }
 

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/jobexecutor/TimerCatchIntermediateEventJobHandler.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/jobexecutor/TimerCatchIntermediateEventJobHandler.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
 
 public class TimerCatchIntermediateEventJobHandler extends TimerEventHandler implements JobHandler {
 
-    private static Logger log = LoggerFactory.getLogger(TimerCatchIntermediateEventJobHandler.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TimerCatchIntermediateEventJobHandler.class);
 
     public static final String TYPE = "timer-intermediate-transition";
 
@@ -55,12 +55,12 @@ public class TimerCatchIntermediateEventJobHandler extends TimerEventHandler imp
             execution.signal(null, null);
         } catch (RuntimeException e) {
             LogMDC.putMDCExecution(execution);
-            log.error("exception during timer execution", e);
+            LOGGER.error("exception during timer execution", e);
             LogMDC.clear();
             throw e;
         } catch (Exception e) {
             LogMDC.putMDCExecution(execution);
-            log.error("exception during timer execution", e);
+            LOGGER.error("exception during timer execution", e);
             LogMDC.clear();
             throw new ActivitiException("exception during timer execution: " + e.getMessage(), e);
         }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/jobexecutor/TimerExecuteNestedActivityJobHandler.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/jobexecutor/TimerExecuteNestedActivityJobHandler.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
  */
 public class TimerExecuteNestedActivityJobHandler extends TimerEventHandler implements JobHandler {
 
-    private static Logger log = LoggerFactory.getLogger(TimerExecuteNestedActivityJobHandler.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TimerExecuteNestedActivityJobHandler.class);
 
     public static final String TYPE = "timer-transition";
     public static final String PROPERTYNAME_TIMER_ACTIVITY_ID = "activityId";
@@ -61,11 +61,11 @@ public class TimerExecuteNestedActivityJobHandler extends TimerEventHandler impl
                     .getActivityBehavior()
                     .execute(execution);
         } catch (RuntimeException e) {
-            log.error("exception during timer execution", e);
+            LOGGER.error("exception during timer execution", e);
             throw e;
 
         } catch (Exception e) {
-            log.error("exception during timer execution", e);
+            LOGGER.error("exception during timer execution", e);
             throw new ActivitiException("exception during timer execution: " + e.getMessage(), e);
         }
     }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/jobexecutor/TimerStartEventJobHandler.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/jobexecutor/TimerStartEventJobHandler.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
 
 public class TimerStartEventJobHandler extends TimerEventHandler implements JobHandler {
 
-    private static Logger log = LoggerFactory.getLogger(TimerStartEventJobHandler.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TimerStartEventJobHandler.class);
 
     public static final String TYPE = "timer-start-event";
 
@@ -65,7 +65,7 @@ public class TimerStartEventJobHandler extends TimerEventHandler implements JobH
             processInstance.start();
 
         } else {
-            log.debug("Ignoring timer of suspended process definition {}", processDefinition.getId());
+            LOGGER.debug("Ignoring timer of suspended process definition {}", processDefinition.getId());
         }
 
     }
@@ -92,13 +92,13 @@ public class TimerStartEventJobHandler extends TimerEventHandler implements JobH
 
                 new StartProcessInstanceCmd<ProcessInstance>(processDefinitionKey, null, null, null, job.getTenantId()).execute(commandContext);
             } else {
-                log.debug("Ignoring timer of suspended process definition {}", processDefinition.getId());
+                LOGGER.debug("Ignoring timer of suspended process definition {}", processDefinition.getId());
             }
         } catch (RuntimeException e) {
-            log.error("exception during timer execution", e);
+            LOGGER.error("exception during timer execution", e);
             throw e;
         } catch (Exception e) {
-            log.error("exception during timer execution", e);
+            LOGGER.error("exception during timer execution", e);
             throw new ActivitiException("exception during timer execution: " + e.getMessage(), e);
         }
     }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/DeadLetterJobEntity.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/DeadLetterJobEntity.java
@@ -26,7 +26,7 @@ public class DeadLetterJobEntity extends AbstractJobEntity {
 
     private static final long serialVersionUID = 1L;
 
-    private static Logger log = LoggerFactory.getLogger(DeadLetterJobEntity.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DeadLetterJobEntity.class);
 
     public DeadLetterJobEntity() {
     }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntity.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntity.java
@@ -77,7 +77,7 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
 
     private static final long serialVersionUID = 1L;
 
-    private static Logger log = LoggerFactory.getLogger(ExecutionEntity.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExecutionEntity.class);
 
     // Persistent referenced entities state //////////////////////////////////////
     protected static final int EVENT_SUBSCRIPTIONS_STATE_BIT = 1;
@@ -287,8 +287,8 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
         createdExecution.setProcessInstance(getProcessInstance());
         createdExecution.setActivity(getActivity());
 
-        if (log.isDebugEnabled()) {
-            log.debug("Child execution {} created with parent {}", createdExecution, this);
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Child execution {} created with parent {}", createdExecution, this);
         }
 
         if (Context.getProcessEngineConfiguration() != null && Context.getProcessEngineConfiguration().getEventDispatcher().isEnabled()) {
@@ -345,7 +345,7 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
     @Override
     @SuppressWarnings("unchecked")
     public void initialize() {
-        log.debug("initializing {}", this);
+        LOGGER.debug("initializing {}", this);
 
         ScopeImpl scope = getScopeObject();
         ensureParentInitialized();
@@ -395,7 +395,7 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
 
     @Override
     public void destroy() {
-        log.debug("destroying {}", this);
+        LOGGER.debug("destroying {}", this);
 
         ensureParentInitialized();
         deleteVariablesInstanceForLeavingScope();
@@ -496,9 +496,9 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
                 otherConcurrentExecutions.add(this);
             }
         }
-        if (log.isDebugEnabled()) {
-            log.debug("inactive concurrent executions in '{}': {}", activity, inactiveConcurrentExecutionsInActivity);
-            log.debug("other concurrent executions: {}", otherConcurrentExecutions);
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("inactive concurrent executions in '{}': {}", activity, inactiveConcurrentExecutionsInActivity);
+            LOGGER.debug("other concurrent executions: {}", otherConcurrentExecutions);
         }
         return inactiveConcurrentExecutionsInActivity;
     }
@@ -540,9 +540,9 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
             }
         }
 
-        if (log.isDebugEnabled()) {
-            log.debug("transitions to take concurrent: {}", transitions);
-            log.debug("active concurrent executions: {}", concurrentActiveExecutions);
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("transitions to take concurrent: {}", transitions);
+            LOGGER.debug("active concurrent executions: {}", concurrentActiveExecutions);
         }
 
         if ((transitions.size() == 1)
@@ -562,12 +562,12 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
                 // never ended as the combination of {activityId,executionId} is not valid anymore
                 Context.getCommandContext().getHistoryManager().recordActivityEnd(prunedExecution);
 
-                log.debug("pruning execution {}", prunedExecution);
+                LOGGER.debug("pruning execution {}", prunedExecution);
                 prunedExecution.remove();
 
             }
 
-            log.debug("activating the concurrent root {} as the single path of execution going forward", concurrentRoot);
+            LOGGER.debug("activating the concurrent root {} as the single path of execution going forward", concurrentRoot);
             concurrentRoot.setActive(true);
             concurrentRoot.setActivity(activity);
             concurrentRoot.setConcurrent(false);
@@ -579,7 +579,7 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
 
             recyclableExecutions.remove(concurrentRoot);
 
-            log.debug("recyclable executions for reuse: {}", recyclableExecutions);
+            LOGGER.debug("recyclable executions for reuse: {}", recyclableExecutions);
 
             // first create the concurrent executions
             while (!transitions.isEmpty()) {
@@ -588,11 +588,11 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
                 ExecutionEntity outgoingExecution = null;
                 if (recyclableExecutions.isEmpty()) {
                     outgoingExecution = concurrentRoot.createExecution();
-                    log.debug("new {} with parent {} created to take transition {}",
+                    LOGGER.debug("new {} with parent {} created to take transition {}",
                             outgoingExecution, outgoingExecution.getParent(), outgoingTransition);
                 } else {
                     outgoingExecution = (ExecutionEntity) recyclableExecutions.remove(0);
-                    log.debug("recycled {} to take transition {}", outgoingExecution, outgoingTransition);
+                    LOGGER.debug("recycled {} to take transition {}", outgoingExecution, outgoingTransition);
                 }
 
                 outgoingExecution.setActive(true);
@@ -604,7 +604,7 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
 
             // prune the executions that are not recycled
             for (ActivityExecution prunedExecution : recyclableExecutions) {
-                log.debug("pruning execution {}", prunedExecution);
+                LOGGER.debug("pruning execution {}", prunedExecution);
                 prunedExecution.end();
             }
 
@@ -1057,8 +1057,8 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
     @Override
     public void destroyScope(String reason) {
 
-        if (log.isDebugEnabled()) {
-            log.debug("performing destroy scope behavior for execution {}", this);
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("performing destroy scope behavior for execution {}", this);
         }
 
         // remove all child executions and sub process instances:
@@ -1084,7 +1084,7 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
         List<InterpretableExecution> childExecutions = new ArrayList<InterpretableExecution>(getExecutions());
         for (InterpretableExecution childExecution : childExecutions) {
             if (childExecution.isEventScope()) {
-                log.debug("removing eventScope {}", childExecution);
+                LOGGER.debug("removing eventScope {}", childExecution);
                 childExecution.destroy();
                 childExecution.remove();
             }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/SuspendedJobEntity.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/SuspendedJobEntity.java
@@ -26,7 +26,7 @@ public class SuspendedJobEntity extends AbstractJobEntity {
 
     private static final long serialVersionUID = 1L;
 
-    private static Logger log = LoggerFactory.getLogger(SuspendedJobEntity.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SuspendedJobEntity.class);
 
     public SuspendedJobEntity() {
     }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/TableDataManager.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/TableDataManager.java
@@ -52,7 +52,7 @@ import org.slf4j.LoggerFactory;
  */
 public class TableDataManager extends AbstractManager {
 
-    private static Logger log = LoggerFactory.getLogger(TableDataManager.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TableDataManager.class);
 
     public static Map<Class<?>, String> apiTypeToTableNameMap = new HashMap<Class<?>, String>();
     public static Map<Class<? extends PersistentObject>, String> persistentObjectToTableNameMap = new HashMap<Class<? extends PersistentObject>, String>();
@@ -124,7 +124,7 @@ public class TableDataManager extends AbstractManager {
             for (String tableName : getTablesPresentInDatabase()) {
                 tableCount.put(tableName, getTableCount(tableName));
             }
-            log.debug("Number of rows per activiti table: {}", tableCount);
+            LOGGER.debug("Number of rows per activiti table: {}", tableCount);
         } catch (Exception e) {
             throw new ActivitiException("couldn't get table counts", e);
         }
@@ -139,7 +139,7 @@ public class TableDataManager extends AbstractManager {
             DatabaseMetaData databaseMetaData = connection.getMetaData();
             ResultSet tables = null;
             try {
-                log.debug("retrieving activiti tables from jdbc metadata");
+                LOGGER.debug("retrieving activiti tables from jdbc metadata");
                 String databaseTablePrefix = getDbSqlSession().getDbSqlSessionFactory().getDatabaseTablePrefix();
                 String tableNameFilter = databaseTablePrefix + "ACT_%";
                 if ("postgres".equals(getDbSqlSession().getDbSqlSessionFactory().getDatabaseType())) {
@@ -164,7 +164,7 @@ public class TableDataManager extends AbstractManager {
                     String tableName = tables.getString("TABLE_NAME");
                     tableName = tableName.toUpperCase();
                     tableNames.add(tableName);
-                    log.debug("  retrieved activiti table name {}", tableName);
+                    LOGGER.debug("  retrieved activiti table name {}", tableName);
                 }
             } finally {
                 tables.close();
@@ -176,7 +176,7 @@ public class TableDataManager extends AbstractManager {
     }
 
     protected long getTableCount(String tableName) {
-        log.debug("selecting table count for {}", tableName);
+        LOGGER.debug("selecting table count for {}", tableName);
         Long count = (Long) getDbSqlSession().selectOne("selectTableCount",
                 Collections.singletonMap("tableName", tableName));
         return count;

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/TimerJobEntity.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/TimerJobEntity.java
@@ -47,7 +47,7 @@ public class TimerJobEntity extends AbstractJobEntity {
 
     private static final long serialVersionUID = 1L;
 
-    private static Logger log = LoggerFactory.getLogger(TimerJobEntity.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TimerJobEntity.class);
 
     public TimerJobEntity() {
     }
@@ -89,8 +89,8 @@ public class TimerJobEntity extends AbstractJobEntity {
         restoreExtraData(commandContext, jobHandlerConfiguration);
 
         if (this.getDuedate() != null && !isValidTime(this.getDuedate())) {
-            if (log.isDebugEnabled()) {
-                log.debug("Timer {} fired. but the dueDate is after the endDate.  Deleting timer.", getId());
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Timer {} fired. but the dueDate is after the endDate.  Deleting timer.", getId());
             }
             delete();
             return;
@@ -105,8 +105,8 @@ public class TimerJobEntity extends AbstractJobEntity {
         JobHandler jobHandler = jobHandlers.get(jobHandlerType);
         jobHandler.execute(this, jobHandlerConfiguration, execution, commandContext);
 
-        if (log.isDebugEnabled()) {
-            log.debug("Timer {} fired. Deleting timer.", getId());
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Timer {} fired. Deleting timer.", getId());
         }
         delete();
 

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/pvm/runtime/AtomicOperationActivityExecute.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/pvm/runtime/AtomicOperationActivityExecute.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
  */
 public class AtomicOperationActivityExecute implements AtomicOperation {
 
-    private static Logger log = LoggerFactory.getLogger(AtomicOperationActivityExecute.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AtomicOperationActivityExecute.class);
 
     public boolean isAsync(InterpretableExecution execution) {
         return false;
@@ -43,7 +43,7 @@ public class AtomicOperationActivityExecute implements AtomicOperation {
             throw new PvmException("no behavior specified in " + activity);
         }
 
-        log.debug("{} executes {}: {}", execution, activity, activityBehavior.getClass().getName());
+        LOGGER.debug("{} executes {}: {}", execution, activity, activityBehavior.getClass().getName());
 
         try {
             if (Context.getProcessEngineConfiguration() != null && Context.getProcessEngineConfiguration().getEventDispatcher().isEnabled()) {

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/pvm/runtime/AtomicOperationProcessEnd.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/pvm/runtime/AtomicOperationProcessEnd.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
  */
 public class AtomicOperationProcessEnd extends AbstractEventAtomicOperation {
 
-    private static Logger log = LoggerFactory.getLogger(AtomicOperationProcessEnd.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AtomicOperationProcessEnd.class);
 
     @Override
     protected ScopeImpl getScope(InterpretableExecution execution) {
@@ -49,10 +49,10 @@ public class AtomicOperationProcessEnd extends AbstractEventAtomicOperation {
             try {
                 subProcessActivityBehavior.completing(superExecution, execution);
             } catch (RuntimeException e) {
-                log.error("Error while completing sub process of execution {}", execution, e);
+                LOGGER.error("Error while completing sub process of execution {}", execution, e);
                 throw e;
             } catch (Exception e) {
-                log.error("Error while completing sub process of execution {}", execution, e);
+                LOGGER.error("Error while completing sub process of execution {}", execution, e);
                 throw new ActivitiException("Error while completing sub process of execution " + execution, e);
             }
         }
@@ -66,10 +66,10 @@ public class AtomicOperationProcessEnd extends AbstractEventAtomicOperation {
             try {
                 subProcessActivityBehavior.completed(superExecution);
             } catch (RuntimeException e) {
-                log.error("Error while completing sub process of execution {}", execution, e);
+                LOGGER.error("Error while completing sub process of execution {}", execution, e);
                 throw e;
             } catch (Exception e) {
-                log.error("Error while completing sub process of execution {}", execution, e);
+                LOGGER.error("Error while completing sub process of execution {}", execution, e);
                 throw new ActivitiException("Error while completing sub process of execution " + execution, e);
             }
         }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/pvm/runtime/AtomicOperationTransitionCreateScope.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/pvm/runtime/AtomicOperationTransitionCreateScope.java
@@ -21,7 +21,7 @@ import org.slf4j.LoggerFactory;
  */
 public class AtomicOperationTransitionCreateScope implements AtomicOperation {
 
-    private static Logger log = LoggerFactory.getLogger(AtomicOperationTransitionCreateScope.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AtomicOperationTransitionCreateScope.class);
 
     public boolean isAsync(InterpretableExecution execution) {
         ActivityImpl activity = (ActivityImpl) execution.getActivity();
@@ -38,7 +38,7 @@ public class AtomicOperationTransitionCreateScope implements AtomicOperation {
             execution.setTransition(null);
             execution.setActivity(null);
             execution.setActive(false);
-            log.debug("create scope: parent {} continues as execution {}", execution, propagatingExecution);
+            LOGGER.debug("create scope: parent {} continues as execution {}", execution, propagatingExecution);
             propagatingExecution.initialize();
 
         } else {

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/pvm/runtime/AtomicOperationTransitionDestroyScope.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/pvm/runtime/AtomicOperationTransitionDestroyScope.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
  */
 public class AtomicOperationTransitionDestroyScope implements AtomicOperation {
 
-    private static Logger log = LoggerFactory.getLogger(AtomicOperationTransitionDestroyScope.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AtomicOperationTransitionDestroyScope.class);
 
     public boolean isAsync(InterpretableExecution execution) {
         return false;
@@ -46,7 +46,7 @@ public class AtomicOperationTransitionDestroyScope implements AtomicOperation {
                 InterpretableExecution concurrentRoot = (InterpretableExecution) execution.getParent();
                 parentScopeInstance = (InterpretableExecution) execution.getParent().getParent();
 
-                log.debug("moving concurrent {} one scope up under {}", execution, parentScopeInstance);
+                LOGGER.debug("moving concurrent {} one scope up under {}", execution, parentScopeInstance);
                 List<InterpretableExecution> parentScopeInstanceExecutions = (List<InterpretableExecution>) parentScopeInstance.getExecutions();
                 List<InterpretableExecution> concurrentRootExecutions = (List<InterpretableExecution>) concurrentRoot.getExecutions();
                 // if the parent scope had only one single scope child
@@ -71,7 +71,7 @@ public class AtomicOperationTransitionDestroyScope implements AtomicOperation {
                         lastConcurrent.setConcurrent(false);
 
                     } else {
-                        log.debug("merging last concurrent {} into concurrent root {}", lastConcurrent, concurrentRoot);
+                        LOGGER.debug("merging last concurrent {} into concurrent root {}", lastConcurrent, concurrentRoot);
 
                         // We can't just merge the data of the lastConcurrent into the concurrentRoot.
                         // This is because the concurrent root might be in a takeAll-loop. So the
@@ -84,7 +84,7 @@ public class AtomicOperationTransitionDestroyScope implements AtomicOperation {
                 }
 
             } else if (execution.isConcurrent() && execution.isScope()) {
-                log.debug("scoped concurrent {} becomes concurrent and remains under {}", execution, execution.getParent());
+                LOGGER.debug("scoped concurrent {} becomes concurrent and remains under {}", execution, execution.getParent());
 
                 // TODO!
                 execution.destroy();
@@ -95,7 +95,7 @@ public class AtomicOperationTransitionDestroyScope implements AtomicOperation {
                 propagatingExecution.setActivity((ActivityImpl) execution.getActivity());
                 propagatingExecution.setTransition(execution.getTransition());
                 propagatingExecution.setActive(true);
-                log.debug("destroy scope: scoped {} continues as parent scope {}", execution, propagatingExecution);
+                LOGGER.debug("destroy scope: scoped {} continues as parent scope {}", execution, propagatingExecution);
                 execution.destroy();
                 execution.remove();
             }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/pvm/runtime/AtomicOperationTransitionNotifyListenerTake.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/pvm/runtime/AtomicOperationTransitionNotifyListenerTake.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
  */
 public class AtomicOperationTransitionNotifyListenerTake implements AtomicOperation {
 
-    private static Logger log = LoggerFactory.getLogger(AtomicOperationTransitionNotifyListenerTake.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AtomicOperationTransitionNotifyListenerTake.class);
 
     public boolean isAsync(InterpretableExecution execution) {
         return false;
@@ -57,8 +57,8 @@ public class AtomicOperationTransitionNotifyListenerTake implements AtomicOperat
             execution.performOperation(this);
 
         } else {
-            if (log.isDebugEnabled()) {
-                log.debug("{} takes transition {}", execution, transition);
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("{} takes transition {}", execution, transition);
             }
             execution.setExecutionListenerIndex(0);
             execution.setEventName(null);

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/pvm/runtime/ExecutionImpl.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/pvm/runtime/ExecutionImpl.java
@@ -56,7 +56,7 @@ public class ExecutionImpl implements
 
     private static final long serialVersionUID = 1L;
 
-    private static Logger log = LoggerFactory.getLogger(ExecutionImpl.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExecutionImpl.class);
 
     // current position /////////////////////////////////////////////////////////
 
@@ -206,7 +206,7 @@ public class ExecutionImpl implements
         List<InterpretableExecution> childExecutions = new ArrayList<InterpretableExecution>(getExecutions());
         for (InterpretableExecution childExecution : childExecutions) {
             if (childExecution.isEventScope()) {
-                log.debug("removing eventScope {}", childExecution);
+                LOGGER.debug("removing eventScope {}", childExecution);
                 childExecution.destroy();
                 childExecution.remove();
             }
@@ -216,7 +216,7 @@ public class ExecutionImpl implements
     @Override
     public void destroyScope(String reason) {
 
-        log.debug("performing destroy scope behavior for execution {}", this);
+        LOGGER.debug("performing destroy scope behavior for execution {}", this);
 
         // remove all child executions and sub process instances:
         List<InterpretableExecution> executions = new ArrayList<InterpretableExecution>(getExecutions());
@@ -540,9 +540,9 @@ public class ExecutionImpl implements
                 otherConcurrentExecutions.add(this);
             }
         }
-        if (log.isDebugEnabled()) {
-            log.debug("inactive concurrent executions in '{}': {}", activity, inactiveConcurrentExecutionsInActivity);
-            log.debug("other concurrent executions: {}", otherConcurrentExecutions);
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("inactive concurrent executions in '{}': {}", activity, inactiveConcurrentExecutionsInActivity);
+            LOGGER.debug("other concurrent executions: {}", otherConcurrentExecutions);
         }
         return inactiveConcurrentExecutionsInActivity;
     }
@@ -568,9 +568,9 @@ public class ExecutionImpl implements
             }
         }
 
-        if (log.isDebugEnabled()) {
-            log.debug("transitions to take concurrent: {}", transitions);
-            log.debug("active concurrent executions: {}", concurrentActiveExecutions);
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("transitions to take concurrent: {}", transitions);
+            LOGGER.debug("active concurrent executions: {}", concurrentActiveExecutions);
         }
 
         if ((transitions.size() == 1)
@@ -583,12 +583,12 @@ public class ExecutionImpl implements
                 // Some recyclable executions are inactivated (joined executions)
                 // Others are already ended (end activities)
                 if (!prunedExecution.isEnded()) {
-                    log.debug("pruning execution {}", prunedExecution);
+                    LOGGER.debug("pruning execution {}", prunedExecution);
                     prunedExecution.remove();
                 }
             }
 
-            log.debug("activating the concurrent root {} as the single path of execution going forward", concurrentRoot);
+            LOGGER.debug("activating the concurrent root {} as the single path of execution going forward", concurrentRoot);
             concurrentRoot.setActive(true);
             concurrentRoot.setActivity(activity);
             concurrentRoot.setConcurrent(false);
@@ -600,7 +600,7 @@ public class ExecutionImpl implements
 
             recyclableExecutions.remove(concurrentRoot);
 
-            log.debug("recyclable executions for reused: {}", recyclableExecutions);
+            LOGGER.debug("recyclable executions for reused: {}", recyclableExecutions);
 
             // first create the concurrent executions
             while (!transitions.isEmpty()) {
@@ -609,10 +609,10 @@ public class ExecutionImpl implements
                 ExecutionImpl outgoingExecution = null;
                 if (recyclableExecutions.isEmpty()) {
                     outgoingExecution = concurrentRoot.createExecution();
-                    log.debug("new {} created to take transition {}", outgoingExecution, outgoingTransition);
+                    LOGGER.debug("new {} created to take transition {}", outgoingExecution, outgoingTransition);
                 } else {
                     outgoingExecution = (ExecutionImpl) recyclableExecutions.remove(0);
-                    log.debug("recycled {} to take transition {}", outgoingExecution, outgoingTransition);
+                    LOGGER.debug("recycled {} to take transition {}", outgoingExecution, outgoingTransition);
                 }
 
                 outgoingExecution.setActive(true);
@@ -623,7 +623,7 @@ public class ExecutionImpl implements
 
             // prune the executions that are not recycled
             for (ActivityExecution prunedExecution : recyclableExecutions) {
-                log.debug("pruning execution {}", prunedExecution);
+                LOGGER.debug("pruning execution {}", prunedExecution);
                 prunedExecution.end();
             }
 
@@ -641,8 +641,8 @@ public class ExecutionImpl implements
             while (nextOperation != null) {
                 AtomicOperation currentOperation = this.nextOperation;
                 this.nextOperation = null;
-                if (log.isTraceEnabled()) {
-                    log.trace("AtomicOperation: {} on {}", currentOperation, this);
+                if (LOGGER.isTraceEnabled()) {
+                    LOGGER.trace("AtomicOperation: {} on {}", currentOperation, this);
                 }
                 currentOperation.execute(this);
             }
@@ -740,7 +740,7 @@ public class ExecutionImpl implements
     }
 
     public void setVariableLocally(String variableName, Object value) {
-        log.debug("setting variable '{}' to value '{}' on {}", variableName, value, this);
+        LOGGER.debug("setting variable '{}' to value '{}' on {}", variableName, value, this);
         variables.put(variableName, value);
     }
 

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/pvm/runtime/OutgoingExecution.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/pvm/runtime/OutgoingExecution.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
  */
 public class OutgoingExecution {
 
-    private static Logger log = LoggerFactory.getLogger(OutgoingExecution.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(OutgoingExecution.class);
 
     protected InterpretableExecution outgoingExecution;
     protected PvmTransition outgoingTransition;
@@ -47,7 +47,7 @@ public class OutgoingExecution {
         if (!outgoingExecution.isDeleteRoot()) {
             outgoingExecution.take(outgoingTransition, fireActivityCompletedEvent);
         } else {
-            log.debug("Not taking transition '{}', outgoing execution has ended.", outgoingTransition);
+            LOGGER.debug("Not taking transition '{}', outgoing execution has ended.", outgoingTransition);
         }
     }
 }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/rules/RulesDeployer.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/rules/RulesDeployer.java
@@ -34,10 +34,10 @@ import org.slf4j.LoggerFactory;
  */
 public class RulesDeployer implements Deployer {
 
-    private static final Logger log = LoggerFactory.getLogger(RulesDeployer.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(RulesDeployer.class);
 
     public void deploy(DeploymentEntity deployment, Map<String, Object> deploymentSettings) {
-        log.debug("Processing deployment {}", deployment.getName());
+        LOGGER.debug("Processing deployment {}", deployment.getName());
 
         KnowledgeBuilder knowledgeBuilder = null;
 
@@ -47,7 +47,7 @@ public class RulesDeployer implements Deployer {
 
         Map<String, ResourceEntity> resources = deployment.getResources();
         for (String resourceName : resources.keySet()) {
-            log.info("Processing resource {}", resourceName);
+            LOGGER.info("Processing resource {}", resourceName);
             if (resourceName.endsWith(".drl")) { // is only parsing .drls sufficient? what about other rule dsl's? (@see ResourceType)
                 if (knowledgeBuilder == null) {
                     knowledgeBuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/util/ReflectUtil.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/util/ReflectUtil.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class ReflectUtil {
 
-    private static final Logger LOG = LoggerFactory.getLogger(ReflectUtil.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ReflectUtil.class);
 
     private static final Pattern GETTER_PATTERN = Pattern.compile("(get|is)[A-Z].*");
     private static final Pattern SETTER_PATTERN = Pattern.compile("set[A-Z].*");
@@ -55,7 +55,7 @@ public abstract class ReflectUtil {
 
         if (classLoader != null) {
             try {
-                LOG.trace("Trying to load class with custom classloader: {}", className);
+                LOGGER.trace("Trying to load class with custom classloader: {}", className);
                 clazz = loadClass(classLoader, className);
             } catch (Throwable t) {
                 throwable = t;
@@ -63,7 +63,7 @@ public abstract class ReflectUtil {
         }
         if (clazz == null) {
             try {
-                LOG.trace("Trying to load class with current thread context classloader: {}", className);
+                LOGGER.trace("Trying to load class with current thread context classloader: {}", className);
                 clazz = loadClass(Thread.currentThread().getContextClassLoader(), className);
             } catch (Throwable t) {
                 if (throwable == null) {
@@ -72,7 +72,7 @@ public abstract class ReflectUtil {
             }
             if (clazz == null) {
                 try {
-                    LOG.trace("Trying to load class with local classloader: {}", className);
+                    LOGGER.trace("Trying to load class with local classloader: {}", className);
                     clazz = loadClass(ReflectUtil.class.getClassLoader(), className);
                 } catch (Throwable t) {
                     if (throwable == null) {

--- a/modules/flowable5-spring-test/src/test/java/org/activiti/spring/test/email/JndiEmailTest.java
+++ b/modules/flowable5-spring-test/src/test/java/org/activiti/spring/test/email/JndiEmailTest.java
@@ -22,7 +22,7 @@ import org.springframework.test.context.ContextConfiguration;
 @ContextConfiguration("classpath:org/activiti/spring/test/email/jndiEmailConfiguaration-context.xml")
 public class JndiEmailTest extends SpringFlowableTestCase {
 
-    private static Logger logger = LoggerFactory.getLogger(JndiEmailTest.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(JndiEmailTest.class);
 
     @BeforeClass
     public void setUp() {
@@ -41,9 +41,9 @@ public class JndiEmailTest extends SpringFlowableTestCase {
             builder = SimpleNamingContextBuilder.emptyActivatedContextBuilder();
             builder.bind("java:comp/env/Session", mailSession);
         } catch (NamingException e) {
-            logger.error("Naming error in email setup", e);
+            LOGGER.error("Naming error in email setup", e);
         } catch (NoSuchProviderException e) {
-            logger.error("provider error in email setup", e);
+            LOGGER.error("provider error in email setup", e);
         }
     }
 

--- a/modules/flowable5-spring-test/src/test/java/org/activiti/spring/test/email/MockEmailTransport.java
+++ b/modules/flowable5-spring-test/src/test/java/org/activiti/spring/test/email/MockEmailTransport.java
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory;
  */
 public class MockEmailTransport extends Transport {
 
-    private static Logger logger = LoggerFactory.getLogger(MockEmailTransport.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(MockEmailTransport.class);
 
     public MockEmailTransport(Session smtpSession, URLName urlName) {
         super(smtpSession, urlName);
@@ -26,9 +26,9 @@ public class MockEmailTransport extends Transport {
     @Override
     public void sendMessage(Message message, Address[] addresses) throws MessagingException {
         try {
-            logger.info(message.getContent().toString());
+            LOGGER.info(message.getContent().toString());
         } catch (IOException ex) {
-            logger.error("Error occured while sending email" + ex);
+            LOGGER.error("Error occured while sending email" + ex);
         }
     }
 

--- a/modules/flowable5-spring-test/src/test/java/org/activiti/spring/test/servicetask/DelegateExpressionBean.java
+++ b/modules/flowable5-spring-test/src/test/java/org/activiti/spring/test/servicetask/DelegateExpressionBean.java
@@ -24,13 +24,13 @@ import org.slf4j.LoggerFactory;
  */
 public class DelegateExpressionBean implements JavaDelegate {
 
-    private static final Logger log = LoggerFactory.getLogger(DelegateExpressionBean.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DelegateExpressionBean.class);
     private SentenceGenerator sentenceGenerator;
 
     private FixedValue someField;
 
     public void execute(DelegateExecution execution) {
-        log.info("Entering DelegateExpressionBean.execute()");
+        LOGGER.info("Entering DelegateExpressionBean.execute()");
         if (sentenceGenerator != null) {
             execution.setVariable("myVar", sentenceGenerator.getSentence());
         } else {
@@ -41,7 +41,7 @@ public class DelegateExpressionBean implements JavaDelegate {
         } else {
             execution.setVariable("fieldInjection", "Field injection not working");
         }
-        log.info("Leaving DelegateExpressionBean.execute()");
+        LOGGER.info("Leaving DelegateExpressionBean.execute()");
     }
 
     public void setSentenceGenerator(SentenceGenerator sentenceGenerator) {

--- a/modules/flowable5-spring/src/main/java/org/activiti/spring/SpringConfigurationHelper.java
+++ b/modules/flowable5-spring/src/main/java/org/activiti/spring/SpringConfigurationHelper.java
@@ -29,10 +29,10 @@ import org.springframework.core.io.UrlResource;
  */
 public class SpringConfigurationHelper {
 
-    private static Logger log = LoggerFactory.getLogger(SpringConfigurationHelper.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SpringConfigurationHelper.class);
 
     private static ProcessEngine buildProcessEngine(URL resource) {
-        log.debug("==== BUILDING SPRING APPLICATION CONTEXT AND PROCESS ENGINE =========================================");
+        LOGGER.debug("==== BUILDING SPRING APPLICATION CONTEXT AND PROCESS ENGINE =========================================");
 
         ApplicationContext applicationContext = new GenericXmlApplicationContext(new UrlResource(resource));
         Map<String, ProcessEngine> beansOfType = applicationContext.getBeansOfType(ProcessEngine.class);
@@ -42,7 +42,7 @@ public class SpringConfigurationHelper {
 
         ProcessEngine processEngine = beansOfType.values().iterator().next();
 
-        log.debug("==== SPRING PROCESS ENGINE CREATED ==================================================================");
+        LOGGER.debug("==== SPRING PROCESS ENGINE CREATED ==================================================================");
         return processEngine;
     }
 

--- a/modules/flowable5-test/src/main/java/org/activiti/engine/impl/test/TestHelper.java
+++ b/modules/flowable5-test/src/main/java/org/activiti/engine/impl/test/TestHelper.java
@@ -51,7 +51,7 @@ import junit.framework.AssertionFailedError;
  */
 public abstract class TestHelper {
 
-    private static Logger log = LoggerFactory.getLogger(TestHelper.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestHelper.class);
 
     public static final String EMPTY_LINE = "\n";
 
@@ -82,12 +82,12 @@ public abstract class TestHelper {
         try {
             method = testClass.getMethod(methodName, (Class<?>[]) null);
         } catch (Exception e) {
-            log.warn("Could not get method by reflection. This could happen if you are using @Parameters in combination with annotations.", e);
+            LOGGER.warn("Could not get method by reflection. This could happen if you are using @Parameters in combination with annotations.", e);
             return null;
         }
         Deployment deploymentAnnotation = method.getAnnotation(Deployment.class);
         if (deploymentAnnotation != null) {
-            log.debug("annotation @Deployment creates deployment for {}.{}", testClass.getSimpleName(), methodName);
+            LOGGER.debug("annotation @Deployment creates deployment for {}.{}", testClass.getSimpleName(), methodName);
             String[] resources = deploymentAnnotation.resources();
             if (resources.length == 0) {
                 String name = method.getName();
@@ -111,7 +111,7 @@ public abstract class TestHelper {
     }
 
     public static void annotationDeploymentTearDown(ProcessEngine processEngine, String deploymentId, Class<?> testClass, String methodName) {
-        log.debug("annotation @Deployment deletes deployment for {}.{}", testClass.getSimpleName(), methodName);
+        LOGGER.debug("annotation @Deployment deletes deployment for {}.{}", testClass.getSimpleName(), methodName);
         if (deploymentId != null) {
             try {
                 ProcessEngineConfigurationImpl processEngineConfig = (ProcessEngineConfigurationImpl) processEngine.getProcessEngineConfiguration();
@@ -129,7 +129,7 @@ public abstract class TestHelper {
         try {
             method = testClass.getMethod(methodName, (Class<?>[]) null);
         } catch (Exception e) {
-            log.warn("Could not get method by reflection. This could happen if you are using @Parameters in combination with annotations.", e);
+            LOGGER.warn("Could not get method by reflection. This could happen if you are using @Parameters in combination with annotations.", e);
             return;
         }
 
@@ -221,9 +221,9 @@ public abstract class TestHelper {
     public static ProcessEngine getProcessEngine(String configurationResource) {
         ProcessEngine processEngine = processEngines.get(configurationResource);
         if (processEngine == null) {
-            log.debug("==== BUILDING PROCESS ENGINE ========================================================================");
+            LOGGER.debug("==== BUILDING PROCESS ENGINE ========================================================================");
             processEngine = ProcessEngineConfiguration.createProcessEngineConfigurationFromResource(configurationResource).buildProcessEngine();
-            log.debug("==== PROCESS ENGINE CREATED =========================================================================");
+            LOGGER.debug("==== PROCESS ENGINE CREATED =========================================================================");
             processEngines.put(configurationResource, processEngine);
         }
         return processEngine;
@@ -241,7 +241,7 @@ public abstract class TestHelper {
      * the DB is not clean. If the DB is not clean, it is cleaned by performing a create a drop.
      */
     public static void assertAndEnsureCleanDb(ProcessEngine processEngine) {
-        log.debug("verifying that db is clean after test");
+        LOGGER.debug("verifying that db is clean after test");
         Map<String, Long> tableCounts = processEngine.getManagementService().getTableCount();
         StringBuilder outputMessage = new StringBuilder();
         for (String tableName : tableCounts.keySet()) {
@@ -254,8 +254,8 @@ public abstract class TestHelper {
         }
         if (outputMessage.length() > 0) {
             outputMessage.insert(0, "DB NOT CLEAN: \n");
-            log.error(EMPTY_LINE);
-            log.error(outputMessage.toString());
+            LOGGER.error(EMPTY_LINE);
+            LOGGER.error(outputMessage.toString());
 
             ((ProcessEngineImpl) processEngine)
                     .getProcessEngineConfiguration().getCommandExecutor()

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/event/end/DummyServiceTask.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/event/end/DummyServiceTask.java
@@ -19,7 +19,7 @@ import org.activiti.engine.impl.pvm.delegate.ActivityExecution;
 
 public class DummyServiceTask extends TaskActivityBehavior {
 
-    private static final Logger log = Logger.getLogger("DummyServiceTask");
+    private static final Logger LOGGER = Logger.getLogger("DummyServiceTask");
 
     public DummyServiceTask() {
         super();

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/concurrency/CompetingSignalsTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/concurrency/CompetingSignalsTest.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  */
 public class CompetingSignalsTest extends PluggableFlowableTestCase {
 
-    private static Logger log = LoggerFactory.getLogger(CompetingSignalsTest.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(CompetingSignalsTest.class);
 
     Thread testThread = Thread.currentThread();
     static ControllableThread activeThread;
@@ -57,7 +57,7 @@ public class CompetingSignalsTest extends PluggableFlowableTestCase {
             } catch (FlowableOptimisticLockingException e) {
                 this.exception = e;
             }
-            log.debug("{} ends", getName());
+            LOGGER.debug("{} ends", getName());
         }
     }
 
@@ -74,19 +74,19 @@ public class CompetingSignalsTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("CompetingSignalsProcess");
         String processInstanceId = processInstance.getId();
 
-        log.debug("test thread starts thread one");
+        LOGGER.debug("test thread starts thread one");
         SignalThread threadOne = new SignalThread(processInstanceId);
         threadOne.startAndWaitUntilControlIsReturned();
 
-        log.debug("test thread continues to start thread two");
+        LOGGER.debug("test thread continues to start thread two");
         SignalThread threadTwo = new SignalThread(processInstanceId);
         threadTwo.startAndWaitUntilControlIsReturned();
 
-        log.debug("test thread notifies thread 1");
+        LOGGER.debug("test thread notifies thread 1");
         threadOne.proceedAndWaitTillDone();
         assertNull(threadOne.exception);
 
-        log.debug("test thread notifies thread 2");
+        LOGGER.debug("test thread notifies thread 2");
         threadTwo.proceedAndWaitTillDone();
         assertNotNull(threadTwo.exception);
         assertTextPresent("was updated by another transaction concurrently", threadTwo.exception.getMessage());
@@ -105,19 +105,19 @@ public class CompetingSignalsTest extends PluggableFlowableTestCase {
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("CompetingSignalsProcess");
             String processInstanceId = processInstance.getId();
 
-            log.debug("test thread starts thread one");
+            LOGGER.debug("test thread starts thread one");
             SignalThread threadOne = new SignalThread(processInstanceId);
             threadOne.startAndWaitUntilControlIsReturned();
 
-            log.debug("test thread continues to start thread two");
+            LOGGER.debug("test thread continues to start thread two");
             SignalThread threadTwo = new SignalThread(processInstanceId);
             threadTwo.startAndWaitUntilControlIsReturned();
 
-            log.debug("test thread notifies thread 1");
+            LOGGER.debug("test thread notifies thread 1");
             threadOne.proceedAndWaitTillDone();
             assertNull(threadOne.exception);
 
-            log.debug("test thread notifies thread 2");
+            LOGGER.debug("test thread notifies thread 2");
             threadTwo.proceedAndWaitTillDone();
             assertNull(threadTwo.exception);
         } finally {

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/concurrency/ConcurrentEngineUsageTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/concurrency/ConcurrentEngineUsageTest.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ConcurrentEngineUsageTest extends PluggableFlowableTestCase {
 
-    private static Logger log = LoggerFactory.getLogger(ConcurrentEngineUsageTest.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConcurrentEngineUsageTest.class);
     private static final int MAX_RETRIES = 5;
 
     @Deployment
@@ -56,7 +56,7 @@ public class ConcurrentEngineUsageTest extends PluggableFlowableTestCase {
             executor.shutdown();
             boolean isEnded = executor.awaitTermination(20000, TimeUnit.MILLISECONDS);
             if (!isEnded) {
-                log.error("Executor was not shut down after timeout, not al tasks have been executed");
+                LOGGER.error("Executor was not shut down after timeout, not al tasks have been executed");
                 executor.shutdownNow();
 
             }
@@ -85,7 +85,7 @@ public class ConcurrentEngineUsageTest extends PluggableFlowableTestCase {
                 success = true;
             } catch (PersistenceException pe) {
                 retries = retries - 1;
-                log.debug("Retrying process start - {}", (MAX_RETRIES - retries));
+                LOGGER.debug("Retrying process start - {}", (MAX_RETRIES - retries));
                 try {
                     Thread.sleep(timeout);
                 } catch (InterruptedException ignore) {
@@ -94,7 +94,7 @@ public class ConcurrentEngineUsageTest extends PluggableFlowableTestCase {
             }
         }
         if (!success) {
-            log.debug("Retrying process start FAILED {} times", MAX_RETRIES);
+            LOGGER.debug("Retrying process start FAILED {} times", MAX_RETRIES);
         }
     }
 
@@ -108,7 +108,7 @@ public class ConcurrentEngineUsageTest extends PluggableFlowableTestCase {
                 success = true;
             } catch (PersistenceException pe) {
                 retries = retries - 1;
-                log.debug("Retrying task completion - {}", (MAX_RETRIES - retries));
+                LOGGER.debug("Retrying task completion - {}", (MAX_RETRIES - retries));
                 try {
                     Thread.sleep(timeout);
                 } catch (InterruptedException ignore) {
@@ -118,7 +118,7 @@ public class ConcurrentEngineUsageTest extends PluggableFlowableTestCase {
         }
 
         if (!success) {
-            log.debug("Retrying task completion FAILED {} times", MAX_RETRIES);
+            LOGGER.debug("Retrying task completion FAILED {} times", MAX_RETRIES);
         }
     }
 

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/concurrency/ControllableThread.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/concurrency/ControllableThread.java
@@ -21,7 +21,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ControllableThread extends Thread {
 
-    private static Logger log = LoggerFactory.getLogger(ControllableThread.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ControllableThread.class);
 
     public ControllableThread() {
         String className = getClass().getName();
@@ -30,7 +30,7 @@ public class ControllableThread extends Thread {
     }
 
     public synchronized void startAndWaitUntilControlIsReturned() {
-        log.debug("test thread will start {} and wait till it returns control", getName());
+        LOGGER.debug("test thread will start {} and wait till it returns control", getName());
         start();
         try {
             wait();
@@ -40,7 +40,7 @@ public class ControllableThread extends Thread {
     }
 
     public synchronized void returnControlToTestThreadAndWait() {
-        log.debug("{} will notify test thread and till test thread proceeds this thread", getName());
+        LOGGER.debug("{} will notify test thread and till test thread proceeds this thread", getName());
         this.notify();
         try {
             this.wait();
@@ -50,7 +50,7 @@ public class ControllableThread extends Thread {
     }
 
     public synchronized void proceedAndWaitTillDone() {
-        log.debug("test thread will notify {} and wait until it completes", getName());
+        LOGGER.debug("test thread will notify {} and wait until it completes", getName());
         notify();
         try {
             join();

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/db/MetaDataTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/db/MetaDataTest.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
  */
 public class MetaDataTest extends PluggableFlowableTestCase {
 
-    private static Logger log = LoggerFactory.getLogger(MetaDataTest.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(MetaDataTest.class);
 
     public void testMetaData() {
         ProcessEngineConfigurationImpl activiti5ProcessEngineConfig = (ProcessEngineConfigurationImpl) processEngineConfiguration.getFlowable5CompatibilityHandler().getRawProcessConfiguration();
@@ -46,9 +46,9 @@ public class MetaDataTest extends PluggableFlowableTestCase {
                         ResultSetMetaData resultSetMetaData = tables.getMetaData();
                         int columnCount = resultSetMetaData.getColumnCount();
                         for (int i = 1; i <= columnCount; i++) {
-                            log.info("result set column {}|{}|{}|{}", i, resultSetMetaData.getColumnName(i), resultSetMetaData.getColumnLabel(i), tables.getString(i));
+                            LOGGER.info("result set column {}|{}|{}|{}", i, resultSetMetaData.getColumnName(i), resultSetMetaData.getColumnLabel(i), tables.getString(i));
                         }
-                        log.info("-------------------------------------------------------");
+                        LOGGER.info("-------------------------------------------------------");
                     }
                 } catch (Exception e) {
                     e.printStackTrace();

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/jobexecutor/TweetExceptionHandler.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/jobexecutor/TweetExceptionHandler.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
  */
 public class TweetExceptionHandler implements JobHandler {
 
-    private static Logger log = LoggerFactory.getLogger(TweetExceptionHandler.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TweetExceptionHandler.class);
 
     protected int exceptionsRemaining = 2;
 
@@ -37,7 +37,7 @@ public class TweetExceptionHandler implements JobHandler {
             exceptionsRemaining--;
             throw new RuntimeException("exception remaining: " + exceptionsRemaining);
         }
-        log.info("no more exceptions to throw.");
+        LOGGER.info("no more exceptions to throw.");
     }
 
     public int getExceptionsRemaining() {

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/pvm/EventCollector.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/pvm/EventCollector.java
@@ -29,7 +29,7 @@ public class EventCollector implements ExecutionListener {
 
     private static final long serialVersionUID = 1L;
 
-    private static Logger log = LoggerFactory.getLogger(EventCollector.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(EventCollector.class);
 
     public List<String> events = new ArrayList<String>();
 
@@ -39,7 +39,7 @@ public class EventCollector implements ExecutionListener {
 
     public void notify(ExecutionListenerExecution execution) {
 
-        log.debug("collecting event: {} on {}", execution.getEventName(), execution.getEventSource());
+        LOGGER.debug("collecting event: {} on {}", execution.getEventName(), execution.getEventSource());
         events.add(execution.getEventName() + " on " + execution.getEventSource());
     }
 

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/pvm/activities/ParallelGateway.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/pvm/activities/ParallelGateway.java
@@ -29,7 +29,7 @@ public class ParallelGateway implements ActivityBehavior {
 
     private static final long serialVersionUID = 1L;
 
-    private static Logger log = LoggerFactory.getLogger(ParallelGateway.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ParallelGateway.class);
 
     public void execute(DelegateExecution execution) {
         ActivityExecution activityExecution = (ActivityExecution) execution;
@@ -45,11 +45,11 @@ public class ParallelGateway implements ActivityBehavior {
         int nbrOfExecutionsJoined = joinedExecutions.size();
 
         if (nbrOfExecutionsJoined == nbrOfExecutionsToJoin) {
-            log.debug("parallel gateway '{}' activates: {} of {} joined", activity.getId(), nbrOfExecutionsJoined, nbrOfExecutionsToJoin);
+            LOGGER.debug("parallel gateway '{}' activates: {} of {} joined", activity.getId(), nbrOfExecutionsJoined, nbrOfExecutionsToJoin);
             activityExecution.takeAll(outgoingTransitions, joinedExecutions);
 
-        } else if (log.isDebugEnabled()) {
-            log.debug("parallel gateway '{}' does not activate: {} of {} joined", activity.getId(), nbrOfExecutionsJoined, nbrOfExecutionsToJoin);
+        } else if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("parallel gateway '{}' does not activate: {} of {} joined", activity.getId(), nbrOfExecutionsJoined, nbrOfExecutionsToJoin);
         }
     }
 }

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/regression/DeleteProcessInstanceTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/regression/DeleteProcessInstanceTest.java
@@ -19,13 +19,13 @@ import org.slf4j.LoggerFactory;
  */
 public class DeleteProcessInstanceTest extends PluggableFlowableTestCase {
 
-    private static Logger log = LoggerFactory.getLogger(DeleteProcessInstanceTest.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DeleteProcessInstanceTest.class);
 
     @Deployment
     public void testNoEndTimeSet() {
 
         // Note that the instance with a Task Type of "user" is being started.
-        log.info("Starting an instance of \"Demo Partial Deletion\" with a Task Type of \"user\".");
+        LOGGER.info("Starting an instance of \"Demo Partial Deletion\" with a Task Type of \"user\".");
 
         // Set the inputs for the first process instance, which we will be able to completely delete.
         Map<String, Object> inputParamsUser = new HashMap<String, Object>();
@@ -34,7 +34,7 @@ public class DeleteProcessInstanceTest extends PluggableFlowableTestCase {
         // Start the process instance & ensure it's started.
         ProcessInstance instanceUser = runtimeService.startProcessInstanceByKey("DemoPartialDeletion", inputParamsUser);
         assertNotNull(instanceUser);
-        log.info("Process instance (of process model {}) started with id: {}.", instanceUser.getProcessDefinitionId(), instanceUser.getId());
+        LOGGER.info("Process instance (of process model {}) started with id: {}.", instanceUser.getProcessDefinitionId(), instanceUser.getId());
 
         // Assert that the process instance is active.
         Execution executionUser = runtimeService.createExecutionQuery().processInstanceId(instanceUser.getProcessInstanceId()).singleResult();
@@ -51,12 +51,12 @@ public class DeleteProcessInstanceTest extends PluggableFlowableTestCase {
             // Retrieve the HistoricProcessInstance and assert that there is an end time.
             HistoricProcessInstance hInstanceUser = historyService.createHistoricProcessInstanceQuery().processInstanceId(instanceUser.getId()).singleResult();
             assertNotNull(hInstanceUser.getEndTime());
-            log.info("End time for the deleted instance of \"Demo Partial Deletion\" that was started with a Task Type of \"user\": {}.", hInstanceUser.getEndTime());
-            log.info("Successfully deleted the instance of \"Demo Partial Deletion\" that was started with a Task Type of \"user\".");
+            LOGGER.info("End time for the deleted instance of \"Demo Partial Deletion\" that was started with a Task Type of \"user\": {}.", hInstanceUser.getEndTime());
+            LOGGER.info("Successfully deleted the instance of \"Demo Partial Deletion\" that was started with a Task Type of \"user\".");
         }
 
         // Note that the instance with a Task Type of "java" is being started.
-        log.info("Starting an instance of \"Demo Partial Deletion\" with a Task Type of \"java\".");
+        LOGGER.info("Starting an instance of \"Demo Partial Deletion\" with a Task Type of \"java\".");
 
         // Set the inputs for the second process instance, which we will NOT be able to completely delete.
         Map<String, Object> inputParamsJava = new HashMap<String, Object>();
@@ -65,7 +65,7 @@ public class DeleteProcessInstanceTest extends PluggableFlowableTestCase {
         // Start the process instance & ensure it's started.
         ProcessInstance instanceJava = runtimeService.startProcessInstanceByKey("DemoPartialDeletion", inputParamsJava);
         assertNotNull(instanceJava);
-        log.info("Process instance (of process model {}) started with id: {}.", instanceJava.getProcessDefinitionId(), instanceJava.getId());
+        LOGGER.info("Process instance (of process model {}) started with id: {}.", instanceJava.getProcessDefinitionId(), instanceJava.getId());
 
         // Assert that the process instance is active.
         Execution executionJava = runtimeService.createExecutionQuery().processInstanceId(instanceJava.getProcessInstanceId()).singleResult();

--- a/modules/flowable5-test/src/test/java/org/activiti/standalone/jta/BitronixDataSourceFactoryBean.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/standalone/jta/BitronixDataSourceFactoryBean.java
@@ -14,7 +14,7 @@ import bitronix.tm.resource.jdbc.PoolingDataSource;
  * @author Marcus Klimstra (CGI)
  */
 public class BitronixDataSourceFactoryBean extends ResourceBean implements FactoryBean<PoolingDataSource>, DisposableBean {
-    private static final Logger LOG = LoggerFactory.getLogger(BitronixDataSourceFactoryBean.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(BitronixDataSourceFactoryBean.class);
 
     private PoolingDataSource ds;
 
@@ -49,7 +49,7 @@ public class BitronixDataSourceFactoryBean extends ResourceBean implements Facto
             ds.setIgnoreRecoveryFailures(getIgnoreRecoveryFailures());
             ds.setDriverProperties(getDriverProperties());
 
-            LOG.debug("Initializing PoolingDataSource with id {}", ds.getUniqueName());
+            LOGGER.debug("Initializing PoolingDataSource with id {}", ds.getUniqueName());
             ds.init();
         }
         return ds;
@@ -57,7 +57,7 @@ public class BitronixDataSourceFactoryBean extends ResourceBean implements Facto
 
     @Override
     public void destroy() throws Exception {
-        LOG.debug("Closing PoolingDataSource with id {}", ds.getUniqueName());
+        LOGGER.debug("Closing PoolingDataSource with id {}", ds.getUniqueName());
         ds.close();
         ds = null;
     }

--- a/modules/flowable5-test/src/test/java/org/activiti/standalone/jta/CloseXADataSourceLifecycleListener.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/standalone/jta/CloseXADataSourceLifecycleListener.java
@@ -31,18 +31,18 @@ public class CloseXADataSourceLifecycleListener implements ProcessEngineLifecycl
     private PoolingDataSource dataSource;
     private BitronixTransactionManager transactionManager;
 
-    private static final Logger LOG = LoggerFactory.getLogger(CloseXADataSourceLifecycleListener.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(CloseXADataSourceLifecycleListener.class);
 
     @Override
     public void onProcessEngineBuilt(ProcessEngine processEngine) {
-        LOG.info("--------------------- Callback for engine start");
+        LOGGER.info("--------------------- Callback for engine start");
     }
 
     @Override
     public void onProcessEngineClosed(ProcessEngine processEngine) {
-        LOG.info("--------------------- Callback for engine end");
+        LOGGER.info("--------------------- Callback for engine end");
         if (dataSource != null) {
-            LOG.info("--------------------- Closing datasource");
+            LOGGER.info("--------------------- Closing datasource");
             dataSource.close();
         }
 


### PR DESCRIPTION
Replacing:

- private static Logger LOG    
- private static Logger log          
- private static Logger logger     
- private static final Logger LOG         
- private static final Logger log     
- private static final Logger logger    

with `private static final Logger LOGGER`

There are still some `protected` and `package` declarations that need more review.  The plan is to have a new push for those 42 occurrences.