### PR TITLE
added updateUserPassword function

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/IdentityService.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/IdentityService.java
@@ -12,8 +12,6 @@
  */
 package org.flowable.engine;
 
-import java.util.List;
-
 import org.flowable.engine.common.api.FlowableObjectNotFoundException;
 import org.flowable.idm.api.Group;
 import org.flowable.idm.api.GroupQuery;
@@ -22,6 +20,8 @@ import org.flowable.idm.api.NativeUserQuery;
 import org.flowable.idm.api.Picture;
 import org.flowable.idm.api.User;
 import org.flowable.idm.api.UserQuery;
+
+import java.util.List;
 
 /**
  * Service to manage {@link User}s and {@link Group}s.
@@ -39,14 +39,24 @@ public interface IdentityService {
     User newUser(String userId);
 
     /**
-     * Saves the user. If the user already existed, the user is updated.
+     * Saves the user. If the user already existed, the user is updated except user password.
+     * Use {@link #updateUserPassword(User)} to update existing user password.
      * 
      * @param user
      *            user to save, cannot be null.
      * @throws RuntimeException
      *             when a user with the same name already exists.
+     * @see #updateUserPassword(User)
      */
     void saveUser(User user);
+
+    /**
+     * Update user password. Use {@link #saveUser(User)} for new user.
+     *
+     * @param user user password to change, cannot be null.
+     * @see #saveUser(User)
+     */
+    void updateUserPassword(User user);
 
     /**
      * Creates a {@link UserQuery} that allows to programmatically query the users.

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/IdentityServiceImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/IdentityServiceImpl.java
@@ -12,8 +12,6 @@
  */
 package org.flowable.engine.impl;
 
-import java.util.List;
-
 import org.flowable.engine.IdentityService;
 import org.flowable.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.flowable.engine.impl.cmd.GetPotentialStarterGroupsCmd;
@@ -26,6 +24,8 @@ import org.flowable.idm.api.NativeUserQuery;
 import org.flowable.idm.api.Picture;
 import org.flowable.idm.api.User;
 import org.flowable.idm.api.UserQuery;
+
+import java.util.List;
 
 /**
  * @author Tom Baeyens
@@ -54,6 +54,10 @@ public class IdentityServiceImpl extends ServiceImpl implements IdentityService 
 
     public void saveUser(User user) {
         processEngineConfiguration.getIdmIdentityService().saveUser(user);
+    }
+
+    public void updateUserPassword(User user) {
+        processEngineConfiguration.getIdmIdentityService().updateUserPassword(user);
     }
 
     public UserQuery createUserQuery() {

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/IdmEngineConfigurator.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/IdmEngineConfigurator.java
@@ -12,8 +12,6 @@
  */
 package org.flowable.engine.impl.cfg;
 
-import javax.sql.DataSource;
-
 import org.flowable.engine.cfg.AbstractProcessEngineConfigurator;
 import org.flowable.engine.common.api.FlowableException;
 import org.flowable.engine.common.impl.transaction.TransactionContextAwareDataSource;
@@ -21,6 +19,8 @@ import org.flowable.engine.common.impl.transaction.TransactionContextAwareTransa
 import org.flowable.idm.engine.IdmEngine;
 import org.flowable.idm.engine.IdmEngineConfiguration;
 import org.flowable.idm.engine.impl.cfg.StandaloneIdmEngineConfiguration;
+
+import javax.sql.DataSource;
 
 /**
  * @author Tijs Rademakers
@@ -52,6 +52,8 @@ public class IdmEngineConfigurator extends AbstractProcessEngineConfigurator {
             idmEngineConfiguration.setDatabaseSchemaUpdate(processEngineConfiguration.getDatabaseSchemaUpdate());
             idmEngineConfiguration.setDatabaseTablePrefix(processEngineConfiguration.getDatabaseTablePrefix());
             idmEngineConfiguration.setDatabaseWildcardEscapeCharacter(processEngineConfiguration.getDatabaseWildcardEscapeCharacter());
+            idmEngineConfiguration.setPasswordEncoder(processEngineConfiguration.getPasswordEncoder());
+            idmEngineConfiguration.setPasswordSalt(processEngineConfiguration.getPasswordSalt());
 
             if (processEngineConfiguration.isTransactionsExternallyManaged()) {
                 idmEngineConfiguration.setTransactionsExternallyManaged(true);

--- a/modules/flowable-engine/src/test/resources/flowable.cfg.xml
+++ b/modules/flowable-engine/src/test/resources/flowable.cfg.xml
@@ -50,6 +50,7 @@
     <property name="asyncHistoryEnabled" value="false" />
     
     <property name="enableProcessDefinitionInfoCache" value="true" />
+    <property name="passwordEncoder" ref="passwordEncoder"/>
   </bean>
   
   <bean id="asyncExecutor" class="org.flowable.engine.impl.asyncexecutor.DefaultAsyncJobExecutor">
@@ -59,5 +60,9 @@
     
   <bean id="throwCustomExceptionBean" class="org.flowable.engine.test.bpmn.event.error.mapError.ThrowCustomExceptionBean" />
   <bean id="throwCustomExceptionDelegate" class="org.flowable.engine.test.bpmn.event.error.mapError.ThrowCustomExceptionDelegate" />
+
+  <bean id="passwordEncoder" class="org.flowable.idm.engine.impl.authentication.ApacheDigester">
+    <constructor-arg value="MD5"/>
+  </bean>
 
 </beans>

--- a/modules/flowable-idm-api/src/main/java/org/flowable/idm/api/IdmIdentityService.java
+++ b/modules/flowable-idm-api/src/main/java/org/flowable/idm/api/IdmIdentityService.java
@@ -12,9 +12,9 @@
  */
 package org.flowable.idm.api;
 
-import java.util.List;
-
 import org.flowable.engine.common.api.FlowableIllegalArgumentException;
+
+import java.util.List;
 
 /**
  * Service to manage {@link User}s and {@link Group}s.
@@ -34,14 +34,24 @@ public interface IdmIdentityService {
     User newUser(String userId);
 
     /**
-     * Saves the user. If the user already existed, the user is updated.
+     * Saves the user. If the user already existed, the user is updated except user password.
+     * Use {@link #updateUserPassword(User)} to update existing user password.
      * 
      * @param user
      *            user to save, cannot be null.
      * @throws RuntimeException
      *             when a user with the same name already exists.
+     * @see #updateUserPassword(User)
      */
     void saveUser(User user);
+
+    /**
+     * Update user password. Use {@link #saveUser(User)} for new user.
+     *
+     * @param user user password to change, cannot be null.
+     * @see #saveUser(User)
+     */
+    void updateUserPassword(User user);
 
     /**
      * Creates a {@link UserQuery} that allows to programmatically query the users.

--- a/modules/flowable-idm-engine/src/main/java/org/flowable/idm/engine/impl/cmd/SaveUserCmd.java
+++ b/modules/flowable-idm-engine/src/main/java/org/flowable/idm/engine/impl/cmd/SaveUserCmd.java
@@ -12,8 +12,6 @@
  */
 package org.flowable.idm.engine.impl.cmd;
 
-import java.io.Serializable;
-
 import org.flowable.engine.common.api.FlowableIllegalArgumentException;
 import org.flowable.engine.common.impl.persistence.entity.Entity;
 import org.flowable.idm.api.PasswordEncoder;
@@ -22,6 +20,8 @@ import org.flowable.idm.api.User;
 import org.flowable.idm.engine.impl.interceptor.Command;
 import org.flowable.idm.engine.impl.interceptor.CommandContext;
 import org.flowable.idm.engine.impl.persistence.entity.UserEntity;
+
+import java.io.Serializable;
 
 /**
  * @author Joram Barrez
@@ -54,6 +54,8 @@ public class SaveUserCmd implements Command<Void>, Serializable {
                 commandContext.getDbSqlSession().insert((Entity) user);
             }
         } else {
+            UserEntity dbUser = commandContext.getUserEntityManager().findById(user.getId());
+            user.setPassword(dbUser.getPassword());
             commandContext.getUserEntityManager().updateUser(user);
         }
 

--- a/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/IdentityServiceTest.java
+++ b/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/IdentityServiceTest.java
@@ -13,10 +13,6 @@
 
 package org.flowable.idm.engine.test.api.identity;
 
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
-
 import org.flowable.engine.common.api.FlowableException;
 import org.flowable.engine.common.api.FlowableIllegalArgumentException;
 import org.flowable.engine.common.api.FlowableOptimisticLockingException;
@@ -24,7 +20,12 @@ import org.flowable.idm.api.Group;
 import org.flowable.idm.api.Picture;
 import org.flowable.idm.api.Token;
 import org.flowable.idm.api.User;
+import org.flowable.idm.engine.impl.authentication.ApacheDigester;
 import org.flowable.idm.engine.test.PluggableFlowableIdmTestCase;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
 
 /**
  * @author Frederik Heremans
@@ -336,6 +337,35 @@ public class IdentityServiceTest extends PluggableFlowableIdmTestCase {
         assertFalse(idmIdentityService.checkPassword("userId", null));
         assertFalse(idmIdentityService.checkPassword(null, "passwd"));
         assertFalse(idmIdentityService.checkPassword(null, null));
+    }
+
+    public void testChangePassword() {
+
+        idmEngineConfiguration.setPasswordEncoder(new ApacheDigester(ApacheDigester.Digester.MD5));
+
+        User user = idmIdentityService.newUser("johndoe");
+        user.setPassword("xxx");
+        idmIdentityService.saveUser(user);
+
+        user = idmIdentityService.createUserQuery().userId("johndoe").list().get(0);
+        user.setFirstName("John Doe");
+        idmIdentityService.saveUser(user);
+        User johndoe = idmIdentityService.createUserQuery().userId("johndoe").list().get(0);
+        assertFalse(johndoe.getPassword().equals("xxx"));
+        assertTrue(johndoe.getFirstName().equals("John Doe"));
+        assertTrue(idmIdentityService.checkPassword("johndoe", "xxx"));
+
+        user = idmIdentityService.createUserQuery().userId("johndoe").list().get(0);
+        user.setPassword("yyy");
+        idmIdentityService.saveUser(user);
+        assertTrue(idmIdentityService.checkPassword("johndoe", "xxx"));
+
+        user = idmIdentityService.createUserQuery().userId("johndoe").list().get(0);
+        user.setPassword("yyy");
+        idmIdentityService.updateUserPassword(user);
+        assertTrue(idmIdentityService.checkPassword("johndoe", "yyy"));
+
+        idmIdentityService.deleteUser("johndoe");
     }
 
     public void testUserOptimisticLockingException() {

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/identity/UserResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/identity/UserResource.java
@@ -13,12 +13,6 @@
 
 package org.flowable.rest.service.api.identity;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
-import io.swagger.annotations.Authorization;
 import org.flowable.idm.api.User;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -29,6 +23,13 @@ import org.springframework.web.bind.annotation.RestController;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
 
 /**
  * @author Frederik Heremans
@@ -70,9 +71,10 @@ public class UserResource extends BaseUserResource {
         }
         if (userRequest.isPasswordChanged()) {
             user.setPassword(userRequest.getPassword());
+            identityService.updateUserPassword(user);
+        } else {
+            identityService.saveUser(user);
         }
-
-        identityService.saveUser(user);
 
         return restResponseFactory.createUserResponse(user, false);
     }

--- a/modules/flowable-ui-idm/flowable-ui-idm-logic/src/main/java/org/flowable/app/idm/service/ProfileServiceImpl.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-logic/src/main/java/org/flowable/app/idm/service/ProfileServiceImpl.java
@@ -12,10 +12,6 @@
  */
 package org.flowable.app.idm.service;
 
-import java.io.BufferedInputStream;
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.flowable.app.security.SecurityUtils;
@@ -25,6 +21,10 @@ import org.flowable.idm.api.Picture;
 import org.flowable.idm.api.User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 
 /**
  * @author Joram Barrez
@@ -55,7 +55,7 @@ public class ProfileServiceImpl extends AbstractIdmService implements ProfileSer
             throw new NotFoundException();
         }
         user.setPassword(newPassword);
-        identityService.saveUser(user);
+        identityService.updateUserPassword(user);
     }
 
     public Pair<String, InputStream> getProfilePicture() {

--- a/modules/flowable-ui-idm/flowable-ui-idm-logic/src/main/java/org/flowable/app/idm/service/UserServiceImpl.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-logic/src/main/java/org/flowable/app/idm/service/UserServiceImpl.java
@@ -12,11 +12,6 @@
  */
 package org.flowable.app.idm.service;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
 import org.apache.commons.lang3.StringUtils;
 import org.flowable.app.idm.model.UserInformation;
 import org.flowable.app.service.exception.BadRequestException;
@@ -28,6 +23,11 @@ import org.flowable.idm.api.User;
 import org.flowable.idm.api.UserQuery;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * @author Joram Barrez
@@ -84,7 +84,7 @@ public class UserServiceImpl extends AbstractIdmService implements UserService {
             User user = identityService.createUserQuery().userId(userId).singleResult();
             if (user != null) {
                 user.setPassword(newPassword);
-                identityService.saveUser(user);
+                identityService.updateUserPassword(user);
             }
         }
     }
@@ -115,12 +115,15 @@ public class UserServiceImpl extends AbstractIdmService implements UserService {
             throw new ConflictingRequestException("User already registered", "ACCOUNT.SIGNUP.ERROR.ALREADY-REGISTERED");
         }
 
-        User user = identityService.newUser(id != null ? id : email);
+        User user = identityService.newUser(id);
         user.setFirstName(firstName);
         user.setLastName(lastName);
         user.setEmail(email);
-        user.setPassword(password);
         identityService.saveUser(user);
+
+        User savedUser = identityService.createUserQuery().userEmail(email).singleResult();
+        savedUser.setPassword(password);
+        identityService.updateUserPassword(user);
 
         return user;
     }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/IdentityService.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/IdentityService.java
@@ -12,8 +12,6 @@
  */
 package org.activiti.engine;
 
-import java.util.List;
-
 import org.flowable.idm.api.Group;
 import org.flowable.idm.api.GroupQuery;
 import org.flowable.idm.api.NativeGroupQuery;
@@ -21,6 +19,8 @@ import org.flowable.idm.api.NativeUserQuery;
 import org.flowable.idm.api.Picture;
 import org.flowable.idm.api.User;
 import org.flowable.idm.api.UserQuery;
+
+import java.util.List;
 
 /**
  * Service to manage {@link User}s and {@link Group}s.
@@ -38,14 +38,24 @@ public interface IdentityService {
     User newUser(String userId);
 
     /**
-     * Saves the user. If the user already existed, the user is updated.
+     * Saves the user. If the user already existed, the user is updated except user password.
+     * Use {@link #updateUserPassword(User)} to update existing user password.
      * 
      * @param user
      *            user to save, cannot be null.
      * @throws RuntimeException
      *             when a user with the same name already exists.
+     * @see #updateUserPassword(User)
      */
     void saveUser(User user);
+
+    /**
+     * Update user password. Use {@link #saveUser(User)} for new user.
+     *
+     * @param user user password to change, cannot be null.
+     * @see #saveUser(User)
+     */
+    void updateUserPassword(User user);
 
     /**
      * Creates a {@link UserQuery} that allows to programmatically query the users.

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/IdentityServiceImpl.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/IdentityServiceImpl.java
@@ -12,8 +12,6 @@
  */
 package org.activiti.engine.impl;
 
-import java.util.List;
-
 import org.activiti.engine.IdentityService;
 import org.activiti.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.activiti.engine.impl.identity.Authentication;
@@ -24,6 +22,8 @@ import org.flowable.idm.api.NativeUserQuery;
 import org.flowable.idm.api.Picture;
 import org.flowable.idm.api.User;
 import org.flowable.idm.api.UserQuery;
+
+import java.util.List;
 
 /**
  * @author Tom Baeyens
@@ -52,6 +52,10 @@ public class IdentityServiceImpl extends ServiceImpl implements IdentityService 
 
     public void saveUser(User user) {
         processEngineConfiguration.getIdmIdentityService().saveUser(user);
+    }
+
+    public void updateUserPassword(User user) {
+        processEngineConfiguration.getIdmIdentityService().updateUserPassword(user);
     }
 
     public UserQuery createUserQuery() {


### PR DESCRIPTION
Update the rest of flowable module with new _updateUserPassword_ function. Current _saveUser_ function is not able to recognize either hashing is required or not

`User user = idmIdentityService.createUserQuery().userId("johndoe").singleResult();`
`user.setEmail("newemail@email.org");`
`idmIdentityService.saveUser(user);`
Above code will cause password encoder hashing existing hashed password 

Affected Modules:
flowable-engine, flowable-idm-api, flowable-idm-engine, flowable-rest, flowable-ui-idm, flowable5-engine

