### PR TITLE
Recording of task events for user identity links is inconsistent (#448)

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/ClaimTaskCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/ClaimTaskCmd.java
@@ -17,6 +17,7 @@ import org.flowable.engine.compatibility.Flowable5CompatibilityHandler;
 import org.flowable.engine.impl.interceptor.CommandContext;
 import org.flowable.engine.impl.persistence.entity.TaskEntity;
 import org.flowable.engine.impl.util.Flowable5Util;
+import org.flowable.engine.task.IdentityLinkType;
 
 /**
  * @author Joram Barrez
@@ -39,28 +40,26 @@ public class ClaimTaskCmd extends NeedsActiveTaskCmd<Void> {
             return null;
         }
 
+        if (userId != null && task.getAssignee() != null) {
+            if (!task.getAssignee().equals(userId)) {
+                // When the task is already claimed by another user, throw
+                // exception. Otherwise, ignore this, post-conditions of method already met.
+                throw new FlowableTaskAlreadyClaimedException(task.getId(), task.getAssignee());
+            }
+        }
+
         if (userId != null) {
             task.setClaimTime(commandContext.getProcessEngineConfiguration().getClock().getCurrentTime());
-
-            if (task.getAssignee() != null) {
-                if (!task.getAssignee().equals(userId)) {
-                    // When the task is already claimed by another user, throw
-                    // exception. Otherwise, ignore this, post-conditions of method already met.
-                    throw new FlowableTaskAlreadyClaimedException(task.getId(), task.getAssignee());
-                }
-                commandContext.getHistoryManager().recordTaskInfoChange(task);
-                
-            } else {
-                commandContext.getTaskEntityManager().changeTaskAssignee(task, userId);
-            }
-            
         } else {
             // Task claim time should be null
             task.setClaimTime(null);
-
-            // Task should be assigned to no one
-            commandContext.getTaskEntityManager().changeTaskAssignee(task, null);
         }
+
+        new AddIdentityLinkCmd(taskId, userId, AddIdentityLinkCmd.IDENTITY_USER, IdentityLinkType.ASSIGNEE)
+                .execute(commandContext, task);
+
+        // to update claim time
+        commandContext.getHistoryManager().recordTaskInfoChange(task);
 
         return null;
     }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/history/AbstractHistoryManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/history/AbstractHistoryManager.java
@@ -27,6 +27,7 @@ import org.flowable.engine.impl.persistence.entity.CommentEntity;
 import org.flowable.engine.impl.persistence.entity.ExecutionEntity;
 import org.flowable.engine.impl.persistence.entity.HistoricActivityInstanceEntity;
 import org.flowable.engine.task.Event;
+import org.flowable.engine.task.IdentityLink;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,11 +65,6 @@ public abstract class AbstractHistoryManager extends AbstractManager implements 
     }
 
     @Override
-    public void createUserIdentityLinkComment(String taskId, String userId, String type, boolean create) {
-        createIdentityLinkComment(taskId, userId, null, type, create, false);
-    }
-
-    @Override
     public void createGroupIdentityLinkComment(String taskId, String groupId, String type, boolean create) {
         createIdentityLinkComment(taskId, null, groupId, type, create, false);
     }
@@ -78,13 +74,10 @@ public abstract class AbstractHistoryManager extends AbstractManager implements 
         createIdentityLinkComment(taskId, userId, null, type, create, forceNullUserId);
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see org.flowable.engine.impl.history.HistoryManagerInterface# createIdentityLinkComment(java.lang.String, java.lang.String, java.lang.String, java.lang.String, boolean, boolean)
+    /**
+     * Creates a new comment to indicate a new {@link IdentityLink} has been created or deleted, if history is enabled.
      */
-    @Override
-    public void createIdentityLinkComment(String taskId, String userId, String groupId, String type, boolean create, boolean forceNullUserId) {
+    private void createIdentityLinkComment(String taskId, String userId, String groupId, String type, boolean create, boolean forceNullUserId) {
         if (isHistoryEnabled()) {
             String authenticatedUserId = Authentication.getAuthenticatedUserId();
             CommentEntity comment = getCommentEntityManager().create();
@@ -114,11 +107,6 @@ public abstract class AbstractHistoryManager extends AbstractManager implements 
 
     @Override
     public void createProcessInstanceIdentityLinkComment(String processInstanceId, String userId, String groupId, String type, boolean create) {
-        createProcessInstanceIdentityLinkComment(processInstanceId, userId, groupId, type, create, false);
-    }
-
-    @Override
-    public void createProcessInstanceIdentityLinkComment(String processInstanceId, String userId, String groupId, String type, boolean create, boolean forceNullUserId) {
         if (isHistoryEnabled()) {
             String authenticatedUserId = Authentication.getAuthenticatedUserId();
             CommentEntity comment = getCommentEntityManager().create();
@@ -126,7 +114,7 @@ public abstract class AbstractHistoryManager extends AbstractManager implements 
             comment.setType(CommentEntity.TYPE_EVENT);
             comment.setTime(getClock().getCurrentTime());
             comment.setProcessInstanceId(processInstanceId);
-            if (userId != null || forceNullUserId) {
+            if (userId != null) {
                 if (create) {
                     comment.setAction(Event.ACTION_ADD_USER_LINK);
                 } else {

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/history/HistoryManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/history/HistoryManager.java
@@ -124,19 +124,9 @@ public interface HistoryManager {
     void createIdentityLinkComment(String taskId, String userId, String groupId, String type, boolean create);
 
     /**
-     * Creates a new comment to indicate a new user {@link IdentityLink} has been created or deleted, if history is enabled.
-     */
-    void createUserIdentityLinkComment(String taskId, String userId, String type, boolean create);
-
-    /**
      * Creates a new comment to indicate a new group {@link IdentityLink} has been created or deleted, if history is enabled.
      */
     void createGroupIdentityLinkComment(String taskId, String groupId, String type, boolean create);
-
-    /**
-     * Creates a new comment to indicate a new {@link IdentityLink} has been created or deleted, if history is enabled.
-     */
-    void createIdentityLinkComment(String taskId, String userId, String groupId, String type, boolean create, boolean forceNullUserId);
 
     /**
      * Creates a new comment to indicate a new user {@link IdentityLink} has been created or deleted, if history is enabled.
@@ -147,11 +137,6 @@ public interface HistoryManager {
      * Creates a new comment to indicate a new {@link IdentityLink} has been created or deleted, if history is enabled.
      */
     void createProcessInstanceIdentityLinkComment(String processInstanceId, String userId, String groupId, String type, boolean create);
-
-    /**
-     * Creates a new comment to indicate a new {@link IdentityLink} has been created or deleted, if history is enabled.
-     */
-    void createProcessInstanceIdentityLinkComment(String processInstanceId, String userId, String groupId, String type, boolean create, boolean forceNullUserId);
 
     /**
      * Creates a new comment to indicate a new attachment has been created or deleted, if history is enabled.
@@ -167,7 +152,7 @@ public interface HistoryManager {
      * Record the creation of a new {@link IdentityLink}, if audit history is enabled.
      */
     void recordIdentityLinkCreated(IdentityLinkEntity identityLink);
-    
+
     /**
      * Record the deletion of a {@link IdentityLink}, if audit history is enabled
      */

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/cfg/executioncount/VerifyDatabaseOperationsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/cfg/executioncount/VerifyDatabaseOperationsTest.java
@@ -328,7 +328,7 @@ public class VerifyDatabaseOperationsTest extends PluggableFlowableTestCase {
             assertExecutedCommands("StartProcessInstanceCmd", "org.flowable.engine.impl.TaskQueryImpl", "ClaimTaskCmd", "CompleteTaskCmd");
     
             assertNoDeletes("ClaimTaskCmd");
-            assertDatabaseInserts("ClaimTaskCmd", "HistoricIdentityLinkEntityImpl-bulk-with-2", 1L, "IdentityLinkEntityImpl", 1L, "HistoricIdentityLinkEntityImpl", 1L);
+            assertDatabaseInserts("ClaimTaskCmd", "CommentEntityImpl", 2L, "HistoricIdentityLinkEntityImpl-bulk-with-2", 1L, "IdentityLinkEntityImpl", 1L, "HistoricIdentityLinkEntityImpl", 1L);
         }
     }
 


### PR DESCRIPTION
Please have a look at the unit tests. As for the implementation:
- In `ClaimTaskCmd` I tried honoring the contract of `TaskSerive.claim` by doing just what is supposed to be the difference to `TaskService.setAssignee` and then calling `AddIdentityLinkCmd`. Still not that nice.
- I tried to refactor unused/superfluous methods in the history manager. There are still problems left: `org.flowable.engine.impl.history.HistoryManager#createIdentityLinkComment` `create` is always false, `org.flowable.engine.impl.history.HistoryManager#createGroupIdentityLinkComment` `create` is always true and `org.flowable.engine.impl.history.HistoryManager#createUserIdentityLinkComment` `create` and `forceNullUserId` depend on each other