### PR TITLE
Initial Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: java
+
+jdk:
+  - oraclejdk8
+  # remove the jdk7 version because of class version issues with 'org/mindrot/jbcrypt/BCrypt' in PasswordEncoderTest.testjBCrytpEncoderInstance test
+  #- oraclejdk7
+
+cache:
+  directories:
+  - $HOME/.m2
+
+notifications:
+    on_success: change  # options: [always|never|change] default: always
+    on_failure: always  # options: [always|never|change] default: always
+    on_start: never     # options: [always|never|change] default: always
+
+script:
+  mvn test -B
+
+after_failure:
+  - cat /home/travis/build/flowable/flowable-engine/modules/*/target/surefire-reports/*.txt

--- a/README.md
+++ b/README.md
@@ -1,7 +1,15 @@
 Flowable (V6)
 ========
 
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.flowable/flowable-engine/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.flowable/flowable-engine)
+[Maven Central:  
+    ![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.flowable/flowable-engine/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.flowable/flowable-engine)
+
+[Travis CI:  
+	![build status badge](https://travis-ci.org/flowable/flowable-engine.svg?branch=master)](https://travis-ci.org/flowable/flowable-engine)
+
+[License:  
+	![license](https://img.shields.io/hexpm/l/plug.svg)](https://github.com/flowable/flowable-engine/blob/master/LICENSE)
+
 
 Homepage: http://flowable.org/
 


### PR DESCRIPTION
This is an initial attempt at using [Travis-CI](https://travis-ci.org/) with Flowable.   It provides a basic “smoke test” for any branches, pull requests, and pushes without going the whole Jenkins route.
 
The changes are pretty basic once the Travis account is setup for Flowable and repository is synced.

It is currently set to send email on failures and when the failure is corrected to the project members.  This can be adjusted.

I originally had it building with JDK 7 and JDK  8 (8 seems to be the default) but the JDK 7 version failed with a class version mismatch in the test file, `org.flowable.idm.engine.test.api.identity.authentication.jBCryptHashingt` so only JDK 8 is set in the `.travis.yml` file for now.  JDK 7 can be turned back on when the test is excluded  via POM changes; right @jbarrez ?

To help find errors I added `cat` in the `after_failure clause` of the `.travis.yml` file  to find the errors in the tests.

Ping me if there are any questions or issues.