### PR TITLE
Move Travis build machine to Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: java
 
+dist: trusty
+sudo: required
+
 jdk:
   - oraclejdk8
   # remove the jdk7 version because of class version issues with 'org/mindrot/jbcrypt/BCrypt' in PasswordEncoderTest.testjBCrytpEncoderInstance test


### PR DESCRIPTION
Travis CI is moving to Ubuntu Trusty soon as the default.  This PR switches to Trusty.  Locally I have had two successful Travis-CI builds on this distro.