### PR TITLE
callActivity + ioSpecification + dataInputAssociation seems broken

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/tasklistener/VariablesListener.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/tasklistener/VariablesListener.java
@@ -1,0 +1,16 @@
+package org.flowable.examples.bpmn.tasklistener;
+
+import org.flowable.engine.delegate.DelegateTask;
+import org.flowable.engine.delegate.TaskListener;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class VariablesListener implements TaskListener {
+
+    public static List<String> messages = new LinkedList<>();
+
+    public void notify(DelegateTask delegateTask) {
+        messages.add(String.format("%s: %s", delegateTask.getEventName(), delegateTask.getVariables()));
+    }
+}

--- a/modules/flowable-engine/src/test/resources/org/flowable/examples/bpmn/callactivity/childInOut.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/examples/bpmn/callactivity/childInOut.bpmn20.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions" targetNamespace="http://flowable.org/bpmn20"
+             xmlns:flowable="http://flowable.org/bpmn"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL">
+
+    <process id="child" name="Child Process">
+
+        <startEvent id="theStart" />
+        <sequenceFlow id="flow1" sourceRef="theStart" targetRef="theTask" />
+        <userTask id="theTask" name="task 1" flowable:assignee="Bob">
+            <extensionElements>
+                <flowable:taskListener event="create" class="org.flowable.examples.bpmn.tasklistener.VariablesListener"/>
+            </extensionElements>
+        </userTask>
+        <sequenceFlow id="flow2" sourceRef="theStart" targetRef="theEnd" />
+        <endEvent id="theEnd" />
+
+    </process>
+
+</definitions>

--- a/modules/flowable-engine/src/test/resources/org/flowable/examples/bpmn/callactivity/parentInOut.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/examples/bpmn/callactivity/parentInOut.bpmn20.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions" targetNamespace="http://flowable.org/bpmn20"
+             xmlns:flowable="http://flowable.org/bpmn"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL">
+
+    <process id="parent" name="Parent Process">
+
+        <startEvent id="theStart" />
+        <sequenceFlow id="flow1" sourceRef="theStart" targetRef="callActivity" />
+        <callActivity id="callActivity" calledElement="child">
+            <extensionElements>
+                <flowable:in target="variableChild" source="variableParent"/>
+            </extensionElements>
+        </callActivity>
+        <sequenceFlow id="flow2" sourceRef="theStart" targetRef="theEnd" />
+        <endEvent id="theEnd" />
+
+    </process>
+
+</definitions>

--- a/modules/flowable-engine/src/test/resources/org/flowable/examples/bpmn/callactivity/parentIoSpecification.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/examples/bpmn/callactivity/parentIoSpecification.bpmn20.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions" targetNamespace="http://flowable.org/bpmn20"
+             xmlns:flowable="http://flowable.org/bpmn"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL">
+
+    <process id="parent" name="Parent Process">
+        <property id="variableParent"/>
+        <startEvent id="theStart" />
+        <sequenceFlow id="flow1" sourceRef="theStart" targetRef="callActivity" />
+        <callActivity id="callActivity" calledElement="child">
+            <ioSpecification>
+                <dataInput id="variableChild" name="variableChild"/>
+                <inputSet>
+                    <dataInputRefs>variableChild</dataInputRefs>
+                </inputSet>
+                <outputSet/>
+            </ioSpecification>
+            <dataInputAssociation>
+                <sourceRef>variableParent</sourceRef>
+                <targetRef>variableChild</targetRef>
+            </dataInputAssociation>
+        </callActivity>
+        <sequenceFlow id="flow2" sourceRef="theStart" targetRef="theEnd" />
+        <endEvent id="theEnd" />
+    </process>
+
+</definitions>


### PR DESCRIPTION
PROBLEM
===

Attempting to build a BPMN model using `<callActivity/>`, `<ioSpecification/>` and `<dataInputAssociation/>` refuses to pass parent variables to the child process.  Using the flowable extensions `<flowable:in>` works fine.

It may ultimately lie in a modeling error, but after struggling for some time, I figured I should get some verification from the experts.

REPRODUCING
===

Run the tests included in this PR with:

```
mvn test -Dtest=org.flowable.engine.test.bpmn.subprocess.CallActivityTest -PerrorLogging
```

1. `org.flowable.engine.test.bpmn.subprocess.CallActivityTest.testCallActivityInOut` passes
2. `org.flowable.engine.test.bpmn.subprocess.CallActivityTest.testCallActivityIoSpecification` fails

EXPECTED OUTCOME
===

1. `org.flowable.engine.test.bpmn.subprocess.CallActivityTest.testCallActivityInOut` passes
2. `org.flowable.engine.test.bpmn.subprocess.CallActivityTest.testCallActivityIoSpecification` passes
