### PR TITLE
Add openjdk7 to travis given recent updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ sudo: required
 
 jdk:
   - oraclejdk8
-  # remove the jdk7 version because of class version issues with 'org/mindrot/jbcrypt/BCrypt' in PasswordEncoderTest.testjBCrytpEncoderInstance test
-  #- oraclejdk7
+  - openjdk7
 
 cache:
   directories:


### PR DESCRIPTION
Cannot use Oracle JDK7 on Trusty as it is not supported on that version of Linux.