### PR TITLE
loop collection as an expression

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/MultiInstanceActivityBehavior.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/MultiInstanceActivityBehavior.java
@@ -267,7 +267,7 @@ public abstract class MultiInstanceActivityBehavior extends FlowNodeActivityBeha
     @SuppressWarnings("rawtypes")
     protected void executeOriginalBehavior(DelegateExecution execution, int loopCounter) {
         if (usesCollection() && collectionElementVariable != null) {
-            Collection collection = (Collection) resolveCollection(execution);
+            Collection collection = (Collection) resolveAndValidateCollection(execution);
 
             Object value = null;
             int index = 0;
@@ -286,24 +286,23 @@ public abstract class MultiInstanceActivityBehavior extends FlowNodeActivityBeha
     @SuppressWarnings("rawtypes")
     protected Collection resolveAndValidateCollection(DelegateExecution execution) {
         Object obj = resolveCollection(execution);
-        if (collectionExpression != null) {
-            if (!(obj instanceof Collection)) {
-                throw new FlowableIllegalArgumentException(collectionExpression.getExpressionText() + "' didn't resolve to a Collection");
-            }
-
-        } else if (collectionVariable != null) {
-            if (obj == null) {
+        if (obj instanceof Collection) {
+            return (Collection) obj;
+            
+        } else if (obj instanceof String) {
+            Object collectionVariable = execution.getVariable((String) obj);
+            if (collectionVariable instanceof Collection) {
+                return (Collection) collectionVariable;
+            } else if (collectionVariable == null){
                 throw new FlowableIllegalArgumentException("Variable " + collectionVariable + " is not found");
-            }
-
-            if (!(obj instanceof Collection)) {
+            } else {
                 throw new FlowableIllegalArgumentException("Variable " + collectionVariable + "' is not a Collection");
             }
-
+            
         } else {
             throw new FlowableIllegalArgumentException("Couldn't resolve collection expression nor variable reference");
+            
         }
-        return (Collection) obj;
     }
 
     protected Object resolveCollection(DelegateExecution execution) {

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/parser/handler/AbstractActivityBpmnParseHandler.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/parser/handler/AbstractActivityBpmnParseHandler.java
@@ -66,11 +66,7 @@ public abstract class AbstractActivityBpmnParseHandler<T extends FlowNode> exten
 
         // activiti:collection
         if (StringUtils.isNotEmpty(loopCharacteristics.getInputDataItem())) {
-            if (loopCharacteristics.getInputDataItem().contains("{")) {
-                miActivityBehavior.setCollectionExpression(expressionManager.createExpression(loopCharacteristics.getInputDataItem()));
-            } else {
-                miActivityBehavior.setCollectionVariable(loopCharacteristics.getInputDataItem());
-            }
+            miActivityBehavior.setCollectionExpression(expressionManager.createExpression(loopCharacteristics.getInputDataItem()));
         }
 
         // activiti:elementVariable

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/task/DelegateTaskTest.testChangeCategoryInDelegateTask.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/task/DelegateTaskTest.testChangeCategoryInDelegateTask.bpmn20.xml
@@ -1,47 +1,54 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" 
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-    xmlns:activiti="http://activiti.org/bpmn" 
-    xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" 
-    xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" 
-    xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" 
-    typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://www.activiti.org/test">
-    
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://www.activiti.org/test">
   <process id="delegateTaskTest" isExecutable="true">
-  
     <startEvent id="startevent1" name="Start"></startEvent>
     <sequenceFlow id="flow1" sourceRef="startevent1" targetRef="approvalTask"></sequenceFlow>
-    
     <userTask id="approvalTask" name="Approval" activiti:category="approval">
-        <extensionElements>
-            <activiti:taskListener event="complete" class="org.flowable.engine.impl.bpmn.listener.ScriptTaskListener" >
-              <activiti:field name="script">
-                <activiti:string>
-                <![CDATA[
-                
-                  // Update category based on outcome 
+      <extensionElements>
+        <activiti:taskListener event="complete" class="org.flowable.engine.impl.bpmn.listener.ScriptTaskListener">
+          <activiti:field name="script">
+            <activiti:string><![CDATA[// Update category based on outcome 
                   var outcome = task.getVariableLocal('outcome');
                   if (outcome == 'approve') {
                      task.setCategory('approved');
                   } else {
                      task.setCategory('rejected');
                   }
-                  taskService.saveTask(task);
-                  
-                ]]>  
-                </activiti:string>
-              </activiti:field>
-              <activiti:field name="language" stringValue="JavaScript" />
-            </activiti:taskListener>
-        </extensionElements>
-        <multiInstanceLoopCharacteristics isSequential="false" activiti:collection="${approvers}" activiti:elementVariable="approver">
-            <loopDataInputRef>approvers</loopDataInputRef>
-            <inputDataItem name="approver" />
-        </multiInstanceLoopCharacteristics>
+                  taskService.saveTask(task);]]></activiti:string>
+          </activiti:field>
+          <activiti:field name="language">
+            <activiti:string><![CDATA[JavaScript]]></activiti:string>
+          </activiti:field>
+        </activiti:taskListener>
+      </extensionElements>
+      <multiInstanceLoopCharacteristics isSequential="false" activiti:collection="${approvers}" activiti:elementVariable="approver"></multiInstanceLoopCharacteristics>
     </userTask>
     <sequenceFlow id="flow2" sourceRef="approvalTask" targetRef="theEnd"></sequenceFlow>
-    
     <endEvent id="theEnd" name="End"></endEvent>
-    
   </process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_delegateTaskTest">
+    <bpmndi:BPMNPlane bpmnElement="delegateTaskTest" id="BPMNPlane_delegateTaskTest">
+      <bpmndi:BPMNShape bpmnElement="startevent1" id="BPMNShape_startevent1">
+        <omgdc:Bounds height="35.0" width="35.0" x="0.0" y="15.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="approvalTask" id="BPMNShape_approvalTask">
+        <omgdc:Bounds height="60.0" width="100.0" x="80.0" y="0.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="theEnd" id="BPMNShape_theEnd">
+        <omgdc:Bounds height="35.0" width="35.0" x="230.0" y="15.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="flow1" id="BPMNEdge_flow1">
+        <omgdi:waypoint x="35.0" y="32.0"></omgdi:waypoint>
+        <omgdi:waypoint x="42.0" y="30.0"></omgdi:waypoint>
+        <omgdi:waypoint x="42.0" y="30.0"></omgdi:waypoint>
+        <omgdi:waypoint x="80.0" y="30.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="flow2" id="BPMNEdge_flow2">
+        <omgdi:waypoint x="180.0" y="30.0"></omgdi:waypoint>
+        <omgdi:waypoint x="192.0" y="30.0"></omgdi:waypoint>
+        <omgdi:waypoint x="192.0" y="30.0"></omgdi:waypoint>
+        <omgdi:waypoint x="230.0" y="32.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
 </definitions>

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/multiinstance/DynamicMultiInstanceTest.testParallelUserTasksBasedOnCollection.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/multiinstance/DynamicMultiInstanceTest.testParallelUserTasksBasedOnCollection.bpmn20.xml
@@ -1,26 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions id="definition" 
-  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns:activiti="http://activiti.org/bpmn"
-  targetNamespace="Examples">
-  
-  <process id="miParallelUserTasksBasedOnCollection">
-  
-    <startEvent id="theStart" />
-    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="miTasks" />
-    
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="Examples" id="definition">
+  <process id="miParallelUserTasksBasedOnCollection" isExecutable="true">
+    <startEvent id="theStart"></startEvent>
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="miTasks"></sequenceFlow>
     <userTask id="miTasks" name="My Task ${loopCounter}" activiti:assignee="${assignee}">
-      <multiInstanceLoopCharacteristics isSequential="false">
-        <loopDataInputRef>assigneeList</loopDataInputRef>
-        <inputDataItem name="assignee" />
-        <completionCondition>${nrOfCompletedInstances/nrOfInstances >= 0.6 }</completionCondition>
+      <multiInstanceLoopCharacteristics isSequential="false" activiti:collection="${assigneeList}" activiti:elementVariable="assignee">
+        <completionCondition>${nrOfCompletedInstances/nrOfInstances &gt;= 0.6 }</completionCondition>
       </multiInstanceLoopCharacteristics>
     </userTask>
-    
-    <sequenceFlow id="flow3" sourceRef="miTasks" targetRef="theEnd" />
-    <endEvent id="theEnd" />
-    
+    <sequenceFlow id="flow3" sourceRef="miTasks" targetRef="theEnd"></sequenceFlow>
+    <endEvent id="theEnd"></endEvent>
   </process>
-
+  <bpmndi:BPMNDiagram id="BPMNDiagram_miParallelUserTasksBasedOnCollection">
+    <bpmndi:BPMNPlane bpmnElement="miParallelUserTasksBasedOnCollection" id="BPMNPlane_miParallelUserTasksBasedOnCollection">
+      <bpmndi:BPMNShape bpmnElement="theStart" id="BPMNShape_theStart">
+        <omgdc:Bounds height="35.0" width="35.0" x="0.0" y="15.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="miTasks" id="BPMNShape_miTasks">
+        <omgdc:Bounds height="60.0" width="100.0" x="80.0" y="0.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="theEnd" id="BPMNShape_theEnd">
+        <omgdc:Bounds height="35.0" width="35.0" x="230.0" y="15.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="flow1" id="BPMNEdge_flow1">
+        <omgdi:waypoint x="35.0" y="32.0"></omgdi:waypoint>
+        <omgdi:waypoint x="42.0" y="30.0"></omgdi:waypoint>
+        <omgdi:waypoint x="42.0" y="30.0"></omgdi:waypoint>
+        <omgdi:waypoint x="80.0" y="30.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="flow3" id="BPMNEdge_flow3">
+        <omgdi:waypoint x="180.0" y="30.0"></omgdi:waypoint>
+        <omgdi:waypoint x="192.0" y="30.0"></omgdi:waypoint>
+        <omgdi:waypoint x="192.0" y="30.0"></omgdi:waypoint>
+        <omgdi:waypoint x="230.0" y="32.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
 </definitions>

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.callActivityWithBoundaryErrorEvent.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.callActivityWithBoundaryErrorEvent.bpmn20.xml
@@ -1,36 +1,63 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions id="definition" 
-  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns:activiti="http://activiti.org/bpmn"
-  targetNamespace="Examples">
-  
-  <process id="process" name="process1">
-  
-    <startEvent id="startevent1" name="Start" />
-    
-    <callActivity id="callActivity1" name="Call activity" calledElement="callActivityProcess">
-      <multiInstanceLoopCharacteristics isSequential="false" activiti:collection="assignees" activiti:elementVariable="assignee"></multiInstanceLoopCharacteristics>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="Examples" id="definition">
+  <process id="process" name="process1" isExecutable="true">
+    <startEvent id="startevent1" name="Start"></startEvent>
+    <callActivity id="callActivity1" name="Call activity" calledElement="callActivityProcess" activiti:inheritVariables="false">
+      <multiInstanceLoopCharacteristics isSequential="false" activiti:collection="${assignees}" activiti:elementVariable="assignee"></multiInstanceLoopCharacteristics>
     </callActivity>
-    
-    <boundaryEvent id="boundaryerror1" cancelActivity="true" attachedToRef="callActivity1">
+    <boundaryEvent id="boundaryerror1" attachedToRef="callActivity1">
       <errorEventDefinition errorRef="errorId1"></errorEventDefinition>
     </boundaryEvent>
-    
-    <sequenceFlow id="flow1" name="" sourceRef="startevent1" targetRef="callActivity1" />
-    
-    <endEvent id="endevent1" name="End" />
-    
-    <sequenceFlow id="flow2" name="" sourceRef="callActivity1" targetRef="endevent1"/>
-    
-    <userTask id="handleErrorTask" name="Handle Error"/>
-    
-    <sequenceFlow id="flow3" name="" sourceRef="boundaryerror1" targetRef="handleErrorTask"/>
-    
-    <endEvent id="endevent2" name="End"/>
-    
-    <sequenceFlow id="flow4" name="" sourceRef="handleErrorTask" targetRef="endevent2"/>
-    
+    <sequenceFlow id="flow1" sourceRef="startevent1" targetRef="callActivity1"></sequenceFlow>
+    <endEvent id="endevent1" name="End"></endEvent>
+    <sequenceFlow id="flow2" sourceRef="callActivity1" targetRef="endevent1"></sequenceFlow>
+    <userTask id="handleErrorTask" name="Handle Error"></userTask>
+    <sequenceFlow id="flow3" sourceRef="boundaryerror1" targetRef="handleErrorTask"></sequenceFlow>
+    <endEvent id="endevent2" name="End"></endEvent>
+    <sequenceFlow id="flow4" sourceRef="handleErrorTask" targetRef="endevent2"></sequenceFlow>
   </process>
-  
+  <bpmndi:BPMNDiagram id="BPMNDiagram_process">
+    <bpmndi:BPMNPlane bpmnElement="process" id="BPMNPlane_process">
+      <bpmndi:BPMNShape bpmnElement="startevent1" id="BPMNShape_startevent1">
+        <omgdc:Bounds height="35.0" width="35.0" x="0.0" y="15.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="callActivity1" id="BPMNShape_callActivity1">
+        <omgdc:Bounds height="60.0" width="100.0" x="80.0" y="0.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="boundaryerror1" id="BPMNShape_boundaryerror1">
+        <omgdc:Bounds height="30.0" width="30.0" x="145.0" y="45.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="endevent1" id="BPMNShape_endevent1">
+        <omgdc:Bounds height="35.0" width="35.0" x="230.0" y="15.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="handleErrorTask" id="BPMNShape_handleErrorTask">
+        <omgdc:Bounds height="60.0" width="100.0" x="0.0" y="120.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="endevent2" id="BPMNShape_endevent2">
+        <omgdc:Bounds height="35.0" width="35.0" x="150.0" y="135.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="flow1" id="BPMNEdge_flow1">
+        <omgdi:waypoint x="35.0" y="32.0"></omgdi:waypoint>
+        <omgdi:waypoint x="42.0" y="30.0"></omgdi:waypoint>
+        <omgdi:waypoint x="42.0" y="30.0"></omgdi:waypoint>
+        <omgdi:waypoint x="80.0" y="30.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="flow2" id="BPMNEdge_flow2">
+        <omgdi:waypoint x="180.0" y="30.0"></omgdi:waypoint>
+        <omgdi:waypoint x="192.0" y="30.0"></omgdi:waypoint>
+        <omgdi:waypoint x="192.0" y="30.0"></omgdi:waypoint>
+        <omgdi:waypoint x="230.0" y="32.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="flow3" id="BPMNEdge_flow3">
+        <omgdi:waypoint x="160.0" y="75.0"></omgdi:waypoint>
+        <omgdi:waypoint x="160.0" y="190.0"></omgdi:waypoint>
+        <omgdi:waypoint x="50.0" y="190.0"></omgdi:waypoint>
+        <omgdi:waypoint x="50.0" y="180.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="flow4" id="BPMNEdge_flow4">
+        <omgdi:waypoint x="100.0" y="150.0"></omgdi:waypoint>
+        <omgdi:waypoint x="150.0" y="152.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
 </definitions>

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.callActivityWithBoundaryErrorEventSequential.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.callActivityWithBoundaryErrorEventSequential.bpmn20.xml
@@ -1,36 +1,63 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions id="definition" 
-  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns:activiti="http://activiti.org/bpmn"
-  targetNamespace="Examples">
-  
-  <process id="process" name="process1">
-  
-    <startEvent id="startevent1" name="Start" />
-    
-    <callActivity id="callActivity1" name="Call activity" calledElement="callActivityProcess">
-      <multiInstanceLoopCharacteristics isSequential="true" activiti:collection="assignees" activiti:elementVariable="assignee"></multiInstanceLoopCharacteristics>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="Examples" id="definition">
+  <process id="process" name="process1" isExecutable="true">
+    <startEvent id="startevent1" name="Start"></startEvent>
+    <callActivity id="callActivity1" name="Call activity" calledElement="callActivityProcess" activiti:inheritVariables="false">
+      <multiInstanceLoopCharacteristics isSequential="true" activiti:collection="${assignees}" activiti:elementVariable="assignee"></multiInstanceLoopCharacteristics>
     </callActivity>
-    
-    <boundaryEvent id="boundaryerror1" cancelActivity="true" attachedToRef="callActivity1">
+    <boundaryEvent id="boundaryerror1" attachedToRef="callActivity1">
       <errorEventDefinition errorRef="errorId1"></errorEventDefinition>
     </boundaryEvent>
-    
-    <sequenceFlow id="flow1" name="" sourceRef="startevent1" targetRef="callActivity1" />
-    
-    <endEvent id="endevent1" name="End" />
-    
-    <sequenceFlow id="flow2" name="" sourceRef="callActivity1" targetRef="endevent1"/>
-    
-    <userTask id="handleErrorTask" name="Handle Error"/>
-    
-    <sequenceFlow id="flow3" name="" sourceRef="boundaryerror1" targetRef="handleErrorTask"/>
-    
-    <endEvent id="endevent2" name="End"/>
-    
-    <sequenceFlow id="flow4" name="" sourceRef="handleErrorTask" targetRef="endevent2"/>
-    
+    <sequenceFlow id="flow1" sourceRef="startevent1" targetRef="callActivity1"></sequenceFlow>
+    <endEvent id="endevent1" name="End"></endEvent>
+    <sequenceFlow id="flow2" sourceRef="callActivity1" targetRef="endevent1"></sequenceFlow>
+    <userTask id="handleErrorTask" name="Handle Error"></userTask>
+    <sequenceFlow id="flow3" sourceRef="boundaryerror1" targetRef="handleErrorTask"></sequenceFlow>
+    <endEvent id="endevent2" name="End"></endEvent>
+    <sequenceFlow id="flow4" sourceRef="handleErrorTask" targetRef="endevent2"></sequenceFlow>
   </process>
-  
+  <bpmndi:BPMNDiagram id="BPMNDiagram_process">
+    <bpmndi:BPMNPlane bpmnElement="process" id="BPMNPlane_process">
+      <bpmndi:BPMNShape bpmnElement="startevent1" id="BPMNShape_startevent1">
+        <omgdc:Bounds height="35.0" width="35.0" x="0.0" y="15.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="callActivity1" id="BPMNShape_callActivity1">
+        <omgdc:Bounds height="60.0" width="100.0" x="80.0" y="0.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="boundaryerror1" id="BPMNShape_boundaryerror1">
+        <omgdc:Bounds height="30.0" width="30.0" x="145.0" y="45.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="endevent1" id="BPMNShape_endevent1">
+        <omgdc:Bounds height="35.0" width="35.0" x="230.0" y="15.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="handleErrorTask" id="BPMNShape_handleErrorTask">
+        <omgdc:Bounds height="60.0" width="100.0" x="0.0" y="120.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="endevent2" id="BPMNShape_endevent2">
+        <omgdc:Bounds height="35.0" width="35.0" x="150.0" y="135.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="flow1" id="BPMNEdge_flow1">
+        <omgdi:waypoint x="35.0" y="32.0"></omgdi:waypoint>
+        <omgdi:waypoint x="42.0" y="30.0"></omgdi:waypoint>
+        <omgdi:waypoint x="42.0" y="30.0"></omgdi:waypoint>
+        <omgdi:waypoint x="80.0" y="30.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="flow2" id="BPMNEdge_flow2">
+        <omgdi:waypoint x="180.0" y="30.0"></omgdi:waypoint>
+        <omgdi:waypoint x="192.0" y="30.0"></omgdi:waypoint>
+        <omgdi:waypoint x="192.0" y="30.0"></omgdi:waypoint>
+        <omgdi:waypoint x="230.0" y="32.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="flow3" id="BPMNEdge_flow3">
+        <omgdi:waypoint x="160.0" y="75.0"></omgdi:waypoint>
+        <omgdi:waypoint x="160.0" y="190.0"></omgdi:waypoint>
+        <omgdi:waypoint x="50.0" y="190.0"></omgdi:waypoint>
+        <omgdi:waypoint x="50.0" y="180.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="flow4" id="BPMNEdge_flow4">
+        <omgdi:waypoint x="100.0" y="150.0"></omgdi:waypoint>
+        <omgdi:waypoint x="150.0" y="152.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
 </definitions>

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testChangingCollection.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testChangingCollection.bpmn20.xml
@@ -4,7 +4,7 @@
     <startEvent id="start" name="Start"></startEvent>
     <endEvent id="end" name="End"></endEvent>
     <userTask id="multi" name="Multi">
-      <multiInstanceLoopCharacteristics isSequential="false" activiti:collection="multi_users" activiti:elementVariable="assignee"></multiInstanceLoopCharacteristics>
+      <multiInstanceLoopCharacteristics isSequential="false" activiti:collection="${multi_users}" activiti:elementVariable="assignee"></multiInstanceLoopCharacteristics>
     </userTask>
     <sequenceFlow id="flow1" sourceRef="start" targetRef="multi"></sequenceFlow>
     <sequenceFlow id="flow2" sourceRef="multi" targetRef="end"></sequenceFlow>

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testExecutionListenersOnMultiInstanceSubprocess.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testExecutionListenersOnMultiInstanceSubprocess.bpmn20.xml
@@ -1,26 +1,55 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:activiti="http://activiti.org/bpmn"
-	typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath"
-	targetNamespace="http://www.activiti.org/test">
-	<process id="MultiInstanceTest" name="MultiInstanceTest">
-		<documentation>Place documentation for the 'MultiInstanceTest' processhere.</documentation>
-		<startEvent id="startevent1" name="Start"></startEvent>
-		<subProcess id="subprocess1" name="Sub Process">
-			<extensionElements>
-				<activiti:executionListener event="start" class="org.flowable.engine.test.bpmn.multiinstance.MultiInstanceTest$TestStartExecutionListener"></activiti:executionListener>
-				<activiti:executionListener event="end" class="org.flowable.engine.test.bpmn.multiinstance.MultiInstanceTest$TestEndExecutionListener"></activiti:executionListener>
-			</extensionElements>
-			<multiInstanceLoopCharacteristics isSequential="false">
-				<loopDataInputRef>assignees</loopDataInputRef>
-				<inputDataItem name="assignee"></inputDataItem>
-			</multiInstanceLoopCharacteristics>
-			<startEvent id="startevent2" name="Start"></startEvent>
-			<endEvent id="endevent2" name="End"></endEvent>
-			<sequenceFlow id="flow3" name="" sourceRef="startevent2" targetRef="endevent2"></sequenceFlow>
-		</subProcess>
-		<endEvent id="endevent1" name="End"></endEvent>
-		<sequenceFlow id="flow1" name="" sourceRef="startevent1" targetRef="subprocess1"></sequenceFlow>
-		<sequenceFlow id="flow2" name="" sourceRef="subprocess1" targetRef="endevent1"></sequenceFlow>
-	</process>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://www.activiti.org/test">
+  <process id="MultiInstanceTest" name="MultiInstanceTest" isExecutable="true">
+    <documentation>Place documentation for the 'MultiInstanceTest' processhere.</documentation>
+    <startEvent id="startevent1" name="Start"></startEvent>
+    <subProcess id="subprocess1" name="Sub Process">
+      <extensionElements>
+        <activiti:executionListener event="start" class="org.flowable.engine.test.bpmn.multiinstance.MultiInstanceTest$TestStartExecutionListener"></activiti:executionListener>
+        <activiti:executionListener event="end" class="org.flowable.engine.test.bpmn.multiinstance.MultiInstanceTest$TestEndExecutionListener"></activiti:executionListener>
+      </extensionElements>
+      <multiInstanceLoopCharacteristics isSequential="false" activiti:collection="${assignees}" activiti:elementVariable="assignee"></multiInstanceLoopCharacteristics>
+      <startEvent id="startevent2" name="Start"></startEvent>
+      <endEvent id="endevent2" name="End"></endEvent>
+      <sequenceFlow id="flow3" sourceRef="startevent2" targetRef="endevent2"></sequenceFlow>
+    </subProcess>
+    <endEvent id="endevent1" name="End"></endEvent>
+    <sequenceFlow id="flow1" sourceRef="startevent1" targetRef="subprocess1"></sequenceFlow>
+    <sequenceFlow id="flow2" sourceRef="subprocess1" targetRef="endevent1"></sequenceFlow>
+  </process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_MultiInstanceTest">
+    <bpmndi:BPMNPlane bpmnElement="MultiInstanceTest" id="BPMNPlane_MultiInstanceTest">
+      <bpmndi:BPMNShape bpmnElement="startevent1" id="BPMNShape_startevent1">
+        <omgdc:Bounds height="35.0" width="35.0" x="0.0" y="20.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="subprocess1" id="BPMNShape_subprocess1">
+        <omgdc:Bounds height="70.0" width="150.0" x="80.0" y="0.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="startevent2" id="BPMNShape_startevent2">
+        <omgdc:Bounds height="35.0" width="35.0" x="100.0" y="20.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="endevent2" id="BPMNShape_endevent2">
+        <omgdc:Bounds height="35.0" width="35.0" x="180.0" y="20.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="endevent1" id="BPMNShape_endevent1">
+        <omgdc:Bounds height="35.0" width="35.0" x="280.0" y="20.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="flow3" id="BPMNEdge_flow3">
+        <omgdi:waypoint x="135.0" y="37.0"></omgdi:waypoint>
+        <omgdi:waypoint x="142.0" y="35.0"></omgdi:waypoint>
+        <omgdi:waypoint x="142.0" y="35.0"></omgdi:waypoint>
+        <omgdi:waypoint x="180.0" y="37.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="flow1" id="BPMNEdge_flow1">
+        <omgdi:waypoint x="35.0" y="37.0"></omgdi:waypoint>
+        <omgdi:waypoint x="42.0" y="35.0"></omgdi:waypoint>
+        <omgdi:waypoint x="42.0" y="35.0"></omgdi:waypoint>
+        <omgdi:waypoint x="80.0" y="35.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="flow2" id="BPMNEdge_flow2">
+        <omgdi:waypoint x="230.0" y="35.0"></omgdi:waypoint>
+        <omgdi:waypoint x="280.0" y="37.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
 </definitions>

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testInfiniteLoopWithDelegateExpressionFix.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testInfiniteLoopWithDelegateExpressionFix.bpmn20.xml
@@ -1,47 +1,32 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" xmlns:tns="http://www.activiti.org/test" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" expressionLanguage="http://www.w3.org/1999/XPath" id="m1417526206910" name="" targetNamespace="http://www.activiti.org/test" typeLanguage="http://www.w3.org/2001/XMLSchema">
-  <process id="infiniteLoopTest" isClosed="false" isExecutable="true" name="Infinite Loop Test" processType="None">
-    <startEvent id="_2" name="StartEvent"/>
-    <serviceTask activiti:delegateExpression="${SampleTask}" activiti:exclusive="true" id="_3" name="ServiceTask">
-      <multiInstanceLoopCharacteristics activiti:collection="sampleValues" activiti:elementVariable="value" isSequential="false"/>
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" xmlns:tns="http://www.activiti.org/test" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://www.activiti.org/test" id="m1417526206910" name="">
+  <process id="infiniteLoopTest" name="Infinite Loop Test" isExecutable="true" isClosed="false" processType="None">
+    <startEvent id="_2" name="StartEvent"></startEvent>
+    <serviceTask id="_3" name="ServiceTask" activiti:delegateExpression="${SampleTask}">
+      <multiInstanceLoopCharacteristics isSequential="false" activiti:collection="${sampleValues}" activiti:elementVariable="value"></multiInstanceLoopCharacteristics>
     </serviceTask>
-    <endEvent id="_5" name="EndEvent"/>
-    <sequenceFlow id="_37" sourceRef="_2" targetRef="_3"/>
-    <sequenceFlow id="_38" sourceRef="_3" targetRef="_5"/>
+    <endEvent id="_5" name="EndEvent"></endEvent>
+    <sequenceFlow id="_37" sourceRef="_2" targetRef="_3"></sequenceFlow>
+    <sequenceFlow id="_38" sourceRef="_3" targetRef="_5"></sequenceFlow>
   </process>
-  <bpmndi:BPMNDiagram documentation="background=#FFFFFF;count=1;horizontalcount=1;orientation=0;width=842.4;height=1195.2;imageableWidth=832.4;imageableHeight=1185.2;imageableX=5.0;imageableY=5.0" id="Diagram-_1" name="New Diagram">
-    <bpmndi:BPMNPlane bpmnElement="infiniteLoopTest">
-      <bpmndi:BPMNShape bpmnElement="_2" id="Shape-_2">
-        <omgdc:Bounds height="32.0" width="32.0" x="75.0" y="285.0"/>
-        <bpmndi:BPMNLabel>
-          <omgdc:Bounds height="32.0" width="32.0" x="0.0" y="0.0"/>
-        </bpmndi:BPMNLabel>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_infiniteLoopTest">
+    <bpmndi:BPMNPlane bpmnElement="infiniteLoopTest" id="BPMNPlane_infiniteLoopTest">
+      <bpmndi:BPMNShape bpmnElement="_2" id="BPMNShape__2">
+        <omgdc:Bounds height="35.0" width="35.0" x="75.0" y="285.0"></omgdc:Bounds>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape bpmnElement="_3" id="Shape-_3">
-        <omgdc:Bounds height="85.0" width="100.0" x="270.0" y="250.0"/>
-        <bpmndi:BPMNLabel>
-          <omgdc:Bounds height="85.0" width="100.0" x="0.0" y="0.0"/>
-        </bpmndi:BPMNLabel>
+      <bpmndi:BPMNShape bpmnElement="_3" id="BPMNShape__3">
+        <omgdc:Bounds height="85.0" width="100.0" x="270.0" y="250.0"></omgdc:Bounds>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape bpmnElement="_5" id="Shape-_5">
-        <omgdc:Bounds height="32.0" width="32.0" x="485.0" y="275.0"/>
-        <bpmndi:BPMNLabel>
-          <omgdc:Bounds height="32.0" width="32.0" x="0.0" y="0.0"/>
-        </bpmndi:BPMNLabel>
+      <bpmndi:BPMNShape bpmnElement="_5" id="BPMNShape__5">
+        <omgdc:Bounds height="35.0" width="35.0" x="485.0" y="275.0"></omgdc:Bounds>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge bpmnElement="_37" id="BPMNEdge__37" sourceElement="_2" targetElement="_3">
-        <omgdi:waypoint x="107.0" y="301.0"/>
-        <omgdi:waypoint x="270.0" y="292.5"/>
-        <bpmndi:BPMNLabel>
-          <omgdc:Bounds height="0.0" width="0.0" x="0.0" y="0.0"/>
-        </bpmndi:BPMNLabel>
+      <bpmndi:BPMNEdge bpmnElement="_37" id="BPMNEdge__37">
+        <omgdi:waypoint x="110.0" y="302.0"></omgdi:waypoint>
+        <omgdi:waypoint x="270.0" y="292.0"></omgdi:waypoint>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge bpmnElement="_38" id="BPMNEdge__38" sourceElement="_3" targetElement="_5">
-        <omgdi:waypoint x="370.0" y="292.5"/>
-        <omgdi:waypoint x="485.0" y="291.0"/>
-        <bpmndi:BPMNLabel>
-          <omgdc:Bounds height="0.0" width="0.0" x="0.0" y="0.0"/>
-        </bpmndi:BPMNLabel>
+      <bpmndi:BPMNEdge bpmnElement="_38" id="BPMNEdge__38">
+        <omgdi:waypoint x="370.0" y="292.0"></omgdi:waypoint>
+        <omgdi:waypoint x="485.0" y="292.0"></omgdi:waypoint>
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testNestedMultiInstanceTasks.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testNestedMultiInstanceTasks.bpmn20.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="Examples">
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="Examples">
   <process id="miNestedMultiInstanceTasks" isExecutable="true">
     <startEvent id="theStart"></startEvent>
     <sequenceFlow id="flow1" sourceRef="theStart" targetRef="subprocess1"></sequenceFlow>
     <sequenceFlow id="flow3" sourceRef="subprocess1" targetRef="theEnd"></sequenceFlow>
     <endEvent id="theEnd"></endEvent>
     <subProcess id="subprocess1" name="${subProcess}">
-      <multiInstanceLoopCharacteristics isSequential="false" activiti:collection="subProcesses" activiti:elementVariable="subProcess"></multiInstanceLoopCharacteristics>
+      <multiInstanceLoopCharacteristics isSequential="false" activiti:collection="${subProcesses}" activiti:elementVariable="subProcess"></multiInstanceLoopCharacteristics>
       <startEvent id="startevent1" name="Start"></startEvent>
       <endEvent id="endevent1" name="End"></endEvent>
       <userTask id="miTasks" name="My Task ${loopCounter}" activiti:assignee="kermit_${loopCounter}">
-        <multiInstanceLoopCharacteristics isSequential="false" activiti:collection="assignees" activiti:elementVariable="assignee"></multiInstanceLoopCharacteristics>
+        <multiInstanceLoopCharacteristics isSequential="false" activiti:collection="${assignees}" activiti:elementVariable="assignee"></multiInstanceLoopCharacteristics>
       </userTask>
       <sequenceFlow id="flow4" sourceRef="startevent1" targetRef="miTasks"></sequenceFlow>
       <sequenceFlow id="flow5" sourceRef="miTasks" targetRef="endevent1"></sequenceFlow>
@@ -18,40 +18,40 @@
   </process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_miNestedMultiInstanceTasks">
     <bpmndi:BPMNPlane bpmnElement="miNestedMultiInstanceTasks" id="BPMNPlane_miNestedMultiInstanceTasks">
-      <bpmndi:BPMNShape bpmnElement="miTasks" id="BPMNShape_miTasks">
-        <omgdc:Bounds height="60.0" width="100.0" x="180.0" y="82.0"></omgdc:Bounds>
+      <bpmndi:BPMNShape bpmnElement="theStart" id="BPMNShape_theStart">
+        <omgdc:Bounds height="35.0" width="35.0" x="1.0" y="94.0"></omgdc:Bounds>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape bpmnElement="theEnd" id="BPMNShape_theEnd">
-        <omgdc:Bounds height="35.0" width="35.0" x="440.0" y="100.0"></omgdc:Bounds>
+        <omgdc:Bounds height="35.0" width="35.0" x="451.0" y="100.0"></omgdc:Bounds>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape bpmnElement="theStart" id="BPMNShape_theStart">
-        <omgdc:Bounds height="35.0" width="35.0" x="-10.0" y="94.0"></omgdc:Bounds>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape bpmnElement="subprocess1" id="BPMNShape_subprocess1" isExpanded="false">
-        <omgdc:Bounds height="171.0" width="291.0" x="90.0" y="24.0"></omgdc:Bounds>
+      <bpmndi:BPMNShape bpmnElement="subprocess1" id="BPMNShape_subprocess1">
+        <omgdc:Bounds height="171.0" width="291.0" x="101.0" y="24.0"></omgdc:Bounds>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape bpmnElement="startevent1" id="BPMNShape_startevent1">
-        <omgdc:Bounds height="35.0" width="35.0" x="110.0" y="94.0"></omgdc:Bounds>
+        <omgdc:Bounds height="35.0" width="35.0" x="121.0" y="94.0"></omgdc:Bounds>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape bpmnElement="endevent1" id="BPMNShape_endevent1">
-        <omgdc:Bounds height="35.0" width="35.0" x="330.0" y="94.0"></omgdc:Bounds>
+        <omgdc:Bounds height="35.0" width="35.0" x="341.0" y="94.0"></omgdc:Bounds>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge bpmnElement="flow3" id="BPMNEdge_flow3">
-        <omgdi:waypoint x="381.0" y="109.0"></omgdi:waypoint>
-        <omgdi:waypoint x="440.0" y="117.0"></omgdi:waypoint>
-      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape bpmnElement="miTasks" id="BPMNShape_miTasks">
+        <omgdc:Bounds height="60.0" width="100.0" x="191.0" y="82.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge bpmnElement="flow1" id="BPMNEdge_flow1">
-        <omgdi:waypoint x="25.0" y="111.0"></omgdi:waypoint>
-        <omgdi:waypoint x="42.0" y="107.0"></omgdi:waypoint>
-        <omgdi:waypoint x="90.0" y="109.0"></omgdi:waypoint>
+        <omgdi:waypoint x="36.0" y="111.0"></omgdi:waypoint>
+        <omgdi:waypoint x="53.0" y="107.0"></omgdi:waypoint>
+        <omgdi:waypoint x="101.0" y="109.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="flow3" id="BPMNEdge_flow3">
+        <omgdi:waypoint x="392.0" y="109.0"></omgdi:waypoint>
+        <omgdi:waypoint x="451.0" y="117.0"></omgdi:waypoint>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge bpmnElement="flow4" id="BPMNEdge_flow4">
-        <omgdi:waypoint x="145.0" y="111.0"></omgdi:waypoint>
-        <omgdi:waypoint x="180.0" y="112.0"></omgdi:waypoint>
+        <omgdi:waypoint x="156.0" y="111.0"></omgdi:waypoint>
+        <omgdi:waypoint x="191.0" y="112.0"></omgdi:waypoint>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge bpmnElement="flow5" id="BPMNEdge_flow5">
-        <omgdi:waypoint x="280.0" y="112.0"></omgdi:waypoint>
-        <omgdi:waypoint x="330.0" y="111.0"></omgdi:waypoint>
+        <omgdi:waypoint x="291.0" y="112.0"></omgdi:waypoint>
+        <omgdi:waypoint x="341.0" y="111.0"></omgdi:waypoint>
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testParallelEmptyCollection.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testParallelEmptyCollection.bpmn20.xml
@@ -6,7 +6,7 @@
     <sequenceFlow id="flow2" sourceRef="usertask1" targetRef="end"></sequenceFlow>
     <endEvent id="end"></endEvent>
     <userTask id="usertask1" name="Multi">
-      <multiInstanceLoopCharacteristics isSequential="true" activiti:collection="collection"></multiInstanceLoopCharacteristics>
+      <multiInstanceLoopCharacteristics isSequential="true" activiti:collection="${collection}"></multiInstanceLoopCharacteristics>
     </userTask>
   </process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_testParalellEmptyCollection">

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testParallelUserTasksBasedOnCollection.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testParallelUserTasksBasedOnCollection.bpmn20.xml
@@ -1,26 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions id="definition" 
-  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns:activiti="http://activiti.org/bpmn"
-  targetNamespace="Examples">
-  
-  <process id="miParallelUserTasksBasedOnCollection">
-  
-    <startEvent id="theStart" />
-    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="miTasks" />
-    
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="Examples" id="definition">
+  <process id="miParallelUserTasksBasedOnCollection" isExecutable="true">
+    <startEvent id="theStart"></startEvent>
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="miTasks"></sequenceFlow>
     <userTask id="miTasks" name="My Task ${loopCounter}" activiti:assignee="${assignee}">
-      <multiInstanceLoopCharacteristics isSequential="false">
-        <loopDataInputRef>assigneeList</loopDataInputRef>
-        <inputDataItem name="assignee" />
-        <completionCondition>${nrOfCompletedInstances/nrOfInstances >= 0.6 }</completionCondition>
+      <multiInstanceLoopCharacteristics isSequential="false" activiti:collection="${assigneeList}" activiti:elementVariable="assignee">
+        <completionCondition>${nrOfCompletedInstances/nrOfInstances &gt;= 0.6 }</completionCondition>
       </multiInstanceLoopCharacteristics>
     </userTask>
-    
-    <sequenceFlow id="flow3" sourceRef="miTasks" targetRef="theEnd" />
-    <endEvent id="theEnd" />
-    
+    <sequenceFlow id="flow3" sourceRef="miTasks" targetRef="theEnd"></sequenceFlow>
+    <endEvent id="theEnd"></endEvent>
   </process>
-
+  <bpmndi:BPMNDiagram id="BPMNDiagram_miParallelUserTasksBasedOnCollection">
+    <bpmndi:BPMNPlane bpmnElement="miParallelUserTasksBasedOnCollection" id="BPMNPlane_miParallelUserTasksBasedOnCollection">
+      <bpmndi:BPMNShape bpmnElement="theStart" id="BPMNShape_theStart">
+        <omgdc:Bounds height="35.0" width="35.0" x="0.0" y="15.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="miTasks" id="BPMNShape_miTasks">
+        <omgdc:Bounds height="60.0" width="100.0" x="80.0" y="0.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="theEnd" id="BPMNShape_theEnd">
+        <omgdc:Bounds height="35.0" width="35.0" x="230.0" y="15.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="flow1" id="BPMNEdge_flow1">
+        <omgdi:waypoint x="35.0" y="32.0"></omgdi:waypoint>
+        <omgdi:waypoint x="42.0" y="30.0"></omgdi:waypoint>
+        <omgdi:waypoint x="42.0" y="30.0"></omgdi:waypoint>
+        <omgdi:waypoint x="80.0" y="30.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="flow3" id="BPMNEdge_flow3">
+        <omgdi:waypoint x="180.0" y="30.0"></omgdi:waypoint>
+        <omgdi:waypoint x="192.0" y="30.0"></omgdi:waypoint>
+        <omgdi:waypoint x="192.0" y="30.0"></omgdi:waypoint>
+        <omgdi:waypoint x="230.0" y="32.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
 </definitions>

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testParallelUserTasksCustomExtensions.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testParallelUserTasksCustomExtensions.bpmn20.xml
@@ -1,24 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions id="definition" 
-  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns:activiti="http://activiti.org/bpmn"
-  targetNamespace="Examples">
-  
-  <process id="miParallelUserTasks">
-  
-    <startEvent id="theStart" />
-    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="miTasks" />
-    
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="Examples" id="definition">
+  <process id="miParallelUserTasks" isExecutable="true">
+    <startEvent id="theStart"></startEvent>
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="miTasks"></sequenceFlow>
     <userTask id="miTasks" name="My Task ${loopCounter}" activiti:assignee="${assignee}">
-      <multiInstanceLoopCharacteristics isSequential="false"
-          activiti:collection="assigneeList" activiti:elementVariable="assignee">
-      </multiInstanceLoopCharacteristics>
+      <multiInstanceLoopCharacteristics isSequential="false" activiti:collection="${assigneeList}" activiti:elementVariable="assignee"></multiInstanceLoopCharacteristics>
     </userTask>
-    
-    <sequenceFlow id="flow3" sourceRef="miTasks" targetRef="theEnd" />
-    <endEvent id="theEnd" />
-    
+    <sequenceFlow id="flow3" sourceRef="miTasks" targetRef="theEnd"></sequenceFlow>
+    <endEvent id="theEnd"></endEvent>
   </process>
-
+  <bpmndi:BPMNDiagram id="BPMNDiagram_miParallelUserTasks">
+    <bpmndi:BPMNPlane bpmnElement="miParallelUserTasks" id="BPMNPlane_miParallelUserTasks">
+      <bpmndi:BPMNShape bpmnElement="theStart" id="BPMNShape_theStart">
+        <omgdc:Bounds height="35.0" width="35.0" x="0.0" y="15.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="miTasks" id="BPMNShape_miTasks">
+        <omgdc:Bounds height="60.0" width="100.0" x="80.0" y="0.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="theEnd" id="BPMNShape_theEnd">
+        <omgdc:Bounds height="35.0" width="35.0" x="230.0" y="15.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="flow1" id="BPMNEdge_flow1">
+        <omgdi:waypoint x="35.0" y="32.0"></omgdi:waypoint>
+        <omgdi:waypoint x="42.0" y="30.0"></omgdi:waypoint>
+        <omgdi:waypoint x="42.0" y="30.0"></omgdi:waypoint>
+        <omgdi:waypoint x="80.0" y="30.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="flow3" id="BPMNEdge_flow3">
+        <omgdi:waypoint x="180.0" y="30.0"></omgdi:waypoint>
+        <omgdi:waypoint x="192.0" y="30.0"></omgdi:waypoint>
+        <omgdi:waypoint x="192.0" y="30.0"></omgdi:waypoint>
+        <omgdi:waypoint x="230.0" y="32.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
 </definitions>

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testParallelUserTasksCustomExtensionsLoopIndexVariable.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testParallelUserTasksCustomExtensionsLoopIndexVariable.bpmn20.xml
@@ -1,37 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="Examples" id="definition">
-  <process id="miParallelUserTasksLoopVariable" isExecutable="true">
-    <startEvent id="theStart"></startEvent>
-    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="miTasks"></sequenceFlow>
-    <userTask id="miTasks" name="My Task ${loopValueIndex}" activiti:assignee="${assignee}">
-      <multiInstanceLoopCharacteristics isSequential="false" activiti:collection="${assigneeList}" activiti:elementVariable="assignee"></multiInstanceLoopCharacteristics>
+<definitions id="definition" 
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:activiti="http://activiti.org/bpmn"
+  targetNamespace="Examples">
+  
+  <process id="miParallelUserTasksLoopVariable">
+  
+    <startEvent id="theStart" />
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="miTasks" />
+    
+    <userTask id="miTasks" name="My Task ${loopValueIndex}" activiti:assignee="${assignee}" >
+      <multiInstanceLoopCharacteristics isSequential="false"
+              activiti:collection="${assigneeList}" activiti:elementVariable="assignee"
+              activiti:elementIndexVariable="loopValueIndex"/>
     </userTask>
-    <sequenceFlow id="flow3" sourceRef="miTasks" targetRef="theEnd"></sequenceFlow>
-    <endEvent id="theEnd"></endEvent>
+    
+    <sequenceFlow id="flow3" sourceRef="miTasks" targetRef="theEnd" />
+    <endEvent id="theEnd" />
+    
   </process>
-  <bpmndi:BPMNDiagram id="BPMNDiagram_miParallelUserTasksLoopVariable">
-    <bpmndi:BPMNPlane bpmnElement="miParallelUserTasksLoopVariable" id="BPMNPlane_miParallelUserTasksLoopVariable">
-      <bpmndi:BPMNShape bpmnElement="theStart" id="BPMNShape_theStart">
-        <omgdc:Bounds height="35.0" width="35.0" x="0.0" y="15.0"></omgdc:Bounds>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape bpmnElement="miTasks" id="BPMNShape_miTasks">
-        <omgdc:Bounds height="60.0" width="100.0" x="80.0" y="0.0"></omgdc:Bounds>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape bpmnElement="theEnd" id="BPMNShape_theEnd">
-        <omgdc:Bounds height="35.0" width="35.0" x="230.0" y="15.0"></omgdc:Bounds>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge bpmnElement="flow1" id="BPMNEdge_flow1">
-        <omgdi:waypoint x="35.0" y="32.0"></omgdi:waypoint>
-        <omgdi:waypoint x="42.0" y="30.0"></omgdi:waypoint>
-        <omgdi:waypoint x="42.0" y="30.0"></omgdi:waypoint>
-        <omgdi:waypoint x="80.0" y="30.0"></omgdi:waypoint>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge bpmnElement="flow3" id="BPMNEdge_flow3">
-        <omgdi:waypoint x="180.0" y="30.0"></omgdi:waypoint>
-        <omgdi:waypoint x="192.0" y="30.0"></omgdi:waypoint>
-        <omgdi:waypoint x="192.0" y="30.0"></omgdi:waypoint>
-        <omgdi:waypoint x="230.0" y="32.0"></omgdi:waypoint>
-      </bpmndi:BPMNEdge>
-    </bpmndi:BPMNPlane>
-  </bpmndi:BPMNDiagram>
+
 </definitions>

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testParallelUserTasksCustomExtensionsLoopIndexVariable.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testParallelUserTasksCustomExtensionsLoopIndexVariable.bpmn20.xml
@@ -1,24 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions id="definition" 
-  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns:activiti="http://activiti.org/bpmn"
-  targetNamespace="Examples">
-  
-  <process id="miParallelUserTasksLoopVariable">
-  
-    <startEvent id="theStart" />
-    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="miTasks" />
-    
-    <userTask id="miTasks" name="My Task ${loopValueIndex}" activiti:assignee="${assignee}" >
-      <multiInstanceLoopCharacteristics isSequential="false"
-              activiti:collection="assigneeList" activiti:elementVariable="assignee"
-              activiti:elementIndexVariable="loopValueIndex"/>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="Examples" id="definition">
+  <process id="miParallelUserTasksLoopVariable" isExecutable="true">
+    <startEvent id="theStart"></startEvent>
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="miTasks"></sequenceFlow>
+    <userTask id="miTasks" name="My Task ${loopValueIndex}" activiti:assignee="${assignee}">
+      <multiInstanceLoopCharacteristics isSequential="false" activiti:collection="${assigneeList}" activiti:elementVariable="assignee"></multiInstanceLoopCharacteristics>
     </userTask>
-    
-    <sequenceFlow id="flow3" sourceRef="miTasks" targetRef="theEnd" />
-    <endEvent id="theEnd" />
-    
+    <sequenceFlow id="flow3" sourceRef="miTasks" targetRef="theEnd"></sequenceFlow>
+    <endEvent id="theEnd"></endEvent>
   </process>
-
+  <bpmndi:BPMNDiagram id="BPMNDiagram_miParallelUserTasksLoopVariable">
+    <bpmndi:BPMNPlane bpmnElement="miParallelUserTasksLoopVariable" id="BPMNPlane_miParallelUserTasksLoopVariable">
+      <bpmndi:BPMNShape bpmnElement="theStart" id="BPMNShape_theStart">
+        <omgdc:Bounds height="35.0" width="35.0" x="0.0" y="15.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="miTasks" id="BPMNShape_miTasks">
+        <omgdc:Bounds height="60.0" width="100.0" x="80.0" y="0.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="theEnd" id="BPMNShape_theEnd">
+        <omgdc:Bounds height="35.0" width="35.0" x="230.0" y="15.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="flow1" id="BPMNEdge_flow1">
+        <omgdi:waypoint x="35.0" y="32.0"></omgdi:waypoint>
+        <omgdi:waypoint x="42.0" y="30.0"></omgdi:waypoint>
+        <omgdi:waypoint x="42.0" y="30.0"></omgdi:waypoint>
+        <omgdi:waypoint x="80.0" y="30.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="flow3" id="BPMNEdge_flow3">
+        <omgdi:waypoint x="180.0" y="30.0"></omgdi:waypoint>
+        <omgdi:waypoint x="192.0" y="30.0"></omgdi:waypoint>
+        <omgdi:waypoint x="192.0" y="30.0"></omgdi:waypoint>
+        <omgdi:waypoint x="230.0" y="32.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
 </definitions>

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testSequentialEmptyCollection.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testSequentialEmptyCollection.bpmn20.xml
@@ -6,7 +6,7 @@
     <sequenceFlow id="flow2" sourceRef="usertask1" targetRef="end"></sequenceFlow>
     <endEvent id="end"></endEvent>
     <userTask id="usertask1" name="Multi">
-      <multiInstanceLoopCharacteristics isSequential="true" activiti:collection="collection"></multiInstanceLoopCharacteristics>
+      <multiInstanceLoopCharacteristics isSequential="true" activiti:collection="${collection}"></multiInstanceLoopCharacteristics>
     </userTask>
   </process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_testSequentialEmptyCollection">

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testSequentialSubprocessEmptyCollection.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testSequentialSubprocessEmptyCollection.bpmn20.xml
@@ -4,7 +4,7 @@
     <startEvent id="start"></startEvent>
     <endEvent id="end"></endEvent>
     <subProcess id="subprocess1" name="Sub Process">
-      <multiInstanceLoopCharacteristics isSequential="true" activiti:collection="collection"></multiInstanceLoopCharacteristics>
+      <multiInstanceLoopCharacteristics isSequential="true" activiti:collection="${collection}"></multiInstanceLoopCharacteristics>
       <startEvent id="startevent1" name="Start"></startEvent>
       <userTask id="usertask1" name="User Task"></userTask>
       <endEvent id="endevent1" name="End"></endEvent>


### PR DESCRIPTION
In a multi-instance tag, we want to use the field collection with an expression. Currently, it doesn't work with the Groovy Scripting engine because the code detect that the field is an expression based on a JUEL syntaxe attribute. This PR fix that.