### PR TITLE
Explicit type can be replaced with <>

### DIFF
--- a/modules/flowable-camel/src/main/java/org/flowable/camel/CamelBehavior.java
+++ b/modules/flowable-camel/src/main/java/org/flowable/camel/CamelBehavior.java
@@ -42,20 +42,20 @@ import org.flowable.spring.SpringProcessEngineConfiguration;
 /**
  * This abstract class takes the place of the now-deprecated CamelBehaviour class (which can still be used for legacy compatibility) and significantly improves on its flexibility. Additional
  * implementations can be created that change the way in which Flowable interacts with Camel per your specific needs.
- * 
+ * <p>
  * Three out-of-the-box implementations of CamelBehavior are provided: (1) CamelBehaviorDefaultImpl: Works just like CamelBehaviour does; copies variables into and out of Camel as or from properties.
  * (2) CamelBehaviorBodyAsMapImpl: Works by copying variables into and out of Camel using a Map<String,Object> object in the body. (3) CamelBehaviorCamelBodyImpl: Works by copying a single variable
  * value into Camel as a String body and copying the Camel body into that same variable. The process variable in must be named "camelBody".
- * 
+ * <p>
  * The chosen implementation should be set within your ProcessEngineConfiguration. To specify the implementation using Spring, include the following line in your configuration file as part of the
  * properties for "org.flowable.spring.SpringProcessEngineConfiguration":
- * 
+ * <p>
  * <property name="camelBehaviorClass" value="org.flowable.camel.impl.CamelBehaviorCamelBodyImpl"/>
- * 
+ * <p>
  * Note also that the manner in which variables are copied to the process engine from Camel has changed. It will always copy Camel properties to the process variables set; they can safely be ignored,
  * of course, if not required. It will conditionally copy the Camel body to the "camelBody" variable if it is of type java.lang.String, OR it will copy the Camel body to individual variables within
  * the process engine if it is of type Map<String,Object>.
- * 
+ *
  * @author Ryan Johnston (@rjfsu), Tijs Rademakers, Saeid Mirzaei
  * @version 5.12
  */
@@ -89,16 +89,16 @@ public abstract class CamelBehavior extends AbstractBpmnActivityBehavior impleme
 
     protected void copyVariables(Map<String, Object> variables, Exchange exchange, FlowableEndpoint endpoint) {
         switch (toTargetType) {
-        case BODY_AS_MAP:
-            copyVariablesToBodyAsMap(variables, exchange);
-            break;
+            case BODY_AS_MAP:
+                copyVariablesToBodyAsMap(variables, exchange);
+                break;
 
-        case BODY:
-            copyVariablesToBody(variables, exchange);
-            break;
+            case BODY:
+                copyVariablesToBody(variables, exchange);
+                break;
 
-        case PROPERTIES:
-            copyVariablesToProperties(variables, exchange);
+            case PROPERTIES:
+                copyVariablesToProperties(variables, exchange);
         }
     }
 
@@ -195,7 +195,7 @@ public abstract class CamelBehavior extends AbstractBpmnActivityBehavior impleme
     }
 
     protected void copyVariablesToBodyAsMap(Map<String, Object> variables, Exchange exchange) {
-        exchange.getIn().setBody(new HashMap<String, Object>(variables));
+        exchange.getIn().setBody(new HashMap<>(variables));
     }
 
     protected void copyVariablesToBody(Map<String, Object> variables, Exchange exchange) {

--- a/modules/flowable-camel/src/main/java/org/flowable/camel/ExchangeUtils.java
+++ b/modules/flowable-camel/src/main/java/org/flowable/camel/ExchangeUtils.java
@@ -23,7 +23,7 @@ import org.flowable.engine.common.api.FlowableException;
 
 /**
  * This class contains one method - prepareVariables - that is used to copy variables from Camel into the process engine.
- * 
+ *
  * @author Ryan Johnston (@rjfsu), Tijs Rademakers, Arnold Schrijver
  * @author Saeid Mirzaei
  */
@@ -31,11 +31,11 @@ public class ExchangeUtils {
 
     public static final String CAMELBODY = "camelBody";
     protected static final String IGNORE_MESSAGE_PROPERTY = "CamelMessageHistory";
-    static Map<String, Pattern> patternsCache = new HashMap<String, Pattern>();
+    static Map<String, Pattern> patternsCache = new HashMap<>();
 
     /**
      * Copies variables from Camel into the process engine.
-     * 
+     * <p>
      * This method will copy the Camel body to the "camelBody" variable. It will copy the Camel body to individual variables within Flowable if it is of type Map&lt;String, Object&gt; or it will copy
      * the Object as it comes.
      * <ul>
@@ -44,7 +44,6 @@ public class ExchangeUtils {
      * Object&gt;</li>
      * <li>If the copyVariablesFromHeader parameter is set on the endpoint, each Camel Header will be copied to an individual process variable.</li>
      * </ul>
-     * 
      */
 
     private static Pattern createPattern(String propertyString, boolean asBoolean) {
@@ -70,7 +69,7 @@ public class ExchangeUtils {
     }
 
     public static Map<String, Object> prepareVariables(Exchange exchange, FlowableEndpoint endpoint) {
-        Map<String, Object> camelVarMap = new HashMap<String, Object>();
+        Map<String, Object> camelVarMap = new HashMap<>();
 
         String copyProperties = endpoint.getCopyVariablesFromProperties();
         // don't other if the property is null, or is a false
@@ -117,7 +116,7 @@ public class ExchangeUtils {
         if (camelBody instanceof Map<?, ?>) {
             Map<?, ?> camelBodyMap = (Map<?, ?>) camelBody;
             for (@SuppressWarnings("rawtypes")
-            Map.Entry e : camelBodyMap.entrySet()) {
+                    Map.Entry e : camelBodyMap.entrySet()) {
                 if (e.getKey() instanceof String && !IGNORE_MESSAGE_PROPERTY.equalsIgnoreCase((String) e.getKey())) {
                     camelVarMap.put((String) e.getKey(), e.getValue());
                 }
@@ -136,11 +135,9 @@ public class ExchangeUtils {
 
     /**
      * Gets the value of the Camel header that contains the userId to be set as the process initiator. Returns null if no header name was specified on the Camel route.
-     * 
-     * @param exchange
-     *            The Camel Exchange object
-     * @param endpoint
-     *            The endPoint implementation
+     *
+     * @param exchange The Camel Exchange object
+     * @param endpoint The endPoint implementation
      * @return The userId of the user to be set as the process initiator
      */
     public static String prepareInitiator(Exchange exchange, FlowableEndpoint endpoint) {

--- a/modules/flowable-camel/src/main/java/org/flowable/camel/FlowableEndpoint.java
+++ b/modules/flowable-camel/src/main/java/org/flowable/camel/FlowableEndpoint.java
@@ -32,7 +32,7 @@ import org.flowable.engine.common.api.FlowableException;
  * This class has been modified to be consistent with the changes to CamelBehavior and its implementations. The set of changes significantly increases the flexibility of our Camel integration, as you
  * can either choose one of three "out-of-the-box" modes, or you can choose to create your own. Please reference the comments for the "CamelBehavior" class for more information on the out-of-the-box
  * implementation class options.
- * 
+ *
  * @author Ryan Johnston (@rjfsu), Tijs Rademakers, Arnold Schrijver
  */
 public class FlowableEndpoint extends DefaultEndpoint {
@@ -59,7 +59,7 @@ public class FlowableEndpoint extends DefaultEndpoint {
 
     protected String processInitiatorHeaderName;
 
-    protected Map<String, Object> returnVarMap = new HashMap<String, Object>();
+    protected Map<String, Object> returnVarMap = new HashMap<>();
 
     protected long timeout = 5000;
 

--- a/modules/flowable-camel/src/main/java/org/flowable/camel/SimpleContextProvider.java
+++ b/modules/flowable-camel/src/main/java/org/flowable/camel/SimpleContextProvider.java
@@ -12,15 +12,15 @@
  */
 package org.flowable.camel;
 
-import org.apache.camel.CamelContext;
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.camel.CamelContext;
+
 public class SimpleContextProvider implements ContextProvider {
 
-    private Map<String, CamelContext> contexts = new HashMap<String, CamelContext>();
+    private Map<String, CamelContext> contexts = new HashMap<>();
 
     public SimpleContextProvider(Map<String, CamelContext> contexts) {
         this.contexts = contexts;

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/CamelVariableBodyMapTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/CamelVariableBodyMapTest.java
@@ -57,9 +57,9 @@ public class CamelVariableBodyMapTest extends SpringFlowableTestCase {
         }
     }
 
-    @Deployment(resources = { "process/HelloCamelBodyMap.bpmn20.xml" })
+    @Deployment(resources = {"process/HelloCamelBodyMap.bpmn20.xml"})
     public void testCamelBody() throws Exception {
-        Map<String, Object> varMap = new HashMap<String, Object>();
+        Map<String, Object> varMap = new HashMap<>();
         varMap.put("camelBody", "hello world");
         service1.expectedBodiesReceived(varMap);
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("HelloCamel", varMap);

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/CamelVariableBodyTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/CamelVariableBodyTest.java
@@ -56,10 +56,10 @@ public class CamelVariableBodyTest extends SpringFlowableTestCase {
         }
     }
 
-    @Deployment(resources = { "process/HelloCamelBody.bpmn20.xml" })
+    @Deployment(resources = {"process/HelloCamelBody.bpmn20.xml"})
     public void testCamelBody() throws Exception {
         service1.expectedBodiesReceived("hello world");
-        Map<String, Object> varMap = new HashMap<String, Object>();
+        Map<String, Object> varMap = new HashMap<>();
         varMap.put("camelBody", "hello world");
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("HelloCamel", varMap);
         // Ensure that the variable is equal to the expected value.

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/ErrorHandlingTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/ErrorHandlingTest.java
@@ -24,9 +24,8 @@ import org.springframework.test.context.ContextConfiguration;
 
 /**
  * Demonstrates an issue in Activiti 5.12. Exception on Camel routes will be lost, if default error handling is used.
- * 
+ *
  * @author stefan.schulze@accelsis.biz
- * 
  */
 @ContextConfiguration("classpath:error-camel-flowable-context.xml")
 public class ErrorHandlingTest extends SpringFlowableTestCase {
@@ -38,12 +37,12 @@ public class ErrorHandlingTest extends SpringFlowableTestCase {
 
     /**
      * Process instance should be removed after completion. Works as intended, if no exception interrupts the Camel route.
-     * 
+     *
      * @throws Exception
      */
-    @Deployment(resources = { "process/errorHandling.bpmn20.xml" })
+    @Deployment(resources = {"process/errorHandling.bpmn20.xml"})
     public void testCamelRouteWorksAsIntended() throws Exception {
-        Map<String, Object> variables = new HashMap<String, Object>();
+        Map<String, Object> variables = new HashMap<>();
         variables.put("routing", Routing.DEFAULT);
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("ErrorHandling", variables);
@@ -59,12 +58,12 @@ public class ErrorHandlingTest extends SpringFlowableTestCase {
 
     /**
      * Expected behavior, with default error handling in Camel: Roll-back to previous wait state. Fails with Activiti 5.12.
-     * 
+     *
      * @throws Exception
      */
-    @Deployment(resources = { "process/errorHandling.bpmn20.xml" })
+    @Deployment(resources = {"process/errorHandling.bpmn20.xml"})
     public void testRollbackOnException() throws Exception {
-        Map<String, Object> variables = new HashMap<String, Object>();
+        Map<String, Object> variables = new HashMap<>();
         variables.put("routing", Routing.PROVOKE_ERROR);
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("ErrorHandling", variables);
@@ -76,12 +75,12 @@ public class ErrorHandlingTest extends SpringFlowableTestCase {
 
     /**
      * Exception caught and processed by Camel dead letter queue handler. Process instance proceeds to ReceiveTask as expected.
-     * 
+     *
      * @throws Exception
      */
-    @Deployment(resources = { "process/errorHandling.bpmn20.xml" })
+    @Deployment(resources = {"process/errorHandling.bpmn20.xml"})
     public void testErrorHandledByCamel() throws Exception {
-        Map<String, Object> variables = new HashMap<String, Object>();
+        Map<String, Object> variables = new HashMap<>();
         variables.put("routing", Routing.HANDLE_ERROR);
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("ErrorHandling", variables);

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/examples/ping/PingPongTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/examples/ping/PingPongTest.java
@@ -43,10 +43,10 @@ public class PingPongTest extends SpringFlowableTestCase {
 
     @Deployment
     public void testPingPong() {
-        Map<String, Object> variables = new HashMap<String, Object>();
+        Map<String, Object> variables = new HashMap<>();
 
         variables.put("input", "Hello");
-        Map<String, String> outputMap = new HashMap<String, String>();
+        Map<String, String> outputMap = new HashMap<>();
         variables.put("outputMap", outputMap);
 
         runtimeService.startProcessInstanceByKey("PingPongProcess", variables);

--- a/modules/flowable-cdi/src/main/java/org/flowable/cdi/BusinessProcess.java
+++ b/modules/flowable-cdi/src/main/java/org/flowable/cdi/BusinessProcess.java
@@ -38,40 +38,40 @@ import org.flowable.engine.task.Task;
 /**
  * Bean supporting contextual business process management. This allows us to implement a unit of work, in which a particular CDI scope (Conversation / Request / Thread) is associated with a particular
  * Execution / ProcessInstance or Task.
- * <p />
+ * <p/>
  * The protocol is that we <em>associate</em> the {@link BusinessProcess} bean with a particular Execution / Task, then perform some changes (retrieve / set process variables) and then end the unit of
  * work. This bean makes sure that our changes are only "flushed" to the process engine when we successfully complete the unit of work.
- * <p />
+ * <p/>
  * A typical usage scenario might look like this:<br />
  * <strong>1st unit of work ("process instantiation"):</strong>
- * 
+ * <p>
  * <pre>
  * conversation.begin();
  * ...
- * businessProcess.setVariable("billingId", "1"); // setting variables before starting the process 
+ * businessProcess.setVariable("billingId", "1"); // setting variables before starting the process
  * businessProcess.startProcessByKey("billingProcess");
  * conversation.end();
  * </pre>
- * 
+ * <p>
  * <strong>2nd unit of work ("perform a user task"):</strong>
- * 
+ * <p>
  * <pre>
  * conversation.begin();
  * businessProcess.startTask(id); // now we have associated a task with the current conversation
- * ...                            // this allows us to retrieve and change process variables  
+ * ...                            // this allows us to retrieve and change process variables
  *                                // and @BusinessProcessScoped beans
  * businessProcess.setVariable("billingDetails", "someValue"); // these changes are cached in the conversation
  * ...
  * businessProcess.completeTask(); // now all changed process variables are flushed
  * conversation.end();
  * </pre>
- * <p />
+ * <p/>
  * <strong>NOTE:</strong> in the absence of a conversation, (non faces request, i.e. when processing a JAX-RS, JAX-WS, JMS, remote EJB or plain Servlet requests), the {@link BusinessProcess} bean
  * associates with the current Request (see {@link RequestScoped @RequestScoped}).
- * <p />
+ * <p/>
  * <strong>NOTE:</strong> in the absence of a request, ie. when the JobExecutor accesses {@link BusinessProcessScoped @BusinessProcessScoped} beans, the execution is associated with the current
  * thread.
- * 
+ *
  * @author Daniel Meyer
  * @author Falko Menge
  */
@@ -258,11 +258,9 @@ public class BusinessProcess implements Serializable {
 
     /**
      * Associate with the provided execution. This starts a unit of work.
-     * 
-     * @param executionId
-     *            the id of the execution to associate with.
-     * @throws FlowableCdiException
-     *             if no such execution exists
+     *
+     * @param executionId the id of the execution to associate with.
+     * @throws FlowableCdiException if no such execution exists
      */
     public void associateExecutionById(String executionId) {
         Execution execution = processEngine.getRuntimeService().createExecutionQuery().executionId(executionId).singleResult();
@@ -274,7 +272,7 @@ public class BusinessProcess implements Serializable {
 
     /**
      * returns true if an {@link Execution} is associated.
-     * 
+     *
      * @see #associateExecutionById(String)
      */
     public boolean isAssociated() {
@@ -285,11 +283,9 @@ public class BusinessProcess implements Serializable {
      * Signals the current execution, see {@link RuntimeService#trigger(String)}
      * <p/>
      * Ends the current unit of work (flushes changes to process variables set using {@link #setVariable(String, Object)} or made on {@link BusinessProcessScoped @BusinessProcessScoped} beans).
-     * 
-     * @throws FlowableCdiException
-     *             if no execution is currently associated
-     * @throws FlowableException
-     *             if the command fails
+     *
+     * @throws FlowableCdiException if no execution is currently associated
+     * @throws FlowableException    if the command fails
      */
     public void triggerExecution() {
         assertAssociated();
@@ -299,8 +295,8 @@ public class BusinessProcess implements Serializable {
 
     /**
      * @see #triggerExecution()
-     * 
-     *      In addition, this method allows to end the current conversation
+     * <p>
+     * In addition, this method allows to end the current conversation
      */
     public void triggerExecution(boolean endConversation) {
         triggerExecution();
@@ -314,14 +310,10 @@ public class BusinessProcess implements Serializable {
     /**
      * Associates the task with the provided taskId with the current conversation.
      * <p/>
-     * 
-     * @param taskId
-     *            the id of the task
-     * 
+     *
+     * @param taskId the id of the task
      * @return the resumed task
-     * 
-     * @throws FlowableCdiException
-     *             if no such task is found
+     * @throws FlowableCdiException if no such task is found
      */
     public Task startTask(String taskId) {
         Task currentTask = associationManager.getTask();
@@ -339,8 +331,8 @@ public class BusinessProcess implements Serializable {
 
     /**
      * @see #startTask(String)
-     * 
-     *      this method allows to start a conversation if no conversation is active
+     * <p>
+     * this method allows to start a conversation if no conversation is active
      */
     public Task startTask(String taskId, boolean beginConversation) {
         if (beginConversation) {
@@ -356,11 +348,9 @@ public class BusinessProcess implements Serializable {
      * Completes the current UserTask, see {@link TaskService#complete(String)}
      * <p/>
      * Ends the current unit of work (flushes changes to process variables set using {@link #setVariable(String, Object)} or made on {@link BusinessProcessScoped @BusinessProcessScoped} beans).
-     * 
-     * @throws FlowableCdiException
-     *             if no task is currently associated
-     * @throws FlowableException
-     *             if the command fails
+     *
+     * @throws FlowableCdiException if no task is currently associated
+     * @throws FlowableException    if the command fails
      */
     public void completeTask() {
         assertTaskAssociated();
@@ -370,9 +360,8 @@ public class BusinessProcess implements Serializable {
 
     /**
      * @see BusinessProcess#completeTask()
-     * 
-     *      In addition this allows to end the current conversation.
-     * 
+     * <p>
+     * In addition this allows to end the current conversation.
      */
     public void completeTask(boolean endConversation) {
         completeTask();
@@ -388,8 +377,7 @@ public class BusinessProcess implements Serializable {
     // -------------------------------------------------
 
     /**
-     * @param variableName
-     *            the name of the process variable for which the value is to be retrieved
+     * @param variableName the name of the process variable for which the value is to be retrieved
      * @return the value of the provided process variable or 'null' if no such variable is set
      */
     @SuppressWarnings("unchecked")
@@ -405,15 +393,12 @@ public class BusinessProcess implements Serializable {
 
     /**
      * Set a value for a process variable.
-     * <p />
-     * 
+     * <p/>
+     * <p>
      * <strong>NOTE:</strong> If no execution is currently associated, the value is temporarily cached and flushed to the process instance at the end of the unit of work
-     * 
-     * @param variableName
-     *            the name of the process variable for which a value is to be set
-     * @param value
-     *            the value to be set
-     * 
+     *
+     * @param variableName the name of the process variable for which a value is to be set
+     * @param value        the value to be set
      */
     public void setVariable(String variableName, Object value) {
         associationManager.setVariable(variableName, value);
@@ -471,10 +456,8 @@ public class BusinessProcess implements Serializable {
 
     /**
      * Returns the currently associated {@link Task} or 'null'
-     * 
-     * @throws FlowableCdiException
-     *             if no {@link Task} is associated. Use {@link #isTaskAssociated()} to check whether an association exists.
-     * 
+     *
+     * @throws FlowableCdiException if no {@link Task} is associated. Use {@link #isTaskAssociated()} to check whether an association exists.
      */
     public Task getTask() {
         return associationManager.getTask();
@@ -497,9 +480,8 @@ public class BusinessProcess implements Serializable {
 
     /**
      * Returns the {@link ProcessInstance} currently associated or 'null'
-     * 
-     * @throws FlowableCdiException
-     *             if no {@link Execution} is associated. Use {@link #isAssociated()} to check whether an association exists.
+     *
+     * @throws FlowableCdiException if no {@link Execution} is associated. Use {@link #isAssociated()} to check whether an association exists.
      */
     public ProcessInstance getProcessInstance() {
         Execution execution = getExecution();
@@ -530,7 +512,7 @@ public class BusinessProcess implements Serializable {
 
     protected Map<String, Object> getAndClearCachedVariables() {
         Map<String, Object> beanStore = getCachedVariables();
-        Map<String, Object> copy = new HashMap<String, Object>(beanStore);
+        Map<String, Object> copy = new HashMap<>(beanStore);
         beanStore.clear();
         return copy;
     }

--- a/modules/flowable-cdi/src/main/java/org/flowable/cdi/impl/FlowableExtension.java
+++ b/modules/flowable-cdi/src/main/java/org/flowable/cdi/impl/FlowableExtension.java
@@ -29,8 +29,8 @@ import javax.enterprise.inject.spi.Extension;
 
 import org.flowable.cdi.annotation.BusinessProcessScoped;
 import org.flowable.cdi.impl.context.BusinessProcessContext;
-import org.flowable.cdi.impl.util.FlowableServices;
 import org.flowable.cdi.impl.util.BeanManagerLookup;
+import org.flowable.cdi.impl.util.FlowableServices;
 import org.flowable.cdi.impl.util.ProgrammaticBeanLookup;
 import org.flowable.cdi.spi.ProcessEngineLookup;
 import org.flowable.engine.ProcessEngine;
@@ -40,9 +40,9 @@ import org.slf4j.LoggerFactory;
 
 /**
  * CDI-Extension registering a custom context for {@link BusinessProcessScoped} beans.
- * 
+ * <p>
  * Also starts / stops the {@link ProcessEngine} and deploys all processes listed in the 'processes.xml'-file.
- * 
+ *
  * @author Daniel Meyer
  */
 public class FlowableExtension implements Extension {
@@ -75,7 +75,7 @@ public class FlowableExtension implements Extension {
     protected ProcessEngine lookupProcessEngine(BeanManager beanManager) {
         ServiceLoader<ProcessEngineLookup> processEngineServiceLoader = ServiceLoader.load(ProcessEngineLookup.class);
         Iterator<ProcessEngineLookup> serviceIterator = processEngineServiceLoader.iterator();
-        List<ProcessEngineLookup> discoveredLookups = new ArrayList<ProcessEngineLookup>();
+        List<ProcessEngineLookup> discoveredLookups = new ArrayList<>();
         while (serviceIterator.hasNext()) {
             ProcessEngineLookup serviceInstance = serviceIterator.next();
             discoveredLookups.add(serviceInstance);

--- a/modules/flowable-cdi/src/main/java/org/flowable/cdi/impl/ProcessDeployer.java
+++ b/modules/flowable-cdi/src/main/java/org/flowable/cdi/impl/ProcessDeployer.java
@@ -32,7 +32,7 @@ import org.w3c.dom.NodeList;
 /**
  * Used to deploy processes. When the flowable-cdi extension is initialized, the classpath is scanned for a file named {@value #PROCESSES_FILE_NAME}. All processes listed in that file are
  * automatically deployed to the engine.
- * 
+ *
  * @author Daniel Meyer
  */
 public class ProcessDeployer {
@@ -51,7 +51,7 @@ public class ProcessDeployer {
 
     /**
      * Deploys a single process
-     * 
+     *
      * @return the processDefinitionId of the deployed process as returned by {@link ProcessDefinition#getId()}
      */
     public String deployProcess(String resourceName) {
@@ -88,7 +88,7 @@ public class ProcessDeployer {
     }
 
     public Set<String> getResourceNames() {
-        Set<String> result = new HashSet<String>();
+        Set<String> result = new HashSet<>();
         URL processFileUrl = getClass().getClassLoader().getResource(PROCESSES_FILE_NAME);
         if (processFileUrl == null) {
             LOGGER.debug("No '{}'-file provided.", PROCESSES_FILE_NAME);

--- a/modules/flowable-cdi/src/main/java/org/flowable/cdi/impl/annotation/StartProcessInterceptor.java
+++ b/modules/flowable-cdi/src/main/java/org/flowable/cdi/impl/annotation/StartProcessInterceptor.java
@@ -30,7 +30,7 @@ import org.flowable.engine.common.api.FlowableException;
 
 /**
  * implementation of the {@link StartProcess} annotation
- * 
+ *
  * @author Daniel Meyer
  */
 @Interceptor
@@ -74,7 +74,7 @@ public class StartProcessInterceptor implements Serializable {
     }
 
     private Map<String, Object> extractVariables(StartProcess startProcessAnnotation, InvocationContext ctx) throws Exception {
-        Map<String, Object> variables = new HashMap<String, Object>();
+        Map<String, Object> variables = new HashMap<>();
         for (Field field : ctx.getMethod().getDeclaringClass().getDeclaredFields()) {
             if (!field.isAnnotationPresent(ProcessVariable.class)) {
                 continue;

--- a/modules/flowable-cdi/src/main/java/org/flowable/cdi/impl/context/DefaultContextAssociationManager.java
+++ b/modules/flowable-cdi/src/main/java/org/flowable/cdi/impl/context/DefaultContextAssociationManager.java
@@ -40,9 +40,9 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Default implementation of the business process association manager. Uses a fallback-strategy to associate the process instance with the "broadest" active scope, starting with the conversation.
- * <p />
+ * <p/>
  * Subclass in order to implement custom association schemes and association with custom scopes.
- * 
+ *
  * @author Daniel Meyer
  */
 @SuppressWarnings("serial")
@@ -55,7 +55,7 @@ public class DefaultContextAssociationManager implements ContextAssociationManag
         @Inject
         private RuntimeService runtimeService;
 
-        protected Map<String, Object> cachedVariables = new HashMap<String, Object>();
+        protected Map<String, Object> cachedVariables = new HashMap<>();
         protected Execution execution;
         protected Task task;
 
@@ -125,11 +125,11 @@ public class DefaultContextAssociationManager implements ContextAssociationManag
 
     /**
      * Override to add different / additional contexts.
-     * 
+     *
      * @return a list of {@link Scope}-types, which are used in the given order to resolve the broadest active context (@link #getBroadestActiveContext()})
      */
     protected List<Class<? extends ScopedAssociation>> getAvailableScopedAssociationClasses() {
-        ArrayList<Class<? extends ScopedAssociation>> scopeTypes = new ArrayList<Class<? extends ScopedAssociation>>();
+        ArrayList<Class<? extends ScopedAssociation>> scopeTypes = new ArrayList<>();
         scopeTypes.add(ConversationScopedAssociation.class);
         scopeTypes.add(RequestScopedAssociation.class);
         return scopeTypes;

--- a/modules/flowable-cdi/src/main/java/org/flowable/cdi/impl/context/ExecutionContextHolder.java
+++ b/modules/flowable-cdi/src/main/java/org/flowable/cdi/impl/context/ExecutionContextHolder.java
@@ -22,7 +22,7 @@ import org.flowable.engine.impl.persistence.entity.ExecutionEntity;
  */
 public class ExecutionContextHolder {
 
-    protected static ThreadLocal<Stack<ExecutionContext>> executionContextStackThreadLocal = new ThreadLocal<Stack<ExecutionContext>>();
+    protected static ThreadLocal<Stack<ExecutionContext>> executionContextStackThreadLocal = new ThreadLocal<>();
 
     public static ExecutionContext getExecutionContext() {
         return getStack(executionContextStackThreadLocal).peek();
@@ -44,7 +44,7 @@ public class ExecutionContextHolder {
     protected static <T> Stack<T> getStack(ThreadLocal<Stack<T>> threadLocal) {
         Stack<T> stack = threadLocal.get();
         if (stack == null) {
-            stack = new Stack<T>();
+            stack = new Stack<>();
             threadLocal.set(stack);
         }
         return stack;

--- a/modules/flowable-cdi/src/main/java/org/flowable/cdi/impl/event/CdiEventSupportBpmnParseHandler.java
+++ b/modules/flowable-cdi/src/main/java/org/flowable/cdi/impl/event/CdiEventSupportBpmnParseHandler.java
@@ -15,7 +15,6 @@ package org.flowable.cdi.impl.event;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.flowable.bpmn.model.FlowableListener;
 import org.flowable.bpmn.model.BaseElement;
 import org.flowable.bpmn.model.BusinessRuleTask;
 import org.flowable.bpmn.model.CallActivity;
@@ -25,6 +24,7 @@ import org.flowable.bpmn.model.EventGateway;
 import org.flowable.bpmn.model.EventSubProcess;
 import org.flowable.bpmn.model.ExclusiveGateway;
 import org.flowable.bpmn.model.FlowElement;
+import org.flowable.bpmn.model.FlowableListener;
 import org.flowable.bpmn.model.ImplementationType;
 import org.flowable.bpmn.model.InclusiveGateway;
 import org.flowable.bpmn.model.ManualTask;
@@ -50,13 +50,13 @@ import org.flowable.engine.parse.BpmnParseHandler;
 
 /**
  * {@link BpmnParseHandler} registering the {@link CdiExecutionListener} for distributing execution events using the cdi event infrastructure
- * 
+ *
  * @author Daniel Meyer
  * @author Joram Barrez
  */
 public class CdiEventSupportBpmnParseHandler implements BpmnParseHandler {
 
-    protected static final Set<Class<? extends BaseElement>> supportedTypes = new HashSet<Class<? extends BaseElement>>();
+    protected static final Set<Class<? extends BaseElement>> supportedTypes = new HashSet<>();
 
     static {
         supportedTypes.add(StartEvent.class);

--- a/modules/flowable-cdi/src/test/java/org/flowable/cdi/test/bpmn/SignalEventTest.java
+++ b/modules/flowable-cdi/src/test/java/org/flowable/cdi/test/bpmn/SignalEventTest.java
@@ -62,14 +62,14 @@ public class SignalEventTest extends CdiFlowableTestCase {
     }
 
     @Test
-    @Deployment(resources = { "org/flowable/cdi/test/bpmn/SignalEventTests.catchAlertSignalBoundaryWithReceiveTask.bpmn20.xml",
-            "org/flowable/cdi/test/bpmn/SignalEventTests.throwAlertSignalWithDelegate.bpmn20.xml" })
+    @Deployment(resources = {"org/flowable/cdi/test/bpmn/SignalEventTests.catchAlertSignalBoundaryWithReceiveTask.bpmn20.xml",
+            "org/flowable/cdi/test/bpmn/SignalEventTests.throwAlertSignalWithDelegate.bpmn20.xml"})
     public void testSignalCatchBoundaryWithVariables() {
-        HashMap<String, Object> variables1 = new HashMap<String, Object>();
+        HashMap<String, Object> variables1 = new HashMap<>();
         variables1.put("processName", "catchSignal");
         ProcessInstance piCatchSignal = runtimeService.startProcessInstanceByKey("catchSignal", variables1);
 
-        HashMap<String, Object> variables2 = new HashMap<String, Object>();
+        HashMap<String, Object> variables2 = new HashMap<>();
         variables2.put("processName", "throwSignal");
         variables2.put("signalProcessInstanceId", piCatchSignal.getProcessInstanceId());
         ProcessInstance piThrowSignal = runtimeService.startProcessInstanceByKey("throwSignal", variables2);

--- a/modules/flowable-cdi/src/test/java/org/flowable/cdi/test/impl/event/TestEventListener.java
+++ b/modules/flowable-cdi/src/test/java/org/flowable/cdi/test/impl/event/TestEventListener.java
@@ -55,7 +55,7 @@ public class TestEventListener {
         eventsReceived.clear();
     }
 
-    private final Set<BusinessProcessEvent> eventsReceivedByKey = new HashSet<BusinessProcessEvent>();
+    private final Set<BusinessProcessEvent> eventsReceivedByKey = new HashSet<>();
 
     // receives all events related to "process1"
     public void onProcessEventByKey(@Observes @BusinessProcess("process1") BusinessProcessEvent businessProcessEvent) {
@@ -68,7 +68,7 @@ public class TestEventListener {
 
     // ---------------------------------------------------------
 
-    private final Set<BusinessProcessEvent> eventsReceived = new HashSet<BusinessProcessEvent>();
+    private final Set<BusinessProcessEvent> eventsReceived = new HashSet<>();
 
     // receives all events
     public void onProcessEvent(@Observes BusinessProcessEvent businessProcessEvent) {

--- a/modules/flowable-cdi/src/test/java/org/flowable/experimental/ProcessVariablesTest.java
+++ b/modules/flowable-cdi/src/test/java/org/flowable/experimental/ProcessVariablesTest.java
@@ -31,7 +31,7 @@ public class ProcessVariablesTest extends CdiFlowableTestCase {
     public void testResolveString() {
         BusinessProcess businessProcess = getBeanInstance(BusinessProcess.class);
 
-        Map<String, Object> processVariables = new HashMap<String, Object>();
+        Map<String, Object> processVariables = new HashMap<>();
         businessProcess.setVariable("testKeyString", "testValue");
         businessProcess.startProcessByKey("businessProcessBeanTest", processVariables);
         businessProcess.startTask(taskService.createTaskQuery().singleResult().getId());

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -13,6 +13,8 @@
 
 package org.flowable.engine.impl.cfg;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import java.io.InputStream;
 import java.io.Reader;
 import java.net.URL;
@@ -355,8 +357,6 @@ import org.flowable.variable.service.impl.types.VariableTypes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 /**
  * @author Tom Baeyens
  * @author Joram Barrez
@@ -412,7 +412,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     protected PropertyDataManager propertyDataManager;
     protected ResourceDataManager resourceDataManager;
     protected TaskDataManager taskDataManager;
-    
+
     // ENTITY MANAGERS ///////////////////////////////////////////////////////////
 
     protected AttachmentEntityManager attachmentEntityManager;
@@ -448,7 +448,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     // History Manager
 
     protected HistoryManager historyManager;
-    
+
     protected boolean isAsyncHistoryEnabled;
     protected boolean isAsyncHistoryJsonGzipCompressionEnabled;
     protected boolean isAsyncHistoryJsonGroupingEnabled;
@@ -503,7 +503,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     protected List<JobHandler> customJobHandlers;
     protected Map<String, JobHandler> jobHandlers;
     protected AsyncRunnableExecutionExceptionHandler asyncRunnableExecutionExceptionHandler;
-    
+
     protected List<HistoryJobHandler> customHistoryJobHandlers;
     protected Map<String, HistoryJobHandler> historyJobHandlers;
 
@@ -517,7 +517,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
      * The number of retries for a job.
      */
     protected int asyncExecutorNumberOfRetries = 3;
-    protected int asyncHistoryExecutorNumberOfRetries = 10; 
+    protected int asyncHistoryExecutorNumberOfRetries = 10;
 
     /**
      * The minimal number of threads that are kept alive in the threadpool for job execution. Default value = 2. (This property is only applicable when using the {@link DefaultAsyncJobExecutor}).
@@ -532,7 +532,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     /**
      * The time (in milliseconds) a thread used for job execution must be kept alive before it is destroyed. Default setting is 5 seconds. Having a setting > 0 takes resources, but in the case of many
      * job executions it avoids creating new threads all the time. If 0, threads will be destroyed after they've been used for job execution.
-     *
+     * <p>
      * (This property is only applicable when using the {@link DefaultAsyncJobExecutor}).
      */
     protected long asyncExecutorThreadKeepAliveTime = 5000L;
@@ -545,36 +545,36 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     /**
      * The queue onto which jobs will be placed before they are actually executed. Threads form the async executor threadpool will take work from this queue.
-     *
+     * <p>
      * By default null. If null, an {@link ArrayBlockingQueue} will be created of size {@link #asyncExecutorThreadPoolQueueSize}.
-     *
+     * <p>
      * When the queue is full, the job will be executed by the calling thread (ThreadPoolExecutor.CallerRunsPolicy())
-     *
+     * <p>
      * (This property is only applicable when using the {@link DefaultAsyncJobExecutor}).
      */
     protected BlockingQueue<Runnable> asyncExecutorThreadPoolQueue;
 
     /**
      * The time (in seconds) that is waited to gracefully shut down the threadpool used for job execution when the a shutdown on the executor (or process engine) is requested. Default value = 60.
-     *
+     * <p>
      * (This property is only applicable when using the {@link DefaultAsyncJobExecutor}).
      */
     protected long asyncExecutorSecondsToWaitOnShutdown = 60L;
 
     /**
      * The number of timer jobs that are acquired during one query (before a job is executed, an acquirement thread fetches jobs from the database and puts them on the queue).
-     *
+     * <p>
      * Default value = 1, as this lowers the potential on optimistic locking exceptions. Change this value if you know what you are doing.
-     *
+     * <p>
      * (This property is only applicable when using the {@link DefaultAsyncJobExecutor}).
      */
     protected int asyncExecutorMaxTimerJobsPerAcquisition = 1;
 
     /**
      * The number of async jobs that are acquired during one query (before a job is executed, an acquirement thread fetches jobs from the database and puts them on the queue).
-     *
+     * <p>
      * Default value = 1, as this lowers the potential on optimistic locking exceptions. Change this value if you know what you are doing.
-     *
+     * <p>
      * (This property is only applicable when using the {@link DefaultAsyncJobExecutor}).
      */
     protected int asyncExecutorMaxAsyncJobsDuePerAcquisition = 1;
@@ -582,7 +582,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     /**
      * The time (in milliseconds) the timer acquisition thread will wait to execute the next acquirement query. This happens when no new timer jobs were found or when less timer jobs have been fetched
      * than set in {@link #asyncExecutorMaxTimerJobsPerAcquisition}. Default value = 10 seconds.
-     *
+     * <p>
      * (This property is only applicable when using the {@link DefaultAsyncJobExecutor}).
      */
     protected int asyncExecutorDefaultTimerJobAcquireWaitTime = 10 * 1000;
@@ -590,7 +590,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     /**
      * The time (in milliseconds) the async job acquisition thread will wait to execute the next acquirement query. This happens when no new async jobs were found or when less async jobs have been
      * fetched than set in {@link #asyncExecutorMaxAsyncJobsDuePerAcquisition}. Default value = 10 seconds.
-     *
+     * <p>
      * (This property is only applicable when using the {@link DefaultAsyncJobExecutor}).
      */
     protected int asyncExecutorDefaultAsyncJobAcquireWaitTime = 10 * 1000;
@@ -603,29 +603,29 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     /**
      * When a job is acquired, it is locked so other async executors can't lock and execute it. While doing this, the 'name' of the lock owner is written into a column of the job.
-     *
+     * <p>
      * By default, a random UUID will be generated when the executor is created.
-     *
+     * <p>
      * It is important that each async executor instance in a cluster of Flowable engines has a different name!
-     *
+     * <p>
      * (This property is only applicable when using the {@link DefaultAsyncJobExecutor}).
      */
     protected String asyncExecutorLockOwner;
 
     /**
      * The amount of time (in milliseconds) a timer job is locked when acquired by the async executor. During this period of time, no other async executor will try to acquire and lock this job.
-     *
+     * <p>
      * Default value = 5 minutes;
-     *
+     * <p>
      * (This property is only applicable when using the {@link DefaultAsyncJobExecutor}).
      */
     protected int asyncExecutorTimerLockTimeInMillis = 5 * 60 * 1000;
 
     /**
      * The amount of time (in milliseconds) an async job is locked when acquired by the async executor. During this period of time, no other async executor will try to acquire and lock this job.
-     *
+     * <p>
      * Default value = 5 minutes;
-     *
+     * <p>
      * (This property is only applicable when using the {@link DefaultAsyncJobExecutor}).
      */
     protected int asyncExecutorAsyncJobLockTimeInMillis = 5 * 60 * 1000;
@@ -633,20 +633,20 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     /**
      * The amount of time (in milliseconds) that is between two consecutive checks of 'expired jobs'. Expired jobs are jobs that were locked (a lock owner + time was written by some executor, but the
      * job was never completed).
-     *
+     * <p>
      * During such a check, jobs that are expired are again made available, meaning the lock owner and lock time will be removed. Other executors will now be able to pick it up.
-     *
+     * <p>
      * A job is deemed expired if the current time has passed the lock time.
-     *
+     * <p>
      * By default one minute.
      */
     protected int asyncExecutorResetExpiredJobsInterval = 60 * 1000;
-    
+
     /**
      * The amount of time (in milliseconds) a job can maximum be in the 'executable' state before being deemed expired.
      * Note that this won't happen when using the threadpool based executor, as the acquire thread will fetch these kind of jobs earlier.
      * However, in the message queue based execution, it could be some job is posted to a queue but then never is locked nor executed.
-     * 
+     * <p>
      * By default 24 hours, as this should be a very exceptional case.
      */
     protected int asyncExecutorResetExpiredJobsMaxTimeout = 24 * 60 * 60 * 1000;
@@ -659,7 +659,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     /**
      * Experimental!
-     *
+     * <p>
      * Set this to true when using the message queue based job executor.
      */
     protected boolean asyncExecutorMessageQueueMode;
@@ -667,7 +667,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     /**
      * Allows to define a custom factory for creating the {@link Runnable} that is executed by the async executor.
-     *
+     * <p>
      * (This property is only applicable when using the {@link DefaultAsyncJobExecutor}).
      */
     protected ExecuteAsyncRunnableFactory asyncExecutorExecuteAsyncRunnableFactory;
@@ -703,11 +703,11 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     /**
      * This flag determines whether variables of the type 'serializable' will be tracked. This means that, when true, in a JavaDelegate you can write
-     *
+     * <p>
      * MySerializableVariable myVariable = (MySerializableVariable) execution.getVariable("myVariable"); myVariable.setNumber(123);
-     *
+     * <p>
      * And the changes to the java object will be reflected in the database. Otherwise, a manual call to setVariable will be needed.
-     *
+     * <p>
      * By default true for backwards compatibility.
      */
     protected boolean serializableVariableTypeTrackDeserializedObjects = true;
@@ -736,7 +736,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     /**
      * Set this to true if you want to have extra checks on the BPMN xml that is parsed. See http://www.jorambarrez.be/blog/2013/02/19/uploading-a-funny-xml -can-bring-down-your-server/
-     *
+     * <p>
      * Unfortunately, this feature is not available on some platforms (JDK 6, JBoss), hence the reason why it is disabled by default. If your platform allows the use of StaxSource during XML parsing,
      * do enable it.
      */
@@ -745,7 +745,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     /**
      * The following settings will determine the amount of entities loaded at once when the engine needs to load multiple entities (eg. when suspending a process definition with all its process
      * instances).
-     *
+     * <p>
      * The default setting is quite low, as not to surprise anyone with sudden memory spikes. Change it to something higher if the environment Flowable runs in allows it.
      */
     protected int batchSizeProcessInstances = 25;
@@ -757,7 +757,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     /**
      * Using field injection together with a delegate expression for a service task / execution listener / task listener is not thread-sade , see user guide section 'Field Injection' for more
      * information.
-     *
+     * <p>
      * Set this flag to false to throw an exception at runtime when a field is injected and a delegateExpression is used.
      *
      * @since 5.21
@@ -777,7 +777,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     /**
      * Some databases have a limit of how many parameters one sql insert can have (eg SQL Server, 2000 params (!= insert statements) ). Tweak this parameter in case of exceptions indicating too much
      * is being put into one bulk insert, or make it higher if your database can cope with it and there are inserts with a huge amount of data.
-     *
+     * <p>
      * By default: 100 (75 for mssql server as it has a hard limit of 2000 parameters in a statement)
      */
     protected int maxNrOfStatementsInBulkInsert = 100;
@@ -941,11 +941,11 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
             if (customPreCommandInterceptors != null) {
                 commandInterceptors.addAll(customPreCommandInterceptors);
             }
-            
+
             commandInterceptors.addAll(getDefaultCommandInterceptors());
-            
+
             commandInterceptors.add(new BpmnOverrideContextInterceptor());
-            
+
             if (customPostCommandInterceptors != null) {
                 commandInterceptors.addAll(customPostCommandInterceptors);
             }
@@ -957,12 +957,12 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         if (defaultCommandInterceptors == null) {
             List<CommandInterceptor> interceptors = new ArrayList<>();
             interceptors.add(new LogInterceptor());
-    
+
             CommandInterceptor transactionInterceptor = createTransactionInterceptor();
             if (transactionInterceptor != null) {
                 interceptors.add(transactionInterceptor);
             }
-    
+
             if (commandContextFactory != null) {
                 CommandContextInterceptor commandContextInterceptor = new CommandContextInterceptor(commandContextFactory);
                 engineConfigurations.put(EngineConfigurationConstants.KEY_PROCESS_ENGINE_CONFIG, this);
@@ -971,16 +971,16 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
                 commandContextInterceptor.setCurrentEngineConfigurationKey(EngineConfigurationConstants.KEY_PROCESS_ENGINE_CONFIG);
                 interceptors.add(commandContextInterceptor);
             }
-    
+
             if (transactionContextFactory != null) {
                 interceptors.add(new TransactionContextInterceptor(transactionContextFactory));
             }
-    
+
             defaultCommandInterceptors = interceptors;
         }
         return defaultCommandInterceptors;
     }
-    
+
     // services
     // /////////////////////////////////////////////////////////////////
 
@@ -1010,7 +1010,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
             maxNrOfStatementsInBulkInsert = DEFAULT_MAX_NR_OF_STATEMENTS_BULK_INSERT_SQL_SERVER;
         }
     }
-    
+
     public void initDbSchemaManager() {
         if (this.dbSchemaManager == null) {
             this.dbSchemaManager = new ProcessDbSchemaManager();
@@ -1252,17 +1252,17 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
             if (usingRelationalDatabase) {
                 initDbSqlSessionFactory();
             }
-            
+
             if (isAsyncHistoryEnabled) {
                 initAsyncHistorySessionFactory();
             }
-            
+
             if (agendaFactory != null) {
                 addSessionFactory(new AgendaSessionFactory(agendaFactory));
             }
 
             addSessionFactory(new GenericManagerFactory(EntityCache.class, EntityCacheImpl.class));
-            
+
             commandContextFactory.setSessionFactories(sessionFactories);
         }
 
@@ -1287,9 +1287,9 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         dbSqlSessionFactory.setDatabaseCatalog(databaseCatalog);
         dbSqlSessionFactory.setDatabaseSchema(databaseSchema);
         dbSqlSessionFactory.setMaxNrOfStatementsInBulkInsert(maxNrOfStatementsInBulkInsert);
-        
+
         initDbSqlSessionFactoryEntitySettings();
-        
+
         addSessionFactory(dbSqlSessionFactory);
     }
 
@@ -1297,17 +1297,17 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         for (Class<? extends Entity> clazz : EntityDependencyOrder.INSERT_ORDER) {
             // All entities except one of the bpmn engine are bulk inserteable
             dbSqlSessionFactory.getInsertionOrder().add(clazz);
-            
+
             if (isBulkInsertEnabled) {
                 dbSqlSessionFactory.getBulkInserteableEntityClasses().add(clazz);
             }
         }
-        
+
         // Oracle doesn't support bulk inserting for event log entries
         if (isBulkInsertEnabled && "oracle".equals(databaseType)) {
             dbSqlSessionFactory.getBulkInserteableEntityClasses().remove(EventLogEntryEntityImpl.class);
         }
-        
+
         for (Class<? extends Entity> clazz : EntityDependencyOrder.DELETE_ORDER) {
             dbSqlSessionFactory.getDeletionOrder().add(clazz);
         }
@@ -1316,7 +1316,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     public DbSqlSessionFactory createDbSqlSessionFactory() {
         return new DbSqlSessionFactory();
     }
-    
+
     public void initAsyncHistorySessionFactory() {
         AsyncHistorySessionFactory asyncHistorySessionFactory = new AsyncHistorySessionFactory();
         if (asyncHistoryListener == null) {
@@ -1404,7 +1404,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
             configurator.beforeInit(this);
         }
     }
-    
+
     public void initVariableServiceConfiguration() {
         this.variableServiceConfiguration = new VariableServiceConfiguration();
         this.variableServiceConfiguration.setCommandExecutor(this.commandExecutor);
@@ -1412,25 +1412,25 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         this.variableServiceConfiguration.setClock(this.clock);
         this.variableServiceConfiguration.setObjectMapper(this.objectMapper);
         this.variableServiceConfiguration.setEventDispatcher(this.eventDispatcher);
-        
+
         if (this.customPreVariableTypes != null) {
             this.variableServiceConfiguration.setCustomPreVariableTypes(this.customPreVariableTypes);
         }
-        
-        List<VariableType> processEngineVariableTypes = new ArrayList<VariableType>();
+
+        List<VariableType> processEngineVariableTypes = new ArrayList<>();
         processEngineVariableTypes.add(new CustomObjectType("item", ItemInstance.class));
         processEngineVariableTypes.add(new CustomObjectType("message", MessageInstance.class));
         if (this.customPostVariableTypes != null) {
             processEngineVariableTypes.addAll(this.customPostVariableTypes);
         }
-        
+
         this.variableServiceConfiguration.setCustomPostVariableTypes(processEngineVariableTypes);
-        
+
         this.variableServiceConfiguration.setMaxLengthString(this.getMaxLengthString());
         this.variableServiceConfiguration.setSerializableVariableTypeTrackDeserializedObjects(this.isSerializableVariableTypeTrackDeserializedObjects());
-        
+
         this.variableServiceConfiguration.init();
-        
+
         addServiceConfiguration(EngineConfigurationConstants.KEY_VARIABLE_SERVICE_CONFIG, this.variableServiceConfiguration);
     }
 
@@ -1727,21 +1727,21 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
             }
         }
     }
-    
+
     protected void initHistoryJobHandlers() {
         if (isAsyncHistoryEnabled) {
             historyJobHandlers = new HashMap<>();
-            
+
             AsyncHistoryJobHandler asyncHistoryJobHandler = new AsyncHistoryJobHandler();
             asyncHistoryJobHandler.initDefaultTransformers();
             asyncHistoryJobHandler.setAsyncHistoryJsonGroupingEnabled(isAsyncHistoryJsonGroupingEnabled);
             historyJobHandlers.put(asyncHistoryJobHandler.getType(), asyncHistoryJobHandler);
-            
+
             AsyncHistoryJobZippedHandler asyncHistoryJobZippedHandler = new AsyncHistoryJobZippedHandler();
             asyncHistoryJobZippedHandler.initDefaultTransformers();
             asyncHistoryJobZippedHandler.setAsyncHistoryJsonGroupingEnabled(isAsyncHistoryJsonGroupingEnabled);
             historyJobHandlers.put(asyncHistoryJobZippedHandler.getType(), asyncHistoryJobZippedHandler);
-    
+
             if (getCustomHistoryJobHandlers() != null) {
                 for (HistoryJobHandler customJobHandler : getCustomHistoryJobHandlers()) {
                     historyJobHandlers.put(customJobHandler.getType(), customJobHandler);
@@ -1801,11 +1801,11 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         asyncExecutor.setProcessEngineConfiguration(this);
         asyncExecutor.setAutoActivate(asyncExecutorActivate);
     }
-    
+
     public void initAsyncHistoryExecutor() {
         if (asyncHistoryExecutor == null) {
             DefaultAsyncJobExecutor defaultAsyncHistoryExecutor = new DefaultAsyncHistoryJobExecutor();
-            
+
             // Message queue mode
             defaultAsyncHistoryExecutor.setMessageQueueMode(asyncHistoryExecutorMessageQueueMode);
 
@@ -1956,7 +1956,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
             formEngines = new HashMap<>();
             FormEngine defaultFormEngine = new JuelFormEngine();
             formEngines.put(null, defaultFormEngine); // default form engine is
-                                                      // looked up with null
+            // looked up with null
             formEngines.put(defaultFormEngine.getName(), defaultFormEngine);
         }
         if (customFormEngines != null) {
@@ -2080,7 +2080,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         if (this.eventDispatcher == null) {
             this.eventDispatcher = new FlowableEventDispatcherImpl();
         }
-        
+
         if (this.additionalEventDispatchActions == null) {
             this.additionalEventDispatchActions = new ArrayList<>();
             this.additionalEventDispatchActions.add(new BpmnModelEventDispatchAction());
@@ -2148,7 +2148,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
             if (flowable5CompatibilityHandler != null) {
                 LOGGER.info("Found compatibility handler instance : {}", flowable5CompatibilityHandler.getClass());
-                
+
                 flowable5CompatibilityHandler.setFlowable6ProcessEngineConfiguration(this);
             }
         }
@@ -2471,10 +2471,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     /**
      * Add or replace the address of the given web-service endpoint with the given value
      *
-     * @param endpointName
-     *            The endpoint name for which a new address must be set
-     * @param address
-     *            The new address of the endpoint
+     * @param endpointName The endpoint name for which a new address must be set
+     * @param address      The new address of the endpoint
      */
     public ProcessEngineConfiguration addWsEndpointAddress(QName endpointName, URL address) {
         this.wsOverridenEndpointAddresses.put(endpointName, address);
@@ -2484,8 +2482,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     /**
      * Remove the address definition of the given web-service endpoint
      *
-     * @param endpointName
-     *            The endpoint name for which the address definition must be removed
+     * @param endpointName The endpoint name for which the address definition must be removed
      */
     public ProcessEngineConfiguration removeWsEndpointAddress(QName endpointName) {
         this.wsOverridenEndpointAddresses.remove(endpointName);
@@ -2634,7 +2631,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         this.jobHandlers = jobHandlers;
         return this;
     }
-    
+
     public Map<String, HistoryJobHandler> getHistoryJobHandlers() {
         return historyJobHandlers;
     }
@@ -2688,7 +2685,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         this.customJobHandlers = customJobHandlers;
         return this;
     }
-    
+
     public List<HistoryJobHandler> getCustomHistoryJobHandlers() {
         return customHistoryJobHandlers;
     }
@@ -3233,7 +3230,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         this.deadLetterJobDataManager = deadLetterJobDataManager;
         return this;
     }
-    
+
     public HistoryJobDataManager getHistoryJobDataManager() {
         return historyJobDataManager;
     }
@@ -3453,7 +3450,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         this.deadLetterJobEntityManager = deadLetterJobEntityManager;
         return this;
     }
-    
+
     public HistoryJobEntityManager getHistoryJobEntityManager() {
         return historyJobEntityManager;
     }
@@ -3533,18 +3530,18 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     public void setCandidateManager(CandidateManager candidateManager) {
         this.candidateManager = candidateManager;
     }
-    
+
     public AsyncRunnableExecutionExceptionHandler getAsyncRunnableExecutionExceptionHandler() {
         return asyncRunnableExecutionExceptionHandler;
     }
 
     public ProcessEngineConfigurationImpl setAsyncRunnableExecutionExceptionHandler(
-                    AsyncRunnableExecutionExceptionHandler asyncRunnableExecutionExceptionHandler) {
-        
+            AsyncRunnableExecutionExceptionHandler asyncRunnableExecutionExceptionHandler) {
+
         this.asyncRunnableExecutionExceptionHandler = asyncRunnableExecutionExceptionHandler;
         return this;
     }
-    
+
     public HistoryManager getHistoryManager() {
         return historyManager;
     }
@@ -3571,7 +3568,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         this.isAsyncHistoryJsonGzipCompressionEnabled = isAsyncHistoryJsonGzipCompressionEnabled;
         return this;
     }
-    
+
     public boolean isAsyncHistoryJsonGroupingEnabled() {
         return isAsyncHistoryJsonGroupingEnabled;
     }
@@ -3580,7 +3577,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         this.isAsyncHistoryJsonGroupingEnabled = isAsyncHistoryJsonGroupingEnabled;
         return this;
     }
-    
+
     public int getAsyncHistoryJsonGroupingThreshold() {
         return asyncHistoryJsonGroupingThreshold;
     }
@@ -3789,7 +3786,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         this.asyncExecutorNumberOfRetries = asyncExecutorNumberOfRetries;
         return this;
     }
-    
+
     public int getAsyncHistoryExecutorNumberOfRetries() {
         return asyncHistoryExecutorNumberOfRetries;
     }
@@ -3924,7 +3921,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         this.asyncExecutorResetExpiredJobsInterval = asyncExecutorResetExpiredJobsInterval;
         return this;
     }
-    
+
     public int getAsyncExecutorResetExpiredJobsMaxTimeout() {
         return asyncExecutorResetExpiredJobsMaxTimeout;
     }
@@ -3942,7 +3939,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         this.asyncExecutorExecuteAsyncRunnableFactory = asyncExecutorExecuteAsyncRunnableFactory;
         return this;
     }
-    
+
     public int getAsyncExecutorResetExpiredJobsPageSize() {
         return asyncExecutorResetExpiredJobsPageSize;
     }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/ExecutionEntityManagerImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/ExecutionEntityManagerImpl.java
@@ -211,9 +211,9 @@ public class ExecutionEntityManagerImpl extends AbstractEntityManager<ExecutionE
     // CREATE METHODS
 
     @Override
-    public ExecutionEntity createProcessInstanceExecution(ProcessDefinition processDefinition, String businessKey, String tenantId, 
-                    String initiatorVariableName, String startActivityId) {
-        
+    public ExecutionEntity createProcessInstanceExecution(ProcessDefinition processDefinition, String businessKey, String tenantId,
+                                                          String initiatorVariableName, String startActivityId) {
+
         ExecutionEntity processInstanceExecution = executionDataManager.create();
 
         if (CountingEntityUtil.isExecutionRelatedEntityCountEnabledGlobally()) {
@@ -293,9 +293,9 @@ public class ExecutionEntityManagerImpl extends AbstractEntityManager<ExecutionE
     }
 
     @Override
-    public ExecutionEntity createSubprocessInstance(ProcessDefinition processDefinition, ExecutionEntity superExecutionEntity, 
-                    String businessKey, String activityId) {
-        
+    public ExecutionEntity createSubprocessInstance(ProcessDefinition processDefinition, ExecutionEntity superExecutionEntity,
+                                                    String businessKey, String activityId) {
+
         ExecutionEntity subProcessInstance = executionDataManager.create();
         inheritCommonProperties(superExecutionEntity, subProcessInstance);
         subProcessInstance.setProcessDefinitionId(processDefinition.getId());
@@ -389,24 +389,24 @@ public class ExecutionEntityManagerImpl extends AbstractEntityManager<ExecutionE
                 for (ExecutionEntity miExecutionEntity : subExecutionEntity.getExecutions()) {
                     if (miExecutionEntity.getSubProcessInstance() != null) {
                         deleteProcessInstanceCascade(miExecutionEntity.getSubProcessInstance(), deleteReason, deleteHistory);
-                        
+
                         if (getEventDispatcher().isEnabled()) {
                             FlowElement callActivityElement = miExecutionEntity.getCurrentFlowElement();
-                            getEventDispatcher().dispatchEvent(FlowableEventBuilder.createActivityCancelledEvent(callActivityElement.getId(), 
-                                            callActivityElement.getName(), miExecutionEntity.getId(), miExecutionEntity.getProcessInstanceId(), 
-                                            miExecutionEntity.getProcessDefinitionId(), "callActivity", deleteReason));
+                            getEventDispatcher().dispatchEvent(FlowableEventBuilder.createActivityCancelledEvent(callActivityElement.getId(),
+                                    callActivityElement.getName(), miExecutionEntity.getId(), miExecutionEntity.getProcessInstanceId(),
+                                    miExecutionEntity.getProcessDefinitionId(), "callActivity", deleteReason));
                         }
                     }
                 }
 
             } else if (subExecutionEntity.getSubProcessInstance() != null) {
                 deleteProcessInstanceCascade(subExecutionEntity.getSubProcessInstance(), deleteReason, deleteHistory);
-                
+
                 if (getEventDispatcher().isEnabled()) {
                     FlowElement callActivityElement = subExecutionEntity.getCurrentFlowElement();
-                    getEventDispatcher().dispatchEvent(FlowableEventBuilder.createActivityCancelledEvent(callActivityElement.getId(), 
-                                    callActivityElement.getName(), subExecutionEntity.getId(), subExecutionEntity.getProcessInstanceId(), 
-                                    subExecutionEntity.getProcessDefinitionId(), "callActivity", deleteReason));
+                    getEventDispatcher().dispatchEvent(FlowableEventBuilder.createActivityCancelledEvent(callActivityElement.getId(),
+                            callActivityElement.getName(), subExecutionEntity.getId(), subExecutionEntity.getProcessInstanceId(),
+                            subExecutionEntity.getProcessDefinitionId(), "callActivity", deleteReason));
                 }
             }
         }
@@ -441,18 +441,18 @@ public class ExecutionEntityManagerImpl extends AbstractEntityManager<ExecutionE
         getHistoryManager().recordProcessInstanceEnd(processInstanceExecutionEntity, deleteReason, null);
         processInstanceExecutionEntity.setDeleted(true);
     }
-    
+
     @Override
     public void deleteExecutionAndRelatedData(ExecutionEntity executionEntity, String deleteReason, boolean cancel, FlowElement cancelActivity) {
         if (executionEntity.isActive()
-                && executionEntity.getCurrentFlowElement() != null 
+                && executionEntity.getCurrentFlowElement() != null
                 && !executionEntity.isMultiInstanceRoot()
                 && !(executionEntity.getCurrentFlowElement() instanceof BoundaryEvent)) {  // Boundary events will handle the history themselves (see TriggerExecutionOperation for example)
             getHistoryManager().recordActivityEnd(executionEntity, deleteReason);
         }
         deleteRelatedDataForExecution(executionEntity, deleteReason);
         delete(executionEntity);
-        
+
         if (cancel) {
             dispatchActivityCancelled(executionEntity, cancelActivity != null ? cancelActivity : executionEntity.getCurrentFlowElement());
         }
@@ -460,12 +460,12 @@ public class ExecutionEntityManagerImpl extends AbstractEntityManager<ExecutionE
 
     @Override
     public void deleteExecutionAndRelatedData(ExecutionEntity executionEntity, String deleteReason) {
-       deleteExecutionAndRelatedData(executionEntity, deleteReason, false, null);
+        deleteExecutionAndRelatedData(executionEntity, deleteReason, false, null);
     }
 
     @Override
     public void deleteProcessInstanceExecutionEntity(String processInstanceId,
-            String currentFlowElementId, String deleteReason, boolean cascade, boolean cancel, boolean fireEvents) {
+                                                     String currentFlowElementId, String deleteReason, boolean cascade, boolean cancel, boolean fireEvents) {
 
         ExecutionEntity processInstanceEntity = findById(processInstanceId);
 
@@ -479,14 +479,14 @@ public class ExecutionEntityManagerImpl extends AbstractEntityManager<ExecutionE
 
         // Call activities
         for (ExecutionEntity subExecutionEntity : processInstanceEntity.getExecutions()) {
-            if (subExecutionEntity.getSubProcessInstance() != null &&  !subExecutionEntity.isEnded()) {
+            if (subExecutionEntity.getSubProcessInstance() != null && !subExecutionEntity.isEnded()) {
                 deleteProcessInstanceCascade(subExecutionEntity.getSubProcessInstance(), deleteReason, cascade);
-                
+
                 if (getEventDispatcher().isEnabled() && fireEvents) {
                     FlowElement callActivityElement = subExecutionEntity.getCurrentFlowElement();
-                    getEventDispatcher().dispatchEvent(FlowableEventBuilder.createActivityCancelledEvent(callActivityElement.getId(), 
-                                    callActivityElement.getName(), subExecutionEntity.getId(), processInstanceId, subExecutionEntity.getProcessDefinitionId(), 
-                                    "callActivity", deleteReason));
+                    getEventDispatcher().dispatchEvent(FlowableEventBuilder.createActivityCancelledEvent(callActivityElement.getId(),
+                            callActivityElement.getName(), subExecutionEntity.getId(), processInstanceId, subExecutionEntity.getProcessDefinitionId(),
+                            "callActivity", deleteReason));
                 }
             }
         }
@@ -518,7 +518,7 @@ public class ExecutionEntityManagerImpl extends AbstractEntityManager<ExecutionE
     public void deleteChildExecutions(ExecutionEntity executionEntity, String deleteReason, boolean cancel) {
         deleteChildExecutions(executionEntity, null, deleteReason, cancel, null);
     }
-    
+
     @Override
     public void deleteChildExecutions(ExecutionEntity executionEntity, Collection<String> executionIdsNotToDelete, String deleteReason, boolean cancel, FlowElement cancelActivity) {
 
@@ -534,13 +534,13 @@ public class ExecutionEntityManagerImpl extends AbstractEntityManager<ExecutionE
                         && !executionIdsNotToDelete.contains(childExecutionEntity.getId()))) {
 
                     if (childExecutionEntity.isProcessInstanceType()) {
-                        deleteProcessInstanceExecutionEntity(childExecutionEntity.getId(), 
+                        deleteProcessInstanceExecutionEntity(childExecutionEntity.getId(),
                                 cancelActivity != null ? cancelActivity.getId() : null, deleteReason, true, cancel, true);
 
                     } else {
                         deleteExecutionAndRelatedData(childExecutionEntity, deleteReason);
                         if (cancel) {
-                            dispatchExecutionCancelled(childExecutionEntity, 
+                            dispatchExecutionCancelled(childExecutionEntity,
                                     cancelActivity != null ? cancelActivity : childExecutionEntity.getCurrentFlowElement());
                         }
 
@@ -552,20 +552,20 @@ public class ExecutionEntityManagerImpl extends AbstractEntityManager<ExecutionE
     }
 
     public List<ExecutionEntity> collectChildren(ExecutionEntity executionEntity) {
-       return collectChildren(executionEntity, null);
+        return collectChildren(executionEntity, null);
     }
-    
+
     protected List<ExecutionEntity> collectChildren(ExecutionEntity executionEntity, Collection<String> executionIdsToExclude) {
-        List<ExecutionEntity> childExecutions = new ArrayList<ExecutionEntity>();
+        List<ExecutionEntity> childExecutions = new ArrayList<>();
         collectChildren(executionEntity, childExecutions, executionIdsToExclude != null ? executionIdsToExclude : Collections.<String>emptyList());
         return childExecutions;
     }
 
     @SuppressWarnings("unchecked")
-    protected void collectChildren(ExecutionEntity executionEntity, List<ExecutionEntity> collectedChildExecution,  Collection<String> executionIdsToExclude) {
+    protected void collectChildren(ExecutionEntity executionEntity, List<ExecutionEntity> collectedChildExecution, Collection<String> executionIdsToExclude) {
         List<ExecutionEntity> childExecutions = (List<ExecutionEntity>) executionEntity.getExecutions();
         if (childExecutions != null && childExecutions.size() > 0) {
-            
+
             // Have a fixed ordering of child executions (important for the order in which events are sent)
             Collections.sort(childExecutions, new Comparator<ExecutionEntity>() {
                 @Override
@@ -573,13 +573,13 @@ public class ExecutionEntityManagerImpl extends AbstractEntityManager<ExecutionE
                     return e1.getStartTime().compareTo(e2.getStartTime());
                 }
             });
-            
+
             for (ExecutionEntity childExecution : childExecutions) {
                 if (!executionIdsToExclude.contains(childExecution.getId())) {
                     if (!childExecution.isDeleted()) {
                         collectedChildExecution.add(childExecution);
                     }
-                    
+
                     collectChildren(childExecution, collectedChildExecution, executionIdsToExclude);
                 }
             }
@@ -590,11 +590,11 @@ public class ExecutionEntityManagerImpl extends AbstractEntityManager<ExecutionE
             if (!subProcessInstance.isDeleted()) {
                 collectedChildExecution.add(subProcessInstance);
             }
-            
+
             collectChildren(subProcessInstance, collectedChildExecution, executionIdsToExclude);
         }
     }
-    
+
     protected void dispatchExecutionCancelled(ExecutionEntity execution, FlowElement cancelActivity) {
 
         ExecutionEntityManager executionEntityManager = CommandContextUtil.getExecutionEntityManager();
@@ -616,7 +616,7 @@ public class ExecutionEntityManagerImpl extends AbstractEntityManager<ExecutionE
             dispatchActivityCancelled(execution, cancelActivity);
         }
     }
-    
+
     protected void dispatchActivityCancelled(ExecutionEntity execution, FlowElement cancelActivity) {
         CommandContextUtil.getProcessEngineConfiguration()
                 .getEventDispatcher()
@@ -625,7 +625,7 @@ public class ExecutionEntityManagerImpl extends AbstractEntityManager<ExecutionE
                                 execution.getCurrentFlowElement().getName(), execution.getId(), execution.getProcessInstanceId(),
                                 execution.getProcessDefinitionId(), getActivityType((FlowNode) execution.getCurrentFlowElement()), cancelActivity));
     }
-    
+
     protected String getActivityType(FlowNode flowNode) {
         String elementType = flowNode.getClass().getSimpleName();
         elementType = elementType.substring(0, 1).toLowerCase() + elementType.substring(1);
@@ -676,7 +676,7 @@ public class ExecutionEntityManagerImpl extends AbstractEntityManager<ExecutionE
 
         if (executionEntity.getId().equals(executionEntity.getProcessInstanceId())
                 && (!enableExecutionRelationshipCounts
-                        || (enableExecutionRelationshipCounts && ((CountingExecutionEntity) executionEntity).getIdentityLinkCount() > 0))) {
+                || (enableExecutionRelationshipCounts && ((CountingExecutionEntity) executionEntity).getIdentityLinkCount() > 0))) {
             IdentityLinkEntityManager identityLinkEntityManager = getIdentityLinkEntityManager();
             Collection<IdentityLinkEntity> identityLinks = identityLinkEntityManager.findIdentityLinksByProcessInstanceId(executionEntity.getProcessInstanceId());
             for (IdentityLinkEntity identityLink : identityLinks) {
@@ -698,7 +698,7 @@ public class ExecutionEntityManagerImpl extends AbstractEntityManager<ExecutionE
 
                 CommandContextUtil.getVariableService().deleteVariableInstance(variableInstanceEntity);
                 CountingEntityUtil.handleDeleteVariableInstanceEntityCount(variableInstanceEntity, true);
-                
+
                 if (variableInstanceEntity.getByteArrayRef() != null && variableInstanceEntity.getByteArrayRef().getId() != null) {
                     getByteArrayEntityManager().deleteByteArrayById(variableInstanceEntity.getByteArrayRef().getId());
                 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.java
@@ -61,7 +61,7 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
     /**
      * Multi-instance user task cancelled by terminate end event.
      */
-    @Deployment(resources = { "org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.bpmn20.xml" })
+    @Deployment(resources = {"org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.bpmn20.xml"})
     public void testMultiInstanceCancelledWhenFlowToTerminateEnd() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("multiInstanceUserTaskEvents");
         assertNotNull(processInstance);
@@ -169,7 +169,7 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
      * Multi-instance user task cancelled by message boundary event defined on
      * multi-instance user task.
      */
-    @Deployment(resources = { "org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.bpmn20.xml" })
+    @Deployment(resources = {"org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.bpmn20.xml"})
     public void testMultiInstanceCancelledByMessageBoundaryEvent() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("multiInstanceUserTaskEvents");
         assertNotNull(processInstance);
@@ -270,7 +270,7 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
      */
     @Deployment(resources = {
             "org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.testCallActivityTerminateEnd.bpmn20.xml",
-            "org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.testCalledActivityTerminateEnd.bpmn20.xml" })
+            "org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.testCalledActivityTerminateEnd.bpmn20.xml"})
     public void testMultiInstanceInCallActivityCancelledByMessageBoundaryEvent() throws Exception {
         ProcessInstance processInstance = runtimeService
                 .startProcessInstanceByKey("multiInstanceCallActivityTerminateEnd");
@@ -415,7 +415,7 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
      */
     @Deployment(resources = {
             "org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.testCallActivityTerminateEnd.bpmn20.xml",
-            "org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.testCalledActivityTerminateEnd.bpmn20.xml" })
+            "org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.testCalledActivityTerminateEnd.bpmn20.xml"})
     public void testMultiInstanceInCallActivityCancelledWhenFlowToTerminateEnd() throws Exception {
         ProcessInstance processInstance = runtimeService
                 .startProcessInstanceByKey("multiInstanceCallActivityTerminateEnd");
@@ -526,31 +526,29 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
         // time so the ordering of these events can fluctuate
         int multiCount = 0;
         boolean foundBoundary = false;
-        for (int i=0; i < 4; i++) {
-          activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-          assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, activityEvent.getType());
-          if ("cancelBoundaryEvent1".equals(activityEvent.getActivityId())) {
-              foundBoundary = true;
-              assertEquals("cancelBoundaryEvent1", activityEvent.getActivityId());
-              assertEquals("boundaryEvent", activityEvent.getActivityType());
-          }
-          else  if ("calledtask1".equals(activityEvent.getActivityId())){
-            // cancelled event for one of the multi-instance user task instances or the root
-            FlowableActivityCancelledEvent cancelledEvent = (FlowableActivityCancelledEvent) activityEvent;
-            assertEquals("calledtask1", cancelledEvent.getActivityId());
-            assertEquals("userTask", cancelledEvent.getActivityType());
-            assertEquals("Multi User Task-${loopCounter}", cancelledEvent.getActivityName());
-            multiCount++;
-          }
-          else {
-              fail("Unknown activity id " + activityEvent.getActivityId());
-          }
+        for (int i = 0; i < 4; i++) {
+            activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
+            assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, activityEvent.getType());
+            if ("cancelBoundaryEvent1".equals(activityEvent.getActivityId())) {
+                foundBoundary = true;
+                assertEquals("cancelBoundaryEvent1", activityEvent.getActivityId());
+                assertEquals("boundaryEvent", activityEvent.getActivityType());
+            } else if ("calledtask1".equals(activityEvent.getActivityId())) {
+                // cancelled event for one of the multi-instance user task instances or the root
+                FlowableActivityCancelledEvent cancelledEvent = (FlowableActivityCancelledEvent) activityEvent;
+                assertEquals("calledtask1", cancelledEvent.getActivityId());
+                assertEquals("userTask", cancelledEvent.getActivityType());
+                assertEquals("Multi User Task-${loopCounter}", cancelledEvent.getActivityName());
+                multiCount++;
+            } else {
+                fail("Unknown activity id " + activityEvent.getActivityId());
+            }
         }
         assertTrue(foundBoundary);
         assertEquals(3, multiCount);
 
         // external subprocess cancelled
-        FlowableCancelledEvent processCancelledEvent = (FlowableCancelledEvent)  testListener.getEventsReceived().get(idx++);
+        FlowableCancelledEvent processCancelledEvent = (FlowableCancelledEvent) testListener.getEventsReceived().get(idx++);
         assertEquals(FlowableEngineEventType.PROCESS_CANCELLED, processCancelledEvent.getType());
         assertEquals(subprocessInstance.getId(), processCancelledEvent.getExecutionId());
 
@@ -650,7 +648,7 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertEquals(3, tasks.size());
         Task userTask1 = null;
-        for (Task t: tasks) {
+        for (Task t : tasks) {
             if ("User Task1 in Parent".equals(t.getName())) {
                 userTask1 = t;
                 break;
@@ -675,18 +673,18 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
         assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
         assertEquals("endevent1", activityEvent.getActivityId());
         assertEquals("endEvent", activityEvent.getActivityType());
-        
+
         int miEventCount = 0;
-        for (int i=0; i<4; i++) {
-            
+        for (int i = 0; i < 4; i++) {
+
             activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
             if ("cancelBoundaryEvent1".equals(activityEvent.getActivityId())) {
                 assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, activityEvent.getType());
                 assertEquals("cancelBoundaryEvent1", activityEvent.getActivityId());
                 assertEquals("boundaryEvent", activityEvent.getActivityType());
 
-            } else if("task2".equals(activityEvent.getActivityId())) {
-                
+            } else if ("task2".equals(activityEvent.getActivityId())) {
+
                 // cancelled event for one of the multi-instance user task instances
                 assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, activityEvent.getType());
                 FlowableActivityCancelledEvent cancelledEvent = (FlowableActivityCancelledEvent) activityEvent;
@@ -694,14 +692,14 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
                 assertEquals("userTask", cancelledEvent.getActivityType());
                 assertEquals("Multi User Task-${loopCounter}", cancelledEvent.getActivityName());
                 miEventCount++;
-                
-            } else if("task2".equals(activityEvent.getActivityId())) {
-               
-                
+
+            } else if ("task2".equals(activityEvent.getActivityId())) {
+
+
             } else {
                 fail("Unknown activity id " + activityEvent.getActivityId());
             }
-            
+
         }
         assertEquals(3, miEventCount);
 
@@ -713,7 +711,7 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
         assertEquals("subProcess", activityEvent.getActivityType());
 
         entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT, entityEvent.getType());  
+        assertEquals(FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT, entityEvent.getType());
         executionEntity = (ExecutionEntity) entityEvent.getEntity();
         assertEquals(processInstance.getId(), executionEntity.getId());
 
@@ -726,7 +724,7 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
         private List<FlowableEvent> eventsReceived;
 
         public MultiInstanceUserActivityEventListener() {
-            eventsReceived = new ArrayList<FlowableEvent>();
+            eventsReceived = new ArrayList<>();
         }
 
         public List<FlowableEvent> getEventsReceived() {
@@ -742,19 +740,19 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
 
             FlowableEngineEventType engineEventType = (FlowableEngineEventType) event.getType();
             switch (engineEventType) {
-            case ACTIVITY_STARTED:
-            case ACTIVITY_COMPLETED:
-            case ACTIVITY_CANCELLED:
-            case TASK_CREATED:
-            case TASK_COMPLETED:
-            case PROCESS_STARTED:
-            case PROCESS_COMPLETED:
-            case PROCESS_CANCELLED:
-            case PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT:
-                eventsReceived.add(event);
-                break;
-            default:
-                break;
+                case ACTIVITY_STARTED:
+                case ACTIVITY_COMPLETED:
+                case ACTIVITY_CANCELLED:
+                case TASK_CREATED:
+                case TASK_COMPLETED:
+                case PROCESS_STARTED:
+                case PROCESS_COMPLETED:
+                case PROCESS_CANCELLED:
+                case PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT:
+                    eventsReceived.add(event);
+                    break;
+                default:
+                    break;
             }
         }
 

--- a/modules/flowable-groovy-script-static-engine/src/main/java/org/flowable/engine/impl/scripting/GroovyStaticScriptEngine.java
+++ b/modules/flowable-groovy-script-static-engine/src/main/java/org/flowable/engine/impl/scripting/GroovyStaticScriptEngine.java
@@ -53,14 +53,14 @@ public class GroovyStaticScriptEngine extends GroovyScriptEngineImpl {
     @Override
     public Object eval(String script, ScriptContext ctx) throws ScriptException {
         COMPILE_OPTIONS.remove();
-        Map<String,ClassNode> variableTypes = new HashMap<String, ClassNode>();
-        for (Map.Entry<String,Object> entry : ctx.getBindings(ScriptContext.ENGINE_SCOPE).entrySet()) {
+        Map<String, ClassNode> variableTypes = new HashMap<>();
+        for (Map.Entry<String, Object> entry : ctx.getBindings(ScriptContext.ENGINE_SCOPE).entrySet()) {
             variableTypes.put(entry.getKey(),
                     ClassHelper.make(entry.getValue().getClass()));
         }
 
-        variableTypes.put("execution",ClassHelper.make(clazz));
-        Map<String,Object> options = new HashMap<String, Object>();
+        variableTypes.put("execution", ClassHelper.make(clazz));
+        Map<String, Object> options = new HashMap<>();
         options.put(VAR_TYPES, variableTypes);
         COMPILE_OPTIONS.set(options);
         Object ret = super.eval(script, ctx);
@@ -82,7 +82,7 @@ public class GroovyStaticScriptEngine extends GroovyScriptEngineImpl {
             Class<?> scriptClass = ctxtLoader.loadClass(Script.class.getName());
             clazz = ctxtLoader.loadClass("org.flowable.engine.delegate.VariableScope");
 
-            if(scriptClass == Script.class) {
+            if (scriptClass == Script.class) {
                 return ctxtLoader;
             }
         } catch (ClassNotFoundException var2) {

--- a/modules/flowable-jmx/src/main/java/org/flowable/management/jmx/DefaultManagementAgent.java
+++ b/modules/flowable-jmx/src/main/java/org/flowable/management/jmx/DefaultManagementAgent.java
@@ -46,7 +46,7 @@ public class DefaultManagementAgent implements ManagementAgent {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultManagementAgent.class);
 
     protected MBeanServer server;
-    protected final ConcurrentMap<ObjectName, ObjectName> mbeansRegistered = new ConcurrentHashMap<ObjectName, ObjectName>();
+    protected final ConcurrentMap<ObjectName, ObjectName> mbeansRegistered = new ConcurrentHashMap<>();
     protected JMXConfigurator jmxConfigurator;
     protected Registry registry;
     protected JMXConnectorServer cs;

--- a/modules/flowable-jmx/src/main/java/org/flowable/management/jmx/MBeanInfoAssembler.java
+++ b/modules/flowable-jmx/src/main/java/org/flowable/management/jmx/MBeanInfoAssembler.java
@@ -47,7 +47,7 @@ public class MBeanInfoAssembler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MBeanInfoAssembler.class);
 
-    protected final WeakHashMap<Class<?>, MBeanAttributesAndOperations> cache = new WeakHashMap<Class<?>, MBeanAttributesAndOperations>(10);
+    protected final WeakHashMap<Class<?>, MBeanAttributesAndOperations> cache = new WeakHashMap<>(10);
 
     public MBeanInfoAssembler() {
     }
@@ -63,11 +63,11 @@ public class MBeanInfoAssembler {
         }
 
         // maps and lists to contain information about attributes and operations
-        Map<String, ManagedAttributeInfo> attributes = new LinkedHashMap<String, ManagedAttributeInfo>();
-        Set<ManagedOperationInfo> operations = new LinkedHashSet<ManagedOperationInfo>();
-        Set<ModelMBeanAttributeInfo> mBeanAttributes = new LinkedHashSet<ModelMBeanAttributeInfo>();
-        Set<ModelMBeanOperationInfo> mBeanOperations = new LinkedHashSet<ModelMBeanOperationInfo>();
-        Set<ModelMBeanNotificationInfo> mBeanNotifications = new LinkedHashSet<ModelMBeanNotificationInfo>();
+        Map<String, ManagedAttributeInfo> attributes = new LinkedHashMap<>();
+        Set<ManagedOperationInfo> operations = new LinkedHashSet<>();
+        Set<ModelMBeanAttributeInfo> mBeanAttributes = new LinkedHashSet<>();
+        Set<ModelMBeanOperationInfo> mBeanOperations = new LinkedHashSet<>();
+        Set<ModelMBeanNotificationInfo> mBeanNotifications = new LinkedHashSet<>();
 
         // extract details from default managed bean
         if (defaultManagedBean != null) {
@@ -102,8 +102,8 @@ public class MBeanInfoAssembler {
         if (cached == null) {
             doExtractAttributesAndOperations(managedClass, attributes, operations);
             cached = new MBeanAttributesAndOperations();
-            cached.attributes = new LinkedHashMap<String, ManagedAttributeInfo>(attributes);
-            cached.operations = new LinkedHashSet<ManagedOperationInfo>(operations);
+            cached.attributes = new LinkedHashMap<>(attributes);
+            cached.operations = new LinkedHashSet<>(operations);
 
             // clear before we re-add them
             attributes.clear();

--- a/modules/flowable-jmx/src/main/java/org/flowable/management/jmx/mbeans/ProcessDefinitionsMBean.java
+++ b/modules/flowable-jmx/src/main/java/org/flowable/management/jmx/mbeans/ProcessDefinitionsMBean.java
@@ -42,9 +42,9 @@ public class ProcessDefinitionsMBean {
     @ManagedAttribute(description = "List of Process definitions")
     public List<List<String>> getProcessDefinitions() {
         List<ProcessDefinition> deployments = repositoryService.createProcessDefinitionQuery().list();
-        List<List<String>> result = new ArrayList<List<String>>(deployments.size());
+        List<List<String>> result = new ArrayList<>(deployments.size());
         for (ProcessDefinition deployment : deployments) {
-            List<String> item = new ArrayList<String>(3);
+            List<String> item = new ArrayList<>(3);
             item.add(deployment.getId());
             item.add(deployment.getName());
             item.add(Integer.toString(deployment.getVersion()));
@@ -59,7 +59,7 @@ public class ProcessDefinitionsMBean {
     @ManagedOperation(description = "get a specific process definition")
     public List<String> getProcessDefinitionById(String id) {
         ProcessDefinition pd = repositoryService.createProcessDefinitionQuery().processDefinitionId(id).singleResult();
-        List<String> item = new ArrayList<String>(3);
+        List<String> item = new ArrayList<>(3);
         item.add(pd.getId());
         item.add(pd.getName());
         item.add(Integer.toString(pd.getVersion()));
@@ -73,9 +73,9 @@ public class ProcessDefinitionsMBean {
     @ManagedAttribute(description = "List of deployed Processes")
     public List<List<String>> getDeployments() {
         List<Deployment> deployments = repositoryService.createDeploymentQuery().list();
-        List<List<String>> result = new ArrayList<List<String>>(deployments.size());
+        List<List<String>> result = new ArrayList<>(deployments.size());
         for (Deployment deployment : deployments) {
-            List<String> item = new ArrayList<String>(3);
+            List<String> item = new ArrayList<>(3);
             item.add(deployment.getId());
             item.add(deployment.getName());
             item.add(deployment.getTenantId());

--- a/modules/flowable-jmx/src/test/java/org/flowable/management/jmx/mbeans/ProcessDefinitionsTest.java
+++ b/modules/flowable-jmx/src/test/java/org/flowable/management/jmx/mbeans/ProcessDefinitionsTest.java
@@ -83,7 +83,7 @@ public class ProcessDefinitionsTest {
     public void testGetProcessDefinitions() {
 
         when(repositoryService.createProcessDefinitionQuery()).thenReturn(processDefinitionQuery);
-        List<ProcessDefinition> processDefinitionList = new ArrayList<ProcessDefinition>();
+        List<ProcessDefinition> processDefinitionList = new ArrayList<>();
         ProcessDefinitionEntity pd = new ProcessDefinitionEntityImpl();
         pd.setId("testId");
         pd.setName("testName");
@@ -116,7 +116,7 @@ public class ProcessDefinitionsTest {
     public void testDeployments() {
         when(repositoryService.createDeploymentQuery()).thenReturn(deploymentQuery);
         DeploymentEntity deployment = new DeploymentEntityImpl();
-        List<Deployment> deploymentList = new ArrayList<Deployment>();
+        List<Deployment> deploymentList = new ArrayList<>();
         deployment.setId("testDeploymentId");
         deployment.setName("testDeploymentName");
         deployment.setTenantId("tenantId");

--- a/modules/flowable-ldap/src/main/java/org/flowable/ldap/LDAPConfiguration.java
+++ b/modules/flowable-ldap/src/main/java/org/flowable/ldap/LDAPConfiguration.java
@@ -26,11 +26,11 @@ import org.flowable.ldap.LDAPGroupCache.LDAPGroupCacheListener;
 /**
  * A {@link ProcessEngineConfigurator} that integrates a LDAP system with the Flowable process engine. The LDAP system will be consulted primarily for getting user information and in particular for
  * fetching groups of a user.
- * 
+ * <p>
  * This class is extensible and many methods can be overridden when the default behavior is not fitting your use case.
- * 
+ * <p>
  * Check the docs (specifically the setters) to see how this class can be tweaked.
- * 
+ *
  * @author Joram Barrez
  */
 public class LDAPConfiguration {
@@ -45,7 +45,7 @@ public class LDAPConfiguration {
     protected String securityAuthentication = "simple";
 
     // For parameters like connection pooling settings, etc.
-    protected Map<String, String> customConnectionParameters = new HashMap<String, String>();
+    protected Map<String, String> customConnectionParameters = new HashMap<>();
 
     // Query configuration
     protected String baseDn;
@@ -131,7 +131,7 @@ public class LDAPConfiguration {
 
     /**
      * The {@link InitialContextFactory} name used to connect to the LDAP system.
-     * 
+     * <p>
      * By default set to 'com.sun.jndi.ldap.LdapCtxFactory'.
      */
     public void setInitialContextFactory(String initialContextFactory) {
@@ -144,7 +144,7 @@ public class LDAPConfiguration {
 
     /**
      * The value that is used for the 'java.naming.security.authentication' property used to connect to the LDAP system.
-     * 
+     * <p>
      * By default set to 'simple'.
      */
     public void setSecurityAuthentication(String securityAuthentication) {
@@ -158,7 +158,7 @@ public class LDAPConfiguration {
     /**
      * Allows to set all LDAP connection parameters which do not have a dedicated setter. See for example http://docs.oracle.com/javase/tutorial/jndi/ldap/jndi.html for custom properties. Such
      * properties are for example to configure connection pooling, specific security settings, etc.
-     * 
+     * <p>
      * All the provided parameters will be provided when creating a {@link InitialDirContext}, ie when a connection to the LDAP system is established.
      */
     public void setCustomConnectionParameters(Map<String, String> customConnectionParameters) {
@@ -171,7 +171,7 @@ public class LDAPConfiguration {
 
     /**
      * The base 'distinguished name' (DN) from which the searches for users and groups are started.
-     * 
+     * <p>
      * Use {@link #setUserBaseDn(String)} or {@link #setGroupBaseDn(String)} when needing to differentiate between user and group base DN.
      */
     public void setBaseDn(String baseDn) {
@@ -217,13 +217,13 @@ public class LDAPConfiguration {
 
     /**
      * The query that is executed when searching for a user by userId.
-     * 
+     * <p>
      * For example: (&amp;(objectClass=inetOrgPerson)(uid={0}))
-     * 
+     * <p>
      * Here, all the objects in LDAP with the class 'inetOrgPerson' and who have the matching 'uid' attribute value will be returned.
-     * 
+     * <p>
      * As shown in the example, the user id is injected by the typical {@link MessageFormat}, ie by using <i>{0}</i>
-     * 
+     * <p>
      * If setting the query alone is insufficient for your specific LDAP setup, you can alternatively plug in a different {@link LDAPQueryBuilder}, which allows for more customization than only the
      * query.
      */
@@ -241,13 +241,13 @@ public class LDAPConfiguration {
 
     /**
      * The query that is executed when searching for a user by full name.
-     * 
+     * <p>
      * For example: (&amp;(objectClass=inetOrgPerson)(|({0}=*{1}*)({2}={3})))
-     * 
+     * <p>
      * Here, all the objects in LDAP with the class 'inetOrgPerson' and who have the matching first name or last name will be returned
-     * 
+     * <p>
      * Several things will be injected in the expression: {0} : the first name attribute {1} : the search text {2} : the last name attribute {3} : the search text
-     * 
+     * <p>
      * If setting the query alone is insufficient for your specific LDAP setup, you can alternatively plug in a different {@link LDAPQueryBuilder}, which allows for more customization than only the
      * query.
      */
@@ -262,7 +262,7 @@ public class LDAPConfiguration {
     public void setQueryAllUsers(String queryAllUsers) {
         this.queryAllUsers = queryAllUsers;
     }
-    
+
     public String getQueryAllGroups() {
         return queryAllGroups;
     }
@@ -273,13 +273,13 @@ public class LDAPConfiguration {
 
     /**
      * The query that is executed when searching for the groups of a specific user.
-     * 
+     * <p>
      * For example: (&amp;(objectClass=groupOfUniqueNames)(uniqueMember={0}))
-     * 
+     * <p>
      * Here, all the objects in LDAP with the class 'groupOfUniqueNames' and where the provided DN is a 'uniqueMember' are returned.
-     * 
+     * <p>
      * As shown in the example, the user id is injected by the typical {@link MessageFormat}, ie by using <i>{0}</i>
-     * 
+     * <p>
      * If setting the query alone is insufficient for your specific LDAP setup, you can alternatively plug in a different {@link LDAPQueryBuilder}, which allows for more customization than only the
      * query.
      */
@@ -293,9 +293,9 @@ public class LDAPConfiguration {
 
     /**
      * Name of the attribute that matches the user id.
-     * 
+     * <p>
      * This property is used when looking for a {@link User} object and the mapping between the LDAP object and the Flowable {@link User} object is done.
-     * 
+     * <p>
      * This property is optional and is only needed if searching for {@link User} objects using the Flowable API.
      */
     public void setUserIdAttribute(String userIdAttribute) {
@@ -308,7 +308,7 @@ public class LDAPConfiguration {
 
     /**
      * Name of the attribute that matches the user first name.
-     * 
+     * <p>
      * This property is used when looking for a {@link User} object and the mapping between the LDAP object and the Flowable {@link User} object is done.
      */
     public void setUserFirstNameAttribute(String userFirstNameAttribute) {
@@ -321,7 +321,7 @@ public class LDAPConfiguration {
 
     /**
      * Name of the attribute that matches the user last name.
-     * 
+     * <p>
      * This property is used when looking for a {@link User} object and the mapping between the LDAP object and the Flowable {@link User} object is done.
      */
     public void setUserLastNameAttribute(String userLastNameAttribute) {
@@ -334,7 +334,7 @@ public class LDAPConfiguration {
 
     /**
      * Name of the attribute that matches the user email.
-     * 
+     * <p>
      * This property is used when looking for a {@link User} object and the mapping between the LDAP object and the Flowable {@link User} object is done.
      */
     public void setUserEmailAttribute(String userEmailAttribute) {
@@ -347,7 +347,7 @@ public class LDAPConfiguration {
 
     /**
      * Name of the attribute that matches the group id.
-     * 
+     * <p>
      * This property is used when looking for a {@link Group} object and the mapping between the LDAP object and the Flowable {@link Group} object is done.
      */
     public void setGroupIdAttribute(String groupIdAttribute) {
@@ -360,7 +360,7 @@ public class LDAPConfiguration {
 
     /**
      * Name of the attribute that matches the group name.
-     * 
+     * <p>
      * This property is used when looking for a {@link Group} object and the mapping between the LDAP object and the Flowable {@link Group} object is done.
      */
     public void setGroupNameAttribute(String groupNameAttribute) {
@@ -373,7 +373,7 @@ public class LDAPConfiguration {
 
     /**
      * Name of the attribute that matches the group type.
-     * 
+     * <p>
      * This property is used when looking for a {@link Group} object and the mapping between the LDAP object and the Flowable {@link Group} object is done.
      */
     public void setGroupTypeAttribute(String groupTypeAttribute) {
@@ -383,7 +383,7 @@ public class LDAPConfiguration {
     /**
      * Set a custom {@link LDAPQueryBuilder} if the default implementation is not suitable. The {@link LDAPQueryBuilder} instance is used when the {@link LDAPUserManager} or {@link LDAPGroupManager}
      * does an actual query against the LDAP system.
-     * 
+     * <p>
      * The default implementation uses the properties as set on this instance such as {@link #setQueryGroupsForUser(String)} and {@link #setQueryUserByUserId(String)}.
      */
     public LDAPQueryBuilder getLdapQueryBuilder() {
@@ -400,9 +400,9 @@ public class LDAPConfiguration {
 
     /**
      * Allows to set the size of the {@link LDAPGroupCache}. This is an LRU cache that caches groups for users and thus avoids hitting the LDAP system each time the groups of a user needs to be known.
-     * 
+     * <p>
      * The cache will not be instantiated if the value is less then zero. By default set to -1, so no caching is done.
-     * 
+     * <p>
      * Note that the group cache is instantiated on the {@link LDAPGroupManagerFactory}. As such, if you have a custom implementation of the {@link LDAPGroupManagerFactory}, do not forget to add the
      * group cache functionality.
      */
@@ -418,7 +418,7 @@ public class LDAPConfiguration {
      * Sets the expiration time of the {@link LDAPGroupCache} in milliseconds. When groups for a specific user are fetched, and if the group cache exists (see {@link #setGroupCacheSize(int)}), the
      * groups will be stored in this cache for the time set in this property. ie. when the groups were fetched at 00:00 and the expiration time is 30 mins, any fetch of the groups for that user after
      * 00:30 will not come from the cache, but do a fetch again from the LDAP system. Likewise, everything group fetch for that user done between 00:00 - 00:30 will come from the cache.
-     * 
+     * <p>
      * By default set to one hour.
      */
     public void setGroupCacheExpirationTime(long groupCacheExpirationTime) {

--- a/modules/flowable-ldap/src/main/java/org/flowable/ldap/impl/LDAPGroupQueryImpl.java
+++ b/modules/flowable-ldap/src/main/java/org/flowable/ldap/impl/LDAPGroupQueryImpl.java
@@ -71,10 +71,10 @@ public class LDAPGroupQueryImpl extends GroupQueryImpl {
                 return groups;
             }
         }
-        
+
         String searchExpression = ldapConfigurator.getLdapQueryBuilder().buildQueryGroupsForUser(ldapConfigurator, userId);
         List<Group> groups = executeGroupQuery(searchExpression);
-        
+
         // Cache results for later
         if (ldapGroupCache != null) {
             ldapGroupCache.add(userId, groups);
@@ -82,20 +82,20 @@ public class LDAPGroupQueryImpl extends GroupQueryImpl {
 
         return groups;
     }
-    
+
     protected List<Group> findAllGroups() {
         String searchExpression = ldapConfigurator.getQueryAllGroups();
         List<Group> groups = executeGroupQuery(searchExpression);
         return groups;
     }
-    
+
     protected List<Group> executeGroupQuery(final String searchExpression) {
         LDAPTemplate ldapTemplate = new LDAPTemplate(ldapConfigurator);
         return ldapTemplate.execute(new LDAPCallBack<List<Group>>() {
 
             public List<Group> executeInContext(InitialDirContext initialDirContext) {
 
-                List<Group> groups = new ArrayList<Group>();
+                List<Group> groups = new ArrayList<>();
                 try {
                     String baseDn = ldapConfigurator.getGroupBaseDn() != null ? ldapConfigurator.getGroupBaseDn() : ldapConfigurator.getBaseDn();
                     NamingEnumeration<?> namingEnum = initialDirContext.search(baseDn, searchExpression, createSearchControls());

--- a/modules/flowable-ldap/src/main/java/org/flowable/ldap/impl/LDAPUserQueryImpl.java
+++ b/modules/flowable-ldap/src/main/java/org/flowable/ldap/impl/LDAPUserQueryImpl.java
@@ -56,18 +56,18 @@ public class LDAPUserQueryImpl extends UserQueryImpl {
 
     protected List<User> executeQuery() {
         if (getId() != null) {
-            List<User> result = new ArrayList<User>();
+            List<User> result = new ArrayList<>();
             result.add(findById(getId()));
             return result;
-            
+
         } else if (getIdIgnoreCase() != null) {
-            List<User> result = new ArrayList<User>();
+            List<User> result = new ArrayList<>();
             result.add(findById(getIdIgnoreCase()));
             return result;
-            
+
         } else if (getFullNameLike() != null) {
             return executeNameQuery(getFullNameLike());
-            
+
         } else if (getFullNameLikeIgnoreCase() != null) {
             return executeNameQuery(getFullNameLikeIgnoreCase());
 
@@ -75,13 +75,13 @@ public class LDAPUserQueryImpl extends UserQueryImpl {
             return executeAllUserQuery();
         }
     }
-    
+
     protected List<User> executeNameQuery(String name) {
         String fullName = name.replaceAll("%", "");
         String searchExpression = ldapConfigurator.getLdapQueryBuilder().buildQueryByFullNameLike(ldapConfigurator, fullName);
         return executeUsersQuery(searchExpression);
     }
-    
+
     protected List<User> executeAllUserQuery() {
         String searchExpression = ldapConfigurator.getQueryAllUsers();
         return executeUsersQuery(searchExpression);
@@ -115,13 +115,13 @@ public class LDAPUserQueryImpl extends UserQueryImpl {
 
         });
     }
-    
+
     protected List<User> executeUsersQuery(final String searchExpression) {
         LDAPTemplate ldapTemplate = new LDAPTemplate(ldapConfigurator);
         return ldapTemplate.execute(new LDAPCallBack<List<User>>() {
 
             public List<User> executeInContext(InitialDirContext initialDirContext) {
-                List<User> result = new ArrayList<User>();
+                List<User> result = new ArrayList<>();
                 try {
                     String baseDn = ldapConfigurator.getUserBaseDn() != null ? ldapConfigurator.getUserBaseDn() : ldapConfigurator.getBaseDn();
                     NamingEnumeration<?> namingEnum = initialDirContext.search(baseDn, searchExpression, createSearchControls());

--- a/modules/flowable-osgi/src/main/java/org/flowable/osgi/Activator.java
+++ b/modules/flowable-osgi/src/main/java/org/flowable/osgi/Activator.java
@@ -28,21 +28,21 @@ import org.slf4j.LoggerFactory;
 
 /**
  * OSGi Activator
- * 
+ *
  * @author <a href="gnodet@gmail.com">Guillaume Nodet</a>
  */
 public class Activator implements BundleActivator {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Activator.class);
 
-    private List<Runnable> callbacks = new ArrayList<Runnable>();
+    private List<Runnable> callbacks = new ArrayList<>();
 
     public void start(BundleContext context) throws Exception {
         callbacks.add(new Service(context, URLStreamHandlerService.class.getName(), new BpmnURLHandler(), props("url.handler.protocol", "bpmn")));
         callbacks.add(new Service(context, URLStreamHandlerService.class.getName(), new BarURLHandler(), props("url.handler.protocol", "bar")));
         try {
-            callbacks.add(new Service(context, new String[] { ArtifactUrlTransformer.class.getName(), ArtifactListener.class.getName() }, new BpmnDeploymentListener(), null));
-            callbacks.add(new Service(context, new String[] { ArtifactUrlTransformer.class.getName(), ArtifactListener.class.getName() }, new BarDeploymentListener(), null));
+            callbacks.add(new Service(context, new String[]{ArtifactUrlTransformer.class.getName(), ArtifactListener.class.getName()}, new BpmnDeploymentListener(), null));
+            callbacks.add(new Service(context, new String[]{ArtifactUrlTransformer.class.getName(), ArtifactListener.class.getName()}, new BarDeploymentListener(), null));
         } catch (NoClassDefFoundError e) {
             LOGGER.warn("FileInstall package is not available, disabling fileinstall support");
             LOGGER.debug("FileInstall package is not available, disabling fileinstall support", e);
@@ -57,14 +57,14 @@ public class Activator implements BundleActivator {
     }
 
     private static Dictionary<String, String> props(String... args) {
-        Dictionary<String, String> props = new Hashtable<String, String>();
+        Dictionary<String, String> props = new Hashtable<>();
         for (int i = 0; i < args.length / 2; i++) {
             props.put(args[2 * i], args[2 * i + 1]);
         }
         return props;
     }
 
-    @SuppressWarnings({ "rawtypes" })
+    @SuppressWarnings({"rawtypes"})
     private static class Service implements Runnable {
 
         private final ServiceRegistration registration;

--- a/modules/flowable-osgi/src/main/java/org/flowable/osgi/BarTransformer.java
+++ b/modules/flowable-osgi/src/main/java/org/flowable/osgi/BarTransformer.java
@@ -47,17 +47,17 @@ public class BarTransformer {
         String pathHeader;
         JarInputStream jis = new JarInputStream(url.openStream());
         try {
-            Set<String> paths = new TreeSet<String>();
+            Set<String> paths = new TreeSet<>();
             ZipEntry e;
             while ((e = jis.getNextEntry()) != null) {
                 String n = e.getName();
                 int i = n.lastIndexOf('/');
                 if (-1 == i) {// Add root path if the .bpmn20.xml is in the root
-                              // of the bar file and the value is
-                              // example.bpmn20.xml
+                    // of the bar file and the value is
+                    // example.bpmn20.xml
                     paths.add("/"); // Extender#checkBundle calls the
-                                    // HeaderParser#parseHeader and it does not
-                                    // parse an empty string
+                    // HeaderParser#parseHeader and it does not
+                    // parse an empty string
                 } else if (i < n.length() - 1) {
                     paths.add(n.substring(0, i + 1));
                 }
@@ -129,7 +129,7 @@ public class BarTransformer {
     public static String[] extractNameVersionType(String url) {
         Matcher m = ARTIFACT_MATCHER.matcher(url);
         if (!m.matches()) {
-            return new String[] { url, DEFAULT_VERSION };
+            return new String[]{url, DEFAULT_VERSION};
         } else {
             // System.err.println(m.groupCount());
             // for (int i = 1; i <= m.groupCount(); i++) {
@@ -164,7 +164,7 @@ public class BarTransformer {
                     cleanupModifier(v, d5);
                 }
             }
-            return new String[] { d1, v.toString(), d6 };
+            return new String[]{d1, v.toString(), d6};
         }
     }
 

--- a/modules/flowable-osgi/src/main/java/org/flowable/osgi/Extender.java
+++ b/modules/flowable-osgi/src/main/java/org/flowable/osgi/Extender.java
@@ -60,7 +60,7 @@ public class Extender implements BundleTrackerCustomizer, ServiceTrackerCustomiz
     private final BundleTracker bundleTracker;
     private final ServiceTracker engineServiceTracker;
     private long timeout = 5000;
-    private Map<Long, List<BundleScriptEngineResolver>> resolvers = new ConcurrentHashMap<Long, List<BundleScriptEngineResolver>>();
+    private Map<Long, List<BundleScriptEngineResolver>> resolvers = new ConcurrentHashMap<>();
 
     public Extender(BundleContext context) {
         Extender.context = context;
@@ -135,9 +135,8 @@ public class Extender implements BundleTrackerCustomizer, ServiceTrackerCustomiz
 
     /**
      * this method checks the initial bundle that are installed/active before bundle tracker is opened.
-     * 
-     * @param b
-     *            the bundle to check
+     *
+     * @param b the bundle to check
      */
     private void checkInitialBundle(Bundle b) {
         // If the bundle is active, check it
@@ -156,7 +155,7 @@ public class Extender implements BundleTrackerCustomizer, ServiceTrackerCustomiz
     }
 
     private void checkBundleScriptEngines(Bundle bundle) {
-        List<BundleScriptEngineResolver> r = new ArrayList<BundleScriptEngineResolver>();
+        List<BundleScriptEngineResolver> r = new ArrayList<>();
         registerScriptEngines(bundle, r);
         for (BundleScriptEngineResolver service : r) {
             service.register();
@@ -167,7 +166,7 @@ public class Extender implements BundleTrackerCustomizer, ServiceTrackerCustomiz
     private void checkBundle(Bundle bundle) {
         LOGGER.debug("Scanning bundle {} for flowable process", bundle.getSymbolicName());
         try {
-            List<URL> pathList = new ArrayList<URL>();
+            List<URL> pathList = new ArrayList<>();
             String flowableHeader = bundle.getHeaders().get(BUNDLE_FLOWABLE_HEADER);
             if (flowableHeader == null) {
                 flowableHeader = "OSGI-INF/flowable/";
@@ -238,7 +237,7 @@ public class Extender implements BundleTrackerCustomizer, ServiceTrackerCustomiz
         }
     }
 
-    @SuppressWarnings({ "rawtypes" })
+    @SuppressWarnings({"rawtypes"})
     private void addEntries(Bundle bundle, String path, String filePattern, List<URL> pathList) {
         Enumeration e = bundle.findEntries(path, filePattern, false);
         while (e != null && e.hasMoreElements()) {
@@ -319,10 +318,10 @@ public class Extender implements BundleTrackerCustomizer, ServiceTrackerCustomiz
         return null;
     }
 
-    @SuppressWarnings({ "rawtypes" })
+    @SuppressWarnings({"rawtypes"})
     protected void registerScriptEngines(Bundle bundle, List<BundleScriptEngineResolver> resolvers) {
         URL configURL = null;
-        for (Enumeration e = bundle.findEntries(META_INF_SERVICES_DIR, SCRIPT_ENGINE_SERVICE_FILE, false); e != null && e.hasMoreElements();) {
+        for (Enumeration e = bundle.findEntries(META_INF_SERVICES_DIR, SCRIPT_ENGINE_SERVICE_FILE, false); e != null && e.hasMoreElements(); ) {
             configURL = (URL) e.nextElement();
         }
         if (configURL != null) {
@@ -357,7 +356,7 @@ public class Extender implements BundleTrackerCustomizer, ServiceTrackerCustomiz
             }
         }
 
-        @SuppressWarnings({ "rawtypes" })
+        @SuppressWarnings({"rawtypes"})
         public ScriptEngine resolveScriptEngine(String name) {
             try {
                 BufferedReader in = new BufferedReader(new InputStreamReader(configFile.openStream()));

--- a/modules/flowable-osgi/src/main/java/org/flowable/osgi/HeaderParser.java
+++ b/modules/flowable-osgi/src/main/java/org/flowable/osgi/HeaderParser.java
@@ -25,20 +25,19 @@ import java.util.Map;
 
 /**
  * Utility class to parse a standard OSGi header with paths.
- * 
+ *
  * @version $Rev$, $Date$
  */
 public class HeaderParser {
 
     /**
      * Parse a given OSGi header into a list of paths
-     * 
-     * @param header
-     *            the OSGi header to parse
+     *
+     * @param header the OSGi header to parse
      * @return the list of paths extracted from this header
      */
     public static List<PathElement> parseHeader(String header) {
-        List<PathElement> elements = new ArrayList<PathElement>();
+        List<PathElement> elements = new ArrayList<>();
         if (header == null || header.trim().length() == 0) {
             return elements;
         }
@@ -79,8 +78,8 @@ public class HeaderParser {
 
         public PathElement(String path) {
             this.path = path;
-            this.attributes = new HashMap<String, String>();
-            this.directives = new HashMap<String, String>();
+            this.attributes = new HashMap<>();
+            this.directives = new HashMap<>();
         }
 
         public String getName() {

--- a/modules/flowable-osgi/src/main/java/org/flowable/osgi/blueprint/BlueprintELResolver.java
+++ b/modules/flowable-osgi/src/main/java/org/flowable/osgi/blueprint/BlueprintELResolver.java
@@ -18,8 +18,8 @@ import org.slf4j.LoggerFactory;
 public class BlueprintELResolver extends ELResolver {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BlueprintELResolver.class);
-    private Map<String, JavaDelegate> delegateMap = new HashMap<String, JavaDelegate>();
-    private Map<String, ActivityBehavior> activityBehaviourMap = new HashMap<String, ActivityBehavior>();
+    private Map<String, JavaDelegate> delegateMap = new HashMap<>();
+    private Map<String, ActivityBehavior> activityBehaviourMap = new HashMap<>();
 
     public Object getValue(ELContext context, Object base, Object property) {
         if (base == null) {

--- a/modules/flowable-osgi/src/main/java/org/flowable/osgi/blueprint/ProcessEngineFactoryWithELResolver.java
+++ b/modules/flowable-osgi/src/main/java/org/flowable/osgi/blueprint/ProcessEngineFactoryWithELResolver.java
@@ -33,7 +33,7 @@ public class ProcessEngineFactoryWithELResolver extends ProcessEngineFactory {
 
         List<ResolverFactory> resolverFactories = configImpl.getResolverFactories();
         if (resolverFactories == null) {
-            resolverFactories = new ArrayList<ResolverFactory>();
+            resolverFactories = new ArrayList<>();
             resolverFactories.add(new VariableScopeResolverFactory());
             resolverFactories.add(new BeansResolverFactory());
         }
@@ -43,7 +43,7 @@ public class ProcessEngineFactoryWithELResolver extends ProcessEngineFactory {
     }
 
     public class BlueprintExpressionManager extends AbstractExpressionManager {
-        
+
         public BlueprintExpressionManager() {
             this.delegateInterceptor = new DefaultDelegateInterceptor();
             this.expressionFactory = new ExpressionFactoryImpl();

--- a/modules/flowable-ui-admin/src/main/java/org/flowable/admin/app/rest/client/DisplayJsonClientResource.java
+++ b/modules/flowable-ui-admin/src/main/java/org/flowable/admin/app/rest/client/DisplayJsonClientResource.java
@@ -12,6 +12,11 @@
  */
 package org.flowable.admin.app.rest.client;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -53,11 +58,6 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 @RestController
 public class DisplayJsonClientResource extends AbstractClientResource {
 
@@ -70,8 +70,8 @@ public class DisplayJsonClientResource extends AbstractClientResource {
     protected ProcessInstanceService processInstanceService;
 
     protected ObjectMapper objectMapper = new ObjectMapper();
-    protected List<String> eventElementTypes = new ArrayList<String>();
-    protected Map<String, InfoMapper> propertyMappers = new HashMap<String, InfoMapper>();
+    protected List<String> eventElementTypes = new ArrayList<>();
+    protected Map<String, InfoMapper> propertyMappers = new HashMap<>();
 
     public DisplayJsonClientResource() {
         eventElementTypes.add("StartEvent");
@@ -128,10 +128,10 @@ public class DisplayJsonClientResource extends AbstractClientResource {
 
             try {
                 GraphicInfo diagramInfo = new GraphicInfo();
-                Set<String> completedElements = new HashSet<String>(completedActivityInstances);
+                Set<String> completedElements = new HashSet<>(completedActivityInstances);
                 completedElements.addAll(completedFlows);
 
-                Set<String> currentElements = new HashSet<String>(currentActivityinstances);
+                Set<String> currentElements = new HashSet<>(currentActivityinstances);
 
                 processProcessElements(config, pojoModel, displayNode, diagramInfo, completedElements, currentElements);
 
@@ -168,7 +168,7 @@ public class DisplayJsonClientResource extends AbstractClientResource {
 
         return displayNode;
     }
-    
+
     @RequestMapping(value = "/rest/admin/process-instances/{processInstanceId}/history-model-json", method = RequestMethod.GET, produces = "application/json")
     public JsonNode getHistoryProcessInstanceModelJSON(@PathVariable String processInstanceId, @RequestParam(required = true) String processDefinitionId) {
         ObjectNode displayNode = objectMapper.createObjectNode();
@@ -180,13 +180,13 @@ public class DisplayJsonClientResource extends AbstractClientResource {
 
             // Fetch process-instance activities
             List<String> completedActivityInstances = processInstanceService.getCompletedActivityInstancesAndProcessDefinitionId(config, processInstanceId);
-            
+
             // Gather completed flows
             List<String> completedFlows = gatherCompletedFlows(completedActivityInstances, null, pojoModel);
 
             try {
                 GraphicInfo diagramInfo = new GraphicInfo();
-                Set<String> completedElements = new HashSet<String>(completedActivityInstances);
+                Set<String> completedElements = new HashSet<>(completedActivityInstances);
                 completedElements.addAll(completedFlows);
 
                 processProcessElements(config, pojoModel, displayNode, diagramInfo, completedElements, null);
@@ -219,10 +219,10 @@ public class DisplayJsonClientResource extends AbstractClientResource {
     }
 
     protected List<String> gatherCompletedFlows(List<String> completedActivityInstances,
-            List<String> currentActivityinstances, BpmnModel pojoModel) {
+                                                List<String> currentActivityinstances, BpmnModel pojoModel) {
 
-        List<String> completedFlows = new ArrayList<String>();
-        List<String> activities = new ArrayList<String>(completedActivityInstances);
+        List<String> completedFlows = new ArrayList<>();
+        List<String> activities = new ArrayList<>(completedActivityInstances);
         if (currentActivityinstances != null) {
             activities.addAll(currentActivityinstances);
         }
@@ -312,8 +312,8 @@ public class DisplayJsonClientResource extends AbstractClientResource {
     }
 
     protected void processElements(Collection<FlowElement> elementList,
-            BpmnModel model, ArrayNode elementArray, ArrayNode flowArray,
-            GraphicInfo diagramInfo, Set<String> completedElements, Set<String> currentElements) {
+                                   BpmnModel model, ArrayNode elementArray, ArrayNode flowArray,
+                                   GraphicInfo diagramInfo, Set<String> completedElements, Set<String> currentElements) {
 
         for (FlowElement element : elementList) {
 
@@ -436,12 +436,12 @@ public class DisplayJsonClientResource extends AbstractClientResource {
 
     protected void fillGraphicInfo(ObjectNode elementNode, GraphicInfo graphicInfo, boolean includeWidthAndHeight) {
         commonFillGraphicInfo(elementNode, graphicInfo.getX(),
-                graphicInfo.getY(), graphicInfo.getWidth(),
-                graphicInfo.getHeight(), includeWidthAndHeight);
+            graphicInfo.getY(), graphicInfo.getWidth(),
+            graphicInfo.getHeight(), includeWidthAndHeight);
     }
 
     protected void commonFillGraphicInfo(ObjectNode elementNode, double x,
-            double y, double width, double height, boolean includeWidthAndHeight) {
+                                         double y, double width, double height, boolean includeWidthAndHeight) {
 
         elementNode.put("x", x);
         elementNode.put("y", y);

--- a/modules/flowable-ui-admin/src/main/java/org/flowable/admin/conf/DispatcherServletConfiguration.java
+++ b/modules/flowable-ui-admin/src/main/java/org/flowable/admin/conf/DispatcherServletConfiguration.java
@@ -41,8 +41,8 @@ import org.springframework.web.servlet.view.json.MappingJackson2JsonView;
 
 @Configuration
 @ComponentScan(basePackages = {
-        "org.flowable.admin.app.rest",
-        "org.flowable.app.rest" })
+    "org.flowable.admin.app.rest",
+    "org.flowable.app.rest"})
 @EnableWebMvc
 public class DispatcherServletConfiguration extends WebMvcConfigurerAdapter {
 
@@ -58,7 +58,7 @@ public class DispatcherServletConfiguration extends WebMvcConfigurerAdapter {
     public ViewResolver contentNegotiatingViewResolver() {
         LOGGER.debug("Configuring the ContentNegotiatingViewResolver");
         ContentNegotiatingViewResolver viewResolver = new ContentNegotiatingViewResolver();
-        List<ViewResolver> viewResolvers = new ArrayList<ViewResolver>();
+        List<ViewResolver> viewResolvers = new ArrayList<>();
 
         UrlBasedViewResolver urlBasedViewResolver = new UrlBasedViewResolver();
         urlBasedViewResolver.setViewClass(JstlView.class);
@@ -68,7 +68,7 @@ public class DispatcherServletConfiguration extends WebMvcConfigurerAdapter {
 
         viewResolver.setViewResolvers(viewResolvers);
 
-        List<View> defaultViews = new ArrayList<View>();
+        List<View> defaultViews = new ArrayList<>();
         defaultViews.add(new MappingJackson2JsonView());
         viewResolver.setDefaultViews(defaultViews);
 
@@ -112,7 +112,7 @@ public class DispatcherServletConfiguration extends WebMvcConfigurerAdapter {
         LOGGER.debug("Creating requestMappingHandlerMapping");
         RequestMappingHandlerMapping requestMappingHandlerMapping = new RequestMappingHandlerMapping();
         requestMappingHandlerMapping.setUseSuffixPatternMatch(false);
-        Object[] interceptors = { localeChangeInterceptor() };
+        Object[] interceptors = {localeChangeInterceptor()};
         requestMappingHandlerMapping.setInterceptors(interceptors);
         return requestMappingHandlerMapping;
     }

--- a/modules/flowable-ui-admin/src/main/java/org/flowable/admin/service/engine/ProcessInstanceService.java
+++ b/modules/flowable-ui-admin/src/main/java/org/flowable/admin/service/engine/ProcessInstanceService.java
@@ -208,7 +208,7 @@ public class ProcessInstanceService {
     }
 
     public JsonNode getJobs(ServerConfig serverConfig, String processInstanceId) {
-        return jobService.listJobs(serverConfig, Collections.singletonMap("processInstanceId", new String[] { processInstanceId }));
+        return jobService.listJobs(serverConfig, Collections.singletonMap("processInstanceId", new String[]{processInstanceId}));
     }
 
     public List<String> getCompletedActivityInstancesAndProcessDefinitionId(ServerConfig serverConfig, String processInstanceId) {
@@ -222,7 +222,7 @@ public class ProcessInstanceService {
         HttpGet get = new HttpGet(clientUtil.getServerUrl(serverConfig, builder));
         JsonNode node = clientUtil.executeRequest(get, serverConfig);
 
-        List<String> result = new ArrayList<String>();
+        List<String> result = new ArrayList<>();
         if (node.has("data") && node.get("data").isArray()) {
             ArrayNode data = (ArrayNode) node.get("data");
             ObjectNode activity = null;
@@ -242,7 +242,7 @@ public class ProcessInstanceService {
         HttpGet get = new HttpGet(clientUtil.getServerUrl(serverConfig, builder));
         JsonNode node = clientUtil.executeRequest(get, serverConfig);
 
-        List<String> result = new ArrayList<String>();
+        List<String> result = new ArrayList<>();
         if (node.isArray()) {
             ArrayNode data = (ArrayNode) node;
             for (int i = 0; i < data.size(); i++) {

--- a/modules/flowable-ui-admin/src/main/java/org/flowable/admin/service/engine/ServerConfigService.java
+++ b/modules/flowable-ui-admin/src/main/java/org/flowable/admin/service/engine/ServerConfigService.java
@@ -12,6 +12,9 @@
  */
 package org.flowable.admin.service.engine;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.flowable.admin.app.rest.dto.ServerConfigRepresentation;
 import org.flowable.admin.domain.EndpointType;
 import org.flowable.admin.domain.ServerConfig;
@@ -21,9 +24,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * @author jbarrez
@@ -120,7 +120,7 @@ public class ServerConfigService extends AbstractEncryptingService {
     }
 
     protected List<ServerConfigRepresentation> createServerConfigRepresentation(List<ServerConfig> serverConfigs) {
-        List<ServerConfigRepresentation> serversRepresentations = new ArrayList<ServerConfigRepresentation>();
+        List<ServerConfigRepresentation> serversRepresentations = new ArrayList<>();
         for (ServerConfig serverConfig : serverConfigs) {
             serversRepresentations.add(createServerConfigRepresentation(serverConfig));
         }
@@ -147,53 +147,53 @@ public class ServerConfigService extends AbstractEncryptingService {
 
         switch (endpointType) {
 
-        case PROCESS:
-            serverConfig.setName(environment.getRequiredProperty(REST_PROCESS_APP_NAME));
-            serverConfig.setDescription(environment.getRequiredProperty(REST_PROCESS_APP_DESCRIPTION));
-            serverConfig.setServerAddress(environment.getRequiredProperty(REST_PROCESS_APP_HOST));
-            serverConfig.setPort(environment.getRequiredProperty(REST_PROCESS_APP_PORT, Integer.class));
-            serverConfig.setContextRoot(environment.getRequiredProperty(REST_PROCESS_APP_CONTEXT_ROOT));
-            serverConfig.setRestRoot(environment.getRequiredProperty(REST_PROCESS_APP_REST_ROOT));
-            serverConfig.setUserName(environment.getRequiredProperty(REST_PROCESS_APP_USER));
-            serverConfig.setPassword(environment.getRequiredProperty(REST_PROCESS_APP_PASSWORD));
-            serverConfig.setEndpointType(endpointType.getEndpointCode());
-            break;
+            case PROCESS:
+                serverConfig.setName(environment.getRequiredProperty(REST_PROCESS_APP_NAME));
+                serverConfig.setDescription(environment.getRequiredProperty(REST_PROCESS_APP_DESCRIPTION));
+                serverConfig.setServerAddress(environment.getRequiredProperty(REST_PROCESS_APP_HOST));
+                serverConfig.setPort(environment.getRequiredProperty(REST_PROCESS_APP_PORT, Integer.class));
+                serverConfig.setContextRoot(environment.getRequiredProperty(REST_PROCESS_APP_CONTEXT_ROOT));
+                serverConfig.setRestRoot(environment.getRequiredProperty(REST_PROCESS_APP_REST_ROOT));
+                serverConfig.setUserName(environment.getRequiredProperty(REST_PROCESS_APP_USER));
+                serverConfig.setPassword(environment.getRequiredProperty(REST_PROCESS_APP_PASSWORD));
+                serverConfig.setEndpointType(endpointType.getEndpointCode());
+                break;
 
-        case DMN:
-            serverConfig.setName(environment.getRequiredProperty(REST_DMN_APP_NAME));
-            serverConfig.setDescription(environment.getRequiredProperty(REST_DMN_APP_DESCRIPTION));
-            serverConfig.setServerAddress(environment.getRequiredProperty(REST_DMN_APP_HOST));
-            serverConfig.setPort(environment.getRequiredProperty(REST_DMN_APP_PORT, Integer.class));
-            serverConfig.setContextRoot(environment.getRequiredProperty(REST_DMN_APP_CONTEXT_ROOT));
-            serverConfig.setRestRoot(environment.getRequiredProperty(REST_DMN_APP_REST_ROOT));
-            serverConfig.setUserName(environment.getRequiredProperty(REST_DMN_APP_USER));
-            serverConfig.setPassword(environment.getRequiredProperty(REST_DMN_APP_PASSWORD));
-            serverConfig.setEndpointType(endpointType.getEndpointCode());
-            break;
+            case DMN:
+                serverConfig.setName(environment.getRequiredProperty(REST_DMN_APP_NAME));
+                serverConfig.setDescription(environment.getRequiredProperty(REST_DMN_APP_DESCRIPTION));
+                serverConfig.setServerAddress(environment.getRequiredProperty(REST_DMN_APP_HOST));
+                serverConfig.setPort(environment.getRequiredProperty(REST_DMN_APP_PORT, Integer.class));
+                serverConfig.setContextRoot(environment.getRequiredProperty(REST_DMN_APP_CONTEXT_ROOT));
+                serverConfig.setRestRoot(environment.getRequiredProperty(REST_DMN_APP_REST_ROOT));
+                serverConfig.setUserName(environment.getRequiredProperty(REST_DMN_APP_USER));
+                serverConfig.setPassword(environment.getRequiredProperty(REST_DMN_APP_PASSWORD));
+                serverConfig.setEndpointType(endpointType.getEndpointCode());
+                break;
 
-        case FORM:
-            serverConfig.setName(environment.getRequiredProperty(REST_FORM_APP_NAME));
-            serverConfig.setDescription(environment.getRequiredProperty(REST_FORM_APP_DESCRIPTION));
-            serverConfig.setServerAddress(environment.getRequiredProperty(REST_FORM_APP_HOST));
-            serverConfig.setPort(environment.getRequiredProperty(REST_FORM_APP_PORT, Integer.class));
-            serverConfig.setContextRoot(environment.getRequiredProperty(REST_FORM_APP_CONTEXT_ROOT));
-            serverConfig.setRestRoot(environment.getRequiredProperty(REST_FORM_APP_REST_ROOT));
-            serverConfig.setUserName(environment.getRequiredProperty(REST_FORM_APP_USER));
-            serverConfig.setPassword(environment.getRequiredProperty(REST_FORM_APP_PASSWORD));
-            serverConfig.setEndpointType(endpointType.getEndpointCode());
-            break;
+            case FORM:
+                serverConfig.setName(environment.getRequiredProperty(REST_FORM_APP_NAME));
+                serverConfig.setDescription(environment.getRequiredProperty(REST_FORM_APP_DESCRIPTION));
+                serverConfig.setServerAddress(environment.getRequiredProperty(REST_FORM_APP_HOST));
+                serverConfig.setPort(environment.getRequiredProperty(REST_FORM_APP_PORT, Integer.class));
+                serverConfig.setContextRoot(environment.getRequiredProperty(REST_FORM_APP_CONTEXT_ROOT));
+                serverConfig.setRestRoot(environment.getRequiredProperty(REST_FORM_APP_REST_ROOT));
+                serverConfig.setUserName(environment.getRequiredProperty(REST_FORM_APP_USER));
+                serverConfig.setPassword(environment.getRequiredProperty(REST_FORM_APP_PASSWORD));
+                serverConfig.setEndpointType(endpointType.getEndpointCode());
+                break;
 
-        case CONTENT:
-            serverConfig.setName(environment.getRequiredProperty(REST_CONTENT_APP_NAME));
-            serverConfig.setDescription(environment.getRequiredProperty(REST_CONTENT_APP_DESCRIPTION));
-            serverConfig.setServerAddress(environment.getRequiredProperty(REST_CONTENT_APP_HOST));
-            serverConfig.setPort(environment.getRequiredProperty(REST_CONTENT_APP_PORT, Integer.class));
-            serverConfig.setContextRoot(environment.getRequiredProperty(REST_CONTENT_APP_CONTEXT_ROOT));
-            serverConfig.setRestRoot(environment.getRequiredProperty(REST_CONTENT_APP_REST_ROOT));
-            serverConfig.setUserName(environment.getRequiredProperty(REST_CONTENT_APP_USER));
-            serverConfig.setPassword(environment.getRequiredProperty(REST_CONTENT_APP_PASSWORD));
-            serverConfig.setEndpointType(endpointType.getEndpointCode());
-            break;
+            case CONTENT:
+                serverConfig.setName(environment.getRequiredProperty(REST_CONTENT_APP_NAME));
+                serverConfig.setDescription(environment.getRequiredProperty(REST_CONTENT_APP_DESCRIPTION));
+                serverConfig.setServerAddress(environment.getRequiredProperty(REST_CONTENT_APP_HOST));
+                serverConfig.setPort(environment.getRequiredProperty(REST_CONTENT_APP_PORT, Integer.class));
+                serverConfig.setContextRoot(environment.getRequiredProperty(REST_CONTENT_APP_CONTEXT_ROOT));
+                serverConfig.setRestRoot(environment.getRequiredProperty(REST_CONTENT_APP_REST_ROOT));
+                serverConfig.setUserName(environment.getRequiredProperty(REST_CONTENT_APP_USER));
+                serverConfig.setPassword(environment.getRequiredProperty(REST_CONTENT_APP_PASSWORD));
+                serverConfig.setEndpointType(endpointType.getEndpointCode());
+                break;
         }
 
         return serverConfig;

--- a/modules/flowable-ui-idm/flowable-ui-idm-conf/src/main/java/org/flowable/app/conf/SecurityConfiguration.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-conf/src/main/java/org/flowable/app/conf/SecurityConfiguration.java
@@ -45,7 +45,7 @@ import org.springframework.security.web.header.writers.XXssProtectionHeaderWrite
 
 /**
  * Based on http://docs.spring.io/spring-security/site/docs/3.2.x/reference/htmlsingle/#multiple-httpsecurity
- * 
+ *
  * @author Joram Barrez
  * @author Tijs Rademakers
  */
@@ -59,10 +59,10 @@ public class SecurityConfiguration {
     //
     // GLOBAL CONFIG
     //
-    
+
     @Autowired
     protected IdmIdentityService identityService;
-    
+
     @Autowired
     protected PasswordEncoder passwordEncoder;
 
@@ -79,7 +79,7 @@ public class SecurityConfiguration {
             } catch (Exception e) {
                 LOGGER.error("Could not configure ldap authentication mechanism:", e);
             }
-            
+
         } else {
             // Default auth (database backed)
             try {
@@ -104,7 +104,7 @@ public class SecurityConfiguration {
         daoAuthenticationProvider.setPasswordEncoder(passwordEncoder);
         return daoAuthenticationProvider;
     }
-    
+
     @Bean(name = "ldapAuthenticationProvider")
     public AuthenticationProvider ldapAuthenticationProvider() {
         CustomLdapAuthenticationProvider ldapAuthenticationProvider = new CustomLdapAuthenticationProvider(
@@ -138,36 +138,36 @@ public class SecurityConfiguration {
         @Override
         protected void configure(HttpSecurity http) throws Exception {
             http
-                .exceptionHandling()
-                .authenticationEntryPoint(authenticationEntryPoint)
-                .and()
+                    .exceptionHandling()
+                    .authenticationEntryPoint(authenticationEntryPoint)
+                    .and()
                     .sessionManagement()
                     .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-                .and()
+                    .and()
                     .rememberMe()
                     .rememberMeServices(rememberMeServices())
                     .key(env.getProperty("security.rememberme.key"))
-                .and()
+                    .and()
                     .logout()
                     .logoutUrl("/app/logout")
                     .logoutSuccessHandler(ajaxLogoutSuccessHandler)
                     .addLogoutHandler(new ClearFlowableCookieLogoutHandler())
                     .permitAll()
-                .and()
+                    .and()
                     .csrf()
                     .disable() // Disabled, cause enabling it will cause sessions
                     .headers()
                     .frameOptions()
                     .sameOrigin()
                     .addHeaderWriter(new XXssProtectionHeaderWriter())
-                .and()
+                    .and()
                     .authorizeRequests()
                     .antMatchers("/*").permitAll()
                     .antMatchers("/app/rest/authenticate").permitAll()
                     .antMatchers("/app/**").hasAuthority(DefaultPrivileges.ACCESS_IDM);
 
             // Custom login form configurer to allow for non-standard HTTP-methods (eg. LOCK)
-            CustomFormLoginConfig<HttpSecurity> loginConfig = new CustomFormLoginConfig<HttpSecurity>();
+            CustomFormLoginConfig<HttpSecurity> loginConfig = new CustomFormLoginConfig<>();
             loginConfig.loginProcessingUrl("/app/authentication")
                     .successHandler(ajaxAuthenticationSuccessHandler)
                     .failureHandler(ajaxAuthenticationFailureHandler)
@@ -200,15 +200,15 @@ public class SecurityConfiguration {
         protected void configure(HttpSecurity http) throws Exception {
 
             http
-                .sessionManagement()
-                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-                .and()
+                    .sessionManagement()
+                    .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                    .and()
                     .csrf()
                     .disable()
                     .antMatcher("/api" + "/**")
                     .authorizeRequests()
                     .antMatchers("/api" + "/**").authenticated()
-                .and().httpBasic();
+                    .and().httpBasic();
         }
     }
 

--- a/modules/flowable-ui-idm/flowable-ui-idm-conf/src/main/java/org/flowable/app/security/UserDetailsService.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-conf/src/main/java/org/flowable/app/security/UserDetailsService.java
@@ -44,7 +44,7 @@ public class UserDetailsService implements org.springframework.security.core.use
 
     @Autowired
     protected UserService userService;
-    
+
     @Autowired
     protected Environment environment;
 
@@ -64,7 +64,7 @@ public class UserDetailsService implements org.springframework.security.core.use
         if (!environment.getProperty("ldap.enabled", Boolean.class, false)) {
             actualLogin = login.toLowerCase();
             userFromDatabase = identityService.createUserQuery().userIdIgnoreCase(actualLogin).singleResult();
-            
+
         } else {
             userFromDatabase = identityService.createUserQuery().userId(actualLogin).singleResult();
         }
@@ -74,7 +74,7 @@ public class UserDetailsService implements org.springframework.security.core.use
             throw new UsernameNotFoundException("User " + actualLogin + " was not found in the database");
         }
 
-        Collection<GrantedAuthority> grantedAuthorities = new ArrayList<GrantedAuthority>();
+        Collection<GrantedAuthority> grantedAuthorities = new ArrayList<>();
         UserInformation userInformation = userService.getUserInformation(userFromDatabase.getId());
         for (String privilege : userInformation.getPrivileges()) {
             grantedAuthorities.add(new SimpleGrantedAuthority(privilege));

--- a/modules/flowable-ui-idm/flowable-ui-idm-logic/src/main/java/org/flowable/app/idm/model/PrivilegeRepresentation.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-logic/src/main/java/org/flowable/app/idm/model/PrivilegeRepresentation.java
@@ -64,7 +64,7 @@ public class PrivilegeRepresentation extends AbstractRepresentation {
 
     public void addUser(UserRepresentation userRepresentation) {
         if (users == null) {
-            users = new ArrayList<UserRepresentation>();
+            users = new ArrayList<>();
         }
         users.add(userRepresentation);
     }
@@ -79,7 +79,7 @@ public class PrivilegeRepresentation extends AbstractRepresentation {
 
     public void addGroup(GroupRepresentation groupRepresentation) {
         if (groups == null) {
-            groups = new ArrayList<GroupRepresentation>();
+            groups = new ArrayList<>();
         }
         groups.add(groupRepresentation);
     }

--- a/modules/flowable-ui-idm/flowable-ui-idm-logic/src/main/java/org/flowable/app/idm/model/UpdateUsersRepresentation.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-logic/src/main/java/org/flowable/app/idm/model/UpdateUsersRepresentation.java
@@ -27,7 +27,7 @@ public class UpdateUsersRepresentation extends AbstractRepresentation {
     protected String lastName;
     protected String email;
     protected String password;
-    protected List<String> users = new ArrayList<String>();
+    protected List<String> users = new ArrayList<>();
 
     public UpdateUsersRepresentation() {
 

--- a/modules/flowable-ui-idm/flowable-ui-idm-logic/src/main/java/org/flowable/app/idm/service/UserCacheImpl.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-logic/src/main/java/org/flowable/app/idm/service/UserCacheImpl.java
@@ -12,6 +12,11 @@
  */
 package org.flowable.app.idm.service;
 
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.ExecutionException;
@@ -31,16 +36,11 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
-import com.google.common.util.concurrent.UncheckedExecutionException;
-
 /**
  * Cache containing User objects to prevent too much DB-traffic (users exist separately from the Flowable tables, they need to be fetched afterward one by one to join with those entities).
- * 
+ * <p>
  * TODO: This could probably be made more efficient with bulk getting. The Google cache impl allows this: override loadAll and use getAll() to fetch multiple entities.
- * 
+ *
  * @author Frederik Heremans
  * @author Joram Barrez
  */
@@ -73,12 +73,12 @@ public class UserCacheImpl implements UserCache {
                         } else {
                             userFromDatabase = identityService.createUserQuery().userId(userId).singleResult();
                         }
-                        
+
                         if (userFromDatabase == null) {
                             throw new UsernameNotFoundException("User " + userId + " was not found in the database");
                         }
 
-                        Collection<GrantedAuthority> grantedAuthorities = new ArrayList<GrantedAuthority>();
+                        Collection<GrantedAuthority> grantedAuthorities = new ArrayList<>();
                         UserInformation userInformation = userService.getUserInformation(userFromDatabase.getId());
                         for (String privilege : userInformation.getPrivileges()) {
                             grantedAuthorities.add(new SimpleGrantedAuthority(privilege));

--- a/modules/flowable-ui-idm/flowable-ui-idm-logic/src/main/java/org/flowable/app/idm/service/UserServiceImpl.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-logic/src/main/java/org/flowable/app/idm/service/UserServiceImpl.java
@@ -12,6 +12,11 @@
  */
 package org.flowable.app.idm.service;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import org.apache.commons.lang3.StringUtils;
 import org.flowable.app.idm.model.UserInformation;
 import org.flowable.app.service.exception.BadRequestException;
@@ -23,11 +28,6 @@ import org.flowable.idm.api.User;
 import org.flowable.idm.api.UserQuery;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 
 /**
  * @author Joram Barrez
@@ -136,14 +136,14 @@ public class UserServiceImpl extends AbstractIdmService implements UserService {
         }
 
         List<Privilege> userPrivileges = identityService.createPrivilegeQuery().userId(userId).list();
-        Set<String> privilegeNames = new HashSet<String>();
+        Set<String> privilegeNames = new HashSet<>();
         for (Privilege userPrivilege : userPrivileges) {
             privilegeNames.add(userPrivilege.getName());
         }
 
         List<Group> groups = identityService.createGroupQuery().groupMember(userId).list();
         if (groups.size() > 0) {
-            List<String> groupIds = new ArrayList<String>();
+            List<String> groupIds = new ArrayList<>();
             for (Group group : groups) {
                 groupIds.add(group.getId());
             }
@@ -154,7 +154,7 @@ public class UserServiceImpl extends AbstractIdmService implements UserService {
             }
         }
 
-        return new UserInformation(user, groups, new ArrayList<String>(privilegeNames));
+        return new UserInformation(user, groups, new ArrayList<>(privilegeNames));
     }
 
 }

--- a/modules/flowable-ui-idm/flowable-ui-idm-rest/src/main/java/org/flowable/app/rest/api/ApiGroupsResource.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-rest/src/main/java/org/flowable/app/rest/api/ApiGroupsResource.java
@@ -31,21 +31,21 @@ public class ApiGroupsResource {
 
     @Autowired
     protected GroupService groupService;
-    
-    @RequestMapping(value = "/idm/groups/{groupId}", method = RequestMethod.GET, produces = { "application/json" })
+
+    @RequestMapping(value = "/idm/groups/{groupId}", method = RequestMethod.GET, produces = {"application/json"})
     public GroupRepresentation getGroupInformation(@PathVariable String groupId) {
         Group group = groupService.getGroup(groupId);
         if (group != null) {
             return new GroupRepresentation(group);
-            
+
         } else {
             throw new NotFoundException();
         }
     }
 
-    @RequestMapping(value = "/idm/groups", method = RequestMethod.GET, produces = { "application/json" })
+    @RequestMapping(value = "/idm/groups", method = RequestMethod.GET, produces = {"application/json"})
     public List<GroupRepresentation> findGroupsByFilter(@RequestParam("filter") String filter) {
-        List<GroupRepresentation> result = new ArrayList<GroupRepresentation>();
+        List<GroupRepresentation> result = new ArrayList<>();
         List<Group> groups = groupService.getGroups(filter);
         for (Group group : groups) {
             result.add(new GroupRepresentation(group));

--- a/modules/flowable-ui-idm/flowable-ui-idm-rest/src/main/java/org/flowable/app/rest/api/ApiUsersResource.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-rest/src/main/java/org/flowable/app/rest/api/ApiUsersResource.java
@@ -35,7 +35,7 @@ public class ApiUsersResource {
     @Autowired
     protected UserService userService;
 
-    @RequestMapping(value = "/idm/users/{userId}", method = RequestMethod.GET, produces = { "application/json" })
+    @RequestMapping(value = "/idm/users/{userId}", method = RequestMethod.GET, produces = {"application/json"})
     public UserRepresentation getUserInformation(@PathVariable String userId) {
         UserInformation userInformation = userService.getUserInformation(userId);
         if (userInformation != null) {
@@ -56,10 +56,10 @@ public class ApiUsersResource {
         }
     }
 
-    @RequestMapping(value = "/idm/users", method = RequestMethod.GET, produces = { "application/json" })
+    @RequestMapping(value = "/idm/users", method = RequestMethod.GET, produces = {"application/json"})
     public List<UserRepresentation> findUsersByFilter(@RequestParam("filter") String filter) {
         List<User> users = userService.getUsers(filter, null, null);
-        List<UserRepresentation> result = new ArrayList<UserRepresentation>();
+        List<UserRepresentation> result = new ArrayList<>();
         for (User user : users) {
             result.add(new UserRepresentation(user));
         }

--- a/modules/flowable-ui-idm/flowable-ui-idm-rest/src/main/java/org/flowable/app/rest/idm/IdmGroupsResource.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-rest/src/main/java/org/flowable/app/rest/idm/IdmGroupsResource.java
@@ -43,7 +43,7 @@ public class IdmGroupsResource {
 
     @RequestMapping(method = RequestMethod.GET)
     public List<GroupRepresentation> getGroups(@RequestParam(required = false) String filter) {
-        List<GroupRepresentation> result = new ArrayList<GroupRepresentation>();
+        List<GroupRepresentation> result = new ArrayList<>();
         for (Group group : groupService.getGroups(filter)) {
             result.add(new GroupRepresentation(group));
         }
@@ -57,12 +57,12 @@ public class IdmGroupsResource {
 
     @RequestMapping(value = "/{groupId}/users", method = RequestMethod.GET)
     public ResultListDataRepresentation getGroupUsers(@PathVariable String groupId,
-            @RequestParam(required = false) String filter,
-            @RequestParam(required = false) Integer page,
-            @RequestParam(required = false) Integer pageSize) {
+                                                      @RequestParam(required = false) String filter,
+                                                      @RequestParam(required = false) Integer page,
+                                                      @RequestParam(required = false) Integer pageSize) {
 
         List<User> users = groupService.getGroupUsers(groupId, filter, page, pageSize);
-        List<UserRepresentation> userRepresentations = new ArrayList<UserRepresentation>(users.size());
+        List<UserRepresentation> userRepresentations = new ArrayList<>(users.size());
         for (User user : users) {
             userRepresentations.add(new UserRepresentation(user));
         }

--- a/modules/flowable-ui-idm/flowable-ui-idm-rest/src/main/java/org/flowable/app/rest/idm/IdmPrivilegesResource.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-rest/src/main/java/org/flowable/app/rest/idm/IdmPrivilegesResource.java
@@ -44,7 +44,7 @@ public class IdmPrivilegesResource {
     @RequestMapping(value = "/rest/admin/privileges", method = RequestMethod.GET)
     public List<PrivilegeRepresentation> getPrivileges() {
         List<Privilege> privileges = privilegeService.findPrivileges();
-        List<PrivilegeRepresentation> representations = new ArrayList<PrivilegeRepresentation>(privileges.size());
+        List<PrivilegeRepresentation> representations = new ArrayList<>(privileges.size());
         for (Privilege privilege : privileges) {
             representations.add(new PrivilegeRepresentation(privilege.getId(), privilege.getName()));
         }
@@ -84,7 +84,7 @@ public class IdmPrivilegesResource {
 
     @RequestMapping(value = "/rest/admin/privileges/{privilegeId}/users", method = RequestMethod.POST)
     public void addUserPrivilege(@PathVariable String privilegeId,
-            @RequestBody AddUserPrivilegeRepresentation representation) {
+                                 @RequestBody AddUserPrivilegeRepresentation representation) {
         privilegeService.addUserPrivilege(privilegeId, representation.getUserId());
     }
 
@@ -100,7 +100,7 @@ public class IdmPrivilegesResource {
 
     @RequestMapping(value = "/rest/admin/privileges/{privilegeId}/groups", method = RequestMethod.POST)
     public void addGroupPrivilege(@PathVariable String privilegeId,
-            @RequestBody AddGroupPrivilegeRepresentation representation) {
+                                  @RequestBody AddGroupPrivilegeRepresentation representation) {
         privilegeService.addGroupPrivilege(privilegeId, representation.getGroupId());
     }
 

--- a/modules/flowable-ui-idm/flowable-ui-idm-rest/src/main/java/org/flowable/app/rest/idm/IdmUsersResource.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-rest/src/main/java/org/flowable/app/rest/idm/IdmUsersResource.java
@@ -32,7 +32,6 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * 
  * @author Frederik Heremans
  * @author Joram Barrez
  */
@@ -61,7 +60,7 @@ public class IdmUsersResource {
     }
 
     protected List<UserRepresentation> convertToUserRepresentations(List<User> users) {
-        List<UserRepresentation> result = new ArrayList<UserRepresentation>(users.size());
+        List<UserRepresentation> result = new ArrayList<>(users.size());
         for (User user : users) {
             result.add(new UserRepresentation(user));
         }

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-conf/src/main/java/org/flowable/app/security/RemoteIdmAuthenticationProvider.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-conf/src/main/java/org/flowable/app/security/RemoteIdmAuthenticationProvider.java
@@ -28,7 +28,7 @@ public class RemoteIdmAuthenticationProvider implements AuthenticationProvider {
             throw new FlowableException("user not found " + authentication.getPrincipal());
         }
 
-        Collection<GrantedAuthority> grantedAuthorities = new ArrayList<GrantedAuthority>();
+        Collection<GrantedAuthority> grantedAuthorities = new ArrayList<>();
         for (String privilege : user.getPrivileges()) {
             grantedAuthorities.add(new SimpleGrantedAuthority(privilege));
         }

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/model/editor/FormFieldValuesRepresentation.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/model/editor/FormFieldValuesRepresentation.java
@@ -21,7 +21,7 @@ public class FormFieldValuesRepresentation extends AbstractRepresentation {
 
     protected Long formId;
     protected String formName;
-    protected List<FormFieldSummaryRepresentation> fields = new ArrayList<FormFieldSummaryRepresentation>();
+    protected List<FormFieldSummaryRepresentation> fields = new ArrayList<>();
 
     public Long getFormId() {
         return formId;

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/model/editor/ReviveModelResultRepresentation.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/model/editor/ReviveModelResultRepresentation.java
@@ -20,7 +20,7 @@ import java.util.List;
  */
 public class ReviveModelResultRepresentation {
 
-    private List<UnresolveModelRepresentation> unresolvedModels = new ArrayList<UnresolveModelRepresentation>();
+    private List<UnresolveModelRepresentation> unresolvedModels = new ArrayList<>();
 
     public List<UnresolveModelRepresentation> getUnresolvedModels() {
         return unresolvedModels;

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/repository/editor/ModelHistoryRepositoryImpl.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/repository/editor/ModelHistoryRepositoryImpl.java
@@ -39,7 +39,7 @@ public class ModelHistoryRepositoryImpl implements ModelHistoryRepository {
     }
 
     public List<ModelHistory> findByModelTypAndCreatedBy(String createdBy, Integer modelType) {
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("modelType", modelType);
         params.put("createdBy", createdBy);
         return sqlSessionTemplate.selectList(NAMESPACE + "selectModelHistoryByTypeAndCreatedBy", params);

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/repository/editor/ModelRelationRepositoryImpl.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/repository/editor/ModelRelationRepositoryImpl.java
@@ -36,7 +36,7 @@ public class ModelRelationRepositoryImpl implements ModelRelationRepository {
 
     @Override
     public List<ModelRelation> findByParentModelIdAndType(String parentModelId, String type) {
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("parentModelId", parentModelId);
         params.put("type", type);
         return sqlSessionTemplate.selectList("selectModelRelationByParentModelIdAndType", params);

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/repository/editor/ModelRepositoryImpl.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/repository/editor/ModelRepositoryImpl.java
@@ -40,7 +40,7 @@ public class ModelRepositoryImpl implements ModelRepository {
 
     @Override
     public List<Model> findByModelType(Integer modelType, String sort) {
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("modelType", modelType);
         params.put("sort", sort);
         return findModelsByParameters(params);
@@ -48,7 +48,7 @@ public class ModelRepositoryImpl implements ModelRepository {
 
     @Override
     public List<Model> findByModelTypeAndFilter(Integer modelType, String filter, String sort) {
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("modelType", modelType);
         params.put("filter", filter);
         params.put("sort", sort);
@@ -57,7 +57,7 @@ public class ModelRepositoryImpl implements ModelRepository {
 
     @Override
     public List<Model> findByKeyAndType(String key, Integer modelType) {
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("key", key);
         params.put("modelType", modelType);
         return findModelsByParameters(params);
@@ -70,7 +70,7 @@ public class ModelRepositoryImpl implements ModelRepository {
 
     @Override
     public Long countByModelTypeAndCreatedBy(int modelType, String createdBy) {
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("createdBy", createdBy);
         params.put("modelType", modelType);
         return sqlSessionTemplate.selectOne(NAMESPACE + "countByModelTypeAndCreatedBy", params);

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/service/editor/AppDefinitionImportService.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/service/editor/AppDefinitionImportService.java
@@ -81,9 +81,9 @@ public class AppDefinitionImportService {
 
             AppDefinitionRepresentation appDefinition = createAppDefinitionRepresentation(appModel);
 
-            Map<String, Model> existingProcessModelMap = new HashMap<String, Model>();
-            Map<String, Model> existingFormModelMap = new HashMap<String, Model>();
-            Map<String, Model> existingDecisionTableMap = new HashMap<String, Model>();
+            Map<String, Model> existingProcessModelMap = new HashMap<>();
+            Map<String, Model> existingFormModelMap = new HashMap<>();
+            Map<String, Model> existingDecisionTableMap = new HashMap<>();
             if (appDefinition.getDefinition() != null && CollectionUtils.isNotEmpty(appDefinition.getDefinition().getModels())) {
                 for (AppModelDefinition modelDef : appDefinition.getDefinition().getModels()) {
                     Model processModel = modelService.getModel(modelDef.getId());
@@ -110,13 +110,13 @@ public class AppDefinitionImportService {
     }
 
     protected AppDefinitionRepresentation importAppDefinition(HttpServletRequest request, InputStream is, String fileName, Model existingAppModel, Map<String, Model> existingProcessModelMap,
-            Map<String, Model> existingFormModelMap, Map<String, Model> existingDecisionTableModelMap) {
+                                                              Map<String, Model> existingFormModelMap, Map<String, Model> existingDecisionTableModelMap) {
 
         if (fileName != null && (fileName.endsWith(".zip"))) {
-            Map<String, String> formMap = new HashMap<String, String>();
-            Map<String, String> decisionTableMap = new HashMap<String, String>();
-            Map<String, String> bpmnModelMap = new HashMap<String, String>();
-            Map<String, byte[]> thumbnailMap = new HashMap<String, byte[]>();
+            Map<String, String> formMap = new HashMap<>();
+            Map<String, String> decisionTableMap = new HashMap<>();
+            Map<String, String> bpmnModelMap = new HashMap<>();
+            Map<String, byte[]> thumbnailMap = new HashMap<>();
 
             Model appDefinitionModel = readZipFile(is, formMap, decisionTableMap, bpmnModelMap, thumbnailMap);
             if (StringUtils.isNotEmpty(appDefinitionModel.getKey()) && StringUtils.isNotEmpty(appDefinitionModel.getModelEditorJson())) {
@@ -169,7 +169,7 @@ public class AppDefinitionImportService {
     }
 
     protected Model readZipFile(InputStream inputStream, Map<String, String> formMap, Map<String, String> decisionTableMap,
-            Map<String, String> bpmnModelMap, Map<String, byte[]> thumbnailMap) {
+                                Map<String, String> bpmnModelMap, Map<String, byte[]> thumbnailMap) {
 
         Model appDefinitionModel = null;
         ZipInputStream zipInputStream = null;
@@ -233,7 +233,7 @@ public class AppDefinitionImportService {
 
     protected Map<String, Model> importForms(Map<String, String> formMap, Map<String, byte[]> thumbnailMap, Map<String, Model> existingFormModelMap) {
 
-        Map<String, Model> oldFormIdAndModelMap = new HashMap<String, Model>();
+        Map<String, Model> oldFormIdAndModelMap = new HashMap<>();
 
         for (String formKey : formMap.keySet()) {
 
@@ -271,9 +271,9 @@ public class AppDefinitionImportService {
     }
 
     protected Map<String, Model> importDecisionTables(Map<String, String> decisionTableMap, Map<String, byte[]> thumbnailMap,
-            Map<String, Model> existingDecisionTableMap) {
+                                                      Map<String, Model> existingDecisionTableMap) {
 
-        Map<String, Model> oldDecisionTableIdAndModelMap = new HashMap<String, Model>();
+        Map<String, Model> oldDecisionTableIdAndModelMap = new HashMap<>();
 
         for (String decisionTableKey : decisionTableMap.keySet()) {
 
@@ -311,9 +311,9 @@ public class AppDefinitionImportService {
     }
 
     protected Map<String, Model> importBpmnModels(Map<String, String> bpmnModelMap, Map<String, Model> formKeyAndModelMap,
-            Map<String, Model> decisionTableKeyAndModelMap, Map<String, byte[]> thumbnailMap, Map<String, Model> existingProcessModelMap) {
+                                                  Map<String, Model> decisionTableKeyAndModelMap, Map<String, byte[]> thumbnailMap, Map<String, Model> existingProcessModelMap) {
 
-        Map<String, Model> bpmnModelIdAndModelMap = new HashMap<String, Model>();
+        Map<String, Model> bpmnModelIdAndModelMap = new HashMap<>();
         for (String bpmnModelKey : bpmnModelMap.keySet()) {
 
             Model existingModel = null;
@@ -333,16 +333,16 @@ public class AppDefinitionImportService {
                 throw new InternalServerErrorException("Error reading BPMN json for " + bpmnModelKey);
             }
 
-            Map<String, String> oldFormIdFormKeyMap = new HashMap<String, String>();
-            Map<String, ModelInfo> formKeyModelIdMap = new HashMap<String, ModelInfo>();
+            Map<String, String> oldFormIdFormKeyMap = new HashMap<>();
+            Map<String, ModelInfo> formKeyModelIdMap = new HashMap<>();
             for (String oldFormId : formKeyAndModelMap.keySet()) {
                 Model formModel = formKeyAndModelMap.get(oldFormId);
                 oldFormIdFormKeyMap.put(oldFormId, formModel.getKey());
                 formKeyModelIdMap.put(formModel.getKey(), new ModelInfo(formModel.getId(), formModel.getName(), formModel.getKey()));
             }
 
-            Map<String, String> oldDecisionTableIdDecisionTableKeyMap = new HashMap<String, String>();
-            Map<String, ModelInfo> decisionTableKeyModelIdMap = new HashMap<String, ModelInfo>();
+            Map<String, String> oldDecisionTableIdDecisionTableKeyMap = new HashMap<>();
+            Map<String, ModelInfo> decisionTableKeyModelIdMap = new HashMap<>();
             for (String oldDecisionTableId : decisionTableKeyAndModelMap.keySet()) {
                 Model decisionTableModel = decisionTableKeyAndModelMap.get(oldDecisionTableId);
                 oldDecisionTableIdDecisionTableKeyMap.put(oldDecisionTableId, decisionTableModel.getKey());

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/service/editor/AppDefinitionServiceImpl.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/service/editor/AppDefinitionServiceImpl.java
@@ -76,8 +76,8 @@ public class AppDefinitionServiceImpl implements AppDefinitionService {
 
     @Override
     public List<AppDefinitionServiceRepresentation> getAppDefinitions() {
-        Map<String, AbstractModel> modelMap = new HashMap<String, AbstractModel>();
-        List<AppDefinitionServiceRepresentation> resultList = new ArrayList<AppDefinitionServiceRepresentation>();
+        Map<String, AbstractModel> modelMap = new HashMap<>();
+        List<AppDefinitionServiceRepresentation> resultList = new ArrayList<>();
 
         List<Model> createdByModels = modelRepository.findByModelType(AbstractModel.MODEL_TYPE_APP, ModelSort.NAME_ASC);
         for (Model model : createdByModels) {
@@ -93,14 +93,14 @@ public class AppDefinitionServiceImpl implements AppDefinitionService {
 
     /**
      * Gathers all 'deployable' app definitions for the current user.
-     * 
+     * <p>
      * To find these: - All historical app models are fetched. Only the highest version of each app model is retained. - All historical app models shared with the groups the current user is part of
      * are fetched. Only the highest version of each app model is retained.
      */
     @Override
     public List<AppDefinitionServiceRepresentation> getDeployableAppDefinitions(User user) {
-        Map<String, ModelHistory> modelMap = new HashMap<String, ModelHistory>();
-        List<AppDefinitionServiceRepresentation> resultList = new ArrayList<AppDefinitionServiceRepresentation>();
+        Map<String, ModelHistory> modelMap = new HashMap<>();
+        List<AppDefinitionServiceRepresentation> resultList = new ArrayList<>();
 
         List<ModelHistory> createdByModels = modelHistoryRepository.findByModelTypAndCreatedBy(
                 user.getId(), AbstractModel.MODEL_TYPE_APP);
@@ -181,7 +181,7 @@ public class AppDefinitionServiceImpl implements AppDefinitionService {
             resultInfo.setIcon(appDefinition.getIcon());
             List<AppModelDefinition> models = appDefinition.getModels();
             if (CollectionUtils.isNotEmpty(models)) {
-                List<String> modelIds = new ArrayList<String>();
+                List<String> modelIds = new ArrayList<>();
                 for (AppModelDefinition appModelDef : models) {
                     modelIds.add(appModelDef.getId());
                 }

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/service/editor/BaseAppDefinitionService.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/service/editor/BaseAppDefinitionService.java
@@ -12,6 +12,10 @@
  */
 package org.flowable.app.service.editor;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -44,10 +48,6 @@ import org.flowable.dmn.xml.converter.DmnXMLConverter;
 import org.flowable.editor.dmn.converter.DmnJsonConverter;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 /**
  * @author Yvo Swillens
  */
@@ -66,7 +66,7 @@ public class BaseAppDefinitionService {
     protected DmnXMLConverter dmnXMLConverter = new DmnXMLConverter();
 
     protected Map<String, StartEvent> processNoneStartEvents(BpmnModel bpmnModel) {
-        Map<String, StartEvent> startEventMap = new HashMap<String, StartEvent>();
+        Map<String, StartEvent> startEventMap = new HashMap<>();
         for (Process process : bpmnModel.getProcesses()) {
             for (FlowElement flowElement : process.getFlowElements()) {
                 if (flowElement instanceof StartEvent) {
@@ -205,14 +205,14 @@ public class BaseAppDefinitionService {
                 zos.write(entry.getValue());
                 zos.closeEntry();
             }
-            
+
             IOUtils.closeQuietly(zos);
 
             // this is the zip file as byte[]
             deployZipArtifact = baos.toByteArray();
-            
+
             IOUtils.closeQuietly(baos);
-            
+
         } catch (IOException ioe) {
             throw new InternalServerErrorException("Could not create deploy zip artifact");
         }

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/service/editor/BpmnDisplayJsonConverter.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/service/editor/BpmnDisplayJsonConverter.java
@@ -65,8 +65,8 @@ public class BpmnDisplayJsonConverter {
     protected BpmnJsonConverter bpmnJsonConverter = new BpmnJsonConverter();
 
     protected ObjectMapper objectMapper = new ObjectMapper();
-    protected List<String> eventElementTypes = new ArrayList<String>();
-    protected Map<String, InfoMapper> propertyMappers = new HashMap<String, InfoMapper>();
+    protected List<String> eventElementTypes = new ArrayList<>();
+    protected Map<String, InfoMapper> propertyMappers = new HashMap<>();
 
     public BpmnDisplayJsonConverter() {
         eventElementTypes.add("StartEvent");
@@ -246,12 +246,12 @@ public class BpmnDisplayJsonConverter {
 
                 if (element instanceof SubProcess) {
                     SubProcess subProcess = (SubProcess) element;
-                    
+
                     // skip collapsed sub processes
                     if (graphicInfo != null && graphicInfo.getExpanded() != null && !graphicInfo.getExpanded()) {
                         continue;
                     }
-                    
+
                     processElements(subProcess.getFlowElements(), model, elementArray, flowArray, diagramInfo);
                     processArtifacts(subProcess.getArtifacts(), model, elementArray, flowArray, diagramInfo);
                 }

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/service/editor/FlowableDecisionTableService.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/service/editor/FlowableDecisionTableService.java
@@ -12,6 +12,10 @@
  */
 package org.flowable.app.service.editor;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.InputStreamReader;
@@ -53,10 +57,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * @author erikwinlof
@@ -100,7 +100,7 @@ public class FlowableDecisionTableService extends BaseFlowableModelService {
             models = modelRepository.findByModelType(AbstractModel.MODEL_TYPE_DECISION_TABLE, ModelSort.NAME_ASC);
         }
 
-        List<DecisionTableRepresentation> reps = new ArrayList<DecisionTableRepresentation>();
+        List<DecisionTableRepresentation> reps = new ArrayList<>();
 
         for (Model model : models) {
             reps.add(new DecisionTableRepresentation(model));
@@ -272,7 +272,7 @@ public class FlowableDecisionTableService extends BaseFlowableModelService {
         model.setName(saveRepresentation.getDecisionTableRepresentation().getName());
         model.setKey(decisionKey);
         model.setDescription(saveRepresentation.getDecisionTableRepresentation().getDescription());
-        
+
         saveRepresentation.getDecisionTableRepresentation().getDecisionTableDefinition().setKey(decisionKey);
 
         String editorJson = null;

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/service/editor/FlowableFormService.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/service/editor/FlowableFormService.java
@@ -64,7 +64,7 @@ public class FlowableFormService {
     }
 
     public List<FormRepresentation> getForms(String[] formIds) {
-        List<FormRepresentation> formRepresentations = new ArrayList<FormRepresentation>();
+        List<FormRepresentation> formRepresentations = new ArrayList<>();
 
         if (formIds == null || formIds.length == 0) {
             throw new BadRequestException("No formIds provided in the request");

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/service/editor/FlowableModelQueryService.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/service/editor/FlowableModelQueryService.java
@@ -92,7 +92,7 @@ public class FlowableModelQueryService {
             }
         }
 
-        List<ModelRepresentation> resultList = new ArrayList<ModelRepresentation>();
+        List<ModelRepresentation> resultList = new ArrayList<>();
         List<Model> models = null;
 
         String validFilter = makeValidFilterText(filterText);
@@ -105,7 +105,7 @@ public class FlowableModelQueryService {
         }
 
         if (CollectionUtils.isNotEmpty(models)) {
-            List<String> addedModelIds = new ArrayList<String>();
+            List<String> addedModelIds = new ArrayList<>();
             for (Model model : models) {
                 if (!addedModelIds.contains(model.getId())) {
                     addedModelIds.add(model.getId());
@@ -121,9 +121,9 @@ public class FlowableModelQueryService {
 
     public ResultListDataRepresentation getModelsToIncludeInAppDefinition() {
 
-        List<ModelRepresentation> resultList = new ArrayList<ModelRepresentation>();
+        List<ModelRepresentation> resultList = new ArrayList<>();
 
-        List<String> addedModelIds = new ArrayList<String>();
+        List<String> addedModelIds = new ArrayList<>();
         List<Model> models = modelRepository.findByModelType(AbstractModel.MODEL_TYPE_BPMN, ModelSort.MODIFIED_DESC);
 
         if (CollectionUtils.isNotEmpty(models)) {

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/service/editor/ModelImageService.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/service/editor/ModelImageService.java
@@ -109,7 +109,7 @@ public class ModelImageService {
 
     protected void calculateWidthForFlowElements(Collection<FlowElement> elementList, BpmnModel bpmnModel, GraphicInfo diagramInfo) {
         for (FlowElement flowElement : elementList) {
-            List<GraphicInfo> graphicInfoList = new ArrayList<GraphicInfo>();
+            List<GraphicInfo> graphicInfoList = new ArrayList<>();
             if (flowElement instanceof SequenceFlow) {
                 List<GraphicInfo> flowGraphics = bpmnModel.getFlowLocationGraphicInfo(flowElement.getId());
                 if (flowGraphics != null && flowGraphics.size() > 0) {
@@ -128,7 +128,7 @@ public class ModelImageService {
 
     protected void calculateWidthForArtifacts(Collection<Artifact> artifactList, BpmnModel bpmnModel, GraphicInfo diagramInfo) {
         for (Artifact artifact : artifactList) {
-            List<GraphicInfo> graphicInfoList = new ArrayList<GraphicInfo>();
+            List<GraphicInfo> graphicInfoList = new ArrayList<>();
             if (artifact instanceof Association) {
                 graphicInfoList.addAll(bpmnModel.getFlowLocationGraphicInfo(artifact.getId()));
             } else {
@@ -155,7 +155,7 @@ public class ModelImageService {
 
     protected void scaleFlowElements(Collection<FlowElement> elementList, BpmnModel bpmnModel, double scaleFactor) {
         for (FlowElement flowElement : elementList) {
-            List<GraphicInfo> graphicInfoList = new ArrayList<GraphicInfo>();
+            List<GraphicInfo> graphicInfoList = new ArrayList<>();
             if (flowElement instanceof SequenceFlow) {
                 List<GraphicInfo> flowList = bpmnModel.getFlowLocationGraphicInfo(flowElement.getId());
                 if (flowList != null) {
@@ -176,7 +176,7 @@ public class ModelImageService {
 
     protected void scaleArtifacts(Collection<Artifact> artifactList, BpmnModel bpmnModel, double scaleFactor) {
         for (Artifact artifact : artifactList) {
-            List<GraphicInfo> graphicInfoList = new ArrayList<GraphicInfo>();
+            List<GraphicInfo> graphicInfoList = new ArrayList<>();
             if (artifact instanceof Association) {
                 List<GraphicInfo> flowList = bpmnModel.getFlowLocationGraphicInfo(artifact.getId());
                 if (flowList != null) {

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/service/editor/ModelServiceImpl.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/service/editor/ModelServiceImpl.java
@@ -12,6 +12,11 @@
  */
 package org.flowable.app.service.editor;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
@@ -64,11 +69,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 @Service
 @Transactional
@@ -172,7 +172,7 @@ public class ModelServiceImpl implements ModelService {
 
         return modelKeyResponse;
     }
-    
+
     @Override
     public String createModelJson(ModelRepresentation model) {
         String json = null;
@@ -243,7 +243,7 @@ public class ModelServiceImpl implements ModelService {
             stencilNode.put("id", "StartNoneEvent");
             json = editorNode.toString();
         }
-        
+
         return json;
     }
 
@@ -350,14 +350,14 @@ public class ModelServiceImpl implements ModelService {
 
     @Override
     public Model saveModel(String modelId, String name, String key, String description, String editorJson,
-            boolean newVersion, String newVersionComment, User updatedBy) {
+                           boolean newVersion, String newVersionComment, User updatedBy) {
 
         Model modelObject = modelRepository.get(modelId);
         return internalSave(name, key, description, editorJson, newVersion, newVersionComment, null, updatedBy, modelObject);
     }
 
     protected Model internalSave(String name, String key, String description, String editorJson, boolean newVersion,
-            String newVersionComment, byte[] imageBytes, User updatedBy, Model modelObject) {
+                                 String newVersionComment, byte[] imageBytes, User updatedBy, Model modelObject) {
 
         if (!newVersion) {
 
@@ -419,7 +419,7 @@ public class ModelServiceImpl implements ModelService {
         // Hence, we remove first all relations, comments, etc. while collecting all models.
         // Then, once all foreign key problem makers are removed, we remove the models
 
-        List<Model> allModels = new ArrayList<Model>();
+        List<Model> allModels = new ArrayList<>();
         internalDeleteModelAndChildren(model, allModels);
 
         for (Model modelToDelete : allModels) {
@@ -484,8 +484,8 @@ public class ModelServiceImpl implements ModelService {
     public BpmnModel getBpmnModel(AbstractModel model) {
         BpmnModel bpmnModel = null;
         try {
-            Map<String, Model> formMap = new HashMap<String, Model>();
-            Map<String, Model> decisionTableMap = new HashMap<String, Model>();
+            Map<String, Model> formMap = new HashMap<>();
+            Map<String, Model> decisionTableMap = new HashMap<>();
 
             List<Model> referencedModels = modelRepository.findByParentModelId(model.getId());
             for (Model childModel : referencedModels) {
@@ -511,12 +511,12 @@ public class ModelServiceImpl implements ModelService {
     public BpmnModel getBpmnModel(AbstractModel model, Map<String, Model> formMap, Map<String, Model> decisionTableMap) {
         try {
             ObjectNode editorJsonNode = (ObjectNode) objectMapper.readTree(model.getModelEditorJson());
-            Map<String, String> formKeyMap = new HashMap<String, String>();
+            Map<String, String> formKeyMap = new HashMap<>();
             for (Model formModel : formMap.values()) {
                 formKeyMap.put(formModel.getId(), formModel.getKey());
             }
 
-            Map<String, String> decisionTableKeyMap = new HashMap<String, String>();
+            Map<String, String> decisionTableKeyMap = new HashMap<>();
             for (Model decisionTableModel : decisionTableMap.values()) {
                 decisionTableKeyMap.put(decisionTableModel.getId(), decisionTableModel.getKey());
             }
@@ -636,7 +636,7 @@ public class ModelServiceImpl implements ModelService {
             return;
         }
 
-        Set<String> alreadyPersistedModelIds = new HashSet<String>(persistedModelRelations.size());
+        Set<String> alreadyPersistedModelIds = new HashSet<>(persistedModelRelations.size());
         for (ModelRelation persistedModelRelation : persistedModelRelations) {
             if (!idsReferencedInJson.contains(persistedModelRelation.getModelId())) {
                 // model used to be referenced, but not anymore. Delete it.

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/service/editor/ServiceParameters.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/service/editor/ServiceParameters.java
@@ -12,6 +12,9 @@
  */
 package org.flowable.app.service.editor;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -26,14 +29,10 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.lang3.StringUtils;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 /**
  * Wrapper around parameters that should be passed trough to the delegated service call.
- * 
- * @author Frederik Heremans
  *
+ * @author Frederik Heremans
  */
 public class ServiceParameters {
 
@@ -41,7 +40,7 @@ public class ServiceParameters {
     protected Set<String> validParameterNames;
 
     public ServiceParameters() {
-        parameters = new HashMap<String, Object>();
+        parameters = new HashMap<>();
     }
 
     public void addParameter(String name, Object value) {
@@ -66,7 +65,7 @@ public class ServiceParameters {
 
     public void addValidParameterNames(String[] validParameters) {
         if (validParameterNames == null) {
-            validParameterNames = new HashSet<String>();
+            validParameterNames = new HashSet<>();
         }
         this.validParameterNames.addAll(Arrays.asList(validParameters));
     }
@@ -80,7 +79,7 @@ public class ServiceParameters {
             return Collections.unmodifiableMap(parameters);
         } else {
             // Only return valid parameters
-            Map<String, Object> result = new HashMap<String, Object>();
+            Map<String, Object> result = new HashMap<>();
             for (Entry<String, Object> parameter : parameters.entrySet()) {
                 if (validParameterNames.contains(parameter.getKey())) {
                     result.put(parameter.getKey(), parameter.getValue());

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/service/editor/mapper/AbstractInfoMapper.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/service/editor/mapper/AbstractInfoMapper.java
@@ -12,6 +12,10 @@
  */
 package org.flowable.app.service.editor.mapper;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -19,16 +23,12 @@ import java.util.Date;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
-import org.flowable.bpmn.model.FlowableListener;
 import org.flowable.bpmn.model.Activity;
 import org.flowable.bpmn.model.FieldExtension;
 import org.flowable.bpmn.model.FlowElement;
+import org.flowable.bpmn.model.FlowableListener;
 import org.flowable.bpmn.model.MultiInstanceLoopCharacteristics;
 import org.flowable.editor.language.json.converter.util.CollectionUtils;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 public abstract class AbstractInfoMapper implements InfoMapper {
 
@@ -83,7 +83,7 @@ public abstract class AbstractInfoMapper implements InfoMapper {
 
     protected void createListenerPropertyNodes(String name, List<FlowableListener> listeners) {
         if (CollectionUtils.isNotEmpty(listeners)) {
-            List<String> listenerValues = new ArrayList<String>();
+            List<String> listenerValues = new ArrayList<>();
             for (FlowableListener listener : listeners) {
                 StringBuilder listenerBuilder = new StringBuilder();
                 listenerBuilder.append(listener.getEvent());
@@ -121,7 +121,7 @@ public abstract class AbstractInfoMapper implements InfoMapper {
 
     protected void createFieldPropertyNodes(String name, List<FieldExtension> fields) {
         if (CollectionUtils.isNotEmpty(fields)) {
-            List<String> fieldValues = new ArrayList<String>();
+            List<String> fieldValues = new ArrayList<>();
             for (FieldExtension field : fields) {
                 StringBuilder fieldBuilder = new StringBuilder();
                 fieldBuilder.append(field.getFieldName());

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/service/editor/mapper/UserTaskInfoMapper.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/service/editor/mapper/UserTaskInfoMapper.java
@@ -31,7 +31,7 @@ public class UserTaskInfoMapper extends AbstractInfoMapper {
         createPropertyNode("Form key", userTask.getFormKey());
         createPropertyNode("Priority", userTask.getPriority());
         if (CollectionUtils.isNotEmpty(userTask.getFormProperties())) {
-            List<String> formPropertyValues = new ArrayList<String>();
+            List<String> formPropertyValues = new ArrayList<>();
             for (FormProperty formProperty : userTask.getFormProperties()) {
                 StringBuilder propertyBuilder = new StringBuilder();
                 if (StringUtils.isNotEmpty(formProperty.getName())) {

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-rest/src/main/java/org/flowable/app/rest/editor/AbstractModelHistoryResource.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-rest/src/main/java/org/flowable/app/rest/editor/AbstractModelHistoryResource.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.app.rest.editor;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -23,8 +25,6 @@ import org.flowable.app.repository.editor.ModelHistoryRepository;
 import org.flowable.app.service.api.ModelService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RestController;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 @RestController
 public class AbstractModelHistoryResource {
@@ -44,7 +44,7 @@ public class AbstractModelHistoryResource {
         List<ModelHistory> history = modelHistoryRepository.findByModelId(model.getId());
         ResultListDataRepresentation result = new ResultListDataRepresentation();
 
-        List<ModelRepresentation> representations = new ArrayList<ModelRepresentation>();
+        List<ModelRepresentation> representations = new ArrayList<>();
 
         // Also include the latest version of the model
         if (Boolean.TRUE.equals(includeLatestVersion)) {

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-rest/src/main/java/org/flowable/app/rest/editor/EditorGroupsResource.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-rest/src/main/java/org/flowable/app/rest/editor/EditorGroupsResource.java
@@ -36,7 +36,7 @@ public class EditorGroupsResource {
 
     @RequestMapping(value = "/rest/editor-groups", method = RequestMethod.GET)
     public ResultListDataRepresentation getGroups(@RequestParam(required = false, value = "filter") String filter) {
-        List<GroupRepresentation> result = new ArrayList<GroupRepresentation>();
+        List<GroupRepresentation> result = new ArrayList<>();
         List<RemoteGroup> groups = remoteIdmService.findGroupsByNameFilter(filter);
         for (RemoteGroup group : groups) {
             result.add(new GroupRepresentation(group));

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-rest/src/main/java/org/flowable/app/rest/editor/EditorUsersResource.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-rest/src/main/java/org/flowable/app/rest/editor/EditorUsersResource.java
@@ -34,7 +34,7 @@ public class EditorUsersResource {
     @RequestMapping(value = "/rest/editor-users", method = RequestMethod.GET)
     public ResultListDataRepresentation getUsers(@RequestParam(value = "filter", required = false) String filter) {
         List<? extends User> matchingUsers = remoteIdmService.findUsersByNameFilter(filter);
-        List<UserRepresentation> userRepresentations = new ArrayList<UserRepresentation>(matchingUsers.size());
+        List<UserRepresentation> userRepresentations = new ArrayList<>(matchingUsers.size());
         for (User user : matchingUsers) {
             userRepresentations.add(new UserRepresentation(user));
         }

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-rest/src/main/java/org/flowable/app/rest/editor/FormsResource.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-rest/src/main/java/org/flowable/app/rest/editor/FormsResource.java
@@ -78,7 +78,7 @@ public class FormsResource {
             models = modelRepository.findByModelType(AbstractModel.MODEL_TYPE_FORM, ModelSort.NAME_ASC);
         }
 
-        List<FormRepresentation> reps = new ArrayList<FormRepresentation>();
+        List<FormRepresentation> reps = new ArrayList<>();
 
         for (Model model : models) {
             reps.add(new FormRepresentation(model));

--- a/modules/flowable-ui-task/flowable-ui-task-conf/src/main/java/org/flowable/app/security/RemoteIdmAuthenticationProvider.java
+++ b/modules/flowable-ui-task/flowable-ui-task-conf/src/main/java/org/flowable/app/security/RemoteIdmAuthenticationProvider.java
@@ -28,7 +28,7 @@ public class RemoteIdmAuthenticationProvider implements AuthenticationProvider {
             throw new FlowableException("user not found " + authentication.getPrincipal());
         }
 
-        Collection<GrantedAuthority> grantedAuthorities = new ArrayList<GrantedAuthority>();
+        Collection<GrantedAuthority> grantedAuthorities = new ArrayList<>();
         for (String privilege : user.getPrivileges()) {
             grantedAuthorities.add(new SimpleGrantedAuthority(privilege));
         }

--- a/modules/flowable-ui-task/flowable-ui-task-logic/src/main/java/org/flowable/app/model/runtime/ProcessInstanceRepresentation.java
+++ b/modules/flowable-ui-task/flowable-ui-task-logic/src/main/java/org/flowable/app/model/runtime/ProcessInstanceRepresentation.java
@@ -25,7 +25,7 @@ import org.flowable.idm.api.User;
 
 /**
  * REST representation of a process instance.
- * 
+ *
  * @author Tijs Rademakers
  */
 public class ProcessInstanceRepresentation extends AbstractRepresentation {
@@ -47,7 +47,7 @@ public class ProcessInstanceRepresentation extends AbstractRepresentation {
     protected boolean graphicalNotationDefined;
     protected boolean startFormDefined;
 
-    protected List<RestVariable> variables = new ArrayList<RestVariable>();
+    protected List<RestVariable> variables = new ArrayList<>();
 
     public ProcessInstanceRepresentation(ProcessInstance processInstance, ProcessDefinition processDefinition, boolean graphicalNotation, User startedBy) {
         this(processInstance, graphicalNotation, startedBy);

--- a/modules/flowable-ui-task/flowable-ui-task-logic/src/main/java/org/flowable/app/service/editor/mapper/AbstractInfoMapper.java
+++ b/modules/flowable-ui-task/flowable-ui-task-logic/src/main/java/org/flowable/app/service/editor/mapper/AbstractInfoMapper.java
@@ -12,6 +12,10 @@
  */
 package org.flowable.app.service.editor.mapper;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -25,10 +29,6 @@ import org.flowable.bpmn.model.FlowElement;
 import org.flowable.bpmn.model.FlowableListener;
 import org.flowable.bpmn.model.MultiInstanceLoopCharacteristics;
 import org.flowable.editor.language.json.converter.util.CollectionUtils;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 public abstract class AbstractInfoMapper implements InfoMapper {
 
@@ -77,7 +77,7 @@ public abstract class AbstractInfoMapper implements InfoMapper {
 
     protected void createListenerPropertyNodes(String name, List<FlowableListener> listeners) {
         if (CollectionUtils.isNotEmpty(listeners)) {
-            List<String> listenerValues = new ArrayList<String>();
+            List<String> listenerValues = new ArrayList<>();
             for (FlowableListener listener : listeners) {
                 StringBuilder listenerBuilder = new StringBuilder();
                 listenerBuilder.append(listener.getEvent());
@@ -113,7 +113,7 @@ public abstract class AbstractInfoMapper implements InfoMapper {
 
     protected void createFieldPropertyNodes(String name, List<FieldExtension> fields) {
         if (CollectionUtils.isNotEmpty(fields)) {
-            List<String> fieldValues = new ArrayList<String>();
+            List<String> fieldValues = new ArrayList<>();
             for (FieldExtension field : fields) {
                 StringBuilder fieldBuilder = new StringBuilder();
                 fieldBuilder.append(field.getFieldName());

--- a/modules/flowable-ui-task/flowable-ui-task-logic/src/main/java/org/flowable/app/service/editor/mapper/UserTaskInfoMapper.java
+++ b/modules/flowable-ui-task/flowable-ui-task-logic/src/main/java/org/flowable/app/service/editor/mapper/UserTaskInfoMapper.java
@@ -31,7 +31,7 @@ public class UserTaskInfoMapper extends AbstractInfoMapper {
         createPropertyNode("Form key", userTask.getFormKey());
         createPropertyNode("Priority", userTask.getPriority());
         if (CollectionUtils.isNotEmpty(userTask.getFormProperties())) {
-            List<String> formPropertyValues = new ArrayList<String>();
+            List<String> formPropertyValues = new ArrayList<>();
             for (FormProperty formProperty : userTask.getFormProperties()) {
                 StringBuilder propertyBuilder = new StringBuilder();
                 if (StringUtils.isNotEmpty(formProperty.getName())) {

--- a/modules/flowable-ui-task/flowable-ui-task-logic/src/main/java/org/flowable/app/service/idm/UserCacheImpl.java
+++ b/modules/flowable-ui-task/flowable-ui-task-logic/src/main/java/org/flowable/app/service/idm/UserCacheImpl.java
@@ -12,6 +12,11 @@
  */
 package org.flowable.app.service.idm;
 
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.ExecutionException;
@@ -28,16 +33,11 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
-import com.google.common.util.concurrent.UncheckedExecutionException;
-
 /**
  * Cache containing User objects to prevent too much DB-traffic (users exist separately from the Flowable tables, they need to be fetched afterward one by one to join with those entities).
- * 
+ * <p>
  * TODO: This could probably be made more efficient with bulk getting. The Google cache impl allows this: override loadAll and use getAll() to fetch multiple entities.
- * 
+ *
  * @author Frederik Heremans
  * @author Joram Barrez
  */
@@ -66,7 +66,7 @@ public class UserCacheImpl implements UserCache {
                             throw new UsernameNotFoundException("User " + userId + " was not found in the database");
                         }
 
-                        Collection<GrantedAuthority> grantedAuthorities = new ArrayList<GrantedAuthority>();
+                        Collection<GrantedAuthority> grantedAuthorities = new ArrayList<>();
 
                         return new CachedUser(user, grantedAuthorities);
                     }

--- a/modules/flowable-ui-task/flowable-ui-task-logic/src/main/java/org/flowable/app/service/runtime/AppVersionService.java
+++ b/modules/flowable-ui-task/flowable-ui-task-logic/src/main/java/org/flowable/app/service/runtime/AppVersionService.java
@@ -46,7 +46,7 @@ public class AppVersionService {
                 LOGGER.warn("Could not load version.properties", e);
             }
 
-            Map<String, String> temp = new HashMap<String, String>();
+            Map<String, String> temp = new HashMap<>();
             putIfExists(properties, TYPE, temp, "type");
             putIfExists(properties, MAJOR_VERSION, temp, "majorVersion");
             putIfExists(properties, MINOR_VERSION, temp, "minorVersion");

--- a/modules/flowable-ui-task/flowable-ui-task-logic/src/main/java/org/flowable/app/service/runtime/FlowableAbstractTaskService.java
+++ b/modules/flowable-ui-task/flowable-ui-task-logic/src/main/java/org/flowable/app/service/runtime/FlowableAbstractTaskService.java
@@ -82,11 +82,11 @@ public abstract class FlowableAbstractTaskService {
                         }
                     }
 
-                    Map<String, Object> variableMap = new HashMap<String, Object>();
+                    Map<String, Object> variableMap = new HashMap<>();
                     if ((CollectionUtils.isNotEmpty(userTask.getCandidateGroups()) && userTask.getCandidateGroups().size() == 1
                             && userTask.getCandidateGroups().get(0).contains("${taskAssignmentBean.assignTaskToCandidateGroups('"))
                             || (CollectionUtils.isNotEmpty(userTask.getCandidateUsers()) && userTask.getCandidateUsers().size() == 1
-                                    && userTask.getCandidateUsers().get(0).contains("${taskAssignmentBean.assignTaskToCandidateUsers('"))) {
+                            && userTask.getCandidateUsers().get(0).contains("${taskAssignmentBean.assignTaskToCandidateUsers('"))) {
 
                         List<HistoricVariableInstance> processVariables = historyService.createHistoricVariableInstanceQuery().processInstanceId(task.getProcessInstanceId()).list();
                         if (CollectionUtils.isNotEmpty(processVariables)) {
@@ -100,7 +100,7 @@ public abstract class FlowableAbstractTaskService {
                         List<? extends Group> groups = remoteIdmService.getUser(currentUser.getId()).getGroups();
                         if (CollectionUtils.isNotEmpty(groups)) {
 
-                            List<String> groupIds = new ArrayList<String>();
+                            List<String> groupIds = new ArrayList<>();
                             if (userTask.getCandidateGroups().size() == 1 && userTask.getCandidateGroups().get(0).contains("${taskAssignmentBean.assignTaskToCandidateGroups('")) {
 
                                 String candidateGroupString = userTask.getCandidateGroups().get(0);

--- a/modules/flowable-ui-task/flowable-ui-task-logic/src/main/java/org/flowable/app/service/runtime/FlowableAppDefinitionService.java
+++ b/modules/flowable-ui-task/flowable-ui-task-logic/src/main/java/org/flowable/app/service/runtime/FlowableAppDefinitionService.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.app.service.runtime;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -36,8 +38,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 /**
  * @author Tijs Rademakers
  */
@@ -49,7 +49,7 @@ public class FlowableAppDefinitionService {
 
     @Autowired
     protected RepositoryService repositoryService;
-    
+
     @Autowired
     protected RemoteIdmService remoteIdmService;
 
@@ -65,7 +65,7 @@ public class FlowableAppDefinitionService {
         resultList.add(taskAppDefinitionRepresentation);
 
         // Custom apps
-        Map<String, Deployment> deploymentMap = new HashMap<String, Deployment>();
+        Map<String, Deployment> deploymentMap = new HashMap<>();
         List<Deployment> deployments = repositoryService.createDeploymentQuery().list();
         for (Deployment deployment : deployments) {
             if (deployment.getKey() != null) {
@@ -83,18 +83,18 @@ public class FlowableAppDefinitionService {
             if (CollectionUtils.isNotEmpty(appDefinition.getUsersAccess()) || CollectionUtils.isNotEmpty(appDefinition.getGroupsAccess())) {
                 appDefinitionHaveAccessControl = true;
             }
-            
+
             resultList.add(appDefinition);
         }
-        
+
         if (appDefinitionHaveAccessControl) {
             User currentUser = SecurityUtils.getCurrentUserObject();
             String userId = currentUser.getId();
             List<RemoteGroup> groups = getUserGroups(userId);
-            
+
             List<AppDefinitionRepresentation> appDefinitionList = new ArrayList<>(resultList);
             resultList.clear();
-            
+
             for (AppDefinitionRepresentation appDefinition : appDefinitionList) {
                 if (hasAppAccess(appDefinition, userId, groups)) {
                     resultList.add(appDefinition);
@@ -115,32 +115,32 @@ public class FlowableAppDefinitionService {
 
         return createRepresentation(deployment);
     }
-    
+
     protected List<RemoteGroup> getUserGroups(String userId) {
         return remoteIdmService.getUser(userId).getGroups();
     }
-    
+
     protected boolean hasAppAccess(AppDefinitionRepresentation appDefinition, String userId, List<RemoteGroup> groups) {
         if (CollectionUtils.isEmpty(appDefinition.getUsersAccess()) && CollectionUtils.isEmpty(appDefinition.getGroupsAccess())) {
             return true;
         }
-        
+
         if (CollectionUtils.isNotEmpty(appDefinition.getUsersAccess())) {
             if (appDefinition.getUsersAccess().contains(userId)) {
                 return true;
             }
         }
-        
+
         if (CollectionUtils.isNotEmpty(appDefinition.getGroupsAccess())) {
-           for (String groupId : appDefinition.getGroupsAccess()) {
-               for (RemoteGroup group : groups) {
-                   if (group.getId().equals(groupId)) {
-                       return true;
-                   }
-               }
-           }
+            for (String groupId : appDefinition.getGroupsAccess()) {
+                for (RemoteGroup group : groups) {
+                    if (group.getId().equals(groupId)) {
+                        return true;
+                    }
+                }
+            }
         }
-        
+
         return false;
     }
 
@@ -161,19 +161,19 @@ public class FlowableAppDefinitionService {
         if (StringUtils.isNotEmpty(appModel.getUsersAccess())) {
             resultAppDef.setUsersAccess(convertToList(appModel.getUsersAccess()));
         }
-        
+
         if (StringUtils.isNotEmpty(appModel.getGroupsAccess())) {
             resultAppDef.setGroupsAccess(convertToList(appModel.getGroupsAccess()));
         }
-        
+
         return resultAppDef;
     }
-    
+
     protected List<String> convertToList(String commaSeperatedString) {
         List<String> resultList = new ArrayList<>();
         String[] stringArray = commaSeperatedString.split(",");
         resultList.addAll(Arrays.asList(stringArray));
-        
+
         return resultList;
     }
 }

--- a/modules/flowable-ui-task/flowable-ui-task-logic/src/main/java/org/flowable/app/service/runtime/FlowableCommentService.java
+++ b/modules/flowable-ui-task/flowable-ui-task-logic/src/main/java/org/flowable/app/service/runtime/FlowableCommentService.java
@@ -59,7 +59,7 @@ public class FlowableCommentService {
         List<Comment> comments = getCommentsForTask(taskId);
 
         // Create representation for all comments
-        List<CommentRepresentation> commentList = new ArrayList<CommentRepresentation>();
+        List<CommentRepresentation> commentList = new ArrayList<>();
         for (Comment comment : comments) {
             commentList.add(new CommentRepresentation(comment));
         }
@@ -94,7 +94,7 @@ public class FlowableCommentService {
         List<Comment> comments = getCommentsForProcessInstance(processInstanceId);
 
         // Create representation for all comments
-        List<CommentRepresentation> commentList = new ArrayList<CommentRepresentation>();
+        List<CommentRepresentation> commentList = new ArrayList<>();
         for (Comment comment : comments) {
             commentList.add(new CommentRepresentation(comment));
         }

--- a/modules/flowable-ui-task/flowable-ui-task-logic/src/main/java/org/flowable/app/service/runtime/FlowableProcessDefinitionService.java
+++ b/modules/flowable-ui-task/flowable-ui-task-logic/src/main/java/org/flowable/app/service/runtime/FlowableProcessDefinitionService.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.app.service.runtime;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.List;
@@ -42,8 +44,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * @author Tijs Rademakers
@@ -163,7 +163,7 @@ public class FlowableProcessDefinitionService {
     }
 
     protected List<ProcessDefinitionRepresentation> convertDefinitionList(List<ProcessDefinition> definitions) {
-        List<ProcessDefinitionRepresentation> result = new ArrayList<ProcessDefinitionRepresentation>();
+        List<ProcessDefinitionRepresentation> result = new ArrayList<>();
         if (CollectionUtils.isNotEmpty(definitions)) {
             for (ProcessDefinition processDefinition : definitions) {
                 ProcessDefinitionRepresentation rep = new ProcessDefinitionRepresentation(processDefinition);

--- a/modules/flowable-ui-task/flowable-ui-task-logic/src/main/java/org/flowable/app/service/runtime/FlowableProcessInstanceQueryService.java
+++ b/modules/flowable-ui-task/flowable-ui-task-logic/src/main/java/org/flowable/app/service/runtime/FlowableProcessInstanceQueryService.java
@@ -12,6 +12,9 @@
  */
 package org.flowable.app.service.runtime;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -34,9 +37,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * @author Tijs Rademakers
@@ -76,7 +76,7 @@ public class FlowableProcessInstanceQueryService {
             // Results need to be filtered in an app-context. We need to fetch the deployment id for this app and use that in the query
             List<Deployment> deployments = repositoryService.createDeploymentQuery().deploymentKey(deploymentKeyNode.asText()).list();
 
-            List<String> deploymentIds = new ArrayList<String>();
+            List<String> deploymentIds = new ArrayList<>();
             for (Deployment deployment : deployments) {
                 deploymentIds.add(deployment.getId());
             }
@@ -144,7 +144,7 @@ public class FlowableProcessInstanceQueryService {
     }
 
     protected List<ProcessInstanceRepresentation> convertInstanceList(List<HistoricProcessInstance> instances) {
-        List<ProcessInstanceRepresentation> result = new ArrayList<ProcessInstanceRepresentation>();
+        List<ProcessInstanceRepresentation> result = new ArrayList<>();
         if (CollectionUtils.isNotEmpty(instances)) {
 
             for (HistoricProcessInstance processInstance : instances) {

--- a/modules/flowable-ui-task/flowable-ui-task-logic/src/main/java/org/flowable/app/service/runtime/FlowableTaskActionService.java
+++ b/modules/flowable-ui-task/flowable-ui-task-logic/src/main/java/org/flowable/app/service/runtime/FlowableTaskActionService.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.app.service.runtime;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -33,8 +35,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * @author Tijs Rademakers
@@ -225,7 +225,7 @@ public class FlowableTaskActionService extends FlowableAbstractTaskService {
 
     protected List<UserRepresentation> getInvolvedUsers(String taskId) {
         List<HistoricIdentityLink> idLinks = historyService.getHistoricIdentityLinksForTask(taskId);
-        List<UserRepresentation> result = new ArrayList<UserRepresentation>(idLinks.size());
+        List<UserRepresentation> result = new ArrayList<>(idLinks.size());
 
         for (HistoricIdentityLink link : idLinks) {
             // Only include users and non-assignee links

--- a/modules/flowable-ui-task/flowable-ui-task-logic/src/main/java/org/flowable/app/service/runtime/FlowableTaskFormService.java
+++ b/modules/flowable-ui-task/flowable-ui-task-logic/src/main/java/org/flowable/app/service/runtime/FlowableTaskFormService.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.app.service.runtime;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -38,8 +40,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * @author Tijs Rademakers
@@ -111,7 +111,7 @@ public class FlowableTaskFormService {
         List<HistoricVariableInstance> historicVariables = historyService.createHistoricVariableInstanceQuery().processInstanceId(task.getProcessInstanceId()).list();
 
         // Get all process-variables to extract values from
-        Map<String, ProcessInstanceVariableRepresentation> processInstanceVariables = new HashMap<String, ProcessInstanceVariableRepresentation>();
+        Map<String, ProcessInstanceVariableRepresentation> processInstanceVariables = new HashMap<>();
 
         for (HistoricVariableInstance historicVariableInstance : historicVariables) {
             ProcessInstanceVariableRepresentation processInstanceVariableRepresentation = new ProcessInstanceVariableRepresentation(
@@ -119,7 +119,7 @@ public class FlowableTaskFormService {
             processInstanceVariables.put(historicVariableInstance.getId(), processInstanceVariableRepresentation);
         }
 
-        List<ProcessInstanceVariableRepresentation> processInstanceVariableRepresenations = new ArrayList<ProcessInstanceVariableRepresentation>(processInstanceVariables.values());
+        List<ProcessInstanceVariableRepresentation> processInstanceVariableRepresenations = new ArrayList<>(processInstanceVariables.values());
         return processInstanceVariableRepresenations;
     }
 

--- a/modules/flowable-ui-task/flowable-ui-task-logic/src/main/java/org/flowable/app/service/runtime/FlowableTaskQueryService.java
+++ b/modules/flowable-ui-task/flowable-ui-task-logic/src/main/java/org/flowable/app/service/runtime/FlowableTaskQueryService.java
@@ -12,6 +12,10 @@
  */
 package org.flowable.app.service.runtime;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
+
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -48,10 +52,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
 /**
  * @author Tijs Rademakers
@@ -106,7 +106,7 @@ public class FlowableTaskQueryService {
         JsonNode deploymentKeyNode = requestNode.get("deploymentKey");
         if (deploymentKeyNode != null && !deploymentKeyNode.isNull()) {
             List<Deployment> deployments = repositoryService.createDeploymentQuery().deploymentKey(deploymentKeyNode.asText()).list();
-            List<String> deploymentIds = new ArrayList<String>(deployments.size());
+            List<String> deploymentIds = new ArrayList<>(deployments.size());
             for (Deployment deployment : deployments) {
                 deploymentIds.add(deployment.getId());
             }
@@ -168,7 +168,7 @@ public class FlowableTaskQueryService {
 
         JsonNode includeProcessInstanceNode = requestNode.get("includeProcessInstance");
         // todo Once a ProcessInstanceInfo class has been implement use it instead rather than just the name
-        Map<String, String> processInstancesNames = new HashMap<String, String>();
+        Map<String, String> processInstancesNames = new HashMap<>();
         if (includeProcessInstanceNode != null) {
             handleIncludeProcessInstance(taskInfoQueryWrapper, includeProcessInstanceNode, tasks, processInstancesNames);
         }
@@ -281,7 +281,7 @@ public class FlowableTaskQueryService {
 
     protected void handleIncludeProcessInstance(TaskInfoQueryWrapper taskInfoQueryWrapper, JsonNode includeProcessInstanceNode, List<? extends TaskInfo> tasks, Map<String, String> processInstanceNames) {
         if (includeProcessInstanceNode.asBoolean() && CollectionUtils.isNotEmpty(tasks)) {
-            Set<String> processInstanceIds = new HashSet<String>();
+            Set<String> processInstanceIds = new HashSet<>();
             for (TaskInfo task : tasks) {
                 if (task.getProcessInstanceId() != null) {
                     processInstanceIds.add(task.getProcessInstanceId());
@@ -304,7 +304,7 @@ public class FlowableTaskQueryService {
     }
 
     protected List<TaskRepresentation> convertTaskInfoList(List<? extends TaskInfo> tasks, Map<String, String> processInstanceNames) {
-        List<TaskRepresentation> result = new ArrayList<TaskRepresentation>();
+        List<TaskRepresentation> result = new ArrayList<>();
         if (CollectionUtils.isNotEmpty(tasks)) {
             for (TaskInfo task : tasks) {
                 ProcessDefinitionEntity processDefinition = null;

--- a/modules/flowable-ui-task/flowable-ui-task-logic/src/main/java/org/flowable/app/service/runtime/FlowableTaskService.java
+++ b/modules/flowable-ui-task/flowable-ui-task-logic/src/main/java/org/flowable/app/service/runtime/FlowableTaskService.java
@@ -80,7 +80,7 @@ public class FlowableTaskService extends FlowableAbstractTaskService {
 
     protected List<UserRepresentation> getInvolvedUsers(String taskId) {
         List<HistoricIdentityLink> idLinks = historyService.getHistoricIdentityLinksForTask(taskId);
-        List<UserRepresentation> result = new ArrayList<UserRepresentation>(idLinks.size());
+        List<UserRepresentation> result = new ArrayList<>(idLinks.size());
 
         for (HistoricIdentityLink link : idLinks) {
             // Only include users and non-assignee links

--- a/modules/flowable-ui-task/flowable-ui-task-logic/src/main/java/org/flowable/app/service/runtime/PermissionService.java
+++ b/modules/flowable-ui-task/flowable-ui-task-logic/src/main/java/org/flowable/app/service/runtime/PermissionService.java
@@ -42,7 +42,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Centralized service for all permission-checks.
- * 
+ *
  * @author Frederik Heremans
  */
 @Service
@@ -104,7 +104,7 @@ public class PermissionService {
     }
 
     private List<String> getGroupIdsForUser(User user) {
-        List<String> groupIds = new ArrayList<String>();
+        List<String> groupIds = new ArrayList<>();
         for (Group group : remoteIdmService.getUser(user.getId()).getGroups()) {
             groupIds.add(String.valueOf(group.getId()));
         }

--- a/modules/flowable-ui-task/flowable-ui-task-rest/src/main/java/org/flowable/app/rest/idm/WorkflowGroupsResource.java
+++ b/modules/flowable-ui-task/flowable-ui-task-rest/src/main/java/org/flowable/app/rest/idm/WorkflowGroupsResource.java
@@ -35,7 +35,7 @@ public class WorkflowGroupsResource {
     public ResultListDataRepresentation getGroups(@RequestParam(value = "filter", required = false) String filter) {
 
         List<? extends Group> matchingGroups = remoteIdmService.findGroupsByNameFilter(filter);
-        List<GroupRepresentation> groupRepresentations = new ArrayList<GroupRepresentation>();
+        List<GroupRepresentation> groupRepresentations = new ArrayList<>();
         for (Group group : matchingGroups) {
             groupRepresentations.add(new GroupRepresentation(group));
         }

--- a/modules/flowable-ui-task/flowable-ui-task-rest/src/main/java/org/flowable/app/rest/idm/WorkflowUsersResource.java
+++ b/modules/flowable-ui-task/flowable-ui-task-rest/src/main/java/org/flowable/app/rest/idm/WorkflowUsersResource.java
@@ -48,8 +48,8 @@ public class WorkflowUsersResource {
 
     @RequestMapping(value = "/rest/workflow-users", method = RequestMethod.GET)
     public ResultListDataRepresentation getUsers(@RequestParam(value = "filter", required = false) String filter,
-            @RequestParam(value = "excludeTaskId", required = false) String excludeTaskId,
-            @RequestParam(value = "excludeProcessId", required = false) String excludeProcessId) {
+                                                 @RequestParam(value = "excludeTaskId", required = false) String excludeTaskId,
+                                                 @RequestParam(value = "excludeProcessId", required = false) String excludeProcessId) {
 
         List<? extends User> matchingUsers = remoteIdmService.findUsersByNameFilter(filter);
 
@@ -60,7 +60,7 @@ public class WorkflowUsersResource {
             filterUsersInvolvedInProcess(excludeProcessId, matchingUsers);
         }
 
-        List<UserRepresentation> userRepresentations = new ArrayList<UserRepresentation>(matchingUsers.size());
+        List<UserRepresentation> userRepresentations = new ArrayList<>(matchingUsers.size());
         for (User user : matchingUsers) {
             userRepresentations.add(new UserRepresentation(user));
         }
@@ -83,7 +83,7 @@ public class WorkflowUsersResource {
     protected Set<String> getInvolvedUsersAsSet(List<IdentityLink> involvedPeople) {
         Set<String> involved = null;
         if (involvedPeople.size() > 0) {
-            involved = new HashSet<String>();
+            involved = new HashSet<>();
             for (IdentityLink link : involvedPeople) {
                 if (link.getUserId() != null) {
                     involved.add(link.getUserId());

--- a/modules/flowable-ui-task/flowable-ui-task-rest/src/main/java/org/flowable/app/rest/runtime/AbstractRelatedContentResource.java
+++ b/modules/flowable-ui-task/flowable-ui-task-rest/src/main/java/org/flowable/app/rest/runtime/AbstractRelatedContentResource.java
@@ -258,7 +258,7 @@ public abstract class AbstractRelatedContentResource {
     }
 
     protected ResultListDataRepresentation createResultRepresentation(List<ContentItem> results) {
-        List<ContentItemRepresentation> resultList = new ArrayList<ContentItemRepresentation>(results.size());
+        List<ContentItemRepresentation> resultList = new ArrayList<>(results.size());
 
         for (ContentItem content : results) {
             resultList.add(createContentItemResponse(content));

--- a/modules/flowable-ui-task/flowable-ui-task-rest/src/main/java/org/flowable/app/rest/runtime/HistoricTaskQueryResource.java
+++ b/modules/flowable-ui-task/flowable-ui-task-rest/src/main/java/org/flowable/app/rest/runtime/HistoricTaskQueryResource.java
@@ -12,6 +12,9 @@
  */
 package org.flowable.app.rest.runtime;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -34,9 +37,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 @RestController
 public class HistoricTaskQueryResource {
@@ -88,7 +88,7 @@ public class HistoricTaskQueryResource {
     }
 
     protected List<TaskRepresentation> convertTaskInfoList(List<HistoricTaskInstance> tasks) {
-        List<TaskRepresentation> result = new ArrayList<TaskRepresentation>();
+        List<TaskRepresentation> result = new ArrayList<>();
         if (CollectionUtils.isNotEmpty(tasks)) {
             TaskRepresentation representation = null;
             for (HistoricTaskInstance task : tasks) {

--- a/modules/flowable-ui-task/flowable-ui-task-rest/src/main/java/org/flowable/app/rest/runtime/RuntimeDisplayJsonClientResource.java
+++ b/modules/flowable-ui-task/flowable-ui-task-rest/src/main/java/org/flowable/app/rest/runtime/RuntimeDisplayJsonClientResource.java
@@ -12,6 +12,11 @@
  */
 package org.flowable.app.rest.runtime;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -70,11 +75,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 @RestController
 public class RuntimeDisplayJsonClientResource {
 
@@ -97,8 +97,8 @@ public class RuntimeDisplayJsonClientResource {
     protected DebuggerService debuggerService;
 
     protected ObjectMapper objectMapper = new ObjectMapper();
-    protected List<String> eventElementTypes = new ArrayList<String>();
-    protected Map<String, InfoMapper> propertyMappers = new HashMap<String, InfoMapper>();
+    protected List<String> eventElementTypes = new ArrayList<>();
+    protected Map<String, InfoMapper> propertyMappers = new HashMap<>();
 
     public RuntimeDisplayJsonClientResource() {
         eventElementTypes.add("StartEvent");
@@ -140,8 +140,8 @@ public class RuntimeDisplayJsonClientResource {
         // Fetch process-instance activities
         List<HistoricActivityInstance> activityInstances = historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstanceId).list();
 
-        Set<String> completedActivityInstances = new HashSet<String>();
-        Set<String> currentElements = new HashSet<String>();
+        Set<String> completedActivityInstances = new HashSet<>();
+        Set<String> currentElements = new HashSet<>();
         if (CollectionUtils.isNotEmpty(activityInstances)) {
             for (HistoricActivityInstance activityInstance : activityInstances) {
                 if (activityInstance.getEndTime() != null) {
@@ -155,7 +155,7 @@ public class RuntimeDisplayJsonClientResource {
         List<Job> jobs = managementService.createJobQuery().processInstanceId(processInstanceId).list();
         if (CollectionUtils.isNotEmpty(jobs)) {
             List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstanceId).list();
-            Map<String, Execution> executionMap = new HashMap<String, Execution>();
+            Map<String, Execution> executionMap = new HashMap<>();
             for (Execution execution : executions) {
                 executionMap.put(execution.getId(), execution);
             }
@@ -170,7 +170,7 @@ public class RuntimeDisplayJsonClientResource {
         // Gather completed flows
         List<String> completedFlows = gatherCompletedFlows(completedActivityInstances, currentElements, pojoModel);
 
-        Set<String> completedElements = new HashSet<String>(completedActivityInstances);
+        Set<String> completedElements = new HashSet<>(completedActivityInstances);
         completedElements.addAll(completedFlows);
 
         List<String> breakpoints = new ArrayList<>();
@@ -238,8 +238,8 @@ public class RuntimeDisplayJsonClientResource {
         // Fetch process-instance activities
         List<HistoricActivityInstance> activityInstances = historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstanceId).list();
 
-        Set<String> completedActivityInstances = new HashSet<String>();
-        Set<String> currentActivityinstances = new HashSet<String>();
+        Set<String> completedActivityInstances = new HashSet<>();
+        Set<String> currentActivityinstances = new HashSet<>();
         if (CollectionUtils.isNotEmpty(activityInstances)) {
             for (HistoricActivityInstance activityInstance : activityInstances) {
                 if (activityInstance.getEndTime() != null) {
@@ -549,8 +549,8 @@ public class RuntimeDisplayJsonClientResource {
 
     protected List<String> gatherCompletedFlows(Set<String> completedActivityInstances, Set<String> currentActivityinstances, BpmnModel pojoModel) {
 
-        List<String> completedFlows = new ArrayList<String>();
-        List<String> activities = new ArrayList<String>(completedActivityInstances);
+        List<String> completedFlows = new ArrayList<>();
+        List<String> activities = new ArrayList<>(completedActivityInstances);
         activities.addAll(currentActivityinstances);
 
         // TODO: not a robust way of checking when parallel paths are active, should be revisited


### PR DESCRIPTION
This is a continuation of [PR #483](https://github.com/flowable/flowable-engine/pull/483) which read:

This is based on the coding style post last year.

The specific item is #48: Explicit type can be replaced with <>.

Which read: Correct all new expressions with type arguments which can be replaced with diamond type <>. That is no need to specify the type again.