### PR TITLE
Fixed that an indentity link for 'starter' is created for subprocesses

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/ExecutionEntityManagerImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/ExecutionEntityManagerImpl.java
@@ -307,8 +307,11 @@ public class ExecutionEntityManagerImpl extends AbstractEntityManager<ExecutionE
         subProcessInstance.setSuperExecution(superExecutionEntity);
         subProcessInstance.setRootProcessInstanceId(superExecutionEntity.getRootProcessInstanceId());
         subProcessInstance.setScope(true); // process instance is always a scope for all child executions
+
+        String authenticatedUserId = Authentication.getAuthenticatedUserId();
+
         subProcessInstance.setStartActivityId(activityId);
-        subProcessInstance.setStartUserId(Authentication.getAuthenticatedUserId());
+        subProcessInstance.setStartUserId(authenticatedUserId);
         subProcessInstance.setBusinessKey(businessKey);
 
         // Store in database
@@ -320,6 +323,10 @@ public class ExecutionEntityManagerImpl extends AbstractEntityManager<ExecutionE
 
         subProcessInstance.setProcessInstanceId(subProcessInstance.getId());
         superExecutionEntity.setSubProcessInstance(subProcessInstance);
+
+        if (authenticatedUserId != null) {
+            IdentityLinkUtil.createProcessInstanceIdentityLink(subProcessInstance, authenticatedUserId, null, IdentityLinkType.STARTER);
+        }
 
         if (CommandContextUtil.getProcessEngineConfiguration() != null && CommandContextUtil.getProcessEngineConfiguration().getEventDispatcher().isEnabled()) {
             CommandContextUtil.getProcessEngineConfiguration().getEventDispatcher().dispatchEvent(FlowableEventBuilder.createEntityEvent(FlowableEngineEventType.ENTITY_CREATED, subProcessInstance));


### PR DESCRIPTION
This patch fixes so that subprocesses started by a call-activity create a 'starter' identity-link for the subprocess if the authorized user is set in the engine. This 'starter' identity-link will be the same as `startUserId `on the `ExecutionEntity`.
This behaviour mirrors how it works for starting a main process and makes call-activities consistent.
I have additionally included a unit test to verify this behaviour.

This was seen in Flowable-6.1.2 and previously discussed on the forum - https://forum.flowable.org/t/starter-identity-link-not-created-for-call-activity-process/823

Regards,
Paul