### PR TITLE
Explicit type can be replaced with <>

### DIFF
--- a/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/AbstractSimulationRun.java
+++ b/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/AbstractSimulationRun.java
@@ -34,7 +34,7 @@ public abstract class AbstractSimulationRun implements SimulationRun, Simulation
     /**
      * Map for eventType -> event handlers to execute events on simulation engine
      */
-    protected Map<String, SimulationEventHandler> eventHandlerMap = new HashMap<String, SimulationEventHandler>();
+    protected Map<String, SimulationEventHandler> eventHandlerMap = new HashMap<>();
     protected ProcessEngine processEngine;
 
     public AbstractSimulationRun(Map<String, SimulationEventHandler> eventHandlers) {

--- a/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/SimUtils.java
+++ b/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/SimUtils.java
@@ -16,13 +16,15 @@ import java.util.Random;
 
 /**
  * Simulation utils used in the simulation run and scenario. e.g. random number generator should be centralized for all sim runs.
- * 
+ *
  * @author martin.grofcik
  */
 
 public class SimUtils {
-    /** main random number generator */
-    private static volatile ThreadLocal<Random> randomGenerator = new ThreadLocal<Random>();
+    /**
+     * main random number generator
+     */
+    private static volatile ThreadLocal<Random> randomGenerator = new ThreadLocal<>();
 
     public static void setSeed(long seed) {
         randomGenerator.set(new Random(seed));

--- a/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/SimpleEventCalendar.java
+++ b/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/SimpleEventCalendar.java
@@ -31,7 +31,7 @@ public class SimpleEventCalendar implements EventCalendar {
 
     private static final int NULL = -1;
 
-    protected List<SimulationEvent> eventList = new ArrayList<SimulationEvent>();
+    protected List<SimulationEvent> eventList = new ArrayList<>();
     protected int minIndex = NULL;
     protected Comparator<SimulationEvent> eventComparator;
     protected final ClockReader clockReader;
@@ -101,9 +101,8 @@ public class SimpleEventCalendar implements EventCalendar {
 
     /**
      * is event the first event in the calendar?
-     * 
-     * @param event
-     *            - used in comparison
+     *
+     * @param event - used in comparison
      * @return is minimal event decision
      */
     private boolean isMinimal(SimulationEvent event) {

--- a/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/SimulationRunContext.java
+++ b/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/SimulationRunContext.java
@@ -24,7 +24,7 @@ import org.flowable.variable.service.delegate.VariableScope;
 
 /**
  * Context in which simulation is run. It contains references to process engine, event calendar.
- * 
+ *
  * @author martin.grofcik
  */
 public abstract class SimulationRunContext {
@@ -32,22 +32,22 @@ public abstract class SimulationRunContext {
     //
     // Process engine on which simulation will be executed
     //
-    protected static ThreadLocal<Stack<ProcessEngine>> processEngineThreadLocal = new ThreadLocal<Stack<ProcessEngine>>();
+    protected static ThreadLocal<Stack<ProcessEngine>> processEngineThreadLocal = new ThreadLocal<>();
 
     //
     // Simulation objects
     //
-    protected static ThreadLocal<Stack<EventCalendar>> eventCalendarThreadLocal = new ThreadLocal<Stack<EventCalendar>>();
+    protected static ThreadLocal<Stack<EventCalendar>> eventCalendarThreadLocal = new ThreadLocal<>();
 
     //
     // Simulation run Id
     //
-    protected static ThreadLocal<Stack<String>> simulationRunIdThreadLocal = new ThreadLocal<Stack<String>>();
+    protected static ThreadLocal<Stack<String>> simulationRunIdThreadLocal = new ThreadLocal<>();
 
     //
     // Variable scope used for getting/setting variables to the simulationManager
     //
-    protected static ThreadLocal<Stack<VariableScope>> executionThreadLocal = new ThreadLocal<Stack<VariableScope>>();
+    protected static ThreadLocal<Stack<VariableScope>> executionThreadLocal = new ThreadLocal<>();
 
     public static RuntimeService getRuntimeService() {
         Stack<ProcessEngine> stack = getStack(processEngineThreadLocal);
@@ -140,7 +140,7 @@ public abstract class SimulationRunContext {
     protected static <T> Stack<T> getStack(ThreadLocal<Stack<T>> threadLocal) {
         Stack<T> stack = threadLocal.get();
         if (stack == null) {
-            stack = new Stack<T>();
+            stack = new Stack<>();
             threadLocal.set(stack);
         }
         return stack;

--- a/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/delegate/UserTaskExecutionListener.java
+++ b/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/delegate/UserTaskExecutionListener.java
@@ -25,7 +25,7 @@ import org.flowable.task.service.delegate.DelegateTask;
 
 /**
  * in the case of task event create simulation event in the event calendar
- * 
+ *
  * @author martin.grofcik
  */
 public class UserTaskExecutionListener implements TaskListener {
@@ -44,7 +44,7 @@ public class UserTaskExecutionListener implements TaskListener {
     public void notify(DelegateTask delegateTask) {
         SimulationEvent eventToSimulate = findUserTaskCompleteEvent(delegateTask);
         if (eventToSimulate != null) {
-            Map<String, Object> properties = new HashMap<String, Object>();
+            Map<String, Object> properties = new HashMap<>();
             properties.put("taskId", delegateTask.getId());
             properties.put("variables", eventToSimulate.getProperty(UserTaskCompleteTransformer.TASK_VARIABLES));
             // we were able to resolve event to simulate automatically

--- a/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/delegate/event/impl/AbstractRecordFlowableEventListener.java
+++ b/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/delegate/event/impl/AbstractRecordFlowableEventListener.java
@@ -44,7 +44,7 @@ public abstract class AbstractRecordFlowableEventListener implements FlowableEve
     protected abstract void store(Collection<SimulationEvent> simulationEvents);
 
     protected Collection<SimulationEvent> transform(FlowableEvent event) {
-        List<SimulationEvent> simEvents = new ArrayList<SimulationEvent>();
+        List<SimulationEvent> simEvents = new ArrayList<>();
         for (Function<FlowableEvent, SimulationEvent> t : transformers) {
             SimulationEvent simEvent = t.apply(event);
             if (simEvent != null)

--- a/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/delegate/event/impl/DeploymentCreateTransformer.java
+++ b/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/delegate/event/impl/DeploymentCreateTransformer.java
@@ -41,7 +41,7 @@ public class DeploymentCreateTransformer extends Flowable2SimulationEventFunctio
 
             DeploymentEntity deploymentEntity = (DeploymentEntity) ((FlowableEntityEvent) event).getEntity();
 
-            Map<String, Object> simEventProperties = new HashMap<String, Object>();
+            Map<String, Object> simEventProperties = new HashMap<>();
             simEventProperties.put(resourcesKey, deploymentEntity.getResources());
 
             return new SimulationEvent.Builder(simulationEventType).simulationTime(CommandContextUtil.getProcessEngineConfiguration().getClock().getCurrentTime().getTime()).properties(simEventProperties).priority(1).build();

--- a/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/delegate/event/impl/EventLogProcessInstanceCreateTransformer.java
+++ b/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/delegate/event/impl/EventLogProcessInstanceCreateTransformer.java
@@ -59,7 +59,7 @@ public class EventLogProcessInstanceCreateTransformer extends EventLog2Simulatio
             String businessKeyValue = (String) data.get(Fields.BUSINESS_KEY);
             String processInstanceId = (String) data.get(Fields.PROCESS_INSTANCE_ID);
 
-            Map<String, Object> simEventProperties = new HashMap<String, Object>();
+            Map<String, Object> simEventProperties = new HashMap<>();
             simEventProperties.put(processDefinitionIdKey, processDefinitionId);
             simEventProperties.put(this.businessKey, businessKeyValue);
             simEventProperties.put(variablesKey, variableMap);

--- a/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/delegate/event/impl/EventLogTransformer.java
+++ b/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/delegate/event/impl/EventLogTransformer.java
@@ -31,7 +31,7 @@ public class EventLogTransformer {
     }
 
     public List<SimulationEvent> transform(List<EventLogEntry> eventLog) {
-        List<SimulationEvent> simulationEvents = new ArrayList<SimulationEvent>();
+        List<SimulationEvent> simulationEvents = new ArrayList<>();
         for (EventLogEntry logEntry : eventLog) {
             simulationEvents.addAll(transformEntry(logEntry));
         }
@@ -39,7 +39,7 @@ public class EventLogTransformer {
     }
 
     protected Collection<SimulationEvent> transformEntry(EventLogEntry event) {
-        List<SimulationEvent> simEvents = new ArrayList<SimulationEvent>();
+        List<SimulationEvent> simEvents = new ArrayList<>();
         for (Function<EventLogEntry, SimulationEvent> t : transformers) {
             SimulationEvent simEvent = t.apply(event);
             if (simEvent != null)

--- a/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/delegate/event/impl/EventLogUserTaskCompleteTransformer.java
+++ b/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/delegate/event/impl/EventLogUserTaskCompleteTransformer.java
@@ -63,7 +63,7 @@ public class EventLogUserTaskCompleteTransformer extends EventLog2SimulationEven
             }
             String taskDefinitionKeyValue = (String) data.get(Fields.TASK_DEFINITION_KEY);
 
-            Map<String, Object> properties = new HashMap<String, Object>();
+            Map<String, Object> properties = new HashMap<>();
             properties.put("taskId", taskIdValue);
             properties.put(TASK_DEFINITION_KEY, taskDefinitionKeyValue);
             properties.put(PROCESS_INSTANCE_ID, event.getProcessInstanceId());

--- a/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/delegate/event/impl/InMemoryRecordFlowableEventListener.java
+++ b/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/delegate/event/impl/InMemoryRecordFlowableEventListener.java
@@ -21,7 +21,6 @@ import org.flowable.crystalball.simulator.delegate.event.Function;
 import org.flowable.engine.common.api.delegate.event.FlowableEvent;
 
 /**
- * 
  * @author martin.grofcik
  */
 public class InMemoryRecordFlowableEventListener extends AbstractRecordFlowableEventListener {
@@ -30,7 +29,7 @@ public class InMemoryRecordFlowableEventListener extends AbstractRecordFlowableE
 
     public InMemoryRecordFlowableEventListener(List<Function<FlowableEvent, SimulationEvent>> transformers) {
         super(transformers);
-        events = new HashSet<SimulationEvent>();
+        events = new HashSet<>();
     }
 
     public Collection<SimulationEvent> getSimulationEvents() {

--- a/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/delegate/event/impl/ProcessInstanceCreateTransformer.java
+++ b/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/delegate/event/impl/ProcessInstanceCreateTransformer.java
@@ -48,7 +48,7 @@ public class ProcessInstanceCreateTransformer extends Flowable2SimulationEventFu
             ProcessInstance processInstance = (ProcessInstance) ((FlowableEntityEvent) event).getEntity();
             ExecutionEntity executionEntity = (ExecutionEntity) ((FlowableEntityEvent) event).getEntity();
 
-            Map<String, Object> simEventProperties = new HashMap<String, Object>();
+            Map<String, Object> simEventProperties = new HashMap<>();
             simEventProperties.put(processDefinitionIdKey, processInstance.getProcessDefinitionId());
             simEventProperties.put(businessKey, processInstance.getBusinessKey());
             simEventProperties.put(variablesKey, executionEntity.getVariables());

--- a/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/delegate/event/impl/UserTaskCompleteTransformer.java
+++ b/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/delegate/event/impl/UserTaskCompleteTransformer.java
@@ -40,7 +40,7 @@ public class UserTaskCompleteTransformer extends Flowable2SimulationEventFunctio
         if (FlowableEngineEventType.TASK_COMPLETED == event.getType()) {
             Task task = (Task) ((FlowableEntityEvent) event).getEntity();
 
-            Map<String, Object> properties = new HashMap<String, Object>();
+            Map<String, Object> properties = new HashMap<>();
             properties.put("taskId", task.getId());
             properties.put(TASK_DEFINITION_KEY, task.getTaskDefinitionKey());
             properties.put(PROCESS_INSTANCE_ID, task.getProcessInstanceId());

--- a/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/impl/DeployResourcesEventHandler.java
+++ b/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/impl/DeployResourcesEventHandler.java
@@ -29,14 +29,16 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Start new process event handler for playback purposes
- * 
+ *
  * @author martin.grofcik
  */
 public class DeployResourcesEventHandler implements SimulationEventHandler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DeployResourcesEventHandler.class);
 
-    /** process to start key */
+    /**
+     * process to start key
+     */
     protected String resourcesKey;
 
     public DeployResourcesEventHandler(String resourcesKey) {
@@ -53,7 +55,7 @@ public class DeployResourcesEventHandler implements SimulationEventHandler {
         @SuppressWarnings("unchecked")
         Map<String, ResourceEntity> resources = (Map<String, ResourceEntity>) event.getProperty(resourcesKey);
 
-        List<InputStream> inputStreams = new ArrayList<InputStream>();
+        List<InputStream> inputStreams = new ArrayList<>();
 
         try {
             DeploymentBuilder deploymentBuilder = SimulationRunContext.getRepositoryService().createDeployment();

--- a/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/impl/StartReplayLogEventHandler.java
+++ b/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/impl/StartReplayLogEventHandler.java
@@ -23,14 +23,16 @@ import org.slf4j.LoggerFactory;
 
 /**
  * This class schedules replay start simulation event and takes care about process start and next event schedule
- * 
+ *
  * @author martin.grofcik
  */
 public class StartReplayLogEventHandler implements SimulationEventHandler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(StartReplayLogEventHandler.class.getName());
 
-    /** variable name where original process instance ID is stored - only for internal replay purposes */
+    /**
+     * variable name where original process instance ID is stored - only for internal replay purposes
+     */
     public static final String PROCESS_INSTANCE_ID = "_replay.processInstanceId";
     public static final String SIMULATION_RUN_ID = "_replay.simulationRunId";
 
@@ -57,7 +59,7 @@ public class StartReplayLogEventHandler implements SimulationEventHandler {
         // start process now
         String processDefinitionId = (String) event.getProperty(processToStartIdKey);
         String eventBusinessKey = (String) event.getProperty(this.businessKey);
-        Map<String, Object> variables = new HashMap<String, Object>();
+        Map<String, Object> variables = new HashMap<>();
         Map<String, Object> processVariables = (Map<String, Object>) event.getProperty(variablesKey);
         if (processVariables != null) {
             variables.putAll(processVariables);

--- a/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/impl/clock/ThreadLocalClock.java
+++ b/modules/flowable-crystalball/src/main/java/org/flowable/crystalball/simulator/impl/clock/ThreadLocalClock.java
@@ -24,7 +24,7 @@ import org.springframework.beans.factory.FactoryBean;
  * This class provides thread local clock implementation. Each thread can run its own simulation engine and can behave according to its internal thread local clock
  */
 public class ThreadLocalClock implements Clock {
-    private static volatile ThreadLocal<Clock> THREAD_CLOCK = new ThreadLocal<Clock>();
+    private static volatile ThreadLocal<Clock> THREAD_CLOCK = new ThreadLocal<>();
     protected FactoryBean<Clock> clockFactory;
 
     public ThreadLocalClock(FactoryBean<Clock> clockFactory) {

--- a/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/SimpleSimulationRunTest.java
+++ b/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/SimpleSimulationRunTest.java
@@ -266,7 +266,7 @@ public class SimpleSimulationRunTest {
 
         TaskService taskService = processEngine.getTaskService();
 
-        Map<String, Object> variables = new HashMap<String, Object>();
+        Map<String, Object> variables = new HashMap<>();
         variables.put(TEST_VARIABLE, TEST_VALUE);
         processEngine.getRuntimeService().startProcessInstanceByKey("oneTaskProcess", "oneTaskProcessBusinessKey", variables);
         EventRecorderTestUtils.increaseTime(clock);
@@ -278,7 +278,7 @@ public class SimpleSimulationRunTest {
     }
 
     private List<Function<FlowableEvent, SimulationEvent>> getTransformers() {
-        List<Function<FlowableEvent, SimulationEvent>> transformers = new ArrayList<Function<FlowableEvent, SimulationEvent>>();
+        List<Function<FlowableEvent, SimulationEvent>> transformers = new ArrayList<>();
         transformers.add(new DeploymentCreateTransformer(DEPLOYMENT_CREATED_EVENT_TYPE, DEPLOYMENT_RESOURCES_KEY));
         transformers.add(new ProcessInstanceCreateTransformer(PROCESS_INSTANCE_START_EVENT_TYPE, PROCESS_DEFINITION_ID_KEY, BUSINESS_KEY, VARIABLES_KEY));
         transformers.add(new UserTaskCompleteTransformer(USER_TASK_COMPLETED_EVENT_TYPE));
@@ -286,7 +286,7 @@ public class SimpleSimulationRunTest {
     }
 
     public static Map<String, SimulationEventHandler> getHandlers() {
-        Map<String, SimulationEventHandler> handlers = new HashMap<String, SimulationEventHandler>();
+        Map<String, SimulationEventHandler> handlers = new HashMap<>();
         handlers.put(DEPLOYMENT_CREATED_EVENT_TYPE, new DeployResourcesEventHandler(DEPLOYMENT_RESOURCES_KEY));
         handlers.put(PROCESS_INSTANCE_START_EVENT_TYPE, new StartProcessByIdEventHandler(PROCESS_DEFINITION_ID_KEY, BUSINESS_KEY, VARIABLES_KEY));
         handlers.put(USER_TASK_COMPLETED_EVENT_TYPE, new PlaybackUserTaskCompleteEventHandler());

--- a/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/impl/playback/AbstractPlaybackTest.java
+++ b/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/impl/playback/AbstractPlaybackTest.java
@@ -238,14 +238,14 @@ public abstract class AbstractPlaybackTest extends AbstractFlowableTestCase {
     }
 
     protected List<Function<FlowableEvent, SimulationEvent>> getTransformers() {
-        List<Function<FlowableEvent, SimulationEvent>> transformers = new ArrayList<Function<FlowableEvent, SimulationEvent>>();
+        List<Function<FlowableEvent, SimulationEvent>> transformers = new ArrayList<>();
         transformers.add(new ProcessInstanceCreateTransformer(PROCESS_INSTANCE_START_EVENT_TYPE, PROCESS_DEFINITION_ID_KEY, BUSINESS_KEY, VARIABLES_KEY));
         transformers.add(new UserTaskCompleteTransformer(USER_TASK_COMPLETED_EVENT_TYPE));
         return transformers;
     }
 
     protected Map<String, SimulationEventHandler> getHandlers() {
-        Map<String, SimulationEventHandler> handlers = new HashMap<String, SimulationEventHandler>();
+        Map<String, SimulationEventHandler> handlers = new HashMap<>();
         handlers.put(PROCESS_INSTANCE_START_EVENT_TYPE, new StartProcessByIdEventHandler(PROCESS_DEFINITION_ID_KEY, BUSINESS_KEY, VARIABLES_KEY));
         handlers.put(USER_TASK_COMPLETED_EVENT_TYPE, new PlaybackUserTaskCompleteEventHandler());
         return handlers;

--- a/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/impl/playback/PlaybackProcessStartTest.java
+++ b/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/impl/playback/PlaybackProcessStartTest.java
@@ -38,7 +38,7 @@ public class PlaybackProcessStartTest extends AbstractPlaybackTest {
     @CheckStatus(methodName = "demoCheckStatus")
     @Deployment
     public void testDemo() {
-        Map<String, Object> variables = new HashMap<String, Object>();
+        Map<String, Object> variables = new HashMap<>();
         variables.put(TEST_VARIABLE, TEST_VALUE);
         processEngine.getRuntimeService().startProcessInstanceByKey(SIMPLEST_PROCESS, BUSINESS_KEY, variables);
     }

--- a/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/impl/playback/PlaybackRunTest.java
+++ b/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/impl/playback/PlaybackRunTest.java
@@ -99,7 +99,7 @@ public class PlaybackRunTest {
         processEngine.getProcessEngineConfiguration().setClock(clock);
         processEngine.getRepositoryService().createDeployment().addClasspathResource(THE_SIMPLEST_PROCESS).deploy();
 
-        Map<String, Object> variables = new HashMap<String, Object>();
+        Map<String, Object> variables = new HashMap<>();
         variables.put(TEST_VARIABLE, TEST_VALUE);
         processEngine.getRuntimeService().startProcessInstanceByKey(SIMPLEST_PROCESS, BUSINESS_KEY, variables);
         checkStatus(processEngine);
@@ -121,7 +121,7 @@ public class PlaybackRunTest {
     }
 
     private List<Function<FlowableEvent, SimulationEvent>> getTransformers() {
-        List<Function<FlowableEvent, SimulationEvent>> transformers = new ArrayList<Function<FlowableEvent, SimulationEvent>>();
+        List<Function<FlowableEvent, SimulationEvent>> transformers = new ArrayList<>();
         transformers.add(new DeploymentCreateTransformer(DEPLOYMENT_CREATED_EVENT_TYPE, DEPLOYMENT_RESOURCES_KEY));
         transformers.add(new ProcessInstanceCreateTransformer(PROCESS_INSTANCE_START_EVENT_TYPE, PROCESS_DEFINITION_ID_KEY, BUSINESS_KEY, VARIABLES_KEY));
         transformers.add(new UserTaskCompleteTransformer(USER_TASK_COMPLETED_EVENT_TYPE));
@@ -129,7 +129,7 @@ public class PlaybackRunTest {
     }
 
     public static Map<String, SimulationEventHandler> getHandlers() {
-        Map<String, SimulationEventHandler> handlers = new HashMap<String, SimulationEventHandler>();
+        Map<String, SimulationEventHandler> handlers = new HashMap<>();
         handlers.put(DEPLOYMENT_CREATED_EVENT_TYPE, new DeployResourcesEventHandler(DEPLOYMENT_RESOURCES_KEY));
         handlers.put(PROCESS_INSTANCE_START_EVENT_TYPE, new StartProcessByIdEventHandler(PROCESS_DEFINITION_ID_KEY, BUSINESS_KEY, VARIABLES_KEY));
         handlers.put(USER_TASK_COMPLETED_EVENT_TYPE, new PlaybackUserTaskCompleteEventHandler());

--- a/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/impl/replay/ReplayEventLogTest.java
+++ b/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/impl/replay/ReplayEventLogTest.java
@@ -66,13 +66,13 @@ public class ReplayEventLogTest {
         HistoryService historyService = processEngine.getHistoryService();
 
         // record events
-        Map<String, Object> variables = new HashMap<String, Object>();
+        Map<String, Object> variables = new HashMap<>();
         variables.put(TEST_VARIABLE, TEST_VALUE);
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey(USERTASK_PROCESS, BUSINESS_KEY, variables);
 
         Task task = taskService.createTaskQuery().taskDefinitionKey("userTask").singleResult();
         TimeUnit.MILLISECONDS.sleep(50);
-        variables = new HashMap<String, Object>();
+        variables = new HashMap<>();
         variables.put(TASK_TEST_VARIABLE, TASK_TEST_VALUE);
         taskService.complete(task.getId(), variables);
 
@@ -140,14 +140,14 @@ public class ReplayEventLogTest {
     }
 
     private static List<Function<EventLogEntry, SimulationEvent>> getTransformers() {
-        List<Function<EventLogEntry, SimulationEvent>> transformers = new ArrayList<Function<EventLogEntry, SimulationEvent>>();
+        List<Function<EventLogEntry, SimulationEvent>> transformers = new ArrayList<>();
         transformers.add(new EventLogProcessInstanceCreateTransformer(PROCESS_INSTANCE_START_EVENT_TYPE, PROCESS_DEFINITION_ID_KEY, BUSINESS_KEY, VARIABLES_KEY));
         transformers.add(new EventLogUserTaskCompleteTransformer(USER_TASK_COMPLETED_EVENT_TYPE));
         return transformers;
     }
 
     public static Map<String, SimulationEventHandler> getReplayHandlers(String processInstanceId) {
-        Map<String, SimulationEventHandler> handlers = new HashMap<String, SimulationEventHandler>();
+        Map<String, SimulationEventHandler> handlers = new HashMap<>();
         handlers.put(PROCESS_INSTANCE_START_EVENT_TYPE, new StartReplayLogEventHandler(processInstanceId, PROCESS_DEFINITION_ID_KEY, BUSINESS_KEY, VARIABLES_KEY));
         handlers.put(USER_TASK_COMPLETED_EVENT_TYPE, new ReplayUserTaskCompleteEventHandler());
         return handlers;

--- a/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/impl/replay/ReplayRunTest.java
+++ b/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/impl/replay/ReplayRunTest.java
@@ -63,7 +63,7 @@ public class ReplayRunTest {
         TaskService taskService = processEngine.getTaskService();
         RuntimeService runtimeService = processEngine.getRuntimeService();
 
-        Map<String, Object> variables = new HashMap<String, Object>();
+        Map<String, Object> variables = new HashMap<>();
         variables.put(TEST_VARIABLE, TEST_VALUE);
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey(USERTASK_PROCESS, BUSINESS_KEY, variables);
 
@@ -117,14 +117,14 @@ public class ReplayRunTest {
     }
 
     private static List<Function<FlowableEvent, SimulationEvent>> getTransformers() {
-        List<Function<FlowableEvent, SimulationEvent>> transformers = new ArrayList<Function<FlowableEvent, SimulationEvent>>();
+        List<Function<FlowableEvent, SimulationEvent>> transformers = new ArrayList<>();
         transformers.add(new ProcessInstanceCreateTransformer(PROCESS_INSTANCE_START_EVENT_TYPE, PROCESS_DEFINITION_ID_KEY, BUSINESS_KEY, VARIABLES_KEY));
         transformers.add(new UserTaskCompleteTransformer(USER_TASK_COMPLETED_EVENT_TYPE));
         return transformers;
     }
 
     public static Map<String, SimulationEventHandler> getReplayHandlers(String processInstanceId) {
-        Map<String, SimulationEventHandler> handlers = new HashMap<String, SimulationEventHandler>();
+        Map<String, SimulationEventHandler> handlers = new HashMap<>();
         handlers.put(PROCESS_INSTANCE_START_EVENT_TYPE,
                 new StartReplayProcessEventHandler(processInstanceId, PROCESS_INSTANCE_START_EVENT_TYPE, PROCESS_INSTANCE_START_EVENT_TYPE, listener.getSimulationEvents(), PROCESS_DEFINITION_ID_KEY, BUSINESS_KEY, VARIABLES_KEY));
         handlers.put(USER_TASK_COMPLETED_EVENT_TYPE, new PlaybackUserTaskCompleteEventHandler());

--- a/modules/flowable-engine-common/src/main/java/org/flowable/engine/common/impl/de/odysseus/el/misc/BooleanOperations.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/engine/common/impl/de/odysseus/el/misc/BooleanOperations.java
@@ -25,8 +25,8 @@ import java.util.Set;
 import org.flowable.engine.common.impl.javax.el.ELException;
 
 public class BooleanOperations {
-	private static final Set<Class<? extends Number>> SIMPLE_INTEGER_TYPES = new HashSet<Class<? extends Number>>();
-	private static final Set<Class<? extends Number>> SIMPLE_FLOAT_TYPES = new HashSet<Class<? extends Number>>();
+	private static final Set<Class<? extends Number>> SIMPLE_INTEGER_TYPES = new HashSet<>();
+	private static final Set<Class<? extends Number>> SIMPLE_FLOAT_TYPES = new HashSet<>();
 	
 	static {
 		SIMPLE_INTEGER_TYPES.add(Byte.class);

--- a/modules/flowable-engine-common/src/main/java/org/flowable/engine/common/impl/de/odysseus/el/tree/impl/Cache.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/engine/common/impl/de/odysseus/el/tree/impl/Cache.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */ 
+ */
 package org.flowable.engine.common.impl.de.odysseus.el.tree.impl;
 
 import java.util.concurrent.ConcurrentHashMap;
@@ -27,58 +27,55 @@ import org.flowable.engine.common.impl.de.odysseus.el.tree.TreeCache;
  * Concurrent (thread-safe) FIFO tree cache (using classes from
  * <code>java.util.concurrent</code>). After the cache size reached a certain
  * limit, some least recently used entry are removed, when adding a new entry.
- * 
+ *
  * @author Christoph Beck
  */
 public final class Cache implements TreeCache {
-	private final ConcurrentMap<String, Tree> map;
-	private final ConcurrentLinkedQueue<String> queue;
-	private final AtomicInteger size;
-	private final int capacity;
+    private final ConcurrentMap<String, Tree> map;
+    private final ConcurrentLinkedQueue<String> queue;
+    private final AtomicInteger size;
+    private final int capacity;
 
-	/**
-	 * Creates a new cache with the specified capacity
-	 * and default concurrency level (16).
-	 * 
-	 * @param capacity
-	 *            Cache size. The actual size may exceed it temporarily.
-	 */
-	public Cache(int capacity) {
-		this(capacity, 16);
-	}
+    /**
+     * Creates a new cache with the specified capacity
+     * and default concurrency level (16).
+     *
+     * @param capacity Cache size. The actual size may exceed it temporarily.
+     */
+    public Cache(int capacity) {
+        this(capacity, 16);
+    }
 
-	/**
-	 * Creates a new cache with the specified capacity and concurrency level.
-	 * 
-	 * @param capacity
-	 *            Cache size. The actual map size may exceed it temporarily.
-	 * @param concurrencyLevel
-	 *            The estimated number of concurrently updating threads. The
-	 *            implementation performs internal sizing to try to accommodate
-	 *            this many threads.
-	 */
-	public Cache(int capacity, int concurrencyLevel) {
-		this.map = new ConcurrentHashMap<String, Tree>(16, 0.75f, concurrencyLevel);
-		this.queue = new ConcurrentLinkedQueue<String>();
-		this.size = new AtomicInteger();
-		this.capacity = capacity;
-	}
-	
-	public int size() {
-		return size.get();
-	}
+    /**
+     * Creates a new cache with the specified capacity and concurrency level.
+     *
+     * @param capacity         Cache size. The actual map size may exceed it temporarily.
+     * @param concurrencyLevel The estimated number of concurrently updating threads. The
+     *                         implementation performs internal sizing to try to accommodate
+     *                         this many threads.
+     */
+    public Cache(int capacity, int concurrencyLevel) {
+        this.map = new ConcurrentHashMap<>(16, 0.75f, concurrencyLevel);
+        this.queue = new ConcurrentLinkedQueue<>();
+        this.size = new AtomicInteger();
+        this.capacity = capacity;
+    }
 
-	public Tree get(String expression) {
-		return map.get(expression);
-	}
+    public int size() {
+        return size.get();
+    }
 
-	public void put(String expression, Tree tree) {
-		if (map.putIfAbsent(expression, tree) == null) {
-			queue.offer(expression);
-			if (size.incrementAndGet() > capacity) {
-				size.decrementAndGet();
-				map.remove(queue.poll());
-			}
-		}
-	}
+    public Tree get(String expression) {
+        return map.get(expression);
+    }
+
+    public void put(String expression, Tree tree) {
+        if (map.putIfAbsent(expression, tree) == null) {
+            queue.offer(expression);
+            if (size.incrementAndGet() > capacity) {
+                size.decrementAndGet();
+                map.remove(queue.poll());
+            }
+        }
+    }
 }

--- a/modules/flowable-engine-common/src/main/java/org/flowable/engine/common/impl/de/odysseus/el/tree/impl/Parser.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/engine/common/impl/de/odysseus/el/tree/impl/Parser.java
@@ -175,7 +175,7 @@ public class Parser {
 
 	public void putExtensionHandler(Scanner.ExtensionToken token, ExtensionHandler extension) {
 		if (extensions.isEmpty()) {
-			extensions = new HashMap<Scanner.ExtensionToken, ExtensionHandler>(16);
+			extensions = new HashMap<>(16);
 		}
 		extensions.put(token, extension);
 	}
@@ -279,7 +279,7 @@ public class Parser {
 	 */
 	protected final Token lookahead(int index) throws ScanException, ParseException {
 		if (lookahead.isEmpty()) {
-			lookahead = new LinkedList<LookaheadToken>();
+			lookahead = new LinkedList<>();
 		}
 		while (index >= lookahead.size()) {
 			lookahead.add(new LookaheadToken(scanner.next(), scanner.getPosition()));
@@ -331,7 +331,7 @@ public class Parser {
 		if (token.getSymbol() == EOF && t == null) {
 			return new Tree(e, functions, identifiers, e.isDeferred());
 		}
-		ArrayList<AstNode> list = new ArrayList<AstNode>();
+		ArrayList<AstNode> list = new ArrayList<>();
 		if (t != null) {
 			list.add(t);
 		}
@@ -706,7 +706,7 @@ public class Parser {
 		List<AstNode> l = Collections.emptyList();
 		AstNode v = expr(false);
 		if (v != null) {
-			l = new ArrayList<AstNode>();
+			l = new ArrayList<>();
 			l.add(v);
 			while (token.getSymbol() == COMMA) {
 				consumeToken();
@@ -758,7 +758,7 @@ public class Parser {
 
 	protected final AstFunction function(String name, AstParameters params) {
 		if (functions.isEmpty()) {
-			functions = new ArrayList<FunctionNode>(4);
+			functions = new ArrayList<>(4);
 		}
 		AstFunction function = createAstFunction(name, functions.size(), params);
 		functions.add(function);
@@ -767,7 +767,7 @@ public class Parser {
 	
 	protected final AstIdentifier identifier(String name) {
 		if (identifiers.isEmpty()) {
-			identifiers = new ArrayList<IdentifierNode>(4);
+			identifiers = new ArrayList<>(4);
 		}
 		AstIdentifier identifier = createAstIdentifier(name, identifiers.size());
 		identifiers.add(identifier);

--- a/modules/flowable-engine-common/src/main/java/org/flowable/engine/common/impl/de/odysseus/el/tree/impl/Scanner.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/engine/common/impl/de/odysseus/el/tree/impl/Scanner.java
@@ -107,8 +107,8 @@ public class Scanner {
 		}
 	}
 
-	private static final HashMap<String, Token> KEYMAP = new HashMap<String, Token>();
-	private static final HashMap<Symbol, Token> FIXMAP = new HashMap<Symbol, Token>();
+	private static final HashMap<String, Token> KEYMAP = new HashMap<>();
+	private static final HashMap<Symbol, Token> FIXMAP = new HashMap<>();
 
 	private static void addFixToken(Token token) {
 		FIXMAP.put(token.getSymbol(), token);

--- a/modules/flowable-engine-common/src/main/java/org/flowable/engine/common/impl/de/odysseus/el/util/SimpleContext.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/engine/common/impl/de/odysseus/el/util/SimpleContext.java
@@ -42,7 +42,7 @@ public class SimpleContext extends ELContext {
 
 		public void setFunction(String prefix, String localName, Method method) {
 			if (map.isEmpty()) {
-				map = new HashMap<String, Method>();
+				map = new HashMap<>();
 			}
 			map.put(prefix + ":" + localName, method);
 		}
@@ -59,7 +59,7 @@ public class SimpleContext extends ELContext {
 		@Override
 		public ValueExpression setVariable(String variable, ValueExpression expression) {
 			if (map.isEmpty()) {
-				map = new HashMap<String, ValueExpression>();
+				map = new HashMap<>();
 			}
 			return map.put(variable, expression);
 		}

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/CancelUserTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/CancelUserTaskTest.java
@@ -244,7 +244,7 @@ public class CancelUserTaskTest extends PluggableFlowableTestCase {
         private List<FlowableEvent> eventsReceived;
 
         public UserActivityEventListener() {
-            eventsReceived = new ArrayList<FlowableEvent>();
+            eventsReceived = new ArrayList<>();
         }
 
         public List<FlowableEvent> getEventsReceived() {

--- a/modules/flowable-ui-admin/src/main/java/org/flowable/admin/app/rest/client/AbstractClientResource.java
+++ b/modules/flowable-ui-admin/src/main/java/org/flowable/admin/app/rest/client/AbstractClientResource.java
@@ -51,7 +51,7 @@ public abstract class AbstractClientResource {
 
     protected Map<String, String[]> getRequestParametersWithoutServerId(HttpServletRequest request) {
         Map<String, String[]> parameterMap = request.getParameterMap();
-        Map<String, String[]> resultMap = new HashMap<String, String[]>();
+        Map<String, String[]> resultMap = new HashMap<>();
         resultMap.putAll(parameterMap);
         resultMap.remove(SERVER_ID);
         return resultMap;

--- a/modules/flowable5-compatibility/src/main/java/org/flowable/compatibility/DefaultFlowable5CompatibilityHandler.java
+++ b/modules/flowable5-compatibility/src/main/java/org/flowable/compatibility/DefaultFlowable5CompatibilityHandler.java
@@ -13,6 +13,8 @@
 
 package org.flowable.compatibility;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.Date;
@@ -72,8 +74,6 @@ import org.flowable.job.service.impl.persistence.entity.JobEntity;
 import org.flowable.task.service.impl.persistence.entity.TaskEntity;
 import org.flowable.task.service.impl.persistence.entity.TaskEntityImpl;
 import org.flowable.variable.service.impl.persistence.entity.VariableInstance;
-
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * @author Joram Barrez
@@ -264,7 +264,7 @@ public class DefaultFlowable5CompatibilityHandler implements Flowable5Compatibil
 
             // Copy resources
             DeploymentEntity activiti6DeploymentEntity = activiti6DeploymentBuilder.getDeployment();
-            Map<String, org.activiti.engine.impl.persistence.entity.ResourceEntity> activiti5Resources = new HashMap<String, org.activiti.engine.impl.persistence.entity.ResourceEntity>();
+            Map<String, org.activiti.engine.impl.persistence.entity.ResourceEntity> activiti5Resources = new HashMap<>();
             for (String resourceKey : activiti6DeploymentEntity.getResources().keySet()) {
                 ResourceEntity activiti6ResourceEntity = activiti6DeploymentEntity.getResources().get(resourceKey);
 
@@ -312,7 +312,7 @@ public class DefaultFlowable5CompatibilityHandler implements Flowable5Compatibil
     }
 
     public ProcessInstance startProcessInstance(String processDefinitionKey, String processDefinitionId,
-            Map<String, Object> variables, Map<String, Object> transientVariables, String businessKey, String tenantId, String processInstanceName) {
+                                                Map<String, Object> variables, Map<String, Object> transientVariables, String businessKey, String tenantId, String processInstanceName) {
 
         org.activiti.engine.impl.identity.Authentication.setAuthenticatedUserId(Authentication.getAuthenticatedUserId());
 
@@ -351,7 +351,7 @@ public class DefaultFlowable5CompatibilityHandler implements Flowable5Compatibil
     }
 
     public ProcessInstance startProcessInstanceByMessage(String messageName, Map<String, Object> variables,
-            Map<String, Object> transientVariables, String businessKey, String tenantId) {
+                                                         Map<String, Object> transientVariables, String businessKey, String tenantId) {
 
         try {
 

--- a/modules/flowable5-compatibility/src/main/java/org/flowable/compatibility/DefaultProcessEngineFactory.java
+++ b/modules/flowable5-compatibility/src/main/java/org/flowable/compatibility/DefaultProcessEngineFactory.java
@@ -206,7 +206,7 @@ public class DefaultProcessEngineFactory {
 
     protected void copyPostDeployers(ProcessEngineConfigurationImpl flowable6Configuration, org.activiti.engine.impl.cfg.ProcessEngineConfigurationImpl flowable5Configuration) {
         if (flowable6Configuration.getCustomPostDeployers() != null) {
-            List<org.activiti.engine.impl.persistence.deploy.Deployer> activiti5Deployers = new ArrayList<org.activiti.engine.impl.persistence.deploy.Deployer>();
+            List<org.activiti.engine.impl.persistence.deploy.Deployer> activiti5Deployers = new ArrayList<>();
             for (Deployer deployer : flowable6Configuration.getCustomPostDeployers()) {
                 if (deployer instanceof RulesDeployer) {
                     activiti5Deployers.add(new org.activiti.engine.impl.rules.RulesDeployer());
@@ -235,7 +235,7 @@ public class DefaultProcessEngineFactory {
             return null;
         }
 
-        List<BpmnParseHandler> parseHandlers = new ArrayList<BpmnParseHandler>(activiti5BpmnParseHandlers.size());
+        List<BpmnParseHandler> parseHandlers = new ArrayList<>(activiti5BpmnParseHandlers.size());
         for (Object activiti6BpmnParseHandler : activiti5BpmnParseHandlers) {
             parseHandlers.add((BpmnParseHandler) activiti6BpmnParseHandler);
         }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/ProcessEngineConfiguration.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/ProcessEngineConfiguration.java
@@ -30,46 +30,46 @@ import org.flowable.job.service.impl.asyncexecutor.AsyncExecutor;
 
 /**
  * Configuration information from which a process engine can be build.
- * 
+ * <p>
  * <p>
  * Most common is to create a process engine based on the default configuration file:
- * 
+ * <p>
  * <pre>
  * ProcessEngine processEngine = ProcessEngineConfiguration
  *         .createProcessEngineConfigurationFromResourceDefault()
  *         .buildProcessEngine();
  * </pre>
  * </p>
- * 
+ * <p>
  * <p>
  * To create a process engine programatic, without a configuration file, the first option is {@link #createStandaloneProcessEngineConfiguration()}
- * 
+ * <p>
  * <pre>
  * ProcessEngine processEngine = ProcessEngineConfiguration
  *         .createStandaloneProcessEngineConfiguration()
  *         .buildProcessEngine();
  * </pre>
- * 
+ * <p>
  * This creates a new process engine with all the defaults to connect to a remote h2 database (jdbc:h2:tcp://localhost/activiti) in standalone mode. Standalone mode means that Activiti will manage the
  * transactions on the JDBC connections that it creates. One transaction per service method. For a description of how to write the configuration files, see the userguide.
  * </p>
- * 
+ * <p>
  * <p>
  * The second option is great for testing: {@link #createStandaloneInMemProcessEngineConfiguration()}
- * 
+ * <p>
  * <pre>
  * ProcessEngine processEngine = ProcessEngineConfiguration
  *         .createStandaloneInMemProcessEngineConfiguration()
  *         .buildProcessEngine();
  * </pre>
- * 
+ * <p>
  * This creates a new process engine with all the defaults to connect to an memory h2 database (jdbc:h2:tcp://localhost/activiti) in standalone mode. The DB schema strategy default is in this case
  * <code>create-drop</code>. Standalone mode means that Activiti will manage the transactions on the JDBC connections that it creates. One transaction per service method.
  * </p>
- * 
+ * <p>
  * <p>
  * On all forms of creating a process engine, you can first customize the configuration before calling the {@link #buildProcessEngine()} method by calling any of the setters like this:
- * 
+ * <p>
  * <pre>
  * ProcessEngine processEngine = ProcessEngineConfiguration
  *         .createProcessEngineConfigurationFromResourceDefault()
@@ -79,9 +79,9 @@ import org.flowable.job.service.impl.asyncexecutor.AsyncExecutor;
  *         .buildProcessEngine();
  * </pre>
  * </p>
- * 
- * @see ProcessEngines
+ *
  * @author Tom Baeyens
+ * @see ProcessEngines
  */
 public abstract class ProcessEngineConfiguration {
 
@@ -100,7 +100,9 @@ public abstract class ProcessEngineConfiguration {
      */
     public static final String DB_SCHEMA_UPDATE_TRUE = "true";
 
-    /** The tenant id indicating 'no tenant' */
+    /**
+     * The tenant id indicating 'no tenant'
+     */
     public static final String NO_TENANT_ID = "";
 
     protected String processEngineName = ProcessEngines.NAME_DEFAULT;
@@ -116,8 +118,8 @@ public abstract class ProcessEngineConfiguration {
     protected boolean useTLS;
     protected String mailServerDefaultFrom = "activiti@localhost";
     protected String mailSessionJndi;
-    protected Map<String, MailServerInfo> mailServers = new HashMap<String, MailServerInfo>();
-    protected Map<String, String> mailSessionsJndi = new HashMap<String, String>();
+    protected Map<String, MailServerInfo> mailServers = new HashMap<>();
+    protected Map<String, String> mailSessionsJndi = new HashMap<>();
 
     protected String databaseType;
     protected String databaseSchemaUpdate = DB_SCHEMA_UPDATE_FALSE;
@@ -152,29 +154,35 @@ public abstract class ProcessEngineConfiguration {
      * retried again.
      */
     protected int lockTimeAsyncJobWaitTime = 60;
-    /** define the default wait time for a failed job in seconds */
+    /**
+     * define the default wait time for a failed job in seconds
+     */
     protected int defaultFailedJobWaitTime = 10;
-    /** define the default wait time for a failed async job in seconds */
+    /**
+     * define the default wait time for a failed async job in seconds
+     */
     protected int asyncFailedJobWaitTime = 10;
 
-    /** process diagram generator. Default value is DefaultProcessDiagramGenerator */
+    /**
+     * process diagram generator. Default value is DefaultProcessDiagramGenerator
+     */
     protected ProcessDiagramGenerator processDiagramGenerator;
 
     /**
      * Allows configuring a database table prefix which is used for all runtime operations of the process engine. For example, if you specify a prefix named 'PRE1.', activiti will query for executions
      * in a table named 'PRE1.ACT_RU_EXECUTION_'.
-     * 
-     * <p />
+     * <p>
+     * <p/>
      * <strong>NOTE: the prefix is not respected by automatic database schema management. If you use {@link ProcessEngineConfiguration#DB_SCHEMA_UPDATE_CREATE_DROP} or
      * {@link ProcessEngineConfiguration#DB_SCHEMA_UPDATE_TRUE}, activiti will create the database tables using the default names, regardless of the prefix configured here.</strong>
-     * 
+     *
      * @since 5.9
      */
     protected String databaseTablePrefix = "";
 
     /**
      * Escape character for doing wildcard searches.
-     * 
+     * <p>
      * This will be added at then end of queries that include for example a LIKE clause. For example: SELECT * FROM table WHERE column LIKE '%\%%' ESCAPE '\';
      */
     protected String databaseWildcardEscapeCharacter;
@@ -193,7 +201,7 @@ public abstract class ProcessEngineConfiguration {
     /**
      * Set to true in case the defined databaseTablePrefix is a schema-name, instead of an actual table name prefix. This is relevant for checking if Activiti-tables exist, the databaseTablePrefix
      * will not be used here - since the schema is taken into account already, adding a prefix for the table-check will result in wrong table-names.
-     * 
+     *
      * @since 5.15
      */
     protected boolean tablePrefixIsSchema;
@@ -217,7 +225,9 @@ public abstract class ProcessEngineConfiguration {
 
     protected boolean enableProcessDefinitionInfoCache;
 
-    /** use one of the static createXxxx methods instead */
+    /**
+     * use one of the static createXxxx methods instead
+     */
     protected ProcessEngineConfiguration() {
     }
 

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/ProcessEngines.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/ProcessEngines.java
@@ -46,7 +46,7 @@ import org.slf4j.LoggerFactory;
  * <br>
  * The {@link #init()} method will try to build one {@link ProcessEngine} for each flowable.cfg.xml file found on the classpath. If you have more then one, make sure you specify different
  * process.engine.name values.
- * 
+ *
  * @author Tom Baeyens
  * @author Joram Barrez
  */
@@ -57,10 +57,10 @@ public abstract class ProcessEngines {
     public static final String NAME_DEFAULT = "default";
 
     protected static boolean isInitialized;
-    protected static Map<String, ProcessEngine> processEngines = new HashMap<String, ProcessEngine>();
-    protected static Map<String, ProcessEngineInfo> processEngineInfosByName = new HashMap<String, ProcessEngineInfo>();
-    protected static Map<String, ProcessEngineInfo> processEngineInfosByResourceUrl = new HashMap<String, ProcessEngineInfo>();
-    protected static List<ProcessEngineInfo> processEngineInfos = new ArrayList<ProcessEngineInfo>();
+    protected static Map<String, ProcessEngine> processEngines = new HashMap<>();
+    protected static Map<String, ProcessEngineInfo> processEngineInfosByName = new HashMap<>();
+    protected static Map<String, ProcessEngineInfo> processEngineInfosByResourceUrl = new HashMap<>();
+    protected static List<ProcessEngineInfo> processEngineInfos = new ArrayList<>();
 
     /**
      * Initializes all process engines that can be found on the classpath for resources <code>flowable.cfg.xml</code> (plain Activiti style configuration) and for resources
@@ -70,7 +70,7 @@ public abstract class ProcessEngines {
         if (!isInitialized()) {
             if (processEngines == null) {
                 // Create new map to store process-engines if current map is null
-                processEngines = new HashMap<String, ProcessEngine>();
+                processEngines = new HashMap<>();
             }
             ClassLoader classLoader = ReflectUtil.getClassLoader();
             Enumeration<URL> resources = null;
@@ -81,11 +81,11 @@ public abstract class ProcessEngines {
             }
 
             // Remove duplicated configuration URL's using set. Some classloaders may return identical URL's twice, causing duplicate startups
-            Set<URL> configUrls = new HashSet<URL>();
+            Set<URL> configUrls = new HashSet<>();
             while (resources.hasMoreElements()) {
                 configUrls.add(resources.nextElement());
             }
-            for (Iterator<URL> iterator = configUrls.iterator(); iterator.hasNext();) {
+            for (Iterator<URL> iterator = configUrls.iterator(); iterator.hasNext(); ) {
                 URL resource = iterator.next();
                 LOGGER.info("Initializing process engine using configuration '{}'", resource.toString());
                 initProcessEngineFromResource(resource);
@@ -111,8 +111,8 @@ public abstract class ProcessEngines {
     protected static void initProcessEngineFromSpringResource(URL resource) {
         try {
             Class<?> springConfigurationHelperClass = ReflectUtil.loadClass("org.activiti.spring.SpringConfigurationHelper");
-            Method method = springConfigurationHelperClass.getDeclaredMethod("buildProcessEngine", new Class<?>[] { URL.class });
-            ProcessEngine processEngine = (ProcessEngine) method.invoke(null, new Object[] { resource });
+            Method method = springConfigurationHelperClass.getDeclaredMethod("buildProcessEngine", new Class<?>[]{URL.class});
+            ProcessEngine processEngine = (ProcessEngine) method.invoke(null, new Object[]{resource});
 
             String processEngineName = processEngine.getName();
             ProcessEngineInfo processEngineInfo = new ProcessEngineInfoImpl(processEngineName, resource.toString(), null);
@@ -192,7 +192,9 @@ public abstract class ProcessEngines {
         }
     }
 
-    /** Get initialization results. */
+    /**
+     * Get initialization results.
+     */
     public static List<ProcessEngineInfo> getProcessEngineInfos() {
         return processEngineInfos;
     }
@@ -211,9 +213,8 @@ public abstract class ProcessEngines {
 
     /**
      * obtain a process engine by name.
-     * 
-     * @param processEngineName
-     *            is the name of the process engine or null for the default process engine.
+     *
+     * @param processEngineName is the name of the process engine or null for the default process engine.
      */
     public static ProcessEngine getProcessEngine(String processEngineName) {
         if (!isInitialized()) {
@@ -241,11 +242,13 @@ public abstract class ProcessEngines {
         return processEngines;
     }
 
-    /** closes all process engines. This method should be called when the server shuts down. */
+    /**
+     * closes all process engines. This method should be called when the server shuts down.
+     */
     public static synchronized void destroy() {
         if (isInitialized()) {
-            Map<String, ProcessEngine> engines = new HashMap<String, ProcessEngine>(processEngines);
-            processEngines = new HashMap<String, ProcessEngine>();
+            Map<String, ProcessEngine> engines = new HashMap<>(processEngines);
+            processEngines = new HashMap<>();
 
             for (String processEngineName : engines.keySet()) {
                 ProcessEngine processEngine = engines.get(processEngineName);

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/AbstractNativeQuery.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/AbstractNativeQuery.java
@@ -28,7 +28,7 @@ import org.apache.commons.lang3.StringUtils;
 
 /**
  * Abstract superclass for all native query types.
- * 
+ *
  * @author Bernd Ruecker (camunda)
  */
 public abstract class AbstractNativeQuery<T extends NativeQuery<?, ?>, U> implements Command<Object>, NativeQuery<T, U>,
@@ -47,7 +47,7 @@ public abstract class AbstractNativeQuery<T extends NativeQuery<?, ?>, U> implem
     protected int firstResult;
     protected ResultType resultType;
 
-    private Map<String, Object> parameters = new HashMap<String, Object>();
+    private Map<String, Object> parameters = new HashMap<>();
     private String sqlStatement;
 
     protected AbstractNativeQuery(CommandExecutor commandExecutor) {
@@ -147,10 +147,9 @@ public abstract class AbstractNativeQuery<T extends NativeQuery<?, ?>, U> implem
 
     /**
      * Executes the actual query to retrieve the list of results.
-     * 
+     *
      * @param maxResults
      * @param firstResult
-     *
      */
     public abstract List<U> executeList(CommandContext commandContext, Map<String, Object> parameterMap, int firstResult, int maxResults);
 
@@ -165,7 +164,7 @@ public abstract class AbstractNativeQuery<T extends NativeQuery<?, ?>, U> implem
     }
 
     private Map<String, Object> getParameterMap() {
-        HashMap<String, Object> parameterMap = new HashMap<String, Object>();
+        HashMap<String, Object> parameterMap = new HashMap<>();
         parameterMap.put("sql", sqlStatement);
         parameterMap.putAll(parameters);
         return parameterMap;

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/AbstractVariableQueryImpl.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/AbstractVariableQueryImpl.java
@@ -25,14 +25,14 @@ import org.flowable.variable.service.impl.types.VariableTypes;
 
 /**
  * Abstract query class that adds methods to query for variable values.
- * 
+ *
  * @author Frederik Heremans
  */
 public abstract class AbstractVariableQueryImpl<T extends Query<?, ?>, U> extends AbstractQuery<T, U> {
 
     private static final long serialVersionUID = 1L;
 
-    protected List<QueryVariableValue> queryVariableValues = new ArrayList<QueryVariableValue>();
+    protected List<QueryVariableValue> queryVariableValues = new ArrayList<>();
 
     public AbstractVariableQueryImpl() {
     }
@@ -174,14 +174,14 @@ public abstract class AbstractVariableQueryImpl<T extends Query<?, ?>, U> extend
         if (value == null || isBoolean(value)) {
             // Null-values and booleans can only be used in EQUALS and NOT_EQUALS
             switch (operator) {
-            case GREATER_THAN:
-                throw new ActivitiIllegalArgumentException("Booleans and null cannot be used in 'greater than' condition");
-            case LESS_THAN:
-                throw new ActivitiIllegalArgumentException("Booleans and null cannot be used in 'less than' condition");
-            case GREATER_THAN_OR_EQUAL:
-                throw new ActivitiIllegalArgumentException("Booleans and null cannot be used in 'greater than or equal' condition");
-            case LESS_THAN_OR_EQUAL:
-                throw new ActivitiIllegalArgumentException("Booleans and null cannot be used in 'less than or equal' condition");
+                case GREATER_THAN:
+                    throw new ActivitiIllegalArgumentException("Booleans and null cannot be used in 'greater than' condition");
+                case LESS_THAN:
+                    throw new ActivitiIllegalArgumentException("Booleans and null cannot be used in 'less than' condition");
+                case GREATER_THAN_OR_EQUAL:
+                    throw new ActivitiIllegalArgumentException("Booleans and null cannot be used in 'greater than or equal' condition");
+                case LESS_THAN_OR_EQUAL:
+                    throw new ActivitiIllegalArgumentException("Booleans and null cannot be used in 'less than or equal' condition");
             }
 
             if (operator == QueryOperator.EQUALS_IGNORE_CASE && !(value instanceof String)) {

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/DeploymentQueryProperty.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/DeploymentQueryProperty.java
@@ -34,14 +34,14 @@ import org.activiti.engine.repository.DeploymentQuery;
 
 /**
  * Contains the possible properties that can be used in a {@link DeploymentQuery}.
- * 
+ *
  * @author Joram Barrez
  */
 public class DeploymentQueryProperty implements QueryProperty {
 
     private static final long serialVersionUID = 1L;
 
-    private static final Map<String, DeploymentQueryProperty> properties = new HashMap<String, DeploymentQueryProperty>();
+    private static final Map<String, DeploymentQueryProperty> properties = new HashMap<>();
 
     public static final DeploymentQueryProperty DEPLOYMENT_ID = new DeploymentQueryProperty("RES.ID_");
     public static final DeploymentQueryProperty DEPLOYMENT_NAME = new DeploymentQueryProperty("RES.NAME_");

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/Direction.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/Direction.java
@@ -21,7 +21,7 @@ import java.util.Map;
  */
 public class Direction {
 
-    private static final Map<String, Direction> directions = new HashMap<String, Direction>();
+    private static final Map<String, Direction> directions = new HashMap<>();
 
     public static final Direction ASCENDING = new Direction("asc");
     public static final Direction DESCENDING = new Direction("desc");

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/ExecutionQueryImpl.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/ExecutionQueryImpl.java
@@ -12,6 +12,9 @@
  */
 package org.activiti.engine.impl;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -26,9 +29,6 @@ import org.activiti.engine.runtime.Execution;
 import org.activiti.engine.runtime.ExecutionQuery;
 import org.flowable.engine.DynamicBpmnConstants;
 import org.flowable.engine.repository.ProcessDefinition;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * @author Joram Barrez
@@ -75,7 +75,7 @@ public class ExecutionQueryImpl extends AbstractVariableQueryImpl<ExecutionQuery
     protected String nameLikeIgnoreCase;
     protected String deploymentId;
     protected List<String> deploymentIds;
-    protected List<ExecutionQueryImpl> orQueryObjects = new ArrayList<ExecutionQueryImpl>();
+    protected List<ExecutionQueryImpl> orQueryObjects = new ArrayList<>();
 
     public ExecutionQueryImpl() {
     }
@@ -238,7 +238,7 @@ public class ExecutionQueryImpl extends AbstractVariableQueryImpl<ExecutionQuery
             throw new ActivitiIllegalArgumentException("event type is null");
         }
         if (eventSubscriptions == null) {
-            eventSubscriptions = new ArrayList<EventSubscriptionQueryValue>();
+            eventSubscriptions = new ArrayList<>();
         }
         eventSubscriptions.add(new EventSubscriptionQueryValue(eventName, eventType));
         return this;
@@ -316,7 +316,7 @@ public class ExecutionQueryImpl extends AbstractVariableQueryImpl<ExecutionQuery
                 .findExecutionCountByQueryCriteria(this);
     }
 
-    @SuppressWarnings({ "unchecked" })
+    @SuppressWarnings({"unchecked"})
     public List<Execution> executeList(CommandContext commandContext, Page page) {
         checkQueryOk();
         ensureVariablesInitialized();

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/ExecutionQueryProperty.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/ExecutionQueryProperty.java
@@ -21,14 +21,14 @@ import org.activiti.engine.runtime.ExecutionQuery;
 
 /**
  * Contains the possible properties that can be used in a {@link ExecutionQuery}.
- * 
+ *
  * @author Joram Barrez
  */
 public class ExecutionQueryProperty implements QueryProperty {
 
     private static final long serialVersionUID = 1L;
 
-    private static final Map<String, ExecutionQueryProperty> properties = new HashMap<String, ExecutionQueryProperty>();
+    private static final Map<String, ExecutionQueryProperty> properties = new HashMap<>();
 
     public static final ExecutionQueryProperty PROCESS_INSTANCE_ID = new ExecutionQueryProperty("RES.ID_");
     public static final ExecutionQueryProperty PROCESS_DEFINITION_KEY = new ExecutionQueryProperty("ProcessDefinitionKey");

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/GroupQueryProperty.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/GroupQueryProperty.java
@@ -21,14 +21,14 @@ import org.flowable.idm.api.GroupQuery;
 
 /**
  * Contains the possible properties that can be used by the {@link GroupQuery}.
- * 
+ *
  * @author Joram Barrez
  */
 public class GroupQueryProperty implements QueryProperty {
 
     private static final long serialVersionUID = 1L;
 
-    private static final Map<String, GroupQueryProperty> properties = new HashMap<String, GroupQueryProperty>();
+    private static final Map<String, GroupQueryProperty> properties = new HashMap<>();
 
     public static final GroupQueryProperty GROUP_ID = new GroupQueryProperty("RES.ID_");
     public static final GroupQueryProperty NAME = new GroupQueryProperty("RES.NAME_");

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/HistoricActivityInstanceQueryProperty.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/HistoricActivityInstanceQueryProperty.java
@@ -21,14 +21,14 @@ import org.activiti.engine.query.QueryProperty;
 
 /**
  * Contains the possible properties which can be used in a {@link HistoricActivityInstanceQuery}.
- * 
+ *
  * @author Tom Baeyens
  */
 public class HistoricActivityInstanceQueryProperty implements QueryProperty {
 
     private static final long serialVersionUID = 1L;
 
-    private static final Map<String, HistoricActivityInstanceQueryProperty> properties = new HashMap<String, HistoricActivityInstanceQueryProperty>();
+    private static final Map<String, HistoricActivityInstanceQueryProperty> properties = new HashMap<>();
 
     public static final HistoricActivityInstanceQueryProperty HISTORIC_ACTIVITY_INSTANCE_ID = new HistoricActivityInstanceQueryProperty("ID_");
     public static final HistoricActivityInstanceQueryProperty PROCESS_INSTANCE_ID = new HistoricActivityInstanceQueryProperty("PROC_INST_ID_");

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/HistoricDetailQueryProperty.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/HistoricDetailQueryProperty.java
@@ -21,14 +21,14 @@ import org.activiti.engine.query.QueryProperty;
 
 /**
  * Contains the possible properties which can be used in a {@link HistoricDetailQuery}.
- * 
+ *
  * @author Tom Baeyens
  */
 public class HistoricDetailQueryProperty implements QueryProperty {
 
     private static final long serialVersionUID = 1L;
 
-    private static final Map<String, HistoricDetailQueryProperty> properties = new HashMap<String, HistoricDetailQueryProperty>();
+    private static final Map<String, HistoricDetailQueryProperty> properties = new HashMap<>();
 
     public static final HistoricDetailQueryProperty PROCESS_INSTANCE_ID = new HistoricDetailQueryProperty("PROC_INST_ID_");
     public static final HistoricDetailQueryProperty VARIABLE_NAME = new HistoricDetailQueryProperty("NAME_");

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/HistoricProcessInstanceQueryImpl.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/HistoricProcessInstanceQueryImpl.java
@@ -13,6 +13,9 @@
 
 package org.activiti.engine.impl;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -27,9 +30,6 @@ import org.activiti.engine.impl.interceptor.CommandContext;
 import org.activiti.engine.impl.interceptor.CommandExecutor;
 import org.flowable.engine.DynamicBpmnConstants;
 import org.flowable.engine.repository.ProcessDefinition;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * @author Tom Baeyens
@@ -76,7 +76,7 @@ public class HistoricProcessInstanceQueryImpl extends AbstractVariableQueryImpl<
     protected String nameLikeIgnoreCase;
     protected String locale;
     protected boolean withLocalizationFallback;
-    protected List<HistoricProcessInstanceQueryImpl> orQueryObjects = new ArrayList<HistoricProcessInstanceQueryImpl>();
+    protected List<HistoricProcessInstanceQueryImpl> orQueryObjects = new ArrayList<>();
     protected HistoricProcessInstanceQueryImpl currentOrQueryObject;
     protected boolean inOrStatement;
 

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/HistoricProcessInstanceQueryProperty.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/HistoricProcessInstanceQueryProperty.java
@@ -20,14 +20,14 @@ import org.activiti.engine.query.QueryProperty;
 
 /**
  * Contains the possible properties which can be used in a {@link HistoricProcessInstanceQueryProperty}.
- * 
+ *
  * @author Joram Barrez
  */
 public class HistoricProcessInstanceQueryProperty implements QueryProperty {
 
     private static final long serialVersionUID = 1L;
 
-    private static final Map<String, HistoricProcessInstanceQueryProperty> properties = new HashMap<String, HistoricProcessInstanceQueryProperty>();
+    private static final Map<String, HistoricProcessInstanceQueryProperty> properties = new HashMap<>();
 
     public static final HistoricProcessInstanceQueryProperty PROCESS_INSTANCE_ID_ = new HistoricProcessInstanceQueryProperty("RES.PROC_INST_ID_");
     public static final HistoricProcessInstanceQueryProperty PROCESS_DEFINITION_ID = new HistoricProcessInstanceQueryProperty("RES.PROC_DEF_ID_");

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/HistoricTaskInstanceQueryImpl.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/HistoricTaskInstanceQueryImpl.java
@@ -13,6 +13,9 @@
 
 package org.activiti.engine.impl;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -28,9 +31,6 @@ import org.activiti.engine.impl.interceptor.CommandExecutor;
 import org.flowable.engine.DynamicBpmnConstants;
 import org.flowable.idm.api.Group;
 import org.flowable.variable.service.impl.types.VariableTypes;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * @author Tom Baeyens
@@ -106,7 +106,7 @@ public class HistoricTaskInstanceQueryImpl extends AbstractVariableQueryImpl<His
     protected boolean includeTaskLocalVariables;
     protected boolean includeProcessVariables;
     protected Integer taskVariablesLimit;
-    protected List<HistoricTaskInstanceQueryImpl> orQueryObjects = new ArrayList<HistoricTaskInstanceQueryImpl>();
+    protected List<HistoricTaskInstanceQueryImpl> orQueryObjects = new ArrayList<>();
     protected HistoricTaskInstanceQueryImpl currentOrQueryObject;
     protected boolean inOrStatement;
 
@@ -407,7 +407,7 @@ public class HistoricTaskInstanceQueryImpl extends AbstractVariableQueryImpl<His
         }
 
         final int nameListSize = taskNameList.size();
-        final List<String> caseIgnoredTaskNameList = new ArrayList<String>(nameListSize);
+        final List<String> caseIgnoredTaskNameList = new ArrayList<>(nameListSize);
         for (String taskName : taskNameList) {
             caseIgnoredTaskNameList.add(taskName.toLowerCase());
         }
@@ -1283,7 +1283,7 @@ public class HistoricTaskInstanceQueryImpl extends AbstractVariableQueryImpl<His
 
     public List<String> getCandidateGroups() {
         if (candidateGroup != null) {
-            List<String> candidateGroupList = new ArrayList<String>(1);
+            List<String> candidateGroupList = new ArrayList<>(1);
             candidateGroupList.add(candidateGroup);
             return candidateGroupList;
 
@@ -1299,7 +1299,7 @@ public class HistoricTaskInstanceQueryImpl extends AbstractVariableQueryImpl<His
     protected List<String> getGroupsForCandidateUser(String candidateUser) {
         IdentityService identityService = Context.getProcessEngineConfiguration().getIdentityService();
         List<Group> groups = identityService.createGroupQuery().groupMember(candidateUser).list();
-        List<String> groupIds = new ArrayList<String>();
+        List<String> groupIds = new ArrayList<>();
         for (Group group : groups) {
             groupIds.add(group.getId());
         }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/HistoricTaskInstanceQueryProperty.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/HistoricTaskInstanceQueryProperty.java
@@ -25,7 +25,7 @@ public class HistoricTaskInstanceQueryProperty implements QueryProperty {
 
     private static final long serialVersionUID = 1L;
 
-    private static final Map<String, HistoricTaskInstanceQueryProperty> properties = new HashMap<String, HistoricTaskInstanceQueryProperty>();
+    private static final Map<String, HistoricTaskInstanceQueryProperty> properties = new HashMap<>();
 
     public static final HistoricTaskInstanceQueryProperty HISTORIC_TASK_INSTANCE_ID = new HistoricTaskInstanceQueryProperty("RES.ID_");
     public static final HistoricTaskInstanceQueryProperty PROCESS_DEFINITION_ID = new HistoricTaskInstanceQueryProperty("RES.PROC_DEF_ID_");

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/HistoricVariableInstanceQueryProperty.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/HistoricVariableInstanceQueryProperty.java
@@ -21,14 +21,14 @@ import org.activiti.engine.query.QueryProperty;
 
 /**
  * Contains the possible properties which can be used in a {@link HistoricVariableInstanceQuery}.
- * 
+ *
  * @author Christian Lipphardt (camunda)
  */
 public class HistoricVariableInstanceQueryProperty implements QueryProperty {
 
     private static final long serialVersionUID = 1L;
 
-    private static final Map<String, HistoricVariableInstanceQueryProperty> properties = new HashMap<String, HistoricVariableInstanceQueryProperty>();
+    private static final Map<String, HistoricVariableInstanceQueryProperty> properties = new HashMap<>();
 
     public static final HistoricVariableInstanceQueryProperty PROCESS_INSTANCE_ID = new HistoricVariableInstanceQueryProperty("PROC_INST_ID_");
     public static final HistoricVariableInstanceQueryProperty VARIABLE_NAME = new HistoricVariableInstanceQueryProperty("NAME_");

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/JobQueryProperty.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/JobQueryProperty.java
@@ -21,14 +21,14 @@ import org.activiti.engine.runtime.JobQuery;
 
 /**
  * Contains the possible properties that can be used in a {@link JobQuery}.
- * 
+ *
  * @author Joram Barrez
  */
 public class JobQueryProperty implements QueryProperty {
 
     private static final long serialVersionUID = 1L;
 
-    private static final Map<String, JobQueryProperty> properties = new HashMap<String, JobQueryProperty>();
+    private static final Map<String, JobQueryProperty> properties = new HashMap<>();
 
     public static final JobQueryProperty JOB_ID = new JobQueryProperty("ID_");
     public static final JobQueryProperty PROCESS_INSTANCE_ID = new JobQueryProperty("RES.PROCESS_INSTANCE_ID_");

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/ManagementServiceImpl.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/ManagementServiceImpl.java
@@ -109,7 +109,7 @@ public class ManagementServiceImpl extends ServiceImpl implements ManagementServ
     @Override
     public <MapperType, ResultType> ResultType executeCustomSql(CustomSqlExecution<MapperType, ResultType> customSqlExecution) {
         Class<MapperType> mapperClass = customSqlExecution.getMapperClass();
-        return commandExecutor.execute(new ExecuteCustomSqlCmd<MapperType, ResultType>(mapperClass, customSqlExecution));
+        return commandExecutor.execute(new ExecuteCustomSqlCmd<>(mapperClass, customSqlExecution));
     }
 
     @Override

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/ModelQueryProperty.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/ModelQueryProperty.java
@@ -21,7 +21,7 @@ import org.activiti.engine.repository.ModelQuery;
 
 /**
  * Contains the possible properties that can be used in a {@link ModelQuery}.
- * 
+ *
  * @author Tijs Rademakers
  * @author Joram Barrez
  */
@@ -29,7 +29,7 @@ public class ModelQueryProperty implements QueryProperty {
 
     private static final long serialVersionUID = 1L;
 
-    private static final Map<String, ModelQueryProperty> properties = new HashMap<String, ModelQueryProperty>();
+    private static final Map<String, ModelQueryProperty> properties = new HashMap<>();
 
     public static final ModelQueryProperty MODEL_CATEGORY = new ModelQueryProperty("RES.CATEGORY_");
     public static final ModelQueryProperty MODEL_ID = new ModelQueryProperty("RES.ID_");

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/ProcessDefinitionQueryImpl.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/ProcessDefinitionQueryImpl.java
@@ -281,7 +281,7 @@ public class ProcessDefinitionQueryImpl extends AbstractQuery<ProcessDefinitionQ
         if (authorizationUserId != null) {
             IdentityService identityService = Context.getProcessEngineConfiguration().getIdentityService();
             List<Group> groups = identityService.createGroupQuery().groupMember(authorizationUserId).list();
-            List<String> groupIds = new ArrayList<String>();
+            List<String> groupIds = new ArrayList<>();
             for (Group group : groups) {
                 groupIds.add(group.getId());
             }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/ProcessDefinitionQueryProperty.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/ProcessDefinitionQueryProperty.java
@@ -21,14 +21,14 @@ import org.activiti.engine.repository.ProcessDefinitionQuery;
 
 /**
  * Contains the possible properties that can be used in a {@link ProcessDefinitionQuery}.
- * 
+ *
  * @author Joram Barrez
  */
 public class ProcessDefinitionQueryProperty implements QueryProperty {
 
     private static final long serialVersionUID = 1L;
 
-    private static final Map<String, ProcessDefinitionQueryProperty> properties = new HashMap<String, ProcessDefinitionQueryProperty>();
+    private static final Map<String, ProcessDefinitionQueryProperty> properties = new HashMap<>();
 
     public static final ProcessDefinitionQueryProperty PROCESS_DEFINITION_KEY = new ProcessDefinitionQueryProperty("RES.KEY_");
     public static final ProcessDefinitionQueryProperty PROCESS_DEFINITION_CATEGORY = new ProcessDefinitionQueryProperty("RES.CATEGORY_");

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/ProcessInstanceHistoryLogImpl.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/ProcessInstanceHistoryLogImpl.java
@@ -18,7 +18,7 @@ public class ProcessInstanceHistoryLogImpl implements ProcessInstanceHistoryLog 
 
     protected HistoricProcessInstance historicProcessInstance;
 
-    protected List<HistoricData> historicData = new ArrayList<HistoricData>();
+    protected List<HistoricData> historicData = new ArrayList<>();
 
     public ProcessInstanceHistoryLogImpl(HistoricProcessInstance historicProcessInstance) {
         this.historicProcessInstance = historicProcessInstance;

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/ProcessInstanceQueryImpl.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/ProcessInstanceQueryImpl.java
@@ -13,6 +13,9 @@
 
 package org.activiti.engine.impl;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -28,9 +31,6 @@ import org.activiti.engine.impl.persistence.entity.SuspensionState;
 import org.activiti.engine.runtime.ProcessInstance;
 import org.activiti.engine.runtime.ProcessInstanceQuery;
 import org.flowable.engine.DynamicBpmnConstants;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * @author Tom Baeyens
@@ -74,7 +74,7 @@ public class ProcessInstanceQueryImpl extends AbstractVariableQueryImpl<ProcessI
     protected String tenantIdLike;
     protected boolean withoutTenantId;
 
-    protected List<ProcessInstanceQueryImpl> orQueryObjects = new ArrayList<ProcessInstanceQueryImpl>();
+    protected List<ProcessInstanceQueryImpl> orQueryObjects = new ArrayList<>();
     protected ProcessInstanceQueryImpl currentOrQueryObject;
     protected boolean inOrStatement;
 

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/ProcessInstanceQueryProperty.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/ProcessInstanceQueryProperty.java
@@ -21,14 +21,14 @@ import org.activiti.engine.runtime.ProcessInstanceQuery;
 
 /**
  * Contains the possible properties that can be used in a {@link ProcessInstanceQuery}.
- * 
+ *
  * @author Joram Barrez
  */
 public class ProcessInstanceQueryProperty implements QueryProperty {
 
     private static final long serialVersionUID = 1L;
 
-    private static final Map<String, ProcessInstanceQueryProperty> properties = new HashMap<String, ProcessInstanceQueryProperty>();
+    private static final Map<String, ProcessInstanceQueryProperty> properties = new HashMap<>();
 
     public static final ProcessInstanceQueryProperty PROCESS_INSTANCE_ID = new ProcessInstanceQueryProperty("RES.ID_");
     public static final ProcessInstanceQueryProperty PROCESS_DEFINITION_KEY = new ProcessInstanceQueryProperty("ProcessDefinitionKey");

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/RuntimeServiceImpl.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/RuntimeServiceImpl.java
@@ -214,7 +214,7 @@ public class RuntimeServiceImpl extends ServiceImpl implements RuntimeService {
         if (variableName == null) {
             throw new ActivitiIllegalArgumentException("variableName is null");
         }
-        Map<String, Object> variables = new HashMap<String, Object>();
+        Map<String, Object> variables = new HashMap<>();
         variables.put(variableName, value);
         commandExecutor.execute(new SetExecutionVariablesCmd(executionId, variables, false));
     }
@@ -223,7 +223,7 @@ public class RuntimeServiceImpl extends ServiceImpl implements RuntimeService {
         if (variableName == null) {
             throw new ActivitiIllegalArgumentException("variableName is null");
         }
-        Map<String, Object> variables = new HashMap<String, Object>();
+        Map<String, Object> variables = new HashMap<>();
         variables.put(variableName, value);
         commandExecutor.execute(new SetExecutionVariablesCmd(executionId, variables, true));
     }
@@ -237,13 +237,13 @@ public class RuntimeServiceImpl extends ServiceImpl implements RuntimeService {
     }
 
     public void removeVariable(String executionId, String variableName) {
-        Collection<String> variableNames = new ArrayList<String>();
+        Collection<String> variableNames = new ArrayList<>();
         variableNames.add(variableName);
         commandExecutor.execute(new RemoveExecutionVariablesCmd(executionId, variableNames, false));
     }
 
     public void removeVariableLocal(String executionId, String variableName) {
-        Collection<String> variableNames = new ArrayList<String>();
+        Collection<String> variableNames = new ArrayList<>();
         variableNames.add(variableName);
         commandExecutor.execute(new RemoveExecutionVariablesCmd(executionId, variableNames, true));
     }
@@ -354,7 +354,7 @@ public class RuntimeServiceImpl extends ServiceImpl implements RuntimeService {
 
     @Override
     public ProcessInstance startProcessInstanceByMessageAndTenantId(String messageName, String businessKey,
-            Map<String, Object> processVariables, String tenantId) {
+                                                                    Map<String, Object> processVariables, String tenantId) {
         return commandExecutor.execute(new StartProcessInstanceByMessageCmd(messageName, businessKey, processVariables, tenantId));
     }
 
@@ -379,7 +379,7 @@ public class RuntimeServiceImpl extends ServiceImpl implements RuntimeService {
     }
 
     public void signalEventReceivedWithTenantId(String signalName,
-            Map<String, Object> processVariables, String tenantId) {
+                                                Map<String, Object> processVariables, String tenantId) {
         commandExecutor.execute(new SignalEventReceivedCmd(signalName, null, processVariables, tenantId));
     }
 

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/TaskQueryImpl.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/TaskQueryImpl.java
@@ -12,6 +12,9 @@
  */
 package org.activiti.engine.impl;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -29,9 +32,6 @@ import org.flowable.engine.DynamicBpmnConstants;
 import org.flowable.idm.api.Group;
 import org.flowable.task.service.DelegationState;
 import org.flowable.variable.service.impl.types.VariableTypes;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * @author Joram Barrez
@@ -109,7 +109,7 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
     protected String locale;
     protected boolean withLocalizationFallback;
     protected boolean orActive;
-    protected List<TaskQueryImpl> orQueryObjects = new ArrayList<TaskQueryImpl>();
+    protected List<TaskQueryImpl> orQueryObjects = new ArrayList<>();
     protected TaskQueryImpl currentOrQueryObject;
 
     public TaskQueryImpl() {
@@ -211,7 +211,7 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
         }
 
         final int nameListSize = nameList.size();
-        final List<String> caseIgnoredNameList = new ArrayList<String>(nameListSize);
+        final List<String> caseIgnoredNameList = new ArrayList<>(nameListSize);
         for (String name : nameList) {
             caseIgnoredNameList.add(name.toLowerCase());
         }
@@ -427,7 +427,9 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
         return this;
     }
 
-    /** @see #taskUnassigned */
+    /**
+     * @see #taskUnassigned
+     */
     @Deprecated
     public TaskQuery taskUnnassigned() {
         return taskUnassigned();
@@ -1139,7 +1141,7 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
 
     public List<String> getCandidateGroups() {
         if (candidateGroup != null) {
-            List<String> candidateGroupList = new ArrayList<String>(1);
+            List<String> candidateGroupList = new ArrayList<>(1);
             candidateGroupList.add(candidateGroup);
             return candidateGroupList;
 
@@ -1158,7 +1160,7 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
     protected List<String> getGroupsForCandidateUser(String candidateUser) {
         IdentityService identityService = Context.getProcessEngineConfiguration().getIdentityService();
         List<Group> groups = identityService.createGroupQuery().groupMember(candidateUser).list();
-        List<String> groupIds = new ArrayList<String>();
+        List<String> groupIds = new ArrayList<>();
         for (Group group : groups) {
             groupIds.add(group.getId());
         }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/TaskQueryProperty.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/TaskQueryProperty.java
@@ -34,14 +34,14 @@ import org.activiti.engine.task.TaskQuery;
 
 /**
  * Contains the possible properties that can be used in a {@link TaskQuery}.
- * 
+ *
  * @author Joram Barrez
  */
 public class TaskQueryProperty implements QueryProperty {
 
     private static final long serialVersionUID = 1L;
 
-    private static final Map<String, TaskQueryProperty> properties = new HashMap<String, TaskQueryProperty>();
+    private static final Map<String, TaskQueryProperty> properties = new HashMap<>();
 
     public static final TaskQueryProperty TASK_ID = new TaskQueryProperty("RES.ID_");
     public static final TaskQueryProperty NAME = new TaskQueryProperty("RES.NAME_");

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/TaskServiceImpl.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/TaskServiceImpl.java
@@ -271,7 +271,7 @@ public class TaskServiceImpl extends ServiceImpl implements TaskService {
         if (variableName == null) {
             throw new ActivitiIllegalArgumentException("variableName is null");
         }
-        Map<String, Object> variables = new HashMap<String, Object>();
+        Map<String, Object> variables = new HashMap<>();
         variables.put(variableName, value);
         commandExecutor.execute(new SetTaskVariablesCmd(taskId, variables, false));
     }
@@ -280,7 +280,7 @@ public class TaskServiceImpl extends ServiceImpl implements TaskService {
         if (variableName == null) {
             throw new ActivitiIllegalArgumentException("variableName is null");
         }
-        Map<String, Object> variables = new HashMap<String, Object>();
+        Map<String, Object> variables = new HashMap<>();
         variables.put(variableName, value);
         commandExecutor.execute(new SetTaskVariablesCmd(taskId, variables, true));
     }
@@ -294,13 +294,13 @@ public class TaskServiceImpl extends ServiceImpl implements TaskService {
     }
 
     public void removeVariable(String taskId, String variableName) {
-        Collection<String> variableNames = new ArrayList<String>();
+        Collection<String> variableNames = new ArrayList<>();
         variableNames.add(variableName);
         commandExecutor.execute(new RemoveTaskVariablesCmd(taskId, variableNames, false));
     }
 
     public void removeVariableLocal(String taskId, String variableName) {
-        Collection<String> variableNames = new ArrayList<String>(1);
+        Collection<String> variableNames = new ArrayList<>(1);
         variableNames.add(variableName);
         commandExecutor.execute(new RemoveTaskVariablesCmd(taskId, variableNames, true));
     }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/UserQueryProperty.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/UserQueryProperty.java
@@ -21,14 +21,14 @@ import org.flowable.idm.api.UserQuery;
 
 /**
  * Contains the possible properties that can be used by the {@link UserQuery}.
- * 
+ *
  * @author Joram Barrez
  */
 public class UserQueryProperty implements QueryProperty {
 
     private static final long serialVersionUID = 1L;
 
-    private static final Map<String, UserQueryProperty> properties = new HashMap<String, UserQueryProperty>();
+    private static final Map<String, UserQueryProperty> properties = new HashMap<>();
 
     public static final UserQueryProperty USER_ID = new UserQueryProperty("RES.ID_");
     public static final UserQueryProperty FIRST_NAME = new UserQueryProperty("RES.FIRST_");

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/BoundaryEventActivityBehavior.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/BoundaryEventActivityBehavior.java
@@ -59,7 +59,7 @@ public class BoundaryEventActivityBehavior extends FlowNodeActivityBehavior {
 
             executionEntity.setActivity(boundaryActivity);
 
-            interruptedExecutions = new ArrayList<ExecutionEntity>(executionEntity.getExecutions());
+            interruptedExecutions = new ArrayList<>(executionEntity.getExecutions());
             for (ExecutionEntity interruptedExecution : interruptedExecutions) {
                 interruptedExecution.deleteCascade("interrupting boundary event '" + executionEntity.getActivity().getId() + "' fired");
             }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/BpmnActivityBehavior.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/BpmnActivityBehavior.java
@@ -38,9 +38,9 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Helper class for implementing BPMN 2.0 activities, offering convenience methods specific to BPMN 2.0.
- * 
+ * <p>
  * This class can be used by inheritance or aggregation.
- * 
+ *
  * @author Joram Barrez
  */
 public class BpmnActivityBehavior implements Serializable {
@@ -51,7 +51,7 @@ public class BpmnActivityBehavior implements Serializable {
 
     /**
      * Performs the default outgoing BPMN 2.0 behavior, which is having parallel paths of executions for the outgoing sequence flow.
-     * 
+     * <p>
      * More precisely: every sequence flow that has a condition which evaluates to true (or which doesn't have a condition), is selected for continuation of the process instance. If multiple sequencer
      * flow are selected, multiple, parallel paths of executions are created.
      */
@@ -65,7 +65,7 @@ public class BpmnActivityBehavior implements Serializable {
 
     /**
      * Performs the default outgoing BPMN 2.0 behavior (@see {@link #performDefaultOutgoingBehavior(ActivityExecution)}), but without checking the conditions on the outgoing sequence flow.
-     * 
+     * <p>
      * This means that every outgoing sequence flow is selected for continuing the process instance, regardless of having a condition or not. In case of multiple outgoing sequence flow, multiple
      * parallel paths of executions will be created.
      */
@@ -75,7 +75,7 @@ public class BpmnActivityBehavior implements Serializable {
 
     /**
      * dispatch job canceled event for job associated with given execution entity
-     * 
+     *
      * @param activityExecution
      */
     protected void dispatchJobCanceledEvents(ActivityExecution activityExecution) {
@@ -99,23 +99,20 @@ public class BpmnActivityBehavior implements Serializable {
 
     /**
      * Actual implementation of leaving an activity.
-     * 
-     * @param execution
-     *            The current execution context
-     * @param checkConditions
-     *            Whether or not to check conditions before determining whether or not to take a transition.
-     * @param throwExceptionIfExecutionStuck
-     *            If true, an {@link ActivitiException} will be thrown in case no transition could be found to leave the activity.
+     *
+     * @param execution                      The current execution context
+     * @param checkConditions                Whether or not to check conditions before determining whether or not to take a transition.
+     * @param throwExceptionIfExecutionStuck If true, an {@link ActivitiException} will be thrown in case no transition could be found to leave the activity.
      */
     protected void performOutgoingBehavior(ActivityExecution execution,
-            boolean checkConditions, boolean throwExceptionIfExecutionStuck, List<ActivityExecution> reusableExecutions) {
+                                           boolean checkConditions, boolean throwExceptionIfExecutionStuck, List<ActivityExecution> reusableExecutions) {
 
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Leaving activity '{}'", execution.getActivity().getId());
         }
 
         String defaultSequenceFlow = (String) execution.getActivity().getProperty("default");
-        List<PvmTransition> transitionsToTake = new ArrayList<PvmTransition>();
+        List<PvmTransition> transitionsToTake = new ArrayList<>();
 
         List<PvmTransition> outgoingTransitions = execution.getActivity().getOutgoingTransitions();
         for (PvmTransition outgoingTransition : outgoingTransitions) {

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/BusinessRuleTaskActivityBehavior.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/BusinessRuleTaskActivityBehavior.java
@@ -30,15 +30,15 @@ import org.flowable.variable.service.delegate.Expression;
 
 /**
  * activity implementation of the BPMN 2.0 business rule task.
- * 
+ *
  * @author Tijs Rademakers
  */
 public class BusinessRuleTaskActivityBehavior extends TaskActivityBehavior implements BusinessRuleTaskDelegate {
 
     private static final long serialVersionUID = 1L;
 
-    protected Set<Expression> variablesInputExpressions = new HashSet<Expression>();
-    protected Set<Expression> rulesExpressions = new HashSet<Expression>();
+    protected Set<Expression> variablesInputExpressions = new HashSet<>();
+    protected Set<Expression> rulesExpressions = new HashSet<>();
     protected boolean exclude;
     protected String resultVariable;
 
@@ -77,7 +77,7 @@ public class BusinessRuleTaskActivityBehavior extends TaskActivityBehavior imple
 
         Collection<Object> ruleOutputObjects = ksession.getObjects();
         if (ruleOutputObjects != null && !ruleOutputObjects.isEmpty()) {
-            Collection<Object> outputVariables = new ArrayList<Object>();
+            Collection<Object> outputVariables = new ArrayList<>();
             outputVariables.addAll(ruleOutputObjects);
             execution.setVariable(resultVariable, outputVariables);
         }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/CallActivityBehavior.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/CallActivityBehavior.java
@@ -35,14 +35,14 @@ import org.flowable.variable.service.delegate.Expression;
 
 /**
  * Implementation of the BPMN 2.0 call activity (limited currently to calling a subprocess and not (yet) a global task).
- * 
+ *
  * @author Joram Barrez
  */
 public class CallActivityBehavior extends AbstractBpmnActivityBehavior implements SubProcessActivityBehavior {
 
     protected String processDefinitonKey;
-    private List<AbstractDataAssociation> dataInputAssociations = new ArrayList<AbstractDataAssociation>();
-    private List<AbstractDataAssociation> dataOutputAssociations = new ArrayList<AbstractDataAssociation>();
+    private List<AbstractDataAssociation> dataInputAssociations = new ArrayList<>();
+    private List<AbstractDataAssociation> dataOutputAssociations = new ArrayList<>();
     private Expression processDefinitionExpression;
     protected List<MapExceptionEntry> mapExceptions;
     protected boolean inheritVariables;

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/InclusiveGatewayActivityBehavior.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/InclusiveGatewayActivityBehavior.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Implementation of the Inclusive Gateway/OR gateway/inclusive data-based gateway as defined in the BPMN specification.
- * 
+ *
  * @author Tijs Rademakers
  * @author Tom Van Buskirk
  * @author Joram Barrez
@@ -57,7 +57,7 @@ public class InclusiveGatewayActivityBehavior extends GatewayActivityBehavior {
 
             List<ActivityExecution> joinedExecutions = activityExecution.findInactiveConcurrentExecutions(activity);
             String defaultSequenceFlow = (String) activityExecution.getActivity().getProperty("default");
-            List<PvmTransition> transitionsToTake = new ArrayList<PvmTransition>();
+            List<PvmTransition> transitionsToTake = new ArrayList<>();
 
             for (PvmTransition outgoingTransition : activityExecution.getActivity().getOutgoingTransitions()) {
 
@@ -104,7 +104,7 @@ public class InclusiveGatewayActivityBehavior extends GatewayActivityBehavior {
     }
 
     List<? extends ActivityExecution> getLeaveExecutions(ActivityExecution parent) {
-        List<ActivityExecution> executionlist = new ArrayList<ActivityExecution>();
+        List<ActivityExecution> executionlist = new ArrayList<>();
         List<? extends ActivityExecution> subExecutions = parent.getExecutions();
         if (subExecutions.isEmpty()) {
             executionlist.add(parent);
@@ -149,7 +149,7 @@ public class InclusiveGatewayActivityBehavior extends GatewayActivityBehavior {
     }
 
     protected boolean isReachable(PvmActivity srcActivity,
-            PvmActivity targetActivity, Set<PvmActivity> visitedActivities) {
+                                  PvmActivity targetActivity, Set<PvmActivity> visitedActivities) {
 
         // if source has no outputs, it is the end of the process, and its parent process should be checked.
         if (srcActivity.getOutgoingTransitions().isEmpty()) {

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/MailActivityBehavior.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/MailActivityBehavior.java
@@ -50,7 +50,7 @@ public class MailActivityBehavior extends AbstractBpmnActivityBehavior {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MailActivityBehavior.class);
 
-    private static final Class<?>[] ALLOWED_ATT_TYPES = new Class<?>[] {
+    private static final Class<?>[] ALLOWED_ATT_TYPES = new Class<?>[]{
             File.class, File[].class, String.class, String[].class, DataSource.class, DataSource[].class
     };
 
@@ -85,8 +85,8 @@ public class MailActivityBehavior extends AbstractBpmnActivityBehavior {
             String htmlStr = htmlVar == null ? getStringFromField(html, execution)
                     : getStringFromField(getExpression(execution, htmlVar), execution);
             String charSetStr = getStringFromField(charset, execution);
-            List<File> files = new LinkedList<File>();
-            List<DataSource> dataSources = new LinkedList<DataSource>();
+            List<File> files = new LinkedList<>();
+            List<DataSource> dataSources = new LinkedList<>();
             getFilesFromFields(attachments, execution, files, dataSources);
 
             email = createEmail(textStr, htmlStr, attachmentsExist(files, dataSources));
@@ -365,7 +365,7 @@ public class MailActivityBehavior extends AbstractBpmnActivityBehavior {
                 }
             }
         }
-        for (Iterator<File> it = files.iterator(); it.hasNext();) {
+        for (Iterator<File> it = files.iterator(); it.hasNext(); ) {
             File file = it.next();
             if (!fileExists(file)) {
                 it.remove();

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/MultiInstanceActivityBehavior.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/MultiInstanceActivityBehavior.java
@@ -42,12 +42,12 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Implementation of the multi-instance functionality as described in the BPMN 2.0 spec.
- * 
+ * <p>
  * Multi instance functionality is implemented as an {@link ActivityBehavior} that wraps the original {@link ActivityBehavior} of the activity.
- *
+ * <p>
  * Only subclasses of {@link AbstractBpmnActivityBehavior} can have multi-instance behavior. As such, special logic is contained in the {@link AbstractBpmnActivityBehavior} to delegate to the
  * {@link MultiInstanceActivityBehavior} if needed.
- * 
+ *
  * @author Joram Barrez
  * @author Falko Menge
  */
@@ -74,8 +74,7 @@ public abstract class MultiInstanceActivityBehavior extends FlowNodeActivityBeha
 
     /**
      * @param activity
-     * @param innerActivityBehavior
-     *            The original {@link ActivityBehavior} of the activity that will be wrapped inside this behavior.
+     * @param innerActivityBehavior The original {@link ActivityBehavior} of the activity that will be wrapped inside this behavior.
      */
     public MultiInstanceActivityBehavior(ActivityImpl activity, AbstractBpmnActivityBehavior innerActivityBehavior) {
         this.activity = activity;
@@ -244,7 +243,7 @@ public abstract class MultiInstanceActivityBehavior extends FlowNodeActivityBeha
         List<ExecutionListener> listeners = activity.getExecutionListeners(org.activiti.engine.impl.pvm.PvmEvent.EVENTNAME_START);
 
         if (listeners != null) {
-            List<ExecutionListener> filteredExecutionListeners = new ArrayList<ExecutionListener>(listeners.size());
+            List<ExecutionListener> filteredExecutionListeners = new ArrayList<>(listeners.size());
             // Sad that we have to do this, but it's the only way I could find (which is also safe for backwards compatibility)
 
             for (ExecutionListener executionListener : listeners) {
@@ -269,7 +268,7 @@ public abstract class MultiInstanceActivityBehavior extends FlowNodeActivityBeha
     }
 
     protected void logLoopDetails(ActivityExecution execution, String custom, int loopCounter,
-            int nrOfCompletedInstances, int nrOfActiveInstances, int nrOfInstances) {
+                                  int nrOfCompletedInstances, int nrOfActiveInstances, int nrOfInstances) {
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Multi-instance '{}' {}. Details: loopCounter={}, nrOrCompletedInstances={},nrOfActiveInstances={},nrOfInstances={}",
                     execution.getActivity(), custom, loopCounter, nrOfCompletedInstances, nrOfActiveInstances, nrOfInstances);
@@ -337,10 +336,9 @@ public abstract class MultiInstanceActivityBehavior extends FlowNodeActivityBeha
 
     /**
      * ACT-1339. Calling ActivityEndListeners within an {@link AtomicOperation} so that an executionContext is present.
-     * 
+     *
      * @author Aris Tzoumas
      * @author Joram Barrez
-     *
      */
     private static final class CallActivityListenersOperation implements AtomicOperation {
 

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/ParallelMultiInstanceBehavior.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/ParallelMultiInstanceBehavior.java
@@ -44,7 +44,7 @@ public class ParallelMultiInstanceBehavior extends MultiInstanceActivityBehavior
         setLoopVariable(execution, NUMBER_OF_COMPLETED_INSTANCES, 0);
         setLoopVariable(execution, NUMBER_OF_ACTIVE_INSTANCES, nrOfInstances);
 
-        List<ActivityExecution> concurrentExecutions = new ArrayList<ActivityExecution>();
+        List<ActivityExecution> concurrentExecutions = new ArrayList<>();
         for (int loopCounter = 0; loopCounter < nrOfInstances; loopCounter++) {
             ActivityExecution concurrentExecution = execution.createExecution();
             concurrentExecution.setActive(true);
@@ -132,7 +132,7 @@ public class ParallelMultiInstanceBehavior extends MultiInstanceActivityBehavior
             if (joinedExecutions.size() >= nrOfInstances || completionConditionSatisfied(execution)) {
 
                 // Removing all active child executions (ie because completionCondition is true)
-                List<ExecutionEntity> executionsToRemove = new ArrayList<ExecutionEntity>();
+                List<ExecutionEntity> executionsToRemove = new ArrayList<>();
                 for (ActivityExecution childExecution : executionEntity.getParent().getExecutions()) {
                     if (childExecution.isActive()) {
                         executionsToRemove.add((ExecutionEntity) childExecution);

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/ShellActivityBehavior.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/ShellActivityBehavior.java
@@ -83,7 +83,7 @@ public class ShellActivityBehavior extends AbstractBpmnActivityBehavior {
         ActivityExecution activityExecution = (ActivityExecution) execution;
         readFields(activityExecution);
 
-        List<String> argList = new ArrayList<String>();
+        List<String> argList = new ArrayList<>();
         argList.add(commandStr);
 
         if (arg1Str != null)

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/TerminateEndEventActivityBehavior.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/TerminateEndEventActivityBehavior.java
@@ -188,7 +188,7 @@ public class TerminateEndEventActivityBehavior extends FlowNodeActivityBehavior 
             return;
         }
 
-        Map<String, HistoricActivityInstanceEntity> historicActivityInstancMap = new HashMap<String, HistoricActivityInstanceEntity>();
+        Map<String, HistoricActivityInstanceEntity> historicActivityInstancMap = new HashMap<>();
 
         List<HistoricActivityInstance> historicActivityInstances = new HistoricActivityInstanceQueryImpl(Context.getCommandContext())
                 .processInstanceId(processInstanceId)

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/UserTaskActivityBehavior.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/UserTaskActivityBehavior.java
@@ -12,6 +12,9 @@
  */
 package org.activiti.engine.impl.bpmn.behavior;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
@@ -40,12 +43,9 @@ import org.flowable.variable.service.delegate.Expression;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 /**
  * Activity implementation for the user task.
- * 
+ *
  * @author Joram Barrez
  */
 public class UserTaskActivityBehavior extends TaskActivityBehavior {
@@ -64,7 +64,7 @@ public class UserTaskActivityBehavior extends TaskActivityBehavior {
 
     public void execute(DelegateExecution execution) {
         ActivityExecution activityExecution = (ActivityExecution) execution;
-        
+
         Expression activeNameExpression = null;
         Expression activeDescriptionExpression = null;
         Expression activeDueDateExpression = null;
@@ -115,11 +115,11 @@ public class UserTaskActivityBehavior extends TaskActivityBehavior {
             activeCandidateUserExpressions = taskDefinition.getCandidateUserIdExpressions();
             activeCandidateGroupExpressions = taskDefinition.getCandidateGroupIdExpressions();
         }
-        
+
         Expression skipExpression = taskDefinition.getSkipExpression();
         boolean skipUserTask = SkipExpressionUtil.isSkipExpressionEnabled(activityExecution, skipExpression) &&
                 SkipExpressionUtil.shouldSkipFlowElement(activityExecution, skipExpression);
-        
+
         TaskEntity task = TaskEntity.createAndInsert(activityExecution, !skipUserTask);
         task.setExecution(execution);
 
@@ -210,7 +210,7 @@ public class UserTaskActivityBehavior extends TaskActivityBehavior {
         if (!skipUserTask) {
             handleAssignments(activeAssigneeExpression, activeOwnerExpression, activeCandidateUserExpressions,
                     activeCandidateGroupExpressions, task, activityExecution);
-            
+
             task.fireEvent(TaskListener.EVENTNAME_CREATE);
 
             // All properties set, now firing 'create' events
@@ -231,9 +231,9 @@ public class UserTaskActivityBehavior extends TaskActivityBehavior {
         leave(execution);
     }
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @SuppressWarnings({"unchecked", "rawtypes"})
     protected void handleAssignments(Expression assigneeExpression, Expression ownerExpression, Set<Expression> candidateUserExpressions,
-            Set<Expression> candidateGroupExpressions, TaskEntity task, ActivityExecution execution) {
+                                     Set<Expression> candidateGroupExpressions, TaskEntity task, ActivityExecution execution) {
 
         if (assigneeExpression != null) {
             Object assigneeExpressionValue = assigneeExpression.getValue(execution);
@@ -328,7 +328,7 @@ public class UserTaskActivityBehavior extends TaskActivityBehavior {
 
     /**
      * Extract a candidate list from a string.
-     * 
+     *
      * @param str
      * @return
      */
@@ -360,7 +360,7 @@ public class UserTaskActivityBehavior extends TaskActivityBehavior {
                     activeValues = null;
                 } else {
                     ExpressionManager expressionManager = Context.getProcessEngineConfiguration().getExpressionManager();
-                    activeValues = new HashSet<Expression>();
+                    activeValues = new HashSet<>();
                     for (JsonNode valueNode : overrideValuesNode) {
                         activeValues.add(expressionManager.createExpression(valueNode.asText()));
                     }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/WebServiceActivityBehavior.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/WebServiceActivityBehavior.java
@@ -28,7 +28,7 @@ import org.flowable.engine.impl.bpmn.webservice.Operation;
 
 /**
  * An activity behavior that allows calling Web services
- * 
+ *
  * @author Esteban Robles Luna
  * @author Falko Menge
  * @author Joram Barrez
@@ -46,8 +46,8 @@ public class WebServiceActivityBehavior extends AbstractBpmnActivityBehavior {
     protected List<AbstractDataAssociation> dataOutputAssociations;
 
     public WebServiceActivityBehavior() {
-        this.dataInputAssociations = new ArrayList<AbstractDataAssociation>();
-        this.dataOutputAssociations = new ArrayList<AbstractDataAssociation>();
+        this.dataInputAssociations = new ArrayList<>();
+        this.dataOutputAssociations = new ArrayList<>();
     }
 
     public void addDataInputAssociation(AbstractDataAssociation dataAssociation) {

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/deployer/BpmnDeployer.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/deployer/BpmnDeployer.java
@@ -12,6 +12,10 @@
  */
 package org.activiti.engine.impl.bpmn.deployer;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -74,10 +78,6 @@ import org.flowable.variable.service.delegate.Expression;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 /**
  * @author Tom Baeyens
  * @author Joram Barrez
@@ -86,8 +86,8 @@ public class BpmnDeployer implements Deployer {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BpmnDeployer.class);
 
-    public static final String[] BPMN_RESOURCE_SUFFIXES = new String[] { "bpmn20.xml", "bpmn" };
-    public static final String[] DIAGRAM_SUFFIXES = new String[] { "png", "jpg", "gif", "svg" };
+    public static final String[] BPMN_RESOURCE_SUFFIXES = new String[]{"bpmn20.xml", "bpmn"};
+    public static final String[] DIAGRAM_SUFFIXES = new String[]{"png", "jpg", "gif", "svg"};
 
     protected ExpressionManager expressionManager;
     protected BpmnParser bpmnParser;
@@ -96,9 +96,9 @@ public class BpmnDeployer implements Deployer {
     public void deploy(DeploymentEntity deployment, Map<String, Object> deploymentSettings) {
         LOGGER.debug("Processing deployment {}", deployment.getName());
 
-        List<ProcessDefinitionEntity> processDefinitions = new ArrayList<ProcessDefinitionEntity>();
+        List<ProcessDefinitionEntity> processDefinitions = new ArrayList<>();
         Map<String, ResourceEntity> resources = deployment.getResources();
-        Map<String, BpmnModel> bpmnModelMap = new HashMap<String, BpmnModel>();
+        Map<String, BpmnModel> bpmnModelMap = new HashMap<>();
 
         final ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
         for (String resourceName : resources.keySet()) {
@@ -174,7 +174,7 @@ public class BpmnDeployer implements Deployer {
         }
 
         // check if there are process definitions with the same process key to prevent database unique index violation
-        List<String> keyList = new ArrayList<String>();
+        List<String> keyList = new ArrayList<>();
         for (ProcessDefinitionEntity processDefinition : processDefinitions) {
             if (keyList.contains(processDefinition.getKey())) {
                 throw new ActivitiException("The deployment contains process definitions with the same key '" + processDefinition.getKey() + "' (process id attribute), this is not allowed");
@@ -186,7 +186,7 @@ public class BpmnDeployer implements Deployer {
         ProcessDefinitionEntityManager processDefinitionManager = commandContext.getProcessDefinitionEntityManager();
         DbSqlSession dbSqlSession = commandContext.getSession(DbSqlSession.class);
         for (ProcessDefinitionEntity processDefinition : processDefinitions) {
-            List<TimerJobEntity> timers = new ArrayList<TimerJobEntity>();
+            List<TimerJobEntity> timers = new ArrayList<>();
             if (deployment.isNew()) {
                 int processDefinitionVersion;
 
@@ -273,7 +273,7 @@ public class BpmnDeployer implements Deployer {
     }
 
     protected void addProcessDefinitionToCache(ProcessDefinitionEntity processDefinition, Map<String, BpmnModel> bpmnModelMap,
-            ProcessEngineConfigurationImpl processEngineConfiguration, CommandContext commandContext) {
+                                               ProcessEngineConfigurationImpl processEngineConfiguration, CommandContext commandContext) {
 
         // Add to cache
         DeploymentManager deploymentManager = processEngineConfiguration.getDeploymentManager();
@@ -285,7 +285,7 @@ public class BpmnDeployer implements Deployer {
     }
 
     protected void addDefinitionInfoToCache(ProcessDefinitionEntity processDefinition,
-            ProcessEngineConfigurationImpl processEngineConfiguration, CommandContext commandContext) {
+                                            ProcessEngineConfigurationImpl processEngineConfiguration, CommandContext commandContext) {
 
         if (!processEngineConfiguration.isEnableProcessDefinitionInfoCache()) {
             return;
@@ -393,7 +393,7 @@ public class BpmnDeployer implements Deployer {
         List<EventSubscriptionDeclaration> eventDefinitions = (List<EventSubscriptionDeclaration>) processDefinition.getProperty(BpmnParse.PROPERTYNAME_EVENT_SUBSCRIPTION_DECLARATION);
         if (eventDefinitions != null) {
 
-            Set<String> messageNames = new HashSet<String>();
+            Set<String> messageNames = new HashSet<>();
             for (EventSubscriptionDeclaration eventDefinition : eventDefinitions) {
                 if (eventDefinition.getEventType().equals("message") && eventDefinition.isStartEvent()) {
 
@@ -673,15 +673,15 @@ public class BpmnDeployer implements Deployer {
 
     /**
      * Returns the default name of the image resource for a certain process.
-     * 
+     * <p>
      * It will first look for an image resource which matches the process specifically, before resorting to an image resource which matches the BPMN 2.0 xml file resource.
-     * 
+     * <p>
      * Example: if the deployment contains a BPMN 2.0 xml resource called 'abc.bpmn20.xml' containing only one process with key 'myProcess', then this method will look for an image resources called
      * 'abc.myProcess.png' (or .jpg, or .gif, etc.) or 'abc.png' if the previous one wasn't found.
-     * 
+     * <p>
      * Example 2: if the deployment contains a BPMN 2.0 xml resource called 'abc.bpmn20.xml' containing three processes (with keys a, b and c), then this method will first look for an image resource
      * called 'abc.a.png' before looking for 'abc.png' (likewise for b and c). Note that if abc.a.png, abc.b.png and abc.c.png don't exist, all processes will have the same image: abc.png.
-     * 
+     *
      * @return null if no matching image resource is found.
      */
     protected String getDiagramResourceForProcess(String bpmnFileResource, String processKey, Map<String, ResourceEntity> resources) {

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/diagram/Bpmn20NamespaceContext.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/diagram/Bpmn20NamespaceContext.java
@@ -25,9 +25,9 @@ import javax.xml.xpath.XPath;
 
 /**
  * XML {@link NamespaceContext} containing the namespaces used by BPMN 2.0 XML documents.
- *
+ * <p>
  * Can be used in {@link XPath#setNamespaceContext(NamespaceContext)}.
- * 
+ *
  * @author Falko Menge
  */
 public class Bpmn20NamespaceContext implements NamespaceContext {
@@ -40,7 +40,7 @@ public class Bpmn20NamespaceContext implements NamespaceContext {
     /**
      * This is a protected filed so you can extend that context with your own namespaces if necessary
      */
-    protected Map<String, String> namespaceUris = new HashMap<String, String>();
+    protected Map<String, String> namespaceUris = new HashMap<>();
 
     public Bpmn20NamespaceContext() {
         namespaceUris.put(BPMN, "http://www.omg.org/spec/BPMN/20100524/MODEL");
@@ -62,7 +62,7 @@ public class Bpmn20NamespaceContext implements NamespaceContext {
     }
 
     private static <T, E> Set<T> getKeysByValue(Map<T, E> map, E value) {
-        Set<T> keys = new HashSet<T>();
+        Set<T> keys = new HashSet<>();
         for (Entry<T, E> entry : map.entrySet()) {
             if (value.equals(entry.getValue())) {
                 keys.add(entry.getKey());

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/diagram/ProcessDiagramLayoutFactory.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/diagram/ProcessDiagramLayoutFactory.java
@@ -51,13 +51,11 @@ public class ProcessDiagramLayoutFactory {
 
     /**
      * Provides positions and dimensions of elements in a process diagram as provided by {@link RepositoryService#getProcessDiagram(String)}.
-     *
+     * <p>
      * Currently, it only supports BPMN 2.0 models.
      *
-     * @param bpmnXmlStream
-     *            BPMN 2.0 XML file
-     * @param imageStream
-     *            BPMN 2.0 diagram in PNG format (JPEG and other formats supported by {@link ImageIO} may also work)
+     * @param bpmnXmlStream BPMN 2.0 XML file
+     * @param imageStream   BPMN 2.0 diagram in PNG format (JPEG and other formats supported by {@link ImageIO} may also work)
      * @return Layout of the process diagram; null when parameter imageStream is null
      */
     public DiagramLayout getProcessDiagramLayout(InputStream bpmnXmlStream, InputStream imageStream) {
@@ -68,10 +66,8 @@ public class ProcessDiagramLayoutFactory {
     /**
      * Provides positions and dimensions of elements in a BPMN process diagram as provided by {@link RepositoryService#getProcessDiagram(String)}.
      *
-     * @param bpmnModel
-     *            BPMN 2.0 XML document
-     * @param imageStream
-     *            BPMN 2.0 diagram in PNG format (JPEG and other formats supported by {@link ImageIO} may also work)
+     * @param bpmnModel   BPMN 2.0 XML document
+     * @param imageStream BPMN 2.0 diagram in PNG format (JPEG and other formats supported by {@link ImageIO} may also work)
      * @return Layout of the process diagram; null when parameter imageStream is null
      */
     public DiagramLayout getBpmnProcessDiagramLayout(Document bpmnModel, InputStream imageStream) {
@@ -88,7 +84,7 @@ public class ProcessDiagramLayoutFactory {
             diagramBoundsImage = getDiagramBoundsFromImage(imageStream);
         }
 
-        Map<String, DiagramNode> listOfBounds = new HashMap<String, DiagramNode>();
+        Map<String, DiagramNode> listOfBounds = new HashMap<>();
         listOfBounds.put(diagramBoundsXml.getId(), diagramBoundsXml);
         // listOfBounds.putAll(getElementBoundsFromBpmnDi(bpmnModel));
         listOfBounds.putAll(fixFlowNodePositionsIfModelFromAdonis(bpmnModel, getElementBoundsFromBpmnDi(bpmnModel)));
@@ -198,8 +194,8 @@ public class ProcessDiagramLayoutFactory {
         int width = image.getWidth();
         int height = image.getHeight();
 
-        Map<Integer, Boolean> rowIsWhite = new TreeMap<Integer, Boolean>();
-        Map<Integer, Boolean> columnIsWhite = new TreeMap<Integer, Boolean>();
+        Map<Integer, Boolean> rowIsWhite = new TreeMap<>();
+        Map<Integer, Boolean> columnIsWhite = new TreeMap<>();
 
         for (int row = 0; row < height; row++) {
             if (!rowIsWhite.containsKey(row)) {
@@ -274,7 +270,7 @@ public class ProcessDiagramLayoutFactory {
     }
 
     protected Map<String, DiagramNode> getElementBoundsFromBpmnDi(Document bpmnModel) {
-        Map<String, DiagramNode> listOfBounds = new HashMap<String, DiagramNode>();
+        Map<String, DiagramNode> listOfBounds = new HashMap<>();
         // iterate over all DI shapes
         NodeList shapes = bpmnModel.getElementsByTagNameNS(BpmnParser.BPMN_DI_NS, "BPMNShape");
         for (int i = 0; i < shapes.getLength(); i++) {
@@ -307,7 +303,7 @@ public class ProcessDiagramLayoutFactory {
     }
 
     protected Map<String, DiagramElement> transformBoundsForImage(DiagramNode diagramBoundsImage, DiagramNode diagramBoundsXml, Map<String, DiagramNode> listOfBounds) {
-        Map<String, DiagramElement> listOfBoundsForImage = new HashMap<String, DiagramElement>();
+        Map<String, DiagramElement> listOfBoundsForImage = new HashMap<>();
         for (Entry<String, DiagramNode> bounds : listOfBounds.entrySet()) {
             listOfBoundsForImage.put(bounds.getKey(), transformBoundsForImage(diagramBoundsImage, diagramBoundsXml, bounds.getValue()));
         }
@@ -328,7 +324,7 @@ public class ProcessDiagramLayoutFactory {
 
     protected Map<String, DiagramNode> fixFlowNodePositionsIfModelFromAdonis(Document bpmnModel, Map<String, DiagramNode> elementBoundsFromBpmnDi) {
         if (isExportedFromAdonis50(bpmnModel)) {
-            Map<String, DiagramNode> mapOfFixedBounds = new HashMap<String, DiagramNode>();
+            Map<String, DiagramNode> mapOfFixedBounds = new HashMap<>();
             XPathFactory xPathFactory = XPathFactory.newInstance();
             XPath xPath = xPathFactory.newXPath();
             xPath.setNamespaceContext(new Bpmn20NamespaceContext());

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/BpmnParse.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/BpmnParse.java
@@ -75,7 +75,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Specific parsing of one BPMN 2.0 XML file, created by the {@link BpmnParser}.
- * 
+ *
  * @author Tijs Rademakers
  * @author Joram Barrez
  */
@@ -107,13 +107,19 @@ public class BpmnParse implements BpmnXMLConstants {
 
     protected String targetNamespace;
 
-    /** The deployment to which the parsed process definitions will be added. */
+    /**
+     * The deployment to which the parsed process definitions will be added.
+     */
     protected DeploymentEntity deployment;
 
-    /** The end result of the parsing: a list of process definition. */
-    protected List<ProcessDefinitionEntity> processDefinitions = new ArrayList<ProcessDefinitionEntity>();
+    /**
+     * The end result of the parsing: a list of process definition.
+     */
+    protected List<ProcessDefinitionEntity> processDefinitions = new ArrayList<>();
 
-    /** A map for storing sequence flow based on their id during parsing. */
+    /**
+     * A map for storing sequence flow based on their id during parsing.
+     */
     protected Map<String, TransitionImpl> sequenceFlows;
 
     protected BpmnParseHandlers bpmnParserHandlers;
@@ -124,24 +130,24 @@ public class BpmnParse implements BpmnXMLConstants {
 
     protected ActivityImpl currentActivity;
 
-    protected LinkedList<SubProcess> currentSubprocessStack = new LinkedList<SubProcess>();
+    protected LinkedList<SubProcess> currentSubprocessStack = new LinkedList<>();
 
-    protected LinkedList<ScopeImpl> currentScopeStack = new LinkedList<ScopeImpl>();
+    protected LinkedList<ScopeImpl> currentScopeStack = new LinkedList<>();
 
     /**
      * Mapping containing values stored during the first phase of parsing since other elements can reference these messages.
-     * 
+     * <p>
      * All the map's elements are defined outside the process definition(s), which means that this map doesn't need to be re-initialized for each new process definition.
      */
-    protected Map<String, MessageDefinition> messages = new HashMap<String, MessageDefinition>();
-    protected Map<String, StructureDefinition> structures = new HashMap<String, StructureDefinition>();
-    protected Map<String, BpmnInterfaceImplementation> interfaceImplementations = new HashMap<String, BpmnInterfaceImplementation>();
-    protected Map<String, OperationImplementation> operationImplementations = new HashMap<String, OperationImplementation>();
-    protected Map<String, ItemDefinition> itemDefinitions = new HashMap<String, ItemDefinition>();
-    protected Map<String, BpmnInterface> bpmnInterfaces = new HashMap<String, BpmnInterface>();
-    protected Map<String, Operation> operations = new HashMap<String, Operation>();
-    protected Map<String, XMLImporter> importers = new HashMap<String, XMLImporter>();
-    protected Map<String, String> prefixs = new HashMap<String, String>();
+    protected Map<String, MessageDefinition> messages = new HashMap<>();
+    protected Map<String, StructureDefinition> structures = new HashMap<>();
+    protected Map<String, BpmnInterfaceImplementation> interfaceImplementations = new HashMap<>();
+    protected Map<String, OperationImplementation> operationImplementations = new HashMap<>();
+    protected Map<String, ItemDefinition> itemDefinitions = new HashMap<>();
+    protected Map<String, BpmnInterface> bpmnInterfaces = new HashMap<>();
+    protected Map<String, Operation> operations = new HashMap<>();
+    protected Map<String, XMLImporter> importers = new HashMap<>();
+    protected Map<String, String> prefixs = new HashMap<>();
 
     // Factories
     protected ExpressionManager expressionManager;
@@ -398,7 +404,7 @@ public class BpmnParse implements BpmnXMLConstants {
      * Parses the 'definitions' root element
      */
     protected void transformProcessDefinitions() {
-        sequenceFlows = new HashMap<String, TransitionImpl>();
+        sequenceFlows = new HashMap<>();
         for (Process process : bpmnModel.getProcesses()) {
             if (process.isExecutable()) {
                 bpmnParserHandlers.parseElement(this, process);
@@ -417,11 +423,11 @@ public class BpmnParse implements BpmnXMLConstants {
         // certain type.
 
         // Using lists as we want to keep the order in which they are defined
-        List<SequenceFlow> sequenceFlowToParse = new ArrayList<SequenceFlow>();
-        List<BoundaryEvent> boundaryEventsToParse = new ArrayList<BoundaryEvent>();
+        List<SequenceFlow> sequenceFlowToParse = new ArrayList<>();
+        List<BoundaryEvent> boundaryEventsToParse = new ArrayList<>();
 
         // Flow elements that depend on other elements are parse after the first run-through
-        List<FlowElement> defferedFlowElementsToParse = new ArrayList<FlowElement>();
+        List<FlowElement> defferedFlowElementsToParse = new ArrayList<>();
 
         // Activities are parsed first
         for (FlowElement flowElement : flowElements) {
@@ -538,7 +544,7 @@ public class BpmnParse implements BpmnXMLConstants {
         FlowElement flowElement = bpmnModel.getFlowElement(key);
         if (flowElement != null && sequenceFlows.containsKey(key)) {
             TransitionImpl sequenceFlow = sequenceFlows.get(key);
-            List<Integer> waypoints = new ArrayList<Integer>();
+            List<Integer> waypoints = new ArrayList<>();
             for (GraphicInfo waypointInfo : graphicList) {
                 waypoints.add((int) waypointInfo.getX());
                 waypoints.add((int) waypointInfo.getY());

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/BpmnParseHandlers.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/BpmnParseHandlers.java
@@ -33,7 +33,7 @@ public class BpmnParseHandlers {
     protected Map<Class<? extends BaseElement>, List<BpmnParseHandler>> parseHandlers;
 
     public BpmnParseHandlers() {
-        this.parseHandlers = new HashMap<Class<? extends BaseElement>, List<BpmnParseHandler>>();
+        this.parseHandlers = new HashMap<>();
     }
 
     public List<BpmnParseHandler> getHandlersFor(Class<? extends BaseElement> clazz) {
@@ -50,7 +50,7 @@ public class BpmnParseHandlers {
         for (Class<? extends BaseElement> type : bpmnParseHandler.getHandledTypes()) {
             List<BpmnParseHandler> handlers = parseHandlers.get(type);
             if (handlers == null) {
-                handlers = new ArrayList<BpmnParseHandler>();
+                handlers = new ArrayList<>();
                 parseHandlers.put(type, handlers);
             }
             handlers.add(bpmnParseHandler);

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/factory/AbstractBehaviorFactory.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/factory/AbstractBehaviorFactory.java
@@ -30,7 +30,7 @@ public abstract class AbstractBehaviorFactory {
     protected ExpressionManager expressionManager;
 
     public List<FieldDeclaration> createFieldDeclarations(List<FieldExtension> fieldList) {
-        List<FieldDeclaration> fieldDeclarations = new ArrayList<FieldDeclaration>();
+        List<FieldDeclaration> fieldDeclarations = new ArrayList<>();
 
         for (FieldExtension fieldExtension : fieldList) {
             FieldDeclaration fieldDeclaration = null;

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/factory/DefaultListenerFactory.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/factory/DefaultListenerFactory.java
@@ -45,12 +45,13 @@ import org.flowable.job.service.Job;
 
 /**
  * Default implementation of the {@link ListenerFactory}. Used when no custom {@link ListenerFactory} is injected on the {@link ProcessEngineConfigurationImpl}.
- * 
+ *
  * @author Joram Barrez
  */
 public class DefaultListenerFactory extends AbstractBehaviorFactory implements ListenerFactory {
 
-    public static final Map<String, Class<?>> ENTITY_MAPPING = new HashMap<String, Class<?>>();
+    public static final Map<String, Class<?>> ENTITY_MAPPING = new HashMap<>();
+
     static {
         ENTITY_MAPPING.put("attachment", Attachment.class);
         ENTITY_MAPPING.put("comment", Comment.class);
@@ -128,11 +129,9 @@ public class DefaultListenerFactory extends AbstractBehaviorFactory implements L
     }
 
     /**
-     * @param entityType
-     *            the name of the entity
+     * @param entityType the name of the entity
      * @return
-     * @throws ActivitiIllegalArgumentException
-     *             when the given entity name
+     * @throws ActivitiIllegalArgumentException when the given entity name
      */
     protected Class<?> getEntityType(String entityType) {
         if (entityType != null) {

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/handler/AbstractBpmnParseHandler.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/handler/AbstractBpmnParseHandler.java
@@ -65,7 +65,7 @@ public abstract class AbstractBpmnParseHandler<T extends BaseElement> implements
     public static final String PROPERTYNAME_TIMER_DECLARATION = "timerDeclarations";
 
     public Set<Class<? extends BaseElement>> getHandledTypes() {
-        Set<Class<? extends BaseElement>> types = new HashSet<Class<? extends BaseElement>>();
+        Set<Class<? extends BaseElement>> types = new HashSet<>();
         types.add(getHandledType());
         return types;
     }
@@ -141,7 +141,7 @@ public abstract class AbstractBpmnParseHandler<T extends BaseElement> implements
     protected void addEventSubscriptionDeclaration(BpmnParse bpmnParse, EventSubscriptionDeclaration subscription, EventDefinition parsedEventDefinition, ScopeImpl scope) {
         List<EventSubscriptionDeclaration> eventDefinitions = (List<EventSubscriptionDeclaration>) scope.getProperty(PROPERTYNAME_EVENT_SUBSCRIPTION_DECLARATION);
         if (eventDefinitions == null) {
-            eventDefinitions = new ArrayList<EventSubscriptionDeclaration>();
+            eventDefinitions = new ArrayList<>();
             scope.setProperty(PROPERTYNAME_EVENT_SUBSCRIPTION_DECLARATION, eventDefinitions);
         } else {
             // if this is a message event, validate that it is the only one with the provided name for this scope
@@ -151,7 +151,7 @@ public abstract class AbstractBpmnParseHandler<T extends BaseElement> implements
                             && eventDefinition.getEventName().equals(subscription.getEventName())
                             && eventDefinition.isStartEvent() == subscription.isStartEvent()) {
 
-                        LOGGER.warn("Cannot have more than one message event subscription with name '{}' for scope '{}'", subscription.getEventName(), scope                                .getId());
+                        LOGGER.warn("Cannot have more than one message event subscription with name '{}' for scope '{}'", subscription.getEventName(), scope.getId());
                     }
                 }
             }
@@ -241,7 +241,7 @@ public abstract class AbstractBpmnParseHandler<T extends BaseElement> implements
     }
 
     protected Map<String, Object> processDataObjects(BpmnParse bpmnParse, Collection<ValuedDataObject> dataObjects, ScopeImpl scope) {
-        Map<String, Object> variablesMap = new HashMap<String, Object>();
+        Map<String, Object> variablesMap = new HashMap<>();
         // convert data objects to process variables
         if (dataObjects != null) {
             for (ValuedDataObject dataObject : dataObjects) {

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/handler/ErrorEventDefinitionParseHandler.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/handler/ErrorEventDefinitionParseHandler.java
@@ -79,7 +79,7 @@ public class ErrorEventDefinitionParseHandler extends AbstractBpmnParseHandler<E
     }
 
     public void createBoundaryErrorEventDefinition(ErrorEventDefinition errorEventDefinition, boolean interrupting,
-            ActivityImpl activity, ActivityImpl nestedErrorEventActivity) {
+                                                   ActivityImpl activity, ActivityImpl nestedErrorEventActivity) {
 
         nestedErrorEventActivity.setProperty("type", "boundaryError");
         ScopeImpl catchingScope = nestedErrorEventActivity.getParent();
@@ -96,7 +96,7 @@ public class ErrorEventDefinitionParseHandler extends AbstractBpmnParseHandler<E
     protected void addErrorEventDefinition(org.activiti.engine.impl.bpmn.parser.ErrorEventDefinition errorEventDefinition, ScopeImpl catchingScope) {
         List<org.activiti.engine.impl.bpmn.parser.ErrorEventDefinition> errorEventDefinitions = (List<org.activiti.engine.impl.bpmn.parser.ErrorEventDefinition>) catchingScope.getProperty(PROPERTYNAME_ERROR_EVENT_DEFINITIONS);
         if (errorEventDefinitions == null) {
-            errorEventDefinitions = new ArrayList<org.activiti.engine.impl.bpmn.parser.ErrorEventDefinition>();
+            errorEventDefinitions = new ArrayList<>();
             catchingScope.setProperty(PROPERTYNAME_ERROR_EVENT_DEFINITIONS, errorEventDefinitions);
         }
         errorEventDefinitions.add(errorEventDefinition);

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/handler/TimerEventDefinitionParseHandler.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/handler/TimerEventDefinitionParseHandler.java
@@ -70,7 +70,7 @@ public class TimerEventDefinitionParseHandler extends AbstractBpmnParseHandler<T
 
             List<TimerDeclarationImpl> timerDeclarations = (List<TimerDeclarationImpl>) processDefinition.getProperty(PROPERTYNAME_START_TIMER);
             if (timerDeclarations == null) {
-                timerDeclarations = new ArrayList<TimerDeclarationImpl>();
+                timerDeclarations = new ArrayList<>();
                 processDefinition.setProperty(PROPERTYNAME_START_TIMER, timerDeclarations);
             }
             timerDeclarations.add(timerDeclaration);
@@ -165,7 +165,7 @@ public class TimerEventDefinitionParseHandler extends AbstractBpmnParseHandler<T
     protected void addTimerDeclaration(ScopeImpl scope, TimerDeclarationImpl timerDeclaration) {
         List<TimerDeclarationImpl> timerDeclarations = (List<TimerDeclarationImpl>) scope.getProperty(PROPERTYNAME_TIMER_DECLARATION);
         if (timerDeclarations == null) {
-            timerDeclarations = new ArrayList<TimerDeclarationImpl>();
+            timerDeclarations = new ArrayList<>();
             scope.setProperty(PROPERTYNAME_TIMER_DECLARATION, timerDeclarations);
         }
         timerDeclarations.add(timerDeclaration);

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/handler/UserTaskParseHandler.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/handler/UserTaskParseHandler.java
@@ -120,7 +120,7 @@ public class UserTaskParseHandler extends AbstractActivityBpmnParseHandler<UserT
 
         // CustomUserIdentityLinks
         for (String customUserIdentityLinkType : userTask.getCustomUserIdentityLinks().keySet()) {
-            Set<Expression> userIdentityLinkExpression = new HashSet<Expression>();
+            Set<Expression> userIdentityLinkExpression = new HashSet<>();
             for (String userIdentityLink : userTask.getCustomUserIdentityLinks().get(customUserIdentityLinkType)) {
                 userIdentityLinkExpression.add(expressionManager.createExpression(userIdentityLink));
             }
@@ -129,7 +129,7 @@ public class UserTaskParseHandler extends AbstractActivityBpmnParseHandler<UserT
 
         // CustomGroupIdentityLinks
         for (String customGroupIdentityLinkType : userTask.getCustomGroupIdentityLinks().keySet()) {
-            Set<Expression> groupIdentityLinkExpression = new HashSet<Expression>();
+            Set<Expression> groupIdentityLinkExpression = new HashSet<>();
             for (String groupIdentityLink : userTask.getCustomGroupIdentityLinks().get(customGroupIdentityLinkType)) {
                 groupIdentityLinkExpression.add(expressionManager.createExpression(groupIdentityLink));
             }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -13,6 +13,8 @@
 
 package org.activiti.engine.impl.cfg;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
@@ -237,8 +239,6 @@ import org.flowable.variable.service.impl.types.VariableTypes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 /**
  * @author Tom Baeyens
  * @author Joram Barrez
@@ -275,13 +275,17 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     protected CommandInterceptor commandInvoker;
 
-    /** the configurable list which will be {@link #initInterceptorChain(java.util.List) processed} to build the {@link #commandExecutor} */
+    /**
+     * the configurable list which will be {@link #initInterceptorChain(java.util.List) processed} to build the {@link #commandExecutor}
+     */
     protected List<CommandInterceptor> customPreCommandInterceptors;
     protected List<CommandInterceptor> customPostCommandInterceptors;
 
     protected List<CommandInterceptor> commandInterceptors;
 
-    /** this will be initialized during the configurationComplete() */
+    /**
+     * this will be initialized during the configurationComplete()
+     */
     protected CommandExecutor commandExecutor;
 
     // SESSION FACTORIES ////////////////////////////////////////////////////////
@@ -325,7 +329,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     /**
      * The time (in milliseconds) a thread used for job execution must be kept alive before it is destroyed. Default setting is 5 seconds. Having a setting > 0 takes resources, but in the case of many
      * job executions it avoids creating new threads all the time. If 0, threads will be destroyed after they've been used for job execution.
-     * 
+     * <p>
      * (This property is only applicable when using the {@link DefaultAsyncJobExecutor}).
      */
     protected long asyncExecutorThreadKeepAliveTime = 5000L;
@@ -338,36 +342,36 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     /**
      * The queue onto which jobs will be placed before they are actually executed. Threads form the async executor threadpool will take work from this queue.
-     * 
+     * <p>
      * By default null. If null, an {@link ArrayBlockingQueue} will be created of size {@link #asyncExecutorThreadPoolQueueSize}.
-     * 
+     * <p>
      * When the queue is full, the job will be executed by the calling thread (ThreadPoolExecutor.CallerRunsPolicy())
-     * 
+     * <p>
      * (This property is only applicable when using the {@link DefaultAsyncJobExecutor}).
      */
     protected BlockingQueue<Runnable> asyncExecutorThreadPoolQueue;
 
     /**
      * The time (in seconds) that is waited to gracefully shut down the threadpool used for job execution when the a shutdown on the executor (or process engine) is requested. Default value = 60.
-     * 
+     * <p>
      * (This property is only applicable when using the {@link DefaultAsyncJobExecutor}).
      */
     protected long asyncExecutorSecondsToWaitOnShutdown = 60L;
 
     /**
      * The number of timer jobs that are acquired during one query (before a job is executed, an acquirement thread fetches jobs from the database and puts them on the queue).
-     * 
+     * <p>
      * Default value = 1, as this lowers the potential on optimistic locking exceptions. Change this value if you know what you are doing.
-     * 
+     * <p>
      * (This property is only applicable when using the {@link DefaultAsyncJobExecutor}).
      */
     protected int asyncExecutorMaxTimerJobsPerAcquisition = 1;
 
     /**
      * The number of async jobs that are acquired during one query (before a job is executed, an acquirement thread fetches jobs from the database and puts them on the queue).
-     * 
+     * <p>
      * Default value = 1, as this lowers the potential on optimistic locking exceptions. Change this value if you know what you are doing.
-     * 
+     * <p>
      * (This property is only applicable when using the {@link DefaultAsyncJobExecutor}).
      */
     protected int asyncExecutorMaxAsyncJobsDuePerAcquisition = 1;
@@ -375,7 +379,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     /**
      * The time (in milliseconds) the timer acquisition thread will wait to execute the next acquirement query. This happens when no new timer jobs were found or when less timer jobs have been fetched
      * than set in {@link #asyncExecutorMaxTimerJobsPerAcquisition}. Default value = 10 seconds.
-     * 
+     * <p>
      * (This property is only applicable when using the {@link DefaultAsyncJobExecutor}).
      */
     protected int asyncExecutorDefaultTimerJobAcquireWaitTime = 10 * 1000;
@@ -383,7 +387,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     /**
      * The time (in milliseconds) the async job acquisition thread will wait to execute the next acquirement query. This happens when no new async jobs were found or when less async jobs have been
      * fetched than set in {@link #asyncExecutorMaxAsyncJobsDuePerAcquisition}. Default value = 10 seconds.
-     * 
+     * <p>
      * (This property is only applicable when using the {@link DefaultAsyncJobExecutor}).
      */
     protected int asyncExecutorDefaultAsyncJobAcquireWaitTime = 10 * 1000;
@@ -396,38 +400,38 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     /**
      * When a job is acquired, it is locked so other async executors can't lock and execute it. While doing this, the 'name' of the lock owner is written into a column of the job.
-     * 
+     * <p>
      * By default, a random UUID will be generated when the executor is created.
-     * 
+     * <p>
      * It is important that each async executor instance in a cluster of Activiti engines has a different name!
-     * 
+     * <p>
      * (This property is only applicable when using the {@link DefaultAsyncJobExecutor}).
      */
     protected String asyncExecutorLockOwner;
 
     /**
      * The amount of time (in milliseconds) a timer job is locked when acquired by the async executor. During this period of time, no other async executor will try to acquire and lock this job.
-     * 
+     * <p>
      * Default value = 5 minutes;
-     * 
+     * <p>
      * (This property is only applicable when using the {@link DefaultAsyncJobExecutor}).
      */
     protected int asyncExecutorTimerLockTimeInMillis = 5 * 60 * 1000;
 
     /**
      * The amount of time (in milliseconds) an async job is locked when acquired by the async executor. During this period of time, no other async executor will try to acquire and lock this job.
-     * 
+     * <p>
      * Default value = 5 minutes;
-     * 
+     * <p>
      * (This property is only applicable when using the {@link DefaultAsyncJobExecutor}).
      */
     protected int asyncExecutorAsyncJobLockTimeInMillis = 5 * 60 * 1000;
 
     /**
      * The amount of time (in milliseconds) that is waited before trying locking again, when an exclusive job is tried to be locked, but fails and the locking.
-     * 
+     * <p>
      * Default value = 500. If 0, this would stress database traffic a lot in case when a retry is needed, as exclusive jobs would be constantly tried to be locked.
-     * 
+     * <p>
      * (This property is only applicable when using the {@link DefaultAsyncJobExecutor}).
      */
     protected int asyncExecutorLockRetryWaitTimeInMillis = 500;
@@ -482,7 +486,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     protected int historicProcessInstancesQueryLimit = 20000;
 
     protected String wsSyncFactoryClassName = DEFAULT_WS_SYNC_FACTORY;
-    protected ConcurrentMap<QName, URL> wsOverridenEndpointAddresses = new ConcurrentHashMap<QName, URL>();
+    protected ConcurrentMap<QName, URL> wsOverridenEndpointAddresses = new ConcurrentHashMap<>();
 
     protected CommandContextFactory commandContextFactory;
     protected TransactionContextFactory transactionContextFactory;
@@ -498,7 +502,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     /**
      * Set this to true if you want to have extra checks on the BPMN xml that is parsed. See http://www.jorambarrez.be/blog/2013/02/19/uploading-a-funny-xml-can-bring-down-your-server/
-     * 
+     * <p>
      * Unfortunately, this feature is not available on some platforms (JDK 6, JBoss), hence the reason why it is disabled by default. If your platform allows the use of StaxSource during XML parsing,
      * do enable it.
      */
@@ -507,7 +511,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     /**
      * The following settings will determine the amount of entities loaded at once when the engine needs to load multiple entities (eg. when suspending a process definition with all its process
      * instances).
-     * 
+     * <p>
      * The default setting is quite low, as not to surprise anyone with sudden memory spikes. Change it to something higher if the environment Activiti runs in allows it.
      */
     protected int batchSizeProcessInstances = 25;
@@ -521,7 +525,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     /**
      * Some databases have a limit of how many parameters one sql insert can have (eg SQL Server, 2000 params (!= insert statements) ). Tweak this parameter in case of exceptions indicating too much
      * is being put into one bulk insert, or make it higher if your database can cope with it and there are inserts with a huge amount of data.
-     * 
+     * <p>
      * By default: 100.
      */
     protected int maxNrOfStatementsInBulkInsert = 100;
@@ -537,9 +541,9 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     /**
      * Using field injection together with a delegate expression for a service task / execution listener / task listener is not thread-sade , see user guide section 'Field Injection' for more
      * information.
-     * 
+     * <p>
      * Set this flag to false to throw an exception at runtime when a field is injected and a delegateExpression is used. Default is true for backwards compatibility.
-     * 
+     *
      * @since 5.21
      */
     protected DelegateExpressionFieldInjectionMode delegateExpressionFieldInjectionMode = DelegateExpressionFieldInjectionMode.COMPATIBILITY;
@@ -634,7 +638,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     protected void initCommandInterceptors() {
         if (commandInterceptors == null) {
-            commandInterceptors = new ArrayList<CommandInterceptor>();
+            commandInterceptors = new ArrayList<>();
             if (customPreCommandInterceptors != null) {
                 commandInterceptors.addAll(customPreCommandInterceptors);
             }
@@ -647,7 +651,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     }
 
     protected Collection<? extends CommandInterceptor> getDefaultCommandInterceptors() {
-        List<CommandInterceptor> interceptors = new ArrayList<CommandInterceptor>();
+        List<CommandInterceptor> interceptors = new ArrayList<>();
         interceptors.add(new LogInterceptor());
 
         CommandInterceptor transactionInterceptor = createTransactionInterceptor();
@@ -939,7 +943,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     protected void initSessionFactories() {
         if (sessionFactories == null) {
-            sessionFactories = new HashMap<Class<?>, SessionFactory>();
+            sessionFactories = new HashMap<>();
 
             if (dbSqlSessionFactory == null) {
                 dbSqlSessionFactory = new DbSqlSessionFactory();
@@ -999,7 +1003,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     protected void initConfigurators() {
 
-        allConfigurators = new ArrayList<ProcessEngineConfigurator>();
+        allConfigurators = new ArrayList<>();
 
         // Configurators that are explicitly added to the config
         if (configurators != null) {
@@ -1071,7 +1075,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     protected void initDeployers() {
         if (this.deployers == null) {
-            this.deployers = new ArrayList<Deployer>();
+            this.deployers = new ArrayList<>();
             if (customPreDeployers != null) {
                 this.deployers.addAll(customPreDeployers);
             }
@@ -1087,9 +1091,9 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
             // BpmnModel cache
             if (bpmnModelCache == null) {
                 if (bpmnModelCacheLimit <= 0) {
-                    bpmnModelCache = new DefaultDeploymentCache<BpmnModel>();
+                    bpmnModelCache = new DefaultDeploymentCache<>();
                 } else {
-                    bpmnModelCache = new DefaultDeploymentCache<BpmnModel>(bpmnModelCacheLimit);
+                    bpmnModelCache = new DefaultDeploymentCache<>(bpmnModelCacheLimit);
                 }
             }
 
@@ -1104,9 +1108,9 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
             // Knowledge base cache (used for Drools business task)
             if (knowledgeBaseCache == null) {
                 if (knowledgeBaseCacheLimit <= 0) {
-                    knowledgeBaseCache = new DefaultDeploymentCache<Object>();
+                    knowledgeBaseCache = new DefaultDeploymentCache<>();
                 } else {
-                    knowledgeBaseCache = new DefaultDeploymentCache<Object>(knowledgeBaseCacheLimit);
+                    knowledgeBaseCache = new DefaultDeploymentCache<>(knowledgeBaseCacheLimit);
                 }
             }
 
@@ -1118,7 +1122,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     }
 
     protected Collection<? extends Deployer> getDefaultDeployers() {
-        List<Deployer> defaultDeployers = new ArrayList<Deployer>();
+        List<Deployer> defaultDeployers = new ArrayList<>();
 
         if (bpmnDeployer == null) {
             bpmnDeployer = new BpmnDeployer();
@@ -1158,7 +1162,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         bpmnParser.setActivityBehaviorFactory(activityBehaviorFactory);
         bpmnParser.setListenerFactory(listenerFactory);
 
-        List<BpmnParseHandler> parseHandlers = new ArrayList<BpmnParseHandler>();
+        List<BpmnParseHandler> parseHandlers = new ArrayList<>();
         if (getPreBpmnParseHandlers() != null) {
             parseHandlers.addAll(getPreBpmnParseHandlers());
         }
@@ -1180,7 +1184,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     protected List<BpmnParseHandler> getDefaultBpmnParseHandlers() {
 
         // Alpabetic list of default parse handler classes
-        List<BpmnParseHandler> bpmnParserHandlers = new ArrayList<BpmnParseHandler>();
+        List<BpmnParseHandler> bpmnParserHandlers = new ArrayList<>();
         bpmnParserHandlers.add(new BoundaryEventParseHandler());
         bpmnParserHandlers.add(new BusinessRuleParseHandler());
         bpmnParserHandlers.add(new CallActivityParseHandler());
@@ -1214,7 +1218,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         // Replace any default handler if the user wants to replace them
         if (customDefaultBpmnParseHandlers != null) {
 
-            Map<Class<?>, BpmnParseHandler> customParseHandlerMap = new HashMap<Class<?>, BpmnParseHandler>();
+            Map<Class<?>, BpmnParseHandler> customParseHandlerMap = new HashMap<>();
             for (BpmnParseHandler bpmnParseHandler : customDefaultBpmnParseHandlers) {
                 for (Class<?> handledType : bpmnParseHandler.getHandledTypes()) {
                     customParseHandlerMap.put(handledType, bpmnParseHandler);
@@ -1250,7 +1254,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     }
 
     protected List<BpmnParseHandler> getDefaultHistoryParseHandlers() {
-        List<BpmnParseHandler> parseHandlers = new ArrayList<BpmnParseHandler>();
+        List<BpmnParseHandler> parseHandlers = new ArrayList<>();
         parseHandlers.add(new FlowNodeHistoryParseHandler());
         parseHandlers.add(new ProcessHistoryParseHandler());
         parseHandlers.add(new StartEventHistoryParseHandler());
@@ -1271,7 +1275,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     }
 
     protected void initJobHandlers() {
-        jobHandlers = new HashMap<String, JobHandler>();
+        jobHandlers = new HashMap<>();
         TimerExecuteNestedActivityJobHandler timerExecuteNestedActivityJobHandler = new TimerExecuteNestedActivityJobHandler();
         jobHandlers.put(timerExecuteNestedActivityJobHandler.getType(), timerExecuteNestedActivityJobHandler);
 
@@ -1371,7 +1375,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     protected void initFormEngines() {
         if (formEngines == null) {
-            formEngines = new HashMap<String, FormEngine>();
+            formEngines = new HashMap<>();
             FormEngine defaultFormEngine = new JuelFormEngine();
             formEngines.put(null, defaultFormEngine); // default form engine is looked up with null
             formEngines.put(defaultFormEngine.getName(), defaultFormEngine);
@@ -1401,7 +1405,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     protected void initScriptingEngines() {
         if (resolverFactories == null) {
-            resolverFactories = new ArrayList<ResolverFactory>();
+            resolverFactories = new ArrayList<>();
             resolverFactories.add(new VariableScopeResolverFactory());
             resolverFactories.add(new BeansResolverFactory());
         }
@@ -1435,7 +1439,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     protected void initEventHandlers() {
         if (eventHandlers == null) {
-            eventHandlers = new HashMap<String, EventHandler>();
+            eventHandlers = new HashMap<>();
 
             SignalEventHandler signalEventHander = new SignalEventHandler();
             eventHandlers.put(signalEventHander.getEventHandlerType(), signalEventHander);
@@ -1485,7 +1489,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     protected void initBeans() {
         if (beans == null) {
-            beans = new HashMap<Object, Object>();
+            beans = new HashMap<>();
         }
     }
 
@@ -1660,7 +1664,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     public ProcessEngineConfigurationImpl addConfigurator(ProcessEngineConfigurator configurator) {
         if (this.configurators == null) {
-            this.configurators = new ArrayList<ProcessEngineConfigurator>();
+            this.configurators = new ArrayList<>();
         }
         this.configurators.add(configurator);
         return this;
@@ -1726,11 +1730,9 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     /**
      * Add or replace the address of the given web-service endpoint with the given value
-     * 
-     * @param endpointName
-     *            The endpoint name for which a new address must be set
-     * @param address
-     *            The new address of the endpoint
+     *
+     * @param endpointName The endpoint name for which a new address must be set
+     * @param address      The new address of the endpoint
      */
     public ProcessEngineConfiguration addWsEndpointAddress(QName endpointName, URL address) {
         this.wsOverridenEndpointAddresses.put(endpointName, address);
@@ -1739,9 +1741,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     /**
      * Remove the address definition of the given web-service endpoint
-     * 
-     * @param endpointName
-     *            The endpoint name for which the address definition must be removed
+     *
+     * @param endpointName The endpoint name for which the address definition must be removed
      */
     public ProcessEngineConfiguration removeWsEndpointAddress(QName endpointName) {
         this.wsOverridenEndpointAddresses.remove(endpointName);

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cfg/standalone/StandaloneMybatisTransactionContext.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cfg/standalone/StandaloneMybatisTransactionContext.java
@@ -46,11 +46,11 @@ public class StandaloneMybatisTransactionContext implements TransactionContext {
 
     public void addTransactionListener(TransactionState transactionState, TransactionListener transactionListener) {
         if (stateTransactionListeners == null) {
-            stateTransactionListeners = new HashMap<TransactionState, List<TransactionListener>>();
+            stateTransactionListeners = new HashMap<>();
         }
         List<TransactionListener> transactionListeners = stateTransactionListeners.get(transactionState);
         if (transactionListeners == null) {
-            transactionListeners = new ArrayList<TransactionListener>();
+            transactionListeners = new ArrayList<>();
             stateTransactionListeners.put(transactionState, transactionListeners);
         }
         transactionListeners.add(transactionListener);
@@ -70,13 +70,11 @@ public class StandaloneMybatisTransactionContext implements TransactionContext {
 
     /**
      * Fires the event for the provided {@link TransactionState}.
-     * 
-     * @param transactionState
-     *            The {@link TransactionState} for which the listeners will be called.
-     * @param executeInNewContext
-     *            If true, the listeners will be called in a new command context. This is needed for example when firing the {@link TransactionState#COMMITTED} event: the transaction is already
-     *            committed and executing logic in the same context could lead to strange behaviour (for example doing a {@link SqlSession#update(String)} would actually roll back the update (as the
-     *            MyBatis context is already committed and the internal flags have not been correctly set).
+     *
+     * @param transactionState    The {@link TransactionState} for which the listeners will be called.
+     * @param executeInNewContext If true, the listeners will be called in a new command context. This is needed for example when firing the {@link TransactionState#COMMITTED} event: the transaction is already
+     *                            committed and executing logic in the same context could lead to strange behaviour (for example doing a {@link SqlSession#update(String)} would actually roll back the update (as the
+     *                            MyBatis context is already committed and the internal flags have not been correctly set).
      */
     protected void fireTransactionEvent(TransactionState transactionState, boolean executeInNewContext) {
         if (stateTransactionListeners == null) {

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cmd/AbstractSetProcessDefinitionStateCmd.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cmd/AbstractSetProcessDefinitionStateCmd.java
@@ -50,7 +50,7 @@ public abstract class AbstractSetProcessDefinitionStateCmd implements Command<Vo
     protected String tenantId;
 
     public AbstractSetProcessDefinitionStateCmd(ProcessDefinitionEntity processDefinitionEntity,
-            boolean includeProcessInstances, Date executionDate, String tenantId) {
+                                                boolean includeProcessInstances, Date executionDate, String tenantId) {
         this.processDefinitionEntity = processDefinitionEntity;
         this.includeProcessInstances = includeProcessInstances;
         this.executionDate = executionDate;
@@ -58,7 +58,7 @@ public abstract class AbstractSetProcessDefinitionStateCmd implements Command<Vo
     }
 
     public AbstractSetProcessDefinitionStateCmd(String processDefinitionId, String processDefinitionKey,
-            boolean includeProcessInstances, Date executionDate, String tenantId) {
+                                                boolean includeProcessInstances, Date executionDate, String tenantId) {
         this.processDefinitionId = processDefinitionId;
         this.processDefinitionKey = processDefinitionKey;
         this.includeProcessInstances = includeProcessInstances;
@@ -92,7 +92,7 @@ public abstract class AbstractSetProcessDefinitionStateCmd implements Command<Vo
             throw new ActivitiIllegalArgumentException("Process definition id or key cannot be null");
         }
 
-        List<ProcessDefinitionEntity> processDefinitionEntities = new ArrayList<ProcessDefinitionEntity>();
+        List<ProcessDefinitionEntity> processDefinitionEntities = new ArrayList<>();
         ProcessDefinitionEntityManager processDefinitionManager = commandContext.getProcessDefinitionEntityManager();
 
         if (processDefinitionId != null) {
@@ -178,7 +178,7 @@ public abstract class AbstractSetProcessDefinitionStateCmd implements Command<Vo
     }
 
     protected List<ProcessInstance> fetchProcessInstancesPage(CommandContext commandContext,
-            ProcessDefinition processDefinition, int currentPageStartIndex) {
+                                                              ProcessDefinition processDefinition, int currentPageStartIndex) {
 
         if (SuspensionState.ACTIVE.equals(getProcessDefinitionSuspensionState())) {
             return new ProcessInstanceQueryImpl(commandContext)

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cmd/CancelJobsCmd.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cmd/CancelJobsCmd.java
@@ -39,7 +39,7 @@ public class CancelJobsCmd implements Command<Void>, Serializable {
     }
 
     public CancelJobsCmd(String jobId) {
-        this.jobIds = new ArrayList<String>();
+        this.jobIds = new ArrayList<>();
         jobIds.add(jobId);
     }
 

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cmd/DeleteCommentCmd.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cmd/DeleteCommentCmd.java
@@ -51,7 +51,7 @@ public class DeleteCommentCmd implements Command<Void>, Serializable {
 
         } else {
             // Delete all comments on a task of process
-            ArrayList<Comment> comments = new ArrayList<Comment>();
+            ArrayList<Comment> comments = new ArrayList<>();
             if (processInstanceId != null) {
                 comments.addAll(commentManager.findCommentsByProcessInstanceId(processInstanceId));
             }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cmd/DeployCmd.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cmd/DeployCmd.java
@@ -50,7 +50,7 @@ public class DeployCmd<T> implements Command<Deployment>, Serializable {
 
         if (deploymentBuilder.isDuplicateFilterEnabled()) {
 
-            List<Deployment> existingDeployments = new ArrayList<Deployment>();
+            List<Deployment> existingDeployments = new ArrayList<>();
             if (deployment.getTenantId() == null || ProcessEngineConfiguration.NO_TENANT_ID.equals(deployment.getTenantId())) {
                 DeploymentEntity existingDeployment = commandContext
                         .getDeploymentEntityManager()
@@ -95,7 +95,7 @@ public class DeployCmd<T> implements Command<Deployment>, Serializable {
         }
 
         // Deployment settings
-        Map<String, Object> deploymentSettings = new HashMap<String, Object>();
+        Map<String, Object> deploymentSettings = new HashMap<>();
         deploymentSettings.put(DeploymentSettings.IS_BPMN20_XSD_VALIDATION_ENABLED, deploymentBuilder.isBpmn20XsdValidationEnabled());
         deploymentSettings.put(DeploymentSettings.IS_PROCESS_VALIDATION_ENABLED, deploymentBuilder.isProcessValidationEnabled());
 

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cmd/GetExecutionsVariablesCmd.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cmd/GetExecutionsVariablesCmd.java
@@ -45,7 +45,7 @@ public class GetExecutionsVariablesCmd implements Command<List<VariableInstance>
             throw new ActivitiIllegalArgumentException("Set of executionIds is empty");
         }
 
-        List<VariableInstance> instances = new ArrayList<VariableInstance>();
+        List<VariableInstance> instances = new ArrayList<>();
         List<VariableInstanceEntity> entities = commandContext.getVariableInstanceEntityManager().findVariableInstancesByExecutionIds(executionIds);
         for (VariableInstanceEntity entity : entities) {
             entity.getValue();

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cmd/GetPropertiesCmd.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cmd/GetPropertiesCmd.java
@@ -35,7 +35,7 @@ public class GetPropertiesCmd implements Command<Map<String, String>>, Serializa
                 .getDbSqlSession()
                 .selectList("selectProperties");
 
-        Map<String, String> properties = new HashMap<String, String>();
+        Map<String, String> properties = new HashMap<>();
         for (PropertyEntity propertyEntity : propertyEntities) {
             properties.put(propertyEntity.getName(), propertyEntity.getValue());
         }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cmd/GetTasksLocalVariablesCmd.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cmd/GetTasksLocalVariablesCmd.java
@@ -45,7 +45,7 @@ public class GetTasksLocalVariablesCmd implements Command<List<VariableInstance>
             throw new ActivitiIllegalArgumentException("Set of taskIds is empty");
         }
 
-        List<VariableInstance> instances = new ArrayList<VariableInstance>();
+        List<VariableInstance> instances = new ArrayList<>();
         List<VariableInstanceEntity> entities = commandContext.getVariableInstanceEntityManager().findVariableInstancesByTaskIds(taskIds);
         for (VariableInstanceEntity entity : entities) {
             entity.getValue();

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cmd/MessageEventReceivedCmd.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cmd/MessageEventReceivedCmd.java
@@ -45,7 +45,7 @@ public class MessageEventReceivedCmd extends NeedsActiveExecutionCmd<Void> {
             if (processVariables instanceof Serializable) {
                 this.payload = (Serializable) processVariables;
             } else {
-                this.payload = new HashMap<String, Object>(processVariables);
+                this.payload = new HashMap<>(processVariables);
             }
 
         } else {

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cmd/SignalEventReceivedCmd.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cmd/SignalEventReceivedCmd.java
@@ -45,7 +45,7 @@ public class SignalEventReceivedCmd implements Command<Void> {
             if (processVariables instanceof Serializable) {
                 this.payload = (Serializable) processVariables;
             } else {
-                this.payload = new HashMap<String, Object>(processVariables);
+                this.payload = new HashMap<>(processVariables);
             }
         } else {
             this.payload = null;

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/context/Context.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/context/Context.java
@@ -13,6 +13,8 @@
 
 package org.activiti.engine.impl.context;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -28,19 +30,17 @@ import org.activiti.engine.impl.jobexecutor.JobExecutorContext;
 import org.activiti.engine.impl.persistence.deploy.ProcessDefinitionInfoCacheObject;
 import org.activiti.engine.impl.pvm.runtime.InterpretableExecution;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 /**
  * @author Tom Baeyens
  * @author Daniel Meyer
  */
 public class Context {
 
-    protected static ThreadLocal<Stack<CommandContext>> commandContextThreadLocal = new ThreadLocal<Stack<CommandContext>>();
-    protected static ThreadLocal<Stack<ProcessEngineConfigurationImpl>> processEngineConfigurationStackThreadLocal = new ThreadLocal<Stack<ProcessEngineConfigurationImpl>>();
-    protected static ThreadLocal<Stack<ExecutionContext>> executionContextStackThreadLocal = new ThreadLocal<Stack<ExecutionContext>>();
-    protected static ThreadLocal<JobExecutorContext> jobExecutorContextThreadLocal = new ThreadLocal<JobExecutorContext>();
-    protected static ThreadLocal<Map<String, ObjectNode>> bpmnOverrideContextThreadLocal = new ThreadLocal<Map<String, ObjectNode>>();
+    protected static ThreadLocal<Stack<CommandContext>> commandContextThreadLocal = new ThreadLocal<>();
+    protected static ThreadLocal<Stack<ProcessEngineConfigurationImpl>> processEngineConfigurationStackThreadLocal = new ThreadLocal<>();
+    protected static ThreadLocal<Stack<ExecutionContext>> executionContextStackThreadLocal = new ThreadLocal<>();
+    protected static ThreadLocal<JobExecutorContext> jobExecutorContextThreadLocal = new ThreadLocal<>();
+    protected static ThreadLocal<Map<String, ObjectNode>> bpmnOverrideContextThreadLocal = new ThreadLocal<>();
     protected static ResourceBundle.Control resourceBundleControl = new ResourceBundleControl();
 
     public static CommandContext getCommandContext() {
@@ -95,7 +95,7 @@ public class Context {
     protected static <T> Stack<T> getStack(ThreadLocal<Stack<T>> threadLocal) {
         Stack<T> stack = threadLocal.get();
         if (stack == null) {
-            stack = new Stack<T>();
+            stack = new Stack<>();
             threadLocal.set(stack);
         }
         return stack;
@@ -131,7 +131,7 @@ public class Context {
                         language, id, definitionInfoNode);
 
             } else {
-                HashSet<Locale> candidateLocales = new LinkedHashSet<Locale>();
+                HashSet<Locale> candidateLocales = new LinkedHashSet<>();
                 candidateLocales.addAll(resourceBundleControl.getCandidateLocales(id, new Locale(language)));
                 candidateLocales.addAll(resourceBundleControl.getCandidateLocales(id, Locale.getDefault()));
                 for (Locale locale : candidateLocales) {
@@ -167,7 +167,7 @@ public class Context {
     protected static Map<String, ObjectNode> getBpmnOverrideContext() {
         Map<String, ObjectNode> bpmnOverrideMap = bpmnOverrideContextThreadLocal.get();
         if (bpmnOverrideMap == null) {
-            bpmnOverrideMap = new HashMap<String, ObjectNode>();
+            bpmnOverrideMap = new HashMap<>();
         }
         return bpmnOverrideMap;
     }
@@ -175,7 +175,7 @@ public class Context {
     protected static void addBpmnOverrideElement(String id, ObjectNode infoNode) {
         Map<String, ObjectNode> bpmnOverrideMap = bpmnOverrideContextThreadLocal.get();
         if (bpmnOverrideMap == null) {
-            bpmnOverrideMap = new HashMap<String, ObjectNode>();
+            bpmnOverrideMap = new HashMap<>();
             bpmnOverrideContextThreadLocal.set(bpmnOverrideMap);
         }
         bpmnOverrideMap.put(id, infoNode);

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/db/DbSqlSession.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/db/DbSqlSession.java
@@ -71,10 +71,10 @@ public class DbSqlSession implements Session {
 
     protected SqlSession sqlSession;
     protected DbSqlSessionFactory dbSqlSessionFactory;
-    protected Map<Class<? extends PersistentObject>, List<PersistentObject>> insertedObjects = new HashMap<Class<? extends PersistentObject>, List<PersistentObject>>();
-    protected Map<Class<?>, Map<String, CachedObject>> cachedObjects = new HashMap<Class<?>, Map<String, CachedObject>>();
-    protected List<DeleteOperation> deleteOperations = new ArrayList<DeleteOperation>();
-    protected List<DeserializedObject> deserializedObjects = new ArrayList<DeserializedObject>();
+    protected Map<Class<? extends PersistentObject>, List<PersistentObject>> insertedObjects = new HashMap<>();
+    protected Map<Class<?>, Map<String, CachedObject>> cachedObjects = new HashMap<>();
+    protected List<DeleteOperation> deleteOperations = new ArrayList<>();
+    protected List<DeserializedObject> deserializedObjects = new ArrayList<>();
     protected String connectionMetadataDefaultCatalog;
     protected String connectionMetadataDefaultSchema;
 
@@ -156,7 +156,7 @@ public class DbSqlSession implements Session {
 
     /**
      * Use this {@link DeleteOperation} to execute a dedicated delete statement. It is important to note there won't be any optimistic locking checks done for these kind of delete operations!
-     *
+     * <p>
      * For example, a usage of this operation would be to delete all variables for a certain execution, when that certain execution is removed. The optimistic locking happens on the execution, but the
      * variables can be removed by a simple 'delete from var_table where execution_id is xxx'. It could very well be there are no variables, which would also work with this query, but not with the
      * regular {@link CheckedDeleteOperation}.
@@ -259,7 +259,7 @@ public class DbSqlSession implements Session {
     public class BulkCheckedDeleteOperation implements DeleteOperation {
 
         protected Class<? extends PersistentObject> persistentObjectClass;
-        protected List<PersistentObject> persistentObjects = new ArrayList<PersistentObject>();
+        protected List<PersistentObject> persistentObjects = new ArrayList<>();
 
         public BulkCheckedDeleteOperation(Class<? extends PersistentObject> persistentObjectClass) {
             this.persistentObjectClass = persistentObjectClass;
@@ -336,7 +336,7 @@ public class DbSqlSession implements Session {
 
     // select ///////////////////////////////////////////////////////////////////
 
-    @SuppressWarnings({ "rawtypes" })
+    @SuppressWarnings({"rawtypes"})
     public List selectList(String statement) {
         return selectList(statement, null, 0, Integer.MAX_VALUE);
     }
@@ -374,7 +374,7 @@ public class DbSqlSession implements Session {
         return selectListWithRawParameter(statement, parameter, parameter.getFirstResult(), parameter.getMaxResults());
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @SuppressWarnings({"rawtypes", "unchecked"})
     public List selectListWithRawParameter(String statement, Object parameter, int firstResult, int maxResults) {
         statement = dbSqlSessionFactory.mapStatement(statement);
         if (firstResult == -1 || maxResults == -1) {
@@ -384,7 +384,7 @@ public class DbSqlSession implements Session {
         return filterLoadedObjects(loadedObjects);
     }
 
-    @SuppressWarnings({ "rawtypes" })
+    @SuppressWarnings({"rawtypes"})
     public List selectListWithRawParameterWithoutFilter(String statement, Object parameter, int firstResult, int maxResults) {
         statement = dbSqlSessionFactory.mapStatement(statement);
         if (firstResult == -1 || maxResults == -1) {
@@ -430,7 +430,7 @@ public class DbSqlSession implements Session {
             return loadedObjects;
         }
 
-        List<PersistentObject> filteredObjects = new ArrayList<PersistentObject>(loadedObjects.size());
+        List<PersistentObject> filteredObjects = new ArrayList<>(loadedObjects.size());
         for (Object loadedObject : loadedObjects) {
             PersistentObject cachedPersistentObject = cacheFilter((PersistentObject) loadedObject);
             filteredObjects.add(cachedPersistentObject);
@@ -441,7 +441,7 @@ public class DbSqlSession implements Session {
     protected CachedObject cachePut(PersistentObject persistentObject, boolean storeState) {
         Map<String, CachedObject> classCache = cachedObjects.get(persistentObject.getClass());
         if (classCache == null) {
-            classCache = new HashMap<String, CachedObject>();
+            classCache = new HashMap<>();
             cachedObjects.put(persistentObject.getClass(), classCache);
         }
         CachedObject cachedObject = new CachedObject(persistentObject, storeState);
@@ -487,7 +487,7 @@ public class DbSqlSession implements Session {
     public <T> List<T> findInCache(Class<T> entityClass) {
         Map<String, CachedObject> classCache = cachedObjects.get(entityClass);
         if (classCache != null) {
-            List<T> entities = new ArrayList<T>(classCache.size());
+            List<T> entities = new ArrayList<>(classCache.size());
             for (CachedObject cachedObject : classCache.values()) {
                 entities.add((T) cachedObject.getPersistentObject());
             }
@@ -567,9 +567,9 @@ public class DbSqlSession implements Session {
      * Clears all deleted and inserted objects from the cache, and removes inserts and deletes that cancel each other.
      */
     protected List<DeleteOperation> removeUnnecessaryOperations() {
-        List<DeleteOperation> removedDeleteOperations = new ArrayList<DeleteOperation>();
+        List<DeleteOperation> removedDeleteOperations = new ArrayList<>();
 
-        for (Iterator<DeleteOperation> deleteIterator = deleteOperations.iterator(); deleteIterator.hasNext();) {
+        for (Iterator<DeleteOperation> deleteIterator = deleteOperations.iterator(); deleteIterator.hasNext(); ) {
 
             DeleteOperation deleteOperation = deleteIterator.next();
             Class<? extends PersistentObject> deletedPersistentObjectClass = deleteOperation.getPersistentObjectClass();
@@ -577,7 +577,7 @@ public class DbSqlSession implements Session {
             List<PersistentObject> insertedObjectsOfSameClass = insertedObjects.get(deletedPersistentObjectClass);
             if (insertedObjectsOfSameClass != null && insertedObjectsOfSameClass.size() > 0) {
 
-                for (Iterator<PersistentObject> insertIterator = insertedObjectsOfSameClass.iterator(); insertIterator.hasNext();) {
+                for (Iterator<PersistentObject> insertIterator = insertedObjectsOfSameClass.iterator(); insertIterator.hasNext(); ) {
                     PersistentObject insertedObject = insertIterator.next();
 
                     // if the deleted object is inserted,
@@ -685,7 +685,7 @@ public class DbSqlSession implements Session {
     }
 
     public List<PersistentObject> getUpdatedObjects() {
-        List<PersistentObject> updatedObjects = new ArrayList<PersistentObject>();
+        List<PersistentObject> updatedObjects = new ArrayList<>();
         for (Class<?> clazz : cachedObjects.keySet()) {
 
             Map<String, CachedObject> classCache = cachedObjects.get(clazz);
@@ -719,7 +719,7 @@ public class DbSqlSession implements Session {
     }
 
     public <T extends PersistentObject> List<T> pruneDeletedEntities(List<T> listToPrune) {
-        List<T> prunedList = new ArrayList<T>(listToPrune);
+        List<T> prunedList = new ArrayList<>(listToPrune);
         for (T potentiallyDeleted : listToPrune) {
             for (DeleteOperation deleteOperation : deleteOperations) {
 
@@ -968,7 +968,7 @@ public class DbSqlSession implements Session {
         return (String) sqlSession.selectOne(selectSchemaVersionStatement);
     }
 
-    public static String[] JDBC_METADATA_TABLE_TYPES = { "TABLE" };
+    public static String[] JDBC_METADATA_TABLE_TYPES = {"TABLE"};
 
     public boolean isEngineTablePresent() {
         return isTablePresent("ACT_RU_EXECUTION");

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/db/DbSqlSessionFactory.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/db/DbSqlSessionFactory.java
@@ -28,14 +28,14 @@ import org.apache.ibatis.session.SqlSessionFactory;
  */
 public class DbSqlSessionFactory implements SessionFactory {
 
-    protected static final Map<String, Map<String, String>> databaseSpecificStatements = new HashMap<String, Map<String, String>>();
+    protected static final Map<String, Map<String, String>> databaseSpecificStatements = new HashMap<>();
 
-    public static final Map<String, String> databaseSpecificLimitBeforeStatements = new HashMap<String, String>();
-    public static final Map<String, String> databaseSpecificLimitAfterStatements = new HashMap<String, String>();
-    public static final Map<String, String> databaseSpecificLimitBetweenStatements = new HashMap<String, String>();
-    public static final Map<String, String> databaseSpecificOrderByStatements = new HashMap<String, String>();
-    public static final Map<String, String> databaseOuterJoinLimitBetweenStatements = new HashMap<String, String>();
-    public static final Map<String, String> databaseSpecificLimitBeforeNativeQueryStatements = new HashMap<String, String>();
+    public static final Map<String, String> databaseSpecificLimitBeforeStatements = new HashMap<>();
+    public static final Map<String, String> databaseSpecificLimitAfterStatements = new HashMap<>();
+    public static final Map<String, String> databaseSpecificLimitBetweenStatements = new HashMap<>();
+    public static final Map<String, String> databaseSpecificOrderByStatements = new HashMap<>();
+    public static final Map<String, String> databaseOuterJoinLimitBetweenStatements = new HashMap<>();
+    public static final Map<String, String> databaseSpecificLimitBeforeNativeQueryStatements = new HashMap<>();
 
     static {
 
@@ -207,12 +207,12 @@ public class DbSqlSessionFactory implements SessionFactory {
     protected SqlSessionFactory sqlSessionFactory;
     protected IdGenerator idGenerator;
     protected Map<String, String> statementMappings;
-    protected Map<Class<?>, String> insertStatements = new ConcurrentHashMap<Class<?>, String>();
-    protected Map<Class<?>, String> bulkInsertStatements = new ConcurrentHashMap<Class<?>, String>();
-    protected Map<Class<?>, String> updateStatements = new ConcurrentHashMap<Class<?>, String>();
-    protected Map<Class<?>, String> deleteStatements = new ConcurrentHashMap<Class<?>, String>();
-    protected Map<Class<?>, String> bulkDeleteStatements = new ConcurrentHashMap<Class<?>, String>();
-    protected Map<Class<?>, String> selectStatements = new ConcurrentHashMap<Class<?>, String>();
+    protected Map<Class<?>, String> insertStatements = new ConcurrentHashMap<>();
+    protected Map<Class<?>, String> bulkInsertStatements = new ConcurrentHashMap<>();
+    protected Map<Class<?>, String> updateStatements = new ConcurrentHashMap<>();
+    protected Map<Class<?>, String> deleteStatements = new ConcurrentHashMap<>();
+    protected Map<Class<?>, String> bulkDeleteStatements = new ConcurrentHashMap<>();
+    protected Map<Class<?>, String> selectStatements = new ConcurrentHashMap<>();
     protected boolean isDbHistoryUsed = true;
     protected int maxNrOfStatementsInBulkInsert = 100;
 
@@ -270,7 +270,7 @@ public class DbSqlSessionFactory implements SessionFactory {
     protected static void addDatabaseSpecificStatement(String databaseType, String activitiStatement, String ibatisStatement) {
         Map<String, String> specificStatements = databaseSpecificStatements.get(databaseType);
         if (specificStatements == null) {
-            specificStatements = new HashMap<String, String>();
+            specificStatements = new HashMap<>();
             databaseSpecificStatements.put(databaseType, specificStatements);
         }
         specificStatements.put(activitiStatement, ibatisStatement);
@@ -299,7 +299,7 @@ public class DbSqlSessionFactory implements SessionFactory {
     }
 
     protected void initBulkInsertEnabledMap(String databaseType) {
-        bulkInsertableMap = new HashMap<Class<? extends PersistentObject>, Boolean>();
+        bulkInsertableMap = new HashMap<>();
 
         for (Class<? extends PersistentObject> clazz : EntityDependencyOrder.INSERT_ORDER) {
             bulkInsertableMap.put(clazz, Boolean.TRUE);

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/db/EntityDependencyOrder.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/db/EntityDependencyOrder.java
@@ -52,8 +52,8 @@ import org.activiti.engine.impl.persistence.entity.VariableInstanceEntity;
  */
 public class EntityDependencyOrder {
 
-    public static List<Class<? extends PersistentObject>> DELETE_ORDER = new ArrayList<Class<? extends PersistentObject>>();
-    public static List<Class<? extends PersistentObject>> INSERT_ORDER = new ArrayList<Class<? extends PersistentObject>>();
+    public static List<Class<? extends PersistentObject>> DELETE_ORDER = new ArrayList<>();
+    public static List<Class<? extends PersistentObject>> INSERT_ORDER = new ArrayList<>();
 
     static {
 
@@ -176,7 +176,7 @@ public class EntityDependencyOrder {
         DELETE_ORDER.add(HistoricFormPropertyEntity.class);
         DELETE_ORDER.add(HistoricDetailEntity.class);
 
-        INSERT_ORDER = new ArrayList<Class<? extends PersistentObject>>(DELETE_ORDER);
+        INSERT_ORDER = new ArrayList<>(DELETE_ORDER);
         Collections.reverse(INSERT_ORDER);
 
     }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/event/logger/AbstractEventFlusher.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/event/logger/AbstractEventFlusher.java
@@ -23,7 +23,7 @@ import org.activiti.engine.impl.interceptor.CommandContext;
  */
 public abstract class AbstractEventFlusher implements EventFlusher {
 
-    protected List<EventLoggerEventHandler> eventHandlers = new ArrayList<EventLoggerEventHandler>();
+    protected List<EventLoggerEventHandler> eventHandlers = new ArrayList<>();
 
     @Override
     public void closed(CommandContext commandContext) {

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/event/logger/EventLogger.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/event/logger/EventLogger.java
@@ -12,6 +12,8 @@
  */
 package org.activiti.engine.impl.event.logger;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -45,8 +47,6 @@ import org.flowable.engine.common.runtime.Clock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 /**
  * @author Joram Barrez
  */
@@ -60,7 +60,7 @@ public class EventLogger implements FlowableEventListener {
     protected ObjectMapper objectMapper;
 
     // Mapping of type -> handler
-    protected Map<FlowableEngineEventType, Class<? extends EventLoggerEventHandler>> eventHandlers = new HashMap<FlowableEngineEventType, Class<? extends EventLoggerEventHandler>>();
+    protected Map<FlowableEngineEventType, Class<? extends EventLoggerEventHandler>> eventHandlers = new HashMap<>();
 
     // Listeners for new events
     protected List<EventLoggerListener> listeners;
@@ -172,7 +172,7 @@ public class EventLogger implements FlowableEventListener {
     }
 
     protected EventLoggerEventHandler instantiateEventHandler(FlowableEvent event,
-            Class<? extends EventLoggerEventHandler> eventHandlerClass) {
+                                                              Class<? extends EventLoggerEventHandler> eventHandlerClass) {
         try {
             EventLoggerEventHandler eventHandler = eventHandlerClass.newInstance();
             eventHandler.setTimeStamp(clock.getCurrentTime());
@@ -196,7 +196,7 @@ public class EventLogger implements FlowableEventListener {
 
     public void addEventLoggerListener(EventLoggerListener listener) {
         if (listeners == null) {
-            listeners = new ArrayList<EventLoggerListener>(1);
+            listeners = new ArrayList<>(1);
         }
         listeners.add(listener);
     }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/event/logger/handler/AbstractTaskEventHandler.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/event/logger/handler/AbstractTaskEventHandler.java
@@ -24,7 +24,7 @@ import org.activiti.engine.impl.persistence.entity.TaskEntity;
 public abstract class AbstractTaskEventHandler extends AbstractDatabaseEventLoggerEventHandler {
 
     protected Map<String, Object> handleCommonTaskFields(TaskEntity task) {
-        Map<String, Object> data = new HashMap<String, Object>();
+        Map<String, Object> data = new HashMap<>();
         putInMapIfNotNull(data, Fields.ID, task.getId());
         putInMapIfNotNull(data, Fields.NAME, task.getName());
         putInMapIfNotNull(data, Fields.TASK_DEFINITION_KEY, task.getTaskDefinitionKey());

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/event/logger/handler/ActivityCompensatedEventHandler.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/event/logger/handler/ActivityCompensatedEventHandler.java
@@ -28,7 +28,7 @@ public class ActivityCompensatedEventHandler extends AbstractDatabaseEventLogger
     public EventLogEntryEntity generateEventLogEntry(CommandContext commandContext) {
         FlowableActivityEvent activityEvent = (FlowableActivityEvent) event;
 
-        Map<String, Object> data = new HashMap<String, Object>();
+        Map<String, Object> data = new HashMap<>();
         putInMapIfNotNull(data, Fields.ACTIVITY_ID, activityEvent.getActivityId());
         putInMapIfNotNull(data, Fields.ACTIVITY_NAME, activityEvent.getActivityName());
         putInMapIfNotNull(data, Fields.PROCESS_DEFINITION_ID, activityEvent.getProcessDefinitionId());

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/event/logger/handler/ActivityCompletedEventHandler.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/event/logger/handler/ActivityCompletedEventHandler.java
@@ -28,7 +28,7 @@ public class ActivityCompletedEventHandler extends AbstractDatabaseEventLoggerEv
     public EventLogEntryEntity generateEventLogEntry(CommandContext commandContext) {
         FlowableActivityEvent activityEvent = (FlowableActivityEvent) event;
 
-        Map<String, Object> data = new HashMap<String, Object>();
+        Map<String, Object> data = new HashMap<>();
         putInMapIfNotNull(data, Fields.ACTIVITY_ID, activityEvent.getActivityId());
         putInMapIfNotNull(data, Fields.ACTIVITY_NAME, activityEvent.getActivityName());
         putInMapIfNotNull(data, Fields.PROCESS_DEFINITION_ID, activityEvent.getProcessDefinitionId());

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/event/logger/handler/ActivityErrorReceivedEventHandler.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/event/logger/handler/ActivityErrorReceivedEventHandler.java
@@ -28,7 +28,7 @@ public class ActivityErrorReceivedEventHandler extends AbstractDatabaseEventLogg
     public EventLogEntryEntity generateEventLogEntry(CommandContext commandContext) {
         FlowableActivityEvent activityEvent = (FlowableActivityEvent) event;
 
-        Map<String, Object> data = new HashMap<String, Object>();
+        Map<String, Object> data = new HashMap<>();
         putInMapIfNotNull(data, Fields.ACTIVITY_ID, activityEvent.getActivityId());
         putInMapIfNotNull(data, Fields.ACTIVITY_NAME, activityEvent.getActivityName());
         putInMapIfNotNull(data, Fields.PROCESS_DEFINITION_ID, activityEvent.getProcessDefinitionId());

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/event/logger/handler/ActivityMessageEventHandler.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/event/logger/handler/ActivityMessageEventHandler.java
@@ -28,7 +28,7 @@ public class ActivityMessageEventHandler extends AbstractDatabaseEventLoggerEven
     public EventLogEntryEntity generateEventLogEntry(CommandContext commandContext) {
         FlowableMessageEvent messageEvent = (FlowableMessageEvent) event;
 
-        Map<String, Object> data = new HashMap<String, Object>();
+        Map<String, Object> data = new HashMap<>();
         putInMapIfNotNull(data, Fields.ACTIVITY_ID, messageEvent.getActivityId());
         putInMapIfNotNull(data, Fields.ACTIVITY_NAME, messageEvent.getActivityName());
         putInMapIfNotNull(data, Fields.PROCESS_DEFINITION_ID, messageEvent.getProcessDefinitionId());

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/event/logger/handler/ActivitySignaledEventHandler.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/event/logger/handler/ActivitySignaledEventHandler.java
@@ -28,7 +28,7 @@ public class ActivitySignaledEventHandler extends AbstractDatabaseEventLoggerEve
     public EventLogEntryEntity generateEventLogEntry(CommandContext commandContext) {
         FlowableSignalEvent signalEvent = (FlowableSignalEvent) event;
 
-        Map<String, Object> data = new HashMap<String, Object>();
+        Map<String, Object> data = new HashMap<>();
         putInMapIfNotNull(data, Fields.ACTIVITY_ID, signalEvent.getActivityId());
         putInMapIfNotNull(data, Fields.ACTIVITY_NAME, signalEvent.getActivityName());
         putInMapIfNotNull(data, Fields.PROCESS_DEFINITION_ID, signalEvent.getProcessDefinitionId());

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/event/logger/handler/ActivityStartedEventHandler.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/event/logger/handler/ActivityStartedEventHandler.java
@@ -28,7 +28,7 @@ public class ActivityStartedEventHandler extends AbstractDatabaseEventLoggerEven
     public EventLogEntryEntity generateEventLogEntry(CommandContext commandContext) {
         FlowableActivityEvent activityEvent = (FlowableActivityEvent) event;
 
-        Map<String, Object> data = new HashMap<String, Object>();
+        Map<String, Object> data = new HashMap<>();
         putInMapIfNotNull(data, Fields.ACTIVITY_ID, activityEvent.getActivityId());
         putInMapIfNotNull(data, Fields.ACTIVITY_NAME, activityEvent.getActivityName());
         putInMapIfNotNull(data, Fields.PROCESS_DEFINITION_ID, activityEvent.getProcessDefinitionId());

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/event/logger/handler/EngineClosedEventHandler.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/event/logger/handler/EngineClosedEventHandler.java
@@ -27,7 +27,7 @@ public class EngineClosedEventHandler extends AbstractDatabaseEventLoggerEventHa
 
     @Override
     public EventLogEntryEntity generateEventLogEntry(CommandContext commandContext) {
-        Map<String, Object> data = new HashMap<String, Object>();
+        Map<String, Object> data = new HashMap<>();
         try {
             data.put("ip", InetAddress.getLocalHost().getHostAddress()); // Note that this might give the wrong ip address in case of multiple network interfaces - but it's better than nothing.
         } catch (UnknownHostException e) {

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/event/logger/handler/EngineCreatedEventHandler.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/event/logger/handler/EngineCreatedEventHandler.java
@@ -27,7 +27,7 @@ public class EngineCreatedEventHandler extends AbstractDatabaseEventLoggerEventH
 
     @Override
     public EventLogEntryEntity generateEventLogEntry(CommandContext commandContext) {
-        Map<String, Object> data = new HashMap<String, Object>();
+        Map<String, Object> data = new HashMap<>();
         try {
             data.put("ip", InetAddress.getLocalHost().getHostAddress()); // Note that this might give the wrong ip address in case of multiple network interfaces - but it's better than nothing.
         } catch (UnknownHostException e) {

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/event/logger/handler/ProcessInstanceEndedEventHandler.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/event/logger/handler/ProcessInstanceEndedEventHandler.java
@@ -30,7 +30,7 @@ public class ProcessInstanceEndedEventHandler extends AbstractDatabaseEventLogge
     public EventLogEntryEntity generateEventLogEntry(CommandContext commandContext) {
         ExecutionEntity processInstanceEntity = getEntityFromEvent();
 
-        Map<String, Object> data = new HashMap<String, Object>();
+        Map<String, Object> data = new HashMap<>();
         putInMapIfNotNull(data, Fields.ID, processInstanceEntity.getId());
         putInMapIfNotNull(data, Fields.BUSINESS_KEY, processInstanceEntity.getBusinessKey());
         putInMapIfNotNull(data, Fields.PROCESS_DEFINITION_ID, processInstanceEntity.getProcessDefinitionId());

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/event/logger/handler/ProcessInstanceStartedEventHandler.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/event/logger/handler/ProcessInstanceStartedEventHandler.java
@@ -33,7 +33,7 @@ public class ProcessInstanceStartedEventHandler extends AbstractDatabaseEventLog
         FlowableEntityWithVariablesEvent eventWithVariables = (FlowableEntityWithVariablesEvent) event;
         ExecutionEntity processInstanceEntity = (ExecutionEntity) eventWithVariables.getEntity();
 
-        Map<String, Object> data = new HashMap<String, Object>();
+        Map<String, Object> data = new HashMap<>();
         putInMapIfNotNull(data, Fields.ID, processInstanceEntity.getId());
         putInMapIfNotNull(data, Fields.BUSINESS_KEY, processInstanceEntity.getBusinessKey());
         putInMapIfNotNull(data, Fields.PROCESS_DEFINITION_ID, processInstanceEntity.getProcessDefinitionId());
@@ -41,7 +41,7 @@ public class ProcessInstanceStartedEventHandler extends AbstractDatabaseEventLog
         putInMapIfNotNull(data, Fields.CREATE_TIME, timeStamp);
 
         if (eventWithVariables.getVariables() != null && !eventWithVariables.getVariables().isEmpty()) {
-            Map<String, Object> variableMap = new HashMap<String, Object>();
+            Map<String, Object> variableMap = new HashMap<>();
             for (Object variableName : eventWithVariables.getVariables().keySet()) {
                 putInMapIfNotNull(variableMap, (String) variableName, eventWithVariables.getVariables().get(variableName));
             }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/event/logger/handler/SequenceFlowTakenEventHandler.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/event/logger/handler/SequenceFlowTakenEventHandler.java
@@ -28,7 +28,7 @@ public class SequenceFlowTakenEventHandler extends AbstractDatabaseEventLoggerEv
     public EventLogEntryEntity generateEventLogEntry(CommandContext commandContext) {
         FlowableSequenceFlowTakenEvent sequenceFlowTakenEvent = (FlowableSequenceFlowTakenEvent) event;
 
-        Map<String, Object> data = new HashMap<String, Object>();
+        Map<String, Object> data = new HashMap<>();
         putInMapIfNotNull(data, Fields.ID, sequenceFlowTakenEvent.getId());
 
         putInMapIfNotNull(data, Fields.SOURCE_ACTIVITY_ID, sequenceFlowTakenEvent.getSourceActivityId());

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/event/logger/handler/TaskCompletedEventHandler.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/event/logger/handler/TaskCompletedEventHandler.java
@@ -36,7 +36,7 @@ public class TaskCompletedEventHandler extends AbstractTaskEventHandler {
         putInMapIfNotNull(data, Fields.DURATION, duration);
 
         if (eventWithVariables.getVariables() != null && !eventWithVariables.getVariables().isEmpty()) {
-            Map<String, Object> variableMap = new HashMap<String, Object>();
+            Map<String, Object> variableMap = new HashMap<>();
             for (Object variableName : eventWithVariables.getVariables().keySet()) {
                 putInMapIfNotNull(variableMap, (String) variableName, eventWithVariables.getVariables().get(variableName));
             }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/event/logger/handler/VariableEventHandler.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/event/logger/handler/VariableEventHandler.java
@@ -12,6 +12,9 @@
  */
 package org.activiti.engine.impl.event.logger.handler;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -32,9 +35,6 @@ import org.flowable.variable.service.impl.types.VariableType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 /**
  * @author Joram Barrez
  */
@@ -53,7 +53,7 @@ public abstract class VariableEventHandler extends AbstractDatabaseEventLoggerEv
     public static final String TYPE_JSON = "json";
 
     protected Map<String, Object> createData(FlowableVariableEvent variableEvent) {
-        Map<String, Object> data = new HashMap<String, Object>();
+        Map<String, Object> data = new HashMap<>();
         putInMapIfNotNull(data, Fields.NAME, variableEvent.getVariableName());
         putInMapIfNotNull(data, Fields.PROCESS_DEFINITION_ID, variableEvent.getProcessDefinitionId());
         putInMapIfNotNull(data, Fields.PROCESS_INSTANCE_ID, variableEvent.getProcessInstanceId());

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/form/DefaultFormHandler.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/form/DefaultFormHandler.java
@@ -35,7 +35,7 @@ public class DefaultFormHandler implements FormHandler {
 
     protected Expression formKey;
     protected String deploymentId;
-    protected List<FormPropertyHandler> formPropertyHandlers = new ArrayList<FormPropertyHandler>();
+    protected List<FormPropertyHandler> formPropertyHandlers = new ArrayList<>();
 
     public void parseConfiguration(List<org.flowable.bpmn.model.FormProperty> formProperties, String formKey, DeploymentEntity deployment, ProcessDefinition processDefinition) {
         this.deploymentId = deployment.getId();
@@ -79,7 +79,7 @@ public class DefaultFormHandler implements FormHandler {
     }
 
     protected void initializeFormProperties(FormDataImpl formData, ExecutionEntity execution) {
-        List<FormProperty> formProperties = new ArrayList<FormProperty>();
+        List<FormProperty> formProperties = new ArrayList<>();
         for (FormPropertyHandler formPropertyHandler : formPropertyHandlers) {
             if (formPropertyHandler.isReadable()) {
                 FormProperty formProperty = formPropertyHandler.createFormProperty(execution);
@@ -90,7 +90,7 @@ public class DefaultFormHandler implements FormHandler {
     }
 
     public void submitFormProperties(Map<String, String> properties, ExecutionEntity execution) {
-        Map<String, String> propertiesCopy = new HashMap<String, String>(properties);
+        Map<String, String> propertiesCopy = new HashMap<>(properties);
         for (FormPropertyHandler formPropertyHandler : formPropertyHandlers) {
             // submitFormProperty will remove all the keys which it takes care of
             formPropertyHandler.submitFormProperty(execution, propertiesCopy);

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/form/FormDataImpl.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/form/FormDataImpl.java
@@ -29,7 +29,7 @@ public abstract class FormDataImpl implements FormData, Serializable {
 
     protected String formKey;
     protected String deploymentId;
-    protected List<FormProperty> formProperties = new ArrayList<FormProperty>();
+    protected List<FormProperty> formProperties = new ArrayList<>();
 
     // getters and setters //////////////////////////////////////////////////////
 

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/form/FormHandler.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/form/FormHandler.java
@@ -27,7 +27,7 @@ import org.flowable.engine.repository.ProcessDefinition;
  */
 public interface FormHandler extends Serializable {
 
-    ThreadLocal<FormHandler> current = new ThreadLocal<FormHandler>();
+    ThreadLocal<FormHandler> current = new ThreadLocal<>();
 
     void parseConfiguration(List<FormProperty> formProperties, String formKey, DeploymentEntity deployment, ProcessDefinition processDefinition);
 

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/form/FormTypes.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/form/FormTypes.java
@@ -28,7 +28,7 @@ import org.flowable.engine.form.AbstractFormType;
  */
 public class FormTypes {
 
-    protected Map<String, AbstractFormType> formTypes = new HashMap<String, AbstractFormType>();
+    protected Map<String, AbstractFormType> formTypes = new HashMap<>();
 
     public void addFormType(AbstractFormType formType) {
         formTypes.put(formType.getName(), formType);
@@ -42,7 +42,7 @@ public class FormTypes {
 
         } else if ("enum".equals(formProperty.getType())) {
             // ACT-1023: Using linked hashmap to preserve the order in which the entries are defined
-            Map<String, String> values = new LinkedHashMap<String, String>();
+            Map<String, String> values = new LinkedHashMap<>();
             for (FormValue formValue : formProperty.getFormValues()) {
                 values.put(formValue.getId(), formValue.getName());
             }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/history/parse/FlowNodeHistoryParseHandler.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/history/parse/FlowNodeHistoryParseHandler.java
@@ -49,7 +49,7 @@ public class FlowNodeHistoryParseHandler implements BpmnParseHandler {
 
     protected static final ActivityInstanceStartHandler ACTIVITY_INSTANCE_START_LISTENER = new ActivityInstanceStartHandler();
 
-    protected static Set<Class<? extends BaseElement>> supportedElementClasses = new HashSet<Class<? extends BaseElement>>();
+    protected static Set<Class<? extends BaseElement>> supportedElementClasses = new HashSet<>();
 
     static {
         supportedElementClasses.add(EndEvent.class);

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/identity/Authentication.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/identity/Authentication.java
@@ -18,7 +18,7 @@ package org.activiti.engine.impl.identity;
  */
 public abstract class Authentication {
 
-    static ThreadLocal<String> authenticatedUserIdThreadLocal = new ThreadLocal<String>();
+    static ThreadLocal<String> authenticatedUserIdThreadLocal = new ThreadLocal<>();
 
     public static void setAuthenticatedUserId(String authenticatedUserId) {
         authenticatedUserIdThreadLocal.set(authenticatedUserId);

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/interceptor/CommandContext.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/interceptor/CommandContext.java
@@ -73,9 +73,9 @@ public class CommandContext {
     protected Command<?> command;
     protected TransactionContext transactionContext;
     protected Map<Class<?>, SessionFactory> sessionFactories;
-    protected Map<Class<?>, Session> sessions = new HashMap<Class<?>, Session>();
+    protected Map<Class<?>, Session> sessions = new HashMap<>();
     protected Throwable exception;
-    protected LinkedList<AtomicOperation> nextOperations = new LinkedList<AtomicOperation>();
+    protected LinkedList<AtomicOperation> nextOperations = new LinkedList<>();
     protected ProcessEngineConfigurationImpl processEngineConfiguration;
     protected FailedJobCommandFactory failedJobCommandFactory;
     protected List<CommandContextCloseListener> closeListeners;
@@ -196,7 +196,7 @@ public class CommandContext {
 
     public void addCloseListener(CommandContextCloseListener commandContextCloseListener) {
         if (closeListeners == null) {
-            closeListeners = new ArrayList<CommandContextCloseListener>(1);
+            closeListeners = new ArrayList<>(1);
         }
         closeListeners.add(commandContextCloseListener);
     }
@@ -235,7 +235,7 @@ public class CommandContext {
 
     public void addAttribute(String key, Object value) {
         if (attributes == null) {
-            attributes = new HashMap<String, Object>(1);
+            attributes = new HashMap<>(1);
         }
         attributes.put(key, value);
     }
@@ -247,7 +247,7 @@ public class CommandContext {
         return null;
     }
 
-    @SuppressWarnings({ "unchecked" })
+    @SuppressWarnings({"unchecked"})
     public <T> T getSession(Class<T> sessionClass) {
         Session session = sessions.get(sessionClass);
         if (session == null) {

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/javax/el/BeanELResolver.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/javax/el/BeanELResolver.java
@@ -35,13 +35,13 @@ import java.util.concurrent.ConcurrentHashMap;
  * ELResolvers are combined together using {@link CompositeELResolver} s, to define rich semantics for evaluating an expression. See the javadocs for {@link ELResolver} for details. Because this
  * resolver handles base objects of any type, it should be placed near the end of a composite resolver. Otherwise, it will claim to have resolved a property before any resolvers that come after it get
  * a chance to test if they can do so as well.
- * 
+ *
  * @see CompositeELResolver
  * @see ELResolver
  */
 public class BeanELResolver extends ELResolver {
     protected static final class BeanProperties {
-        private final Map<String, BeanProperty> map = new HashMap<String, BeanProperty>();
+        private final Map<String, BeanProperty> map = new HashMap<>();
 
         public BeanProperties(Class<?> baseClass) {
             PropertyDescriptor[] descriptors;
@@ -138,17 +138,15 @@ public class BeanELResolver extends ELResolver {
      */
     public BeanELResolver(boolean readOnly) {
         this.readOnly = readOnly;
-        this.cache = new ConcurrentHashMap<Class<?>, BeanProperties>();
+        this.cache = new ConcurrentHashMap<>();
     }
 
     /**
      * If the base object is not null, returns the most general type that this resolver accepts for the property argument. Otherwise, returns null. Assuming the base is not null, this method will
      * always return Object.class. This is because any object is accepted as a key and is coerced into a string.
-     * 
-     * @param context
-     *            The context of this evaluation.
-     * @param base
-     *            The bean to analyze.
+     *
+     * @param context The context of this evaluation.
+     * @param base    The bean to analyze.
      * @return null if base is null; otherwise Object.class.
      */
     @Override
@@ -165,11 +163,9 @@ public class BeanELResolver extends ELResolver {
      * <li>{@link ELResolver#TYPE} - The runtime type of the property, from PropertyDescriptor.getPropertyType().</li>
      * <li>{@link ELResolver#RESOLVABLE_AT_DESIGN_TIME} - true.</li>
      * </ul>
-     * 
-     * @param context
-     *            The context of this evaluation.
-     * @param base
-     *            The bean to analyze.
+     *
+     * @param context The context of this evaluation.
+     * @param base    The bean to analyze.
      * @return An Iterator containing zero or more FeatureDescriptor objects, each representing a property on this bean, or null if the base object is null.
      */
     @Override
@@ -215,20 +211,14 @@ public class BeanELResolver extends ELResolver {
      * must be set to true by this resolver, before returning. If this property is not true after this method is called, the caller should ignore the return value. The provided property will first be
      * coerced to a String. If there is a BeanInfoProperty for this property and there were no errors retrieving it, the propertyType of the propertyDescriptor is returned. Otherwise, a
      * PropertyNotFoundException is thrown.
-     * 
-     * @param context
-     *            The context of this evaluation.
-     * @param base
-     *            The bean to analyze.
-     * @param property
-     *            The name of the property to analyze. Will be coerced to a String.
+     *
+     * @param context  The context of this evaluation.
+     * @param base     The bean to analyze.
+     * @param property The name of the property to analyze. Will be coerced to a String.
      * @return If the propertyResolved property of ELContext was set to true, then the most general acceptable type; otherwise undefined.
-     * @throws NullPointerException
-     *             if context is null
-     * @throws PropertyNotFoundException
-     *             if base is not null and the specified property does not exist or is not readable.
-     * @throws ELException
-     *             if an exception was thrown while performing the property or variable resolution. The thrown exception must be included as the cause property of this exception, if available.
+     * @throws NullPointerException      if context is null
+     * @throws PropertyNotFoundException if base is not null and the specified property does not exist or is not readable.
+     * @throws ELException               if an exception was thrown while performing the property or variable resolution. The thrown exception must be included as the cause property of this exception, if available.
      */
     @Override
     public Class<?> getType(ELContext context, Object base, Object property) {
@@ -248,20 +238,14 @@ public class BeanELResolver extends ELResolver {
      * by this resolver, before returning. If this property is not true after this method is called, the caller should ignore the return value. The provided property name will first be coerced to a
      * String. If the property is a readable property of the base object, as per the JavaBeans specification, then return the result of the getter call. If the getter throws an exception, it is
      * propagated to the caller. If the property is not found or is not readable, a PropertyNotFoundException is thrown.
-     * 
-     * @param context
-     *            The context of this evaluation.
-     * @param base
-     *            The bean to analyze.
-     * @param property
-     *            The name of the property to analyze. Will be coerced to a String.
+     *
+     * @param context  The context of this evaluation.
+     * @param base     The bean to analyze.
+     * @param property The name of the property to analyze. Will be coerced to a String.
      * @return If the propertyResolved property of ELContext was set to true, then the value of the given property. Otherwise, undefined.
-     * @throws NullPointerException
-     *             if context is null
-     * @throws PropertyNotFoundException
-     *             if base is not null and the specified property does not exist or is not readable.
-     * @throws ELException
-     *             if an exception was thrown while performing the property or variable resolution. The thrown exception must be included as the cause property of this exception, if available.
+     * @throws NullPointerException      if context is null
+     * @throws PropertyNotFoundException if base is not null and the specified property does not exist or is not readable.
+     * @throws ELException               if an exception was thrown while performing the property or variable resolution. The thrown exception must be included as the cause property of this exception, if available.
      */
     @Override
     public Object getValue(ELContext context, Object base, Object property) {
@@ -291,21 +275,15 @@ public class BeanELResolver extends ELResolver {
     /**
      * If the base object is not null, returns whether a call to {@link #setValue(ELContext, Object, Object, Object)} will always fail. If the base is not null, the propertyResolved property of the
      * ELContext object must be set to true by this resolver, before returning. If this property is not true after this method is called, the caller can safely assume no value was set.
-     * 
-     * @param context
-     *            The context of this evaluation.
-     * @param base
-     *            The bean to analyze.
-     * @param property
-     *            The name of the property to analyze. Will be coerced to a String.
+     *
+     * @param context  The context of this evaluation.
+     * @param base     The bean to analyze.
+     * @param property The name of the property to analyze. Will be coerced to a String.
      * @return If the propertyResolved property of ELContext was set to true, then true if calling the setValue method will always fail or false if it is possible that such a call may succeed;
-     *         otherwise undefined.
-     * @throws NullPointerException
-     *             if context is null
-     * @throws PropertyNotFoundException
-     *             if base is not null and the specified property does not exist or is not readable.
-     * @throws ELException
-     *             if an exception was thrown while performing the property or variable resolution. The thrown exception must be included as the cause property of this exception, if available.
+     * otherwise undefined.
+     * @throws NullPointerException      if context is null
+     * @throws PropertyNotFoundException if base is not null and the specified property does not exist or is not readable.
+     * @throws ELException               if an exception was thrown while performing the property or variable resolution. The thrown exception must be included as the cause property of this exception, if available.
      */
     @Override
     public boolean isReadOnly(ELContext context, Object base, Object property) {
@@ -326,23 +304,15 @@ public class BeanELResolver extends ELResolver {
      * this method will always throw PropertyNotWritableException. The provided property name will first be coerced to a String. If property is a writable property of base (as per the JavaBeans
      * Specification), the setter method is called (passing value). If the property exists but does not have a setter, then a PropertyNotFoundException is thrown. If the property does not exist, a
      * PropertyNotFoundException is thrown.
-     * 
-     * @param context
-     *            The context of this evaluation.
-     * @param base
-     *            The bean to analyze.
-     * @param property
-     *            The name of the property to analyze. Will be coerced to a String.
-     * @param value
-     *            The value to be associated with the specified key.
-     * @throws NullPointerException
-     *             if context is null
-     * @throws PropertyNotFoundException
-     *             if base is not null and the specified property does not exist or is not readable.
-     * @throws PropertyNotWritableException
-     *             if this resolver was constructed in read-only mode, or if there is no setter for the property
-     * @throws ELException
-     *             if an exception was thrown while performing the property or variable resolution. The thrown exception must be included as the cause property of this exception, if available.
+     *
+     * @param context  The context of this evaluation.
+     * @param base     The bean to analyze.
+     * @param property The name of the property to analyze. Will be coerced to a String.
+     * @param value    The value to be associated with the specified key.
+     * @throws NullPointerException         if context is null
+     * @throws PropertyNotFoundException    if base is not null and the specified property does not exist or is not readable.
+     * @throws PropertyNotWritableException if this resolver was constructed in read-only mode, or if there is no setter for the property
+     * @throws ELException                  if an exception was thrown while performing the property or variable resolution. The thrown exception must be included as the cause property of this exception, if available.
      */
     @Override
     public void setValue(ELContext context, Object base, Object property, Object value) {
@@ -372,43 +342,36 @@ public class BeanELResolver extends ELResolver {
 
     /**
      * If the base object is not <code>null</code>, invoke the method, with the given parameters on this bean. The return value from the method is returned.
-     * 
+     * <p>
      * <p>
      * If the base is not <code>null</code>, the <code>propertyResolved</code> property of the <code>ELContext</code> object must be set to <code>true</code> by this resolver, before returning. If
      * this property is not <code>true</code> after this method is called, the caller should ignore the return value.
      * </p>
-     * 
+     * <p>
      * <p>
      * The provided method object will first be coerced to a <code>String</code>. The methods in the bean is then examined and an attempt will be made to select one for invocation. If no suitable can
      * be found, a <code>MethodNotFoundException</code> is thrown.
-     * 
+     * <p>
      * If the given paramTypes is not <code>null</code>, select the method with the given name and parameter types.
-     * 
+     * <p>
      * Else select the method with the given name that has the same number of parameters. If there are more than one such method, the method selection process is undefined.
-     * 
+     * <p>
      * Else select the method with the given name that takes a variable number of arguments.
-     * 
+     * <p>
      * Note the resolution for overloaded methods will likely be clarified in a future version of the spec.
-     * 
+     * <p>
      * The provided parameters are coerced to the corresponding parameter types of the method, and the method is then invoked.
-     * 
-     * @param context
-     *            The context of this evaluation.
-     * @param base
-     *            The bean on which to invoke the method
-     * @param method
-     *            The simple name of the method to invoke. Will be coerced to a <code>String</code>. If method is "&lt;init&gt;"or "&lt;clinit&gt;" a MethodNotFoundException is thrown.
-     * @param paramTypes
-     *            An array of Class objects identifying the method's formal parameter types, in declared order. Use an empty array if the method has no parameters. Can be <code>null</code>, in which
-     *            case the method's formal parameter types are assumed to be unknown.
-     * @param params
-     *            The parameters to pass to the method, or <code>null</code> if no parameters.
+     *
+     * @param context    The context of this evaluation.
+     * @param base       The bean on which to invoke the method
+     * @param method     The simple name of the method to invoke. Will be coerced to a <code>String</code>. If method is "&lt;init&gt;"or "&lt;clinit&gt;" a MethodNotFoundException is thrown.
+     * @param paramTypes An array of Class objects identifying the method's formal parameter types, in declared order. Use an empty array if the method has no parameters. Can be <code>null</code>, in which
+     *                   case the method's formal parameter types are assumed to be unknown.
+     * @param params     The parameters to pass to the method, or <code>null</code> if no parameters.
      * @return The result of the method invocation (<code>null</code> if the method has a <code>void</code> return type).
-     * @throws MethodNotFoundException
-     *             if no suitable method can be found.
-     * @throws ELException
-     *             if an exception was thrown while performing (base, method) resolution. The thrown exception must be included as the cause property of this exception, if available. If the exception
-     *             thrown is an <code>InvocationTargetException</code>, extract its <code>cause</code> and pass it to the <code>ELException</code> constructor.
+     * @throws MethodNotFoundException if no suitable method can be found.
+     * @throws ELException             if an exception was thrown while performing (base, method) resolution. The thrown exception must be included as the cause property of this exception, if available. If the exception
+     *                                 thrown is an <code>InvocationTargetException</code>, extract its <code>cause</code> and pass it to the <code>ELException</code> constructor.
      * @since 2.2
      */
     @Override
@@ -465,9 +428,8 @@ public class BeanELResolver extends ELResolver {
     /**
      * Lookup an expression factory used to coerce method parameters in context under key <code>"javax.el.ExpressionFactory"</code>. If no expression factory can be found under that key, use a default
      * instance created with {@link ExpressionFactory#newInstance()}.
-     * 
-     * @param context
-     *            The context of this evaluation.
+     *
+     * @param context The context of this evaluation.
      * @return expression factory instance
      */
     private ExpressionFactory getExpressionFactory(ELContext context) {
@@ -537,9 +499,8 @@ public class BeanELResolver extends ELResolver {
 
     /**
      * Test whether the given base should be resolved by this ELResolver.
-     * 
-     * @param base
-     *            The bean to analyze.
+     *
+     * @param base The bean to analyze.
      * @return base != null
      */
     private final boolean isResolvable(Object base) {
@@ -548,14 +509,11 @@ public class BeanELResolver extends ELResolver {
 
     /**
      * Lookup BeanProperty for the given (base, property) pair.
-     * 
-     * @param base
-     *            The bean to analyze.
-     * @param property
-     *            The name of the property to analyze. Will be coerced to a String.
+     *
+     * @param base     The bean to analyze.
+     * @param property The name of the property to analyze. Will be coerced to a String.
      * @return The BeanProperty representing (base, property).
-     * @throws PropertyNotFoundException
-     *             if no BeanProperty can be found.
+     * @throws PropertyNotFoundException if no BeanProperty can be found.
      */
     private final BeanProperty toBeanProperty(Object base, Object property) {
         BeanProperties beanProperties = cache.get(base.getClass());
@@ -575,11 +533,10 @@ public class BeanELResolver extends ELResolver {
 
     /**
      * This method is not part of the API, though it can be used (reflectively) by clients of this class to remove entries from the cache when the beans are being unloaded.
-     * 
+     * <p>
      * Note: this method is present in the reference implementation, so we're adding it here to ease migration.
-     * 
-     * @param loader
-     *            The classLoader used to load the beans.
+     *
+     * @param loader The classLoader used to load the beans.
      */
     @SuppressWarnings("unused")
     private final void purgeBeanClasses(ClassLoader loader) {

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/javax/el/CompositeELResolver.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/javax/el/CompositeELResolver.java
@@ -32,15 +32,13 @@ import java.util.List;
  * are collected and combined from all child ELResolvers for these methods.
  */
 public class CompositeELResolver extends ELResolver {
-    private final List<ELResolver> resolvers = new ArrayList<ELResolver>();
+    private final List<ELResolver> resolvers = new ArrayList<>();
 
     /**
      * Adds the given resolver to the list of component resolvers. Resolvers are consulted in the order in which they are added.
-     * 
-     * @param elResolver
-     *            The component resolver to add.
-     * @throws NullPointerException
-     *             If the provided resolver is null.
+     *
+     * @param elResolver The component resolver to add.
+     * @throws NullPointerException If the provided resolver is null.
      */
     public void add(ELResolver elResolver) {
         if (elResolver == null) {
@@ -53,13 +51,11 @@ public class CompositeELResolver extends ELResolver {
      * Returns the most general type that this resolver accepts for the property argument, given a base object. One use for this method is to assist tools in auto-completion. The result is obtained by
      * querying all component resolvers. The Class returned is the most specific class that is a common superclass of all the classes returned by each component resolver's getCommonPropertyType
      * method. If null is returned by a resolver, it is skipped.
-     * 
-     * @param context
-     *            The context of this evaluation.
-     * @param base
-     *            The base object to return the most general property type for, or null to enumerate the set of top-level variables that this resolver can evaluate.
+     *
+     * @param context The context of this evaluation.
+     * @param base    The base object to return the most general property type for, or null to enumerate the set of top-level variables that this resolver can evaluate.
      * @return null if this ELResolver does not know how to handle the given base object; otherwise Object.class if any type of property is accepted; otherwise the most general property type accepted
-     *         for the given base.
+     * for the given base.
      */
     @Override
     public Class<?> getCommonPropertyType(ELContext context, Object base) {
@@ -82,13 +78,11 @@ public class CompositeELResolver extends ELResolver {
      * collected from all component resolvers. The propertyResolved property of the ELContext is not relevant to this method. The results of all ELResolvers are concatenated. The Iterator returned is
      * an iterator over the collection of FeatureDescriptor objects returned by the iterators returned by each component resolver's getFeatureDescriptors method. If null is returned by a resolver, it
      * is skipped.
-     * 
-     * @param context
-     *            The context of this evaluation.
-     * @param base
-     *            The base object to return the most general property type for, or null to enumerate the set of top-level variables that this resolver can evaluate.
+     *
+     * @param context The context of this evaluation.
+     * @param base    The base object to return the most general property type for, or null to enumerate the set of top-level variables that this resolver can evaluate.
      * @return An Iterator containing zero or more (possibly infinitely more) FeatureDescriptor objects, or null if this resolver does not handle the given base object or that the results are too
-     *         complex to represent with this method
+     * complex to represent with this method
      */
     @Override
     public Iterator<FeatureDescriptor> getFeatureDescriptors(final ELContext context, final Object base) {
@@ -133,20 +127,14 @@ public class CompositeELResolver extends ELResolver {
      * </ol>
      * If none of the component resolvers were able to perform this operation, the value null is returned and the propertyResolved flag remains set to false. Any exception thrown by component
      * resolvers during the iteration is propagated to the caller of this method.
-     * 
-     * @param context
-     *            The context of this evaluation.
-     * @param base
-     *            The base object to return the most general property type for, or null to enumerate the set of top-level variables that this resolver can evaluate.
-     * @param property
-     *            The property or variable to return the acceptable type for.
+     *
+     * @param context  The context of this evaluation.
+     * @param base     The base object to return the most general property type for, or null to enumerate the set of top-level variables that this resolver can evaluate.
+     * @param property The property or variable to return the acceptable type for.
      * @return If the propertyResolved property of ELContext was set to true, then the most general acceptable type; otherwise undefined.
-     * @throws NullPointerException
-     *             if context is null
-     * @throws PropertyNotFoundException
-     *             if base is not null and the specified property does not exist or is not readable.
-     * @throws ELException
-     *             if an exception was thrown while performing the property or variable resolution. The thrown exception must be included as the cause property of this exception, if available.
+     * @throws NullPointerException      if context is null
+     * @throws PropertyNotFoundException if base is not null and the specified property does not exist or is not readable.
+     * @throws ELException               if an exception was thrown while performing the property or variable resolution. The thrown exception must be included as the cause property of this exception, if available.
      */
     @Override
     public Class<?> getType(ELContext context, Object base, Object property) {
@@ -171,20 +159,14 @@ public class CompositeELResolver extends ELResolver {
      * </ol>
      * If none of the component resolvers were able to perform this operation, the value null is returned and the propertyResolved flag remains set to false. Any exception thrown by component
      * resolvers during the iteration is propagated to the caller of this method.
-     * 
-     * @param context
-     *            The context of this evaluation.
-     * @param base
-     *            The base object to return the most general property type for, or null to enumerate the set of top-level variables that this resolver can evaluate.
-     * @param property
-     *            The property or variable to return the acceptable type for.
+     *
+     * @param context  The context of this evaluation.
+     * @param base     The base object to return the most general property type for, or null to enumerate the set of top-level variables that this resolver can evaluate.
+     * @param property The property or variable to return the acceptable type for.
      * @return If the propertyResolved property of ELContext was set to true, then the result of the variable or property resolution; otherwise undefined.
-     * @throws NullPointerException
-     *             if context is null
-     * @throws PropertyNotFoundException
-     *             if base is not null and the specified property does not exist or is not readable.
-     * @throws ELException
-     *             if an exception was thrown while performing the property or variable resolution. The thrown exception must be included as the cause property of this exception, if available.
+     * @throws NullPointerException      if context is null
+     * @throws PropertyNotFoundException if base is not null and the specified property does not exist or is not readable.
+     * @throws ELException               if an exception was thrown while performing the property or variable resolution. The thrown exception must be included as the cause property of this exception, if available.
      */
     @Override
     public Object getValue(ELContext context, Object base, Object property) {
@@ -210,20 +192,14 @@ public class CompositeELResolver extends ELResolver {
      * </ol>
      * If none of the component resolvers were able to perform this operation, the value false is returned and the propertyResolved flag remains set to false. Any exception thrown by component
      * resolvers during the iteration is propagated to the caller of this method.
-     * 
-     * @param context
-     *            The context of this evaluation.
-     * @param base
-     *            The base object to return the most general property type for, or null to enumerate the set of top-level variables that this resolver can evaluate.
-     * @param property
-     *            The property or variable to return the acceptable type for.
+     *
+     * @param context  The context of this evaluation.
+     * @param base     The base object to return the most general property type for, or null to enumerate the set of top-level variables that this resolver can evaluate.
+     * @param property The property or variable to return the acceptable type for.
      * @return If the propertyResolved property of ELContext was set to true, then true if the property is read-only or false if not; otherwise undefined.
-     * @throws NullPointerException
-     *             if context is null
-     * @throws PropertyNotFoundException
-     *             if base is not null and the specified property does not exist or is not readable.
-     * @throws ELException
-     *             if an exception was thrown while performing the property or variable resolution. The thrown exception must be included as the cause property of this exception, if available.
+     * @throws NullPointerException      if context is null
+     * @throws PropertyNotFoundException if base is not null and the specified property does not exist or is not readable.
+     * @throws ELException               if an exception was thrown while performing the property or variable resolution. The thrown exception must be included as the cause property of this exception, if available.
      */
     @Override
     public boolean isReadOnly(ELContext context, Object base, Object property) {
@@ -248,23 +224,15 @@ public class CompositeELResolver extends ELResolver {
      * </ol>
      * If none of the component resolvers were able to perform this operation, the propertyResolved flag remains set to false. Any exception thrown by component resolvers during the iteration is
      * propagated to the caller of this method.
-     * 
-     * @param context
-     *            The context of this evaluation.
-     * @param base
-     *            The base object to return the most general property type for, or null to enumerate the set of top-level variables that this resolver can evaluate.
-     * @param property
-     *            The property or variable to return the acceptable type for.
-     * @param value
-     *            The value to set the property or variable to.
-     * @throws NullPointerException
-     *             if context is null
-     * @throws PropertyNotFoundException
-     *             if base is not null and the specified property does not exist or is not readable.
-     * @throws PropertyNotWritableException
-     *             if the given (base, property) pair is handled by this ELResolver but the specified variable or property is not writable.
-     * @throws ELException
-     *             if an exception was thrown while attempting to set the property or variable. The thrown exception must be included as the cause property of this exception, if available.
+     *
+     * @param context  The context of this evaluation.
+     * @param base     The base object to return the most general property type for, or null to enumerate the set of top-level variables that this resolver can evaluate.
+     * @param property The property or variable to return the acceptable type for.
+     * @param value    The value to set the property or variable to.
+     * @throws NullPointerException         if context is null
+     * @throws PropertyNotFoundException    if base is not null and the specified property does not exist or is not readable.
+     * @throws PropertyNotWritableException if the given (base, property) pair is handled by this ELResolver but the specified variable or property is not writable.
+     * @throws ELException                  if an exception was thrown while attempting to set the property or variable. The thrown exception must be included as the cause property of this exception, if available.
      */
     @Override
     public void setValue(ELContext context, Object base, Object property, Object value) {
@@ -279,16 +247,16 @@ public class CompositeELResolver extends ELResolver {
 
     /**
      * Attempts to resolve and invoke the given <code>method</code> on the given <code>base</code> object by querying all component resolvers.
-     * 
+     * <p>
      * <p>
      * If this resolver handles the given (base, method) pair, the <code>propertyResolved</code> property of the <code>ELContext</code> object must be set to <code>true</code> by the resolver, before
      * returning. If this property is not <code>true</code> after this method is called, the caller should ignore the return value.
      * </p>
-     * 
+     * <p>
      * <p>
      * First, <code>propertyResolved</code> is set to <code>false</code> on the provided <code>ELContext</code>.
      * </p>
-     * 
+     * <p>
      * <p>
      * Next, for each component resolver in this composite:
      * <ol>
@@ -297,26 +265,21 @@ public class CompositeELResolver extends ELResolver {
      * <li>Otherwise, iteration stops and no more component resolvers are considered. The value returned by <code>getValue()</code> is returned by this method.</li>
      * </ol>
      * </p>
-     * 
+     * <p>
      * <p>
      * If none of the component resolvers were able to perform this operation, the value <code>null</code> is returned and the <code>propertyResolved</code> flag remains set to <code>false</code>
      * </p>
-     * 
+     * <p>
      * <p>
      * Any exception thrown by component resolvers during the iteration is propagated to the caller of this method.
      * </p>
-     * 
-     * @param context
-     *            The context of this evaluation.
-     * @param base
-     *            The bean on which to invoke the method
-     * @param method
-     *            The simple name of the method to invoke. Will be coerced to a <code>String</code>. If method is "&lt;init&gt;"or "&lt;clinit&gt;" a NoSuchMethodException is raised.
-     * @param paramTypes
-     *            An array of Class objects identifying the method's formal parameter types, in declared order. Use an empty array if the method has no parameters. Can be <code>null</code>, in which
-     *            case the method's formal parameter types are assumed to be unknown.
-     * @param params
-     *            The parameters to pass to the method, or <code>null</code> if no parameters.
+     *
+     * @param context    The context of this evaluation.
+     * @param base       The bean on which to invoke the method
+     * @param method     The simple name of the method to invoke. Will be coerced to a <code>String</code>. If method is "&lt;init&gt;"or "&lt;clinit&gt;" a NoSuchMethodException is raised.
+     * @param paramTypes An array of Class objects identifying the method's formal parameter types, in declared order. Use an empty array if the method has no parameters. Can be <code>null</code>, in which
+     *                   case the method's formal parameter types are assumed to be unknown.
+     * @param params     The parameters to pass to the method, or <code>null</code> if no parameters.
      * @return The result of the method invocation (<code>null</code> if the method has a <code>void</code> return type).
      * @since 2.2
      */

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/javax/el/ELContext.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/javax/el/ELContext.java
@@ -35,7 +35,7 @@ import java.util.Map;
  * between two or more threads.
  */
 public abstract class ELContext {
-    private final Map<Class<?>, Object> context = new HashMap<Class<?>, Object>();
+    private final Map<Class<?>, Object> context = new HashMap<>();
 
     private Locale locale;
     private boolean resolved;
@@ -44,12 +44,10 @@ public abstract class ELContext {
      * Returns the context object associated with the given key. The ELContext maintains a collection of context objects relevant to the evaluation of an expression. These context objects are used by
      * ELResolvers. This method is used to retrieve the context with the given key from the collection. By convention, the object returned will be of the type specified by the key. However, this is
      * not required and the key is used strictly as a unique identifier.
-     * 
-     * @param key
-     *            The unique identifier that was used to associate the context object with this ELContext.
+     *
+     * @param key The unique identifier that was used to associate the context object with this ELContext.
      * @return The context object associated with the given key, or null if no such context was found.
-     * @throws NullPointerException
-     *             if key is null.
+     * @throws NullPointerException if key is null.
      */
     public Object getContext(Class<?> key) {
         return context.get(key);
@@ -58,14 +56,14 @@ public abstract class ELContext {
     /**
      * Retrieves the ELResolver associated with this context. The ELContext maintains a reference to the ELResolver that will be consulted to resolve variables and properties during an expression
      * evaluation. This method retrieves the reference to the resolver. Once an ELContext is constructed, the reference to the ELResolver associated with the context cannot be changed.
-     * 
+     *
      * @return The resolver to be consulted for variable and property resolution during expression evaluation.
      */
     public abstract ELResolver getELResolver();
 
     /**
      * Retrieves the FunctionMapper associated with this ELContext.
-     * 
+     *
      * @return The function mapper to be consulted for the resolution of EL functions.
      */
     public abstract FunctionMapper getFunctionMapper();
@@ -73,7 +71,7 @@ public abstract class ELContext {
     /**
      * Get the Locale stored by a previous invocation to {@link #setLocale(Locale)}. If this method returns non null, this Locale must be used for all localization needs in the implementation. The
      * Locale must not be cached to allow for applications that change Locale dynamically.
-     * 
+     *
      * @return The Locale in which this instance is operating. Used primarily for message localization.
      */
     public Locale getLocale() {
@@ -82,7 +80,7 @@ public abstract class ELContext {
 
     /**
      * Retrieves the VariableMapper associated with this ELContext.
-     * 
+     *
      * @return The variable mapper to be consulted for the resolution of EL variables.
      */
     public abstract VariableMapper getVariableMapper();
@@ -90,7 +88,7 @@ public abstract class ELContext {
     /**
      * Returns whether an {@link ELResolver} has successfully resolved a given (base, property) pair. The {@link CompositeELResolver} checks this property to determine whether it should consider or
      * skip other component resolvers.
-     * 
+     *
      * @return The variable mapper to be consulted for the resolution of EL variables.
      * @see CompositeELResolver
      */
@@ -102,13 +100,10 @@ public abstract class ELContext {
      * Associates a context object with this ELContext. The ELContext maintains a collection of context objects relevant to the evaluation of an expression. These context objects are used by
      * ELResolvers. This method is used to add a context object to that collection. By convention, the contextObject will be of the type specified by the key. However, this is not required and the key
      * is used strictly as a unique identifier.
-     * 
-     * @param key
-     *            The key used by an {@link ELResolver} to identify this context object.
-     * @param contextObject
-     *            The context object to add to the collection.
-     * @throws NullPointerException
-     *             if key is null or contextObject is null.
+     *
+     * @param key           The key used by an {@link ELResolver} to identify this context object.
+     * @param contextObject The context object to add to the collection.
+     * @throws NullPointerException if key is null or contextObject is null.
      */
     public void putContext(Class<?> key, Object contextObject) {
         context.put(key, contextObject);
@@ -117,9 +112,8 @@ public abstract class ELContext {
     /**
      * Set the Locale for this instance. This method may be called by the party creating the instance, such as JavaServer Faces or JSP, to enable the EL implementation to provide localized messages to
      * the user. If no Locale is set, the implementation must use the locale returned by Locale.getDefault( ).
-     * 
-     * @param locale
-     *            The Locale in which this instance is operating. Used primarily for message localization.
+     *
+     * @param locale The Locale in which this instance is operating. Used primarily for message localization.
      */
     public void setLocale(Locale locale) {
         this.locale = locale;
@@ -128,9 +122,8 @@ public abstract class ELContext {
     /**
      * Called to indicate that a ELResolver has successfully resolved a given (base, property) pair. The {@link CompositeELResolver} checks this property to determine whether it should consider or
      * skip other component resolvers.
-     * 
-     * @param resolved
-     *            true if the property has been resolved, or false if not.
+     *
+     * @param resolved true if the property has been resolved, or false if not.
      * @see CompositeELResolver
      */
     public void setPropertyResolved(boolean resolved) {

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/jobexecutor/SingleJobExecutorContext.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/jobexecutor/SingleJobExecutorContext.java
@@ -22,7 +22,7 @@ import org.activiti.engine.impl.persistence.entity.JobEntity;
  */
 public class SingleJobExecutorContext implements JobExecutorContext {
 
-    protected List<JobEntity> currentProcessorJobQueue = new LinkedList<JobEntity>();
+    protected List<JobEntity> currentProcessorJobQueue = new LinkedList<>();
     protected JobEntity currentJob;
 
     public List<JobEntity> getCurrentProcessorJobQueue() {

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/AbstractJobEntity.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/AbstractJobEntity.java
@@ -100,7 +100,7 @@ public abstract class AbstractJobEntity implements Job, PersistentObject, HasRev
     }
 
     public Object getPersistentState() {
-        Map<String, Object> persistentState = new HashMap<String, Object>();
+        Map<String, Object> persistentState = new HashMap<>();
         persistentState.put("retries", retries);
         persistentState.put("duedate", duedate);
         persistentState.put("exceptionMessage", exceptionMessage);

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/AttachmentEntity.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/AttachmentEntity.java
@@ -46,7 +46,7 @@ public class AttachmentEntity implements Attachment, PersistentObject, HasRevisi
     }
 
     public Object getPersistentState() {
-        Map<String, Object> persistentState = new HashMap<String, Object>();
+        Map<String, Object> persistentState = new HashMap<>();
         persistentState.put("name", name);
         persistentState.put("description", description);
         return persistentState;

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/CommentEntity.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/CommentEntity.java
@@ -82,7 +82,7 @@ public class CommentEntity implements Comment, Event, PersistentObject, Serializ
         if (message == null) {
             return null;
         }
-        List<String> messageParts = new ArrayList<String>();
+        List<String> messageParts = new ArrayList<>();
 
         String[] parts = MESSAGE_PARTS_MARKER_REGEX.split(message);
         for (String part : parts) {

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/CommentEntityManager.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/CommentEntityManager.java
@@ -81,7 +81,7 @@ public class CommentEntityManager extends AbstractManager {
     @SuppressWarnings("unchecked")
     public List<Comment> findCommentsByTaskIdAndType(String taskId, String type) {
         checkHistoryEnabled();
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("taskId", taskId);
         params.put("type", type);
         return getDbSqlSession().selectListWithRawParameter("selectCommentsByTaskIdAndType", params, 0, Integer.MAX_VALUE);
@@ -123,7 +123,7 @@ public class CommentEntityManager extends AbstractManager {
 
     public List<Comment> findCommentsByProcessInstanceId(String processInstanceId, String type) {
         checkHistoryEnabled();
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("processInstanceId", processInstanceId);
         params.put("type", type);
         return getDbSqlSession().selectListWithRawParameter("selectCommentsByProcessInstanceIdAndType", params, 0, Integer.MAX_VALUE);

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/DeadLetterJobEntityManager.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/DeadLetterJobEntityManager.java
@@ -52,7 +52,7 @@ public class DeadLetterJobEntityManager extends AbstractManager {
 
     @SuppressWarnings("unchecked")
     public List<Job> findDeadLetterJobsByTypeAndProcessDefinitionKeyNoTenantId(String jobHandlerType, String processDefinitionKey) {
-        Map<String, String> params = new HashMap<String, String>(2);
+        Map<String, String> params = new HashMap<>(2);
         params.put("handlerType", jobHandlerType);
         params.put("processDefinitionKey", processDefinitionKey);
         return getDbSqlSession().selectList("selectDeadLetterJobByTypeAndProcessDefinitionKeyNoTenantId", params);
@@ -60,7 +60,7 @@ public class DeadLetterJobEntityManager extends AbstractManager {
 
     @SuppressWarnings("unchecked")
     public List<Job> findDeadLetterJobsByTypeAndProcessDefinitionKeyAndTenantId(String jobHandlerType, String processDefinitionKey, String tenantId) {
-        Map<String, String> params = new HashMap<String, String>(3);
+        Map<String, String> params = new HashMap<>(3);
         params.put("handlerType", jobHandlerType);
         params.put("processDefinitionKey", processDefinitionKey);
         params.put("tenantId", tenantId);
@@ -69,7 +69,7 @@ public class DeadLetterJobEntityManager extends AbstractManager {
 
     @SuppressWarnings("unchecked")
     public List<Job> findDeadLetterJobsByTypeAndProcessDefinitionId(String jobHandlerType, String processDefinitionId) {
-        Map<String, String> params = new HashMap<String, String>(2);
+        Map<String, String> params = new HashMap<>(2);
         params.put("handlerType", jobHandlerType);
         params.put("processDefinitionId", processDefinitionId);
         return getDbSqlSession().selectList("selectDeadLetterJobByTypeAndProcessDefinitionId", params);
@@ -80,7 +80,7 @@ public class DeadLetterJobEntityManager extends AbstractManager {
     }
 
     public void updateDeadLetterJobTenantIdForDeployment(String deploymentId, String newTenantId) {
-        HashMap<String, Object> params = new HashMap<String, Object>();
+        HashMap<String, Object> params = new HashMap<>();
         params.put("deploymentId", deploymentId);
         params.put("tenantId", newTenantId);
         getDbSqlSession().update("updateDeadLetterJobTenantIdForDeployment", params);

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/DeploymentEntity.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/DeploymentEntity.java
@@ -51,7 +51,7 @@ public class DeploymentEntity implements Serializable, Deployment, PersistentObj
 
     public void addResource(ResourceEntity resource) {
         if (resources == null) {
-            resources = new HashMap<String, ResourceEntity>();
+            resources = new HashMap<>();
         }
         resources.put(resource.getName(), resource);
     }
@@ -63,7 +63,7 @@ public class DeploymentEntity implements Serializable, Deployment, PersistentObj
                     .getCommandContext()
                     .getResourceEntityManager()
                     .findResourcesByDeploymentId(id);
-            resources = new HashMap<String, ResourceEntity>();
+            resources = new HashMap<>();
             for (ResourceEntity resource : resourcesList) {
                 resources.put(resource.getName(), resource);
             }
@@ -72,7 +72,7 @@ public class DeploymentEntity implements Serializable, Deployment, PersistentObj
     }
 
     public Object getPersistentState() {
-        Map<String, Object> persistentState = new HashMap<String, Object>();
+        Map<String, Object> persistentState = new HashMap<>();
         persistentState.put("category", this.category);
         persistentState.put("tenantId", tenantId);
         return persistentState;
@@ -81,13 +81,13 @@ public class DeploymentEntity implements Serializable, Deployment, PersistentObj
     // Deployed artifacts manipulation //////////////////////////////////////////
     public void addDeployedArtifact(Object deployedArtifact) {
         if (deployedArtifacts == null) {
-            deployedArtifacts = new HashMap<Class<?>, List<Object>>();
+            deployedArtifacts = new HashMap<>();
         }
 
         Class<?> clazz = deployedArtifact.getClass();
         List<Object> artifacts = deployedArtifacts.get(clazz);
         if (artifacts == null) {
-            artifacts = new ArrayList<Object>();
+            artifacts = new ArrayList<>();
             deployedArtifacts.put(clazz, artifacts);
         }
 

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/EventLogEntryEntityManager.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/EventLogEntryEntityManager.java
@@ -36,7 +36,7 @@ public class EventLogEntryEntityManager extends AbstractManager {
 
     @SuppressWarnings("unchecked")
     public List<EventLogEntry> findEventLogEntries(long startLogNr, long pageSize) {
-        Map<String, Object> params = new HashMap<String, Object>(2);
+        Map<String, Object> params = new HashMap<>(2);
         params.put("startLogNr", startLogNr);
         if (pageSize > 0) {
             params.put("endLogNr", startLogNr + pageSize + 1);
@@ -46,7 +46,7 @@ public class EventLogEntryEntityManager extends AbstractManager {
 
     @SuppressWarnings("unchecked")
     public List<EventLogEntry> findEventLogEntriesByProcessInstanceId(String processInstanceId) {
-        Map<String, Object> params = new HashMap<String, Object>(2);
+        Map<String, Object> params = new HashMap<>(2);
         params.put("processInstanceId", processInstanceId);
         return getDbSqlSession().selectList("selectEventLogEntriesByProcessInstanceId", params);
     }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/EventSubscriptionEntity.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/EventSubscriptionEntity.java
@@ -152,7 +152,7 @@ public abstract class EventSubscriptionEntity implements PersistentObject, HasRe
     }
 
     public Object getPersistentState() {
-        HashMap<String, Object> persistentState = new HashMap<String, Object>();
+        HashMap<String, Object> persistentState = new HashMap<>();
         persistentState.put("executionId", executionId);
         persistentState.put("configuration", configuration);
         return persistentState;

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/EventSubscriptionEntityManager.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/EventSubscriptionEntityManager.java
@@ -31,8 +31,10 @@ import org.activiti.engine.impl.persistence.AbstractManager;
  */
 public class EventSubscriptionEntityManager extends AbstractManager {
 
-    /** keep track of subscriptions created in the current command */
-    protected List<SignalEventSubscriptionEntity> createdSignalSubscriptions = new ArrayList<SignalEventSubscriptionEntity>();
+    /**
+     * keep track of subscriptions created in the current command
+     */
+    protected List<SignalEventSubscriptionEntity> createdSignalSubscriptions = new ArrayList<>();
 
     public void insert(EventSubscriptionEntity persistentObject) {
         super.insert(persistentObject);
@@ -72,7 +74,7 @@ public class EventSubscriptionEntityManager extends AbstractManager {
         final String query = "selectSignalEventSubscriptionsByEventName";
 
         Set<SignalEventSubscriptionEntity> selectList = null;
-        Map<String, String> params = new HashMap<String, String>();
+        Map<String, String> params = new HashMap<>();
         params.put("eventName", eventName);
         if (tenantId != null && !tenantId.equals(ProcessEngineConfiguration.NO_TENANT_ID)) {
             params.put("tenantId", tenantId);
@@ -88,13 +90,13 @@ public class EventSubscriptionEntityManager extends AbstractManager {
             }
         }
 
-        return new ArrayList<SignalEventSubscriptionEntity>(selectList);
+        return new ArrayList<>(selectList);
     }
 
     @SuppressWarnings("unchecked")
     public List<SignalEventSubscriptionEntity> findSignalEventSubscriptionsByProcessInstanceAndEventName(String processInstanceId, String eventName) {
         final String query = "selectSignalEventSubscriptionsByProcessInstanceAndEventName";
-        Map<String, String> params = new HashMap<String, String>();
+        Map<String, String> params = new HashMap<>();
         params.put("processInstanceId", processInstanceId);
         params.put("eventName", eventName);
         Set<SignalEventSubscriptionEntity> selectList = new HashSet<SignalEventSubscriptionEntity>(getDbSqlSession().selectList(query, params));
@@ -106,7 +108,7 @@ public class EventSubscriptionEntityManager extends AbstractManager {
             }
         }
 
-        return new ArrayList<SignalEventSubscriptionEntity>(selectList);
+        return new ArrayList<>(selectList);
     }
 
     @SuppressWarnings("unchecked")
@@ -121,13 +123,13 @@ public class EventSubscriptionEntityManager extends AbstractManager {
             }
         }
 
-        return new ArrayList<SignalEventSubscriptionEntity>(selectList);
+        return new ArrayList<>(selectList);
     }
 
     @SuppressWarnings("unchecked")
     public List<SignalEventSubscriptionEntity> findSignalEventSubscriptionsByNameAndExecution(String name, String executionId) {
         final String query = "selectSignalEventSubscriptionsByNameAndExecution";
-        Map<String, String> params = new HashMap<String, String>();
+        Map<String, String> params = new HashMap<>();
         params.put("executionId", executionId);
         params.put("eventName", name);
         Set<SignalEventSubscriptionEntity> selectList = new HashSet<SignalEventSubscriptionEntity>(getDbSqlSession().selectList(query, params));
@@ -140,12 +142,12 @@ public class EventSubscriptionEntityManager extends AbstractManager {
             }
         }
 
-        return new ArrayList<SignalEventSubscriptionEntity>(selectList);
+        return new ArrayList<>(selectList);
     }
 
     public List<EventSubscriptionEntity> findEventSubscriptionsByExecutionAndType(String executionId, String type) {
         final String query = "selectEventSubscriptionsByExecutionAndType";
-        Map<String, String> params = new HashMap<String, String>();
+        Map<String, String> params = new HashMap<>();
         params.put("executionId", executionId);
         params.put("eventType", type);
         return getDbSqlSession().selectList(query, params);
@@ -158,7 +160,7 @@ public class EventSubscriptionEntityManager extends AbstractManager {
 
     public List<EventSubscriptionEntity> findEventSubscriptions(String executionId, String type, String activityId) {
         final String query = "selectEventSubscriptionsByExecutionTypeAndActivity";
-        Map<String, String> params = new HashMap<String, String>();
+        Map<String, String> params = new HashMap<>();
         params.put("executionId", executionId);
         params.put("eventType", type);
         params.put("activityId", activityId);
@@ -167,7 +169,7 @@ public class EventSubscriptionEntityManager extends AbstractManager {
 
     public List<EventSubscriptionEntity> findEventSubscriptionsByConfiguration(String type, String configuration, String tenantId) {
         final String query = "selectEventSubscriptionsByConfiguration";
-        Map<String, String> params = new HashMap<String, String>();
+        Map<String, String> params = new HashMap<>();
         params.put("eventType", type);
         params.put("configuration", configuration);
         if (tenantId != null && !tenantId.equals(ProcessEngineConfiguration.NO_TENANT_ID)) {
@@ -178,7 +180,7 @@ public class EventSubscriptionEntityManager extends AbstractManager {
 
     public List<EventSubscriptionEntity> findEventSubscriptionsByTypeAndProcessDefinitionId(String type, String processDefinitionId, String tenantId) {
         final String query = "selectEventSubscriptionsByTypeAndProcessDefinitionId";
-        Map<String, String> params = new HashMap<String, String>();
+        Map<String, String> params = new HashMap<>();
         if (type != null) {
             params.put("eventType", type);
         }
@@ -191,7 +193,7 @@ public class EventSubscriptionEntityManager extends AbstractManager {
 
     public List<EventSubscriptionEntity> findEventSubscriptionsByName(String type, String eventName, String tenantId) {
         final String query = "selectEventSubscriptionsByName";
-        Map<String, String> params = new HashMap<String, String>();
+        Map<String, String> params = new HashMap<>();
         params.put("eventType", type);
         params.put("eventName", eventName);
         if (tenantId != null && !tenantId.equals(ProcessEngineConfiguration.NO_TENANT_ID)) {
@@ -202,7 +204,7 @@ public class EventSubscriptionEntityManager extends AbstractManager {
 
     public List<EventSubscriptionEntity> findEventSubscriptionsByNameAndExecution(String type, String eventName, String executionId) {
         final String query = "selectEventSubscriptionsByNameAndExecution";
-        Map<String, String> params = new HashMap<String, String>();
+        Map<String, String> params = new HashMap<>();
         params.put("eventType", type);
         params.put("eventName", eventName);
         params.put("executionId", executionId);
@@ -210,7 +212,7 @@ public class EventSubscriptionEntityManager extends AbstractManager {
     }
 
     public MessageEventSubscriptionEntity findMessageStartEventSubscriptionByName(String messageName, String tenantId) {
-        Map<String, String> params = new HashMap<String, String>();
+        Map<String, String> params = new HashMap<>();
         params.put("eventName", messageName);
         if (tenantId != null && !tenantId.equals(ProcessEngineConfiguration.NO_TENANT_ID)) {
             params.put("tenantId", tenantId);
@@ -220,7 +222,7 @@ public class EventSubscriptionEntityManager extends AbstractManager {
     }
 
     public void updateEventSubscriptionTenantId(String oldTenantId, String newTenantId) {
-        Map<String, String> params = new HashMap<String, String>();
+        Map<String, String> params = new HashMap<>();
         params.put("oldTenantId", oldTenantId);
         params.put("newTenantId", newTenantId);
         getDbSqlSession().update("updateTenantIdOfEventSubscriptions", params);

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntity.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntity.java
@@ -88,15 +88,21 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
 
     protected ProcessDefinitionImpl processDefinition;
 
-    /** current activity */
+    /**
+     * current activity
+     */
     protected ActivityImpl activity;
 
     protected FlowElement currentFlowElement;
 
-    /** current transition. is null when there is no transition being taken. */
+    /**
+     * current transition. is null when there is no transition being taken.
+     */
     protected TransitionImpl transition;
 
-    /** transition that will be taken. is null when there is no transition being taken. */
+    /**
+     * transition that will be taken. is null when there is no transition being taken.
+     */
     protected TransitionImpl transitionBeingTaken;
 
     /**
@@ -104,21 +110,31 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
      */
     protected ExecutionEntity processInstance;
 
-    /** the parent execution */
+    /**
+     * the parent execution
+     */
     protected ExecutionEntity parent;
 
-    /** nested executions representing scopes or concurrent paths */
+    /**
+     * nested executions representing scopes or concurrent paths
+     */
     protected List<ExecutionEntity> executions;
 
-    /** super execution, not-null if this execution is part of a subprocess */
+    /**
+     * super execution, not-null if this execution is part of a subprocess
+     */
     protected ExecutionEntity superExecution;
 
-    /** reference to a subprocessinstance, not-null if currently subprocess is started from this execution */
+    /**
+     * reference to a subprocessinstance, not-null if currently subprocess is started from this execution
+     */
     protected ExecutionEntity subProcessInstance;
 
     protected StartingExecution startingExecution;
 
-    /** The tenant identifier (if any) */
+    /**
+     * The tenant identifier (if any)
+     */
     protected String tenantId = ProcessEngineConfiguration.NO_TENANT_ID;
     protected String name;
     protected String description;
@@ -169,7 +185,7 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
 
     /**
      * when execution structure is pruned during a takeAll, then the original execution has to be resolved to the replaced execution.
-     * 
+     *
      * @see #takeAll(List, List) {@link OutgoingExecution}
      */
     protected ExecutionEntity replacedBy;
@@ -179,7 +195,7 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
     /**
      * next operation. process execution is in fact runtime interpretation of the process model. each operation is a logical unit of interpretation of the process. so sequentially processing the
      * operations drives the interpretation or execution of a process.
-     * 
+     *
      * @see AtomicOperation
      * @see #performOperation(AtomicOperation)
      */
@@ -191,7 +207,7 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
 
     /**
      * persisted reference to the processDefinition.
-     * 
+     *
      * @see #processDefinition
      * @see #setProcessDefinition(ProcessDefinitionImpl)
      * @see #getProcessDefinition()
@@ -220,7 +236,7 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
 
     /**
      * persisted reference to the current position in the diagram within the {@link #processDefinition}.
-     * 
+     *
      * @see #activity
      * @see #setActivity(ActivityImpl)
      * @see #getActivity()
@@ -234,7 +250,7 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
 
     /**
      * persisted reference to the process instance.
-     * 
+     *
      * @see #getProcessInstance()
      */
     protected String processInstanceId;
@@ -246,7 +262,7 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
 
     /**
      * persisted reference to the parent of this execution.
-     * 
+     *
      * @see #getParent()
      * @see #setParentId(String)
      */
@@ -254,7 +270,7 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
 
     /**
      * persisted reference to the super execution of this execution
-     * 
+     *
      * @see #getSuperExecution()
      * @see #setSuperExecution(ExecutionEntity)
      */
@@ -271,7 +287,9 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
     public ExecutionEntity() {
     }
 
-    /** creates a new execution. properties processDefinition, processInstance and activity will be initialized. */
+    /**
+     * creates a new execution. properties processDefinition, processInstance and activity will be initialized.
+     */
     @Override
     public ExecutionEntity createExecution() {
         // create the new child execution
@@ -325,7 +343,7 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
 
     protected ExecutionEntity newExecution() {
         ExecutionEntity newExecution = new ExecutionEntity();
-        newExecution.executions = new ArrayList<ExecutionEntity>();
+        newExecution.executions = new ArrayList<>();
 
         // Inherit tenant id (if any)
         if (getTenantId() != null) {
@@ -351,8 +369,8 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
         ensureParentInitialized();
 
         // initialize the lists of referenced objects (prevents db queries)
-        variableInstances = new HashMap<String, VariableInstanceEntity>();
-        eventSubscriptions = new ArrayList<EventSubscriptionEntity>();
+        variableInstances = new HashMap<>();
+        eventSubscriptions = new ArrayList<>();
 
         // Cached entity-state initialized to null, all bits are zero, indicating NO entities present
         cachedEntityState = 0;
@@ -426,7 +444,7 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
             // If needed, dispatch an event indicating an activity was signalled
             boolean isUserTask = (activityBehavior instanceof UserTaskActivityBehavior)
                     || ((activityBehavior instanceof MultiInstanceActivityBehavior)
-                            && ((MultiInstanceActivityBehavior) activityBehavior).getInnerActivityBehavior() instanceof UserTaskActivityBehavior);
+                    && ((MultiInstanceActivityBehavior) activityBehavior).getInnerActivityBehavior() instanceof UserTaskActivityBehavior);
 
             if (!isUserTask && Context.getProcessEngineConfiguration() != null
                     && Context.getProcessEngineConfiguration().getEventDispatcher().isEnabled()) {
@@ -447,8 +465,7 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
     }
 
     /**
-     * @param fireActivityCompletionEvent
-     *            This method can be called from other places (like {@link #takeAll(List, List)}), where the event is already fired. In that case, false is passed an no second event is fired.
+     * @param fireActivityCompletionEvent This method can be called from other places (like {@link #takeAll(List, List)}), where the event is already fired. In that case, false is passed an no second event is fired.
      */
     @Override
     public void take(PvmTransition transition, boolean fireActivityCompletionEvent) {
@@ -476,8 +493,8 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
 
     @Override
     public List<ActivityExecution> findInactiveConcurrentExecutions(PvmActivity activity) {
-        List<ActivityExecution> inactiveConcurrentExecutionsInActivity = new ArrayList<ActivityExecution>();
-        List<ActivityExecution> otherConcurrentExecutions = new ArrayList<ActivityExecution>();
+        List<ActivityExecution> inactiveConcurrentExecutionsInActivity = new ArrayList<>();
+        List<ActivityExecution> otherConcurrentExecutions = new ArrayList<>();
         if (isConcurrent()) {
             List<? extends ActivityExecution> concurrentExecutions = getParent().getAllChildExecutions();
             for (ActivityExecution concurrentExecution : concurrentExecutions) {
@@ -504,7 +521,7 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
     }
 
     protected List<ExecutionEntity> getAllChildExecutions() {
-        List<ExecutionEntity> childExecutions = new ArrayList<ExecutionEntity>();
+        List<ExecutionEntity> childExecutions = new ArrayList<>();
         for (ExecutionEntity childExecution : getExecutions()) {
             childExecutions.add(childExecution);
             childExecutions.addAll(childExecution.getAllChildExecutions());
@@ -513,13 +530,13 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
     }
 
     @Override
-    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public void takeAll(List<PvmTransition> transitions, List<ActivityExecution> recyclableExecutions) {
 
         fireActivityCompletedEvent();
 
-        transitions = new ArrayList<PvmTransition>(transitions);
-        recyclableExecutions = (recyclableExecutions != null ? new ArrayList<ActivityExecution>(recyclableExecutions) : new ArrayList<ActivityExecution>());
+        transitions = new ArrayList<>(transitions);
+        recyclableExecutions = (recyclableExecutions != null ? new ArrayList<>(recyclableExecutions) : new ArrayList<ActivityExecution>());
 
         if (recyclableExecutions.size() > 1) {
             for (ActivityExecution recyclableExecution : recyclableExecutions) {
@@ -530,8 +547,8 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
         }
 
         ExecutionEntity concurrentRoot = ((isConcurrent && !isScope) ? getParent() : this);
-        List<ExecutionEntity> concurrentActiveExecutions = new ArrayList<ExecutionEntity>();
-        List<ExecutionEntity> concurrentInActiveExecutions = new ArrayList<ExecutionEntity>();
+        List<ExecutionEntity> concurrentActiveExecutions = new ArrayList<>();
+        List<ExecutionEntity> concurrentInActiveExecutions = new ArrayList<>();
         for (ExecutionEntity execution : concurrentRoot.getExecutions()) {
             if (execution.isActive()) {
                 concurrentActiveExecutions.add(execution);
@@ -575,7 +592,7 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
 
         } else {
 
-            List<OutgoingExecution> outgoingExecutions = new ArrayList<OutgoingExecution>();
+            List<OutgoingExecution> outgoingExecutions = new ArrayList<>();
 
             recyclableExecutions.remove(concurrentRoot);
 
@@ -702,14 +719,16 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
 
     // executions ///////////////////////////////////////////////////////////////
 
-    /** ensures initialization and returns the non-null executions list */
+    /**
+     * ensures initialization and returns the non-null executions list
+     */
     @Override
     public List<ExecutionEntity> getExecutions() {
         ensureExecutionsInitialized();
         return executions;
     }
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @SuppressWarnings({"unchecked", "rawtypes"})
     protected void ensureExecutionsInitialized() {
         if (executions == null) {
             this.executions = Context
@@ -723,7 +742,9 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
         this.executions = executions;
     }
 
-    /** searches for an execution positioned in the given activity */
+    /**
+     * searches for an execution positioned in the given activity
+     */
     @Override
     public ExecutionEntity findExecution(String activityId) {
         if ((getActivity() != null)
@@ -741,7 +762,7 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
 
     @Override
     public List<String> findActiveActivityIds() {
-        List<String> activeActivityIds = new ArrayList<String>();
+        List<String> activeActivityIds = new ArrayList<>();
         collectActiveActivityIds(activeActivityIds);
         return activeActivityIds;
     }
@@ -779,7 +800,9 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
 
     // process definition ///////////////////////////////////////////////////////
 
-    /** ensures initialization and returns the process definition. */
+    /**
+     * ensures initialization and returns the process definition.
+     */
     @Override
     public ProcessDefinitionImpl getProcessDefinition() {
         ensureProcessDefinitionInitialized();
@@ -831,7 +854,9 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
         this.deploymentId = deploymentId;
     }
 
-    /** for setting the process definition, this setter must be used as subclasses can override */
+    /**
+     * for setting the process definition, this setter must be used as subclasses can override
+     */
     protected void ensureProcessDefinitionInitialized() {
         if ((processDefinition == null) && (processDefinitionId != null)) {
             ProcessDefinitionEntity deployedProcessDefinition = (ProcessDefinitionEntity) Context
@@ -851,7 +876,9 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
 
     // process instance /////////////////////////////////////////////////////////
 
-    /** ensures initialization and returns the process instance. */
+    /**
+     * ensures initialization and returns the process instance.
+     */
     @Override
     public ExecutionEntity getProcessInstance() {
         ensureProcessInstanceInitialized();
@@ -882,14 +909,18 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
 
     // activity /////////////////////////////////////////////////////////////////
 
-    /** ensures initialization and returns the activity */
+    /**
+     * ensures initialization and returns the activity
+     */
     @Override
     public ActivityImpl getActivity() {
         ensureActivityInitialized();
         return activity;
     }
 
-    /** must be called before the activity member field or getActivity() is called */
+    /**
+     * must be called before the activity member field or getActivity() is called
+     */
     protected void ensureActivityInitialized() {
         if ((activity == null) && (activityId != null)) {
             activity = getProcessDefinition().findActivity(activityId);
@@ -910,7 +941,9 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
 
     // parent ///////////////////////////////////////////////////////////////////
 
-    /** ensures initialization and returns the parent */
+    /**
+     * ensures initialization and returns the parent
+     */
     @Override
     public ExecutionEntity getParent() {
         ensureParentInitialized();
@@ -1145,7 +1178,7 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
     }
 
     @Override
-    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public void setReplacedBy(InterpretableExecution replacedBy) {
         this.replacedBy = (ExecutionEntity) replacedBy;
 
@@ -1154,7 +1187,7 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
 
         // update the related tasks
 
-        List<TaskEntity> allTasks = new ArrayList<TaskEntity>();
+        List<TaskEntity> allTasks = new ArrayList<>();
         allTasks.addAll(getTasks());
 
         List<TaskEntity> cachedTasks = dbSqlSession.findInCache(TaskEntity.class);
@@ -1247,7 +1280,9 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
         return getParent();
     }
 
-    /** used to calculate the sourceActivityExecution for method {@link #updateActivityInstanceIdInHistoricVariableUpdate(HistoricDetailVariableInstanceUpdateEntity, ExecutionEntity)} */
+    /**
+     * used to calculate the sourceActivityExecution for method {@link #updateActivityInstanceIdInHistoricVariableUpdate(HistoricDetailVariableInstanceUpdateEntity, ExecutionEntity)}
+     */
     @Override
     protected ExecutionEntity getSourceActivityExecution() {
         return (activityId != null ? this : null);
@@ -1255,7 +1290,7 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
 
     @Override
     protected VariableInstanceEntity createVariableInstance(String variableName, Object value,
-            ExecutionEntity sourceActivityExecution) {
+                                                            ExecutionEntity sourceActivityExecution) {
         VariableInstanceEntity result = super.createVariableInstance(variableName, value, sourceActivityExecution);
 
         // Dispatch event, if needed
@@ -1269,7 +1304,7 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
 
     @Override
     protected void updateVariableInstance(VariableInstanceEntity variableInstance, Object value,
-            ExecutionEntity sourceActivityExecution) {
+                                          ExecutionEntity sourceActivityExecution) {
         super.updateVariableInstance(variableInstance, value, sourceActivityExecution);
 
         // Dispatch event, if needed
@@ -1309,7 +1344,7 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
 
     @Override
     public Object getPersistentState() {
-        Map<String, Object> persistentState = new HashMap<String, Object>();
+        Map<String, Object> persistentState = new HashMap<>();
         persistentState.put("processDefinitionId", this.processDefinitionId);
         persistentState.put("businessKey", this.businessKey);
         persistentState.put("activityId", this.activityId);
@@ -1412,12 +1447,12 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
     }
 
     public List<EventSubscriptionEntity> getEventSubscriptions() {
-        return new ArrayList<EventSubscriptionEntity>(getEventSubscriptionsInternal());
+        return new ArrayList<>(getEventSubscriptionsInternal());
     }
 
     public List<CompensateEventSubscriptionEntity> getCompensateEventSubscriptions() {
         List<EventSubscriptionEntity> eventSubscriptions = getEventSubscriptionsInternal();
-        List<CompensateEventSubscriptionEntity> result = new ArrayList<CompensateEventSubscriptionEntity>(eventSubscriptions.size());
+        List<CompensateEventSubscriptionEntity> result = new ArrayList<>(eventSubscriptions.size());
         for (EventSubscriptionEntity eventSubscriptionEntity : eventSubscriptions) {
             if (eventSubscriptionEntity instanceof CompensateEventSubscriptionEntity) {
                 result.add((CompensateEventSubscriptionEntity) eventSubscriptionEntity);
@@ -1428,7 +1463,7 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
 
     public List<CompensateEventSubscriptionEntity> getCompensateEventSubscriptions(String activityId) {
         List<EventSubscriptionEntity> eventSubscriptions = getEventSubscriptionsInternal();
-        List<CompensateEventSubscriptionEntity> result = new ArrayList<CompensateEventSubscriptionEntity>(eventSubscriptions.size());
+        List<CompensateEventSubscriptionEntity> result = new ArrayList<>(eventSubscriptions.size());
         for (EventSubscriptionEntity eventSubscriptionEntity : eventSubscriptions) {
             if (eventSubscriptionEntity instanceof CompensateEventSubscriptionEntity) {
                 if (activityId.equals(eventSubscriptionEntity.getActivityId())) {
@@ -1458,7 +1493,7 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
 
     // referenced job entities //////////////////////////////////////////////////
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @SuppressWarnings({"unchecked", "rawtypes"})
     protected void ensureJobsInitialized() {
         if (jobs == null) {
             jobs = Context.getCommandContext()
@@ -1473,7 +1508,7 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
     }
 
     public List<JobEntity> getJobs() {
-        return new ArrayList<JobEntity>(getJobsInternal());
+        return new ArrayList<>(getJobsInternal());
     }
 
     public void addJob(JobEntity jobEntity) {
@@ -1484,7 +1519,7 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
         getJobsInternal().remove(job);
     }
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @SuppressWarnings({"unchecked", "rawtypes"})
     protected void ensureTimerJobsInitialized() {
         if (timerJobs == null) {
             timerJobs = Context.getCommandContext()
@@ -1499,7 +1534,7 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
     }
 
     public List<TimerJobEntity> getTimerJobs() {
-        return new ArrayList<TimerJobEntity>(getTimerJobsInternal());
+        return new ArrayList<>(getTimerJobsInternal());
     }
 
     public void addTimerJob(TimerJobEntity jobEntity) {
@@ -1512,7 +1547,7 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
 
     // referenced task entities ///////////////////////////////////////////////////
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @SuppressWarnings({"unchecked", "rawtypes"})
     protected void ensureTasksInitialized() {
         if (tasks == null) {
             tasks = Context.getCommandContext()
@@ -1527,7 +1562,7 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
     }
 
     public List<TaskEntity> getTasks() {
-        return new ArrayList<TaskEntity>(getTasksInternal());
+        return new ArrayList<>(getTasksInternal());
     }
 
     public void addTask(TaskEntity taskEntity) {
@@ -1828,7 +1863,7 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
 
     @Override
     public Map<String, Object> getProcessVariables() {
-        Map<String, Object> variables = new HashMap<String, Object>();
+        Map<String, Object> variables = new HashMap<>();
         if (queryVariables != null) {
             for (VariableInstanceEntity variableInstance : queryVariables) {
                 if (variableInstance.getId() != null && variableInstance.getTaskId() == null) {

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntityManager.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntityManager.java
@@ -178,7 +178,7 @@ public class ExecutionEntityManager extends AbstractManager {
 
     @SuppressWarnings("unchecked")
     public List<ExecutionEntity> findEventScopeExecutionsByActivityId(String activityRef, String parentExecutionId) {
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         parameters.put("activityId", activityRef);
         parameters.put("parentExecutionId", parentExecutionId);
 
@@ -200,7 +200,7 @@ public class ExecutionEntityManager extends AbstractManager {
     }
 
     public void updateExecutionTenantIdForDeployment(String deploymentId, String newTenantId) {
-        HashMap<String, Object> params = new HashMap<String, Object>();
+        HashMap<String, Object> params = new HashMap<>();
         params.put("deploymentId", deploymentId);
         params.put("tenantId", newTenantId);
         getDbSqlSession().update("updateExecutionTenantIdForDeployment", params);
@@ -214,7 +214,7 @@ public class ExecutionEntityManager extends AbstractManager {
         lockCal.setTime(expirationTime);
         lockCal.add(Calendar.MILLISECOND, lockMillis);
 
-        HashMap<String, Object> params = new HashMap<String, Object>();
+        HashMap<String, Object> params = new HashMap<>();
         params.put("id", processInstanceId);
         params.put("lockTime", lockCal.getTime());
         params.put("expirationTime", expirationTime);
@@ -226,7 +226,7 @@ public class ExecutionEntityManager extends AbstractManager {
     }
 
     public void clearProcessInstanceLockTime(String processInstanceId) {
-        HashMap<String, Object> params = new HashMap<String, Object>();
+        HashMap<String, Object> params = new HashMap<>();
         params.put("id", processInstanceId);
 
         getDbSqlSession().update("clearProcessInstanceLockTime", params);

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/HistoricActivityInstanceEntity.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/HistoricActivityInstanceEntity.java
@@ -43,7 +43,7 @@ public class HistoricActivityInstanceEntity extends HistoricScopeInstanceEntity 
     }
 
     public Object getPersistentState() {
-        Map<String, Object> persistentState = new HashMap<String, Object>();
+        Map<String, Object> persistentState = new HashMap<>();
         persistentState.put("endTime", endTime);
         persistentState.put("durationInMillis", durationInMillis);
         persistentState.put("deleteReason", deleteReason);

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/HistoricActivityInstanceEntityManager.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/HistoricActivityInstanceEntityManager.java
@@ -39,7 +39,7 @@ public class HistoricActivityInstanceEntityManager extends AbstractManager {
     }
 
     public HistoricActivityInstanceEntity findHistoricActivityInstance(String activityId, String processInstanceId) {
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         parameters.put("activityId", activityId);
         parameters.put("processInstanceId", processInstanceId);
 

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/HistoricIdentityLinkEntity.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/HistoricIdentityLinkEntity.java
@@ -54,7 +54,7 @@ public class HistoricIdentityLinkEntity implements Serializable, HistoricIdentit
     }
 
     public Object getPersistentState() {
-        Map<String, Object> persistentState = new HashMap<String, Object>();
+        Map<String, Object> persistentState = new HashMap<>();
         persistentState.put("id", this.id);
         persistentState.put("type", this.type);
 

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/HistoricIdentityLinkEntityManager.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/HistoricIdentityLinkEntityManager.java
@@ -55,7 +55,7 @@ public class HistoricIdentityLinkEntityManager extends AbstractManager {
 
     @SuppressWarnings("unchecked")
     public List<HistoricIdentityLinkEntity> findHistoricIdentityLinkByTaskUserGroupAndType(String taskId, String userId, String groupId, String type) {
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         parameters.put("taskId", taskId);
         parameters.put("userId", userId);
         parameters.put("groupId", groupId);
@@ -65,7 +65,7 @@ public class HistoricIdentityLinkEntityManager extends AbstractManager {
 
     @SuppressWarnings("unchecked")
     public List<HistoricIdentityLinkEntity> findHistoricIdentityLinkByProcessDefinitionUserAndGroup(String processDefinitionId, String userId, String groupId) {
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         parameters.put("processDefinitionId", processDefinitionId);
         parameters.put("userId", userId);
         parameters.put("groupId", groupId);

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/HistoricProcessInstanceEntity.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/HistoricProcessInstanceEntity.java
@@ -69,7 +69,7 @@ public class HistoricProcessInstanceEntity extends HistoricScopeInstanceEntity i
     }
 
     public Object getPersistentState() {
-        Map<String, Object> persistentState = new HashMap<String, Object>();
+        Map<String, Object> persistentState = new HashMap<>();
         persistentState.put("endTime", endTime);
         persistentState.put("businessKey", businessKey);
         persistentState.put("name", name);
@@ -176,7 +176,7 @@ public class HistoricProcessInstanceEntity extends HistoricScopeInstanceEntity i
     }
 
     public Map<String, Object> getProcessVariables() {
-        Map<String, Object> variables = new HashMap<String, Object>();
+        Map<String, Object> variables = new HashMap<>();
         if (queryVariables != null) {
             for (HistoricVariableInstanceEntity variableInstance : queryVariables) {
                 if (variableInstance.getId() != null && variableInstance.getTaskId() == null) {

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/HistoricTaskInstanceEntity.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/HistoricTaskInstanceEntity.java
@@ -80,7 +80,7 @@ public class HistoricTaskInstanceEntity extends HistoricScopeInstanceEntity impl
     // persistence //////////////////////////////////////////////////////////////
 
     public Object getPersistentState() {
-        Map<String, Object> persistentState = new HashMap<String, Object>();
+        Map<String, Object> persistentState = new HashMap<>();
         persistentState.put("name", name);
         persistentState.put("owner", owner);
         persistentState.put("assignee", assignee);
@@ -243,7 +243,7 @@ public class HistoricTaskInstanceEntity extends HistoricScopeInstanceEntity impl
     }
 
     public Map<String, Object> getTaskLocalVariables() {
-        Map<String, Object> variables = new HashMap<String, Object>();
+        Map<String, Object> variables = new HashMap<>();
         if (queryVariables != null) {
             for (HistoricVariableInstanceEntity variableInstance : queryVariables) {
                 if (variableInstance.getId() != null && variableInstance.getTaskId() != null) {
@@ -255,7 +255,7 @@ public class HistoricTaskInstanceEntity extends HistoricScopeInstanceEntity impl
     }
 
     public Map<String, Object> getProcessVariables() {
-        Map<String, Object> variables = new HashMap<String, Object>();
+        Map<String, Object> variables = new HashMap<>();
         if (queryVariables != null) {
             for (HistoricVariableInstanceEntity variableInstance : queryVariables) {
                 if (variableInstance.getId() != null && variableInstance.getTaskId() == null) {

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/HistoricVariableInstanceEntity.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/HistoricVariableInstanceEntity.java
@@ -107,7 +107,7 @@ public class HistoricVariableInstanceEntity implements ValueFields, HistoricVari
     }
 
     public Object getPersistentState() {
-        HashMap<String, Object> persistentState = new HashMap<String, Object>();
+        HashMap<String, Object> persistentState = new HashMap<>();
 
         persistentState.put("textValue", textValue);
         persistentState.put("textValue2", textValue2);

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/IdentityLinkEntity.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/IdentityLinkEntity.java
@@ -52,7 +52,7 @@ public class IdentityLinkEntity implements Serializable, IdentityLink, BulkDelet
     protected ProcessDefinitionEntity processDef;
 
     public Object getPersistentState() {
-        Map<String, Object> persistentState = new HashMap<String, Object>();
+        Map<String, Object> persistentState = new HashMap<>();
         persistentState.put("id", this.id);
         persistentState.put("type", this.type);
 

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/IdentityLinkEntityManager.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/IdentityLinkEntityManager.java
@@ -62,7 +62,7 @@ public class IdentityLinkEntityManager extends AbstractManager {
 
     @SuppressWarnings("unchecked")
     public List<IdentityLinkEntity> findIdentityLinkByTaskUserGroupAndType(String taskId, String userId, String groupId, String type) {
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         parameters.put("taskId", taskId);
         parameters.put("userId", userId);
         parameters.put("groupId", groupId);
@@ -72,7 +72,7 @@ public class IdentityLinkEntityManager extends AbstractManager {
 
     @SuppressWarnings("unchecked")
     public List<IdentityLinkEntity> findIdentityLinkByProcessInstanceUserGroupAndType(String processInstanceId, String userId, String groupId, String type) {
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         parameters.put("processInstanceId", processInstanceId);
         parameters.put("userId", userId);
         parameters.put("groupId", groupId);
@@ -82,7 +82,7 @@ public class IdentityLinkEntityManager extends AbstractManager {
 
     @SuppressWarnings("unchecked")
     public List<IdentityLinkEntity> findIdentityLinkByProcessDefinitionUserAndGroup(String processDefinitionId, String userId, String groupId) {
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         parameters.put("processDefinitionId", processDefinitionId);
         parameters.put("userId", userId);
         parameters.put("groupId", groupId);

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/JobEntityManager.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/JobEntityManager.java
@@ -105,7 +105,7 @@ public class JobEntityManager extends AbstractManager {
 
     @SuppressWarnings("unchecked")
     public List<JobEntity> findExclusiveJobsToExecute(String processInstanceId) {
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("pid", processInstanceId);
         params.put("now", Context.getProcessEngineConfiguration().getClock().getCurrentTime());
         return getDbSqlSession().selectList("selectExclusiveJobsToExecute", params);
@@ -130,7 +130,7 @@ public class JobEntityManager extends AbstractManager {
 
     @SuppressWarnings("unchecked")
     public List<Job> findJobsByTypeAndProcessDefinitionKeyNoTenantId(String jobHandlerType, String processDefinitionKey) {
-        Map<String, String> params = new HashMap<String, String>(2);
+        Map<String, String> params = new HashMap<>(2);
         params.put("handlerType", jobHandlerType);
         params.put("processDefinitionKey", processDefinitionKey);
         return getDbSqlSession().selectList("selectJobByTypeAndProcessDefinitionKeyNoTenantId", params);
@@ -138,7 +138,7 @@ public class JobEntityManager extends AbstractManager {
 
     @SuppressWarnings("unchecked")
     public List<Job> findJobsByTypeAndProcessDefinitionKeyAndTenantId(String jobHandlerType, String processDefinitionKey, String tenantId) {
-        Map<String, String> params = new HashMap<String, String>(3);
+        Map<String, String> params = new HashMap<>(3);
         params.put("handlerType", jobHandlerType);
         params.put("processDefinitionKey", processDefinitionKey);
         params.put("tenantId", tenantId);
@@ -147,14 +147,14 @@ public class JobEntityManager extends AbstractManager {
 
     @SuppressWarnings("unchecked")
     public List<Job> findJobsByTypeAndProcessDefinitionId(String jobHandlerType, String processDefinitionId) {
-        Map<String, String> params = new HashMap<String, String>(2);
+        Map<String, String> params = new HashMap<>(2);
         params.put("handlerType", jobHandlerType);
         params.put("processDefinitionId", processDefinitionId);
         return getDbSqlSession().selectList("selectJobByTypeAndProcessDefinitionId", params);
     }
 
     public void unacquireJob(String jobId) {
-        Map<String, Object> params = new HashMap<String, Object>(2);
+        Map<String, Object> params = new HashMap<>(2);
         params.put("id", jobId);
         params.put("dueDate", new Date(getProcessEngineConfiguration().getClock().getCurrentTime().getTime()));
         getDbSqlSession().update("unacquireJob", params);
@@ -165,14 +165,14 @@ public class JobEntityManager extends AbstractManager {
     }
 
     public void updateJobTenantIdForDeployment(String deploymentId, String newTenantId) {
-        HashMap<String, Object> params = new HashMap<String, Object>();
+        HashMap<String, Object> params = new HashMap<>();
         params.put("deploymentId", deploymentId);
         params.put("tenantId", newTenantId);
         getDbSqlSession().update("updateJobTenantIdForDeployment", params);
     }
 
     public int updateJobLockForAllJobs(String lockOwner, Date expirationTime) {
-        HashMap<String, Object> params = new HashMap<String, Object>();
+        HashMap<String, Object> params = new HashMap<>();
         params.put("lockOwner", lockOwner);
         params.put("lockExpirationTime", expirationTime);
         params.put("dueDate", Context.getProcessEngineConfiguration().getClock().getCurrentTime());

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ModelEntity.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ModelEntity.java
@@ -46,7 +46,7 @@ public class ModelEntity implements Model, HasRevision, PersistentObject, Serial
     protected String tenantId = ProcessEngineConfiguration.NO_TENANT_ID;
 
     public Object getPersistentState() {
-        Map<String, Object> persistentState = new HashMap<String, Object>();
+        Map<String, Object> persistentState = new HashMap<>();
         persistentState.put("name", this.name);
         persistentState.put("key", key);
         persistentState.put("category", this.category);

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ProcessDefinitionEntity.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ProcessDefinitionEntity.java
@@ -62,9 +62,9 @@ public class ProcessDefinitionEntity extends ProcessDefinitionImpl implements Pr
     protected boolean hasStartFormKey;
     protected int suspensionState = SuspensionState.ACTIVE.getStateCode();
     protected boolean isIdentityLinksInitialized;
-    protected List<IdentityLinkEntity> definitionIdentityLinkEntities = new ArrayList<IdentityLinkEntity>();
-    protected Set<Expression> candidateStarterUserIdExpressions = new HashSet<Expression>();
-    protected Set<Expression> candidateStarterGroupIdExpressions = new HashSet<Expression>();
+    protected List<IdentityLinkEntity> definitionIdentityLinkEntities = new ArrayList<>();
+    protected Set<Expression> candidateStarterUserIdExpressions = new HashSet<>();
+    protected Set<Expression> candidateStarterGroupIdExpressions = new HashSet<>();
 
     // Backwards compatibility
     protected String engineVersion;
@@ -188,7 +188,7 @@ public class ProcessDefinitionEntity extends ProcessDefinitionImpl implements Pr
     // getters and setters //////////////////////////////////////////////////////
 
     public Object getPersistentState() {
-        Map<String, Object> persistentState = new HashMap<String, Object>();
+        Map<String, Object> persistentState = new HashMap<>();
         persistentState.put("suspensionState", this.suspensionState);
         persistentState.put("category", this.category);
         return persistentState;

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ProcessDefinitionEntityManager.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ProcessDefinitionEntityManager.java
@@ -36,7 +36,7 @@ public class ProcessDefinitionEntityManager extends AbstractManager {
     }
 
     public ProcessDefinitionEntity findLatestProcessDefinitionByKeyAndTenantId(String processDefinitionKey, String tenantId) {
-        Map<String, Object> params = new HashMap<String, Object>(2);
+        Map<String, Object> params = new HashMap<>(2);
         params.put("processDefinitionKey", processDefinitionKey);
         params.put("tenantId", tenantId);
         return (ProcessDefinitionEntity) getDbSqlSession().selectOne("selectLatestProcessDefinitionByKeyAndTenantId", params);
@@ -72,14 +72,14 @@ public class ProcessDefinitionEntityManager extends AbstractManager {
     }
 
     public ProcessDefinitionEntity findProcessDefinitionByDeploymentAndKey(String deploymentId, String processDefinitionKey) {
-        Map<String, Object> parameters = new HashMap<String, Object>();
+        Map<String, Object> parameters = new HashMap<>();
         parameters.put("deploymentId", deploymentId);
         parameters.put("processDefinitionKey", processDefinitionKey);
         return (ProcessDefinitionEntity) getDbSqlSession().selectOne("selectProcessDefinitionByDeploymentAndKey", parameters);
     }
 
     public ProcessDefinitionEntity findProcessDefinitionByDeploymentAndKeyAndTenantId(String deploymentId, String processDefinitionKey, String tenantId) {
-        Map<String, Object> parameters = new HashMap<String, Object>();
+        Map<String, Object> parameters = new HashMap<>();
         parameters.put("deploymentId", deploymentId);
         parameters.put("processDefinitionKey", processDefinitionKey);
         parameters.put("tenantId", tenantId);
@@ -113,7 +113,7 @@ public class ProcessDefinitionEntityManager extends AbstractManager {
     }
 
     public void updateProcessDefinitionTenantIdForDeployment(String deploymentId, String newTenantId) {
-        HashMap<String, Object> params = new HashMap<String, Object>();
+        HashMap<String, Object> params = new HashMap<>();
         params.put("deploymentId", deploymentId);
         params.put("tenantId", newTenantId);
         getDbSqlSession().update("updateProcessDefinitionTenantIdForDeploymentId", params);

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ProcessDefinitionInfoEntity.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ProcessDefinitionInfoEntity.java
@@ -33,7 +33,7 @@ public class ProcessDefinitionInfoEntity implements HasRevision, PersistentObjec
     protected String infoJsonId;
 
     public Object getPersistentState() {
-        Map<String, Object> persistentState = new HashMap<String, Object>();
+        Map<String, Object> persistentState = new HashMap<>();
         persistentState.put("processDefinitionId", this.processDefinitionId);
         persistentState.put("infoJsonId", this.infoJsonId);
         return persistentState;

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ResourceEntityManager.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ResourceEntityManager.java
@@ -33,7 +33,7 @@ public class ResourceEntityManager extends AbstractManager {
     }
 
     public ResourceEntity findResourceByDeploymentIdAndResourceName(String deploymentId, String resourceName) {
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("deploymentId", deploymentId);
         params.put("resourceName", resourceName);
         return (ResourceEntity) getDbSqlSession().selectOne("selectResourceByDeploymentIdAndResourceName", params);

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/SuspendedJobEntityManager.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/SuspendedJobEntityManager.java
@@ -57,7 +57,7 @@ public class SuspendedJobEntityManager extends AbstractManager {
 
     @SuppressWarnings("unchecked")
     public List<Job> findSuspendedJobsByTypeAndProcessDefinitionKeyNoTenantId(String jobHandlerType, String processDefinitionKey) {
-        Map<String, String> params = new HashMap<String, String>(2);
+        Map<String, String> params = new HashMap<>(2);
         params.put("handlerType", jobHandlerType);
         params.put("processDefinitionKey", processDefinitionKey);
         return getDbSqlSession().selectList("selectSuspendedJobByTypeAndProcessDefinitionKeyNoTenantId", params);
@@ -65,7 +65,7 @@ public class SuspendedJobEntityManager extends AbstractManager {
 
     @SuppressWarnings("unchecked")
     public List<Job> findSuspendedJobsByTypeAndProcessDefinitionKeyAndTenantId(String jobHandlerType, String processDefinitionKey, String tenantId) {
-        Map<String, String> params = new HashMap<String, String>(3);
+        Map<String, String> params = new HashMap<>(3);
         params.put("handlerType", jobHandlerType);
         params.put("processDefinitionKey", processDefinitionKey);
         params.put("tenantId", tenantId);
@@ -74,7 +74,7 @@ public class SuspendedJobEntityManager extends AbstractManager {
 
     @SuppressWarnings("unchecked")
     public List<Job> findSuspendedJobsByTypeAndProcessDefinitionId(String jobHandlerType, String processDefinitionId) {
-        Map<String, String> params = new HashMap<String, String>(2);
+        Map<String, String> params = new HashMap<>(2);
         params.put("handlerType", jobHandlerType);
         params.put("processDefinitionId", processDefinitionId);
         return getDbSqlSession().selectList("selectSuspendedJobByTypeAndProcessDefinitionId", params);
@@ -85,7 +85,7 @@ public class SuspendedJobEntityManager extends AbstractManager {
     }
 
     public void updateSuspendedJobTenantIdForDeployment(String deploymentId, String newTenantId) {
-        HashMap<String, Object> params = new HashMap<String, Object>();
+        HashMap<String, Object> params = new HashMap<>();
         params.put("deploymentId", deploymentId);
         params.put("tenantId", newTenantId);
         getDbSqlSession().update("updateSuspendedJobTenantIdForDeployment", params);

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/TableDataManager.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/TableDataManager.java
@@ -54,8 +54,8 @@ public class TableDataManager extends AbstractManager {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TableDataManager.class);
 
-    public static Map<Class<?>, String> apiTypeToTableNameMap = new HashMap<Class<?>, String>();
-    public static Map<Class<? extends PersistentObject>, String> persistentObjectToTableNameMap = new HashMap<Class<? extends PersistentObject>, String>();
+    public static Map<Class<?>, String> apiTypeToTableNameMap = new HashMap<>();
+    public static Map<Class<? extends PersistentObject>, String> persistentObjectToTableNameMap = new HashMap<>();
 
     static {
         // runtime
@@ -119,7 +119,7 @@ public class TableDataManager extends AbstractManager {
     }
 
     public Map<String, Long> getTableCount() {
-        Map<String, Long> tableCount = new HashMap<String, Long>();
+        Map<String, Long> tableCount = new HashMap<>();
         try {
             for (String tableName : getTablesPresentInDatabase()) {
                 tableCount.put(tableName, getTableCount(tableName));
@@ -132,7 +132,7 @@ public class TableDataManager extends AbstractManager {
     }
 
     public List<String> getTablesPresentInDatabase() {
-        List<String> tableNames = new ArrayList<String>();
+        List<String> tableNames = new ArrayList<>();
         Connection connection = null;
         try {
             connection = getDbSqlSession().getSqlSession().getConnection();

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/TaskEntity.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/TaskEntity.java
@@ -79,7 +79,7 @@ public class TaskEntity extends VariableScopeImpl implements Task, DelegateTask,
     protected String category;
 
     protected boolean isIdentityLinksInitialized;
-    protected List<IdentityLinkEntity> taskIdentityLinkEntities = new ArrayList<IdentityLinkEntity>();
+    protected List<IdentityLinkEntity> taskIdentityLinkEntities = new ArrayList<>();
 
     protected String executionId;
     protected ExecutionEntity execution;
@@ -110,7 +110,9 @@ public class TaskEntity extends VariableScopeImpl implements Task, DelegateTask,
         this.id = taskId;
     }
 
-    /** creates and initializes a new persistent task. */
+    /**
+     * creates and initializes a new persistent task.
+     */
     public static TaskEntity createAndInsert(ActivityExecution execution, boolean fireEvents) {
         TaskEntity task = create(Context.getProcessEngineConfiguration().getClock().getCurrentTime());
         task.insert((ExecutionEntity) execution, fireEvents);
@@ -132,7 +134,7 @@ public class TaskEntity extends VariableScopeImpl implements Task, DelegateTask,
         }
 
         commandContext.getHistoryManager().recordTaskCreated(this, execution);
-        
+
         if (commandContext.getProcessEngineConfiguration().getEventDispatcher().isEnabled() && fireEvents) {
             commandContext.getProcessEngineConfiguration().getEventDispatcher().dispatchEvent(
                     ActivitiEventBuilder.createEntityEvent(FlowableEngineEventType.ENTITY_CREATED, this));
@@ -221,7 +223,7 @@ public class TaskEntity extends VariableScopeImpl implements Task, DelegateTask,
     }
 
     public Object getPersistentState() {
-        Map<String, Object> persistentState = new HashMap<String, Object>();
+        Map<String, Object> persistentState = new HashMap<>();
         persistentState.put("assignee", this.assignee);
         persistentState.put("owner", this.owner);
         persistentState.put("name", this.name);
@@ -292,7 +294,7 @@ public class TaskEntity extends VariableScopeImpl implements Task, DelegateTask,
 
     @Override
     protected VariableInstanceEntity createVariableInstance(String variableName, Object value,
-            ExecutionEntity sourceActivityExecution) {
+                                                            ExecutionEntity sourceActivityExecution) {
         VariableInstanceEntity result = super.createVariableInstance(variableName, value, sourceActivityExecution);
 
         // Dispatch event, if needed
@@ -306,7 +308,7 @@ public class TaskEntity extends VariableScopeImpl implements Task, DelegateTask,
 
     @Override
     protected void updateVariableInstance(VariableInstanceEntity variableInstance, Object value,
-            ExecutionEntity sourceActivityExecution) {
+                                          ExecutionEntity sourceActivityExecution) {
         super.updateVariableInstance(variableInstance, value, sourceActivityExecution);
 
         // Dispatch event, if needed
@@ -368,7 +370,7 @@ public class TaskEntity extends VariableScopeImpl implements Task, DelegateTask,
                 .getIdentityLinkEntityManager()
                 .findIdentityLinkByTaskUserGroupAndType(id, userId, groupId, type);
 
-        List<String> identityLinkIds = new ArrayList<String>();
+        List<String> identityLinkIds = new ArrayList<>();
         for (IdentityLinkEntity identityLink : identityLinks) {
             Context
                     .getCommandContext()
@@ -378,7 +380,7 @@ public class TaskEntity extends VariableScopeImpl implements Task, DelegateTask,
         }
 
         // fix deleteCandidate() in create TaskListener
-        List<IdentityLinkEntity> removedIdentityLinkEntities = new ArrayList<IdentityLinkEntity>();
+        List<IdentityLinkEntity> removedIdentityLinkEntities = new ArrayList<>();
         for (IdentityLinkEntity identityLinkEntity : this.getIdentityLinks()) {
             if (IdentityLinkType.CANDIDATE.equals(identityLinkEntity.getType()) &&
                     !identityLinkIds.contains(identityLinkEntity.getId())) {
@@ -398,7 +400,7 @@ public class TaskEntity extends VariableScopeImpl implements Task, DelegateTask,
     }
 
     public Set<IdentityLink> getCandidates() {
-        Set<IdentityLink> potentialOwners = new HashSet<IdentityLink>();
+        Set<IdentityLink> potentialOwners = new HashSet<>();
         for (IdentityLinkEntity identityLinkEntity : getIdentityLinks()) {
             if (IdentityLinkType.CANDIDATE.equals(identityLinkEntity.getType())) {
                 potentialOwners.add(identityLinkEntity);
@@ -979,7 +981,7 @@ public class TaskEntity extends VariableScopeImpl implements Task, DelegateTask,
     }
 
     public Map<String, Object> getTaskLocalVariables() {
-        Map<String, Object> variables = new HashMap<String, Object>();
+        Map<String, Object> variables = new HashMap<>();
         if (queryVariables != null) {
             for (VariableInstanceEntity variableInstance : queryVariables) {
                 if (variableInstance.getId() != null && variableInstance.getTaskId() != null) {
@@ -991,7 +993,7 @@ public class TaskEntity extends VariableScopeImpl implements Task, DelegateTask,
     }
 
     public Map<String, Object> getProcessVariables() {
-        Map<String, Object> variables = new HashMap<String, Object>();
+        Map<String, Object> variables = new HashMap<>();
         if (queryVariables != null) {
             for (VariableInstanceEntity variableInstance : queryVariables) {
                 if (variableInstance.getId() != null && variableInstance.getTaskId() == null) {

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/TaskEntityManager.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/TaskEntityManager.java
@@ -36,7 +36,7 @@ import org.flowable.engine.delegate.TaskListener;
  */
 public class TaskEntityManager extends AbstractManager {
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public void deleteTasksByProcessInstanceId(String processInstanceId, String deleteReason, boolean cascade) {
         List<TaskEntity> tasks = (List) getDbSqlSession()
                 .createTaskQuery()
@@ -210,7 +210,7 @@ public class TaskEntityManager extends AbstractManager {
     }
 
     public void updateTaskTenantIdForDeployment(String deploymentId, String newTenantId) {
-        HashMap<String, Object> params = new HashMap<String, Object>();
+        HashMap<String, Object> params = new HashMap<>();
         params.put("deploymentId", deploymentId);
         params.put("tenantId", newTenantId);
         getDbSqlSession().update("updateTaskTenantIdForDeployment", params);

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/TimerJobEntityManager.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/TimerJobEntityManager.java
@@ -85,7 +85,7 @@ public class TimerJobEntityManager extends AbstractManager {
 
     @SuppressWarnings("unchecked")
     public List<Job> findTimerJobsByTypeAndProcessDefinitionKeyNoTenantId(String jobHandlerType, String processDefinitionKey) {
-        Map<String, String> params = new HashMap<String, String>(2);
+        Map<String, String> params = new HashMap<>(2);
         params.put("handlerType", jobHandlerType);
         params.put("processDefinitionKey", processDefinitionKey);
         return getDbSqlSession().selectList("selectTimerJobByTypeAndProcessDefinitionKeyNoTenantId", params);
@@ -93,7 +93,7 @@ public class TimerJobEntityManager extends AbstractManager {
 
     @SuppressWarnings("unchecked")
     public List<Job> findTimerJobsByTypeAndProcessDefinitionKeyAndTenantId(String jobHandlerType, String processDefinitionKey, String tenantId) {
-        Map<String, String> params = new HashMap<String, String>(3);
+        Map<String, String> params = new HashMap<>(3);
         params.put("handlerType", jobHandlerType);
         params.put("processDefinitionKey", processDefinitionKey);
         params.put("tenantId", tenantId);
@@ -102,7 +102,7 @@ public class TimerJobEntityManager extends AbstractManager {
 
     @SuppressWarnings("unchecked")
     public List<Job> findTimerJobsByTypeAndProcessDefinitionId(String jobHandlerType, String processDefinitionId) {
-        Map<String, String> params = new HashMap<String, String>(2);
+        Map<String, String> params = new HashMap<>(2);
         params.put("handlerType", jobHandlerType);
         params.put("processDefinitionId", processDefinitionId);
         return getDbSqlSession().selectList("selectTimerJobByTypeAndProcessDefinitionId", params);
@@ -113,7 +113,7 @@ public class TimerJobEntityManager extends AbstractManager {
     }
 
     public void updateTimerJobTenantIdForDeployment(String deploymentId, String newTenantId) {
-        HashMap<String, Object> params = new HashMap<String, Object>();
+        HashMap<String, Object> params = new HashMap<>();
         params.put("deploymentId", deploymentId);
         params.put("tenantId", newTenantId);
         getDbSqlSession().update("updateTimerJobTenantIdForDeployment", params);

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/VariableInstanceEntity.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/VariableInstanceEntity.java
@@ -99,7 +99,7 @@ public class VariableInstanceEntity extends AbstractEntity implements VariableIn
     }
 
     public Object getPersistentState() {
-        Map<String, Object> persistentState = new HashMap<String, Object>();
+        Map<String, Object> persistentState = new HashMap<>();
         if (longValue != null) {
             persistentState.put("longValue", longValue);
         }
@@ -130,7 +130,7 @@ public class VariableInstanceEntity extends AbstractEntity implements VariableIn
     public void setProcessInstanceId(String processInstanceId) {
         this.processInstanceId = processInstanceId;
     }
-    
+
     public void setProcessDefinitionId(String processDefinitionId) {
     }
 
@@ -210,7 +210,7 @@ public class VariableInstanceEntity extends AbstractEntity implements VariableIn
     public String getProcessInstanceId() {
         return processInstanceId;
     }
-    
+
     public String getProcessDefinitionId() {
         return null;
     }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/VariableInstanceEntityManager.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/VariableInstanceEntityManager.java
@@ -49,7 +49,7 @@ public class VariableInstanceEntityManager extends AbstractManager {
     }
 
     public VariableInstanceEntity findVariableInstanceByExecutionAndName(String executionId, String variableName) {
-        Map<String, String> params = new HashMap<String, String>(2);
+        Map<String, String> params = new HashMap<>(2);
         params.put("executionId", executionId);
         params.put("name", variableName);
         return (VariableInstanceEntity) getDbSqlSession().selectOne("selectVariableInstanceByExecutionAndName", params);
@@ -57,14 +57,14 @@ public class VariableInstanceEntityManager extends AbstractManager {
 
     @SuppressWarnings("unchecked")
     public List<VariableInstanceEntity> findVariableInstancesByExecutionAndNames(String executionId, Collection<String> names) {
-        Map<String, Object> params = new HashMap<String, Object>(2);
+        Map<String, Object> params = new HashMap<>(2);
         params.put("executionId", executionId);
         params.put("names", names);
         return getDbSqlSession().selectList("selectVariableInstancesByExecutionAndNames", params);
     }
 
     public VariableInstanceEntity findVariableInstanceByTaskAndName(String taskId, String variableName) {
-        Map<String, String> params = new HashMap<String, String>(2);
+        Map<String, String> params = new HashMap<>(2);
         params.put("taskId", taskId);
         params.put("name", variableName);
         return (VariableInstanceEntity) getDbSqlSession().selectOne("selectVariableInstanceByTaskAndName", params);
@@ -72,7 +72,7 @@ public class VariableInstanceEntityManager extends AbstractManager {
 
     @SuppressWarnings("unchecked")
     public List<VariableInstanceEntity> findVariableInstancesByTaskAndNames(String taskId, Collection<String> names) {
-        Map<String, Object> params = new HashMap<String, Object>(2);
+        Map<String, Object> params = new HashMap<>(2);
         params.put("taskId", taskId);
         params.put("names", names);
         return getDbSqlSession().selectList("selectVariableInstancesByTaskAndNames", params);

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/VariableScopeImpl.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/VariableScopeImpl.java
@@ -45,7 +45,7 @@ public abstract class VariableScopeImpl implements Serializable, VariableScope {
     protected Map<String, VariableInstanceEntity> variableInstances = null; // needs to be null, the logic depends on it for checking if vars were already fetched
 
     // The cache is used when fetching/setting specific variables
-    protected Map<String, VariableInstanceEntity> usedVariablesCache = new HashMap<String, VariableInstanceEntity>();
+    protected Map<String, VariableInstanceEntity> usedVariablesCache = new HashMap<>();
 
     protected Map<String, VariableInstance> transientVariabes;
 
@@ -61,7 +61,7 @@ public abstract class VariableScopeImpl implements Serializable, VariableScope {
 
     protected void ensureVariableInstancesInitialized() {
         if (variableInstances == null) {
-            variableInstances = new HashMap<String, VariableInstanceEntity>();
+            variableInstances = new HashMap<>();
 
             CommandContext commandContext = Context.getCommandContext();
             if (commandContext == null) {
@@ -92,8 +92,8 @@ public abstract class VariableScopeImpl implements Serializable, VariableScope {
 
     public Map<String, Object> getVariables(Collection<String> variableNames, boolean fetchAllVariables) {
 
-        Map<String, Object> requestedVariables = new HashMap<String, Object>();
-        Set<String> variableNamesToFetch = new HashSet<String>(variableNames);
+        Map<String, Object> requestedVariables = new HashMap<>();
+        Set<String> variableNamesToFetch = new HashSet<>(variableNames);
 
         // Transient variables 'shadow' any existing variables.
         // The values in the fetch-cache will be more recent, so they can override any existing ones
@@ -139,8 +139,8 @@ public abstract class VariableScopeImpl implements Serializable, VariableScope {
 
     public Map<String, VariableInstance> getVariableInstances(Collection<String> variableNames, boolean fetchAllVariables) {
 
-        Map<String, VariableInstance> requestedVariables = new HashMap<String, VariableInstance>();
-        Set<String> variableNamesToFetch = new HashSet<String>(variableNames);
+        Map<String, VariableInstance> requestedVariables = new HashMap<>();
+        Set<String> variableNamesToFetch = new HashSet<>(variableNames);
 
         // The values in the fetch-cache will be more recent, so they can override any existing ones
         for (String variableName : variableNames) {
@@ -239,11 +239,11 @@ public abstract class VariableScopeImpl implements Serializable, VariableScope {
 
     /**
      * The same operation as {@link VariableScopeImpl#getVariable(String)}, but with an extra parameter to indicate whether or not all variables need to be fetched.
-     * 
+     * <p>
      * Note that the default Activiti way (because of backwards compatibility) is to fetch all the variables when doing a get/set of variables. So this means 'true' is the default value for this
      * method, and in fact it will simply delegate to {@link #getVariable(String)}. This can also be the most performant, if you're doing a lot of variable gets in the same transaction (eg in service
      * tasks).
-     * 
+     * <p>
      * In case 'false' is used, only the specific variable will be fetched.
      */
     public Object getVariable(String variableName, boolean fetchAllVariables) {
@@ -439,7 +439,7 @@ public abstract class VariableScopeImpl implements Serializable, VariableScope {
     }
 
     public Map<String, Object> getVariablesLocal() {
-        Map<String, Object> variables = new HashMap<String, Object>();
+        Map<String, Object> variables = new HashMap<>();
         ensureVariableInstancesInitialized();
         for (VariableInstanceEntity variableInstance : variableInstances.values()) {
             variables.put(variableInstance.getName(), variableInstance.getValue());
@@ -456,7 +456,7 @@ public abstract class VariableScopeImpl implements Serializable, VariableScope {
     }
 
     public Map<String, VariableInstance> getVariableInstancesLocal() {
-        Map<String, VariableInstance> variables = new HashMap<String, VariableInstance>();
+        Map<String, VariableInstance> variables = new HashMap<>();
         ensureVariableInstancesInitialized();
         for (VariableInstanceEntity variableInstance : variableInstances.values()) {
             variables.put(variableInstance.getName(), variableInstance);
@@ -479,10 +479,10 @@ public abstract class VariableScopeImpl implements Serializable, VariableScope {
     }
 
     public Map<String, Object> getVariablesLocal(Collection<String> variableNames, boolean fetchAllVariables) {
-        Map<String, Object> requestedVariables = new HashMap<String, Object>();
+        Map<String, Object> requestedVariables = new HashMap<>();
 
         // The values in the fetch-cache will be more recent, so they can override any existing ones
-        Set<String> variableNamesToFetch = new HashSet<String>(variableNames);
+        Set<String> variableNamesToFetch = new HashSet<>(variableNames);
         for (String variableName : variableNames) {
             if (transientVariabes != null && transientVariabes.containsKey(variableName)) {
                 requestedVariables.put(variableName, transientVariabes.get(variableName).getValue());
@@ -513,10 +513,10 @@ public abstract class VariableScopeImpl implements Serializable, VariableScope {
     }
 
     public Map<String, VariableInstance> getVariableInstancesLocal(Collection<String> variableNames, boolean fetchAllVariables) {
-        Map<String, VariableInstance> requestedVariables = new HashMap<String, VariableInstance>();
+        Map<String, VariableInstance> requestedVariables = new HashMap<>();
 
         // The values in the fetch-cache will be more recent, so they can override any existing ones
-        Set<String> variableNamesToFetch = new HashSet<String>(variableNames);
+        Set<String> variableNamesToFetch = new HashSet<>(variableNames);
         for (String variableName : variableNames) {
             if (transientVariabes != null && transientVariabes.containsKey(variableName)) {
                 requestedVariables.put(variableName, transientVariabes.get(variableName));
@@ -549,7 +549,7 @@ public abstract class VariableScopeImpl implements Serializable, VariableScope {
     protected abstract List<VariableInstanceEntity> getSpecificVariables(Collection<String> variableNames);
 
     public Set<String> getVariableNamesLocal() {
-        Set<String> variableNames = new HashSet<String>();
+        Set<String> variableNames = new HashSet<>();
         if (transientVariabes != null) {
             variableNames.addAll(transientVariabes.keySet());
         }
@@ -593,14 +593,14 @@ public abstract class VariableScopeImpl implements Serializable, VariableScope {
 
     public void removeVariables() {
         ensureVariableInstancesInitialized();
-        Set<String> variableNames = new HashSet<String>(variableInstances.keySet());
+        Set<String> variableNames = new HashSet<>(variableInstances.keySet());
         for (String variableName : variableNames) {
             removeVariable(variableName);
         }
     }
 
     public void removeVariablesLocal() {
-        List<String> variableNames = new ArrayList<String>(getVariableNamesLocal());
+        List<String> variableNames = new ArrayList<>(getVariableNamesLocal());
         for (String variableName : variableNames) {
             removeVariableLocal(variableName);
         }
@@ -637,16 +637,15 @@ public abstract class VariableScopeImpl implements Serializable, VariableScope {
 
     /**
      * The default {@link #setVariable(String, Object)} fetches all variables (for historical and backwards compatible reasons) while setting the variables.
-     * 
+     * <p>
      * Setting the fetchAllVariables parameter to true is the default behaviour (ie fetching all variables) Setting the fetchAllVariables parameter to false does not do that.
-     * 
      */
     public void setVariable(String variableName, Object value, boolean fetchAllVariables) {
         setVariable(variableName, value, getSourceActivityExecution(), fetchAllVariables);
     }
 
     protected void setVariable(String variableName, Object value,
-            ExecutionEntity sourceActivityExecution, boolean fetchAllVariables) {
+                               ExecutionEntity sourceActivityExecution, boolean fetchAllVariables) {
 
         if (fetchAllVariables) {
 
@@ -719,14 +718,13 @@ public abstract class VariableScopeImpl implements Serializable, VariableScope {
 
     /**
      * The default {@link #setVariableLocal(String, Object)} fetches all variables (for historical and backwards compatible reasons) while setting the variables.
-     * 
+     * <p>
      * Setting the fetchAllVariables parameter to true is the default behaviour (ie fetching all variables) Setting the fetchAllVariables parameter to false does not do that.
-     * 
      */
     public Object setVariableLocal(String variableName, Object value, boolean fetchAllVariables) {
         return setVariableLocal(variableName, value, getSourceActivityExecution(), fetchAllVariables);
     }
-    
+
     public Object setVariableLocal(String variableName, Object value, ExecutionEntity sourceActivityExecution, boolean fetchAllVariables) {
 
         if (fetchAllVariables) {
@@ -912,7 +910,7 @@ public abstract class VariableScopeImpl implements Serializable, VariableScope {
 
     public void setTransientVariableLocal(String variableName, Object variableValue) {
         if (transientVariabes == null) {
-            transientVariabes = new HashMap<String, VariableInstance>();
+            transientVariabes = new HashMap<>();
         }
         transientVariabes.put(variableName, new TransientVariableInstance(variableName, variableValue));
     }
@@ -941,7 +939,7 @@ public abstract class VariableScopeImpl implements Serializable, VariableScope {
 
     public Map<String, Object> getTransientVariablesLocal() {
         if (transientVariabes != null) {
-            Map<String, Object> variables = new HashMap<String, Object>();
+            Map<String, Object> variables = new HashMap<>();
             for (String variableName : transientVariabes.keySet()) {
                 variables.put(variableName, transientVariabes.get(variableName).getValue());
             }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/pvm/ProcessDefinitionBuilder.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/pvm/ProcessDefinitionBuilder.java
@@ -33,10 +33,10 @@ import org.flowable.engine.impl.delegate.ActivityBehavior;
 public class ProcessDefinitionBuilder {
 
     protected ProcessDefinitionImpl processDefinition;
-    protected Stack<ScopeImpl> scopeStack = new Stack<ScopeImpl>();
+    protected Stack<ScopeImpl> scopeStack = new Stack<>();
     protected ProcessElementImpl processElement = processDefinition;
     protected TransitionImpl transition;
-    protected List<Object[]> unresolvedTransitions = new ArrayList<Object[]>();
+    protected List<Object[]> unresolvedTransitions = new ArrayList<>();
 
     public ProcessDefinitionBuilder() {
         this(null);
@@ -81,7 +81,7 @@ public class ProcessDefinitionBuilder {
         }
         ActivityImpl activity = getActivity();
         transition = activity.createOutgoingTransition(transitionId);
-        unresolvedTransitions.add(new Object[] { transition, destinationActivityId });
+        unresolvedTransitions.add(new Object[]{transition, destinationActivityId});
         processElement = transition;
         return this;
     }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/pvm/process/ActivityImpl.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/pvm/process/ActivityImpl.java
@@ -30,10 +30,10 @@ import org.flowable.variable.service.delegate.Expression;
 public class ActivityImpl extends ScopeImpl implements PvmActivity, HasDIBounds {
 
     private static final long serialVersionUID = 1L;
-    protected List<TransitionImpl> outgoingTransitions = new ArrayList<TransitionImpl>();
-    protected Map<String, TransitionImpl> namedOutgoingTransitions = new HashMap<String, TransitionImpl>();
+    protected List<TransitionImpl> outgoingTransitions = new ArrayList<>();
+    protected Map<String, TransitionImpl> namedOutgoingTransitions = new HashMap<>();
     protected Map<String, Object> variables;
-    protected List<TransitionImpl> incomingTransitions = new ArrayList<TransitionImpl>();
+    protected List<TransitionImpl> incomingTransitions = new ArrayList<>();
     protected ActivityBehavior activityBehavior;
     protected ScopeImpl parent;
     protected boolean isScope;

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/pvm/process/Lane.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/pvm/process/Lane.java
@@ -19,7 +19,7 @@ import java.util.List;
 
 /**
  * A single lane in a BPMN 2.0 LaneSet, currently only used internally for rendering the diagram. The PVM doesn't actually use the laneSets/lanes.
- * 
+ *
  * @author Frederik Heremans
  */
 public class Lane implements HasDIBounds, Serializable {
@@ -84,7 +84,7 @@ public class Lane implements HasDIBounds, Serializable {
 
     public List<String> getFlowNodeIds() {
         if (flowNodeIds == null) {
-            flowNodeIds = new ArrayList<String>();
+            flowNodeIds = new ArrayList<>();
         }
         return flowNodeIds;
     }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/pvm/process/LaneSet.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/pvm/process/LaneSet.java
@@ -19,7 +19,7 @@ import java.util.List;
 
 /**
  * A BPMN 2.0 LaneSet, containing {@link Lane}s, currently only used for rendering the DI info.
- * 
+ *
  * @author Frederik Heremans
  */
 public class LaneSet implements Serializable {
@@ -48,7 +48,7 @@ public class LaneSet implements Serializable {
 
     public List<Lane> getLanes() {
         if (lanes == null) {
-            lanes = new ArrayList<Lane>();
+            lanes = new ArrayList<>();
         }
         return lanes;
     }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/pvm/process/ProcessDefinitionImpl.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/pvm/process/ProcessDefinitionImpl.java
@@ -35,7 +35,7 @@ public class ProcessDefinitionImpl extends ScopeImpl implements PvmProcessDefini
     protected String key;
     protected String description;
     protected ActivityImpl initial;
-    protected Map<ActivityImpl, List<ActivityImpl>> initialActivityStacks = new HashMap<ActivityImpl, List<ActivityImpl>>();
+    protected Map<ActivityImpl, List<ActivityImpl>> initialActivityStacks = new HashMap<>();
     protected List<LaneSet> laneSets;
     protected ParticipantProcess participantProcess;
 
@@ -52,7 +52,9 @@ public class ProcessDefinitionImpl extends ScopeImpl implements PvmProcessDefini
         return createProcessInstanceForInitial(initial);
     }
 
-    /** creates a process instance using the provided activity as initial */
+    /**
+     * creates a process instance using the provided activity as initial
+     */
     public PvmProcessInstance createProcessInstanceForInitial(ActivityImpl initial) {
 
         if (initial == null) {
@@ -90,7 +92,7 @@ public class ProcessDefinitionImpl extends ScopeImpl implements PvmProcessDefini
     public synchronized List<ActivityImpl> getInitialActivityStack(ActivityImpl startActivity) {
         List<ActivityImpl> initialActivityStack = initialActivityStacks.get(startActivity);
         if (initialActivityStack == null) {
-            initialActivityStack = new ArrayList<ActivityImpl>();
+            initialActivityStack = new ArrayList<>();
             ActivityImpl activity = startActivity;
             while (activity != null) {
                 initialActivityStack.add(0, activity);
@@ -169,7 +171,7 @@ public class ProcessDefinitionImpl extends ScopeImpl implements PvmProcessDefini
      */
     public List<LaneSet> getLaneSets() {
         if (laneSets == null) {
-            laneSets = new ArrayList<LaneSet>();
+            laneSets = new ArrayList<>();
         }
         return laneSets;
     }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/pvm/process/ProcessElementImpl.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/pvm/process/ProcessElementImpl.java
@@ -21,7 +21,7 @@ import org.activiti.engine.impl.pvm.PvmProcessElement;
 
 /**
  * common properties for process definition, activity and transition including event listeners.
- * 
+ *
  * @author Tom Baeyens
  */
 public class ProcessElementImpl implements PvmProcessElement {
@@ -39,7 +39,7 @@ public class ProcessElementImpl implements PvmProcessElement {
 
     public void setProperty(String name, Object value) {
         if (properties == null) {
-            properties = new HashMap<String, Object>();
+            properties = new HashMap<>();
         }
         properties.put(name, value);
     }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/pvm/process/ScopeImpl.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/pvm/process/ScopeImpl.java
@@ -31,9 +31,9 @@ public abstract class ScopeImpl extends ProcessElementImpl implements PvmScope {
 
     private static final long serialVersionUID = 1L;
 
-    protected List<ActivityImpl> activities = new ArrayList<ActivityImpl>();
-    protected Map<String, ActivityImpl> namedActivities = new HashMap<String, ActivityImpl>();
-    protected Map<String, List<ExecutionListener>> executionListeners = new HashMap<String, List<ExecutionListener>>();
+    protected List<ActivityImpl> activities = new ArrayList<>();
+    protected Map<String, ActivityImpl> namedActivities = new HashMap<>();
+    protected Map<String, List<ExecutionListener>> executionListeners = new HashMap<>();
     protected IOSpecification ioSpecification;
 
     public ScopeImpl(String id, ProcessDefinitionImpl processDefinition) {
@@ -101,7 +101,7 @@ public abstract class ScopeImpl extends ProcessElementImpl implements PvmScope {
     public void addExecutionListener(String eventName, ExecutionListener executionListener, int index) {
         List<ExecutionListener> listeners = executionListeners.get(eventName);
         if (listeners == null) {
-            listeners = new ArrayList<ExecutionListener>();
+            listeners = new ArrayList<>();
             executionListeners.put(eventName, listeners);
         }
         if (index < 0) {

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/pvm/process/TransitionImpl.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/pvm/process/TransitionImpl.java
@@ -33,8 +33,10 @@ public class TransitionImpl extends ProcessElementImpl implements PvmTransition 
     protected List<ExecutionListener> executionListeners;
     protected Expression skipExpression;
 
-    /** Graphical information: a list of waypoints: x1, y1, x2, y2, x3, y3, .. */
-    protected List<Integer> waypoints = new ArrayList<Integer>();
+    /**
+     * Graphical information: a list of waypoints: x1, y1, x2, y2, x3, y3, ..
+     */
+    protected List<Integer> waypoints = new ArrayList<>();
 
     public TransitionImpl(String id, Expression skipExpression, ProcessDefinitionImpl processDefinition) {
         super(id, processDefinition);
@@ -52,7 +54,7 @@ public class TransitionImpl extends ProcessElementImpl implements PvmTransition 
 
     public void addExecutionListener(ExecutionListener executionListener) {
         if (executionListeners == null) {
-            executionListeners = new ArrayList<ExecutionListener>();
+            executionListeners = new ArrayList<>();
         }
         executionListeners.add(executionListener);
     }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/pvm/runtime/ExecutionImpl.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/pvm/runtime/ExecutionImpl.java
@@ -62,12 +62,16 @@ public class ExecutionImpl implements
 
     protected ProcessDefinitionImpl processDefinition;
 
-    /** current activity */
+    /**
+     * current activity
+     */
     protected ActivityImpl activity;
 
     protected FlowElement currentFlowElement;
 
-    /** current transition. is null when there is no transition being taken. */
+    /**
+     * current transition. is null when there is no transition being taken.
+     */
     protected TransitionImpl transition;
 
     /**
@@ -75,19 +79,29 @@ public class ExecutionImpl implements
      */
     protected ExecutionImpl processInstance;
 
-    /** the parent execution */
+    /**
+     * the parent execution
+     */
     protected ExecutionImpl parent;
 
-    /** nested executions representing scopes or concurrent paths */
+    /**
+     * nested executions representing scopes or concurrent paths
+     */
     protected List<ExecutionImpl> executions;
 
-    /** super execution, not-null if this execution is part of a subprocess */
+    /**
+     * super execution, not-null if this execution is part of a subprocess
+     */
     protected ExecutionImpl superExecution;
 
-    /** reference to a subprocessinstance, not-null if currently subprocess is started from this execution */
+    /**
+     * reference to a subprocessinstance, not-null if currently subprocess is started from this execution
+     */
     protected ExecutionImpl subProcessInstance;
 
-    /** only available until the process instance is started */
+    /**
+     * only available until the process instance is started
+     */
     protected StartingExecution startingExecution;
 
     // state/type of execution //////////////////////////////////////////////////
@@ -124,7 +138,7 @@ public class ExecutionImpl implements
 
     /**
      * when execution structure is pruned during a takeAll, then the original execution has to be resolved to the replaced execution.
-     * 
+     *
      * @see #takeAll(List, List) {@link OutgoingExecution}
      */
     protected ExecutionImpl replacedBy;
@@ -134,7 +148,7 @@ public class ExecutionImpl implements
     /**
      * next operation. process execution is in fact runtime interpretation of the process model. each operation is a logical unit of interpretation of the process. so sequentially processing the
      * operations drives the interpretation or execution of a process.
-     * 
+     *
      * @see AtomicOperation
      * @see #performOperation(AtomicOperation)
      */
@@ -151,7 +165,9 @@ public class ExecutionImpl implements
 
     // lifecycle methods ////////////////////////////////////////////////////////
 
-    /** creates a new execution. properties processDefinition, processInstance and activity will be initialized. */
+    /**
+     * creates a new execution. properties processDefinition, processInstance and activity will be initialized.
+     */
     public ExecutionImpl createExecution() {
         // create the new child execution
         ExecutionImpl createdExecution = newExecution();
@@ -169,7 +185,9 @@ public class ExecutionImpl implements
         return createdExecution;
     }
 
-    /** instantiates a new execution. can be overridden by subclasses */
+    /**
+     * instantiates a new execution. can be overridden by subclasses
+     */
     protected ExecutionImpl newExecution() {
         return new ExecutionImpl();
     }
@@ -231,7 +249,9 @@ public class ExecutionImpl implements
 
     // parent ///////////////////////////////////////////////////////////////////
 
-    /** ensures initialization and returns the parent */
+    /**
+     * ensures initialization and returns the parent
+     */
     public ExecutionImpl getParent() {
         ensureParentInitialized();
         return parent;
@@ -255,7 +275,9 @@ public class ExecutionImpl implements
         return null;
     }
 
-    /** all updates need to go through this setter as subclasses can override this method */
+    /**
+     * all updates need to go through this setter as subclasses can override this method
+     */
     public void setParent(InterpretableExecution parent) {
         this.parent = (ExecutionImpl) parent;
     }
@@ -268,7 +290,9 @@ public class ExecutionImpl implements
 
     // executions ///////////////////////////////////////////////////////////////
 
-    /** ensures initialization and returns the non-null executions list */
+    /**
+     * ensures initialization and returns the non-null executions list
+     */
     public List<ExecutionImpl> getExecutions() {
         ensureExecutionsInitialized();
         return executions;
@@ -318,7 +342,9 @@ public class ExecutionImpl implements
         performOperation(AtomicOperation.ACTIVITY_END);
     }
 
-    /** searches for an execution positioned in the given activity */
+    /**
+     * searches for an execution positioned in the given activity
+     */
     public ExecutionImpl findExecution(String activityId) {
         if ((getActivity() != null)
                 && (getActivity().getId().equals(activityId))) {
@@ -334,7 +360,7 @@ public class ExecutionImpl implements
     }
 
     public List<String> findActiveActivityIds() {
-        List<String> activeActivityIds = new ArrayList<String>();
+        List<String> activeActivityIds = new ArrayList<>();
         collectActiveActivityIds(activeActivityIds);
         return activeActivityIds;
     }
@@ -355,13 +381,15 @@ public class ExecutionImpl implements
      */
     protected void ensureExecutionsInitialized() {
         if (executions == null) {
-            executions = new ArrayList<ExecutionImpl>();
+            executions = new ArrayList<>();
         }
     }
 
     // process definition ///////////////////////////////////////////////////////
 
-    /** ensures initialization and returns the process definition. */
+    /**
+     * ensures initialization and returns the process definition.
+     */
     public ProcessDefinitionImpl getProcessDefinition() {
         ensureProcessDefinitionInitialized();
         return processDefinition;
@@ -381,7 +409,9 @@ public class ExecutionImpl implements
 
     // process instance /////////////////////////////////////////////////////////
 
-    /** ensures initialization and returns the process instance. */
+    /**
+     * ensures initialization and returns the process instance.
+     */
     public ExecutionImpl getProcessInstance() {
         ensureProcessInstanceInitialized();
         return processInstance;
@@ -403,7 +433,9 @@ public class ExecutionImpl implements
         return getProcessInstance().getBusinessKey();
     }
 
-    /** for setting the process instance, this setter must be used as subclasses can override */
+    /**
+     * for setting the process instance, this setter must be used as subclasses can override
+     */
     public void setProcessInstance(InterpretableExecution processInstance) {
         this.processInstance = (ExecutionImpl) processInstance;
     }
@@ -443,7 +475,9 @@ public class ExecutionImpl implements
 
     // activity /////////////////////////////////////////////////////////////////
 
-    /** ensures initialization and returns the activity */
+    /**
+     * ensures initialization and returns the activity
+     */
     public ActivityImpl getActivity() {
         ensureActivityInitialized();
         return activity;
@@ -456,7 +490,9 @@ public class ExecutionImpl implements
         this.activity = activity;
     }
 
-    /** must be called before the activity member field or getActivity() is called */
+    /**
+     * must be called before the activity member field or getActivity() is called
+     */
     protected void ensureActivityInitialized() {
     }
 
@@ -519,8 +555,8 @@ public class ExecutionImpl implements
     }
 
     public List<ActivityExecution> findInactiveConcurrentExecutions(PvmActivity activity) {
-        List<ActivityExecution> inactiveConcurrentExecutionsInActivity = new ArrayList<ActivityExecution>();
-        List<ActivityExecution> otherConcurrentExecutions = new ArrayList<ActivityExecution>();
+        List<ActivityExecution> inactiveConcurrentExecutionsInActivity = new ArrayList<>();
+        List<ActivityExecution> otherConcurrentExecutions = new ArrayList<>();
         if (isConcurrent()) {
             List<? extends ActivityExecution> concurrentExecutions = getParent().getExecutions();
             for (ActivityExecution concurrentExecution : concurrentExecutions) {
@@ -549,8 +585,8 @@ public class ExecutionImpl implements
 
     @SuppressWarnings("unchecked")
     public void takeAll(List<PvmTransition> transitions, List<ActivityExecution> recyclableExecutions) {
-        transitions = new ArrayList<PvmTransition>(transitions);
-        recyclableExecutions = (recyclableExecutions != null ? new ArrayList<ActivityExecution>(recyclableExecutions) : new ArrayList<ActivityExecution>());
+        transitions = new ArrayList<>(transitions);
+        recyclableExecutions = (recyclableExecutions != null ? new ArrayList<>(recyclableExecutions) : new ArrayList<ActivityExecution>());
 
         if (recyclableExecutions.size() > 1) {
             for (ActivityExecution recyclableExecution : recyclableExecutions) {
@@ -561,7 +597,7 @@ public class ExecutionImpl implements
         }
 
         ExecutionImpl concurrentRoot = ((isConcurrent && !isScope) ? getParent() : this);
-        List<ExecutionImpl> concurrentActiveExecutions = new ArrayList<ExecutionImpl>();
+        List<ExecutionImpl> concurrentActiveExecutions = new ArrayList<>();
         for (ExecutionImpl execution : concurrentRoot.getExecutions()) {
             if (execution.isActive()) {
                 concurrentActiveExecutions.add(execution);
@@ -596,7 +632,7 @@ public class ExecutionImpl implements
 
         } else {
 
-            List<OutgoingExecution> outgoingExecutions = new ArrayList<OutgoingExecution>();
+            List<OutgoingExecution> outgoingExecutions = new ArrayList<>();
 
             recyclableExecutions.remove(concurrentRoot);
 
@@ -680,7 +716,7 @@ public class ExecutionImpl implements
     }
 
     public Map<String, Object> getVariables() {
-        Map<String, Object> collectedVariables = new HashMap<String, Object>();
+        Map<String, Object> collectedVariables = new HashMap<>();
         collectVariables(collectedVariables);
         return collectedVariables;
     }
@@ -688,7 +724,7 @@ public class ExecutionImpl implements
     @Override
     public Map<String, Object> getVariables(Collection<String> variableNames) {
         Map<String, Object> allVariables = getVariables();
-        Map<String, Object> filteredVariables = new HashMap<String, Object>();
+        Map<String, Object> filteredVariables = new HashMap<>();
         for (String variableName : variableNames) {
             filteredVariables.put(variableName, allVariables.get(variableName));
         }
@@ -763,7 +799,7 @@ public class ExecutionImpl implements
 
     protected void ensureVariablesInitialized() {
         if (variables == null) {
-            variables = new HashMap<String, Object>();
+            variables = new HashMap<>();
         }
     }
 

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/rules/RulesAgendaFilter.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/rules/RulesAgendaFilter.java
@@ -24,7 +24,7 @@ import org.drools.runtime.rule.AgendaFilter;
  */
 public class RulesAgendaFilter implements AgendaFilter {
 
-    protected List<String> suffixList = new ArrayList<String>();
+    protected List<String> suffixList = new ArrayList<>();
     protected boolean accept;
 
     public RulesAgendaFilter() {

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/runtime/ProcessInstanceBuilderImpl.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/runtime/ProcessInstanceBuilderImpl.java
@@ -72,7 +72,7 @@ public class ProcessInstanceBuilderImpl implements ProcessInstanceBuilder {
 
     public ProcessInstanceBuilder variables(Map<String, Object> variables) {
         if (this.variables == null) {
-            this.variables = new HashMap<String, Object>();
+            this.variables = new HashMap<>();
         }
         if (variables != null) {
             for (String variableName : variables.keySet()) {
@@ -84,7 +84,7 @@ public class ProcessInstanceBuilderImpl implements ProcessInstanceBuilder {
 
     public ProcessInstanceBuilder variable(String variableName, Object value) {
         if (this.variables == null) {
-            this.variables = new HashMap<String, Object>();
+            this.variables = new HashMap<>();
         }
         this.variables.put(variableName, value);
         return this;
@@ -92,7 +92,7 @@ public class ProcessInstanceBuilderImpl implements ProcessInstanceBuilder {
 
     public ProcessInstanceBuilder transientVariables(Map<String, Object> transientVariables) {
         if (this.transientVariables == null) {
-            this.transientVariables = new HashMap<String, Object>();
+            this.transientVariables = new HashMap<>();
         }
         if (transientVariables != null) {
             for (String variableName : transientVariables.keySet()) {
@@ -104,7 +104,7 @@ public class ProcessInstanceBuilderImpl implements ProcessInstanceBuilder {
 
     public ProcessInstanceBuilder transientVariable(String variableName, Object value) {
         if (this.transientVariables == null) {
-            this.transientVariables = new HashMap<String, Object>();
+            this.transientVariables = new HashMap<>();
         }
         this.transientVariables.put(variableName, value);
         return this;

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/scripting/ScriptBindings.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/scripting/ScriptBindings.java
@@ -33,10 +33,10 @@ public class ScriptBindings implements Bindings {
 
     /**
      * The script engine implementations put some key/value pairs into the binding. This list contains those keys, such that they wouldn't be stored as process variable.
-     * 
+     * <p>
      * This list contains the keywords for JUEL, Javascript and Groovy.
      */
-    protected static final Set<String> UNSTORED_KEYS = new HashSet<String>(Arrays.asList("out", "out:print", "lang:import", "context", "elcontext", "print", "println", "nashorn.global"));
+    protected static final Set<String> UNSTORED_KEYS = new HashSet<>(Arrays.asList("out", "out:print", "lang:import", "context", "elcontext", "print", "println", "nashorn.global"));
 
     protected List<Resolver> scriptResolvers;
     protected VariableScope variableScope;

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/scripting/ScriptBindingsFactory.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/scripting/ScriptBindingsFactory.java
@@ -41,7 +41,7 @@ public class ScriptBindingsFactory {
     }
 
     protected List<Resolver> createResolvers(VariableScope variableScope) {
-        List<Resolver> scriptResolvers = new ArrayList<Resolver>();
+        List<Resolver> scriptResolvers = new ArrayList<>();
         for (ResolverFactory scriptResolverFactory : resolverFactories) {
             Resolver resolver = scriptResolverFactory.createResolver(variableScope);
             if (resolver != null) {

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/scripting/ScriptingEngines.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/scripting/ScriptingEngines.java
@@ -49,7 +49,7 @@ public class ScriptingEngines {
 
     public ScriptingEngines(ScriptEngineManager scriptEngineManager) {
         this.scriptEngineManager = scriptEngineManager;
-        cachedEngines = new HashMap<String, ScriptEngine>();
+        cachedEngines = new HashMap<>();
     }
 
     public ScriptingEngines addScriptEngineFactory(ScriptEngineFactory scriptEngineFactory) {
@@ -126,12 +126,16 @@ public class ScriptingEngines {
         return scriptEngine;
     }
 
-    /** override to build a spring aware ScriptingEngines */
+    /**
+     * override to build a spring aware ScriptingEngines
+     */
     protected Bindings createBindings(VariableScope variableScope) {
         return scriptBindingsFactory.createBindings(variableScope);
     }
 
-    /** override to build a spring aware ScriptingEngines */
+    /**
+     * override to build a spring aware ScriptingEngines
+     */
     protected Bindings createBindings(VariableScope variableScope, boolean storeScriptVariables) {
         return scriptBindingsFactory.createBindings(variableScope, storeScriptVariables);
     }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/task/TaskDefinition.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/task/TaskDefinition.java
@@ -26,7 +26,7 @@ import org.flowable.variable.service.delegate.Expression;
 
 /**
  * Container for task definition information gathered at parsing time.
- * 
+ *
  * @author Joram Barrez
  */
 public class TaskDefinition implements Serializable {
@@ -40,14 +40,14 @@ public class TaskDefinition implements Serializable {
     protected Expression ownerExpression;
     protected Expression descriptionExpression;
     protected Expression assigneeExpression;
-    protected Set<Expression> candidateUserIdExpressions = new HashSet<Expression>();
-    protected Set<Expression> candidateGroupIdExpressions = new HashSet<Expression>();
+    protected Set<Expression> candidateUserIdExpressions = new HashSet<>();
+    protected Set<Expression> candidateGroupIdExpressions = new HashSet<>();
     protected Expression dueDateExpression;
     protected Expression businessCalendarNameExpression;
     protected Expression priorityExpression;
     protected Expression categoryExpression;
-    protected Map<String, Set<Expression>> customUserIdentityLinkExpressions = new HashMap<String, Set<Expression>>();
-    protected Map<String, Set<Expression>> customGroupIdentityLinkExpressions = new HashMap<String, Set<Expression>>();
+    protected Map<String, Set<Expression>> customUserIdentityLinkExpressions = new HashMap<>();
+    protected Map<String, Set<Expression>> customGroupIdentityLinkExpressions = new HashMap<>();
     protected Expression skipExpression;
 
     // form fields
@@ -55,7 +55,7 @@ public class TaskDefinition implements Serializable {
     protected Expression formKeyExpression;
 
     // task listeners
-    protected Map<String, List<TaskListener>> taskListeners = new HashMap<String, List<TaskListener>>();
+    protected Map<String, List<TaskListener>> taskListeners = new HashMap<>();
 
     public TaskDefinition(TaskFormHandler taskFormHandler) {
         this.taskFormHandler = taskFormHandler;
@@ -215,7 +215,7 @@ public class TaskDefinition implements Serializable {
         } else {
             List<TaskListener> taskEventListeners = taskListeners.get(eventName);
             if (taskEventListeners == null) {
-                taskEventListeners = new ArrayList<TaskListener>();
+                taskEventListeners = new ArrayList<>();
                 taskListeners.put(eventName, taskEventListeners);
             }
             taskEventListeners.add(taskListener);

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/util/CollectionUtil.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/util/CollectionUtil.java
@@ -19,7 +19,7 @@ import org.activiti.engine.ActivitiIllegalArgumentException;
 
 /**
  * Helper/convenience methods for working with collections.
- * 
+ *
  * @author Joram Barrez
  */
 public class CollectionUtil {
@@ -30,18 +30,18 @@ public class CollectionUtil {
 
     /**
      * Helper method that creates a singleton map.
-     * 
+     * <p>
      * Alternative for Collections.singletonMap(), since that method returns a generic typed map <K,T> depending on the input type, but we often need a <String, Object> map.
      */
     public static Map<String, Object> singletonMap(String key, Object value) {
-        Map<String, Object> map = new HashMap<String, Object>();
+        Map<String, Object> map = new HashMap<>();
         map.put(key, value);
         return map;
     }
 
     /**
      * Helper method to easily create a map.
-     * 
+     * <p>
      * Takes as input a varargs containing the key1, value1, key2, value2, etc. Note: although an Object, we will cast the key to String internally.
      */
     public static Map<String, Object> map(Object... objects) {
@@ -50,7 +50,7 @@ public class CollectionUtil {
             throw new ActivitiIllegalArgumentException("The input should always be even since we expect a list of key-value pairs!");
         }
 
-        Map<String, Object> map = new HashMap<String, Object>();
+        Map<String, Object> map = new HashMap<>();
         for (int i = 0; i < objects.length; i += 2) {
             map.put((String) objects[i], objects[i + 1]);
         }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/variable/DefaultVariableTypes.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/variable/DefaultVariableTypes.java
@@ -29,8 +29,8 @@ public class DefaultVariableTypes implements VariableTypes, Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private final List<VariableType> typesList = new ArrayList<VariableType>();
-    private final Map<String, VariableType> typesMap = new HashMap<String, VariableType>();
+    private final List<VariableType> typesList = new ArrayList<>();
+    private final Map<String, VariableType> typesMap = new HashMap<>();
 
     public DefaultVariableTypes addType(VariableType type) {
         return addType(type, typesList.size());

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/variable/JPAEntityListVariableType.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/variable/JPAEntityListVariableType.java
@@ -17,7 +17,7 @@ import org.flowable.variable.service.impl.types.VariableType;
 /**
  * Variable type capable of storing a list of reference to JPA-entities. Only JPA-Entities which are configured by annotations are supported. Use of compound primary keys is not supported. <br>
  * The variable value should be of type {@link List} and can only contain objects of the same type.
- * 
+ *
  * @author Frederik Heremans
  */
 public class JPAEntityListVariableType implements VariableType, CacheableVariable {
@@ -87,7 +87,7 @@ public class JPAEntityListVariableType implements VariableType, CacheableVariabl
 
         if (value instanceof List<?> && ((List<?>) value).size() > 0) {
             List<?> list = (List<?>) value;
-            List<String> ids = new ArrayList<String>();
+            List<String> ids = new ArrayList<>();
 
             String type = mappings.getJPAClassString(list.get(0));
             for (Object entry : list) {
@@ -113,7 +113,7 @@ public class JPAEntityListVariableType implements VariableType, CacheableVariabl
         if (valueFields.getTextValue() != null && bytes != null) {
             String entityClass = valueFields.getTextValue();
 
-            List<Object> result = new ArrayList<Object>();
+            List<Object> result = new ArrayList<>();
             String[] ids = deserializeIds(bytes);
 
             for (String id : ids) {
@@ -130,7 +130,7 @@ public class JPAEntityListVariableType implements VariableType, CacheableVariabl
      */
     protected byte[] serializeIds(List<String> ids) {
         try {
-            String[] toStore = ids.toArray(new String[] {});
+            String[] toStore = ids.toArray(new String[]{});
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             ObjectOutputStream out = new ObjectOutputStream(baos);
 

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/variable/JPAEntityMappings.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/variable/JPAEntityMappings.java
@@ -37,7 +37,7 @@ public class JPAEntityMappings {
     private JPAEntityScanner enitityScanner;
 
     public JPAEntityMappings() {
-        classMetaDatamap = new HashMap<String, EntityMetaData>();
+        classMetaDatamap = new HashMap<>();
         enitityScanner = new JPAEntityScanner();
     }
 

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/webservice/WSService.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/webservice/WSService.java
@@ -22,7 +22,7 @@ import org.flowable.engine.impl.bpmn.webservice.BpmnInterfaceImplementation;
 
 /**
  * Represents a WS implementation of a {@link BpmnInterface}
- * 
+ *
  * @author Esteban Robles Luna
  */
 public class WSService implements BpmnInterfaceImplementation {
@@ -40,14 +40,14 @@ public class WSService implements BpmnInterfaceImplementation {
     public WSService(String name, String location, String wsdlLocation) {
         this.name = name;
         this.location = location;
-        this.operations = new HashMap<String, WSOperation>();
+        this.operations = new HashMap<>();
         this.wsdlLocation = wsdlLocation;
     }
 
     public WSService(String name, String location, SyncWebServiceClient client) {
         this.name = name;
         this.location = location;
-        this.operations = new HashMap<String, WSOperation>();
+        this.operations = new HashMap<>();
         this.client = client;
     }
 

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/management/TableMetaData.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/management/TableMetaData.java
@@ -17,16 +17,16 @@ import java.util.List;
 
 /**
  * Structure containing meta data (column names, column types, etc.) about a certain database table.
- * 
+ *
  * @author Joram Barrez
  */
 public class TableMetaData {
 
     protected String tableName;
 
-    protected List<String> columnNames = new ArrayList<String>();
+    protected List<String> columnNames = new ArrayList<>();
 
-    protected List<String> columnTypes = new ArrayList<String>();
+    protected List<String> columnTypes = new ArrayList<>();
 
     public TableMetaData() {
 

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/repository/DiagramLayout.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/repository/DiagramLayout.java
@@ -61,7 +61,7 @@ public class DiagramLayout implements Serializable {
     }
 
     public List<DiagramNode> getNodes() {
-        List<DiagramNode> nodes = new ArrayList<DiagramNode>();
+        List<DiagramNode> nodes = new ArrayList<>();
         for (Entry<String, DiagramElement> entry : getElements().entrySet()) {
             DiagramElement element = entry.getValue();
             if (element instanceof DiagramNode) {

--- a/modules/flowable5-spring/src/main/java/org/activiti/spring/SpringProcessEngineConfiguration.java
+++ b/modules/flowable5-spring/src/main/java/org/activiti/spring/SpringProcessEngineConfiguration.java
@@ -50,7 +50,7 @@ public class SpringProcessEngineConfiguration extends ProcessEngineConfiguration
     protected String deploymentMode = "default";
     protected ApplicationContext applicationContext;
     protected Integer transactionSynchronizationAdapterOrder;
-    private Collection<AutoDeploymentStrategy> deploymentStrategies = new ArrayList<AutoDeploymentStrategy>();
+    private Collection<AutoDeploymentStrategy> deploymentStrategies = new ArrayList<>();
 
     public SpringProcessEngineConfiguration() {
         this.transactionsExternallyManaged = true;
@@ -163,9 +163,8 @@ public class SpringProcessEngineConfiguration extends ProcessEngineConfiguration
     /**
      * Gets the {@link AutoDeploymentStrategy} for the provided mode. This method may be overridden to implement custom deployment strategies if required, but implementors should take care not to
      * return <code>null</code>.
-     * 
-     * @param mode
-     *            the mode to get the strategy for
+     *
+     * @param mode the mode to get the strategy for
      * @return the deployment strategy to use for the mode. Never <code>null</code>
      */
     protected AutoDeploymentStrategy getAutoDeploymentStrategy(final String mode) {

--- a/modules/flowable5-spring/src/main/java/org/activiti/spring/autodeployment/ResourceParentFolderAutoDeploymentStrategy.java
+++ b/modules/flowable5-spring/src/main/java/org/activiti/spring/autodeployment/ResourceParentFolderAutoDeploymentStrategy.java
@@ -79,7 +79,7 @@ public class ResourceParentFolderAutoDeploymentStrategy extends AbstractAutoDepl
     }
 
     private Map<String, Set<Resource>> createMap(final Resource[] resources) {
-        final Map<String, Set<Resource>> resourcesMap = new HashMap<String, Set<Resource>>();
+        final Map<String, Set<Resource>> resourcesMap = new HashMap<>();
 
         for (final Resource resource : resources) {
             final String parentFolderName = determineGroupName(resource);


### PR DESCRIPTION
Part 2 of [PR 515](https://github.com/flowable/flowable-engine/pull/515) which read in part:

>This is based on the coding style post last year.
>
>The specific item is #48: Explicit type can be replaced with <>.
>
>Which read: Correct all new expressions with type arguments which can be replaced with diamond type <>. That is no need to specify the type again.