### PR TITLE
Resolve bug in multi-instance parsing.

### DIFF
--- a/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/child/MultiInstanceParser.java
+++ b/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/child/MultiInstanceParser.java
@@ -68,7 +68,7 @@ public class MultiInstanceParser extends BaseChildElementParser {
                 	// initialize collection element parser in case it exists
                 	Map<String, BaseChildElementParser> childParserMap = new HashMap<String, BaseChildElementParser>();
                 	childParserMap.put(ELEMENT_MULTIINSTANCE_COLLECTION, new FlowableCollectionParser());
-                	BpmnXMLUtil.parseChildElements(ELEMENT_MULTIINSTANCE_COLLECTION, multiInstanceDef, xtr, childParserMap, model);
+                	BpmnXMLUtil.parseChildElements(ELEMENT_EXTENSIONS, multiInstanceDef, xtr, childParserMap, model);
                 	
                 } else if (xtr.isEndElement() && getElementName().equalsIgnoreCase(xtr.getLocalName())) {
                 	readyWithMultiInstance = true;

--- a/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/util/BpmnXMLUtil.java
+++ b/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/util/BpmnXMLUtil.java
@@ -147,7 +147,8 @@ public class BpmnXMLUtil implements BpmnXMLConstants {
             } else if (xtr.isEndElement()) {
                 if (ELEMENT_EXTENSIONS.equals(xtr.getLocalName())) {
                     inExtensionElements = false;
-                } else if (elementName.equalsIgnoreCase(xtr.getLocalName())) {
+                } 
+                if (elementName.equalsIgnoreCase(xtr.getLocalName())) {
                     readyWithChildElements = true;
                 }
             }

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testParallelUserTasksCustomCollectionStringExtension.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testParallelUserTasksCustomCollectionStringExtension.bpmn20.xml
@@ -8,7 +8,6 @@
   <process id="miParallelUserTasksCollection">
   
     <startEvent id="theStart" />
-    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="miTasks" />
     
     <userTask id="miTasks" name="My Task ${loopCounter}" flowable:candidateUsers="${participant}">
       <multiInstanceLoopCharacteristics isSequential="false" flowable:elementVariable="participant">
@@ -35,6 +34,7 @@
       </multiInstanceLoopCharacteristics>
     </userTask>
     
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="miTasks" />
     <sequenceFlow id="flow3" sourceRef="miTasks" targetRef="theEnd" />
     <endEvent id="theEnd" />
     


### PR DESCRIPTION
Change-Id: I9a6d3b7612ea7b443151cd12d7f94dc8a75907c0

The MultiInstanceParser fails to include flow elements after a multi-instance user task that uses the new <flowable:collection> element. This failure can be reproduced by reordering the flow elements in the bpmn file. The changeset includes a reordered bpmn file which can be used to reproduce the error as well as a proposed fix.