### PR TITLE
added missing input clause id and label to DMN XML converter

### DIFF
--- a/modules/flowable-dmn-xml-converter/src/main/java/org/flowable/dmn/xml/converter/InputClauseXMLConverter.java
+++ b/modules/flowable-dmn-xml-converter/src/main/java/org/flowable/dmn/xml/converter/InputClauseXMLConverter.java
@@ -40,6 +40,8 @@ public class InputClauseXMLConverter extends BaseDmnXMLConverter {
     @Override
     protected DmnElement convertXMLToElement(XMLStreamReader xtr, DmnDefinition model, DecisionTable decisionTable) throws Exception {
         InputClause clause = new InputClause();
+        clause.setId(xtr.getAttributeValue(null, ATTRIBUTE_ID));
+        clause.setLabel(xtr.getAttributeValue(null, ATTRIBUTE_LABEL));
         parseChildElements(getXMLElementName(), clause, decisionTable, xtr);
         return clause;
     }

--- a/modules/flowable-dmn-xml-converter/src/test/java/org/flowable/dmn/xml/AdditionalConverterTest.java
+++ b/modules/flowable-dmn-xml-converter/src/test/java/org/flowable/dmn/xml/AdditionalConverterTest.java
@@ -59,13 +59,22 @@ public class AdditionalConverterTest extends AbstractConverterTest {
 
         List<InputClause> inputClauses = decisionTable.getInputs();
         assertEquals(2, inputClauses.size());
+        assertNotNull(inputClauses.get(0).getId());
+        assertNotNull(inputClauses.get(0).getLabel());
+        assertNotNull(inputClauses.get(0).getInputExpression().getTypeRef());
+        assertNotNull(inputClauses.get(0).getInputExpression().getId());
+        assertNotNull(inputClauses.get(0).getInputExpression().getText());
 
         List<OutputClause> outputClauses = decisionTable.getOutputs();
         assertEquals(2, outputClauses.size());
+        assertNotNull(outputClauses.get(0).getName());
+        assertNotNull(outputClauses.get(0).getTypeRef());
+        assertNotNull(outputClauses.get(0).getId());
+        assertNotNull(outputClauses.get(0).getLabel());
 
         assertEquals("\"result2\",\"result1\"", decisionTable.getOutputs().get(0).getOutputValues().getText());
         assertEquals("\"2\",\"1\"", decisionTable.getOutputs().get(1).getOutputValues().getText());
-        
+
         List<DecisionRule> rules = decisionTable.getRules();
         assertEquals(2, rules.size());
 


### PR DESCRIPTION
When converting DMN XML to DMN model the properties id and label on input clauses were missing.