### PR TITLE
fixes #510 dispatchers not inheriting base dispatcher

### DIFF
--- a/modules/flowable-ui-task/flowable-ui-task-conf/src/main/java/org/flowable/app/servlet/ContentDispatcherServletConfiguration.java
+++ b/modules/flowable-ui-task/flowable-ui-task-conf/src/main/java/org/flowable/app/servlet/ContentDispatcherServletConfiguration.java
@@ -22,7 +22,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupp
 @Configuration
 @ComponentScan({ "org.flowable.rest.content.exception", "org.flowable.rest.content.service.api" })
 @EnableAsync
-public class ContentDispatcherServletConfiguration extends WebMvcConfigurationSupport {
+public class ContentDispatcherServletConfiguration extends BaseDispatcherServletConfiguration {
 
     protected static final Logger LOGGER = LoggerFactory.getLogger(ContentDispatcherServletConfiguration.class);
 

--- a/modules/flowable-ui-task/flowable-ui-task-conf/src/main/java/org/flowable/app/servlet/DmnDispatcherServletConfiguration.java
+++ b/modules/flowable-ui-task/flowable-ui-task-conf/src/main/java/org/flowable/app/servlet/DmnDispatcherServletConfiguration.java
@@ -22,7 +22,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupp
 @Configuration
 @ComponentScan({ "org.flowable.rest.dmn.exception", "org.flowable.rest.dmn.service.api" })
 @EnableAsync
-public class DmnDispatcherServletConfiguration extends WebMvcConfigurationSupport {
+public class DmnDispatcherServletConfiguration extends BaseDispatcherServletConfiguration {
 
     protected static final Logger LOGGER = LoggerFactory.getLogger(DmnDispatcherServletConfiguration.class);
 

--- a/modules/flowable-ui-task/flowable-ui-task-conf/src/main/java/org/flowable/app/servlet/FormDispatcherServletConfiguration.java
+++ b/modules/flowable-ui-task/flowable-ui-task-conf/src/main/java/org/flowable/app/servlet/FormDispatcherServletConfiguration.java
@@ -22,7 +22,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupp
 @Configuration
 @ComponentScan({ "org.flowable.rest.form.exception", "org.flowable.rest.form.service.api" })
 @EnableAsync
-public class FormDispatcherServletConfiguration extends WebMvcConfigurationSupport {
+public class FormDispatcherServletConfiguration extends BaseDispatcherServletConfiguration {
 
     protected static final Logger LOGGER = LoggerFactory.getLogger(FormDispatcherServletConfiguration.class);
 


### PR DESCRIPTION
because of this the MultipartResolver (needed for Spring MVC multipart/formdata handling) is not initialized for the form / dmn / content REST resources