### PR TITLE
API Improvement : Add new interface - FlowableProcessCancelledEvent

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableActivityEvent.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableActivityEvent.java
@@ -12,7 +12,6 @@
  */
 package org.flowable.engine.delegate.event;
 
-import org.flowable.engine.common.api.delegate.event.FlowableEngineEvent;
 import org.flowable.engine.common.api.delegate.event.FlowableEvent;
 
 /**
@@ -21,7 +20,7 @@ import org.flowable.engine.common.api.delegate.event.FlowableEvent;
  * @author Frederik Heremans
  * @author Joram Barrez
  */
-public interface FlowableActivityEvent extends FlowableEngineEvent {
+public interface FlowableActivityEvent extends FlowableProcessEngineEvent {
 
     /**
      * @return the id of the activity this event is related to. This corresponds to an id defined in the process definition.

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableProcessCancelledEvent.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableProcessCancelledEvent.java
@@ -1,0 +1,9 @@
+package org.flowable.engine.delegate.event;
+
+/**
+ * An {@link org.flowable.engine.common.api.delegate.event.FlowableEvent} related to a process cancel event being sent.
+ *
+ */
+public interface FlowableProcessCancelledEvent extends FlowableProcessEngineEvent, FlowableCancelledEvent {
+
+}

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableProcessEngineEntityEvent.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableProcessEngineEntityEvent.java
@@ -1,0 +1,11 @@
+package org.flowable.engine.delegate.event;
+
+import org.flowable.engine.common.api.delegate.event.FlowableEngineEntityEvent;
+
+/**
+ * An {@link org.flowable.engine.common.api.delegate.event.FlowableEvent} related to an entity event being sent.
+ *
+ */
+public interface FlowableProcessEngineEntityEvent extends FlowableEngineEntityEvent, FlowableProcessEngineEvent {
+
+}

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableSequenceFlowTakenEvent.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableSequenceFlowTakenEvent.java
@@ -20,7 +20,7 @@ import org.flowable.engine.common.api.delegate.event.FlowableEvent;
  * 
  * @author Frederik Heremans
  */
-public interface FlowableSequenceFlowTakenEvent extends FlowableEngineEvent {
+public interface FlowableSequenceFlowTakenEvent extends FlowableProcessEngineEvent {
 
     String getId();
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/impl/FlowableEntityEventImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/impl/FlowableEntityEventImpl.java
@@ -13,16 +13,16 @@
 package org.flowable.engine.delegate.event.impl;
 
 import org.flowable.engine.common.api.FlowableIllegalArgumentException;
-import org.flowable.engine.common.api.delegate.event.FlowableEngineEntityEvent;
 import org.flowable.engine.common.api.delegate.event.FlowableEngineEventType;
 import org.flowable.engine.common.api.delegate.event.FlowableEvent;
+import org.flowable.engine.delegate.event.FlowableProcessEngineEntityEvent;
 
 /**
  * Base class for all {@link FlowableEvent} implementations, related to entities.
  * 
  * @author Frederik Heremans
  */
-public class FlowableEntityEventImpl extends FlowableProcessEventImpl implements FlowableEngineEntityEvent {
+public class FlowableEntityEventImpl extends FlowableProcessEventImpl implements FlowableProcessEngineEntityEvent {
 
     protected Object entity;
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/impl/FlowableEntityExceptionEventImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/impl/FlowableEntityExceptionEventImpl.java
@@ -13,18 +13,17 @@
 package org.flowable.engine.delegate.event.impl;
 
 import org.flowable.engine.common.api.FlowableIllegalArgumentException;
-import org.flowable.engine.common.api.delegate.event.FlowableEngineEntityEvent;
 import org.flowable.engine.common.api.delegate.event.FlowableEngineEventType;
 import org.flowable.engine.common.api.delegate.event.FlowableEvent;
 import org.flowable.engine.common.api.delegate.event.FlowableExceptionEvent;
-import org.flowable.engine.common.impl.event.FlowableEventImpl;
+import org.flowable.engine.delegate.event.FlowableProcessEngineEntityEvent;
 
 /**
  * Base class for all {@link FlowableEvent} implementations, represents an exception occurred, related to an entity.
  * 
  * @author Frederik Heremans
  */
-public class FlowableEntityExceptionEventImpl extends FlowableProcessEventImpl implements FlowableEngineEntityEvent, FlowableExceptionEvent {
+public class FlowableEntityExceptionEventImpl extends FlowableProcessEventImpl implements FlowableProcessEngineEntityEvent, FlowableExceptionEvent {
 
     protected Object entity;
     protected Throwable cause;

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/impl/FlowableProcessCancelledEventImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/impl/FlowableProcessCancelledEventImpl.java
@@ -13,14 +13,14 @@
 package org.flowable.engine.delegate.event.impl;
 
 import org.flowable.engine.common.api.delegate.event.FlowableEngineEventType;
-import org.flowable.engine.delegate.event.FlowableCancelledEvent;
+import org.flowable.engine.delegate.event.FlowableProcessCancelledEvent;
 
 /**
  * An {@link org.flowable.engine.delegate.event.FlowableCancelledEvent} implementation.
  * 
  * @author martin.grofcik
  */
-public class FlowableProcessCancelledEventImpl extends FlowableProcessEventImpl implements FlowableCancelledEvent {
+public class FlowableProcessCancelledEventImpl extends FlowableProcessEventImpl implements FlowableProcessCancelledEvent {
 
     protected Object cause;
 


### PR DESCRIPTION
Expose the getExecution() method defined in the FlowableProcessEngineEvent in the process cancelled event.

This change is needed to eliminate a compile dependency on 'impl' classes used to retrieve the execution in a FlowableEventListener.

From:
FlowableCancelledEvent event = (FlowableCancelledEvent) flowableEvent;
DelegateExecution execution = CommandContextUtil.getExecutionEntityManager().findById(event.getExecutionId());

To:
FlowableProcessCancelledEvent event = (FlowableProcessCancelledEvent) flowableEvent;
DelegateExecution execution = event.getExecution();

Change-Id: I990334a115c82ace335f14c12f647ee99601ac43