### PR TITLE
Fix upgrade scripts for ACT_HI_VARINST

### DIFF
--- a/modules/flowable-engine/src/main/resources/org/flowable/db/create/flowable.db2.create.engine.sql
+++ b/modules/flowable-engine/src/main/resources/org/flowable/db/create/flowable.db2.create.engine.sql
@@ -252,7 +252,7 @@ create table ACT_RU_VARIABLE (
     TYPE_ varchar(255) not null,
     NAME_ varchar(255) not null,
     EXECUTION_ID_ varchar(64),
-	PROC_INST_ID_ varchar(64),
+    PROC_INST_ID_ varchar(64),
     TASK_ID_ varchar(64),
     BYTEARRAY_ID_ varchar(64),
     DOUBLE_ double precision,

--- a/modules/flowable-engine/src/main/resources/org/flowable/db/upgrade/flowable.h2.upgradestep.6120.to.6200.history.sql
+++ b/modules/flowable-engine/src/main/resources/org/flowable/db/upgrade/flowable.h2.upgradestep.6120.to.6200.history.sql
@@ -1,2 +1,2 @@
-alter table ACT_RU_EXECUTION add column CALLBACK_ID_ varchar(255);
-alter table ACT_RU_EXECUTION add column CALLBACK_TYPE_ varchar(255);
+alter table ACT_HI_PROCINST add column CALLBACK_ID_ varchar(255);
+alter table ACT_HI_PROCINST add column CALLBACK_TYPE_ varchar(255);

--- a/modules/flowable-engine/src/main/resources/org/flowable/db/upgrade/flowable.mssql.upgradestep.6120.to.6200.history.sql
+++ b/modules/flowable-engine/src/main/resources/org/flowable/db/upgrade/flowable.mssql.upgradestep.6120.to.6200.history.sql
@@ -1,2 +1,2 @@
-alter table ACT_RU_EXECUTION add CALLBACK_ID_ nvarchar(255);
-alter table ACT_RU_EXECUTION add CALLBACK_TYPE_ nvarchar(255);
+alter table ACT_HI_PROCINST add column CALLBACK_ID_ nvarchar(255);
+alter table ACT_HI_PROCINST add column CALLBACK_TYPE_ nvarchar(255);

--- a/modules/flowable-engine/src/main/resources/org/flowable/db/upgrade/flowable.mysql.upgradestep.6120.to.6200.history.sql
+++ b/modules/flowable-engine/src/main/resources/org/flowable/db/upgrade/flowable.mysql.upgradestep.6120.to.6200.history.sql
@@ -1,2 +1,2 @@
-alter table ACT_RU_EXECUTION add column CALLBACK_ID_ varchar(255);
-alter table ACT_RU_EXECUTION add column CALLBACK_TYPE_ varchar(255);
+alter table ACT_HI_VARINST add column CALLBACK_ID_ varchar(255);
+alter table ACT_HI_VARINST add column CALLBACK_TYPE_ varchar(255);


### PR DESCRIPTION
The 6.1.2 -> 6.2.0 upgrade scripts for h2, hsql and mysql had the wrong table names in the history upgrade scripts.