### PR TITLE
Small code cleanups

### DIFF
--- a/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/child/MultiInstanceParser.java
+++ b/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/child/MultiInstanceParser.java
@@ -67,10 +67,10 @@ public class MultiInstanceParser extends BaseChildElementParser {
 
                 } else if (xtr.isStartElement() && ELEMENT_EXTENSIONS.equalsIgnoreCase(xtr.getLocalName())) {
                     // parse extension elements
-                	  // initialize collection element parser in case it exists
-                	  Map<String, BaseChildElementParser> childParserMap = new HashMap<String, BaseChildElementParser>();
-                	  childParserMap.put(ELEMENT_MULTIINSTANCE_COLLECTION, new FlowableCollectionParser());
-                	  BpmnXMLUtil.parseChildElements(ELEMENT_EXTENSIONS, multiInstanceDef, xtr, childParserMap, model);
+                    // initialize collection element parser in case it exists
+                    Map<String, BaseChildElementParser> childParserMap = new HashMap<>();
+                    childParserMap.put(ELEMENT_MULTIINSTANCE_COLLECTION, new FlowableCollectionParser());
+                    BpmnXMLUtil.parseChildElements(ELEMENT_EXTENSIONS, multiInstanceDef, xtr, childParserMap, model);
 
                 } else if (xtr.isEndElement() && getElementName().equalsIgnoreCase(xtr.getLocalName())) {
                     readyWithMultiInstance = true;

--- a/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/CmmnXmlConverter.java
+++ b/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/CmmnXmlConverter.java
@@ -75,9 +75,9 @@ public class CmmnXmlConverter implements CmmnXmlConstants {
 
     protected static Map<String, BaseCmmnXmlConverter> elementConverters = new HashMap<>();
     protected static Map<String, BaseCmmnXmlConverter> textConverters = new HashMap<>();
-    
+
     protected ClassLoader classloader;
-    
+
     static {
         addElementConverter(new DefinitionsXmlConverter());
         addElementConverter(new DocumentationXmlConverter());
@@ -99,26 +99,26 @@ public class CmmnXmlConverter implements CmmnXmlConstants {
         addElementConverter(new CmmnDiEdgeXmlConverter());
         addElementConverter(new CmmnDiBoundsXmlConverter());
         addElementConverter(new CmmnDiWaypointXmlConverter());
-        
+
         addTextConverter(new StandardEventXmlConverter());
     }
-    
+
     public static void addElementConverter(BaseCmmnXmlConverter converter) {
         elementConverters.put(converter.getXMLElementName(), converter);
     }
-    
+
     public static void addTextConverter(BaseCmmnXmlConverter converter) {
         textConverters.put(converter.getXMLElementName(), converter);
     }
-    
+
     public CmmnModel convertToCmmnModel(InputStreamProvider inputStreamProvider) {
         return convertToCmmnModel(inputStreamProvider, true, true);
     }
-    
+
     public CmmnModel convertToCmmnModel(InputStreamProvider inputStreamProvider, boolean validateSchema, boolean enableSafeBpmnXml) {
         return convertToCmmnModel(inputStreamProvider, validateSchema, enableSafeBpmnXml, DEFAULT_ENCODING);
     }
-    
+
     public CmmnModel convertToCmmnModel(InputStreamProvider inputStreamProvider, boolean validateSchema, boolean enableSafeBpmnXml, String encoding) {
         XMLInputFactory xif = XMLInputFactory.newInstance();
 
@@ -131,7 +131,7 @@ public class CmmnXmlConverter implements CmmnXmlConstants {
         if (xif.isPropertySupported(XMLInputFactory.SUPPORT_DTD)) {
             xif.setProperty(XMLInputFactory.SUPPORT_DTD, false);
         }
-        
+
         if (encoding == null) {
             encoding = DEFAULT_ENCODING;
         }
@@ -145,9 +145,9 @@ public class CmmnXmlConverter implements CmmnXmlConstants {
                 }
             } catch (UnsupportedEncodingException e) {
                 throw new CmmnXMLException("The CMMN 1.1 xml is not properly encoded", e);
-            } catch (XMLStreamException e){
+            } catch (XMLStreamException e) {
                 throw new CmmnXMLException("Error while reading the CMMN 1.1 XML", e);
-            } catch (Exception e){
+            } catch (Exception e) {
                 throw new CmmnXMLException(e.getMessage(), e);
             }
         }
@@ -165,10 +165,10 @@ public class CmmnXmlConverter implements CmmnXmlConstants {
     }
 
     public CmmnModel convertToCmmnModel(XMLStreamReader xtr) {
-        
+
         ConversionHelper conversionHelper = new ConversionHelper();
         conversionHelper.setCmmnModel(new CmmnModel());
-        
+
         try {
             String currentXmlElement = null;
             while (xtr.hasNext()) {
@@ -184,21 +184,21 @@ public class CmmnXmlConverter implements CmmnXmlConstants {
                     if (elementConverters.containsKey(currentXmlElement)) {
                         elementConverters.get(currentXmlElement).convertToCmmnModel(xtr, conversionHelper);
                     }
-                    
+
                 } else if (xtr.isEndElement()) {
                     currentXmlElement = null;
                     if (elementConverters.containsKey(xtr.getLocalName())) {
                         elementConverters.get(xtr.getLocalName()).elementEnd(xtr, conversionHelper);
                     }
-                    
+
                 } else if (xtr.isCharacters() && currentXmlElement != null) {
                     if (textConverters.containsKey(currentXmlElement)) {
                         textConverters.get(currentXmlElement).convertToCmmnModel(xtr, conversionHelper);
                     }
-                    
-                } 
+
+                }
             }
-            
+
         } catch (CmmnXMLException e) {
             throw e;
 
@@ -206,12 +206,12 @@ public class CmmnXmlConverter implements CmmnXmlConstants {
             LOGGER.error("Error processing CMMN XML document", e);
             throw new CmmnXMLException("Error processing CMMN XML document", e);
         }
-        
+
         // Post process all elements: add instances where a reference is used
         processCmmnElements(conversionHelper);
         return conversionHelper.getCmmnModel();
     }
-    
+
     public void validateModel(InputStreamProvider inputStreamProvider) throws Exception {
         Schema schema = createSchema();
 
@@ -242,7 +242,7 @@ public class CmmnXmlConverter implements CmmnXmlConstants {
         }
         return schema;
     }
-    
+
     public byte[] convertToXML(CmmnModel model) {
         return convertToXML(model, DEFAULT_ENCODING);
     }
@@ -259,7 +259,7 @@ public class CmmnXmlConverter implements CmmnXmlConstants {
             XMLStreamWriter xtw = new IndentingXMLStreamWriter(writer);
 
             DefinitionsRootExport.writeRootElement(model, xtw, encoding);
-            
+
             for (Case caseModel : model.getCases()) {
 
                 if (caseModel.getPlanModel().getPlanItems().isEmpty()) {
@@ -271,7 +271,7 @@ public class CmmnXmlConverter implements CmmnXmlConstants {
 
                 Stage planModel = caseModel.getPlanModel();
                 StageExport.writeStage(planModel, xtw);
-                
+
                 // end case element
                 xtw.writeEndElement();
             }
@@ -295,13 +295,13 @@ public class CmmnXmlConverter implements CmmnXmlConstants {
             throw new XMLException("Error writing CMMN XML", e);
         }
     }
-    
+
     protected void processCmmnElements(ConversionHelper conversionHelper) {
         CmmnModel cmmnModel = conversionHelper.getCmmnModel();
         for (Case caze : cmmnModel.getCases()) {
             processPlanFragment(cmmnModel, caze.getPlanModel());
         }
-        
+
         // CMMN doesn't mandate ids on many elements ... adding generated ids 
         // to those elements as this makes the logic much easier
         ensureIds(conversionHelper.getPlanFragments(), "planFragment_");
@@ -319,27 +319,27 @@ public class CmmnXmlConverter implements CmmnXmlConstants {
                 caze.getAllCaseElements().put(caseElement.getId(), caseElement);
             }
         }
-        
+
         // set DI elements
         for (CmmnDiShape diShape : conversionHelper.getDiShapes()) {
             cmmnModel.addGraphicInfo(diShape.getCmmnElementRef(), diShape.getGraphicInfo());
         }
-        
+
         for (CmmnDiEdge diEdge : conversionHelper.getDiEdges()) {
             Association association = new Association();
             association.setId(diEdge.getId());
             association.setSourceRef(diEdge.getCmmnElementRef());
             association.setTargetRef(diEdge.getTargetCmmnElementRef());
             cmmnModel.addAssociation(association);
-            
+
             cmmnModel.addFlowGraphicInfoList(association.getId(), diEdge.getWaypoints());
         }
     }
-    
+
     protected void processPlanFragment(CmmnModel cmmnModel, PlanFragment planFragment) {
         processPlanItems(cmmnModel, planFragment);
         processSentries(planFragment);
-        
+
         if (planFragment instanceof Stage) {
             Stage stage = (Stage) planFragment;
             for (PlanItemDefinition planItemDefinition : stage.getPlanItemDefinitions()) {
@@ -347,7 +347,7 @@ public class CmmnXmlConverter implements CmmnXmlConstants {
                     processPlanFragment(cmmnModel, (PlanFragment) planItemDefinition);
                 }
             }
-            
+
             if (!stage.getExitCriteria().isEmpty()) {
                 resolveExitCriteriaSentry(stage);
             }
@@ -356,19 +356,19 @@ public class CmmnXmlConverter implements CmmnXmlConstants {
 
     protected void processPlanItems(CmmnModel cmmnModel, PlanFragment planFragment) {
         for (PlanItem planItem : planFragment.getPlanItems()) {
-            
+
             Stage parentStage = planItem.getParentStage();
             PlanItemDefinition planItemDefinition = parentStage.findPlanItemDefinition(planItem.getDefinitionRef());
             if (planItemDefinition == null) {
-                throw new FlowableException("No matching plan item definition found for reference " 
+                throw new FlowableException("No matching plan item definition found for reference "
                         + planItem.getDefinitionRef() + " of plan item " + planItem.getId());
             }
             planItem.setPlanItemDefinition(planItemDefinition);
-            
+
             if (!planItem.getEntryCriteria().isEmpty()) {
                 resolveEntryCriteria(planItem);
             }
-            
+
             if (!planItem.getExitCriteria().isEmpty()) {
                 boolean exitCriteriaAllowed = true;
                 if (planItemDefinition instanceof Task) {
@@ -377,17 +377,17 @@ public class CmmnXmlConverter implements CmmnXmlConstants {
                         exitCriteriaAllowed = false;
                     }
                 }
-                
+
                 if (exitCriteriaAllowed) {
                     resolveExitCriteriaSentry((HasExitCriteria) planItem);
                 } else {
-                    LOGGER.warn("Ignoring exit criteria on plan item " + planItem.getId());
+                    LOGGER.warn("Ignoring exit criteria on plan item {}", planItem.getId());
                 }
             }
-            
+
             if (planItemDefinition instanceof PlanFragment) {
-              processPlanFragment(cmmnModel, (PlanFragment)planItemDefinition );
-                
+                processPlanFragment(cmmnModel, (PlanFragment) planItemDefinition);
+
             } else if (planItemDefinition instanceof ProcessTask) {
                 ProcessTask processTask = (ProcessTask) planItemDefinition;
                 if (processTask.getProcessRef() != null) {
@@ -398,9 +398,9 @@ public class CmmnXmlConverter implements CmmnXmlConstants {
                         processTask.setProcess(process);
                     }
                 }
-                
+
             }
-            
+
         }
     }
 
@@ -410,24 +410,24 @@ public class CmmnXmlConverter implements CmmnXmlConstants {
             if (sentry != null) {
                 entryCriterion.setSentry(sentry);
             } else {
-                throw new FlowableException("No sentry found for reference " 
+                throw new FlowableException("No sentry found for reference "
                         + entryCriterion.getSentryRef() + " of entry criterion " + entryCriterion.getId());
             }
         }
     }
-    
+
     protected void resolveExitCriteriaSentry(HasExitCriteria hasExitCriteria) {
         for (Criterion exitCriterion : hasExitCriteria.getExitCriteria()) {
             Sentry sentry = exitCriterion.getParent().findSentry(exitCriterion.getSentryRef());
             if (sentry != null) {
                 exitCriterion.setSentry(sentry);
             } else {
-                throw new FlowableException("No sentry found for reference " 
+                throw new FlowableException("No sentry found for reference "
                         + exitCriterion.getSentryRef() + " of exit criterion " + exitCriterion.getId());
             }
         }
     }
-    
+
     protected void processSentries(PlanFragment planFragment) {
         for (Sentry sentry : planFragment.getSentries()) {
             for (SentryOnPart onPart : sentry.getOnParts()) {
@@ -435,13 +435,13 @@ public class CmmnXmlConverter implements CmmnXmlConstants {
                 if (planItem != null) {
                     onPart.setSource(planItem);
                 } else {
-                    throw new FlowableException("Could not resolve on part source reference " 
+                    throw new FlowableException("Could not resolve on part source reference "
                             + onPart.getSourceRef() + " of sentry " + sentry.getId());
                 }
             }
         }
     }
-    
+
     protected void ensureIds(List<? extends BaseElement> elements, String idPrefix) {
         Map<String, BaseElement> elementsWithId = new HashMap<>();
         Set<BaseElement> baseElementsWithoutId = new HashSet<>();
@@ -452,7 +452,7 @@ public class CmmnXmlConverter implements CmmnXmlConstants {
                 baseElementsWithoutId.add(baseElement);
             }
         }
-        
+
         if (!baseElementsWithoutId.isEmpty()) {
             int counter = 1;
             for (BaseElement baseElement : baseElementsWithoutId) {
@@ -460,7 +460,7 @@ public class CmmnXmlConverter implements CmmnXmlConstants {
                 while (elementsWithId.containsKey(id)) {
                     id = idPrefix + counter++;
                 }
-                
+
                 baseElement.setId(id);
                 elementsWithId.put(id, baseElement);
             }
@@ -478,5 +478,5 @@ public class CmmnXmlConverter implements CmmnXmlConstants {
     public static void setConvertersToCmmnModelMap(Map<String, BaseCmmnXmlConverter> convertersToCmmnModelMap) {
         CmmnXmlConverter.elementConverters = convertersToCmmnModelMap;
     }
-    
+
 }

--- a/modules/flowable-cmmn-engine-configurator/src/main/java/org/flowable/cmmn/engine/configurator/CmmnEngineConfigurator.java
+++ b/modules/flowable-cmmn-engine-configurator/src/main/java/org/flowable/cmmn/engine/configurator/CmmnEngineConfigurator.java
@@ -13,7 +13,7 @@
 package org.flowable.cmmn.engine.configurator;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -41,22 +41,22 @@ public class CmmnEngineConfigurator extends AbstractEngineConfigurator {
 
     protected CmmnEngineConfiguration cmmnEngineConfiguration;
     protected CmmnEngine cmmnEngine;
-    
+
     @Override
     public int getPriority() {
         return EngineConfigurationConstants.PRIORITY_ENGINE_CMMN;
     }
-    
+
     @Override
     protected List<Deployer> getCustomDeployers() {
-        return Arrays.<Deployer>asList(new CmmnDeployer(this));
+        return Collections.<Deployer>singletonList(new CmmnDeployer(this));
     }
-    
+
     @Override
     protected String getMybatisCfgPath() {
         return CmmnEngineConfiguration.DEFAULT_MYBATIS_MAPPING_FILE;
     }
-    
+
     @Override
     public void configure(ProcessEngineConfigurationImpl processEngineConfiguration) {
         if (cmmnEngineConfiguration == null) {
@@ -66,10 +66,10 @@ public class CmmnEngineConfigurator extends AbstractEngineConfigurator {
         initialiseCommonProperties(processEngineConfiguration, cmmnEngineConfiguration);
         initProcessInstanceService(processEngineConfiguration);
         initProcessInstanceStateChangedCallbacks(processEngineConfiguration);
-        
+
         this.cmmnEngine = initCmmnEngine();
     }
-    
+
     protected void initProcessInstanceService(ProcessEngineConfigurationImpl processEngineConfiguration) {
         cmmnEngineConfiguration.setProcessInstanceService(new DefaultProcessInstanceService(processEngineConfiguration.getRuntimeService()));
     }
@@ -89,7 +89,7 @@ public class CmmnEngineConfigurator extends AbstractEngineConfigurator {
     protected List<Class<? extends Entity>> getEntityInsertionOrder() {
         return EntityDependencyOrder.INSERT_ORDER;
     }
-    
+
     @Override
     protected List<Class<? extends Entity>> getEntityDeletionOrder() {
         return EntityDependencyOrder.DELETE_ORDER;
@@ -119,5 +119,5 @@ public class CmmnEngineConfigurator extends AbstractEngineConfigurator {
     public void setCmmnEngine(CmmnEngine cmmnEngine) {
         this.cmmnEngine = cmmnEngine;
     }
-    
+
 }

--- a/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/AbstractProcessEngineIntegrationTest.java
+++ b/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/AbstractProcessEngineIntegrationTest.java
@@ -20,7 +20,6 @@ import org.flowable.cmmn.engine.CmmnManagementService;
 import org.flowable.cmmn.engine.CmmnRepositoryService;
 import org.flowable.cmmn.engine.CmmnRuntimeService;
 import org.flowable.cmmn.engine.configurator.CmmnEngineConfigurator;
-import org.flowable.cmmn.engine.repository.CmmnDeployment;
 import org.flowable.cmmn.engine.test.impl.CmmnTestRunner;
 import org.flowable.engine.ProcessEngine;
 import org.flowable.engine.ProcessEngineConfiguration;
@@ -43,16 +42,16 @@ public abstract class AbstractProcessEngineIntegrationTest {
 
     protected static CmmnEngine cmmnEngine;
     protected static ProcessEngine processEngine;
-    
+
     protected CmmnRepositoryService cmmnRepositoryService;
     protected CmmnRuntimeService cmmnRuntimeService;
     protected CmmnHistoryService cmmnHistoryService;
     protected CmmnManagementService cmmnManagementService;
-    
+
     protected RepositoryService processEngineRepositoryService;
     protected RuntimeService processEngineRuntimeService;
     protected TaskService processEngineTaskService;
-    
+
     @BeforeClass
     public static void bootProcessEngine() {
         if (processEngine == null) {
@@ -73,12 +72,12 @@ public abstract class AbstractProcessEngineIntegrationTest {
         this.cmmnRuntimeService = cmmnEngine.getCmmnRuntimeService();
         this.cmmnHistoryService = cmmnEngine.getCmmnHistoryService();
         this.cmmnManagementService = cmmnEngine.getCmmnManagementService();
-        
+
         this.processEngineRepositoryService = processEngine.getRepositoryService();
         this.processEngineRuntimeService = processEngine.getRuntimeService();
         this.processEngineTaskService = processEngine.getTaskService();
     }
-    
+
     @After
     public void cleanup() {
         for (Deployment deployment : processEngineRepositoryService.createDeploymentQuery().list()) {

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/CmmnEngineConfiguration.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/CmmnEngineConfiguration.java
@@ -14,8 +14,8 @@ package org.flowable.cmmn.engine;
 
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -103,31 +103,31 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class CmmnEngineConfiguration extends AbstractEngineConfiguration {
-    
+
     protected static final Logger LOGGER = LoggerFactory.getLogger(CmmnEngineConfiguration.class);
     public static final String DEFAULT_MYBATIS_MAPPING_FILE = "org/flowable/cmmn/db/mapping/mappings.xml";
     public static final String LIQUIBASE_CHANGELOG_PREFIX = "ACT_CMMN_";
-    
+
     protected String cmmnEngineName = "default";
-    
+
     protected CmmnEngineAgendaFactory cmmnEngineAgendaFactory;
-    
+
     protected CmmnRuntimeService cmmnRuntimeService = new CmmnRuntimeServiceImpl();
     protected CmmnManagementService cmmnManagementService = new CmmnManagementServiceImpl();
     protected CmmnRepositoryService cmmnRepositoryService = new CmmnRepositoryServiceImpl();
     protected CmmnHistoryService cmmnHistoryService = new CmmnHistoryServiceImpl();
-    
+
     protected TableDataManager tableDataManager;
     protected CmmnDeploymentDataManager deploymentDataManager;
     protected CmmnResourceDataManager resourceDataManager;
     protected CaseDefinitionDataManager caseDefinitionDataManager;
     protected CaseInstanceDataManager caseInstanceDataManager;
     protected PlanItemInstanceDataManager planItemInstanceDataManager;
-    protected SentryOnPartInstanceDataManager sentryOnPartInstanceDataManager; 
+    protected SentryOnPartInstanceDataManager sentryOnPartInstanceDataManager;
     protected MilestoneInstanceDataManager milestoneInstanceDataManager;
     protected HistoricCaseInstanceEntityManager historicCaseInstanceEntityManager;
     protected HistoricMilestoneInstanceDataManager historicMilestoneInstanceDataManager;
-    
+
     protected CmmnDeploymentEntityManager cmmnDeploymentEntityManager;
     protected CmmnResourceEntityManager cmmnResourceEntityManager;
     protected CaseDefinitionEntityManager caseDefinitionEntityManager;
@@ -137,10 +137,10 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration {
     protected MilestoneInstanceEntityManager milestoneInstanceEntityManager;
     protected HistoricCaseInstanceDataManager historicCaseInstanceDataManager;
     protected HistoricMilestoneInstanceEntityManager historicMilestoneInstanceEntityManager;
-    
+
     protected CaseInstanceHelper caseInstanceHelper;
     protected CmmnHistoryManager cmmnHistoryManager;
-    
+
     protected boolean enableSafeCmmnXml;
     protected CmmnActivityBehaviorFactory activityBehaviorFactory;
     protected CmmnClassDelegateFactory classDelegateFactory;
@@ -150,13 +150,13 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration {
     protected List<Deployer> customPostDeployers;
     protected List<Deployer> deployers;
     protected CmmnDeploymentManager deploymentManager;
-    
+
     protected int caseDefinitionCacheLimit = -1;
     protected DeploymentCache<CaseDefinitionCacheEntry> caseDefinitionCache;
 
     protected ProcessInstanceService processInstanceService;
     protected Map<String, List<RuntimeInstanceStateChangeCallback>> caseInstanceStateChangeCallbacks;
-    
+
     public static CmmnEngineConfiguration createCmmnEngineConfigurationFromResourceDefault() {
         return createCmmnEngineConfigurationFromResource("flowable.cmmn.cfg.xml", "cmmnEngineConfiguration");
     }
@@ -184,12 +184,12 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration {
     public static CmmnEngineConfiguration createStandaloneInMemCmmnEngineConfiguration() {
         return new StandaloneInMemCmmnEngineConfiguration();
     }
-    
+
     public CmmnEngine buildCmmnEngine() {
         init();
         return new CmmnEngineImpl(this);
     }
-    
+
     protected void init() {
         initCommandContextFactory();
         initTransactionContextFactory();
@@ -205,11 +205,11 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration {
 
         initBeans();
         initTransactionFactory();
-        
+
         if (usingRelationalDatabase) {
             initSqlSessionFactory();
         }
-        
+
         initSessionFactories();
         initServices();
         initDataManagers();
@@ -224,29 +224,29 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration {
         initCaseInstanceCallbacks();
         initClock();
     }
-    
+
     public void initDbSchemaManager() {
         if (this.dbSchemaManager == null) {
             this.dbSchemaManager = new CmmnDbSchemaManager();
         }
     }
-    
+
     public void initDbSchema() {
         ((CmmnDbSchemaManager) this.dbSchemaManager).initSchema(this);
     }
-    
+
     public void initCmmnEngineAgendaFactory() {
         if (cmmnEngineAgendaFactory == null) {
             cmmnEngineAgendaFactory = new DefaultCmmnEngineAgendaFactory();
         }
     }
-    
+
     public void initCommandInvoker() {
         if (commandInvoker == null) {
             commandInvoker = new CmmnCommandInvoker();
         }
     }
-    
+
     public void initSessionFactories() {
         if (sessionFactories == null) {
             sessionFactories = new HashMap<>();
@@ -254,11 +254,11 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration {
             if (usingRelationalDatabase) {
                 initDbSqlSessionFactory();
             }
-            
+
             addSessionFactory(new GenericManagerFactory(EntityCache.class, EntityCacheImpl.class));
             commandContextFactory.setSessionFactories(sessionFactories);
         }
-        
+
         addSessionFactory(new CmmnEngineAgendaSessionFactory(cmmnEngineAgendaFactory));
 
         if (customSessionFactories != null) {
@@ -267,7 +267,7 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration {
             }
         }
     }
-    
+
     protected void initServices() {
         initService(cmmnRuntimeService);
         initService(cmmnManagementService);
@@ -281,7 +281,7 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration {
             ((ServiceImpl) service).setCommandExecutor(commandExecutor);
         }
     }
-    
+
     public void initDataManagers() {
         if (tableDataManager == null) {
             tableDataManager = new TableDataManagerImpl();
@@ -314,7 +314,7 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration {
             historicMilestoneInstanceDataManager = new MybatisHistoricMilestoneInstanceDataManager(this);
         }
     }
-    
+
     public void initEntityManagers() {
         if (cmmnDeploymentEntityManager == null) {
             cmmnDeploymentEntityManager = new CmmnDeploymentEntityManagerImpl(this, deploymentDataManager);
@@ -344,13 +344,13 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration {
             historicMilestoneInstanceEntityManager = new HistoricMilestoneInstanceEntityManagerImpl(this, historicMilestoneInstanceDataManager);
         }
     }
-    
+
     protected void initClassDelegateFactory() {
         if (classDelegateFactory == null) {
             classDelegateFactory = new DefaultCmmnClassDelegateFactory();
         }
     }
-    
+
     protected void initActivityBehaviorFactory() {
         if (activityBehaviorFactory == null) {
             DefaultCmmnActivityBehaviorFactory defaultCmmnActivityBehaviorFactory = new DefaultCmmnActivityBehaviorFactory();
@@ -358,10 +358,10 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration {
             activityBehaviorFactory = defaultCmmnActivityBehaviorFactory;
         }
     }
-    
+
     protected void initDeployers() {
         if (this.cmmnDeployer == null) {
-            this.deployers = new ArrayList<Deployer>();
+            this.deployers = new ArrayList<>();
             if (customPreDeployers != null) {
                 this.deployers.addAll(customPreDeployers);
             }
@@ -371,9 +371,9 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration {
             }
         }
     }
-    
+
     public Collection<? extends Deployer> getDefaultDeployers() {
-        List<Deployer> defaultDeployers = new ArrayList<Deployer>();
+        List<Deployer> defaultDeployers = new ArrayList<>();
 
         if (cmmnDeployer == null) {
             cmmnDeployer = new CmmnDeployer();
@@ -391,13 +391,13 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration {
     protected void initCaseDefinitionCache() {
         if (caseDefinitionCache == null) {
             if (caseDefinitionCacheLimit <= 0) {
-                caseDefinitionCache = new DefaultDeploymentCache<CaseDefinitionCacheEntry>();
+                caseDefinitionCache = new DefaultDeploymentCache<>();
             } else {
-                caseDefinitionCache = new DefaultDeploymentCache<CaseDefinitionCacheEntry>(caseDefinitionCacheLimit);
+                caseDefinitionCache = new DefaultDeploymentCache<>(caseDefinitionCacheLimit);
             }
         }
     }
-    
+
     protected void initDeploymentManager() {
         if (deploymentManager == null) {
             deploymentManager = new CmmnDeploymentManager();
@@ -408,7 +408,7 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration {
             deploymentManager.setDeploymentEntityManager(cmmnDeploymentEntityManager);
         }
     }
-    
+
     public void initCmmnParser() {
         if (cmmnParser == null) {
             CmmnParserImpl cmmnParserImpl = new CmmnParserImpl();
@@ -416,31 +416,31 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration {
             cmmnParser = cmmnParserImpl;
         }
     }
-    
+
     public void initCaseInstanceHelper() {
         if (caseInstanceHelper == null) {
             caseInstanceHelper = new CaseInstanceHelperImpl();
         }
     }
-    
+
     public void initHistoryManager() {
         if (cmmnHistoryManager == null) {
             cmmnHistoryManager = new DefaultCmmnHistoryManager(this);
         }
     }
-    
+
     public void initCaseInstanceCallbacks() {
         if (this.caseInstanceStateChangeCallbacks == null) {
             this.caseInstanceStateChangeCallbacks = new HashMap<>();
         }
         initDefaultCaseInstanceCallbacks();
     }
-    
+
     protected void initDefaultCaseInstanceCallbacks() {
-        this.caseInstanceStateChangeCallbacks.put(PlanItemInstanceCallbackType.CHILD_CASE, 
-                Arrays.<RuntimeInstanceStateChangeCallback>asList(new ChildCaseInstanceStateChangeCallback()));
+        this.caseInstanceStateChangeCallbacks.put(PlanItemInstanceCallbackType.CHILD_CASE,
+                Collections.<RuntimeInstanceStateChangeCallback>singletonList(new ChildCaseInstanceStateChangeCallback()));
     }
-    
+
     @Override
     public String getEngineCfgKey() {
         return EngineConfigurationConstants.KEY_CMMN_ENGINE_CONFIG;
@@ -450,18 +450,18 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration {
     public CommandInterceptor createTransactionInterceptor() {
         return null;
     }
-    
+
     @Override
     public InputStream getMyBatisXmlConfigurationStream() {
         return getResourceAsStream(DEFAULT_MYBATIS_MAPPING_FILE);
     }
-    
+
     @Override
     protected void initDbSqlSessionFactoryEntitySettings() {
         for (Class<? extends Entity> clazz : EntityDependencyOrder.INSERT_ORDER) {
             dbSqlSessionFactory.getInsertionOrder().add(clazz);
         }
-        
+
         for (Class<? extends Entity> clazz : EntityDependencyOrder.DELETE_ORDER) {
             dbSqlSessionFactory.getDeletionOrder().add(clazz);
         }
@@ -480,7 +480,7 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration {
         this.cmmnEngineName = cmmnEngineName;
         return this;
     }
-    
+
     public CmmnRuntimeService getCmmnRuntimeService() {
         return cmmnRuntimeService;
     }
@@ -507,7 +507,7 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration {
         this.cmmnRepositoryService = cmmnRepositoryService;
         return this;
     }
-    
+
     public CmmnHistoryService getCmmnHistoryService() {
         return cmmnHistoryService;
     }
@@ -525,7 +525,7 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration {
         this.cmmnEngineAgendaFactory = cmmnEngineAgendaFactory;
         return this;
     }
-    
+
     public TableDataManager getTableDataManager() {
         return tableDataManager;
     }
@@ -561,7 +561,7 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration {
         this.caseDefinitionDataManager = caseDefinitionDataManager;
         return this;
     }
-    
+
     public CaseInstanceDataManager getCaseInstanceDataManager() {
         return caseInstanceDataManager;
     }
@@ -579,7 +579,7 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration {
         this.planItemInstanceDataManager = planItemInstanceDataManager;
         return this;
     }
-    
+
     public SentryOnPartInstanceDataManager getSentryOnPartInstanceDataManager() {
         return sentryOnPartInstanceDataManager;
     }
@@ -597,7 +597,7 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration {
         this.milestoneInstanceDataManager = milestoneInstanceDataManager;
         return this;
     }
-    
+
     public HistoricCaseInstanceDataManager getHistoricCaseInstanceDataManager() {
         return historicCaseInstanceDataManager;
     }
@@ -642,7 +642,7 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration {
         this.caseDefinitionEntityManager = caseDefinitionEntityManager;
         return this;
     }
-    
+
     public CaseInstanceEntityManager getCaseInstanceEntityManager() {
         return caseInstanceEntityManager;
     }
@@ -651,7 +651,7 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration {
         this.caseInstanceEntityManager = caseInstanceEntityManager;
         return this;
     }
-    
+
     public PlanItemInstanceEntityManager getPlanItemInstanceEntityManager() {
         return planItemInstanceEntityManager;
     }
@@ -660,7 +660,7 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration {
         this.planItemInstanceEntityManager = planItemInstanceEntityManager;
         return this;
     }
-    
+
     public SentryOnPartInstanceEntityManager getSentryOnPartInstanceEntityManager() {
         return sentryOnPartInstanceEntityManager;
     }
@@ -678,7 +678,7 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration {
         this.milestoneInstanceEntityManager = milestoneInstanceEntityManager;
         return this;
     }
-    
+
     public HistoricCaseInstanceEntityManager getHistoricCaseInstanceEntityManager() {
         return historicCaseInstanceEntityManager;
     }
@@ -705,7 +705,7 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration {
         this.caseInstanceHelper = caseInstanceHelper;
         return this;
     }
-    
+
     public CmmnHistoryManager getCmmnHistoryManager() {
         return cmmnHistoryManager;
     }
@@ -714,7 +714,7 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration {
         this.cmmnHistoryManager = cmmnHistoryManager;
         return this;
     }
-    
+
     public boolean isEnableSafeCmmnXml() {
         return enableSafeCmmnXml;
     }
@@ -768,7 +768,7 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration {
         this.deployers = deployers;
         return this;
     }
-    
+
     public CmmnDeploymentManager getDeploymentManager() {
         return deploymentManager;
     }
@@ -786,7 +786,7 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration {
         this.activityBehaviorFactory = activityBehaviorFactory;
         return this;
     }
-    
+
     public CmmnClassDelegateFactory getClassDelegateFactory() {
         return classDelegateFactory;
     }
@@ -813,7 +813,7 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration {
         this.caseDefinitionCache = caseDefinitionCache;
         return this;
     }
-    
+
     public ProcessInstanceService getProcessInstanceService() {
         return processInstanceService;
     }
@@ -831,5 +831,5 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration {
         this.caseInstanceStateChangeCallbacks = caseInstanceStateChangeCallbacks;
         return this;
     }
-    
+
 }

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/DefaultCmmnEngineAgenda.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/DefaultCmmnEngineAgenda.java
@@ -36,80 +36,80 @@ import org.slf4j.LoggerFactory;
  * @author Joram Barrez
  */
 public class DefaultCmmnEngineAgenda extends AbstractAgenda implements CmmnEngineAgenda {
-    
+
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultCmmnEngineAgenda.class);
 
     public DefaultCmmnEngineAgenda(CommandContext commandContext) {
         super(commandContext);
     }
-    
+
     public void addOperation(CmmnOperation operation) {
         operations.add(operation);
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Planned " + operation);
+            LOGGER.debug("Planned {}", operation);
         }
     }
-    
+
     @Override
     public void planInitPlanModelOperation(CaseInstanceEntity caseInstanceEntity) {
         addOperation(new InitPlanModelOperation(commandContext, caseInstanceEntity));
     }
-    
+
     @Override
     public void planInitStageOperation(PlanItemInstanceEntity planItemInstanceEntity) {
         addOperation(new InitStageOperation(commandContext, planItemInstanceEntity));
     }
-    
+
     @Override
     public void planEvaluateCriteria(String caseInstanceEntityId) {
         addOperation(new EvaluateCriteriaOperation(commandContext, caseInstanceEntityId));
     }
-    
+
     @Override
     public void planEvaluateCriteria(String caseInstanceEntityId, PlanItemLifeCycleEvent lifeCycleEvent) {
         addOperation(new EvaluateCriteriaOperation(commandContext, caseInstanceEntityId, lifeCycleEvent));
     }
-    
+
     @Override
     public void planActivatePlanItem(PlanItemInstanceEntity planItemInstanceEntity) {
         addOperation(new ActivatePlanItemOperation(commandContext, planItemInstanceEntity));
     }
-    
+
     @Override
     public void planCompletePlanItem(PlanItemInstanceEntity planItemInstanceEntity) {
         addOperation(new CompletePlanItemOperation(commandContext, planItemInstanceEntity));
     }
-    
+
     @Override
     public void planOccurPlanItem(PlanItemInstanceEntity planItemInstanceEntity) {
         addOperation(new OccurPlanItemOperation(commandContext, planItemInstanceEntity));
     }
-    
+
     @Override
     public void planExitPlanItem(PlanItemInstanceEntity planItemInstanceEntity) {
         addOperation(new ExitPlanItemOperation(commandContext, planItemInstanceEntity));
     }
-    
+
     @Override
     public void planTerminatePlanItem(PlanItemInstanceEntity planItemInstanceEntity) {
         addOperation(new TerminatePlanItemOperation(commandContext, planItemInstanceEntity));
     }
-    
+
     @Override
     public void planTriggerPlanItem(PlanItemInstanceEntity planItemInstanceEntity) {
         addOperation(new TriggerPlanItemOperation(commandContext, planItemInstanceEntity));
     }
-    
+
     @Override
     public void planCompleteCase(CaseInstanceEntity caseInstanceEntity) {
         addOperation(new CompleteCaseInstanceOperation(commandContext, caseInstanceEntity));
     }
-    
+
     @Override
     public void planTerminateCase(String caseInstanceEntityId, boolean manualTermination) {
         addOperation(new TerminateCaseInstanceOperation(commandContext, caseInstanceEntityId, manualTermination));
     }
-    
+
     @Override
     public void planTerminateCase(CaseInstanceEntity caseInstanceEntity, boolean manualTermination) {
         addOperation(new TerminateCaseInstanceOperation(commandContext, caseInstanceEntity, manualTermination));

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/AbstractChangePlanItemInstanceStateOperation.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/AbstractChangePlanItemInstanceStateOperation.java
@@ -24,35 +24,34 @@ import org.flowable.engine.common.impl.interceptor.CommandContext;
  * @author Joram Barrez
  */
 public abstract class AbstractChangePlanItemInstanceStateOperation extends AbstractPlanItemInstanceOperation {
-    
+
     public AbstractChangePlanItemInstanceStateOperation(CommandContext commandContext, PlanItemInstanceEntity planItemInstanceEntity) {
         super(commandContext, planItemInstanceEntity);
     }
-    
+
     @Override
     public void run() {
-        
+
         if (planItemInstanceEntity.getPlanItem() != null) { // can be null for the plan model
             Object behavior = planItemInstanceEntity.getPlanItem().getBehavior();
-            if (behavior != null 
-                    && behavior instanceof PlanItemActivityBehavior
+            if (behavior instanceof PlanItemActivityBehavior
                     && StateTransition.isPossible(planItemInstanceEntity, getLifeCycleTransition())) {
-                ((PlanItemActivityBehavior) behavior).onStateTransition(planItemInstanceEntity, getLifeCycleTransition());  
+                ((PlanItemActivityBehavior) behavior).onStateTransition(planItemInstanceEntity, getLifeCycleTransition());
             }
         }
-            
+
         planItemInstanceEntity.setState(getNewState());
         CommandContextUtil.getAgenda(commandContext).planEvaluateCriteria(planItemInstanceEntity.getCaseInstanceId(), createPlanItemLifeCycleEvent());
     }
-    
+
     protected PlanItemLifeCycleEvent createPlanItemLifeCycleEvent() {
         return new PlanItemLifeCycleEvent(planItemInstanceEntity.getPlanItem(), getLifeCycleTransition());
     }
-    
+
     protected abstract String getNewState();
-    
-    protected abstract String getLifeCycleTransition(); 
-    
+
+    protected abstract String getLifeCycleTransition();
+
     @Override
     public String toString() {
         StringBuilder stringBuilder = new StringBuilder();
@@ -60,19 +59,19 @@ public abstract class AbstractChangePlanItemInstanceStateOperation extends Abstr
         stringBuilder.append("[Change PlanItem state] ");
         if (planItem != null) {
             if (planItem.getName() != null) {
-            stringBuilder.append(planItem.getName());
-            stringBuilder.append("(");
-            stringBuilder.append(planItem.getId());
-            stringBuilder.append(")");
+                stringBuilder.append(planItem.getName());
+                stringBuilder.append("(");
+                stringBuilder.append(planItem.getId());
+                stringBuilder.append(")");
             } else {
                 stringBuilder.append(planItem.getId());
             }
         } else {
-            stringBuilder.append("(plan item instance with id " + planItemInstanceEntity.getId() + ")");
+            stringBuilder.append("(plan item instance with id ").append(planItemInstanceEntity.getId()).append(")");
         }
         stringBuilder.append(": ");
-        stringBuilder.append("new state: [" + getNewState() + "]");
+        stringBuilder.append("new state: [").append(getNewState()).append("]");
         return stringBuilder.toString();
     }
-    
+
 }

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/deployer/CmmnDeployer.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/deployer/CmmnDeployer.java
@@ -39,14 +39,14 @@ import org.slf4j.LoggerFactory;
 
 /**
  * TODO: many similarities with BpmnDeployer, see if it can be merged to the common module
- * 
+ *
  * @author Joram Barrez
  */
 public class CmmnDeployer implements Deployer {
-    
+
     private static final Logger LOGGER = LoggerFactory.getLogger(CmmnDeployer.class);
-    
-    public static final String[] CMMN_RESOURCE_SUFFIXES = new String[] { ".cmmn", ".cmmn11", ".cmmn.xml", ".cmmn11.xml" };
+
+    public static final String[] CMMN_RESOURCE_SUFFIXES = new String[]{".cmmn", ".cmmn11", ".cmmn.xml", ".cmmn11.xml"};
 
     protected IdGenerator idGenerator;
     protected CmmnParser cmmnParser;
@@ -88,7 +88,7 @@ public class CmmnDeployer implements Deployer {
     }
 
     protected Map<CaseDefinitionEntity, CaseDefinitionEntity> getPreviousVersionsOfCaseDefinitions(CmmnParseResult parseResult) {
-        Map<CaseDefinitionEntity, CaseDefinitionEntity> result = new LinkedHashMap<CaseDefinitionEntity, CaseDefinitionEntity>();
+        Map<CaseDefinitionEntity, CaseDefinitionEntity> result = new LinkedHashMap<>();
         for (CaseDefinitionEntity newDefinition : parseResult.getAllCaseDefinitions()) {
             CaseDefinitionEntity existingDefinition = getMostRecentVersionOfCaseDefinition(newDefinition);
             if (existingDefinition != null) {
@@ -126,12 +126,12 @@ public class CmmnDeployer implements Deployer {
             }
         }
     }
-    
+
     protected void verifyCaseDefinitionsDoNotShareKeys(Collection<CaseDefinitionEntity> caseDefinitionEntities) {
-        Set<String> keySet = new LinkedHashSet<String>();
+        Set<String> keySet = new LinkedHashSet<>();
         for (CaseDefinitionEntity caseDefinitionEntity : caseDefinitionEntities) {
             if (keySet.contains(caseDefinitionEntity.getKey())) {
-                throw new FlowableException( "The deployment contains case definitions with the same key (case id attribute), this is not allowed");
+                throw new FlowableException("The deployment contains case definitions with the same key (case id attribute), this is not allowed");
             }
             keySet.add(caseDefinitionEntity.getKey());
         }
@@ -175,7 +175,7 @@ public class CmmnDeployer implements Deployer {
         if (StringUtils.isEmpty(caseDefinitionEntity.getDeploymentId())) {
             throw new IllegalStateException("Provided case definition must have a deployment id.");
         }
-        
+
         CaseDefinitionEntityManager caseDefinitionEntityManager = CommandContextUtil.getCaseDefinitionEntityManager();
         CaseDefinitionEntity persistedCaseDefinitionEntity = null;
         if (caseDefinitionEntity.getTenantId() == null || CmmnEngineConfiguration.NO_TENANT_ID.equals(caseDefinitionEntity.getTenantId())) {
@@ -185,7 +185,7 @@ public class CmmnDeployer implements Deployer {
         }
         return persistedCaseDefinitionEntity;
     }
-    
+
     protected void updateCachingAndArtifacts(CmmnParseResult parseResult) {
         CmmnEngineConfiguration cmmnEngineConfiguration = CommandContextUtil.getCmmnEngineConfiguration();
         DeploymentCache<CaseDefinitionCacheEntry> caseDefinitionCache = cmmnEngineConfiguration.getCaseDefinitionCache();
@@ -216,5 +216,5 @@ public class CmmnDeployer implements Deployer {
     public void setCmmnParser(CmmnParser cmmnParser) {
         this.cmmnParser = cmmnParser;
     }
-    
+
 }

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/history/HistoricCaseInstanceQueryProperty.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/history/HistoricCaseInstanceQueryProperty.java
@@ -25,7 +25,7 @@ public class HistoricCaseInstanceQueryProperty implements QueryProperty {
 
     private static final long serialVersionUID = 1L;
 
-    private static final Map<String, HistoricCaseInstanceQueryProperty> properties = new HashMap<String, HistoricCaseInstanceQueryProperty>();
+    private static final Map<String, HistoricCaseInstanceQueryProperty> properties = new HashMap<>();
 
     public static final HistoricCaseInstanceQueryProperty CASE_INSTANCE_ID = new HistoricCaseInstanceQueryProperty("RES.ID_");
     public static final HistoricCaseInstanceQueryProperty CASE_DEFINITION_KEY = new HistoricCaseInstanceQueryProperty("CaseDefinitionKey");

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/persistence/entity/CmmnDeploymentEntityImpl.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/persistence/entity/CmmnDeploymentEntityImpl.java
@@ -50,7 +50,7 @@ public class CmmnDeploymentEntityImpl extends AbstractEntityNoRevision implement
 
     public void addResource(CmmnResourceEntity resource) {
         if (resources == null) {
-            resources = new HashMap<String, CmmnResourceEntity>();
+            resources = new HashMap<>();
         }
         resources.put(resource.getName(), resource);
     }
@@ -60,7 +60,7 @@ public class CmmnDeploymentEntityImpl extends AbstractEntityNoRevision implement
     }
 
     public Object getPersistentState() {
-        Map<String, Object> persistentState = new HashMap<String, Object>();
+        Map<String, Object> persistentState = new HashMap<>();
         persistentState.put("category", this.category);
         persistentState.put("tenantId", tenantId);
         return persistentState;
@@ -70,13 +70,13 @@ public class CmmnDeploymentEntityImpl extends AbstractEntityNoRevision implement
 
     public void addDeployedArtifact(Object deployedArtifact) {
         if (deployedArtifacts == null) {
-            deployedArtifacts = new HashMap<Class<?>, List<Object>>();
+            deployedArtifacts = new HashMap<>();
         }
 
         Class<?> clazz = deployedArtifact.getClass();
         List<Object> artifacts = deployedArtifacts.get(clazz);
         if (artifacts == null) {
-            artifacts = new ArrayList<Object>();
+            artifacts = new ArrayList<>();
             deployedArtifacts.put(clazz, artifacts);
         }
 

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/persistence/entity/data/impl/MybatisCaseDefinitionDataManager.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/persistence/entity/data/impl/MybatisCaseDefinitionDataManager.java
@@ -51,7 +51,7 @@ public class MybatisCaseDefinitionDataManager extends AbstractCmmnDataManager<Ca
 
     @Override
     public CaseDefinitionEntity findLatestCaseDefinitionByKeyAndTenantId(String caseDefinitionKey, String tenantId) {
-        Map<String, Object> params = new HashMap<String, Object>(2);
+        Map<String, Object> params = new HashMap<>(2);
         params.put("caseDefinitionKey", caseDefinitionKey);
         params.put("tenantId", tenantId);
         return (CaseDefinitionEntity) getDbSqlSession().selectOne("selectLatestCaseDefinitionByKeyAndTenantId", params);
@@ -64,7 +64,7 @@ public class MybatisCaseDefinitionDataManager extends AbstractCmmnDataManager<Ca
 
     @Override
     public CaseDefinitionEntity findCaseDefinitionByDeploymentAndKey(String deploymentId, String caseDefinitionKey) {
-        Map<String, Object> parameters = new HashMap<String, Object>();
+        Map<String, Object> parameters = new HashMap<>();
         parameters.put("deploymentId", deploymentId);
         parameters.put("caseDefinitionKey", caseDefinitionKey);
         return (CaseDefinitionEntity) getDbSqlSession().selectOne("selectCaseDefinitionByDeploymentAndKey", parameters);
@@ -72,7 +72,7 @@ public class MybatisCaseDefinitionDataManager extends AbstractCmmnDataManager<Ca
 
     @Override
     public CaseDefinitionEntity findCaseDefinitionByDeploymentAndKeyAndTenantId(String deploymentId, String caseDefinitionKey, String tenantId) {
-        Map<String, Object> parameters = new HashMap<String, Object>();
+        Map<String, Object> parameters = new HashMap<>();
         parameters.put("deploymentId", deploymentId);
         parameters.put("caseDefinitionKey", caseDefinitionKey);
         parameters.put("tenantId", tenantId);
@@ -81,7 +81,7 @@ public class MybatisCaseDefinitionDataManager extends AbstractCmmnDataManager<Ca
 
     @Override
     public CaseDefinitionEntity findCaseDefinitionByKeyAndVersion(String caseDefinitionKey, Integer caseDefinitionVersion) {
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("caseDefinitionKey", caseDefinitionKey);
         params.put("caseDefinitionVersion", caseDefinitionVersion);
         List<CaseDefinitionEntity> results = getDbSqlSession().selectList("selectCaseDefinitionsByKeyAndVersion", params);
@@ -96,7 +96,7 @@ public class MybatisCaseDefinitionDataManager extends AbstractCmmnDataManager<Ca
     @Override
     @SuppressWarnings("unchecked")
     public CaseDefinitionEntity findCaseDefinitionByKeyAndVersionAndTenantId(String caseDefinitionKey, Integer caseDefinitionVersion, String tenantId) {
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("caseDefinitionKey", caseDefinitionKey);
         params.put("caseDefinitionVersion", caseDefinitionVersion);
         params.put("tenantId", tenantId);
@@ -111,12 +111,12 @@ public class MybatisCaseDefinitionDataManager extends AbstractCmmnDataManager<Ca
 
     @Override
     public void updateCaseDefinitionTenantIdForDeployment(String deploymentId, String newTenantId) {
-        HashMap<String, Object> params = new HashMap<String, Object>();
+        HashMap<String, Object> params = new HashMap<>();
         params.put("deploymentId", deploymentId);
         params.put("tenantId", newTenantId);
         getDbSqlSession().update("updateCaseDefinitionTenantIdForDeploymentId", params);
     }
-    
+
     @Override
     @SuppressWarnings("unchecked")
     public List<CaseDefinition> findCaseDefinitionsByQueryCriteria(CaseDefinitionQueryImpl caseDefinitionQuery) {

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/persistence/entity/data/impl/MybatisResourceDataManager.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/persistence/entity/data/impl/MybatisResourceDataManager.java
@@ -48,7 +48,7 @@ public class MybatisResourceDataManager extends AbstractCmmnDataManager<CmmnReso
 
     @Override
     public CmmnResourceEntity findResourceByDeploymentIdAndResourceName(String deploymentId, String resourceName) {
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("deploymentId", deploymentId);
         params.put("resourceName", resourceName);
         return (CmmnResourceEntity) getDbSqlSession().selectOne("selectCmmnResourceByDeploymentIdAndResourceName", params);

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/persistence/entity/data/impl/TableDataManagerImpl.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/persistence/entity/data/impl/TableDataManagerImpl.java
@@ -33,8 +33,8 @@ import org.flowable.engine.common.impl.persistence.entity.Entity;
  * @author Joram Barrez
  */
 public class TableDataManagerImpl implements TableDataManager {
-    
-    public static Map<Class<? extends Entity>, String> entityToTableNameMap = new HashMap<Class<? extends Entity>, String>();
+
+    public static Map<Class<? extends Entity>, String> entityToTableNameMap = new HashMap<>();
 
     static {
         entityToTableNameMap.put(CmmnDeploymentEntity.class, "ACT_CMMN_RE_DEPLOYMENT");

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/repository/CaseDefinitionQueryProperty.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/repository/CaseDefinitionQueryProperty.java
@@ -25,7 +25,7 @@ public class CaseDefinitionQueryProperty implements QueryProperty {
 
     private static final long serialVersionUID = 1L;
 
-    private static final Map<String, CaseDefinitionQueryProperty> properties = new HashMap<String, CaseDefinitionQueryProperty>();
+    private static final Map<String, CaseDefinitionQueryProperty> properties = new HashMap<>();
 
     public static final CaseDefinitionQueryProperty CASE_DEFINITION_KEY = new CaseDefinitionQueryProperty("RES.KEY_");
     public static final CaseDefinitionQueryProperty CASE_DEFINITION_CATEGORY = new CaseDefinitionQueryProperty("RES.CATEGORY_");

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/repository/CmmnDeploymentQueryProperty.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/repository/CmmnDeploymentQueryProperty.java
@@ -25,7 +25,7 @@ public class CmmnDeploymentQueryProperty implements QueryProperty {
 
     private static final long serialVersionUID = 1L;
 
-    private static final Map<String, CmmnDeploymentQueryProperty> properties = new HashMap<String, CmmnDeploymentQueryProperty>();
+    private static final Map<String, CmmnDeploymentQueryProperty> properties = new HashMap<>();
 
     public static final CmmnDeploymentQueryProperty DEPLOYMENT_ID = new CmmnDeploymentQueryProperty("RES.ID_");
     public static final CmmnDeploymentQueryProperty DEPLOYMENT_NAME = new CmmnDeploymentQueryProperty("RES.NAME_");

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/runtime/CaseInstanceQueryProperty.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/runtime/CaseInstanceQueryProperty.java
@@ -25,7 +25,7 @@ public class CaseInstanceQueryProperty implements QueryProperty {
 
     private static final long serialVersionUID = 1L;
 
-    private static final Map<String, CaseInstanceQueryProperty> properties = new HashMap<String, CaseInstanceQueryProperty>();
+    private static final Map<String, CaseInstanceQueryProperty> properties = new HashMap<>();
 
     public static final CaseInstanceQueryProperty CASE_INSTANCE_ID = new CaseInstanceQueryProperty("RES.ID_");
     public static final CaseInstanceQueryProperty CASE_DEFINITION_KEY = new CaseInstanceQueryProperty("CaseDefinitionKey");

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/runtime/MilestoneInstanceQueryProperty.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/runtime/MilestoneInstanceQueryProperty.java
@@ -25,7 +25,7 @@ public class MilestoneInstanceQueryProperty implements QueryProperty {
 
     private static final long serialVersionUID = 1L;
 
-    private static final Map<String, MilestoneInstanceQueryProperty> properties = new HashMap<String, MilestoneInstanceQueryProperty>();
+    private static final Map<String, MilestoneInstanceQueryProperty> properties = new HashMap<>();
 
     public static final MilestoneInstanceQueryProperty MILESTONE_NAME = new MilestoneInstanceQueryProperty("RES.NAME_");
     public static final MilestoneInstanceQueryProperty MILESTONE_TIMESTAMP = new MilestoneInstanceQueryProperty("RES.TIME_STAMP_");

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/runtime/PlanItemInstanceQueryProperty.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/runtime/PlanItemInstanceQueryProperty.java
@@ -25,11 +25,11 @@ public class PlanItemInstanceQueryProperty implements QueryProperty {
 
     private static final long serialVersionUID = 1L;
 
-    private static final Map<String, PlanItemInstanceQueryProperty> properties = new HashMap<String, PlanItemInstanceQueryProperty>();
+    private static final Map<String, PlanItemInstanceQueryProperty> properties = new HashMap<>();
 
     public static final PlanItemInstanceQueryProperty START_TIME = new PlanItemInstanceQueryProperty("RES.START_TIME_");
     public static final PlanItemInstanceQueryProperty NAME = new PlanItemInstanceQueryProperty("RES.NAME_");
-    
+
     private String name;
 
     public PlanItemInstanceQueryProperty(String name) {

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/repository/CaseDefinitionQueryTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/repository/CaseDefinitionQueryTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 
@@ -33,32 +34,32 @@ import org.junit.Test;
  * @author Joram Barrez
  */
 public class CaseDefinitionQueryTest extends FlowableCmmnTestCase {
-    
+
     private String deploymentId1;
     private String deploymentId2;
     private String deploymentId3;
-    
+
     @Before
     public void deployTestDeployments() {
         this.deploymentId1 = cmmnRepositoryService.createDeployment()
-            .addClasspathResource("org/flowable/cmmn/test/repository/simple-case.cmmn")
-            .addClasspathResource("org/flowable/cmmn/test/repository/simple-case2.cmmn")
-            .deploy()
-            .getId();
-        
+                .addClasspathResource("org/flowable/cmmn/test/repository/simple-case.cmmn")
+                .addClasspathResource("org/flowable/cmmn/test/repository/simple-case2.cmmn")
+                .deploy()
+                .getId();
+
         // v2 of simple-case
         this.deploymentId2 = cmmnRepositoryService.createDeployment()
-            .addClasspathResource("org/flowable/cmmn/test/repository/simple-case.cmmn")
-            .deploy()
-            .getId();
-        
+                .addClasspathResource("org/flowable/cmmn/test/repository/simple-case.cmmn")
+                .deploy()
+                .getId();
+
         // v3 of simple-case
         this.deploymentId3 = cmmnRepositoryService.createDeployment()
-            .addClasspathResource("org/flowable/cmmn/test/repository/simple-case.cmmn")
-            .deploy()
-            .getId();
+                .addClasspathResource("org/flowable/cmmn/test/repository/simple-case.cmmn")
+                .deploy()
+                .getId();
     }
-    
+
     @After
     public void deleteTestDeployments() {
         List<CmmnDeployment> deployments = cmmnRepositoryService.createDeploymentQuery().list();
@@ -66,270 +67,272 @@ public class CaseDefinitionQueryTest extends FlowableCmmnTestCase {
             cmmnRepositoryService.deleteDeploymentAndRelatedData(cmmnDeployment.getId());
         }
     }
-    
+
     @Test
     public void testQueryNoParams() {
         assertEquals(4, cmmnRepositoryService.createCaseDefinitionQuery().list().size());
         assertEquals(4, cmmnRepositoryService.createCaseDefinitionQuery().count());
     }
-    
+
     @Test
     public void testQueryByDeploymentId() {
         assertEquals(2, cmmnRepositoryService.createCaseDefinitionQuery().deploymentId(deploymentId1).list().size());
         assertEquals(2, cmmnRepositoryService.createCaseDefinitionQuery().deploymentId(deploymentId1).count());
-        
+
         assertEquals(1, cmmnRepositoryService.createCaseDefinitionQuery().deploymentId(deploymentId2).list().size());
         assertEquals(1, cmmnRepositoryService.createCaseDefinitionQuery().deploymentId(deploymentId2).count());
-        
+
         assertEquals(1, cmmnRepositoryService.createCaseDefinitionQuery().deploymentId(deploymentId3).list().size());
         assertEquals(1, cmmnRepositoryService.createCaseDefinitionQuery().deploymentId(deploymentId3).count());
     }
-    
+
     @Test
     public void testQueryByInvalidDeploymentId() {
         assertEquals(0, cmmnRepositoryService.createCaseDefinitionQuery().deploymentId("invalid").list().size());
         assertEquals(0, cmmnRepositoryService.createCaseDefinitionQuery().deploymentId("invalid").count());
     }
-    
+
     @Test
     public void testQueryByDeploymentIds() {
         assertEquals(4, cmmnRepositoryService.createCaseDefinitionQuery().deploymentIds(new HashSet<>(Arrays.asList(deploymentId1, deploymentId2, deploymentId3))).list().size());
         assertEquals(4, cmmnRepositoryService.createCaseDefinitionQuery().deploymentIds(new HashSet<>(Arrays.asList(deploymentId1, deploymentId2, deploymentId3))).count());
-        
-        assertEquals(2, cmmnRepositoryService.createCaseDefinitionQuery().deploymentIds(new HashSet<>(Arrays.asList(deploymentId1))).list().size());
-        assertEquals(2, cmmnRepositoryService.createCaseDefinitionQuery().deploymentIds(new HashSet<>(Arrays.asList(deploymentId1))).count());
-        
+
+        assertEquals(2, cmmnRepositoryService.createCaseDefinitionQuery().deploymentIds(new HashSet<>(Collections.singletonList(deploymentId1))).list().size());
+        assertEquals(2, cmmnRepositoryService.createCaseDefinitionQuery().deploymentIds(new HashSet<>(Collections.singletonList(deploymentId1))).count());
+
         assertEquals(2, cmmnRepositoryService.createCaseDefinitionQuery().deploymentIds(new HashSet<>(Arrays.asList(deploymentId2, deploymentId3))).list().size());
         assertEquals(2, cmmnRepositoryService.createCaseDefinitionQuery().deploymentIds(new HashSet<>(Arrays.asList(deploymentId2, deploymentId3))).count());
-        
-        assertEquals(1, cmmnRepositoryService.createCaseDefinitionQuery().deploymentIds(new HashSet<>(Arrays.asList(deploymentId3))).list().size());
-        assertEquals(1, cmmnRepositoryService.createCaseDefinitionQuery().deploymentIds(new HashSet<>(Arrays.asList(deploymentId3))).count());
+
+        assertEquals(1, cmmnRepositoryService.createCaseDefinitionQuery().deploymentIds(new HashSet<>(Collections.singletonList(deploymentId3))).list().size());
+        assertEquals(1, cmmnRepositoryService.createCaseDefinitionQuery().deploymentIds(new HashSet<>(Collections.singletonList(deploymentId3))).count());
     }
-    
+
     @Test
     public void testQueryByInvalidDeploymentIds() {
-        assertEquals(0, cmmnRepositoryService.createCaseDefinitionQuery().deploymentIds(new HashSet<>(Arrays.asList("invalid"))).list().size());
-        assertEquals(0, cmmnRepositoryService.createCaseDefinitionQuery().deploymentIds(new HashSet<>(Arrays.asList("invalid"))).count());
+        assertEquals(0, cmmnRepositoryService.createCaseDefinitionQuery().deploymentIds(new HashSet<>(Collections.singletonList("invalid"))).list().size());
+        assertEquals(0, cmmnRepositoryService.createCaseDefinitionQuery().deploymentIds(new HashSet<>(Collections.singletonList("invalid"))).count());
     }
-    
+
     @Test
     public void testQueryByEmptyDeploymentIds() {
         try {
             cmmnRepositoryService.createCaseDefinitionQuery().deploymentIds(new HashSet<String>()).list();
             fail();
-        } catch (FlowableIllegalArgumentException e) {}
+        } catch (FlowableIllegalArgumentException e) {
+        }
     }
-    
+
     @Test
     public void testQueryByCaseDefinitionId() {
         List<String> caseDefinitionIdsDeployment1 = getCaseDefinitionIds(deploymentId1);
         List<String> caseDefinitionIdsDeployment2 = getCaseDefinitionIds(deploymentId2);
         List<String> caseDefinitionIdsDeployment3 = getCaseDefinitionIds(deploymentId3);
-        
+
         assertNotNull(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionId(caseDefinitionIdsDeployment1.get(0)).singleResult());
         assertEquals(1, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionId(caseDefinitionIdsDeployment1.get(0)).list().size());
         assertEquals(1, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionId(caseDefinitionIdsDeployment1.get(0)).count());
-        
+
         assertNotNull(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionId(caseDefinitionIdsDeployment1.get(1)).singleResult());
         assertEquals(1, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionId(caseDefinitionIdsDeployment1.get(1)).list().size());
         assertEquals(1, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionId(caseDefinitionIdsDeployment1.get(1)).count());
-        
+
         assertNotNull(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionId(caseDefinitionIdsDeployment2.get(0)).singleResult());
         assertEquals(1, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionId(caseDefinitionIdsDeployment2.get(0)).list().size());
         assertEquals(1, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionId(caseDefinitionIdsDeployment2.get(0)).count());
-    
+
         assertNotNull(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionId(caseDefinitionIdsDeployment3.get(0)).singleResult());
         assertEquals(1, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionId(caseDefinitionIdsDeployment3.get(0)).list().size());
         assertEquals(1, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionId(caseDefinitionIdsDeployment3.get(0)).count());
     }
-    
+
     @Test
     public void testQueryByInvalidCaseDefinitionId() {
         assertEquals(0, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionId("invalid").list().size());
         assertEquals(0, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionId("invalid").count());
     }
-    
+
     @Test
     public void testQueryByCaseDefinitionIds() {
         List<String> caseDefinitionIdsDeployment1 = getCaseDefinitionIds(deploymentId1);
         List<String> caseDefinitionIdsDeployment2 = getCaseDefinitionIds(deploymentId2);
-        
+
         assertEquals(2, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionIds(new HashSet<>(caseDefinitionIdsDeployment1)).list().size());
         assertEquals(2, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionIds(new HashSet<>(caseDefinitionIdsDeployment1)).count());
-        
+
         assertEquals(1, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionIds(new HashSet<>(caseDefinitionIdsDeployment2)).list().size());
         assertEquals(1, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionIds(new HashSet<>(caseDefinitionIdsDeployment2)).count());
     }
-    
+
     @Test
     public void testQueryByEmptyCaseDefinitionIds() {
         try {
             cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionIds(new HashSet<String>()).list();
             fail();
-        } catch (FlowableIllegalArgumentException e) { }
+        } catch (FlowableIllegalArgumentException e) {
+        }
     }
-    
+
     @Test
     public void testQueryByInvalidCaseDefinitionIds() {
         assertEquals(0, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionIds(new HashSet<>(Arrays.asList("invalid1", "invalid2"))).list().size());
         assertEquals(0, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionIds(new HashSet<>(Arrays.asList("invalid1", "invalid2"))).count());
-    }    
-    
+    }
+
     @Test
     public void testQueryByCaseDefinitionCategory() {
         assertEquals(4, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionCategory("http://flowable.org/cmmn").list().size());
         assertEquals(4, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionCategory("http://flowable.org/cmmn").count());
     }
-    
+
     @Test
     public void testQueryByInvalidCaseDefinitionCategory() {
         assertEquals(0, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionCategory("invalid").list().size());
         assertEquals(0, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionCategory("invalid").count());
     }
-    
+
     @Test
     public void testQueryByCaseDefinitionCategoryLike() {
         assertEquals(4, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionCategoryLike("http%").list().size());
         assertEquals(4, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionCategoryLike("http%n").count());
     }
-    
+
     @Test
     public void testQueryByInvalidCaseDefinitionCategoryLike() {
         assertEquals(0, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionCategoryLike("invalid%").list().size());
         assertEquals(0, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionCategoryLike("invalid%n").count());
     }
-    
+
     @Test
     public void testQueryByCaseDefinitionCategoryNotEquals() {
         assertEquals(4, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionCategoryNotEquals("another").list().size());
         assertEquals(4, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionCategoryNotEquals("another").count());
-        
+
         assertEquals(0, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionCategoryNotEquals("http://flowable.org/cmmn").list().size());
         assertEquals(0, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionCategoryNotEquals("http://flowable.org/cmmn").count());
     }
-    
+
     @Test
     public void testQueryByCaseDefinitionName() {
         assertEquals(3, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionName("Case 1").list().size());
         assertEquals(3, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionName("Case 1").count());
-        
+
         assertEquals(1, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionName("Case 2").list().size());
         assertEquals(1, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionName("Case 2").count());
-        
+
         assertEquals(deploymentId1, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionName("Case 2").singleResult().getDeploymentId());
     }
-    
+
     @Test
     public void testQueryByInvalidCaseDefinitionName() {
         assertEquals(0, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionName("Case 3").list().size());
         assertEquals(0, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionName("Case 3").count());
     }
-    
+
     @Test
     public void testQueryByCaseDefinitionNameLike() {
         assertEquals(4, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionNameLike("Ca%").list().size());
         assertEquals(4, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionNameLike("Ca%").count());
-        
+
         assertEquals(1, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionNameLike("%2").list().size());
         assertEquals(1, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionNameLike("%2").count());
-        
+
         assertEquals(0, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionNameLike("invalid%").list().size());
         assertEquals(0, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionNameLike("invalid%").count());
     }
-    
+
     @Test
     public void testQueryByCaseDefinitionKey() {
         assertEquals(3, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionKey("myCase").list().size());
         assertEquals(3, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionKey("myCase").count());
-        
+
         assertEquals(1, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionKey("myCase2").list().size());
         assertEquals(1, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionKey("myCase2").count());
     }
-    
+
     @Test
     public void testQueryByInvalidCaseDefinitionKey() {
         assertEquals(0, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionKey("invalid").list().size());
         assertEquals(0, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionKey("invalid").count());
     }
-    
+
     @Test
     public void testQueryByCaseDefinitionKeyLike() {
         assertEquals(4, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionKeyLike("my%").list().size());
         assertEquals(4, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionKeyLike("my%").count());
-        
+
         assertEquals(1, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionKeyLike("%2").list().size());
         assertEquals(1, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionKeyLike("%2").count());
     }
-    
+
     @Test
     public void testQueryByInvalidCaseDefinitionKeyLike() {
         assertEquals(0, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionKeyLike("%invalid").list().size());
         assertEquals(0, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionKeyLike("%invalid").count());
     }
-    
+
     @Test
     public void testQueryByCaseDefinitionVersion() {
         assertEquals(2, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersion(1).list().size());
         assertEquals(2, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersion(1).count());
-        
+
         assertEquals(1, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersion(2).list().size());
         assertEquals(1, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersion(2).count());
-        
+
         assertEquals(1, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersion(2).list().size());
         assertEquals(1, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersion(2).count());
-        
+
         assertEquals(0, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersion(4).list().size());
         assertEquals(0, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersion(4).count());
     }
-    
+
     @Test
     public void testQueryByCaseDefinitionVersionGreaterThan() {
         assertEquals(1, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersionGreaterThan(2).list().size());
         assertEquals(1, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersionGreaterThan(2).count());
-        
+
         assertEquals(0, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersionGreaterThan(3).list().size());
         assertEquals(0, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersionGreaterThan(3).count());
     }
-    
+
     @Test
     public void testQueryByCaseDefinitionVersionGreaterThanOrEquals() {
         assertEquals(2, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersionGreaterThanOrEquals(2).list().size());
         assertEquals(2, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersionGreaterThanOrEquals(2).count());
-        
+
         assertEquals(1, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersionGreaterThanOrEquals(3).list().size());
         assertEquals(1, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersionGreaterThanOrEquals(3).count());
-        
+
         assertEquals(0, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersionGreaterThanOrEquals(4).list().size());
         assertEquals(0, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersionGreaterThanOrEquals(4).count());
     }
-    
+
     @Test
     public void testQueryByCaseDefinitionVersionLowerThan() {
         assertEquals(2, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersionLowerThan(2).list().size());
         assertEquals(2, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersionLowerThan(2).count());
-        
+
         assertEquals(3, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersionLowerThan(3).list().size());
         assertEquals(3, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersionLowerThan(3).count());
     }
-    
+
     @Test
     public void testQueryByCaseDefinitionVersionLowerThanOrEquals() {
         assertEquals(3, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersionLowerThanOrEquals(2).list().size());
         assertEquals(3, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersionLowerThanOrEquals(2).count());
-        
+
         assertEquals(4, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersionLowerThanOrEquals(3).list().size());
         assertEquals(4, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersionLowerThanOrEquals(3).count());
-        
+
         assertEquals(4, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersionLowerThanOrEquals(4).list().size());
         assertEquals(4, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersionLowerThanOrEquals(4).count());
     }
-    
+
     @Test
     public void testQueryByLatestVersion() {
         assertEquals(2, cmmnRepositoryService.createCaseDefinitionQuery().latestVersion().list().size());
         assertEquals(2, cmmnRepositoryService.createCaseDefinitionQuery().latestVersion().count());
     }
-    
+
     @Test
     public void testQueryByLatestVersionAndKey() {
         CaseDefinition caseDefinition = cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionKey("myCase").latestVersion().singleResult();
@@ -339,40 +342,40 @@ public class CaseDefinitionQueryTest extends FlowableCmmnTestCase {
         assertEquals(1, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionKey("myCase").latestVersion().list().size());
         assertEquals(1, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionKey("myCase").latestVersion().count());
     }
-    
+
     @Test
     public void testQueryByCaseDefinitionResourceName() {
         assertEquals(3, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionResourceName("org/flowable/cmmn/test/repository/simple-case.cmmn").list().size());
         assertEquals(3, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionResourceName("org/flowable/cmmn/test/repository/simple-case.cmmn").count());
-        
+
         assertEquals(1, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionResourceName("org/flowable/cmmn/test/repository/simple-case2.cmmn").list().size());
         assertEquals(1, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionResourceName("org/flowable/cmmn/test/repository/simple-case2.cmmn").count());
-        
+
         assertEquals(1, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionResourceName("org/flowable/cmmn/test/repository/simple-case.cmmn").latestVersion().list().size());
         assertEquals(1, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionResourceName("org/flowable/cmmn/test/repository/simple-case.cmmn").latestVersion().count());
     }
-    
+
     @Test
     public void testQueryByInvalidCaseDefinitionResourceName() {
         assertEquals(0, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionResourceName("invalid.cmmn").list().size());
         assertEquals(0, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionResourceName("invalid.cmmn").count());
     }
-    
+
     @Test
     public void testQueryByCaseDefinitionResourceNameLike() {
         assertEquals(4, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionResourceNameLike("%.cmmn").list().size());
         assertEquals(4, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionResourceNameLike("%.cmmn").count());
-        
+
         assertEquals(1, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionResourceNameLike("%2%").list().size());
         assertEquals(1, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionResourceNameLike("%2%").count());
     }
-    
+
     @Test
     public void testQueryByInvalidCaseDefinitionResourceNameLike() {
         assertEquals(0, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionResourceNameLike("%invalid%").list().size());
         assertEquals(0, cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionResourceNameLike("%invalid%").count());
     }
-    
+
     @Test
     public void testQueryOrderByCaseDefinitionCategory() {
         assertEquals(4, cmmnRepositoryService.createCaseDefinitionQuery().orderByCaseDefinitionCategory().asc().list().size());
@@ -380,32 +383,32 @@ public class CaseDefinitionQueryTest extends FlowableCmmnTestCase {
         assertEquals(4, cmmnRepositoryService.createCaseDefinitionQuery().orderByCaseDefinitionCategory().desc().list().size());
         assertEquals(4, cmmnRepositoryService.createCaseDefinitionQuery().orderByCaseDefinitionCategory().desc().count());
     }
-    
+
     @Test
     public void testQueryOrderByCaseDefinitionKey() {
         assertEquals(4, cmmnRepositoryService.createCaseDefinitionQuery().orderByCaseDefinitionKey().asc().list().size());
         assertEquals(4, cmmnRepositoryService.createCaseDefinitionQuery().orderByCaseDefinitionKey().asc().count());
-        List<CaseDefinition> caseDefinitions =  cmmnRepositoryService.createCaseDefinitionQuery().orderByCaseDefinitionKey().asc().list();
-        for (int i=0; i<caseDefinitions.size(); i++) {
-            if (i<=2) {
+        List<CaseDefinition> caseDefinitions = cmmnRepositoryService.createCaseDefinitionQuery().orderByCaseDefinitionKey().asc().list();
+        for (int i = 0; i < caseDefinitions.size(); i++) {
+            if (i <= 2) {
                 assertEquals("myCase", caseDefinitions.get(i).getKey());
             } else {
                 assertEquals("myCase2", caseDefinitions.get(i).getKey());
             }
         }
-        
+
         assertEquals(4, cmmnRepositoryService.createCaseDefinitionQuery().orderByCaseDefinitionKey().desc().list().size());
         assertEquals(4, cmmnRepositoryService.createCaseDefinitionQuery().orderByCaseDefinitionKey().desc().count());
-        caseDefinitions =  cmmnRepositoryService.createCaseDefinitionQuery().orderByCaseDefinitionKey().desc().list();
-        for (int i=0; i<caseDefinitions.size(); i++) {
-            if (i>0) {
+        caseDefinitions = cmmnRepositoryService.createCaseDefinitionQuery().orderByCaseDefinitionKey().desc().list();
+        for (int i = 0; i < caseDefinitions.size(); i++) {
+            if (i > 0) {
                 assertEquals("myCase", caseDefinitions.get(i).getKey());
             } else {
                 assertEquals("myCase2", caseDefinitions.get(i).getKey());
             }
         }
     }
-    
+
     @Test
     public void testQueryOrderByCaseDefinitionId() {
         assertEquals(4, cmmnRepositoryService.createCaseDefinitionQuery().orderByCaseDefinitionId().asc().list().size());
@@ -413,7 +416,7 @@ public class CaseDefinitionQueryTest extends FlowableCmmnTestCase {
         assertEquals(4, cmmnRepositoryService.createCaseDefinitionQuery().orderByCaseDefinitionId().desc().list().size());
         assertEquals(4, cmmnRepositoryService.createCaseDefinitionQuery().orderByCaseDefinitionId().desc().count());
     }
-    
+
     @Test
     public void testQueryOrderByCaseDefinitionName() {
         assertEquals(4, cmmnRepositoryService.createCaseDefinitionQuery().orderByCaseDefinitionName().asc().list().size());
@@ -421,7 +424,7 @@ public class CaseDefinitionQueryTest extends FlowableCmmnTestCase {
         assertEquals(4, cmmnRepositoryService.createCaseDefinitionQuery().orderByCaseDefinitionName().desc().list().size());
         assertEquals(4, cmmnRepositoryService.createCaseDefinitionQuery().orderByCaseDefinitionName().desc().count());
     }
-    
+
     @Test
     public void testQueryOrderByCaseDefinitionDeploymentId() {
         assertEquals(4, cmmnRepositoryService.createCaseDefinitionQuery().orderByDeploymentId().asc().list().size());
@@ -429,27 +432,27 @@ public class CaseDefinitionQueryTest extends FlowableCmmnTestCase {
         assertEquals(4, cmmnRepositoryService.createCaseDefinitionQuery().orderByDeploymentId().desc().list().size());
         assertEquals(4, cmmnRepositoryService.createCaseDefinitionQuery().orderByDeploymentId().desc().count());
     }
-    
+
     @Test
     public void testQueryOrderByCaseDefinitionVersion() {
         assertEquals(4, cmmnRepositoryService.createCaseDefinitionQuery().orderByCaseDefinitionVersion().asc().list().size());
         assertEquals(4, cmmnRepositoryService.createCaseDefinitionQuery().orderByCaseDefinitionVersion().asc().count());
         assertEquals(4, cmmnRepositoryService.createCaseDefinitionQuery().orderByCaseDefinitionVersion().desc().list().size());
         assertEquals(4, cmmnRepositoryService.createCaseDefinitionQuery().orderByCaseDefinitionVersion().desc().count());
-        
+
         List<CaseDefinition> caseDefinitions = cmmnRepositoryService.createCaseDefinitionQuery().orderByCaseDefinitionVersion().desc().list();
         assertEquals(3, caseDefinitions.get(0).getVersion());
         assertEquals(2, caseDefinitions.get(1).getVersion());
         assertEquals(1, caseDefinitions.get(2).getVersion());
         assertEquals(1, caseDefinitions.get(3).getVersion());
-        
+
         caseDefinitions = cmmnRepositoryService.createCaseDefinitionQuery().latestVersion().orderByCaseDefinitionVersion().asc().list();
         assertEquals(1, caseDefinitions.get(0).getVersion());
         assertEquals("myCase2", caseDefinitions.get(0).getKey());
         assertEquals(3, caseDefinitions.get(1).getVersion());
         assertEquals("myCase", caseDefinitions.get(1).getKey());
     }
-    
+
     private List<String> getCaseDefinitionIds(String deploymentId) {
         List<CaseDefinition> caseDefinitions = cmmnRepositoryService.createCaseDefinitionQuery().deploymentId(deploymentId).list();
         List<String> ids = new ArrayList<>();

--- a/modules/flowable-cmmn-model/src/main/java/org/flowable/cmmn/model/PlanFragment.java
+++ b/modules/flowable-cmmn-model/src/main/java/org/flowable/cmmn/model/PlanFragment.java
@@ -25,43 +25,43 @@ public class PlanFragment extends PlanItemDefinition {
     protected Case caze;
     protected Map<String, PlanItem> planItemMap = new LinkedHashMap<>();
     protected List<Sentry> sentries = new ArrayList<>();
-    
+
     public PlanItem findPlanItem(String planItemId) {
         if (planItemMap.containsKey(planItemId)) {
             return planItemMap.get(planItemId);
         }
-        
+
         PlanFragment parentPlanFragment = getParent();
         if (parentPlanFragment != null) {
             return parentPlanFragment.findPlanItem(planItemId);
         }
-        
+
         return null;
     }
-    
+
     public Sentry findSentry(String sentryId) {
         for (Sentry sentry : sentries) {
             if (sentry.getId().equals(sentryId)) {
                 return sentry;
             }
         }
-        
+
         PlanFragment parentPlanFragment = getParent();
         if (parentPlanFragment != null) {
             return parentPlanFragment.findSentry(sentryId);
         }
-        
+
         return null;
     }
-    
+
     public void addPlanItem(PlanItem planItem) {
         planItemMap.put(planItem.getId(), planItem);
     }
-    
+
     public void addSentry(Sentry sentry) {
         sentries.add(sentry);
     }
-    
+
     public Case getCase() {
         return caze;
     }
@@ -71,7 +71,7 @@ public class PlanFragment extends PlanItemDefinition {
     }
 
     public List<PlanItem> getPlanItems() {
-        return new ArrayList<PlanItem>(planItemMap.values());
+        return new ArrayList<>(planItemMap.values());
     }
 
     public Map<String, PlanItem> getPlanItemMap() {
@@ -89,5 +89,5 @@ public class PlanFragment extends PlanItemDefinition {
     public void setSentries(List<Sentry> sentries) {
         this.sentries = sentries;
     }
-    
+
 }

--- a/modules/flowable-cmmn-model/src/main/java/org/flowable/cmmn/model/Stage.java
+++ b/modules/flowable-cmmn-model/src/main/java/org/flowable/cmmn/model/Stage.java
@@ -21,40 +21,40 @@ import java.util.Map;
  * @author Joram Barrez
  */
 public class Stage extends PlanFragment implements HasExitCriteria {
-    
+
     protected boolean isPlanModel;
     protected Map<String, PlanItemDefinition> planItemDefinitionMap = new LinkedHashMap<>();
     protected List<Criterion> exitCriteria = new ArrayList<>();
-    
+
     public void addPlanItemDefinition(PlanItemDefinition planItemDefinition) {
         planItemDefinitionMap.put(planItemDefinition.getId(), planItemDefinition);
     }
-    
+
     public PlanItemDefinition findPlanItemDefinition(String planItemDefinitionId) {
         if (id != null && id.equals(planItemDefinitionId)) {
             return this;
         }
-        
+
         if (planItemDefinitionMap.containsKey(planItemDefinitionId)) {
             return planItemDefinitionMap.get(planItemDefinitionId);
         }
-        
+
         Stage parentStage = getParentStage();
         if (parentStage != null) {
             return parentStage.findPlanItemDefinition(planItemDefinitionId);
         }
-        
+
         return null;
     }
-    
+
     public <T extends PlanItemDefinition> List<T> findPlanItemDefinitionsOfType(Class<T> clazz, boolean recursive) {
         List<T> planItemDefinitions = new ArrayList<>();
         internalFindPlanItemDefinitionsOfType(clazz, this, planItemDefinitions, recursive);
         return planItemDefinitions;
     }
-    
+
     @SuppressWarnings("unchecked")
-    private <T extends PlanItemDefinition> void internalFindPlanItemDefinitionsOfType(Class<T> clazz, Stage stage, List<T> planItemDefinitions,  boolean recursive) {
+    private <T extends PlanItemDefinition> void internalFindPlanItemDefinitionsOfType(Class<T> clazz, Stage stage, List<T> planItemDefinitions, boolean recursive) {
         for (PlanItemDefinition planItemDefinition : stage.getPlanItemDefinitions()) {
             if (clazz.isInstance(planItemDefinition)) {
                 planItemDefinitions.add((T) planItemDefinition);
@@ -66,7 +66,7 @@ public class Stage extends PlanFragment implements HasExitCriteria {
     }
 
     public List<PlanItemDefinition> getPlanItemDefinitions() {
-        return new ArrayList<PlanItemDefinition>(planItemDefinitionMap.values());
+        return new ArrayList<>(planItemDefinitionMap.values());
     }
 
     public Map<String, PlanItemDefinition> getPlanItemDefinitionMap() {
@@ -92,5 +92,5 @@ public class Stage extends PlanFragment implements HasExitCriteria {
     public void setExitCriteria(List<Criterion> exitCriteria) {
         this.exitCriteria = exitCriteria;
     }
-    
+
 }

--- a/modules/flowable-engine-common/src/main/java/org/flowable/engine/common/impl/AbstractNativeQuery.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/engine/common/impl/AbstractNativeQuery.java
@@ -25,7 +25,7 @@ import org.flowable.engine.common.impl.interceptor.CommandExecutor;
 
 /**
  * Abstract superclass for all native query types.
- * 
+ *
  * @author Bernd Ruecker (camunda)
  */
 public abstract class AbstractNativeQuery<T extends NativeQuery<?, ?>, U> extends BaseNativeQuery<T, U> implements Command<Object> {
@@ -120,10 +120,9 @@ public abstract class AbstractNativeQuery<T extends NativeQuery<?, ?>, U> extend
 
     /**
      * Executes the actual query to retrieve the list of results.
-     * 
-     * @param maxResults
-     * @param firstResult
      *
+     * @param commandContext
+     * @param parameterMap
      */
     public abstract List<U> executeList(CommandContext commandContext, Map<String, Object> parameterMap);
 

--- a/modules/flowable-engine-common/src/main/java/org/flowable/engine/common/impl/agenda/AbstractAgenda.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/engine/common/impl/agenda/AbstractAgenda.java
@@ -27,8 +27,8 @@ public abstract class AbstractAgenda implements Agenda {
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractAgenda.class);
 
     protected CommandContext commandContext;
-    protected LinkedList<Runnable> operations = new LinkedList<Runnable>();
-    
+    protected LinkedList<Runnable> operations = new LinkedList<>();
+
     public AbstractAgenda(CommandContext commandContext) {
         this.commandContext = commandContext;
     }
@@ -70,7 +70,7 @@ public abstract class AbstractAgenda implements Agenda {
     public LinkedList<Runnable> getOperations() {
         return operations;
     }
-    
+
     public CommandContext getCommandContext() {
         return commandContext;
     }
@@ -78,15 +78,15 @@ public abstract class AbstractAgenda implements Agenda {
     public void setCommandContext(CommandContext commandContext) {
         this.commandContext = commandContext;
     }
-    
+
     @Override
     public void flush() {
-        
+
     }
 
     @Override
     public void close() {
-        
+
     }
-    
+
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/impl/FlowableEntityExceptionEventImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/impl/FlowableEntityExceptionEventImpl.java
@@ -17,11 +17,10 @@ import org.flowable.engine.common.api.delegate.event.FlowableEngineEntityEvent;
 import org.flowable.engine.common.api.delegate.event.FlowableEngineEventType;
 import org.flowable.engine.common.api.delegate.event.FlowableEvent;
 import org.flowable.engine.common.api.delegate.event.FlowableExceptionEvent;
-import org.flowable.engine.common.impl.event.FlowableEventImpl;
 
 /**
  * Base class for all {@link FlowableEvent} implementations, represents an exception occurred, related to an entity.
- * 
+ *
  * @author Frederik Heremans
  */
 public class FlowableEntityExceptionEventImpl extends FlowableProcessEventImpl implements FlowableEngineEntityEvent, FlowableExceptionEvent {

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -13,11 +13,12 @@
 
 package org.flowable.engine.impl.cfg;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import java.io.InputStream;
 import java.io.Reader;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -279,8 +280,8 @@ import org.flowable.identitylink.service.IdentityLinkServiceConfiguration;
 import org.flowable.idm.engine.IdmEngineConfiguration;
 import org.flowable.image.impl.DefaultProcessDiagramGenerator;
 import org.flowable.job.service.HistoryJobHandler;
-import org.flowable.job.service.JobHandler;
 import org.flowable.job.service.InternalJobManager;
+import org.flowable.job.service.JobHandler;
 import org.flowable.job.service.JobServiceConfiguration;
 import org.flowable.job.service.impl.asyncexecutor.AsyncExecutor;
 import org.flowable.job.service.impl.asyncexecutor.AsyncRunnableExecutionExceptionHandler;
@@ -290,8 +291,8 @@ import org.flowable.job.service.impl.asyncexecutor.ExecuteAsyncRunnableFactory;
 import org.flowable.job.service.impl.asyncexecutor.FailedJobCommandFactory;
 import org.flowable.job.service.impl.asyncexecutor.JobManager;
 import org.flowable.task.service.InternalTaskLocalizationManager;
-import org.flowable.task.service.TaskServiceConfiguration;
 import org.flowable.task.service.InternalTaskVariableScopeResolver;
+import org.flowable.task.service.TaskServiceConfiguration;
 import org.flowable.task.service.history.InternalHistoryTaskManager;
 import org.flowable.validation.ProcessValidator;
 import org.flowable.validation.ProcessValidatorFactory;
@@ -324,8 +325,6 @@ import org.flowable.variable.service.impl.types.VariableType;
 import org.flowable.variable.service.impl.types.VariableTypes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * @author Tom Baeyens
@@ -373,7 +372,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     protected ProcessDefinitionInfoDataManager processDefinitionInfoDataManager;
     protected PropertyDataManager propertyDataManager;
     protected ResourceDataManager resourceDataManager;
-    
+
     // ENTITY MANAGERS ///////////////////////////////////////////////////////////
 
     protected AttachmentEntityManager attachmentEntityManager;
@@ -392,7 +391,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     protected PropertyEntityManager propertyEntityManager;
     protected ResourceEntityManager resourceEntityManager;
     protected TableDataManager tableDataManager;
-    
+
     // Candidate Manager
 
     protected CandidateManager candidateManager;
@@ -655,13 +654,13 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     protected List<VariableType> customPreVariableTypes;
     protected List<VariableType> customPostVariableTypes;
     protected VariableTypes variableTypes;
-    
+
     protected InternalHistoryVariableManager internalHistoryVariableManager;
     protected InternalTaskVariableScopeResolver internalTaskVariableScopeResolver;
     protected InternalHistoryTaskManager internalHistoryTaskManager;
     protected InternalTaskLocalizationManager internalTaskLocalizationManager;
     protected InternalJobManager internalJobManager;
-    
+
     protected Map<String, List<RuntimeInstanceStateChangeCallback>> processInstanceStateChangedCallbacks;
 
     /**
@@ -892,7 +891,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
             }
         }
     }
-    
+
     @Override
     public String getEngineCfgKey() {
         return EngineConfigurationConstants.KEY_PROCESS_ENGINE_CONFIG;
@@ -900,7 +899,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     @Override
     public List<CommandInterceptor> getAdditionalDefaultCommandInterceptors() {
-        return Arrays.<CommandInterceptor>asList(new BpmnOverrideContextInterceptor());
+        return Collections.<CommandInterceptor>singletonList(new BpmnOverrideContextInterceptor());
     }
     // services
     // /////////////////////////////////////////////////////////////////
@@ -1248,7 +1247,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         this.variableServiceConfiguration.setEventDispatcher(this.eventDispatcher);
 
         this.variableServiceConfiguration.setVariableTypes(this.variableTypes);
-        
+
         if (this.internalHistoryVariableManager != null) {
             this.variableServiceConfiguration.setInternalHistoryVariableManager(this.internalHistoryVariableManager);
         } else {
@@ -1262,54 +1261,54 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
         addServiceConfiguration(EngineConfigurationConstants.KEY_VARIABLE_SERVICE_CONFIG, this.variableServiceConfiguration);
     }
-    
+
     public void initIdentityLinkServiceConfiguration() {
         this.identityLinkServiceConfiguration = new IdentityLinkServiceConfiguration();
         this.identityLinkServiceConfiguration.setHistoryLevel(this.historyLevel);
         this.identityLinkServiceConfiguration.setClock(this.clock);
         this.identityLinkServiceConfiguration.setObjectMapper(this.objectMapper);
         this.identityLinkServiceConfiguration.setEventDispatcher(this.eventDispatcher);
-        
+
         this.identityLinkServiceConfiguration.init();
-        
+
         addServiceConfiguration(EngineConfigurationConstants.KEY_IDENTITY_LINK_SERVICE_CONFIG, this.identityLinkServiceConfiguration);
     }
-    
+
     public void initTaskServiceConfiguration() {
         this.taskServiceConfiguration = new TaskServiceConfiguration();
         this.taskServiceConfiguration.setHistoryLevel(this.historyLevel);
         this.taskServiceConfiguration.setClock(this.clock);
         this.taskServiceConfiguration.setObjectMapper(this.objectMapper);
         this.taskServiceConfiguration.setEventDispatcher(this.eventDispatcher);
-        
+
         if (this.internalHistoryTaskManager != null) {
             this.taskServiceConfiguration.setInternalHistoryTaskManager(this.internalHistoryTaskManager);
         } else {
             this.taskServiceConfiguration.setInternalHistoryTaskManager(new DefaultHistoryTaskManager(this));
         }
-        
+
         if (this.internalTaskVariableScopeResolver != null) {
             this.taskServiceConfiguration.setInternalTaskVariableScopeResolver(this.internalTaskVariableScopeResolver);
         } else {
             this.taskServiceConfiguration.setInternalTaskVariableScopeResolver(new DefaultTaskVariableScopeResolver(this));
         }
-        
+
         if (this.internalTaskLocalizationManager != null) {
             this.taskServiceConfiguration.setInternalTaskLocalizationManager(this.internalTaskLocalizationManager);
         } else {
             this.taskServiceConfiguration.setInternalTaskLocalizationManager(new DefaultTaskLocalizationManager(this));
         }
-        
+
         this.taskServiceConfiguration.setEnableTaskRelationshipCounts(this.performanceSettings.isEnableTaskRelationshipCounts());
         this.taskServiceConfiguration.setEnableLocalization(this.performanceSettings.isEnableLocalization());
         this.taskServiceConfiguration.setTaskQueryLimit(this.taskQueryLimit);
         this.taskServiceConfiguration.setHistoricTaskQueryLimit(this.historicTaskQueryLimit);
-        
+
         this.taskServiceConfiguration.init();
-        
+
         addServiceConfiguration(EngineConfigurationConstants.KEY_TASK_SERVICE_CONFIG, this.taskServiceConfiguration);
     }
-    
+
     public void initJobServiceConfiguration() {
         this.jobServiceConfiguration = new JobServiceConfiguration();
         this.jobServiceConfiguration.setHistoryLevel(this.historyLevel);
@@ -1319,26 +1318,26 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         this.jobServiceConfiguration.setCommandExecutor(this.commandExecutor);
         this.jobServiceConfiguration.setExpressionManager(this.expressionManager);
         this.jobServiceConfiguration.setBusinessCalendarManager(this.businessCalendarManager);
-        
+
         this.jobServiceConfiguration.setJobHandlers(this.jobHandlers);
         this.jobServiceConfiguration.setHistoryJobHandlers(this.historyJobHandlers);
         this.jobServiceConfiguration.setFailedJobCommandFactory(this.failedJobCommandFactory);
         this.jobServiceConfiguration.setAsyncRunnableExecutionExceptionHandler(this.asyncRunnableExecutionExceptionHandler);
         this.jobServiceConfiguration.setAsyncExecutorNumberOfRetries(this.asyncExecutorNumberOfRetries);
         this.jobServiceConfiguration.setAsyncExecutorResetExpiredJobsMaxTimeout(this.asyncExecutorResetExpiredJobsMaxTimeout);
-        
+
         if (this.jobManager != null) {
             this.jobServiceConfiguration.setJobManager(this.jobManager);
         }
-        
+
         if (this.internalJobManager != null) {
             this.jobServiceConfiguration.setInternalJobManager(this.internalJobManager);
         } else {
             this.jobServiceConfiguration.setInternalJobManager(new DefaultJobScopeManager(this));
         }
-        
+
         this.jobServiceConfiguration.init();
-        
+
         addServiceConfiguration(EngineConfigurationConstants.KEY_JOB_SERVICE_CONFIG, this.jobServiceConfiguration);
     }
 
@@ -1348,7 +1347,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
             configurator.configure(this);
         }
     }
-    
+
     public void afterInitTaskServiceConfiguration() {
         if (engineConfigurations.containsKey(EngineConfigurationConstants.KEY_IDM_ENGINE_CONFIG)) {
             IdmEngineConfiguration idmEngineConfiguration = (IdmEngineConfiguration) engineConfigurations.get(EngineConfigurationConstants.KEY_IDM_ENGINE_CONFIG);
@@ -1712,7 +1711,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
             asyncExecutor = defaultAsyncExecutor;
         }
-        
+
         asyncExecutor.setJobServiceConfiguration(jobServiceConfiguration);
         asyncExecutor.setAutoActivate(asyncExecutorActivate);
         jobServiceConfiguration.setAsyncExecutor(asyncExecutor);
@@ -1761,7 +1760,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         asyncHistoryExecutor.setJobServiceConfiguration(jobServiceConfiguration);
         asyncHistoryExecutor.setAutoActivate(asyncHistoryExecutorActivate);
     }
-    
+
     // history
     // //////////////////////////////////////////////////////////////////
 
@@ -2446,7 +2445,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         this.variableTypes = variableTypes;
         return this;
     }
-    
+
     public InternalHistoryVariableManager getInternalHistoryVariableManager() {
         return internalHistoryVariableManager;
     }
@@ -3431,7 +3430,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         this.objectMapper = objectMapper;
         return this;
     }
-    
+
     public Map<String, List<RuntimeInstanceStateChangeCallback>> getProcessInstanceStateChangedCallbacks() {
         return processInstanceStateChangedCallbacks;
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ProcessInstanceEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ProcessInstanceEventsTest.java
@@ -22,7 +22,11 @@ import java.util.List;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.flowable.bpmn.model.FlowNode;
-import org.flowable.engine.common.api.delegate.event.*;
+import org.flowable.engine.common.api.delegate.event.FlowableEngineEntityEvent;
+import org.flowable.engine.common.api.delegate.event.FlowableEngineEventType;
+import org.flowable.engine.common.api.delegate.event.FlowableEntityEvent;
+import org.flowable.engine.common.api.delegate.event.FlowableEvent;
+import org.flowable.engine.common.api.delegate.event.FlowableEventListener;
 import org.flowable.engine.delegate.event.FlowableActivityCancelledEvent;
 import org.flowable.engine.delegate.event.FlowableCancelledEvent;
 import org.flowable.engine.delegate.event.FlowableProcessStartedEvent;
@@ -220,7 +224,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
     /**
      * Test create, update and delete events of process instances.
      */
-    @Deployment(resources = { "org/flowable/engine/test/api/runtime/nestedSubProcess.bpmn20.xml", "org/flowable/engine/test/api/runtime/subProcess.bpmn20.xml" })
+    @Deployment(resources = {"org/flowable/engine/test/api/runtime/nestedSubProcess.bpmn20.xml", "org/flowable/engine/test/api/runtime/subProcess.bpmn20.xml"})
     public void testSubProcessInstanceEvents() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("nestedSimpleSubProcess");
         assertNotNull(processInstance);
@@ -319,7 +323,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
     /**
      * Test process with signals start.
      */
-    @Deployment(resources = { "org/flowable/engine/test/bpmn/event/signal/SignalEventTest.testSignalWithGlobalScope.bpmn20.xml" })
+    @Deployment(resources = {"org/flowable/engine/test/bpmn/event/signal/SignalEventTest.testSignalWithGlobalScope.bpmn20.xml"})
     public void testSignalProcessInstanceStart() throws Exception {
         this.runtimeService.startProcessInstanceByKey("processWithSignalCatch");
         listener.clearEventsReceived();
@@ -331,7 +335,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
     /**
      * Test Start->End process on PROCESS_COMPLETED event
      */
-    @Deployment(resources = { "org/flowable/engine/test/api/event/ProcessInstanceEventsTest.noneTaskProcess.bpmn20.xml" })
+    @Deployment(resources = {"org/flowable/engine/test/api/event/ProcessInstanceEventsTest.noneTaskProcess.bpmn20.xml"})
     public void testProcessCompleted_StartEnd() throws Exception {
         this.runtimeService.startProcessInstanceByKey("noneTaskProcess");
 
@@ -341,7 +345,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
     /**
      * Test Start->User org.flowable.task.service.Task process on PROCESS_COMPLETED event
      */
-    @Deployment(resources = { "org/flowable/engine/test/api/event/ProcessInstanceEventsTest.noEndProcess.bpmn20.xml" })
+    @Deployment(resources = {"org/flowable/engine/test/api/event/ProcessInstanceEventsTest.noEndProcess.bpmn20.xml"})
     public void testProcessCompleted_NoEnd() throws Exception {
         ProcessInstance noEndProcess = this.runtimeService.startProcessInstanceByKey("noEndProcess");
         org.flowable.task.service.Task task = taskService.createTaskQuery().processInstanceId(noEndProcess.getId()).singleResult();
@@ -352,10 +356,10 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
 
     /**
      * Test +-->Task1 Start-<> +-->Task1
-     *
+     * <p>
      * process on PROCESS_COMPLETED event
      */
-    @Deployment(resources = { "org/flowable/engine/test/api/event/ProcessInstanceEventsTest.parallelGatewayNoEndProcess.bpmn20.xml" })
+    @Deployment(resources = {"org/flowable/engine/test/api/event/ProcessInstanceEventsTest.parallelGatewayNoEndProcess.bpmn20.xml"})
     public void testProcessCompleted_ParallelGatewayNoEnd() throws Exception {
         this.runtimeService.startProcessInstanceByKey("noEndProcess");
 
@@ -367,7 +371,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
      * <p/>
      * process on PROCESS_COMPLETED event
      */
-    @Deployment(resources = { "org/flowable/engine/test/api/event/ProcessInstanceEventsTest.parallelGatewayTwoEndsProcess.bpmn20.xml" })
+    @Deployment(resources = {"org/flowable/engine/test/api/event/ProcessInstanceEventsTest.parallelGatewayTwoEndsProcess.bpmn20.xml"})
     public void testProcessCompleted_ParallelGatewayTwoEnds() throws Exception {
         this.runtimeService.startProcessInstanceByKey("noEndProcess");
 
@@ -385,7 +389,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
         assertEquals("FlowableEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT was expected 6 times.", 6, events.size());
     }
 
-    @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
+    @Deployment(resources = {"org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
     public void testProcessInstanceCancelledEvents_cancel() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
         assertNotNull(processInstance);
@@ -411,7 +415,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
         listener.clearEventsReceived();
     }
 
-    @Deployment(resources = { "org/flowable/engine/test/api/runtime/nestedSubProcess.bpmn20.xml", "org/flowable/engine/test/api/runtime/subProcess.bpmn20.xml" })
+    @Deployment(resources = {"org/flowable/engine/test/api/runtime/nestedSubProcess.bpmn20.xml", "org/flowable/engine/test/api/runtime/subProcess.bpmn20.xml"})
     public void testProcessInstanceCancelledEvents_cancelProcessHierarchy() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("nestedSimpleSubProcess");
         ProcessInstance subProcess = runtimeService.createProcessInstanceQuery().superProcessInstanceId(processInstance.getId()).singleResult();
@@ -438,12 +442,12 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
 
         List<FlowableEvent> taskCancelledEvents = listener.filterEvents(FlowableEngineEventType.ACTIVITY_CANCELLED);
         assertEquals("ActivitiEventType.ACTIVITY_CANCELLED was expected 2 times.", 2, taskCancelledEvents.size());
-        
+
         FlowableActivityCancelledEvent activityCancelledEvent = (FlowableActivityCancelledEvent) taskCancelledEvents.get(0);
         assertTrue("The cause has to be the same as deleteProcessInstance method call", FlowableActivityCancelledEvent.class.isAssignableFrom(activityCancelledEvent.getClass()));
         assertEquals("The process instance has to point to the subprocess", subProcess.getId(), activityCancelledEvent.getProcessInstanceId());
         assertEquals("The cause has to be the same as in deleteProcessInstance method call", "delete_test", activityCancelledEvent.getCause());
-        
+
         activityCancelledEvent = (FlowableActivityCancelledEvent) taskCancelledEvents.get(1);
         assertTrue("The cause has to be the same as deleteProcessInstance method call", FlowableActivityCancelledEvent.class.isAssignableFrom(activityCancelledEvent.getClass()));
         assertEquals("The process instance has to point to the main process", processInstance.getId(), activityCancelledEvent.getProcessInstanceId());
@@ -453,7 +457,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
         listener.clearEventsReceived();
     }
 
-    @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
+    @Deployment(resources = {"org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
     public void testProcessInstanceCancelledEvents_complete() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
         assertNotNull(processInstance);
@@ -468,7 +472,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
 
     }
 
-    @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
+    @Deployment(resources = {"org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
     public void testProcessInstanceTerminatedEvents_complete() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
         assertNotNull(processInstance);
@@ -511,8 +515,8 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
 
     }
 
-    @Deployment(resources = { "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateInCallActivity.bpmn",
-            "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.subProcessTerminate.bpmn" })
+    @Deployment(resources = {"org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateInCallActivity.bpmn",
+            "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.subProcessTerminate.bpmn"})
     public void testProcessInstanceTerminatedEvents_callActivity() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
 
@@ -529,7 +533,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
 
     }
 
-    @Deployment(resources = { "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateInSubProcessWithBoundaryTerminateAll.bpmn20.xml"})
+    @Deployment(resources = {"org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateInSubProcessWithBoundaryTerminateAll.bpmn20.xml"})
     public void testTerminateAllInSubProcess() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventWithBoundary");
 
@@ -545,8 +549,8 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
 
     }
 
-    @Deployment(resources = { "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateInParentProcess.bpmn",
-                    "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
+    @Deployment(resources = {"org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateInParentProcess.bpmn",
+            "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
     public void testProcessInstanceTerminatedEvents_terminateInParentProcess() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateParentProcess");
 
@@ -617,7 +621,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
 
     @Deployment(resources = {
             "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testParallelCallActivity.bpmn20.xml",
-            "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml" })
+            "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml"})
     public void testDeleteMultiInstanceCallActivityProcessInstance() {
         assertEquals(0, taskService.createTaskQuery().count());
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("miParallelCallActivity");
@@ -632,7 +636,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createProcessInstanceQuery().count());
         assertEquals(0, taskService.createTaskQuery().count());
     }
-    
+
     @Deployment(resources = "org/flowable/engine/test/api/runtime/subProcessWithTerminateEnd.bpmn20.xml")
     public void testProcessInstanceTerminatedEventInSubProcess() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("subProcessWithTerminateEndTest");
@@ -661,13 +665,13 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
             if ("userTask".equals(activityEvent.getActivityType())) {
                 taskFound = true;
                 assertEquals("task", activityEvent.getActivityId());
-            
+
             } else if ("subProcess".equals(activityEvent.getActivityType())) {
                 subProcessFound = true;
                 assertEquals("embeddedSubprocess", activityEvent.getActivityId());
             }
         }
-        
+
         assertTrue(taskFound);
         assertTrue(subProcessFound);
     }
@@ -710,21 +714,17 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
         List<FlowableEvent> activityTerminatedEvents = listener
                 .filterEvents(FlowableEngineEventType.ACTIVITY_CANCELLED);
         assertEquals(4, activityTerminatedEvents.size());
-        for (FlowableEvent flowableEvent: activityTerminatedEvents)
-        {
+        for (FlowableEvent flowableEvent : activityTerminatedEvents) {
             FlowableActivityCancelledEvent activityCancelledEvent = (FlowableActivityCancelledEvent) flowableEvent;
             if ("intermediateCatchEvent".equals(activityCancelledEvent.getActivityType())) {
                 assertEquals("timer", activityCancelledEvent.getActivityId());
                 timerCatchEventFound = true;
-            }
-            else if ("boundaryEvent".equals(activityCancelledEvent.getActivityType())) {
+            } else if ("boundaryEvent".equals(activityCancelledEvent.getActivityType())) {
                 boundaryEventFound = true;
-            }
-            else if ("userTask".equals(activityCancelledEvent.getActivityType())) {
+            } else if ("userTask".equals(activityCancelledEvent.getActivityType())) {
                 assertEquals("Task in subprocess1", activityCancelledEvent.getActivityName());
                 userTaskFound = true;
-            }
-            else if ("subProcess".equals(activityCancelledEvent.getActivityType())) {
+            } else if ("subProcess".equals(activityCancelledEvent.getActivityType())) {
                 assertEquals("subprocess1", activityCancelledEvent.getActivityId());
                 subprocessFound = true;
             }

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/tasklistener/CandidateGroupAssignment.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/tasklistener/CandidateGroupAssignment.java
@@ -13,9 +13,7 @@
 package org.flowable.examples.bpmn.tasklistener;
 
 import org.flowable.engine.delegate.TaskListener;
-import org.flowable.engine.impl.util.TaskHelper;
 import org.flowable.task.service.delegate.DelegateTask;
-import org.flowable.task.service.impl.persistence.entity.TaskEntity;
 
 /**
  * @author Joram Barrez

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/tasklistener/CandidateUserAssignment.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/tasklistener/CandidateUserAssignment.java
@@ -13,9 +13,7 @@
 package org.flowable.examples.bpmn.tasklistener;
 
 import org.flowable.engine.delegate.TaskListener;
-import org.flowable.engine.impl.util.TaskHelper;
 import org.flowable.task.service.delegate.DelegateTask;
-import org.flowable.task.service.impl.persistence.entity.TaskEntity;
 
 /**
  * @author Joram Barrez

--- a/modules/flowable-idm-engine/src/main/java/org/flowable/idm/engine/IdmEngines.java
+++ b/modules/flowable-idm-engine/src/main/java/org/flowable/idm/engine/IdmEngines.java
@@ -14,8 +14,6 @@ package org.flowable.idm.engine;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -72,7 +70,7 @@ public abstract class IdmEngines {
             while (resources.hasMoreElements()) {
                 configUrls.add(resources.nextElement());
             }
-            for (Iterator<URL> iterator = configUrls.iterator(); iterator.hasNext();) {
+            for (Iterator<URL> iterator = configUrls.iterator(); iterator.hasNext(); ) {
                 URL resource = iterator.next();
                 LOGGER.info("Initializing idm engine using configuration '{}'", resource.toString());
                 initIdmEngineFromResource(resource);
@@ -99,8 +97,8 @@ public abstract class IdmEngines {
     protected static void initIdmEngineFromSpringResource(URL resource) {
         try {
             Class<?> springConfigurationHelperClass = ReflectUtil.loadClass("org.flowable.idm.spring.SpringIdmConfigurationHelper");
-            Method method = springConfigurationHelperClass.getDeclaredMethod("buildIdmEngine", new Class<?>[] { URL.class });
-            IdmEngine idmEngine = (IdmEngine) method.invoke(null, new Object[] { resource });
+            Method method = springConfigurationHelperClass.getDeclaredMethod("buildIdmEngine", new Class<?>[]{URL.class});
+            IdmEngine idmEngine = (IdmEngine) method.invoke(null, new Object[]{resource});
 
             String idmEngineName = idmEngine.getName();
             EngineInfo idmEngineInfo = new EngineInfo(idmEngineName, resource.toString(), null);
@@ -172,7 +170,9 @@ public abstract class IdmEngines {
         }
     }
 
-    /** Get initialization results. */
+    /**
+     * Get initialization results.
+     */
     public static List<EngineInfo> getIdmEngineInfos() {
         return idmEngineInfos;
     }
@@ -191,9 +191,8 @@ public abstract class IdmEngines {
 
     /**
      * obtain a idm engine by name.
-     * 
-     * @param idmEngineName
-     *            is the name of the idm engine or null for the default idm engine.
+     *
+     * @param idmEngineName is the name of the idm engine or null for the default idm engine.
      */
     public static IdmEngine getIdmEngine(String idmEngineName) {
         if (!isInitialized()) {

--- a/modules/flowable-ui-task/flowable-ui-task-conf/src/main/java/org/flowable/app/servlet/ContentDispatcherServletConfiguration.java
+++ b/modules/flowable-ui-task/flowable-ui-task-conf/src/main/java/org/flowable/app/servlet/ContentDispatcherServletConfiguration.java
@@ -17,10 +17,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport;
 
 @Configuration
-@ComponentScan({ "org.flowable.rest.content.exception", "org.flowable.rest.content.service.api" })
+@ComponentScan({"org.flowable.rest.content.exception", "org.flowable.rest.content.service.api"})
 @EnableAsync
 public class ContentDispatcherServletConfiguration extends BaseDispatcherServletConfiguration {
 

--- a/modules/flowable-ui-task/flowable-ui-task-conf/src/main/java/org/flowable/app/servlet/DmnDispatcherServletConfiguration.java
+++ b/modules/flowable-ui-task/flowable-ui-task-conf/src/main/java/org/flowable/app/servlet/DmnDispatcherServletConfiguration.java
@@ -17,10 +17,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport;
 
 @Configuration
-@ComponentScan({ "org.flowable.rest.dmn.exception", "org.flowable.rest.dmn.service.api" })
+@ComponentScan({"org.flowable.rest.dmn.exception", "org.flowable.rest.dmn.service.api"})
 @EnableAsync
 public class DmnDispatcherServletConfiguration extends BaseDispatcherServletConfiguration {
 

--- a/modules/flowable-ui-task/flowable-ui-task-conf/src/main/java/org/flowable/app/servlet/FormDispatcherServletConfiguration.java
+++ b/modules/flowable-ui-task/flowable-ui-task-conf/src/main/java/org/flowable/app/servlet/FormDispatcherServletConfiguration.java
@@ -17,10 +17,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport;
 
 @Configuration
-@ComponentScan({ "org.flowable.rest.form.exception", "org.flowable.rest.form.service.api" })
+@ComponentScan({"org.flowable.rest.form.exception", "org.flowable.rest.form.service.api"})
 @EnableAsync
 public class FormDispatcherServletConfiguration extends BaseDispatcherServletConfiguration {
 

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/ProcessEngines.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/ProcessEngines.java
@@ -14,8 +14,6 @@ package org.activiti.engine;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -28,10 +26,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.activiti.engine.impl.ProcessEngineInfoImpl;
 import org.activiti.engine.impl.util.IoUtil;
 import org.activiti.engine.impl.util.ReflectUtil;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
Periodic code cleanups:
* unnecessary semi-colon
* unnecessary 'null' check before 'instanceof'
* expand '*" import
* remove unused imports
* explicit type replaced with <>
* replace string concatenation in logging calls with {}
* replace Arrays.asList{} calls with one argument with Collection.singletonList()
* replace string concatenation in append() sequence to use append()
etc.