### PR TITLE
Provide an abstract base class for a FlowableEventListener

### DIFF
--- a/modules/flowable-engine-common-api/src/main/java/org/flowable/engine/common/api/delegate/event/FlowableEngineEventType.java
+++ b/modules/flowable-engine-common-api/src/main/java/org/flowable/engine/common/api/delegate/event/FlowableEngineEventType.java
@@ -180,11 +180,6 @@ public enum FlowableEngineEventType implements FlowableEventType {
      * Indicates the engine has taken (ie. followed) a sequenceflow from a source activity to a target activity.
      */
     SEQUENCEFLOW_TAKEN,
-
-    /**
-     * When a BPMN Error was thrown, but was not caught within in the process.
-     */
-    UNCAUGHT_BPMN_ERROR,
     
     /**
      * A new variable has been created.
@@ -268,23 +263,7 @@ public enum FlowableEngineEventType implements FlowableEventType {
      * 
      * Note that history (minimum level ACTIVITY) must be enabled to receive this event.
      */
-    HISTORIC_PROCESS_INSTANCE_ENDED,
-
-    /**
-     * A new membership has been created.
-     */
-    MEMBERSHIP_CREATED,
-
-    /**
-     * A single membership has been deleted.
-     */
-    MEMBERSHIP_DELETED,
-
-    /**
-     * All memberships in the related group have been deleted. No individual {@link #MEMBERSHIP_DELETED} events will be dispatched due to possible performance reasons. The event is dispatched before
-     * the memberships are deleted, so they can still be accessed in the dispatch method of the listener.
-     */
-    MEMBERSHIPS_DELETED;
+    HISTORIC_PROCESS_INSTANCE_ENDED;
 
     public static final FlowableEngineEventType[] EMPTY_ARRAY = new FlowableEngineEventType[] {};
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/AbstractFlowableEngineEventListener.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/AbstractFlowableEngineEventListener.java
@@ -1,0 +1,286 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.flowable.engine.delegate.event;
+
+import org.flowable.engine.common.api.delegate.event.FlowableEngineEntityEvent;
+import org.flowable.engine.common.api.delegate.event.FlowableEngineEvent;
+import org.flowable.engine.common.api.delegate.event.FlowableEngineEventType;
+import org.flowable.engine.common.api.delegate.event.FlowableEntityEvent;
+import org.flowable.engine.common.api.delegate.event.FlowableEvent;
+import org.flowable.engine.common.api.delegate.event.FlowableEventListener;
+import org.flowable.engine.common.impl.interceptor.CommandContext;
+import org.flowable.engine.delegate.DelegateExecution;
+import org.flowable.engine.impl.util.CommandContextUtil;
+import org.flowable.variable.service.event.FlowableVariableEvent;
+
+import java.util.Set;
+
+/**
+ *  @author Robert Hafner
+ */
+public abstract class AbstractFlowableEngineEventListener implements FlowableEventListener {
+
+    protected Set<FlowableEngineEventType> types;
+
+    public AbstractFlowableEngineEventListener() {}
+
+    public AbstractFlowableEngineEventListener(Set<FlowableEngineEventType> types) {
+        this.types = types;
+    }
+
+    @Override
+    public void onEvent(FlowableEvent flowableEvent) {
+        if(flowableEvent instanceof FlowableEngineEvent) {
+            FlowableEngineEvent flowableEngineEvent = (FlowableEngineEvent) flowableEvent;
+            FlowableEngineEventType engineEventType = (FlowableEngineEventType) flowableEvent.getType();
+
+            if(types == null || types.contains(engineEventType)) {
+                switch (engineEventType) {
+                    case ENTITY_CREATED:
+                        entityCreated((FlowableEntityEvent) flowableEngineEvent);
+                        break;
+                    case ENTITY_INITIALIZED:
+                        entityInitialized((FlowableEntityEvent) flowableEngineEvent);
+                        break;
+                    case ENTITY_UPDATED:
+                        entityUpdated((FlowableEntityEvent) flowableEngineEvent);
+                        break;
+                    case ENTITY_DELETED:
+                        entityDeleted((FlowableEntityEvent) flowableEngineEvent);
+                        break;
+                    case ENTITY_SUSPENDED:
+                        entitySuspended((FlowableEntityEvent) flowableEngineEvent);
+                        break;
+                    case ENTITY_ACTIVATED:
+                        entityActivated((FlowableEntityEvent) flowableEngineEvent);
+                        break;
+                    case TIMER_SCHEDULED:
+                        timerScheduled((FlowableEntityEvent) flowableEngineEvent);
+                        break;
+                    case TIMER_FIRED:
+                        timerFired((FlowableEntityEvent) flowableEngineEvent);
+                        break;
+                    case JOB_CANCELED:
+                        jobCancelled((FlowableEntityEvent) flowableEngineEvent);
+                        break;
+                    case JOB_EXECUTION_SUCCESS:
+                        jobExecutionSuccess((FlowableEntityEvent) flowableEngineEvent);
+                        break;
+                    case JOB_EXECUTION_FAILURE:
+                        jobExecutionFailure((FlowableEntityEvent) flowableEngineEvent);
+                        break;
+                    case JOB_RETRIES_DECREMENTED:
+                        jobRetriesDecremented((FlowableEntityEvent) flowableEngineEvent);
+                        break;
+                    case JOB_RESCHEDULED:
+                        jobRescheduled((FlowableEntityEvent) flowableEngineEvent);
+                        break;
+                    case CUSTOM:
+                        custom(flowableEngineEvent);
+                        break;
+                    case ENGINE_CREATED:
+                        engineCreated((FlowableProcessEngineEvent) flowableEngineEvent);
+                        break;
+                    case ENGINE_CLOSED:
+                        engineClosed((FlowableProcessEngineEvent) flowableEngineEvent);
+                        break;
+                    case ACTIVITY_STARTED:
+                        activityStarted((FlowableActivityEvent) flowableEngineEvent);
+                        break;
+                    case ACTIVITY_COMPLETED:
+                        activityCompleted((FlowableActivityEvent) flowableEngineEvent);
+                        break;
+                    case ACTIVITY_CANCELLED:
+                        activityCancelled((FlowableActivityCancelledEvent) flowableEngineEvent);
+                        break;
+                    case ACTIVITY_SIGNAL_WAITING:
+                        activitySignalWaiting((FlowableSignalEvent) flowableEngineEvent);
+                        break;
+                    case ACTIVITY_SIGNALED:
+                        activitySignaled((FlowableSignalEvent) flowableEngineEvent);
+                        break;
+                    case ACTIVITY_COMPENSATE:
+                        activityCompensate((FlowableActivityEvent) flowableEngineEvent);
+                        break;
+                    case ACTIVITY_MESSAGE_WAITING:
+                        activityMessageWaiting((FlowableMessageEvent) flowableEngineEvent);
+                        break;
+                    case ACTIVITY_MESSAGE_RECEIVED:
+                        activityMessageReceived((FlowableMessageEvent) flowableEngineEvent);
+                        break;
+                    case ACTIVITY_MESSAGE_CANCELLED:
+                        activityMessageCancelled((FlowableMessageEvent) flowableEngineEvent);
+                        break;
+                    case ACTIVITY_ERROR_RECEIVED:
+                        activityErrorReceived((FlowableErrorEvent) flowableEngineEvent);
+                        break;
+                    case HISTORIC_ACTIVITY_INSTANCE_CREATED:
+                        historicActivityInstanceCreated((FlowableEntityEvent) flowableEngineEvent);
+                        break;
+                    case HISTORIC_ACTIVITY_INSTANCE_ENDED:
+                        historicActivityInstanceEnded((FlowableEntityEvent) flowableEngineEvent);
+                        break;
+                    case SEQUENCEFLOW_TAKEN:
+                        sequenceFlowTaken((FlowableSequenceFlowTakenEvent) flowableEngineEvent);
+                        break;
+                    case VARIABLE_CREATED:
+                        variableCreated((FlowableVariableEvent) flowableEngineEvent);
+                        break;
+                    case VARIABLE_UPDATED:
+                        variableUpdatedEvent((FlowableVariableEvent) flowableEngineEvent);
+                        break;
+                    case VARIABLE_DELETED:
+                        variableDeletedEvent((FlowableVariableEvent) flowableEngineEvent);
+                        break;
+                    case TASK_CREATED:
+                        taskCreated((FlowableEngineEntityEvent) flowableEngineEvent);
+                        break;
+                    case TASK_ASSIGNED:
+                        taskAssigned((FlowableEntityEvent) flowableEngineEvent);
+                        break;
+                    case TASK_COMPLETED:
+                        taskCompleted((FlowableEntityEvent) flowableEngineEvent);
+                        break;
+                    case PROCESS_CREATED:
+                        processCreated((FlowableEntityEvent) flowableEngineEvent);
+                        break;
+                    case PROCESS_STARTED:
+                        processStarted((FlowableProcessStartedEvent) flowableEngineEvent);
+                        break;
+                    case PROCESS_COMPLETED:
+                        processCompleted((FlowableEngineEntityEvent) flowableEngineEvent);
+                        break;
+                    case PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT:
+                        processCompletedWithTerminateEnd((FlowableEngineEntityEvent) flowableEngineEvent);
+                        break;
+                    case PROCESS_COMPLETED_WITH_ERROR_END_EVENT:
+                        processCompletedWithErrorEnd((FlowableEntityEvent) flowableEngineEvent);
+                        break;
+                    case PROCESS_CANCELLED:
+                        processCancelled((FlowableCancelledEvent) flowableEngineEvent);
+                        break;
+                    case HISTORIC_PROCESS_INSTANCE_CREATED:
+                        historicProcessInstanceCreated((FlowableEntityEvent) flowableEngineEvent);
+                        break;
+                    case HISTORIC_PROCESS_INSTANCE_ENDED:
+                        historicProcessInstanceEnded((FlowableEntityEvent) flowableEngineEvent);
+                        break;
+                }
+            }
+        }
+    }
+
+    @Override
+    public boolean isFailOnException() {
+        return true;
+    }
+
+    protected void entityCreated(FlowableEntityEvent event) {}
+
+    protected void entityInitialized(FlowableEntityEvent event) {}
+
+    protected void entityUpdated(FlowableEntityEvent event) {}
+
+    protected void entityDeleted(FlowableEntityEvent event) {}
+
+    protected void entitySuspended(FlowableEntityEvent event) {}
+
+    protected void entityActivated(FlowableEntityEvent event) {}
+
+    protected void timerScheduled(FlowableEntityEvent event) {}
+
+    protected void timerFired(FlowableEntityEvent event) {}
+
+    protected void jobCancelled(FlowableEntityEvent event) {}
+
+    protected void jobExecutionSuccess(FlowableEntityEvent event) {}
+
+    protected void jobExecutionFailure(FlowableEntityEvent event) {}
+
+    protected void jobRetriesDecremented(FlowableEntityEvent event) {}
+
+    protected void jobRescheduled(FlowableEntityEvent event) {}
+
+    protected void custom(FlowableEngineEvent event) {}
+
+    protected void engineCreated(FlowableProcessEngineEvent event) {}
+
+    protected void engineClosed(FlowableProcessEngineEvent flowableEngineEvent) {}
+
+    protected void activityStarted(FlowableActivityEvent event) {}
+
+    protected void activityCompleted(FlowableActivityEvent event) {}
+
+    protected void activityCancelled(FlowableActivityCancelledEvent event) {}
+
+    protected void activitySignalWaiting(FlowableSignalEvent event) {}
+
+    protected void activitySignaled(FlowableSignalEvent event) {}
+
+    protected void activityCompensate(FlowableActivityEvent event) {}
+
+    protected void activityMessageWaiting(FlowableMessageEvent event) {}
+
+    protected void activityMessageReceived(FlowableMessageEvent event) {}
+
+    protected void activityMessageCancelled(FlowableMessageEvent event) {}
+
+    protected void activityErrorReceived(FlowableErrorEvent event) {}
+
+    protected void historicActivityInstanceCreated(FlowableEntityEvent event) {}
+
+    protected void historicActivityInstanceEnded(FlowableEntityEvent event) {}
+
+    protected void sequenceFlowTaken(FlowableSequenceFlowTakenEvent event) {}
+
+    protected void variableCreated(FlowableVariableEvent event) {}
+
+    protected void variableUpdatedEvent(FlowableVariableEvent event) {}
+
+    protected void variableDeletedEvent(FlowableVariableEvent event) {}
+
+    protected void taskCreated(FlowableEngineEntityEvent event) {}
+
+    protected void taskAssigned(FlowableEntityEvent event) {}
+
+    protected void taskCompleted(FlowableEntityEvent event) {}
+
+    protected void processCreated(FlowableEntityEvent event) {}
+
+    protected void processStarted(FlowableProcessStartedEvent event) {}
+
+    protected void processCompleted(FlowableEngineEntityEvent event) {}
+
+    protected void processCompletedWithTerminateEnd(FlowableEngineEntityEvent event) {}
+
+    protected void processCompletedWithErrorEnd(FlowableEntityEvent event) {}
+
+    protected void processCancelled(FlowableCancelledEvent event) {}
+
+    protected void historicProcessInstanceCreated(FlowableEntityEvent event) {}
+
+    protected void historicProcessInstanceEnded(FlowableEntityEvent event) {}
+
+    protected DelegateExecution getExecution(FlowableEngineEvent event) {
+        String executionId = event.getExecutionId();
+
+        if (executionId != null) {
+            CommandContext commandContext = CommandContextUtil.getCommandContext();
+            if (commandContext != null) {
+                return CommandContextUtil.getExecutionEntityManager(commandContext).findById(executionId);
+                }
+            }
+        return null;
+    }
+}

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/CancelCallActivityTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/CancelCallActivityTest.java
@@ -13,15 +13,19 @@
 package org.flowable.engine.test.api.event;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 
+import org.flowable.engine.common.api.delegate.event.FlowableEngineEntityEvent;
 import org.flowable.engine.common.api.delegate.event.FlowableEngineEventType;
 import org.flowable.engine.common.api.delegate.event.FlowableEntityEvent;
 import org.flowable.engine.common.api.delegate.event.FlowableEvent;
-import org.flowable.engine.common.api.delegate.event.FlowableEventListener;
+import org.flowable.engine.delegate.event.AbstractFlowableEngineEventListener;
 import org.flowable.engine.delegate.event.FlowableActivityCancelledEvent;
 import org.flowable.engine.delegate.event.FlowableActivityEvent;
 import org.flowable.engine.delegate.event.FlowableCancelledEvent;
+import org.flowable.engine.delegate.event.FlowableProcessStartedEvent;
 import org.flowable.engine.event.EventLogEntry;
 import org.flowable.engine.impl.event.logger.EventLogger;
 import org.flowable.engine.impl.persistence.entity.ExecutionEntity;
@@ -197,11 +201,22 @@ public class CancelCallActivityTest extends PluggableFlowableTestCase {
         assertEquals(20, mylistener.getEventsReceived().size());
     }
 
-    class CallActivityEventListener implements FlowableEventListener {
+    class CallActivityEventListener extends AbstractFlowableEngineEventListener {
 
         private List<FlowableEvent> eventsReceived;
 
         public CallActivityEventListener() {
+            super(new HashSet<>(Arrays.asList(
+                    FlowableEngineEventType.ENTITY_CREATED,
+                    FlowableEngineEventType.ACTIVITY_STARTED,
+                    FlowableEngineEventType.ACTIVITY_COMPLETED,
+                    FlowableEngineEventType.ACTIVITY_CANCELLED,
+                    FlowableEngineEventType.TASK_CREATED,
+                    FlowableEngineEventType.TASK_COMPLETED,
+                    FlowableEngineEventType.PROCESS_STARTED,
+                    FlowableEngineEventType.PROCESS_COMPLETED,
+                    FlowableEngineEventType.PROCESS_CANCELLED
+            )));
             eventsReceived = new ArrayList<>();
         }
 
@@ -214,29 +229,50 @@ public class CancelCallActivityTest extends PluggableFlowableTestCase {
         }
 
         @Override
-        public void onEvent(FlowableEvent event) {
-            FlowableEngineEventType engineEventType = (FlowableEngineEventType) event.getType();
-            switch (engineEventType) {
-            case ENTITY_CREATED:
-                FlowableEntityEvent entityEvent = (FlowableEntityEvent) event;
-                if (entityEvent.getEntity() instanceof ExecutionEntity) {
-                    eventsReceived.add(event);
-                }
-                break;
-            case ACTIVITY_STARTED:
-            case ACTIVITY_COMPLETED:
-            case ACTIVITY_CANCELLED:
-            case TASK_CREATED:
-            case TASK_COMPLETED:
-            case PROCESS_STARTED:
-            case PROCESS_COMPLETED:
-            case PROCESS_CANCELLED:
+        protected void entityCreated(FlowableEntityEvent event) {
+            if (event.getEntity() instanceof ExecutionEntity) {
                 eventsReceived.add(event);
-                break;
-            default:
-                break;
-
             }
+        }
+
+        @Override
+        protected void activityStarted(FlowableActivityEvent event) {
+            eventsReceived.add(event);
+        }
+
+        @Override
+        protected void activityCancelled(FlowableActivityCancelledEvent event) {
+            eventsReceived.add(event);
+        }
+
+        @Override
+        protected void activityCompleted(FlowableActivityEvent event) {
+            eventsReceived.add(event);
+        }
+
+        @Override
+        protected void taskCreated(FlowableEngineEntityEvent event) {
+            eventsReceived.add(event);
+        }
+
+        @Override
+        protected void taskCompleted(FlowableEntityEvent event) {
+            eventsReceived.add(event);
+        }
+
+        @Override
+        protected void processStarted(FlowableProcessStartedEvent event) {
+            eventsReceived.add(event);
+        }
+
+        @Override
+        protected void processCompleted(FlowableEngineEntityEvent event) {
+            eventsReceived.add(event);
+        }
+
+        @Override
+        protected void processCancelled(FlowableCancelledEvent event) {
+            eventsReceived.add(event);
         }
 
         @Override

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/CancelUserTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/CancelUserTaskTest.java
@@ -13,14 +13,18 @@
 package org.flowable.engine.test.api.event;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 
+import org.flowable.engine.common.api.delegate.event.FlowableEngineEntityEvent;
 import org.flowable.engine.common.api.delegate.event.FlowableEngineEventType;
 import org.flowable.engine.common.api.delegate.event.FlowableEntityEvent;
 import org.flowable.engine.common.api.delegate.event.FlowableEvent;
-import org.flowable.engine.common.api.delegate.event.FlowableEventListener;
+import org.flowable.engine.delegate.event.AbstractFlowableEngineEventListener;
 import org.flowable.engine.delegate.event.FlowableActivityCancelledEvent;
 import org.flowable.engine.delegate.event.FlowableActivityEvent;
+import org.flowable.engine.delegate.event.FlowableCancelledEvent;
 import org.flowable.engine.delegate.event.FlowableProcessStartedEvent;
 import org.flowable.engine.impl.persistence.entity.ExecutionEntity;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
@@ -239,11 +243,22 @@ public class CancelUserTaskTest extends PluggableFlowableTestCase {
         assertEquals(12, testListener.getEventsReceived().size());
     }
 
-    class UserActivityEventListener implements FlowableEventListener {
+    class UserActivityEventListener extends AbstractFlowableEngineEventListener {
 
         private List<FlowableEvent> eventsReceived;
 
         public UserActivityEventListener() {
+            super(new HashSet<>(Arrays.asList(
+                    FlowableEngineEventType.ACTIVITY_STARTED,
+                    FlowableEngineEventType.ACTIVITY_COMPLETED,
+                    FlowableEngineEventType.ACTIVITY_CANCELLED,
+                    FlowableEngineEventType.TASK_CREATED,
+                    FlowableEngineEventType.TASK_COMPLETED,
+                    FlowableEngineEventType.PROCESS_STARTED,
+                    FlowableEngineEventType.PROCESS_COMPLETED,
+                    FlowableEngineEventType.PROCESS_CANCELLED,
+                    FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT
+            )));
             eventsReceived = new ArrayList<>();
         }
 
@@ -256,24 +271,48 @@ public class CancelUserTaskTest extends PluggableFlowableTestCase {
         }
 
         @Override
-        public void onEvent(FlowableEvent event) {
+        protected void activityStarted(FlowableActivityEvent event) {
+            eventsReceived.add(event);
+        }
 
-            FlowableEngineEventType engineEventType = (FlowableEngineEventType) event.getType();
-            switch (engineEventType) {
-            case ACTIVITY_STARTED:
-            case ACTIVITY_COMPLETED:
-            case ACTIVITY_CANCELLED:
-            case TASK_CREATED:
-            case TASK_COMPLETED:
-            case PROCESS_STARTED:
-            case PROCESS_COMPLETED:
-            case PROCESS_CANCELLED:
-            case PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT:
-                eventsReceived.add(event);
-                break;
-            default:
-                break;
-            }
+        @Override
+        protected void activityCompleted(FlowableActivityEvent event) {
+            eventsReceived.add(event);
+        }
+
+        @Override
+        protected void activityCancelled(FlowableActivityCancelledEvent event) {
+            eventsReceived.add(event);
+        }
+
+        @Override
+        protected void taskCreated(FlowableEngineEntityEvent event) {
+            eventsReceived.add(event);
+        }
+
+        @Override
+        protected void taskCompleted(FlowableEntityEvent event) {
+            eventsReceived.add(event);
+        }
+
+        @Override
+        protected void processStarted(FlowableProcessStartedEvent event) {
+            eventsReceived.add(event);
+        }
+
+        @Override
+        protected void processCompleted(FlowableEngineEntityEvent event) {
+            eventsReceived.add(event);
+        }
+
+        @Override
+        protected void processCompletedWithTerminateEnd(FlowableEngineEntityEvent event) {
+            eventsReceived.add(event);
+        }
+
+        @Override
+        protected void processCancelled(FlowableCancelledEvent event) {
+            eventsReceived.add(event);
         }
 
         @Override

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.java
@@ -13,12 +13,15 @@
 package org.flowable.engine.test.api.event;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 
+import org.flowable.engine.common.api.delegate.event.FlowableEngineEntityEvent;
 import org.flowable.engine.common.api.delegate.event.FlowableEngineEventType;
 import org.flowable.engine.common.api.delegate.event.FlowableEntityEvent;
 import org.flowable.engine.common.api.delegate.event.FlowableEvent;
-import org.flowable.engine.common.api.delegate.event.FlowableEventListener;
+import org.flowable.engine.delegate.event.AbstractFlowableEngineEventListener;
 import org.flowable.engine.delegate.event.FlowableActivityCancelledEvent;
 import org.flowable.engine.delegate.event.FlowableActivityEvent;
 import org.flowable.engine.delegate.event.FlowableCancelledEvent;
@@ -811,11 +814,22 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
         assertEquals(idx, testListener.getEventsReceived().size());
     }
 
-    class MultiInstanceUserActivityEventListener implements FlowableEventListener {
+    class MultiInstanceUserActivityEventListener extends AbstractFlowableEngineEventListener {
 
         private List<FlowableEvent> eventsReceived;
 
         public MultiInstanceUserActivityEventListener() {
+            super(new HashSet<>(Arrays.asList(
+                FlowableEngineEventType.ACTIVITY_STARTED,
+                FlowableEngineEventType.ACTIVITY_COMPLETED,
+                FlowableEngineEventType.ACTIVITY_CANCELLED,
+                FlowableEngineEventType.TASK_CREATED,
+                FlowableEngineEventType.TASK_COMPLETED,
+                FlowableEngineEventType.PROCESS_STARTED,
+                FlowableEngineEventType.PROCESS_COMPLETED,
+                FlowableEngineEventType.PROCESS_CANCELLED,
+                FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT
+            )));
             eventsReceived = new ArrayList<>();
         }
 
@@ -828,24 +842,48 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
         }
 
         @Override
-        public void onEvent(FlowableEvent event) {
+        protected void activityStarted(FlowableActivityEvent event) {
+            eventsReceived.add(event);
+        }
 
-            FlowableEngineEventType engineEventType = (FlowableEngineEventType) event.getType();
-            switch (engineEventType) {
-                case ACTIVITY_STARTED:
-                case ACTIVITY_COMPLETED:
-                case ACTIVITY_CANCELLED:
-                case TASK_CREATED:
-                case TASK_COMPLETED:
-                case PROCESS_STARTED:
-                case PROCESS_COMPLETED:
-                case PROCESS_CANCELLED:
-                case PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT:
-                    eventsReceived.add(event);
-                    break;
-                default:
-                    break;
-            }
+        @Override
+        protected void activityCompleted(FlowableActivityEvent event) {
+            eventsReceived.add(event);
+        }
+
+        @Override
+        protected void activityCancelled(FlowableActivityCancelledEvent event) {
+            eventsReceived.add(event);
+        }
+
+        @Override
+        protected void taskCreated(FlowableEngineEntityEvent event) {
+            eventsReceived.add(event);
+        }
+
+        @Override
+        protected void taskCompleted(FlowableEntityEvent event) {
+            eventsReceived.add(event);
+        }
+
+        @Override
+        protected void processStarted(FlowableProcessStartedEvent event) {
+            eventsReceived.add(event);
+        }
+
+        @Override
+        protected void processCompleted(FlowableEngineEntityEvent event) {
+            eventsReceived.add(event);
+        }
+
+        @Override
+        protected void processCompletedWithTerminateEnd(FlowableEngineEntityEvent event) {
+            eventsReceived.add(event);
+        }
+
+        @Override
+        protected void processCancelled(FlowableCancelledEvent event) {
+            eventsReceived.add(event);
         }
 
         @Override

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/TestHistoricActivityEventListener.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/TestHistoricActivityEventListener.java
@@ -13,20 +13,30 @@
 package org.flowable.engine.test.api.event;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 
 import org.flowable.engine.common.api.delegate.event.FlowableEngineEventType;
+import org.flowable.engine.common.api.delegate.event.FlowableEntityEvent;
 import org.flowable.engine.common.api.delegate.event.FlowableEvent;
 import org.flowable.engine.common.api.delegate.event.FlowableEventListener;
+import org.flowable.engine.delegate.event.AbstractFlowableEngineEventListener;
 
 /**
  * @author Joram Barrez
  */
-public class TestHistoricActivityEventListener implements FlowableEventListener {
+public class TestHistoricActivityEventListener extends AbstractFlowableEngineEventListener {
 
     private List<FlowableEvent> eventsReceived;
 
     public TestHistoricActivityEventListener() {
+        super(new HashSet<>(Arrays.asList(
+                FlowableEngineEventType.HISTORIC_PROCESS_INSTANCE_CREATED,
+                FlowableEngineEventType.HISTORIC_PROCESS_INSTANCE_ENDED,
+                FlowableEngineEventType.HISTORIC_ACTIVITY_INSTANCE_CREATED,
+                FlowableEngineEventType.HISTORIC_ACTIVITY_INSTANCE_ENDED
+        )));
         eventsReceived = new ArrayList<>();
     }
 
@@ -39,13 +49,23 @@ public class TestHistoricActivityEventListener implements FlowableEventListener 
     }
 
     @Override
-    public void onEvent(FlowableEvent event) {
-        if (event.getType().equals(FlowableEngineEventType.HISTORIC_PROCESS_INSTANCE_CREATED)
-                || event.getType().equals(FlowableEngineEventType.HISTORIC_PROCESS_INSTANCE_ENDED)
-                || event.getType().equals(FlowableEngineEventType.HISTORIC_ACTIVITY_INSTANCE_CREATED)
-                || event.getType().equals(FlowableEngineEventType.HISTORIC_ACTIVITY_INSTANCE_ENDED)) {
-            eventsReceived.add(event);
-        }
+    protected void historicActivityInstanceCreated(FlowableEntityEvent event) {
+        eventsReceived.add(event);
+    }
+
+    @Override
+    protected void historicActivityInstanceEnded(FlowableEntityEvent event) {
+        eventsReceived.add(event);
+    }
+
+    @Override
+    protected void historicProcessInstanceCreated(FlowableEntityEvent event) {
+        eventsReceived.add(event);
+    }
+
+    @Override
+    protected void historicProcessInstanceEnded(FlowableEntityEvent event) {
+        eventsReceived.add(event);
     }
 
     @Override

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/TestVariableEventListener.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/TestVariableEventListener.java
@@ -16,10 +16,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.flowable.engine.common.api.delegate.event.FlowableEvent;
-import org.flowable.engine.common.api.delegate.event.FlowableEventListener;
+import org.flowable.engine.delegate.event.AbstractFlowableEngineEventListener;
 import org.flowable.variable.service.event.FlowableVariableEvent;
 
-public class TestVariableEventListener implements FlowableEventListener {
+public class TestVariableEventListener extends AbstractFlowableEngineEventListener {
 
     private List<FlowableEvent> eventsReceived;
 
@@ -36,10 +36,18 @@ public class TestVariableEventListener implements FlowableEventListener {
     }
 
     @Override
-    public void onEvent(FlowableEvent event) {
-        if (event instanceof FlowableVariableEvent) {
-            eventsReceived.add(event);
-        }
+    protected void variableCreated(FlowableVariableEvent event) {
+        eventsReceived.add(event);
+    }
+
+    @Override
+    protected void variableUpdatedEvent(FlowableVariableEvent event) {
+        eventsReceived.add(event);
+    }
+
+    @Override
+    protected void variableDeletedEvent(FlowableVariableEvent event) {
+        eventsReceived.add(event);
     }
 
     @Override

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/v6/Flowable6ExecutionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/v6/Flowable6ExecutionTest.java
@@ -16,8 +16,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.flowable.engine.common.api.delegate.event.FlowableEvent;
-import org.flowable.engine.common.api.delegate.event.FlowableEventListener;
 import org.flowable.engine.common.impl.history.HistoryLevel;
+import org.flowable.engine.delegate.event.AbstractFlowableEngineEventListener;
 import org.flowable.engine.delegate.event.FlowableActivityCancelledEvent;
 import org.flowable.engine.delegate.event.FlowableActivityEvent;
 import org.flowable.engine.history.HistoricActivityInstance;
@@ -328,7 +328,7 @@ public class Flowable6ExecutionTest extends PluggableFlowableTestCase {
         processEngineConfiguration.getEventDispatcher().removeEventListener(listener);
     }
 
-    public class SubProcessEventListener implements FlowableEventListener {
+    public class SubProcessEventListener extends AbstractFlowableEngineEventListener {
 
         private List<FlowableEvent> eventsReceived;
 
@@ -345,23 +345,24 @@ public class Flowable6ExecutionTest extends PluggableFlowableTestCase {
         }
 
         @Override
-        public void onEvent(FlowableEvent activitiEvent) {
-            if (activitiEvent instanceof FlowableActivityEvent) {
-                FlowableActivityEvent event = (FlowableActivityEvent) activitiEvent;
-                if ("subProcess".equals(event.getActivityType())) {
-                    eventsReceived.add(event);
-                }
-            } else if (activitiEvent instanceof FlowableActivityCancelledEvent) {
-                FlowableActivityCancelledEvent event = (FlowableActivityCancelledEvent) activitiEvent;
-                if ("subProcess".equals(event.getActivityType())) {
-                    eventsReceived.add(event);
-                }
+        protected void activityStarted(FlowableActivityEvent event) {
+            if ("subProcess".equals(event.getActivityType())) {
+                eventsReceived.add(event);
             }
         }
 
         @Override
-        public boolean isFailOnException() {
-            return true;
+        protected void activityCancelled(FlowableActivityCancelledEvent event) {
+            if ("subProcess".equals(event.getActivityType())) {
+                eventsReceived.add(event);
+            }
+        }
+
+        @Override
+        protected void activityCompleted(FlowableActivityEvent event) {
+            if ("subProcess".equals(event.getActivityType())) {
+                eventsReceived.add(event);
+            }
         }
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/StartTimerEventRepeatWithoutN.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/StartTimerEventRepeatWithoutN.java
@@ -15,10 +15,14 @@ package org.flowable.engine.test.bpmn.event.timer;
 
 import org.flowable.engine.common.api.FlowableException;
 import org.flowable.engine.common.api.delegate.event.FlowableEngineEventType;
+import org.flowable.engine.common.api.delegate.event.FlowableEntityEvent;
 import org.flowable.engine.common.api.delegate.event.FlowableEvent;
-import org.flowable.engine.common.api.delegate.event.FlowableEventListener;
+import org.flowable.engine.delegate.event.AbstractFlowableEngineEventListener;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.test.Deployment;
+
+import java.util.Arrays;
+import java.util.HashSet;
 
 /**
  * @author Saeid Mirzaei Test case for ACT-4066
@@ -29,13 +33,15 @@ public class StartTimerEventRepeatWithoutN extends PluggableFlowableTestCase {
     protected long counter;
     protected StartEventListener startEventListener;
 
-    class StartEventListener implements FlowableEventListener {
+    class StartEventListener extends AbstractFlowableEngineEventListener {
+
+        public StartEventListener() {
+            super(new HashSet<>(Arrays.asList(FlowableEngineEventType.TIMER_FIRED)));
+        }
 
         @Override
-        public void onEvent(FlowableEvent event) {
-            if (event.getType().equals(FlowableEngineEventType.TIMER_FIRED)) {
-                counter++;
-            }
+        protected void timerFired(FlowableEntityEvent event) {
+            counter++;
         }
 
         @Override

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/usertask/SkipExpressionUserTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/usertask/SkipExpressionUserTaskTest.java
@@ -13,14 +13,19 @@
 package org.flowable.examples.bpmn.usertask;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
+import org.flowable.engine.common.api.delegate.event.FlowableEngineEntityEvent;
 import org.flowable.engine.common.api.delegate.event.FlowableEngineEventType;
+import org.flowable.engine.common.api.delegate.event.FlowableEntityEvent;
 import org.flowable.engine.common.api.delegate.event.FlowableEvent;
 import org.flowable.engine.common.api.delegate.event.FlowableEventListener;
 import org.flowable.engine.common.impl.history.HistoryLevel;
+import org.flowable.engine.delegate.event.AbstractFlowableEngineEventListener;
 import org.flowable.engine.history.HistoricActivityInstance;
 import org.flowable.engine.impl.test.HistoryTestHelper;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
@@ -121,19 +126,22 @@ public class SkipExpressionUserTaskTest extends PluggableFlowableTestCase {
         }
     }
     
-    public class SkipFlowableEventListener implements FlowableEventListener {
-        
+    public class SkipFlowableEventListener extends AbstractFlowableEngineEventListener {
+
+        public SkipFlowableEventListener() {
+            super(new HashSet<>(Arrays.asList(FlowableEngineEventType.TASK_CREATED, FlowableEngineEventType.TASK_COMPLETED)));
+        }
         protected List<FlowableEvent> createdEvents = new ArrayList<>();
         protected List<FlowableEvent> completedEvents = new ArrayList<>();
 
         @Override
-        public void onEvent(FlowableEvent event) {
-            if (FlowableEngineEventType.TASK_CREATED == event.getType()) {
-                createdEvents.add(event);
-                
-            } else if (FlowableEngineEventType.TASK_COMPLETED == event.getType()) {
-                completedEvents.add(event);
-            }
+        protected void taskCreated(FlowableEngineEntityEvent event) {
+            createdEvents.add(event);
+        }
+
+        @Override
+        protected void taskCompleted(FlowableEntityEvent event) {
+            completedEvents.add(event);
         }
 
         @Override

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/event/GetProcessOnDefinitionInitializedListener.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/event/GetProcessOnDefinitionInitializedListener.java
@@ -14,25 +14,20 @@ package org.flowable.standalone.event;
 
 import org.flowable.bpmn.model.Process;
 import org.flowable.engine.common.api.delegate.event.FlowableEntityEvent;
-import org.flowable.engine.common.api.delegate.event.FlowableEvent;
-import org.flowable.engine.common.api.delegate.event.FlowableEventListener;
+import org.flowable.engine.delegate.event.AbstractFlowableEngineEventListener;
 import org.flowable.engine.impl.persistence.entity.ProcessDefinitionEntity;
 import org.flowable.engine.impl.util.ProcessDefinitionUtil;
 
-/**
- * This class...
- */
-public class GetProcessOnDefinitionInitializedListener implements FlowableEventListener {
+public class GetProcessOnDefinitionInitializedListener extends AbstractFlowableEngineEventListener {
 
     public static String processId;
 
     @Override
-    public void onEvent(FlowableEvent event) {
-        if (((FlowableEntityEvent) event).getEntity() instanceof ProcessDefinitionEntity) {
-            Process process = ProcessDefinitionUtil.getProcess(((ProcessDefinitionEntity) ((FlowableEntityEvent) event).getEntity()).getId());
+    protected void entityInitialized(FlowableEntityEvent event) {
+        if (event.getEntity() instanceof ProcessDefinitionEntity) {
+            Process process = ProcessDefinitionUtil.getProcess(((ProcessDefinitionEntity) event.getEntity()).getId());
             processId = process.getId();
         }
-
     }
 
     @Override


### PR DESCRIPTION
Benefits:
* Typed callback methods.
* Provides a way to retrieve the execution.

This change also removes enumerated values that are no longer used from the FlowableEngineEventType class.