### PR TITLE
Point to new location of quartz cron trigger tutorial

### DIFF
--- a/userguide/src/en/ch07b-BPMN-Constructs.adoc
+++ b/userguide/src/en/ch07b-BPMN-Constructs.adoc
@@ -107,7 +107,7 @@ Additionally, you can specify time cycle using cron expressions; the example bel
 ----
 
 
-Please see link:$$http://www.quartz-scheduler.org/docs/tutorials/crontrigger.html$$[this tutorial] for using cron expressions.
+Please see link:$$http://www.quartz-scheduler.org/documentation/quartz-2.x/tutorials/crontrigger.html$$[this tutorial] for using cron expressions.
 
 *Note:* The first symbol denotes seconds, not minutes as in normal Unix cron.
 


### PR DESCRIPTION
Quartz has made some changes to their site. The previous location points to a 404 site. I think that the 2.x site should be OK for the trigger.

Maybe you want to update the `CronExpression` to the latest one as well.