### PR TITLE
Centralise Camel dependency and upgrade to latest

### DIFF
--- a/modules/flowable-camel/pom.xml
+++ b/modules/flowable-camel/pom.xml
@@ -32,8 +32,8 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
       <scope>provided</scope>
-	 </dependency>
-   <dependency>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
@@ -61,7 +61,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-mvel</artifactId>
       <scope>test</scope>
-      <version>2.17.1</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.uuid</groupId>

--- a/modules/flowable5-camel-test/pom.xml
+++ b/modules/flowable5-camel-test/pom.xml
@@ -86,7 +86,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-mvel</artifactId>
       <scope>test</scope>
-      <version>2.10.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.uuid</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
 		<spring.security.version>4.2.3.RELEASE</spring.security.version>
 		<jackson.version>2.7.5</jackson.version>
 		<mule.version>3.8.0</mule.version>
+		<camel.version>2.17.1</camel.version>
 		<cxf.version>3.1.6</cxf.version>
 		<batik.version>1.7</batik.version>
 
@@ -868,7 +869,12 @@
 			<dependency>
 				<groupId>org.apache.camel</groupId>
 				<artifactId>camel-spring</artifactId>
-				<version>2.17.1</version>
+				<version>${camel.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.camel</groupId>
+				<artifactId>camel-mvel</artifactId>
+				<version>${camel.version}</version>
 			</dependency>
 			<!-- Mule integration -->
 			<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 		<spring.security.version>4.2.3.RELEASE</spring.security.version>
 		<jackson.version>2.7.5</jackson.version>
 		<mule.version>3.8.0</mule.version>
-		<camel.version>2.17.1</camel.version>
+		<camel.version>2.19.3</camel.version>
 		<cxf.version>3.1.6</cxf.version>
 		<batik.version>1.7</batik.version>
 


### PR DESCRIPTION
This PR adds a `camel.version` property to the root pom and adds the Camel dependencies to `dependencyManagement`. Second commit upgrades Camel 2.17.1 to 2.19.3.