### PR TITLE
Correctly bind headers

### DIFF
--- a/modules/flowable-http/src/main/java/org/flowable/http/impl/HttpActivityBehaviorImpl.java
+++ b/modules/flowable-http/src/main/java/org/flowable/http/impl/HttpActivityBehaviorImpl.java
@@ -20,6 +20,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLSession;
@@ -77,6 +79,7 @@ public class HttpActivityBehaviorImpl extends HttpActivityBehavior {
 
     private static final long serialVersionUID = 1L;
     private static final Logger LOGGER = LoggerFactory.getLogger(HttpActivityBehaviorImpl.class);
+    private static final Pattern HEADER_PATTERN = Pattern.compile("(.+):(.+)");
     
     protected HttpServiceTask httpServiceTask;
 
@@ -257,13 +260,13 @@ public class HttpActivityBehaviorImpl extends HttpActivityBehavior {
         try (BufferedReader reader = new BufferedReader(new StringReader(headers))) {
             String line = reader.readLine();
             while (line != null) {
-                String[] header = line.split(":");
-                if (header.length == 2) {
-                    base.addHeader(header[0], header[1]);
-                    line = reader.readLine();
-                } else {
+                Matcher matcher = HEADER_PATTERN.matcher(line);
+                if (!matcher.matches()) {
                     throw new FlowableException(HTTP_TASK_REQUEST_HEADERS_INVALID);
                 }
+
+                base.addHeader(matcher.group(1), matcher.group(2));
+                line = reader.readLine();
             }
         }
     }

--- a/modules/flowable-http/src/test/java/org/flowable/http/HttpServiceTaskTest.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/HttpServiceTaskTest.java
@@ -289,7 +289,7 @@ public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
         Map<String, Object> variables = new HashMap<>();
         variables.put("method", "POST");
         variables.put("url", "https://localhost:9799/api?code=500");
-        variables.put("headers", "Content-Type: text/plain\nX-Request-ID: 623b94fc-14b8-4ee6-aed7-b16b9321e29f");
+        variables.put("headers", "Content-Type: text/plain\nX-Request-ID: 623b94fc-14b8-4ee6-aed7-b16b9321e29f\nhost:localhost:7000");
         variables.put("body", body);
         variables.put("timeout", 2000);
         variables.put("ignore", true);
@@ -305,7 +305,7 @@ public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
         Map<String, Object> request = new HashMap<>();
         request.put("httpPost500.requestMethod", "POST");
         request.put("httpPost500.requestUrl", "https://localhost:9799/api?code=500");
-        request.put("httpPost500.requestHeaders", "Content-Type: text/plain\nX-Request-ID: 623b94fc-14b8-4ee6-aed7-b16b9321e29f");
+        request.put("httpPost500.requestHeaders", "Content-Type: text/plain\nX-Request-ID: 623b94fc-14b8-4ee6-aed7-b16b9321e29f\nhost:localhost:7000");
         request.put("httpPost500.requestBody", body);
         assertEquals(runtimeService, process.getId(), request);
         // Response assertions


### PR DESCRIPTION
Each header line is split only on first ':' everything before ':' is considered as name and everything after as value

Fixes #575 

I couldn't find a test that tests this behaviour. Is there something that actually tests this class?