### PR TITLE
578 Multi-instance export not working properly

### DIFF
--- a/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/MultiInstanceTaskConverterTest2.java
+++ b/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/MultiInstanceTaskConverterTest2.java
@@ -1,0 +1,112 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.editor.language.xml;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.flowable.bpmn.model.BpmnModel;
+import org.flowable.bpmn.model.FlowElement;
+import org.flowable.bpmn.model.MultiInstanceLoopCharacteristics;
+import org.flowable.bpmn.model.Process;
+import org.flowable.bpmn.model.StartEvent;
+import org.flowable.bpmn.model.SubProcess;
+import org.flowable.bpmn.model.UserTask;
+import org.junit.Test;
+
+/**
+ * @see <a href="https://github.com/flowable/flowable-engine/issues/474">Issue 474</a>
+ */
+public class MultiInstanceTaskConverterTest2 extends AbstractConverterTest {
+	private static final String PARTICIPANT_VALUE = "[\n" +
+"                   {\n" +
+"                     \"principalType\" : \"User\",\n" +
+"                     \"role\" : \"PotentialOwner\",\n" +
+"                     \"principal\" : \"wfuser1\",\n" +
+"                     \"version\" : 1\n" +
+"                   },\n" +
+"                   {\n" +
+"                     \"principalType\" : \"User\",\n" +
+"                     \"role\" : \"PotentialOwner\",\n" +
+"                     \"principal\" : \"wfuser2\",\n" +
+"                     \"version\" : 1\n" +
+"                   }\n" +
+"                 ]";
+
+    @Test
+    public void convertXMLToModel() throws Exception {
+        BpmnModel bpmnModel = readXMLFile();
+        validateModel(bpmnModel);
+    }
+
+    @Test
+    public void convertModelToXML() throws Exception {
+        BpmnModel bpmnModel = readXMLFile();
+        BpmnModel parsedModel = exportAndReadXMLFile(bpmnModel);
+        validateModel(parsedModel);
+        deployProcess(parsedModel);
+    }
+
+    @Override
+    protected String getResource() {
+        return "multiinstancemodel2.bpmn";
+    }
+
+    private void validateModel(BpmnModel model) {
+    	Process main = model.getMainProcess();
+
+    	// verify start
+    	FlowElement flowElement = main.getFlowElement("start1");
+        assertNotNull(flowElement);
+        assertTrue(flowElement instanceof StartEvent);
+
+        // verify user task
+        flowElement = main.getFlowElement("userTask1");
+        assertNotNull(flowElement);
+        assertEquals("User task 1", flowElement.getName());
+        assertTrue(flowElement instanceof UserTask);
+
+        UserTask task = (UserTask) flowElement;
+        MultiInstanceLoopCharacteristics loopCharacteristics = task.getLoopCharacteristics();
+        assertEquals("participant", loopCharacteristics.getElementVariable());
+        assertEquals(PARTICIPANT_VALUE, loopCharacteristics.getCollectionString().trim());
+        assertEquals("delegateExpression", loopCharacteristics.getHandler().getImplementationType());
+        assertEquals("${collectionHandler}", loopCharacteristics.getHandler().getImplementation());
+
+        // verify subprocess
+        flowElement = main.getFlowElement("subprocess1");
+        assertNotNull(flowElement);
+        assertEquals("subProcess", flowElement.getName());
+        assertTrue(flowElement instanceof SubProcess);
+
+        SubProcess subProcess = (SubProcess) flowElement;
+        loopCharacteristics = subProcess.getLoopCharacteristics();
+        assertTrue(loopCharacteristics.isSequential());
+        assertEquals("10", loopCharacteristics.getLoopCardinality());
+        assertEquals(5, subProcess.getFlowElements().size());
+
+        // verify user task in subprocess
+        flowElement = subProcess.getFlowElement("subUserTask1");
+        assertNotNull(flowElement);
+        assertEquals("User task 2", flowElement.getName());
+        assertTrue(flowElement instanceof UserTask);
+
+        task = (UserTask) flowElement;
+        loopCharacteristics = task.getLoopCharacteristics();
+        assertEquals("participant", loopCharacteristics.getElementVariable());
+        assertEquals("${potentialOwnerList}", loopCharacteristics.getInputDataItem());
+        assertEquals("delegateExpression", loopCharacteristics.getHandler().getImplementationType());
+        assertEquals("${collectionHandler}", loopCharacteristics.getHandler().getImplementation());
+    }
+}

--- a/modules/flowable-bpmn-converter/src/test/resources/multiinstancemodel2.bpmn
+++ b/modules/flowable-bpmn-converter/src/test/resources/multiinstancemodel2.bpmn
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:flowable="http://flowable.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://www.flowable.org/test">
+  <process id="multiinstancemodel" name="multiinstancemodel" isExecutable="true">
+    <dataObject id="numTasks" name="numTasks" itemSubjectRef="xsd:string"/>
+    <dataObject id="numActiveTasks" name="numActiveTasks" itemSubjectRef="xsd:string"/>
+    <dataObject itemSubjectRef="xsd:string" name="potentialOwnerList" id="ID_91ee51f3-481d-439c-a62d-8b382a1cf7a1">
+      <extensionElements>
+        <flowable:value>
+        <![CDATA[
+        [
+          {
+            "principalType" : "User",
+            "role" : "PotentialOwner",
+            "principal" : "wfuser1",
+            "version" : 1
+          },
+          {
+            "principalType" : "User",
+            "role" : "PotentialOwner",
+            "principal" : "wfuser2",
+            "version" : 1
+          }
+        ]
+        ]]>
+        </flowable:value>
+      </extensionElements>
+    </dataObject>
+    <sequenceFlow id="sid-4BE8FBF0-B946-48DB-9B18-488BF8DFE4D1" sourceRef="boundaryEvent1" targetRef="sid-194696BA-1A7D-47D7-95A9-A77390D25048"></sequenceFlow>
+    <sequenceFlow id="sid-04DAFAA0-34C1-48DF-BAD5-1038344BBFA9" sourceRef="start1" targetRef="userTask1"></sequenceFlow>
+    <subProcess id="subprocess1" name="subProcess">
+      <multiInstanceLoopCharacteristics isSequential="true">
+        <loopCardinality>10</loopCardinality>
+      </multiInstanceLoopCharacteristics>
+      <endEvent id="sid-565296D1-FCF9-4B31-9048-528B10A27C46"></endEvent>
+      <startEvent id="subStartEvent"></startEvent>
+      <sequenceFlow id="sid-C7145ECA-31A2-4A91-B20A-023CF0764155" sourceRef="subUserTask1" targetRef="sid-565296D1-FCF9-4B31-9048-528B10A27C46"></sequenceFlow>
+      <userTask id="subUserTask1" name="User task 2">
+      <multiInstanceLoopCharacteristics isSequential="false" flowable:elementVariable="participant">
+        <extensionElements>
+          <flowable:collection flowable:delegateExpression="${collectionHandler}">
+             <flowable:expression>${potentialOwnerList}</flowable:expression>
+          </flowable:collection>
+        </extensionElements>
+      </multiInstanceLoopCharacteristics>
+      </userTask>
+      <sequenceFlow id="subFlowId1" sourceRef="subStartEvent" targetRef="subUserTask1"></sequenceFlow>
+    </subProcess>
+    <startEvent id="start1"></startEvent>
+    <boundaryEvent id="boundaryEvent1" attachedToRef="subprocess1" cancelActivity="false">
+      <timerEventDefinition>
+        <timeDuration>PT5M</timeDuration>
+      </timerEventDefinition>
+    </boundaryEvent>
+    <sequenceFlow id="sid-D6D5AFA6-7673-4DFB-B118-675622C58DF2" sourceRef="subprocess1" targetRef="sid-194696BA-1A7D-47D7-95A9-A77390D25048"></sequenceFlow>
+    <sequenceFlow id="sid-287D861F-4498-4A5C-8EC8-E07F79265E90" sourceRef="userTask1" targetRef="subprocess1"></sequenceFlow>
+    <endEvent id="sid-194696BA-1A7D-47D7-95A9-A77390D25048"></endEvent>
+    <userTask id="userTask1" name="User task 1" flowable:async="true" flowable:exclusive="false">
+      <multiInstanceLoopCharacteristics isSequential="false" flowable:elementVariable="participant">
+        <extensionElements>
+          <flowable:collection flowable:delegateExpression="${collectionHandler}">
+            <flowable:string>
+              <![CDATA[[
+                   {
+                     "principalType" : "User",
+                     "role" : "PotentialOwner",
+                     "principal" : "wfuser1",
+                     "version" : 1
+                   },
+                   {
+                     "principalType" : "User",
+                     "role" : "PotentialOwner",
+                     "principal" : "wfuser2",
+                     "version" : 1
+                   }
+                 ]]]>
+            </flowable:string>
+          </flowable:collection>
+        </extensionElements>
+      </multiInstanceLoopCharacteristics>
+    </userTask>
+  </process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_process">
+    <bpmndi:BPMNPlane bpmnElement="process" id="BPMNPlane_process">
+      <bpmndi:BPMNShape bpmnElement="subprocess1" id="BPMNShape_subprocess1" isExpanded="false">
+        <omgdc:Bounds height="160.0" width="348.0" x="345.0" y="125.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="sid-565296D1-FCF9-4B31-9048-528B10A27C46" id="BPMNShape_sid-565296D1-FCF9-4B31-9048-528B10A27C46">
+        <omgdc:Bounds height="35.0" width="35.0" x="585.0" y="190.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="subStartEvent" id="BPMNShape_subStartEvent">
+        <omgdc:Bounds height="35.0" width="35.0" x="365.0" y="189.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="subUserTask1" id="BPMNShape_subUserTask1">
+        <omgdc:Bounds height="80.0" width="100.0" x="440.0" y="164.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="boundaryEvent1" id="BPMNShape_boundaryEvent1">
+        <omgdc:Bounds height="30.0" width="30.0" x="492.0" y="270.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="start1" id="BPMNShape_start1">
+        <omgdc:Bounds height="35.0" width="35.0" x="105.0" y="190.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="sid-194696BA-1A7D-47D7-95A9-A77390D25048" id="BPMNShape_sid-194696BA-1A7D-47D7-95A9-A77390D25048">
+        <omgdc:Bounds height="35.0" width="35.0" x="738.0" y="191.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="userTask1" id="BPMNShape_userTask1">
+        <omgdc:Bounds height="80.0" width="100.0" x="180.0" y="165.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="sid-4BE8FBF0-B946-48DB-9B18-488BF8DFE4D1" id="BPMNEdge_sid-4BE8FBF0-B946-48DB-9B18-488BF8DFE4D1">
+        <omgdi:waypoint x="507.0" y="300.0"></omgdi:waypoint>
+        <omgdi:waypoint x="752.0" y="355.0"></omgdi:waypoint>
+        <omgdi:waypoint x="755.0" y="226.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="sid-04DAFAA0-34C1-48DF-BAD5-1038344BBFA9" id="BPMNEdge_sid-04DAFAA0-34C1-48DF-BAD5-1038344BBFA9">
+        <omgdi:waypoint x="140.0" y="207.0"></omgdi:waypoint>
+        <omgdi:waypoint x="180.0" y="205.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="sid-C7145ECA-31A2-4A91-B20A-023CF0764155" id="BPMNEdge_sid-C7145ECA-31A2-4A91-B20A-023CF0764155">
+        <omgdi:waypoint x="540.0" y="204.0"></omgdi:waypoint>
+        <omgdi:waypoint x="585.0" y="207.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="subFlowId1" id="BPMNEdge_subFlowId1">
+        <omgdi:waypoint x="400.0" y="206.0"></omgdi:waypoint>
+        <omgdi:waypoint x="440.0" y="204.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="sid-D6D5AFA6-7673-4DFB-B118-675622C58DF2" id="BPMNEdge_sid-D6D5AFA6-7673-4DFB-B118-675622C58DF2">
+        <omgdi:waypoint x="693.0" y="205.0"></omgdi:waypoint>
+        <omgdi:waypoint x="738.0" y="208.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="sid-287D861F-4498-4A5C-8EC8-E07F79265E90" id="BPMNEdge_sid-287D861F-4498-4A5C-8EC8-E07F79265E90">
+        <omgdi:waypoint x="280.0" y="205.0"></omgdi:waypoint>
+        <omgdi:waypoint x="345.0" y="205.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>


### PR DESCRIPTION
The flowable prefix is missing from the collection element and the
collection expression is always set as the collection attribute.
Unfortunately, this causes any custom collection handler to get lost
upon export.

I have added a new unit test for these conditions and refactored the
handler export.