### PR TITLE
add candidateAssignedToOthers flag to TaskInfoQuery interface

### DIFF
--- a/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/export/MultiInstanceExport.java
+++ b/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/export/MultiInstanceExport.java
@@ -22,8 +22,8 @@ import org.flowable.bpmn.constants.BpmnXMLConstants;
 import org.flowable.bpmn.converter.util.BpmnXMLUtil;
 import org.flowable.bpmn.model.Activity;
 import org.flowable.bpmn.model.BpmnModel;
-import org.flowable.bpmn.model.ExtensionElement;
 import org.flowable.bpmn.model.CollectionHandler;
+import org.flowable.bpmn.model.ExtensionElement;
 import org.flowable.bpmn.model.MultiInstanceLoopCharacteristics;
 
 public class MultiInstanceExport implements BpmnXMLConstants {
@@ -31,12 +31,14 @@ public class MultiInstanceExport implements BpmnXMLConstants {
     public static void writeMultiInstance(Activity activity, BpmnModel model, XMLStreamWriter xtw) throws Exception {
         if (activity.getLoopCharacteristics() != null) {
             MultiInstanceLoopCharacteristics multiInstanceObject = activity.getLoopCharacteristics();
+            CollectionHandler handler = multiInstanceObject.getHandler();
             if (StringUtils.isNotEmpty(multiInstanceObject.getLoopCardinality()) || StringUtils.isNotEmpty(multiInstanceObject.getInputDataItem())
                     || StringUtils.isNotEmpty(multiInstanceObject.getCompletionCondition()) || StringUtils.isNotEmpty(multiInstanceObject.getCollectionString())) {
 
                 xtw.writeStartElement(ELEMENT_MULTIINSTANCE);
                 BpmnXMLUtil.writeDefaultAttribute(ATTRIBUTE_MULTIINSTANCE_SEQUENTIAL, String.valueOf(multiInstanceObject.isSequential()).toLowerCase(), xtw);
-                if (StringUtils.isNotEmpty(multiInstanceObject.getInputDataItem())) {
+                // if a custom handler is not specified, then use the attribute
+                if (handler == null && StringUtils.isNotEmpty(multiInstanceObject.getInputDataItem())) {
                     BpmnXMLUtil.writeQualifiedAttribute(ATTRIBUTE_MULTIINSTANCE_COLLECTION, multiInstanceObject.getInputDataItem(), xtw);
                 }
                 if (StringUtils.isNotEmpty(multiInstanceObject.getElementVariable())) {
@@ -54,28 +56,31 @@ public class MultiInstanceExport implements BpmnXMLConstants {
                 }
 
                 // check for collection element handler
-                CollectionHandler handler = multiInstanceObject.getHandler();
                 if (handler != null) {
-                	// start extensions
+                    // start extensions
                     xtw.writeStartElement(ELEMENT_EXTENSIONS);
                     
-                    if (StringUtils.isNotEmpty(multiInstanceObject.getCollectionString())) {
-                        // start collection element
-                        xtw.writeStartElement(ELEMENT_MULTIINSTANCE_COLLECTION);
-                        
-                    	if (StringUtils.isNotEmpty(handler.getImplementationType()) && ATTRIBUTE_MULTIINSTANCE_COLLECTION_CLASS.equals(handler.getImplementationType())) {
-                            BpmnXMLUtil.writeQualifiedAttribute(ATTRIBUTE_MULTIINSTANCE_COLLECTION_CLASS, handler.getImplementation(), xtw);
-                        } else if (StringUtils.isNotEmpty(handler.getImplementationType()) && ATTRIBUTE_MULTIINSTANCE_COLLECTION_DELEGATEEXPRESSION.equals(handler.getImplementationType())) {
-                            BpmnXMLUtil.writeQualifiedAttribute(ATTRIBUTE_MULTIINSTANCE_COLLECTION_DELEGATEEXPRESSION, handler.getImplementation(), xtw);
-                        }
+                    // start collection element
+                    xtw.writeStartElement(FLOWABLE_EXTENSIONS_NAMESPACE, ELEMENT_MULTIINSTANCE_COLLECTION);
 
-                        xtw.writeStartElement(FLOWABLE_EXTENSIONS_NAMESPACE, ELEMENT_MULTIINSTANCE_COLLECTION_STRING);
+                    // collection handler attribute
+                    BpmnXMLUtil.writeQualifiedAttribute(handler.getImplementationType(), handler.getImplementation(), xtw);
+                    
+                    if (StringUtils.isNotEmpty(multiInstanceObject.getInputDataItem())) {
+                        // use an expression element if there is a handler specified
+                        xtw.writeStartElement(FLOWABLE_EXTENSIONS_NAMESPACE, ELEMENT_MULTIINSTANCE_COLLECTION_EXPRESSION);
+                        xtw.writeCharacters(multiInstanceObject.getInputDataItem());
+                        xtw.writeEndElement();
+                        
+                    } else if (StringUtils.isNotEmpty(multiInstanceObject.getCollectionString())) {
+                        
+                    	xtw.writeStartElement(FLOWABLE_EXTENSIONS_NAMESPACE, ELEMENT_MULTIINSTANCE_COLLECTION_STRING);
                         xtw.writeCData(multiInstanceObject.getCollectionString().trim());
                         xtw.writeEndElement();
-                        
-                        // end collection element
-                        xtw.writeEndElement();
                     }
+                    
+                    // end collection element
+                    xtw.writeEndElement();
                 }
                 
             	

--- a/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/MultiInstanceTaskConverterTest2.java
+++ b/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/MultiInstanceTaskConverterTest2.java
@@ -1,0 +1,112 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.editor.language.xml;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.flowable.bpmn.model.BpmnModel;
+import org.flowable.bpmn.model.FlowElement;
+import org.flowable.bpmn.model.MultiInstanceLoopCharacteristics;
+import org.flowable.bpmn.model.Process;
+import org.flowable.bpmn.model.StartEvent;
+import org.flowable.bpmn.model.SubProcess;
+import org.flowable.bpmn.model.UserTask;
+import org.junit.Test;
+
+/**
+ * @see <a href="https://github.com/flowable/flowable-engine/issues/474">Issue 474</a>
+ */
+public class MultiInstanceTaskConverterTest2 extends AbstractConverterTest {
+    private static final String PARTICIPANT_VALUE = "[\n" +
+"                   {\n" +
+"                     \"principalType\" : \"User\",\n" +
+"                     \"role\" : \"PotentialOwner\",\n" +
+"                     \"principal\" : \"wfuser1\",\n" +
+"                     \"version\" : 1\n" +
+"                   },\n" +
+"                   {\n" +
+"                     \"principalType\" : \"User\",\n" +
+"                     \"role\" : \"PotentialOwner\",\n" +
+"                     \"principal\" : \"wfuser2\",\n" +
+"                     \"version\" : 1\n" +
+"                   }\n" +
+"                 ]";
+
+    @Test
+    public void convertXMLToModel() throws Exception {
+        BpmnModel bpmnModel = readXMLFile();
+        validateModel(bpmnModel);
+    }
+
+    @Test
+    public void convertModelToXML() throws Exception {
+        BpmnModel bpmnModel = readXMLFile();
+        BpmnModel parsedModel = exportAndReadXMLFile(bpmnModel);
+        validateModel(parsedModel);
+        deployProcess(parsedModel);
+    }
+
+    @Override
+    protected String getResource() {
+        return "multiinstancemodel2.bpmn";
+    }
+
+    private void validateModel(BpmnModel model) {
+        Process main = model.getMainProcess();
+
+        // verify start
+        FlowElement flowElement = main.getFlowElement("start1");
+        assertNotNull(flowElement);
+        assertTrue(flowElement instanceof StartEvent);
+
+        // verify user task
+        flowElement = main.getFlowElement("userTask1");
+        assertNotNull(flowElement);
+        assertEquals("User task 1", flowElement.getName());
+        assertTrue(flowElement instanceof UserTask);
+
+        UserTask task = (UserTask) flowElement;
+        MultiInstanceLoopCharacteristics loopCharacteristics = task.getLoopCharacteristics();
+        assertEquals("participant", loopCharacteristics.getElementVariable());
+        assertEquals(PARTICIPANT_VALUE, loopCharacteristics.getCollectionString().trim());
+        assertEquals("delegateExpression", loopCharacteristics.getHandler().getImplementationType());
+        assertEquals("${collectionHandler}", loopCharacteristics.getHandler().getImplementation());
+
+        // verify subprocess
+        flowElement = main.getFlowElement("subprocess1");
+        assertNotNull(flowElement);
+        assertEquals("subProcess", flowElement.getName());
+        assertTrue(flowElement instanceof SubProcess);
+
+        SubProcess subProcess = (SubProcess) flowElement;
+        loopCharacteristics = subProcess.getLoopCharacteristics();
+        assertTrue(loopCharacteristics.isSequential());
+        assertEquals("10", loopCharacteristics.getLoopCardinality());
+        assertEquals(5, subProcess.getFlowElements().size());
+
+        // verify user task in subprocess
+        flowElement = subProcess.getFlowElement("subUserTask1");
+        assertNotNull(flowElement);
+        assertEquals("User task 2", flowElement.getName());
+        assertTrue(flowElement instanceof UserTask);
+
+        task = (UserTask) flowElement;
+        loopCharacteristics = task.getLoopCharacteristics();
+        assertEquals("participant", loopCharacteristics.getElementVariable());
+        assertEquals("${potentialOwnerList}", loopCharacteristics.getInputDataItem());
+        assertEquals("delegateExpression", loopCharacteristics.getHandler().getImplementationType());
+        assertEquals("${collectionHandler}", loopCharacteristics.getHandler().getImplementation());
+    }
+}

--- a/modules/flowable-bpmn-converter/src/test/resources/multiinstancemodel2.bpmn
+++ b/modules/flowable-bpmn-converter/src/test/resources/multiinstancemodel2.bpmn
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:flowable="http://flowable.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://www.flowable.org/test">
+  <process id="multiinstancemodel" name="multiinstancemodel" isExecutable="true">
+    <dataObject id="numTasks" name="numTasks" itemSubjectRef="xsd:string"/>
+    <dataObject id="numActiveTasks" name="numActiveTasks" itemSubjectRef="xsd:string"/>
+    <dataObject itemSubjectRef="xsd:string" name="potentialOwnerList" id="ID_91ee51f3-481d-439c-a62d-8b382a1cf7a1">
+      <extensionElements>
+        <flowable:value>
+        <![CDATA[
+        [
+          {
+            "principalType" : "User",
+            "role" : "PotentialOwner",
+            "principal" : "wfuser1",
+            "version" : 1
+          },
+          {
+            "principalType" : "User",
+            "role" : "PotentialOwner",
+            "principal" : "wfuser2",
+            "version" : 1
+          }
+        ]
+        ]]>
+        </flowable:value>
+      </extensionElements>
+    </dataObject>
+    <sequenceFlow id="sid-4BE8FBF0-B946-48DB-9B18-488BF8DFE4D1" sourceRef="boundaryEvent1" targetRef="sid-194696BA-1A7D-47D7-95A9-A77390D25048"></sequenceFlow>
+    <sequenceFlow id="sid-04DAFAA0-34C1-48DF-BAD5-1038344BBFA9" sourceRef="start1" targetRef="userTask1"></sequenceFlow>
+    <subProcess id="subprocess1" name="subProcess">
+      <multiInstanceLoopCharacteristics isSequential="true">
+        <loopCardinality>10</loopCardinality>
+      </multiInstanceLoopCharacteristics>
+      <endEvent id="sid-565296D1-FCF9-4B31-9048-528B10A27C46"></endEvent>
+      <startEvent id="subStartEvent"></startEvent>
+      <sequenceFlow id="sid-C7145ECA-31A2-4A91-B20A-023CF0764155" sourceRef="subUserTask1" targetRef="sid-565296D1-FCF9-4B31-9048-528B10A27C46"></sequenceFlow>
+      <userTask id="subUserTask1" name="User task 2">
+      <multiInstanceLoopCharacteristics isSequential="false" flowable:elementVariable="participant">
+        <extensionElements>
+          <flowable:collection flowable:delegateExpression="${collectionHandler}">
+             <flowable:expression>${potentialOwnerList}</flowable:expression>
+          </flowable:collection>
+        </extensionElements>
+      </multiInstanceLoopCharacteristics>
+      </userTask>
+      <sequenceFlow id="subFlowId1" sourceRef="subStartEvent" targetRef="subUserTask1"></sequenceFlow>
+    </subProcess>
+    <startEvent id="start1"></startEvent>
+    <boundaryEvent id="boundaryEvent1" attachedToRef="subprocess1" cancelActivity="false">
+      <timerEventDefinition>
+        <timeDuration>PT5M</timeDuration>
+      </timerEventDefinition>
+    </boundaryEvent>
+    <sequenceFlow id="sid-D6D5AFA6-7673-4DFB-B118-675622C58DF2" sourceRef="subprocess1" targetRef="sid-194696BA-1A7D-47D7-95A9-A77390D25048"></sequenceFlow>
+    <sequenceFlow id="sid-287D861F-4498-4A5C-8EC8-E07F79265E90" sourceRef="userTask1" targetRef="subprocess1"></sequenceFlow>
+    <endEvent id="sid-194696BA-1A7D-47D7-95A9-A77390D25048"></endEvent>
+    <userTask id="userTask1" name="User task 1" flowable:async="true" flowable:exclusive="false">
+      <multiInstanceLoopCharacteristics isSequential="false" flowable:elementVariable="participant">
+        <extensionElements>
+          <flowable:collection flowable:delegateExpression="${collectionHandler}">
+            <flowable:string>
+              <![CDATA[[
+                   {
+                     "principalType" : "User",
+                     "role" : "PotentialOwner",
+                     "principal" : "wfuser1",
+                     "version" : 1
+                   },
+                   {
+                     "principalType" : "User",
+                     "role" : "PotentialOwner",
+                     "principal" : "wfuser2",
+                     "version" : 1
+                   }
+                 ]]]>
+            </flowable:string>
+          </flowable:collection>
+        </extensionElements>
+      </multiInstanceLoopCharacteristics>
+    </userTask>
+  </process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_process">
+    <bpmndi:BPMNPlane bpmnElement="process" id="BPMNPlane_process">
+      <bpmndi:BPMNShape bpmnElement="subprocess1" id="BPMNShape_subprocess1" isExpanded="false">
+        <omgdc:Bounds height="160.0" width="348.0" x="345.0" y="125.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="sid-565296D1-FCF9-4B31-9048-528B10A27C46" id="BPMNShape_sid-565296D1-FCF9-4B31-9048-528B10A27C46">
+        <omgdc:Bounds height="35.0" width="35.0" x="585.0" y="190.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="subStartEvent" id="BPMNShape_subStartEvent">
+        <omgdc:Bounds height="35.0" width="35.0" x="365.0" y="189.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="subUserTask1" id="BPMNShape_subUserTask1">
+        <omgdc:Bounds height="80.0" width="100.0" x="440.0" y="164.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="boundaryEvent1" id="BPMNShape_boundaryEvent1">
+        <omgdc:Bounds height="30.0" width="30.0" x="492.0" y="270.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="start1" id="BPMNShape_start1">
+        <omgdc:Bounds height="35.0" width="35.0" x="105.0" y="190.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="sid-194696BA-1A7D-47D7-95A9-A77390D25048" id="BPMNShape_sid-194696BA-1A7D-47D7-95A9-A77390D25048">
+        <omgdc:Bounds height="35.0" width="35.0" x="738.0" y="191.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="userTask1" id="BPMNShape_userTask1">
+        <omgdc:Bounds height="80.0" width="100.0" x="180.0" y="165.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="sid-4BE8FBF0-B946-48DB-9B18-488BF8DFE4D1" id="BPMNEdge_sid-4BE8FBF0-B946-48DB-9B18-488BF8DFE4D1">
+        <omgdi:waypoint x="507.0" y="300.0"></omgdi:waypoint>
+        <omgdi:waypoint x="752.0" y="355.0"></omgdi:waypoint>
+        <omgdi:waypoint x="755.0" y="226.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="sid-04DAFAA0-34C1-48DF-BAD5-1038344BBFA9" id="BPMNEdge_sid-04DAFAA0-34C1-48DF-BAD5-1038344BBFA9">
+        <omgdi:waypoint x="140.0" y="207.0"></omgdi:waypoint>
+        <omgdi:waypoint x="180.0" y="205.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="sid-C7145ECA-31A2-4A91-B20A-023CF0764155" id="BPMNEdge_sid-C7145ECA-31A2-4A91-B20A-023CF0764155">
+        <omgdi:waypoint x="540.0" y="204.0"></omgdi:waypoint>
+        <omgdi:waypoint x="585.0" y="207.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="subFlowId1" id="BPMNEdge_subFlowId1">
+        <omgdi:waypoint x="400.0" y="206.0"></omgdi:waypoint>
+        <omgdi:waypoint x="440.0" y="204.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="sid-D6D5AFA6-7673-4DFB-B118-675622C58DF2" id="BPMNEdge_sid-D6D5AFA6-7673-4DFB-B118-675622C58DF2">
+        <omgdi:waypoint x="693.0" y="205.0"></omgdi:waypoint>
+        <omgdi:waypoint x="738.0" y="208.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="sid-287D861F-4498-4A5C-8EC8-E07F79265E90" id="BPMNEdge_sid-287D861F-4498-4A5C-8EC8-E07F79265E90">
+        <omgdi:waypoint x="280.0" y="205.0"></omgdi:waypoint>
+        <omgdi:waypoint x="345.0" y="205.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/modules/flowable-camel/pom.xml
+++ b/modules/flowable-camel/pom.xml
@@ -32,8 +32,8 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
       <scope>provided</scope>
-	 </dependency>
-   <dependency>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
@@ -61,7 +61,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-mvel</artifactId>
       <scope>test</scope>
-      <version>2.17.1</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.uuid</groupId>

--- a/modules/flowable-http/src/main/java/org/flowable/http/impl/HttpActivityBehaviorImpl.java
+++ b/modules/flowable-http/src/main/java/org/flowable/http/impl/HttpActivityBehaviorImpl.java
@@ -20,8 +20,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Timer;
 import java.util.TimerTask;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLSession;
@@ -55,7 +53,6 @@ import org.flowable.bpmn.model.ServiceTask;
 import org.flowable.engine.cfg.HttpClientConfig;
 import org.flowable.engine.common.api.FlowableException;
 import org.flowable.engine.delegate.DelegateExecution;
-import org.flowable.variable.service.delegate.Expression;
 import org.flowable.engine.impl.bpmn.parser.FieldDeclaration;
 import org.flowable.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.flowable.engine.impl.el.FixedValue;
@@ -67,6 +64,7 @@ import org.flowable.http.delegate.HttpRequestHandler;
 import org.flowable.http.delegate.HttpResponseHandler;
 import org.flowable.http.impl.handler.ClassDelegateHttpHandler;
 import org.flowable.http.impl.handler.DelegateExpressionHttpHandler;
+import org.flowable.variable.service.delegate.Expression;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -259,8 +257,14 @@ public class HttpActivityBehaviorImpl extends HttpActivityBehavior {
         try (BufferedReader reader = new BufferedReader(new StringReader(headers))) {
             String line = reader.readLine();
             while (line != null) {
-                if (line.indexOf(":") > 0) {
-                    base.addHeader(line.substring(0, line.indexOf(":")), line.substring(line.indexOf(":") + 1));
+                int colonIndex = line.indexOf(":");
+                if (colonIndex > 0) {
+                    String headerName = line.substring(0, colonIndex);
+                    if (line.length() > colonIndex + 2) {
+                        base.addHeader(headerName, line.substring(colonIndex + 1));
+                    } else {
+                        base.addHeader(headerName, null);
+                    }
                     line = reader.readLine();
                     
                 } else {

--- a/modules/flowable-http/src/main/java/org/flowable/http/impl/HttpActivityBehaviorImpl.java
+++ b/modules/flowable-http/src/main/java/org/flowable/http/impl/HttpActivityBehaviorImpl.java
@@ -79,7 +79,6 @@ public class HttpActivityBehaviorImpl extends HttpActivityBehavior {
 
     private static final long serialVersionUID = 1L;
     private static final Logger LOGGER = LoggerFactory.getLogger(HttpActivityBehaviorImpl.class);
-    private static final Pattern HEADER_PATTERN = Pattern.compile("(.+):(.+)");
     
     protected HttpServiceTask httpServiceTask;
 
@@ -260,13 +259,13 @@ public class HttpActivityBehaviorImpl extends HttpActivityBehavior {
         try (BufferedReader reader = new BufferedReader(new StringReader(headers))) {
             String line = reader.readLine();
             while (line != null) {
-                Matcher matcher = HEADER_PATTERN.matcher(line);
-                if (!matcher.matches()) {
+                if (line.indexOf(":") > 0) {
+                    base.addHeader(line.substring(0, line.indexOf(":")), line.substring(line.indexOf(":") + 1));
+                    line = reader.readLine();
+                    
+                } else {
                     throw new FlowableException(HTTP_TASK_REQUEST_HEADERS_INVALID);
                 }
-
-                base.addHeader(matcher.group(1), matcher.group(2));
-                line = reader.readLine();
             }
         }
     }

--- a/modules/flowable-http/src/main/java/org/flowable/http/impl/HttpActivityBehaviorImpl.java
+++ b/modules/flowable-http/src/main/java/org/flowable/http/impl/HttpActivityBehaviorImpl.java
@@ -20,6 +20,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLSession;
@@ -77,6 +79,7 @@ public class HttpActivityBehaviorImpl extends HttpActivityBehavior {
 
     private static final long serialVersionUID = 1L;
     private static final Logger LOGGER = LoggerFactory.getLogger(HttpActivityBehaviorImpl.class);
+    private static final Pattern HEADER_PATTERN = Pattern.compile("(.+):(.+)");
     
     protected HttpServiceTask httpServiceTask;
 
@@ -257,13 +260,13 @@ public class HttpActivityBehaviorImpl extends HttpActivityBehavior {
         try (BufferedReader reader = new BufferedReader(new StringReader(headers))) {
             String line = reader.readLine();
             while (line != null) {
-                String[] header = line.split(":");
-                if (header.length == 2) {
-                    base.addHeader(header[0], header[1]);
-                    line = reader.readLine();
-                } else {
+                Matcher matcher = HEADER_PATTERN.matcher(line);
+                if (!matcher.matches()) {
                     throw new FlowableException(HTTP_TASK_REQUEST_HEADERS_INVALID);
                 }
+
+                base.addHeader(matcher.group(1), matcher.group(2));
+                line = reader.readLine();
             }
         }
     }

--- a/modules/flowable-http/src/test/java/org/flowable/http/HttpServiceTaskTest.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/HttpServiceTaskTest.java
@@ -23,6 +23,7 @@ import org.flowable.engine.common.api.FlowableException;
 import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.flowable.http.HttpServiceTaskTestServer.HttpServiceTaskTestServlet;
 import org.flowable.variable.service.history.HistoricVariableInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -300,6 +301,11 @@ public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
 
         ProcessInstance process = runtimeService.startProcessInstanceByKey("testHttpPut5XX", variables);
         assertFalse(process.isEnded());
+        
+        Map<String, String> headerMap = HttpServiceTaskTestServlet.headerMap;
+        assertEquals("text/plain", headerMap.get("Content-Type"));
+        assertEquals("623b94fc-14b8-4ee6-aed7-b16b9321e29f", headerMap.get("X-Request-ID"));
+        assertEquals("localhost:7000", headerMap.get("Host"));
 
         // Request assertions
         Map<String, Object> request = new HashMap<>();

--- a/modules/flowable-http/src/test/java/org/flowable/http/HttpServiceTaskTest.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/HttpServiceTaskTest.java
@@ -289,7 +289,7 @@ public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
         Map<String, Object> variables = new HashMap<>();
         variables.put("method", "POST");
         variables.put("url", "https://localhost:9799/api?code=500");
-        variables.put("headers", "Content-Type: text/plain\nX-Request-ID: 623b94fc-14b8-4ee6-aed7-b16b9321e29f");
+        variables.put("headers", "Content-Type: text/plain\nX-Request-ID: 623b94fc-14b8-4ee6-aed7-b16b9321e29f\nhost:localhost:7000");
         variables.put("body", body);
         variables.put("timeout", 2000);
         variables.put("ignore", true);
@@ -305,7 +305,7 @@ public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
         Map<String, Object> request = new HashMap<>();
         request.put("httpPost500.requestMethod", "POST");
         request.put("httpPost500.requestUrl", "https://localhost:9799/api?code=500");
-        request.put("httpPost500.requestHeaders", "Content-Type: text/plain\nX-Request-ID: 623b94fc-14b8-4ee6-aed7-b16b9321e29f");
+        request.put("httpPost500.requestHeaders", "Content-Type: text/plain\nX-Request-ID: 623b94fc-14b8-4ee6-aed7-b16b9321e29f\nhost:localhost:7000");
         request.put("httpPost500.requestBody", body);
         assertEquals(runtimeService, process.getId(), request);
         // Response assertions

--- a/modules/flowable-http/src/test/java/org/flowable/http/HttpServiceTaskTest.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/HttpServiceTaskTest.java
@@ -290,7 +290,7 @@ public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
         Map<String, Object> variables = new HashMap<>();
         variables.put("method", "POST");
         variables.put("url", "https://localhost:9799/api?code=500");
-        variables.put("headers", "Content-Type: text/plain\nX-Request-ID: 623b94fc-14b8-4ee6-aed7-b16b9321e29f\nhost:localhost:7000");
+        variables.put("headers", "Content-Type: text/plain\nX-Request-ID: 623b94fc-14b8-4ee6-aed7-b16b9321e29f\nhost:localhost:7000\nTest:");
         variables.put("body", body);
         variables.put("timeout", 2000);
         variables.put("ignore", true);
@@ -306,6 +306,7 @@ public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
         assertEquals("text/plain", headerMap.get("Content-Type"));
         assertEquals("623b94fc-14b8-4ee6-aed7-b16b9321e29f", headerMap.get("X-Request-ID"));
         assertEquals("localhost:7000", headerMap.get("Host"));
+        assertEquals("", headerMap.get("Test"));
 
         // Request assertions
         Map<String, Object> request = new HashMap<>();

--- a/modules/flowable-http/src/test/java/org/flowable/http/HttpServiceTaskTestServer.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/HttpServiceTaskTestServer.java
@@ -15,7 +15,9 @@ package org.flowable.http;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -107,9 +109,11 @@ public class HttpServiceTaskTestServer {
         });
     }
 
-    private static class HttpServiceTaskTestServlet extends HttpServlet {
+    public static class HttpServiceTaskTestServlet extends HttpServlet {
 
         private static final long serialVersionUID = 1L;
+        
+        public static Map<String, String> headerMap = new HashMap<>();
                         
         private String name = "test servlet";
         private ObjectMapper mapper = new ObjectMapper();
@@ -143,7 +147,13 @@ public class HttpServiceTaskTestServer {
 
         @Override
         protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-
+            headerMap.clear();
+            Enumeration<String> headerNames = req.getHeaderNames();
+            while (headerNames.hasMoreElements()) {
+                String header = headerNames.nextElement();
+                headerMap.put(header, req.getHeader(header));
+            }
+            
             HttpTestData data = parseTestData(req, resp);
             int code = data.getCode();
             if (code >= 200 && code < 300) {

--- a/modules/flowable-task-service/src/main/java/org/flowable/task/service/TaskInfoQuery.java
+++ b/modules/flowable-task-service/src/main/java/org/flowable/task/service/TaskInfoQuery.java
@@ -139,6 +139,11 @@ public interface TaskInfoQuery<T extends TaskInfoQuery<?, ?>, V extends TaskInfo
      */
     T taskInvolvedUser(String involvedUser);
 
+    /**
+     * Allows to select a task using {@link #taskCandidateGroup(String)} {@link #taskCandidateGroupIn(List)} or {@link #taskCandidateUser(String)} but ignore the assignee value instead of querying for an empty asisgnee.
+     */
+    T candidateAssignedToOthers();
+
     /** Only select tasks for which users in the given group are candidates. */
     T taskCandidateGroup(String candidateGroup);
 

--- a/modules/flowable-task-service/src/main/java/org/flowable/task/service/impl/HistoricTaskInstanceQueryImpl.java
+++ b/modules/flowable-task-service/src/main/java/org/flowable/task/service/impl/HistoricTaskInstanceQueryImpl.java
@@ -71,6 +71,7 @@ public class HistoricTaskInstanceQueryImpl extends AbstractVariableQueryImpl<His
     protected String taskOwnerLikeIgnoreCase;
     protected String taskAssignee;
     protected String taskAssigneeLike;
+    protected boolean candidateAssignedToOthers;
     protected String taskAssigneeLikeIgnoreCase;
     protected List<String> taskAssigneeIds;
     protected String taskDefinitionKey;
@@ -1046,6 +1047,16 @@ public class HistoricTaskInstanceQueryImpl extends AbstractVariableQueryImpl<His
     }
 
     @Override
+    public HistoricTaskInstanceQuery candidateAssignedToOthers() {
+        if (inOrStatement) {
+            this.currentOrQueryObject.candidateAssignedToOthers = true;
+        } else {
+            this.candidateAssignedToOthers = true;
+        }
+        return this;
+    }
+
+    @Override
     public HistoricTaskInstanceQuery taskCandidateUser(String candidateUser) {
         if (candidateUser == null) {
             throw new FlowableIllegalArgumentException("Candidate user is null");
@@ -1617,6 +1628,14 @@ public class HistoricTaskInstanceQueryImpl extends AbstractVariableQueryImpl<His
 
     public String getCandidateGroup() {
         return candidateGroup;
+    }
+
+    public boolean isCandidateAssignedToOthers() {
+        return candidateAssignedToOthers;
+    }
+
+    public void setCandidateAssignedToOthers(boolean candidateAssignedToOthers) {
+        this.candidateAssignedToOthers = candidateAssignedToOthers;
     }
 
     public String getInvolvedUser() {

--- a/modules/flowable-task-service/src/main/java/org/flowable/task/service/impl/TaskQueryImpl.java
+++ b/modules/flowable-task-service/src/main/java/org/flowable/task/service/impl/TaskQueryImpl.java
@@ -57,6 +57,7 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
     protected String assignee;
     protected String assigneeLike;
     protected String assigneeLikeIgnoreCase;
+    protected boolean candidateAssignedToOthers;
     protected List<String> assigneeIds;
     protected String involvedUser;
     protected String owner;
@@ -497,6 +498,16 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
             currentOrQueryObject.involvedUser = involvedUser;
         } else {
             this.involvedUser = involvedUser;
+        }
+        return this;
+    }
+
+    @Override
+    public TaskQuery candidateAssignedToOthers() {
+        if (orActive) {
+            currentOrQueryObject.candidateAssignedToOthers = true;
+        } else {
+            this.candidateAssignedToOthers = true;
         }
         return this;
     }
@@ -1443,6 +1454,14 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
 
     public String getDelegationStateString() {
         return (delegationState != null ? delegationState.toString() : null);
+    }
+
+    public boolean isCandidateAssignedToOthers() {
+        return candidateAssignedToOthers;
+    }
+
+    public void setCandidateAssignedToOthers(boolean candidateAssignedToOthers) {
+        this.candidateAssignedToOthers = candidateAssignedToOthers;
     }
 
     public String getCandidateUser() {

--- a/modules/flowable-task-service/src/main/resources/org/flowable/task/db/mapping/entity/HistoricTaskInstance.xml
+++ b/modules/flowable-task-service/src/main/resources/org/flowable/task/db/mapping/entity/HistoricTaskInstance.xml
@@ -708,7 +708,9 @@
         and (RES.TENANT_ID_ = '' or RES.TENANT_ID_ is null)
       </if>
       <if test="candidateUser != null || candidateGroups != null">
-        and RES.ASSIGNEE_ is null
+        <if test="!candidateAssignedToOthers">
+          and RES.ASSIGNEE_ is null
+        </if>
         and HI.TYPE_ = 'candidate'
         and
         (
@@ -1010,8 +1012,11 @@
             or (RES.TENANT_ID_ = '' or RES.TENANT_ID_ is null)
           </if>
           <if test="orQueryObject.candidateUser != null || orQueryObject.candidateGroups != null">
-            or (RES.ASSIGNEE_ is null
-            and HI_OR${orIndex}.TYPE_ = 'candidate'
+            or (
+            HI_OR${orIndex}.TYPE_ = 'candidate'
+            <if test="!orQueryObject.candidateAssignedToOthers">
+              and RES.ASSIGNEE_ is null
+            </if>
             and
             (
               <if test="orQueryObject.candidateUser != null">

--- a/modules/flowable-task-service/src/main/resources/org/flowable/task/db/mapping/entity/Task.xml
+++ b/modules/flowable-task-service/src/main/resources/org/flowable/task/db/mapping/entity/Task.xml
@@ -686,7 +686,9 @@
         and RES.PARENT_TASK_ID_ IS NULL
       </if>
       <if test="!bothCandidateAndAssigned &amp;&amp; (candidateUser != null || candidateGroups != null)">
-        and RES.ASSIGNEE_ is null
+        <if test="!candidateAssignedToOthers">
+          and RES.ASSIGNEE_ is null
+        </if>
         and I.TYPE_ = 'candidate'
         and 
         ( 
@@ -802,23 +804,31 @@
           <!-- if dbIdentityUsed set true in process engine configuration -->
           <if test="userIdForCandidateAndAssignee != null">
             <if test="candidateGroups == null">
-              and (RES.ASSIGNEE_ = #{userIdForCandidateAndAssignee} or (RES.ASSIGNEE_ is null and (I.USER_ID_ = #{userIdForCandidateAndAssignee}
-              or I.GROUP_ID_ IN (select g.GROUP_ID_ from ${prefix}ACT_ID_MEMBERSHIP g where g.USER_ID_ = #{userIdForCandidateAndAssignee} ) ) ) )
+              and (RES.ASSIGNEE_ = #{userIdForCandidateAndAssignee}
+                or (
+                <if test="candidateAssignedToOthers">
+                  RES.ASSIGNEE_ is null
+                </if>
+                and (I.USER_ID_ = #{userIdForCandidateAndAssignee}
+                or I.GROUP_ID_ IN (select g.GROUP_ID_ from ${prefix}ACT_ID_MEMBERSHIP g where g.USER_ID_ = #{userIdForCandidateAndAssignee} ) ) ) )
             </if>
           </if>
           <!-- if dbIdentityUsed set false in process engine configuration of using custom session factory of GroupIdentityManager -->
           <if test="candidateGroups != null">
             and (RES.ASSIGNEE_ = #{userIdForCandidateAndAssignee}
-            or (RES.ASSIGNEE_ is null
-            and I.TYPE_ = 'candidate' and (I.USER_ID_ = #{userIdForCandidateAndAssignee}
-            <if test="candidateGroups.size() &gt; 0">
-              or I.GROUP_ID_ IN
-              <foreach item="group" index="index" collection="candidateGroups"
-                       open="(" separator="," close=")">
-                #{group}
-              </foreach>
-            </if>
-            )))
+              or (
+              <if test="!candidateAssignedToOthers">
+                RES.ASSIGNEE_ is null and
+              </if>
+              I.TYPE_ = 'candidate' and (I.USER_ID_ = #{userIdForCandidateAndAssignee}
+              <if test="candidateGroups.size() &gt; 0">
+                or I.GROUP_ID_ IN
+                <foreach item="group" index="index" collection="candidateGroups"
+                         open="(" separator="," close=")">
+                  #{group}
+                </foreach>
+              </if>
+              )))
           </if>
         </when>
       </choose>
@@ -1008,10 +1018,13 @@
             </if>
             
             <if test="!orQueryObject.bothCandidateAndAssigned &amp;&amp; (orQueryObject.candidateUser != null || orQueryObject.candidateGroups != null)">
-              or (RES.ASSIGNEE_ is null
-              and I_OR${orIndex}.TYPE_ = 'candidate'
+              or (
+              <if test="!orQueryObject.candidateAssignedToOthers">
+                RES.ASSIGNEE_ is null and
+              </if>
+              I_OR${orIndex}.TYPE_ = 'candidate'
               and 
-              ( 
+              (
                 <if test="orQueryObject.candidateUser != null">
                   I_OR${orIndex}.USER_ID_ = #{orQueryObject.candidateUser}          
                 </if>
@@ -1132,23 +1145,31 @@
                 <!-- if dbIdentityUsed set true in process engine configuration -->
                 <if test="orQueryObject.userIdForCandidateAndAssignee != null">
                   <if test="orQueryObject.candidateGroups == null">
-                    or (RES.ASSIGNEE_ = #{orQueryObject.userIdForCandidateAndAssignee} or (RES.ASSIGNEE_ is null and (I_OR${orIndex}.USER_ID_ = #{orQueryObject.userIdForCandidateAndAssignee}
-                    or I_OR${orIndex}.GROUP_ID_ IN (select g.GROUP_ID_ from ${prefix}ACT_ID_MEMBERSHIP g where g.USER_ID_ = #{orQueryObject.userIdForCandidateAndAssignee} ) ) ) )
-                  </if>
+                    or (RES.ASSIGNEE_ = #{orQueryObject.userIdForCandidateAndAssignee}
+                      or (
+                      <if test="orQueryObject.candidateAssignedToOthers">
+                        RES.ASSIGNEE_ is null and
+                      </if>
+                      (I_OR${orIndex}.USER_ID_ = #{orQueryObject.userIdForCandidateAndAssignee}
+                      or I_OR${orIndex}.GROUP_ID_ IN (select g.GROUP_ID_ from ${prefix}ACT_ID_MEMBERSHIP g where g.USER_ID_ = #{orQueryObject.userIdForCandidateAndAssignee} ) ) ) )
+                    </if>
                 </if>
                 <!-- if dbIdentityUsed set false in process engine configuration of using custom session factory of GroupIdentityManager -->
                 <if test="orQueryObject.candidateGroups != null">
                   or (RES.ASSIGNEE_ = #{orQueryObject.userIdForCandidateAndAssignee}
-                  or (RES.ASSIGNEE_ is null
-                  and I_OR${orIndex}.TYPE_ = 'candidate' and (I_OR${orIndex}.USER_ID_ = #{orQueryObject.userIdForCandidateAndAssignee}
-                  <if test="orQueryObject.candidateGroups.size() &gt; 0">
-                    or I_OR${orIndex}.GROUP_ID_ IN
-                    <foreach item="group" index="index" collection="orQueryObject.candidateGroups"
-                             open="(" separator="," close=")">
-                      #{group}
-                    </foreach>
-                  </if>
-                  )))
+                    or (
+                    <if test="!orQueryObject.candidateAssignedToOthers">
+                      RES.ASSIGNEE_ is null and
+                    </if>
+                    I_OR${orIndex}.TYPE_ = 'candidate' and (I_OR${orIndex}.USER_ID_ = #{orQueryObject.userIdForCandidateAndAssignee}
+                    <if test="orQueryObject.candidateGroups.size() &gt; 0">
+                      or I_OR${orIndex}.GROUP_ID_ IN
+                      <foreach item="group" index="index" collection="orQueryObject.candidateGroups"
+                               open="(" separator="," close=")">
+                        #{group}
+                      </foreach>
+                    </if>
+                    )))
                 </if>
               </when>
             </choose>

--- a/modules/flowable-task-service/src/main/resources/org/flowable/task/db/mapping/entity/Task.xml
+++ b/modules/flowable-task-service/src/main/resources/org/flowable/task/db/mapping/entity/Task.xml
@@ -806,7 +806,7 @@
             <if test="candidateGroups == null">
               and (RES.ASSIGNEE_ = #{userIdForCandidateAndAssignee}
                 or (
-                <if test="candidateAssignedToOthers">
+                <if test="!candidateAssignedToOthers">
                   RES.ASSIGNEE_ is null
                 </if>
                 and (I.USER_ID_ = #{userIdForCandidateAndAssignee}

--- a/modules/flowable5-camel-test/pom.xml
+++ b/modules/flowable5-camel-test/pom.xml
@@ -86,7 +86,6 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-mvel</artifactId>
       <scope>test</scope>
-      <version>2.10.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.uuid</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
 		<spring.security.version>4.2.3.RELEASE</spring.security.version>
 		<jackson.version>2.7.5</jackson.version>
 		<mule.version>3.8.0</mule.version>
+		<camel.version>2.19.3</camel.version>
 		<cxf.version>3.1.6</cxf.version>
 		<batik.version>1.7</batik.version>
 
@@ -868,7 +869,12 @@
 			<dependency>
 				<groupId>org.apache.camel</groupId>
 				<artifactId>camel-spring</artifactId>
-				<version>2.17.1</version>
+				<version>${camel.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.camel</groupId>
+				<artifactId>camel-mvel</artifactId>
+				<version>${camel.version}</version>
 			</dependency>
 			<!-- Mule integration -->
 			<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 		<spring.security.version>4.2.3.RELEASE</spring.security.version>
 		<jackson.version>2.7.5</jackson.version>
 		<mule.version>3.8.0</mule.version>
-		<camel.version>2.19.3</camel.version>
+		<camel.version>2.17.1</camel.version>
 		<cxf.version>3.1.6</cxf.version>
 		<batik.version>1.7</batik.version>
 


### PR DESCRIPTION
For discussion see on flowable forum: https://forum.flowable.org/t/taskquery-api-questions-multiple-assignees-and-candidates-that-have-been-assigned/131/6

If needed I am of course willing to adapt this pull request.

git commit message:This extra flag has been implemented in order to allow querying without assignee logic. When setting the flag when querying, one can still request tasks or historic tasks regardless of the set assignee.The behaviour without this flag is that a task that is assigned can never be returned when searching for candidateUsers.