### PR TITLE
Issue 600 - process validation fails for multi-instance extensions

### DIFF
--- a/modules/flowable-bpmn-converter/src/test/resources/multiinstancemodel2.bpmn
+++ b/modules/flowable-bpmn-converter/src/test/resources/multiinstancemodel2.bpmn
@@ -41,6 +41,7 @@
              <flowable:expression>${potentialOwnerList}</flowable:expression>
           </flowable:collection>
         </extensionElements>
+        <completionCondition>${nrOfInstances==2}</completionCondition>
       </multiInstanceLoopCharacteristics>
       </userTask>
       <sequenceFlow id="subFlowId1" sourceRef="subStartEvent" targetRef="subUserTask1"></sequenceFlow>


### PR DESCRIPTION
Deployed processes are order-sensitive and the extension elements must
be placed before any additional child elements. Moved the extension code
up in the MultiInstanceExport class. Also added a non-extension element
to the unit test template.