### PR TITLE
Move REST URL creation

### DIFF
--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/display-cmmn/displaymodel.js
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/display-cmmn/displaymodel.js
@@ -189,18 +189,18 @@ var modelUrl;
 
 if (modelType == 'runtime') {
 	if (historyModelId) {
-    	modelUrl = FLOWABLE.CONFIG.contextRoot + '/app/rest/case-instances/history/' + historyModelId + '/model-json';
+    	modelUrl = FLOWABLE.APP_URL.getCaseInstancesHistoryModelJsonUrl(historyModelId);
 	} else {
-    	modelUrl = FLOWABLE.CONFIG.contextRoot + '/app/rest/case-instances/' + modelId + '/model-json';
+    	modelUrl = FLOWABLE.APP_URL.getCaseInstancesModelJsonUrl(modelId);
 	}
 } else if (modelType == 'design') {
 	if (historyModelId) {
-    	modelUrl = FLOWABLE.CONFIG.contextRoot + '/app/rest/models/' + modelId + '/history/' + historyModelId + '/model-json';
+    	modelUrl = FLOWABLE.APP_URL.getModelHistoryModelJsonUrl(modelId, historyModelId);
 	} else {
-    	modelUrl = FLOWABLE.CONFIG.contextRoot + '/app/rest/models/' + modelId + '/model-json';
+    	modelUrl = FLOWABLE.APP_URL.getModelModelJsonUrl(modelId);
 	}
 } else if (modelType == 'case-definition') {
-    modelUrl = FLOWABLE.CONFIG.contextRoot + '/app/rest/case-definitions/' + caseDefinitionId + '/model-json';
+    modelUrl = FLOWABLE.APP_URL.getCaseDefinitionModelJsonUrl(caseDefinitionId);
 }
 
 var request = jQuery.ajax({

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/display/displaymodel.js
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/display/displaymodel.js
@@ -221,18 +221,18 @@ var modelUrl;
 
 if (modelType == 'runtime') {
 	if (historyModelId) {
-    	modelUrl = FLOWABLE.CONFIG.contextRoot + '/app/rest/process-instances/history/' + historyModelId + '/model-json';
+    	modelUrl = FLOWABLE.APP_URL.getProcessInstanceModelJsonHistoryUrl(historyModelId);
 	} else {
-    	modelUrl = FLOWABLE.CONFIG.contextRoot + '/app/rest/process-instances/' + modelId + '/model-json';
+    	modelUrl = FLOWABLE.APP_URL.getProcessInstanceModelJsonUrl(modelId);
 	}
 } else if (modelType == 'design') {
 	if (historyModelId) {
-    	modelUrl = FLOWABLE.CONFIG.contextRoot + '/app/rest/models/' + modelId + '/history/' + historyModelId + '/model-json';
+    	modelUrl = FLOWABLE.APP_URL.getModelHistoryModelJsonUrl(modelId, historyModelId);
 	} else {
-    	modelUrl = FLOWABLE.CONFIG.contextRoot + '/app/rest/models/' + modelId + '/model-json';
+    	modelUrl = FLOWABLE.APP_URL.getModelModelJsonUrl(modelId);
 	}
 } else if (modelType == 'process-definition') {
-    modelUrl = FLOWABLE.CONFIG.contextRoot + '/app/rest/process-definitions/' + processDefinitionId + '/model-json';
+    modelUrl = FLOWABLE.APP_URL.getProcessDefinitionModelJsonUrl(processDefinitionId);
 }
 
 var request = jQuery.ajax({
@@ -245,19 +245,19 @@ request.success(function(data, textStatus, jqXHR) {
     if ((!data.elements || data.elements.length == 0) && (!data.pools || data.pools.length == 0)) return;
 
     INITIAL_CANVAS_WIDTH = data.diagramWidth;
-    
+
     if (modelType == 'design') {
     	INITIAL_CANVAS_WIDTH += 20;
     } else {
         INITIAL_CANVAS_WIDTH += 30;
     }
-    
+
     INITIAL_CANVAS_HEIGHT = data.diagramHeight + 50;
     canvasWidth = INITIAL_CANVAS_WIDTH;
     canvasHeight = INITIAL_CANVAS_HEIGHT;
     viewBoxWidth = INITIAL_CANVAS_WIDTH;
     viewBoxHeight = INITIAL_CANVAS_HEIGHT;
-    
+
     if (modelType == 'design') {
     	var headerBarHeight = 170;
     	var offsetY = 0;

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/editor-app/configuration/properties-case-reference-controller.js
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/editor-app/configuration/properties-case-reference-controller.js
@@ -58,7 +58,7 @@ angular.module('flowableModeler').controller('FlowableCaseReferencePopupCtrl', [
     
     $scope.loadCases = function() {
    	    var modelMetaData = editorManager.getBaseModelData();
-    	$http.get(FLOWABLE.CONFIG.contextRoot + '/app/rest/case-models?excludeId=' + modelMetaData.modelId)
+    	$http.get(FLOWABLE.APP_URL.getCaseModelsUrl('?excludeId=' + modelMetaData.modelId))
     		.success(
     			function(response) {
     				$scope.state.loadingCases = false;

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/editor-app/configuration/properties-decisiontable-reference-controller.js
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/editor-app/configuration/properties-decisiontable-reference-controller.js
@@ -13,7 +13,7 @@
 
 angular.module('flowableModeler').controller('FlowableDecisionTableReferenceCtrl',
     [ '$scope', '$modal', '$http', function($scope, $modal, $http) {
-	
+
      // Config for the modal window
      var opts = {
          template:  'editor-app/configuration/properties/decisiontable-reference-popup.html?version=' + Date.now(),
@@ -23,7 +23,7 @@ angular.module('flowableModeler').controller('FlowableDecisionTableReferenceCtrl
      // Open the dialog
      _internalCreateModal(opts, $modal, $scope);
 }]);
- 
+
 angular.module('flowableModeler').controller('FlowableDecisionTableReferencePopupCtrl', ['$rootScope', '$scope', '$http', '$location', 'editorManager',
     function($rootScope, $scope, $http, $location, editorManager) {
 
@@ -77,7 +77,7 @@ angular.module('flowableModeler').controller('FlowableDecisionTableReferencePopu
                     'name': $scope.selectedDecisionTable.name,
                     'key': $scope.selectedDecisionTable.key
                 };
-                
+
             } else {
                 $scope.property.value = null;
             }
@@ -139,7 +139,7 @@ angular.module('flowableModeler').controller('FlowableDecisionTableReferencePopu
                     .error(function(data, status, headers, config) {
 
                     });
-                
+
                 $scope.close();
             }
         };
@@ -168,7 +168,7 @@ angular.module('flowableModeler').controller('FlowableDecisionTableReferencePopu
 
             if (!$scope.model.decisionTable.name || $scope.model.decisionTable.name.length == 0 ||
             	!$scope.model.decisionTable.key || $scope.model.decisionTable.key.length == 0) {
-            	
+
                 return;
             }
 
@@ -177,7 +177,7 @@ angular.module('flowableModeler').controller('FlowableDecisionTableReferencePopu
 
             $http({
                 method: 'POST',
-                url: FLOWABLE.CONFIG.contextRoot + '/app/rest/models',
+                url: FLOWABLE.APP_URL.getModelsUrl(),
                 data: $scope.model.decisionTable
             }).
             success(function(data, status, headers, config) {
@@ -231,7 +231,7 @@ angular.module('flowableModeler').controller('FlowableDecisionTableReferencePopu
 
                         $scope.model.loading = false;
                         $scope.$hide();
-                        
+
                         $rootScope.addHistoryItem($scope.selectedShape.resourceId);
                         $location.path('decision-table-editor/' + newDecisionTableId);
                     })
@@ -263,7 +263,7 @@ angular.module('flowableModeler').controller('FlowableDecisionTableReferencePopu
 
         $scope.loadDecisionTables = function() {
             var modelMetaData = editorManager.getBaseModelData();
-            $http.get(FLOWABLE.CONFIG.contextRoot + '/app/rest/decision-table-models')
+            $http.get(FLOWABLE.APP_URL.getDecisionTableModelsUrl())
                 .success(
                     function(response) {
                         $scope.state.loadingDecisionTables = false;

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/editor-app/configuration/properties-form-reference-controller.js
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/editor-app/configuration/properties-form-reference-controller.js
@@ -15,7 +15,7 @@ angular.module('flowableModeler').controller('FlowableFormReferenceDisplayCtrl',
     [ '$scope', '$modal', '$http', function($scope, $modal, $http) {
     
     if ($scope.property && $scope.property.value && $scope.property.value.id) {
-   		$http.get(FLOWABLE.CONFIG.contextRoot + '/app/rest/models/' + $scope.property.value.id)
+   		$http.get(FLOWABLE.APP_URL.getModelUrl($scope.property.value.id))
             .success(
                 function(response) {
                     $scope.form = {
@@ -167,7 +167,7 @@ angular.module('flowableModeler').controller('FlowableFormReferencePopupCtrl',
 
         $scope.model.loading = true;
 
-        $http({method: 'POST', url: FLOWABLE.CONFIG.contextRoot + '/app/rest/models', data: $scope.model.form}).
+        $http({method: 'POST', url: FLOWABLE.APP_URL.getModelsUrl(), data: $scope.model.form}).
             success(function(data, status, headers, config) {
                 
                 var newFormId = data.id;
@@ -239,7 +239,7 @@ angular.module('flowableModeler').controller('FlowableFormReferencePopupCtrl',
 
     $scope.loadForms = function() {
         var modelMetaData = editorManager.getBaseModelData();
-        $http.get(FLOWABLE.CONFIG.contextRoot + '/app/rest/form-models')
+        $http.get(FLOWABLE.APP_URL.getFormModelsUrl())
             .success(
                 function(response) {
                     $scope.state.loadingForms = false;

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/editor-app/configuration/properties-process-reference-controller.js
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/editor-app/configuration/properties-process-reference-controller.js
@@ -58,7 +58,7 @@ angular.module('flowableModeler').controller('FlowableProcessReferencePopupCtrl'
     
     $scope.loadProcesses = function() {
    	 
-    	$http.get(FLOWABLE.CONFIG.contextRoot + '/app/rest/models?modelType=0')
+    	$http.get(FLOWABLE.APP_URL.getModelsUrl("?modelType=0"))
     		.success(
     			function(response) {
     				$scope.state.loadingProcesses = false;

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/editor-app/configuration/properties/case-reference-popup.html
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/editor-app/configuration/properties/case-reference-popup.html
@@ -24,7 +24,7 @@
                                <input type="checkbox" value="option1" ng-click="selectCase(caseModel, $event)" ng-checked="caseModel.id == selectedCase.id" />
                            </div>
                            <h4>{{caseModel.name}}</h4>
-                           <img ng-src="{{config.contextRoot}}/app/rest/models/{{caseModel.id}}/thumbnail" />
+                           <img ng-src="{{getModelThumbnailUrl(caseModel.id)}}" />
                          </div>
                          <div ng-show="state.loadingCases">
                             <p class="loading" translate>PROPERTY.CASEREFERENCE.CASE.LOADING</p>

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/editor-app/configuration/properties/decisiontable-reference-popup.html
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/editor-app/configuration/properties/decisiontable-reference-popup.html
@@ -25,7 +25,7 @@
                                <input type="checkbox" value="option1" ng-click="selectDecisionTable(decisionTable, $event)" ng-checked="decisionTable.id == selectedDecisionTable.id" />
                            </div>
                            <h4>{{decisionTable.name}}</h4>
-                           <img ng-src="{{config.contextRoot}}/app/rest/models/{{decisionTable.id}}/thumbnail" />
+                           <img ng-src="{{getModelThumbnailUrl(decisionTable.id)}}" />
                          </div>
                          <div ng-show="state.loadingDecisionTables">
                             <p class="loading" translate>PROPERTY.DECISIONTABLEREFERENCE.DECISIONTABLE.LOADING</p>

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/editor-app/configuration/properties/form-reference-popup.html
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/editor-app/configuration/properties/form-reference-popup.html
@@ -25,7 +25,7 @@
                                <input type="checkbox" value="option1" ng-click="selectForm(form, $event)" ng-checked="form.id == selectedForm.id" />
                            </div>
                            <h4>{{form.name}}</h4>
-                           <img ng-src="{{config.contextRoot}}/app/rest/models/{{form.id}}/thumbnail" />
+                           <img ng-src="{{getModelThumbnailUrl(form.id)}}" />
                          </div>
                          <div ng-show="state.loadingForms">
                             <p class="loading" translate>PROPERTY.FORMREFERENCE.FORM.LOADING</p>

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/editor-app/configuration/properties/process-reference-popup.html
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/editor-app/configuration/properties/process-reference-popup.html
@@ -24,7 +24,7 @@
 			                   <input type="checkbox" value="option1" ng-click="selectProcess(processModel, $event)" ng-checked="processModel.id == selectedProcess.id" />
 			               </div>
 			               <h4>{{processModel.name}}</h4>
-			               <img src="{{config.contextRoot}}/app/rest/models/{{processModel.id}}/thumbnail" />
+			               <img src="{{getModelThumbnailUrl(processModel.id)}}" />
 			             </div>
 			             <div ng-show="state.loadingProcesses">
 			               <p class="loading" translate>PROPERTY.PROCESSREFERENCE.PROCESS.LOADING</p>

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/editor-app/editor.html
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/editor-app/editor.html
@@ -50,7 +50,7 @@
 	                         jqyoui-draggable="{onStart:'startDragCallback', onDrag:'dragCallback'}"
 	                         data-jqyoui-options="{revert: 'invalid', helper: 'clone', opacity : 0.5}">
 	                        <img ng-if="!item.customIcon" ng-src="editor-app/stencilsets/{{getStencilSetName()}}/icons/{{item.icon}}" width="16px;" height="16px;"/>
-	                        <img ng-if="item.customIcon" ng-src="{{config.contextRoot}}/app/rest/image/{{item.icon}}" width="16px;" height="16px;"/>
+                            <img ng-if="item.customIcon" ng-src="{{getImageUrl(item.icon)}}" width="16px;" height="16px;"/>
 	                        {{item.name | translate}}
 	                    </li>
                     </ul>

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/editor-app/partials/root-stencil-item-template.html
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/editor-app/partials/root-stencil-item-template.html
@@ -7,6 +7,6 @@
       data-jqyoui-options="{revert: 'invalid', helper: 'clone', opacity : 0.5}">
         <img ng-if="!group.customIcon" ng-src="editor-app/stencilsets/{{getStencilSetName()}}/icons/{{group.icon}}" width="16px;"
              height="16px;"/>
-        <img ng-if="group.customIcon" ng-src="{{config.contextRoot}}/app/rest/image/{{group.icon}}" width="16px;" height="16px;"/>
+        <img ng-if="group.customIcon" ng-src="{{getImageUrl(group.icon)}}" width="16px;" height="16px;"/>
         {{group.name | translate}}
 </span>

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/editor-app/partials/stencil-item-template.html
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/editor-app/partials/stencil-item-template.html
@@ -22,7 +22,7 @@
         data-jqyoui-options="{revert: 'invalid', helper: 'clone', opacity : 0.5}">
         <img ng-if="!item.customIcon" ng-src="editor-app/stencilsets/{{getStencilSetName()}}/icons/{{item.icon}}" width="16px;"
              height="16px;"/>
-        <img ng-if="item.customIcon" ng-src="{{config.contextRoot}}/app/rest/image/{{item.icon}}" width="16px;" height="16px;"/>
+        <img ng-if="item.customIcon" ng-src="{{getImageUrl(item.icon)}}" width="16px;" height="16px;"/>
         {{item.name | translate}}
     </li>
 </ul>

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/editor-app/popups/icon-template.html
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/editor-app/popups/icon-template.html
@@ -1,4 +1,4 @@
 <div class="ui-grid-cell-contents">
     <img ng-if="!row.entity.customIcon" ng-src="editor-app/stencilsets/{{getStencilSetName()}}/icons/{{row.entity.icon}}" />
-    <img ng-if="row.entity.customIcon" ng-src="{{config.contextRoot}}/app/rest/image/{{row.entity.icon}}"/>
+    <img ng-if="row.entity.customIcon" ng-src="{{getImageUrl(row.entity.icon)}}"/>
 </div>

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/index.html
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/index.html
@@ -169,6 +169,7 @@
 <script src="editor-app/editor/oryx.debug.js" type="text/javascript"></script>
 
 <script src="scripts/app.js"></script>
+<script src="scripts/configuration/url-config.js"></script>
 <script src="scripts/editor-directives.js"></script>
 <script src="scripts/controllers/processes.js"></script>
 <script src="scripts/controllers/process.js"></script>

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/app.js
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/app.js
@@ -128,12 +128,12 @@ flowableModeler
             templateUrl: appResourceRoot + 'views/app-definition-builder.html',
             controller: 'AppDefinitionBuilderController'
         });
-            
+
         if (FLOWABLE.CONFIG.appDefaultRoute) {
             $routeProvider.when('/', {
                 redirectTo: FLOWABLE.CONFIG.appDefaultRoute
             });
-            
+
         } else {
             $routeProvider.when('/', {
                 redirectTo: '/processes'
@@ -229,6 +229,10 @@ flowableModeler
 
             $rootScope.mainPage = $rootScope.mainNavigation[0];
 
+            // Add url helpers to root scope:
+            $rootScope.getModelThumbnailUrl = FLOWABLE.APP_URL.getModelThumbnailUrl;
+            $rootScope.getImageUrl = FLOWABLE.APP_URL.getImageUrl;
+
             /*
              * History of process and form pages accessed by the editor.
              * This is needed because you can navigate to sub processes and forms
@@ -321,18 +325,18 @@ flowableModeler
                     });
                 }
             };
-            
-            $http.get(FLOWABLE.CONFIG.contextRoot + '/app/rest/account')
+
+            $http.get(FLOWABLE.APP_URL.getAccountUrl())
 	        	.success(function (data, status, headers, config) {
 	              	$rootScope.account = data;
 	               	$rootScope.invalidCredentials = false;
 	 				$rootScope.authenticated = true;
 	          	});
-	          	
+
 	        $rootScope.logout = function () {
                 $rootScope.authenticated = false;
                 $rootScope.authenticationError = false;
-                $http.get(FLOWABLE.CONFIG.contextRoot + '/app/logout')
+                $http.get(FLOWABLE.APP_URL.getLogoutUrl())
                     .success(function (data, status, headers, config) {
                         $rootScope.login = null;
                         $rootScope.authenticated = false;

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/common/controllers/about.js
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/common/controllers/about.js
@@ -19,7 +19,7 @@ flowableApp.controller('AboutFlowablePopupCtrl', ['$rootScope', '$scope', '$http
         licenseHolder: ''
     };
 
-    $http({method: 'GET', url: FLOWABLE.CONFIG.contextRoot + '/app/rest/about-info'}).
+    $http({method: 'GET', url: FLOWABLE.APP_URL.getAboutInfoUrl()}).
         success(function(response, status, headers, config) {
             $scope.popup.licenseHolder = response.holder;
             $scope.popup.activitiVersion = response.versionInfo.edition + ' v' + response.versionInfo.majorVersion + '.' + response.versionInfo.minorVersion + '.' + response.versionInfo.revisionVersion;

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/configuration/app-definition-toolbar-default-actions.js
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/configuration/app-definition-toolbar-default-actions.js
@@ -14,7 +14,7 @@
 
 var APP_DEFINITION_TOOLBAR = {
     ACTIONS: {
-    	
+
         saveModel: function (services) {
 
             _internalCreateModal({
@@ -26,13 +26,13 @@ var APP_DEFINITION_TOOLBAR = {
         },
 
         help: function (services) {
-            
+
         },
-        
+
         feedback: function (services) {
-            
+
         },
-        
+
         closeEditor:  function (services) {
         	services.$location.path('/apps');
         }
@@ -43,21 +43,21 @@ var APP_DEFINITION_TOOLBAR = {
 angular.module('flowableModeler').controller('SaveAppDefinitionCtrl',
     [ '$rootScope', '$scope', '$http', '$route', '$location', '$translate',
     function ($rootScope, $scope, $http, $route, $location, $translate) {
-	
+
     var description = '';
     if ($rootScope.currentAppDefinition.description) {
     	description = $rootScope.currentAppDefinition.description;
     }
-    
-    var saveDialog = { 
+
+    var saveDialog = {
         name: $rootScope.currentAppDefinition.name,
         key: $rootScope.currentAppDefinition.key,
         description: description,
         publish: false
     };
-    
+
     $scope.saveDialog = saveDialog;
-    
+
     $scope.status = {
         loading: false
     };
@@ -71,23 +71,23 @@ angular.module('flowableModeler').controller('SaveAppDefinitionCtrl',
     		$location.path('/apps');
     	}, force);
     };
-    
+
     $scope.save = function (saveCallback, force) {
 
         if (!$scope.saveDialog.name || $scope.saveDialog.name.length == 0 ||
         	!$scope.saveDialog.key || $scope.saveDialog.key.length == 0) {
-        	
+
             return;
         }
 
         // Indicator spinner image
         $scope.status.loading = true;
-        
+
         var data = {
             appDefinition: $rootScope.currentAppDefinition,
             publish: $scope.saveDialog.publish
         };
-        
+
         data.appDefinition.name = $scope.saveDialog.name;
         if ($scope.saveDialog.description && $scope.saveDialog.description.length > 0) {
         	data.appDefinition.description = $scope.saveDialog.description;
@@ -96,9 +96,9 @@ angular.module('flowableModeler').controller('SaveAppDefinitionCtrl',
         if (force !== undefined && force !== null && force === true) {
             data.force = true;
         }
-        
+
         delete $scope.conflict;
-        $http({method: 'PUT', url: FLOWABLE.CONFIG.contextRoot + '/app/rest/app-definitions/' + $rootScope.currentAppDefinition.id, data: data}).
+        $http({method: 'PUT', url: FLOWABLE.APP_URL.getAppDefinitionUrl($rootScope.currentAppDefinition.id), data: data}).
             success(function(response, status, headers, config) {
                 // Regular error
                 if (response.error) {

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/configuration/url-config.js
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/configuration/url-config.js
@@ -1,0 +1,247 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+var FLOWABLE = FLOWABLE || {};
+
+/*
+ * Contains methods to retrieve the (mostly) base urls of the different end points.
+ * Two of the methods #getImageUrl and #getModelThumbnailUrl are exposed in the $rootScope for usage in the HTML views.
+ */
+FLOWABLE.APP_URL = {
+
+    /* ACCOUNT URLS */
+
+    getAccountUrl: function () {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/account';
+    },
+
+    getLogoutUrl: function () {
+        return FLOWABLE.CONFIG.contextRoot + '/app/logout';
+    },
+
+    /* MODEL URLS */
+
+    getModelsUrl: function (query = null) {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/models' + (query || "");
+    },
+
+    getModelUrl: function (modelId) {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/models/' + modelId;
+    },
+
+    getModelModelJsonUrl: function (modelId) {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/models/' + modelId + '/model-json';
+    },
+
+    getModelBpmn20ExportUrl: function (modelId) {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/models/' + modelId + '/bpmn20?version=' + Date.now();
+    },
+
+    getCloneModelsUrl: function (modelId) {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/models/' + modelId + '/clone';
+    },
+
+    getModelHistoriesUrl: function (modelId) {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/models/' + modelId + '/history';
+    },
+
+    getModelHistoryUrl: function (modelId, modelHistoryId) {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/models/' + modelId + '/history/' + modelHistoryId;
+    },
+
+    getModelHistoryModelJsonUrl: function (modelId, modelHistoryId) {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/models/' + modelId + '/history/' + modelHistoryId + '/model-json';
+    },
+
+    getModelHistoryBpmn20ExportUrl: function (modelId, modelHistoryId) {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/models/' + modelId + '/history/' + modelHistoryId + '/bpmn20?version=' + Date.now();
+    },
+
+    getCmmnModelDownloadUrl: function (modelId, modelHistoryId = null) {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/models/' + modelId + (modelHistoryId ? '/history/' + modelHistoryId : '') + '/cmmn?version=' + Date.now();
+    },
+
+    getModelParentRelationsUrl: function (modelId) {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/models/' + modelId + '/parent-relations';
+    },
+
+    /* APP DEFINITION URLS  */
+
+    getAppDefinitionImportUrl: function (renewIdmIds) {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/app-definitions/import?renewIdmEntries=' + renewIdmIds;
+    },
+
+    getAppDefinitionTextImportUrl: function (renewIdmIds) {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/app-definitions/text/import?renewIdmEntries=' + renewIdmIds;
+    },
+
+    getAppDefinitionUrl: function (modelId) {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/app-definitions/' + modelId;
+    },
+
+    getAppDefinitionModelImportUrl: function (modelId, renewIdmIds) {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/app-definitions/' + modelId + '/import?renewIdmEntries=' + renewIdmIds;
+    },
+
+    getAppDefinitionModelTextImportUrl: function (modelId, renewIdmIds) {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/app-definitions/' + modelId + '/text/import?renewIdmEntries=' + renewIdmIds;
+    },
+
+    getAppDefinitionPublishUrl: function (modelId) {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/app-definitions/' + modelId + '/publish';
+    },
+
+    getAppDefinitionExportUrl: function (modelId) {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/app-definitions/' + modelId + '/export?version=' + Date.now();
+    },
+
+    getAppDefinitionBarExportUrl: function (modelId) {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/app-definitions/' + modelId + '/export-bar?version=' + Date.now();
+    },
+
+    getAppDefinitionHistoryUrl: function (modelId, historyModelId) {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/app-definitions/' + modelId + '/history/' + historyModelId;
+    },
+
+    getModelsForAppDefinitionUrl: function () {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/models-for-app-definition';
+    },
+
+    getCmmnModelsForAppDefinitionUrl: function () {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/cmmn-models-for-app-definition';
+    },
+
+    /* PROCESS INSTANCE URLS */
+
+    getProcessInstanceModelJsonUrl: function (modelId) {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/process-instances/' + modelId + '/model-json';
+    },
+
+    getProcessInstanceModelJsonHistoryUrl: function (historyModelId) {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/process-instances/history/' + historyModelId + '/model-json';
+    },
+
+    /* PROCESS DEFINITION URLS */
+
+    getProcessDefinitionModelJsonUrl: function (processDefinitionId) {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/process-definitions/' + processDefinitionId + '/model-json';
+    },
+
+    /* PROCESS MODEL URLS */
+
+    getImportProcessModelUrl: function () {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/import-process-model';
+    },
+
+    getImportProcessModelTextUrl: function () {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/import-process-model/text';
+    },
+
+    /* DECISION TABLE URLS */
+
+    getDecisionTableModelsUrl: function () {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/decision-table-models';
+    },
+
+    getDecisionTableImportUrl: function () {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/decision-table-models/import-decision-table';
+    },
+
+    getDecisionTableTextImportUrl: function () {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/decision-table-models/import-decision-table-text';
+    },
+
+    getDecisionTableModelUrl: function (modelId) {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/decision-table-models/' + modelId;
+    },
+
+    getDecisionTableModelValuesUrl: function (query) {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/decision-table-models/values?' + query;
+    },
+
+    getDecisionTableModelsHistoryUrl: function (modelHistoryId) {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/decision-table-models/history/' + modelHistoryId;
+    },
+
+    getDecisionTableModelHistoryUrl: function (modelId, modelHistoryId) {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/decision-table-models/' + modelId + '/history/' + modelHistoryId;
+    },
+
+    /* FORM MODEL URLS */
+
+    getFormModelsUrl: function () {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/form-models';
+    },
+
+    getFormModelValuesUrl: function (query) {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/form-models/values?' + query;
+    },
+
+    getFormModelUrl: function (modelId) {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/form-models/' + modelId;
+    },
+
+    getFormModelHistoryUrl: function (modelId, modelHistoryId) {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/form-models/' + modelId + '/history/' + modelHistoryId;
+    },
+
+    /* CASE MODEL URLS */
+
+    getCaseModelsUrl: function (query = null) {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/case-models' + (query || "");
+    },
+
+    getCaseModelImportUrl: function () {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/import-case-model';
+    },
+
+    getCaseModelTextImportUrl: function () {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/import-case-model/text';
+    },
+
+    getCaseInstancesHistoryModelJsonUrl: function (modelHistoryId) {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/case-instances/history/' + modelHistoryId + '/model-json';
+    },
+
+    getCaseInstancesModelJsonUrl: function (modelId) {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/case-instances/' + modelId + '/model-json';
+    },
+
+    getCaseDefinitionModelJsonUrl: function (caseDefinitionId) {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/case-definitions/' + caseDefinitionId + '/model-json';
+    },
+
+    /* IMAGE URLS (exposed in rootscope in app.js */
+
+    getImageUrl: function (imageId) {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/image/' + imageId;
+    },
+
+    getModelThumbnailUrl: function (modelId, version = null) {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/models/' + modelId + '/thumbnail' + (version ? "?version=" + version : "");
+    },
+
+    /* OTHER URLS */
+
+    getEditorUsersUrl: function () {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/editor-users';
+    },
+
+    getEditorGroupsUrl: function () {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/editor-groups';
+    },
+
+    getAboutInfoUrl: function () {
+        return FLOWABLE.CONFIG.contextRoot + '/app/rest/about-info';
+    }
+
+};

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/controllers/app-definition-builder.js
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/controllers/app-definition-builder.js
@@ -40,7 +40,7 @@ angular.module('flowableModeler')
     ];
     
     $scope.loadApp = function() {
-    	$http({method: 'GET', url: FLOWABLE.CONFIG.contextRoot + '/app/rest/app-definitions/' + $routeParams.modelId}).
+    	$http({method: 'GET', url: FLOWABLE.APP_URL.getAppDefinitionUrl($routeParams.modelId)}).
         	success(function(data, status, headers, config) {
         	    $rootScope.currentAppDefinition = data;
         	    if (!$rootScope.currentAppDefinition.definition.theme) {
@@ -220,7 +220,7 @@ angular.module('flowableModeler')
     $scope.loadModels = function() {
         $scope.popup.loading = true;
         
-        $http({method: 'GET', url: FLOWABLE.CONFIG.contextRoot + '/app/rest/models-for-app-definition'}).
+        $http({method: 'GET', url: FLOWABLE.APP_URL.getModelsForAppDefinitionUrl()}).
           success(function(data, status, headers, config) {
               $scope.popup.models = data;
               $scope.popup.loading = false;
@@ -229,7 +229,7 @@ angular.module('flowableModeler')
              $scope.popup.loading = false;
           });
           
-        $http({method: 'GET', url: FLOWABLE.CONFIG.contextRoot + '/app/rest/cmmn-models-for-app-definition'}).
+        $http({method: 'GET', url: FLOWABLE.APP_URL.getCmmnModelsForAppDefinitionUrl()}).
           success(function(data, status, headers, config) {
               $scope.popup.cmmnModels = data;
               $scope.popup.loading = false;

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/controllers/app-definition.js
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/controllers/app-definition.js
@@ -41,19 +41,15 @@ angular.module('flowableModeler')
     	var definitionUrl;
 
     	if ($routeParams.modelHistoryId) {
-    		url = FLOWABLE.CONFIG.contextRoot + '/app/rest/models/' + $routeParams.modelId
-    			+ '/history/' + $routeParams.modelHistoryId;
-    		definitionUrl = FLOWABLE.CONFIG.contextRoot + '/app/rest/app-definitions/' + $routeParams.modelId
-                + '/history/' + $routeParams.modelHistoryId;
+    		url = FLOWABLE.APP_URL.getModelHistoryUrl($routeParams.modelId, $routeParams.modelHistoryId);
+    		definitionUrl = FLOWABLE.APP_URL.getAppDefinitionHistoryUrl($routeParams.modelId, $routeParams.modelHistoryId);
     	} else {
-    		url = FLOWABLE.CONFIG.contextRoot + '/app/rest/models/' + $routeParams.modelId;
-    		definitionUrl = FLOWABLE.CONFIG.contextRoot + '/app/rest/app-definitions/' + $routeParams.modelId;
+    		url = FLOWABLE.APP_URL.getModelUrl($routeParams.modelId);
+    		definitionUrl = FLOWABLE.APP_URL.getAppDefinitionUrl($routeParams.modelId);
 
-    		$scope.model.appExportUrl = FLOWABLE.CONFIG.contextRoot + '/app/rest/app-definitions/' + $routeParams.modelId +
-                '/export?version=' + Date.now();
+    		$scope.model.appExportUrl = FLOWABLE.APP_URL.getAppDefinitionExportUrl($routeParams.modelId);
 
-    		$scope.model.appBarExportUrl = FLOWABLE.CONFIG.contextRoot + '/app/rest/app-definitions/' + $routeParams.modelId +
-                '/export-bar?version=' + Date.now();
+    		$scope.model.appBarExportUrl = FLOWABLE.APP_URL.getAppDefinitionBarExportUrl($routeParams.modelId);
     	}
 
     	$http({method: 'GET', url: url}).
@@ -84,7 +80,7 @@ angular.module('flowableModeler')
         includeLatestVersion: !$scope.model.app.latestVersion
       };
 
-      $http({method: 'GET', url: FLOWABLE.CONFIG.contextRoot + '/app/rest/models/' + $scope.model.latestModelId + '/history', params: params}).
+      $http({method: 'GET', url: FLOWABLE.APP_URL.getModelHistoriesUrl($scope.model.latestModelId), params: params}).
 	      success(function(data, status, headers, config) {
 	        if ($scope.model.app.latestVersion) {
 	          if (!data.data) {
@@ -214,7 +210,7 @@ angular.module('flowableModeler')
 
         delete $scope.popup.error;
 
-        $http({method: 'POST', url: FLOWABLE.CONFIG.contextRoot + '/app/rest/app-definitions/' + $scope.model.app.id + '/publish', data: data}).
+        $http({method: 'POST', url: FLOWABLE.APP_URL.getAppDefinitionPublishUrl($scope.model.app.id), data: data}).
             success(function(data, status, headers, config) {
                 $scope.$hide();
 
@@ -257,7 +253,7 @@ angular.module('flowableModeler')
             deleteRuntimeApp: true
         };
 
-        $http({method: 'DELETE', url: FLOWABLE.CONFIG.contextRoot + '/app/rest/models/' + $scope.model.app.id, params: params}).
+        $http({method: 'DELETE', url: FLOWABLE.APP_URL.getModelUrl($scope.model.app.id), params: params}).
             success(function(data, status, headers, config) {
                 $scope.$hide();
                 $scope.popup.loading = false;
@@ -294,9 +290,9 @@ angular.module('flowableModeler')
 
           var url;
           if (isIE) {
-              url = FLOWABLE.CONFIG.contextRoot + '/app/rest/app-definitions/' + $scope.model.app.id + '/text/import?renewIdmEntries=' + $scope.popup.renewIdmIds;
+              url = FLOWABLE.APP_URL.getAppDefinitionModelTextImportUrl($scope.model.app.id, $scope.popup.renewIdmIds);
           } else {
-              url = FLOWABLE.CONFIG.contextRoot + '/app/rest/app-definitions/' + $scope.model.app.id + '/import?renewIdmEntries=' + $scope.popup.renewIdmIds;
+              url = FLOWABLE.APP_URL.getAppDefinitionModelImportUrl($scope.model.app.id, $scope.popup.renewIdmIds);
           }
 
           Upload.upload({

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/controllers/app-definitions.js
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/controllers/app-definitions.js
@@ -72,7 +72,7 @@ angular.module('flowableModeler')
 		    params.filterText = $scope.model.filterText;
 		  }
 
-		  $http({method: 'GET', url: FLOWABLE.CONFIG.contextRoot + '/app/rest/models', params: params}).
+		  $http({method: 'GET', url: FLOWABLE.APP_URL.getModelsUrl(), params: params}).
 		  	success(function(data, status, headers, config) {
 	    		$scope.model.apps = data;
 	    		$scope.model.loading = false;
@@ -159,7 +159,7 @@ angular.module('flowableModeler')
 
             $scope.model.loading = true;
 
-            $http({method: 'POST', url: FLOWABLE.CONFIG.contextRoot + '/app/rest/models', data: $scope.model.app}).
+            $http({method: 'POST', url: FLOWABLE.APP_URL.getModelsUrl(), data: $scope.model.app}).
                 success(function (data, status, headers, config) {
                     $scope.$hide();
 
@@ -214,7 +214,7 @@ angular.module('flowableModeler')
 
             $scope.model.loading = true;
 
-            $http({method: 'POST', url: FLOWABLE.CONFIG.contextRoot + '/app/rest/models/'+$scope.model.app.id+'/clone', data: $scope.model.app}).
+            $http({method: 'POST', url: FLOWABLE.APP_URL.getCloneModelsUrl($scope.model.app.id), data: $scope.model.app}).
                 success(function (data, status, headers, config) {
                     $scope.$hide();
 
@@ -252,9 +252,9 @@ angular.module('flowableModeler')
 
           var url;
           if (isIE) {
-             url = FLOWABLE.CONFIG.contextRoot + '/app/rest/app-definitions/text/import?renewIdmEntries=' + $scope.model.renewIdmIds;
+             url = FLOWABLE.APP_URL.getAppDefinitionTextImportUrl($scope.model.renewIdmIds);
           } else {
-              url = FLOWABLE.CONFIG.contextRoot + '/app/rest/app-definitions/import?renewIdmEntries=' + $scope.model.renewIdmIds;
+              url = FLOWABLE.APP_URL.getAppDefinitionImportUrl($scope.model.renewIdmIds);
           }
           Upload.upload({
               url: url,

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/controllers/casemodel.js
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/controllers/casemodel.js
@@ -27,10 +27,9 @@ angular.module('flowableModeler')
     $scope.loadCaseModel = function() {
       var url;
       if ($routeParams.modelHistoryId) {
-        url = FLOWABLE.CONFIG.contextRoot + '/app/rest/models/' + $routeParams.modelId
-          + '/history/' + $routeParams.modelHistoryId;
+        url = FLOWABLE.APP_URL.getModelHistoryUrl($routeParams.modelId, $routeParams.modelHistoryId);
       } else {
-        url = FLOWABLE.CONFIG.contextRoot + '/app/rest/models/' + $routeParams.modelId;
+        url = FLOWABLE.APP_URL.getModelUrl($routeParams.modelId);
       }
       
       $http({method: 'GET', url: url}).
@@ -39,8 +38,7 @@ angular.module('flowableModeler')
           
           $scope.loadVersions();
 
-          $scope.model.cmmnDownloadUrl = FLOWABLE.CONFIG.contextRoot + '/app/rest/models/' + $routeParams.modelId +
-    			($routeParams.modelHistoryId == undefined ? '' : '/history/' + $routeParams.modelHistoryId) + '/cmmn?version=' + Date.now();
+          $scope.model.cmmnDownloadUrl = FLOWABLE.APP_URL.getCmmnModelDownloadUrl($routeParams.modelId, $routeParams.modelHistoryId);
 
 
     	  $rootScope.$on('$routeChangeStart', function(event, next, current) {
@@ -88,7 +86,7 @@ angular.module('flowableModeler')
         includeLatestVersion: !$scope.model.caseModel.latestVersion  
       };
       
-      $http({method: 'GET', url: FLOWABLE.CONFIG.contextRoot + '/app/rest/models/' + $scope.model.latestModelId +'/history', params: params}).
+      $http({method: 'GET', url: FLOWABLE.APP_URL.getModelHistoriesUrl($scope.model.latestModelId), params: params}).
       success(function(data, status, headers, config) {
         if ($scope.model.caseModel.latestVersion) {
           if (!data.data) {

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/controllers/casemodels.js
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/controllers/casemodels.js
@@ -64,7 +64,7 @@ angular.module('flowableModeler')
 		    params.filterText = $scope.model.filterText;
 		  }
 
-		  $http({method: 'GET', url: FLOWABLE.CONFIG.contextRoot + '/app/rest/models', params: params}).
+		  $http({method: 'GET', url: FLOWABLE.APP_URL.getModelsUrl(), params: params}).
 		  	success(function(data, status, headers, config) {
 	    		$scope.model.caseModels = data;
 	    		$scope.model.loading = false;
@@ -156,7 +156,7 @@ angular.module('flowableModeler')
 
         $scope.model.loading = true;
 
-        $http({method: 'POST', url: FLOWABLE.CONFIG.contextRoot + '/app/rest/models', data: $scope.model.caseModel}).
+        $http({method: 'POST', url: FLOWABLE.APP_URL.getModelsUrl(), data: $scope.model.caseModel}).
             success(function(data) {
                 $scope.$hide();
 
@@ -209,7 +209,7 @@ angular.module('flowableModeler')
 
         $scope.model.loading = true;
 
-        $http({method: 'POST', url: FLOWABLE.CONFIG.contextRoot + '/app/rest/models/'+$scope.model.caseModel.id+'/clone', data: $scope.model.caseModel}).
+        $http({method: 'POST', url: FLOWABLE.APP_URL.getCloneModelsUrl($scope.model.caseModel.id), data: $scope.model.caseModel}).
             success(function(data) {
                 $scope.$hide();
 
@@ -246,9 +246,9 @@ angular.module('flowableModeler')
 
           var url;
           if (isIE) {
-              url = FLOWABLE.CONFIG.contextRoot + '/app/rest/import-case-model/text';
+              url = FLOWABLE.APP_URL.getCaseModelTextImportUrl();
           } else {
-              url = FLOWABLE.CONFIG.contextRoot + '/app/rest/import-case-model';
+              url = FLOWABLE.APP_URL.getCaseModelImportUrl();
           }
 
           Upload.upload({

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/controllers/decision-table.js
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/controllers/decision-table.js
@@ -67,11 +67,11 @@ angular.module('flowableModeler')
             $scope.loadDecisionTable = function() {
                 var url, decisionTableUrl;
                 if ($routeParams.modelHistoryId) {
-                    url = FLOWABLE.CONFIG.contextRoot + '/app/rest/models/' + $routeParams.modelId + '/history/' + $routeParams.modelHistoryId;
-                    decisionTableUrl = FLOWABLE.CONFIG.contextRoot + '/app/rest/decision-table-models/history/' + $routeParams.modelHistoryId;
+                    url = FLOWABLE.APP_URL.getModelHistoryUrl($routeParams.modelId, $routeParams.modelHistoryId);
+                    decisionTableUrl = FLOWABLE.APP_URL.getDecisionTableModelsHistoryUrl($routeParams.modelHistoryId);
                 } else {
-                    url = FLOWABLE.CONFIG.contextRoot + '/app/rest/models/' + $routeParams.modelId;
-                    decisionTableUrl = FLOWABLE.CONFIG.contextRoot + '/app/rest/decision-table-models/' + $routeParams.modelId;
+                    url = FLOWABLE.APP_URL.getModelUrl($routeParams.modelId);
+                    decisionTableUrl = FLOWABLE.APP_URL.getDecisionTableModelUrl($routeParams.modelId);
                 }
 
                 $http({method: 'GET', url: url}).
@@ -99,7 +99,7 @@ angular.module('flowableModeler')
                     favorite: !$scope.model.decisionTable.favorite
                 };
 
-                $http({method: 'PUT', url: FLOWABLE.CONFIG.contextRoot + '/app/rest/models/' + $scope.model.latestModelId, data: data}).
+                $http({method: 'PUT', url: FLOWABLE.APP_URL.getModelUrl($scope.model.latestModelId), data: data}).
                     success(function(data, status, headers, config) {
                         $scope.model.favoritePending = false;
                         if ($scope.model.decisionTable.favorite) {
@@ -120,7 +120,7 @@ angular.module('flowableModeler')
                     includeLatestVersion: !$scope.model.decisionTable.latestVersion
                 };
 
-                $http({method: 'GET', url: FLOWABLE.CONFIG.contextRoot + '/app/rest/models/' + $scope.model.latestModelId + '/history', params: params}).
+                $http({method: 'GET', url: FLOWABLE.APP_URL.getModelHistoriesUrl($scope.model.latestModelId), params: params}).
                     success(function(data, status, headers, config) {
                         if ($scope.model.decisionTable.latestVersion) {
                             if (!data.data) {

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/controllers/decision-tables.js
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/controllers/decision-tables.js
@@ -84,7 +84,7 @@ angular.module('flowableModeler')
 		    params.filterText = $scope.model.filterText;
 		  }
 
-		  $http({method: 'GET', url: FLOWABLE.CONFIG.contextRoot + '/app/rest/models', params: params}).
+		  $http({method: 'GET', url: FLOWABLE.APP_URL.getModelsUrl(), params: params}).
 		  	success(function(data, status, headers, config) {
 	    		$scope.model.decisionTables = data;
 	    		$scope.model.loading = false;
@@ -174,7 +174,7 @@ angular.module('flowableModeler')
 
         $scope.model.loading = true;
 
-        $http({method: 'POST', url: FLOWABLE.CONFIG.contextRoot + '/app/rest/models', data: $scope.model.decisionTable}).
+        $http({method: 'POST', url: FLOWABLE.APP_URL.getModelsUrl(), data: $scope.model.decisionTable}).
             success(function(data, status, headers, config) {
                 $scope.$hide();
                 $scope.model.loading = false;
@@ -229,7 +229,7 @@ angular.module('flowableModeler')
 
 				$scope.model.loading = true;
 
-				$http({method: 'POST', url: FLOWABLE.CONFIG.contextRoot + '/app/rest/models/'+$scope.model.decisionTable.id+'/clone', data: $scope.model.decisionTable}).
+				$http({method: 'POST', url: FLOWABLE.APP_URL.getCloneModelsUrl($scope.model.decisionTable.id), data: $scope.model.decisionTable}).
 					success(function(data, status, headers, config) {
 						$scope.$hide();
 						$scope.model.loading = false;
@@ -267,9 +267,9 @@ angular.module('flowableModeler')
 
           var url;
           if (isIE) {
-              url = FLOWABLE.CONFIG.contextRoot + '/app/rest/decision-table-models/import-decision-table-text';
+              url = FLOWABLE.APP_URL.getDecisionTableTextImportUrl();
           } else {
-              url = FLOWABLE.CONFIG.contextRoot + '/app/rest/decision-table-models/import-decision-table';
+              url = FLOWABLE.APP_URL.getDecisionTableImportUrl();
           }
 
           Upload.upload({

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/controllers/form-builder.js
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/controllers/form-builder.js
@@ -151,9 +151,9 @@ angular.module('flowableModeler')
 
                 var url;
                 if ($routeParams.modelHistoryId) {
-                    url = FLOWABLE.CONFIG.contextRoot + '/app/rest/form-models/' + $routeParams.modelId + '/history/' + $routeParams.modelHistoryId;
+                    url = FLOWABLE.APP_URL.getFormModelHistoryUrl($routeParams.modelId, $routeParams.modelHistoryId);
                 } else {
-                    url = FLOWABLE.CONFIG.contextRoot + '/app/rest/form-models/' + $routeParams.modelId;
+                    url = FLOWABLE.APP_URL.getFormModelUrl($routeParams.modelId);
                 }
 
                 $http({method: 'GET', url: url}).

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/controllers/form-readonly-view.js
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/controllers/form-readonly-view.js
@@ -35,10 +35,9 @@ angular.module('flowableModeler')
 
           var url;
           if ($routeParams.modelHistoryId) {
-              url = FLOWABLE.CONFIG.contextRoot + '/app/rest/form-models/' + $routeParams.modelId
-                  + '/history/' + $routeParams.modelHistoryId;
+              url = FLOWABLE.APP_URL.getFormModelHistoryUrl($routeParams.modelId,$routeParams.modelHistoryId);
           } else {
-              url = FLOWABLE.CONFIG.contextRoot + '/app/rest/form-models/' + $routeParams.modelId;
+              url = FLOWABLE.APP_URL.getFormModelUrl($routeParams.modelId);
           }
 
           $http({method: 'GET', url: url}).

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/controllers/form.js
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/controllers/form.js
@@ -11,30 +11,29 @@
  * limitations under the License.
  */
 angular.module('flowableModeler')
-  .controller('FormCtrl', ['$rootScope', '$scope', '$translate', '$http', '$location', '$routeParams','$modal', '$timeout', '$popover', 
+  .controller('FormCtrl', ['$rootScope', '$scope', '$translate', '$http', '$location', '$routeParams','$modal', '$timeout', '$popover',
                               function ($rootScope, $scope, $translate, $http, $location, $routeParams, $modal, $timeout, $popover) {
 
     // Main page (needed for visual indicator of current page)
     $rootScope.setMainPageById('forms');
-    
+
     $scope.formMode = 'read';
-    
+
     // Initialize model
     $scope.model = {
         // Store the main model id, this points to the current version of a model,
         // even when we're showing history
         latestModelId: $routeParams.modelId
     };
-    
+
     $scope.loadForm = function() {
       var url;
       if ($routeParams.modelHistoryId) {
-        url = FLOWABLE.CONFIG.contextRoot + '/app/rest/models/' + $routeParams.modelId
-          + '/history/' + $routeParams.modelHistoryId;
+        url = FLOWABLE.APP_URL.getModelHistoryUrl($routeParams.modelId, $routeParams.modelHistoryId);
       } else {
-        url = FLOWABLE.CONFIG.contextRoot + '/app/rest/models/' + $routeParams.modelId;
+        url = FLOWABLE.APP_URL.getModelUrl($routeParams.modelId);
       }
-      
+
       $http({method: 'GET', url: url}).
         success(function(data, status, headers, config) {
           $scope.model.form = data;
@@ -44,21 +43,21 @@ angular.module('flowableModeler')
           $scope.returnToList();
         });
     };
-    
+
     $scope.useAsNewVersion = function() {
         _internalCreateModal({
     		template: 'views/popup/model-use-as-new-version.html',
     		scope: $scope
     	}, $modal, $scope);
     };
-    
+
     $scope.loadVersions = function() {
-      
+
       var params = {
-        includeLatestVersion: !$scope.model.form.latestVersion  
+        includeLatestVersion: !$scope.model.form.latestVersion
       };
-      
-      $http({method: 'GET', url: FLOWABLE.CONFIG.contextRoot + '/app/rest/models/' + $scope.model.latestModelId + '/history', params: params}).
+
+      $http({method: 'GET', url: FLOWABLE.APP_URL.getModelHistoriesUrl($scope.model.latestModelId), params: params}).
 	      success(function(data, status, headers, config) {
 	        if ($scope.model.form.latestVersion) {
 	          if (!data.data) {
@@ -66,11 +65,11 @@ angular.module('flowableModeler')
 	          }
 	          data.data.unshift($scope.model.form);
 	        }
-	        
+
 	        $scope.model.versions = data;
 	      });
     };
-    
+
     $scope.showVersion = function(version) {
       if (version) {
         if (version.latestVersion) {
@@ -81,11 +80,11 @@ angular.module('flowableModeler')
         }
       }
     };
-    
+
     $scope.returnToList = function() {
         $location.path("/forms/");
     };
-    
+
     $scope.editForm = function() {
         _internalCreateModal({
     		template: 'views/popup/model-edit.html',
@@ -113,7 +112,7 @@ angular.module('flowableModeler')
     		scope: $scope
     	}, $modal, $scope);
     };
-    
+
     $scope.openEditor = function() {
       if ($scope.model.form) {
     	  $location.path("/form-editor/" + $scope.model.form.id);
@@ -124,7 +123,7 @@ angular.module('flowableModeler')
       if (!$scope.historyState) {
         var state = {};
         $scope.historyState = state;
-        
+
         // Create popover
         state.popover = $popover(angular.element($event.target), {
           template: 'views/popover/history.html',
@@ -133,18 +132,18 @@ angular.module('flowableModeler')
           scope: $scope,
           container: 'body'
         });
-        
+
         var destroy = function() {
           state.popover.destroy();
           delete $scope.historyState;
         };
-        
+
         // When popup is hidden or scope is destroyed, hide popup
         state.popover.$scope.$on('tooltip.hide', destroy);
         $scope.$on('$destroy', destroy);
       }
     };
-    
+
     $scope.loadForm();
-    
+
 }]);

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/controllers/forms.js
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/controllers/forms.js
@@ -76,7 +76,7 @@ angular.module('flowableModeler')
 		    params.filterText = $scope.model.filterText;
 		  }
 
-		  $http({method: 'GET', url: FLOWABLE.CONFIG.contextRoot + '/app/rest/models', params: params}).
+		  $http({method: 'GET', url: FLOWABLE.APP_URL.getModelsUrl(), params: params}).
 		  	success(function(data, status, headers, config) {
 	    		$scope.model.forms = data;
 	    		$scope.model.loading = false;
@@ -164,7 +164,7 @@ angular.module('flowableModeler')
 
         $scope.model.loading = true;
 
-        $http({method: 'POST', url: FLOWABLE.CONFIG.contextRoot + '/app/rest/models', data: $scope.model.form}).
+        $http({method: 'POST', url: FLOWABLE.APP_URL.getModelsUrl(), data: $scope.model.form}).
             success(function(data, status, headers, config) {
                 $scope.$hide();
                 $scope.model.loading = false;
@@ -222,7 +222,7 @@ angular.module('flowableModeler')
 
 				$scope.model.loading = true;
 
-				$http({method: 'POST', url: FLOWABLE.CONFIG.contextRoot + '/app/rest/models/'+$scope.model.form.id+'/clone', data: $scope.model.form}).
+				$http({method: 'POST', url: FLOWABLE.APP_URL.getCloneModelsUrl($scope.model.form.id), data: $scope.model.form}).
 					success(function(data, status, headers, config) {
 						$scope.$hide();
 						$scope.model.loading = false;

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/controllers/model-common-actions.js
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/controllers/model-common-actions.js
@@ -63,7 +63,7 @@ angular.module('flowableModeler')
     			$scope.model.description
     		};
 
-    		$http({method: 'PUT', url: FLOWABLE.CONFIG.contextRoot + '/app/rest/models/' + $scope.popup.id, data: updateData}).
+    		$http({method: 'PUT', url: FLOWABLE.APP_URL.getModelUrl($scope.popup.id), data: updateData}).
     			success(function(data, status, headers, config) {
     				if ($scope.model.process) {
     					$scope.model.process = data;
@@ -138,7 +138,7 @@ angular.module('flowableModeler')
         };
 
         // Loading relations when opening
-        $http({method: 'GET', url: FLOWABLE.CONFIG.contextRoot + '/app/rest/models/' + $scope.popup.model.id + '/parent-relations'}).
+        $http({method: 'GET', url: FLOWABLE.APP_URL.getModelParentRelationsUrl($scope.popup.model.id)}).
             success(function (data, status, headers, config) {
                 $scope.popup.loading = false;
                 $scope.popup.loadingRelations = false;
@@ -156,7 +156,7 @@ angular.module('flowableModeler')
                 cascade: $scope.popup.cascade === 'true'
             };
 
-            $http({method: 'DELETE', url: FLOWABLE.CONFIG.contextRoot + '/app/rest/models/' + $scope.popup.model.id, params: params}).
+            $http({method: 'DELETE', url: FLOWABLE.APP_URL.getModelUrl($scope.popup.model.id), params: params}).
                 success(function (data, status, headers, config) {
                     $scope.$hide();
                     $scope.popup.loading = false;
@@ -214,7 +214,7 @@ angular.module('flowableModeler')
 			comment: $scope.popup.comment
 		};
 
-		$http({method: 'POST', url: FLOWABLE.CONFIG.contextRoot + '/app/rest/models/' + $scope.popup.latestModelId + '/history/' + $scope.popup.model.id, data: actionData}).
+		$http({method: 'POST', url: FLOWABLE.APP_URL.getModelHistoryUrl($scope.popup.latestModelId, $scope.popup.model.id), data: actionData}).
 			success(function(data, status, headers, config) {
 
                 var backToOverview = function() {

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/controllers/process.js
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/controllers/process.js
@@ -27,10 +27,10 @@ angular.module('flowableModeler')
     $scope.loadProcess = function() {
       var url;
       if ($routeParams.modelHistoryId) {
-        url = FLOWABLE.CONFIG.contextRoot + '/app/rest/models/' + $routeParams.modelId
+        url = FLOWABLE.APP_URL.getModelUrl($routeParams.modelId);
           + '/history/' + $routeParams.modelHistoryId;
       } else {
-        url = FLOWABLE.CONFIG.contextRoot + '/app/rest/models/' + $routeParams.modelId;
+        url = FLOWABLE.APP_URL.getModelUrl($routeParams.modelId);
       }
       
       $http({method: 'GET', url: url}).
@@ -39,8 +39,9 @@ angular.module('flowableModeler')
           
           $scope.loadVersions();
 
-          $scope.model.bpmn20DownloadUrl = FLOWABLE.CONFIG.contextRoot + '/app/rest/models/' + $routeParams.modelId +
-    			($routeParams.modelHistoryId == undefined ? '' : '/history/' + $routeParams.modelHistoryId) + '/bpmn20?version=' + Date.now();
+          $scope.model.bpmn20DownloadUrl = $routeParams.modelHistoryId == undefined ?
+              FLOWABLE.APP_URL.getModelBpmn20ExportUrl($routeParams.modelId) :
+              FLOWABLE.APP_URL.getModelHistoryBpmn20ExportUrl($routeParams.modelId, $routeParams.modelHistoryId);
 
 
         	  $rootScope.$on('$routeChangeStart', function(event, next, current) {
@@ -88,7 +89,7 @@ angular.module('flowableModeler')
         includeLatestVersion: !$scope.model.process.latestVersion  
       };
       
-      $http({method: 'GET', url: FLOWABLE.CONFIG.contextRoot + '/app/rest/models/' + $scope.model.latestModelId +'/history', params: params}).
+      $http({method: 'GET', url: FLOWABLE.APP_URL.getModelHistoriesUrl($scope.model.latestModelId), params: params}).
       success(function(data, status, headers, config) {
         if ($scope.model.process.latestVersion) {
           if (!data.data) {

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/controllers/processes.js
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/controllers/processes.js
@@ -76,7 +76,7 @@ angular.module('flowableModeler')
 		    params.filterText = $scope.model.filterText;
 		  }
 
-		  $http({method: 'GET', url: FLOWABLE.CONFIG.contextRoot + '/app/rest/models', params: params}).
+		  $http({method: 'GET', url: FLOWABLE.APP_URL.getModelsUrl(), params: params}).
 		  	success(function(data, status, headers, config) {
 	    		$scope.model.processes = data;
 	    		$scope.model.loading = false;
@@ -168,7 +168,7 @@ angular.module('flowableModeler')
 
         $scope.model.loading = true;
 
-        $http({method: 'POST', url: FLOWABLE.CONFIG.contextRoot + '/app/rest/models', data: $scope.model.process}).
+        $http({method: 'POST', url: FLOWABLE.APP_URL.getModelsUrl(), data: $scope.model.process}).
             success(function(data) {
                 $scope.$hide();
 
@@ -221,7 +221,7 @@ angular.module('flowableModeler')
 
         $scope.model.loading = true;
 
-        $http({method: 'POST', url: FLOWABLE.CONFIG.contextRoot + '/app/rest/models/'+$scope.model.process.id+'/clone', data: $scope.model.process}).
+        $http({method: 'POST', url: FLOWABLE.APP_URL.getCloneModelsUrl(), data: $scope.model.process}).
             success(function(data) {
                 $scope.$hide();
 
@@ -258,9 +258,9 @@ angular.module('flowableModeler')
 
           var url;
           if (isIE) {
-              url = FLOWABLE.CONFIG.contextRoot + '/app/rest/import-process-model/text';
+              url = FLOWABLE.APP_URL.getImportProcessModelTextUrl();
           } else {
-              url = FLOWABLE.CONFIG.contextRoot + '/app/rest/import-process-model';
+              url = FLOWABLE.APP_URL.getImportProcessModelUrl();
           }
 
           Upload.upload({

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/editor-directives.js
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/editor-directives.js
@@ -36,7 +36,7 @@ angular.module('flowableModeler')
                 item: '=stencilItem'
             },
             restrict: 'E',
-            template: '<img class="stencil-item-list-icon" ng-if=\"item.customIconId != null && item.customIconId != undefined\" ng-src=\"' + FLOWABLE.CONFIG.contextRoot + '/app/rest/image/{{item.customIconId}}\" width=\"16px\" height=\"16px\"/>' +
+            template: '<img class="stencil-item-list-icon" ng-if=\"item.customIconId != null && item.customIconId != undefined\" ng-src=\"' + getImageUrl(item.customIconId) + '\" width=\"16px\" height=\"16px\"/>' +
             '<img class="stencil-item-list-icon" ng-if=\"(item.customIconId == null || item.customIconId == undefined) && item.icon != null && item.icon != undefined\" ng-src=\"editor-app/stencilsets/bpmn2.0/icons/{{item.icon}}\" width=\"16px\" height=\"16px\"/>'
         };
     }]);

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/services/decision-table-service.js
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/services/decision-table-service.js
@@ -35,7 +35,7 @@ angular.module('flowableModeler').service('DecisionTableService', [ '$rootScope'
             return httpAsPromise(
                 {
                     method: 'GET',
-                    url: FLOWABLE.CONFIG.contextRoot + '/app/rest/decision-table-models',
+                    url: FLOWABLE.APP_URL.getDecisionTableModelsUrl(),
                     params: {filter: filter}
                 }
             );
@@ -45,13 +45,9 @@ angular.module('flowableModeler').service('DecisionTableService', [ '$rootScope'
          * Fetches the details of a decision table.
          */
         this.fetchDecisionTableDetails = function(modelId, historyModelId) {
-            var url = FLOWABLE.CONFIG.contextRoot + '/app/rest/decision-table-models/';
-            if (historyModelId) {
-                url += 'history/' + encodeURIComponent(historyModelId);
-            }
-            else {
-                url += encodeURIComponent(modelId);
-            }
+            var url = historyModelId ?
+                FLOWABLE.APP_URL.getDecisionTableModelHistoryUrl(encodeURIComponent(modelId), encodeURIComponent(historyModelId)) :
+                FLOWABLE.APP_URL.getDecisionTableModelUrl(encodeURIComponent(modelId));
             return httpAsPromise({ method: 'GET', url: url });
         };
 
@@ -118,7 +114,7 @@ angular.module('flowableModeler').service('DecisionTableService', [ '$rootScope'
 
                     $http({
 	                    method: 'PUT',
-	                    url: FLOWABLE.CONFIG.contextRoot + '/app/rest/decision-table-models/' + $rootScope.currentDecisionTable.id,
+	                    url: FLOWABLE.APP_URL.getDecisionTableModelUrl($rootScope.currentDecisionTable.id),
 	                    data: data}).
 	                
 	                	success(function (response, status, headers, config) {
@@ -152,7 +148,7 @@ angular.module('flowableModeler').service('DecisionTableService', [ '$rootScope'
                 }
                 decisionTableIdParams += 'version=' + Date.now();
 
-                $http({method: 'GET', url: FLOWABLE.CONFIG.contextRoot + '/app/rest/decision-table-models/values?' + decisionTableIdParams}).
+                $http({method: 'GET', url: FLOWABLE.APP_URL.getDecisionTableModelValuesUrl(decisionTableIdParams)}).
                     success(function (data) {
                         if (callback) {
                             callback(data);

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/services/form-services.js
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/services/form-services.js
@@ -73,7 +73,7 @@ angular.module('flowableModeler').service('FormBuilderService', ['$http', '$q', 
                     ctx.drawImage(canvas, 0, 0, canvas.width, canvas.height, 0, 0, 300, canvas.height / scale);
                     data.formImageBase64 = extra_canvas.toDataURL("image/png");
 
-                    $http({method: 'PUT', url: FLOWABLE.CONFIG.contextRoot + '/app/rest/form-models/' + $rootScope.currentForm.id, data: data}).
+                    $http({method: 'PUT', url: FLOWABLE.APP_URL.getFormModelUrl($rootScope.currentForm.id), data: data}).
                         success(function (response, status, headers, config) {
 
                             if (saveCallback) {
@@ -199,7 +199,7 @@ angular.module('flowableModeler').service('FormBuilderService', ['$http', '$q', 
 
         var _updateFormCache = function (stepId, formId) {
             if (stepId && formId) {
-                $http({method: 'GET', url: FLOWABLE.CONFIG.contextRoot + '/app/rest/form-models/' + formId}).
+                $http({method: 'GET', url: FLOWABLE.APP_URL.getFormModelUrl(formId)}).
                     success(function(response) {
                         if (response) {
                             var outcomes;
@@ -240,7 +240,7 @@ angular.module('flowableModeler').service('FormBuilderService', ['$http', '$q', 
                 }
                 formIdParams += 'version=' + Date.now();
 
-                $http({method: 'GET', url: FLOWABLE.CONFIG.contextRoot + '/app/rest/form-models/values?' + formIdParams}).
+                $http({method: 'GET', url: FLOWABLE.APP_URL.getFormModelValuesUrl(formIdParams)}).
                     success(function (data) {
                         if (callback) {
                             callback(data);

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/services/identity-services.js
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/scripts/services/identity-services.js
@@ -41,7 +41,7 @@ angular.module('flowableModeler').service('UserService', ['$http', '$q',
 
             return httpAsPromise({
                 method: 'GET',
-                url: FLOWABLE.CONFIG.contextRoot + '/app/rest/editor-users',
+                url: FLOWABLE.APP_URL.getEditorUsersUrl(),
                 params: params
             });
         };
@@ -74,7 +74,7 @@ angular.module('flowableModeler').service('GroupService', ['$http', '$q',
 
             return httpAsPromise({
                 method: 'GET',
-                url: FLOWABLE.CONFIG.contextRoot + '/app/rest/editor-groups',
+                url: FLOWABLE.APP_URL.getEditorGroupsUrl(),
                 params: params
             });
         };

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/views/app-definition-builder.html
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/views/app-definition-builder.html
@@ -111,7 +111,7 @@
                 
                 <div class="col-xs-12 item-wrapper" ng-show="appBuilder.activeTab == 'bpmn'">
                     <div class="item fadein" ng-repeat="model in currentAppDefinition.definition.models">
-                        <div class="item-box" ng-style="{'background-image': 'url(\'' + config.contextRoot + '/app/rest/models/' + model.id + '/thumbnail\')'}">
+                        <div class="item-box" ng-style="{'background-image': 'url(\'' + getModelThumbnailUrl(model.id) + '\')'}">
                             <div class="actions">
                                 <span class="badge">v{{model.version}}</span>
                             </div>
@@ -127,7 +127,7 @@
                 
                 <div class="col-xs-12 item-wrapper" ng-show="appBuilder.activeTab == 'cmmn'">
                     <div class="item fadein" ng-repeat="model in currentAppDefinition.definition.cmmnModels">
-                        <div class="item-box" ng-style="{'background-image': 'url(\'' + config.contextRoot + '/app/rest/models/' + model.id + '/thumbnail\')'}">
+                        <div class="item-box" ng-style="{'background-image': 'url(\'' + getModelThumbnailUrl(model.id) + '\')'}">
                             <div class="actions">
                                 <span class="badge">v{{model.version}}</span>
                             </div>

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/views/app-definition.html
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/views/app-definition.html
@@ -109,7 +109,7 @@
                 
                 <div class="col-xs-12 item-wrapper" ng-show="model.activeTab == 'bpmn'">
                     <div class="item fadein" ng-repeat="model in model.appDefinition.definition.models">
-                        <div class="item-box" ng-style="{'background-image': 'url(\'' + config.contextRoot + '/app/rest/models/' + model.id + '/thumbnail\')'}">
+                        <div class="item-box" ng-style="{'background-image': 'url(\'' + getModelThumbnailUrl(model.id) + '\')'}">
                             <div class="actions">
                                 <span class="badge">v{{model.version}}</span>
                             </div>
@@ -125,7 +125,7 @@
                 
                 <div class="col-xs-12 item-wrapper" ng-show="model.activeTab == 'cmmn'">
                     <div class="item fadein" ng-repeat="model in model.appDefinition.definition.cmmnModels">
-                        <div class="item-box" ng-style="{'background-image': 'url(\'' + config.contextRoot + '/app/rest/models/' + model.id + '/thumbnail\')'}">
+                        <div class="item-box" ng-style="{'background-image': 'url(\'' + getModelThumbnailUrl(model.id) + '\')'}">
                             <div class="actions">
                                 <span class="badge">v{{model.version}}</span>
                             </div>

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/views/casemodels.html
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/views/casemodels.html
@@ -67,7 +67,7 @@
                 </div>
             </div>
 			<div class="item fadein" ng-repeat="caseModel in model.caseModels.data track by $index">
-				<div class="item-box" ng-style="{'background-image': 'url(\'' + config.contextRoot + '/app/rest/models/' + caseModel.id + '/thumbnail?version=' + imageVersion + '\')'}" ng-click="showCaseModelDetails(caseModel);">
+				<div class="item-box" ng-style="{'background-image': 'url(\'' + getModelThumbnailUrl(caseModel.id, imageVersion) + '\')'}" ng-click="showCaseModelDetails(caseModel);">
 					<div class="actions">
 						<span class="badge">v{{caseModel.version}}</span>
 						<div class="btn-group pull-right">

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/views/decision-tables.html
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/views/decision-tables.html
@@ -55,7 +55,7 @@
             </div>
             
             <div class="item fadein" ng-repeat="decisionTable in model.decisionTables.data track by $index">
-                <div class="item-box" ng-style="{'background-image': 'url(\'' + config.contextRoot + '/app/rest/models/' + decisionTable.id + '/thumbnail?version=' + imageVersion + '\')'}" ng-click="showDecisionTableDetails(decisionTable);">
+                <div class="item-box" ng-style="{'background-image': 'url(\'' + getModelThumbnailUrl(decisionTable.id, imageVersion) + '\')'}" ng-click="showDecisionTableDetails(decisionTable);">
                     <div class="actions">
                         <span class="badge">v{{decisionTable.version}}</span>
                         <div class="btn-group pull-right">

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/views/forms.html
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/views/forms.html
@@ -55,7 +55,7 @@
             </div>
             
             <div class="item fadein" ng-repeat="form in model.forms.data track by $index">
-                <div class="item-box" ng-style="{'background-image': 'url(\'' + config.contextRoot + '/app/rest/models/' + form.id + '/thumbnail?version=' + imageVersion + '\')'}" ng-click="showFormDetails(form);">
+                <div class="item-box" ng-style="{'background-image': 'url(\'' + getModelThumbnailUrl(form.id, imageVersion) + '\')'}" ng-click="showFormDetails(form);">
                     <div class="actions">
                         <span class="badge">v{{form.version}}</span>
                         <div class="btn-group pull-right">

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/views/popup/app-definition-models-included.html
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/views/popup/app-definition-models-included.html
@@ -18,7 +18,7 @@
                 
                 <div class="item-wrapper clearfix" ng-show="popup.activeTab == 'bpmn'">
                     <div class="item fadein" ng-repeat="model in popup.models.data">
-                        <div class="item-box" ng-style="{'background-image': 'url(\'' + config.contextRoot + '/app/rest/models/' + model.id + '/thumbnail\')'}" ng-click="selectModel(model); $event.stopPropagation();">
+                        <div class="item-box" ng-style="{'background-image': 'url(\'' + getModelThumbnailUrl(model.id) + '\')'}" ng-click="selectModel(model); $event.stopPropagation();">
                             <span class="badge">v{{model.version}}</span>
                             <div class="btn-group pull-right">
                                 <button type="button" ng-show="isModelSelected(model)" class="btn btn-default" title="{{'PROCESS.ACTION.DETAILS' | translate}}">
@@ -40,7 +40,7 @@
                 
                 <div class="item-wrapper clearfix" ng-show="popup.activeTab == 'cmmn'">
                     <div class="item fadein" ng-repeat="cmmnModel in popup.cmmnModels.data">
-                        <div class="item-box" ng-style="{'background-image': 'url(\'' + config.contextRoot + '/app/rest/models/' + cmmnModel.id + '/thumbnail\')'}" ng-click="selectCmmnModel(cmmnModel); $event.stopPropagation();">
+                        <div class="item-box" ng-style="{'background-image': 'url(\'' + getModelThumbnailUrl(cmmnModel.id) + '\')'}" ng-click="selectCmmnModel(cmmnModel); $event.stopPropagation();">
                             <span class="badge">v{{cmmnModel.version}}</span>
                             <div class="btn-group pull-right">
                                 <button type="button" ng-show="isCmmnModelSelected(cmmnModel)" class="btn btn-default" title="{{'PROCESS.ACTION.DETAILS' | translate}}">

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/views/processes.html
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/views/processes.html
@@ -67,7 +67,7 @@
                 </div>
             </div>
 			<div class="item fadein" ng-repeat="process in model.processes.data track by $index">
-				<div class="item-box" ng-style="{'background-image': 'url(\'' + config.contextRoot + '/app/rest/models/' + process.id + '/thumbnail?version=' + imageVersion + '\')'}" ng-click="showProcessDetails(process);">
+				<div class="item-box" ng-style="{'background-image': 'url(\'' + getModelThumbnailUrl(process.id, imageVersion) + '\')'}" ng-click="showProcessDetails(process);">
 					<div class="actions">
 						<span class="badge">v{{process.version}}</span>
 						<div class="btn-group pull-right">


### PR DESCRIPTION
I've created this pull request to simplify the use of the modeler code in other applications with, for example, another REST service. Hence I have created the APP_URL namespace to hold functions that return the REST URLs. (Note, I have not used the URL namespace as to not clash with the editor, of course, they can always be combined or renamed).

I have also created a forum post (https://forum.flowable.org/t/bringing-all-rest-urls-together/1060) to include everyone in the discussion of whether or not this is useful.