### PR TITLE
Generify DataResponse and PaginateList

### DIFF
--- a/modules/flowable-common-rest/src/main/java/org/flowable/rest/api/DataResponse.java
+++ b/modules/flowable-common-rest/src/main/java/org/flowable/rest/api/DataResponse.java
@@ -13,23 +13,25 @@
 
 package org.flowable.rest.api;
 
+import java.util.List;
+
 /**
  * @author Tijs Rademakers
  */
-public class DataResponse {
+public class DataResponse<T> {
 
-    Object data;
+    List<T> data;
     long total;
     int start;
     String sort;
     String order;
     int size;
 
-    public Object getData() {
+    public List<T> getData() {
         return data;
     }
 
-    public DataResponse setData(Object data) {
+    public DataResponse<T> setData(List<T> data) {
         this.data = data;
         return this;
     }

--- a/modules/flowable-common-rest/src/main/java/org/flowable/rest/api/DefaultPaginateList.java
+++ b/modules/flowable-common-rest/src/main/java/org/flowable/rest/api/DefaultPaginateList.java
@@ -18,11 +18,10 @@ import java.util.List;
 /**
  * @author Tijs Rademakers
  */
-public class DefaultPaginateList extends AbstractPaginateList {
+public class DefaultPaginateList<T> extends AbstractPaginateList<T, T> {
 
-    @SuppressWarnings("rawtypes")
     @Override
-    protected List processList(List list) {
+    protected List<T> processList(List<T> list) {
         return list;
     }
 }

--- a/modules/flowable-content-rest/src/main/java/org/flowable/rest/content/service/api/content/ContentItemBaseResource.java
+++ b/modules/flowable-content-rest/src/main/java/org/flowable/rest/content/service/api/content/ContentItemBaseResource.java
@@ -46,7 +46,7 @@ public class ContentItemBaseResource {
     @Autowired
     protected ContentService contentService;
 
-    protected DataResponse getContentItemsFromQueryRequest(ContentItemQueryRequest request, Map<String, String> requestParams) {
+    protected DataResponse<ContentItemResponse> getContentItemsFromQueryRequest(ContentItemQueryRequest request, Map<String, String> requestParams) {
 
         ContentItemQuery contentItemQuery = contentService.createContentItemQuery();
 

--- a/modules/flowable-content-rest/src/main/java/org/flowable/rest/content/service/api/content/ContentItemCollectionResource.java
+++ b/modules/flowable-content-rest/src/main/java/org/flowable/rest/content/service/api/content/ContentItemCollectionResource.java
@@ -99,7 +99,7 @@ public class ContentItemCollectionResource extends ContentItemBaseResource {
             @ApiResponse(code = 200, message = "The content items are returned.")
     })
     @RequestMapping(value = "/content-service/content-items", method = RequestMethod.GET, produces = "application/json")
-    public DataResponse getContentItems(@ApiParam(hidden = true) @RequestParam Map<String, String> requestParams, HttpServletRequest httpRequest) {
+    public DataResponse<ContentItemResponse> getContentItems(@ApiParam(hidden = true) @RequestParam Map<String, String> requestParams, HttpServletRequest httpRequest) {
         // Create a Content item query request
         ContentItemQueryRequest request = new ContentItemQueryRequest();
 

--- a/modules/flowable-content-rest/src/main/java/org/flowable/rest/content/service/api/content/ContentItemPaginateList.java
+++ b/modules/flowable-content-rest/src/main/java/org/flowable/rest/content/service/api/content/ContentItemPaginateList.java
@@ -15,13 +15,14 @@ package org.flowable.rest.content.service.api.content;
 
 import java.util.List;
 
+import org.flowable.content.api.ContentItem;
 import org.flowable.rest.api.AbstractPaginateList;
 import org.flowable.rest.content.ContentRestResponseFactory;
 
 /**
  * @author Tijs Rademakers
  */
-public class ContentItemPaginateList extends AbstractPaginateList {
+public class ContentItemPaginateList extends AbstractPaginateList<ContentItemResponse, ContentItem> {
 
     protected ContentRestResponseFactory restResponseFactory;
 
@@ -29,9 +30,8 @@ public class ContentItemPaginateList extends AbstractPaginateList {
         this.restResponseFactory = restResponseFactory;
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
-    protected List processList(List list) {
+    protected List<ContentItemResponse> processList(List<ContentItem> list) {
         return restResponseFactory.createContentItemResponseList(list);
     }
 }

--- a/modules/flowable-content-rest/src/main/java/org/flowable/rest/content/service/api/content/ContentItemQueryResource.java
+++ b/modules/flowable-content-rest/src/main/java/org/flowable/rest/content/service/api/content/ContentItemQueryResource.java
@@ -45,7 +45,7 @@ public class ContentItemQueryResource extends ContentItemBaseResource {
             @ApiResponse(code = 400, message = "Indicates a parameter was passed in the wrong format. The status-message contains additional information.")
     })
     @RequestMapping(value = "/query/content-items", method = RequestMethod.POST, produces = "application/json")
-    public DataResponse getQueryResult(@RequestBody ContentItemQueryRequest request, @ApiParam(hidden = true) @RequestParam Map<String, String> requestParams, HttpServletRequest httpRequest) {
+    public DataResponse<ContentItemResponse> getQueryResult(@RequestBody ContentItemQueryRequest request, @ApiParam(hidden = true) @RequestParam Map<String, String> requestParams, HttpServletRequest httpRequest) {
 
         return getContentItemsFromQueryRequest(request, requestParams);
     }

--- a/modules/flowable-dmn-rest/src/main/java/org/flowable/rest/dmn/service/api/history/HistoricDecisionExecutionsDmnPaginateList.java
+++ b/modules/flowable-dmn-rest/src/main/java/org/flowable/rest/dmn/service/api/history/HistoricDecisionExecutionsDmnPaginateList.java
@@ -14,13 +14,14 @@ package org.flowable.rest.dmn.service.api.history;
 
 import java.util.List;
 
+import org.flowable.dmn.api.DmnHistoricDecisionExecution;
 import org.flowable.rest.api.AbstractPaginateList;
 import org.flowable.rest.dmn.service.api.DmnRestResponseFactory;
 
 /**
  * @author Tijs Rademakers
  */
-public class HistoricDecisionExecutionsDmnPaginateList extends AbstractPaginateList {
+public class HistoricDecisionExecutionsDmnPaginateList extends AbstractPaginateList<HistoricDecisionExecutionResponse, DmnHistoricDecisionExecution> {
 
     protected DmnRestResponseFactory dmnRestResponseFactory;
 
@@ -28,9 +29,8 @@ public class HistoricDecisionExecutionsDmnPaginateList extends AbstractPaginateL
         this.dmnRestResponseFactory = dmnRestResponseFactory;
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
-    protected List processList(List list) {
+    protected List<HistoricDecisionExecutionResponse> processList(List<DmnHistoricDecisionExecution> list) {
         return dmnRestResponseFactory.createHistoricDecisionExecutionResponseList(list);
     }
 }

--- a/modules/flowable-dmn-rest/src/main/java/org/flowable/rest/dmn/service/api/history/HistoryDecisionExecutionCollectionResource.java
+++ b/modules/flowable-dmn-rest/src/main/java/org/flowable/rest/dmn/service/api/history/HistoryDecisionExecutionCollectionResource.java
@@ -78,7 +78,7 @@ public class HistoryDecisionExecutionCollectionResource {
             @ApiResponse(code = 400, message = "Indicates a parameter was passed in the wrong format. The status-message contains additional information.")
     })
     @RequestMapping(value = "/dmn-history/historic-decision-executions", method = RequestMethod.GET, produces = "application/json")
-    public DataResponse getDecisionTables(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
+    public DataResponse<HistoricDecisionExecutionResponse> getDecisionTables(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
         DmnHistoricDecisionExecutionQuery historicDecisionExecutionQuery = dmnHistoryService.createHistoricDecisionExecutionQuery();
 
         // Populate filter-parameters

--- a/modules/flowable-dmn-rest/src/main/java/org/flowable/rest/dmn/service/api/repository/DecisionTableCollectionResource.java
+++ b/modules/flowable-dmn-rest/src/main/java/org/flowable/rest/dmn/service/api/repository/DecisionTableCollectionResource.java
@@ -84,7 +84,7 @@ public class DecisionTableCollectionResource {
             @ApiResponse(code = 400, message = "Indicates a parameter was passed in the wrong format or that latest is used with other parameters other than key and keyLike. The status-message contains additional information.")
     })
     @RequestMapping(value = "/dmn-repository/decision-tables", method = RequestMethod.GET, produces = "application/json")
-    public DataResponse getDecisionTables(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
+    public DataResponse<DecisionTableResponse> getDecisionTables(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
         DmnDecisionTableQuery decisionTableQuery = dmnRepositoryService.createDecisionTableQuery();
 
         // Populate filter-parameters

--- a/modules/flowable-dmn-rest/src/main/java/org/flowable/rest/dmn/service/api/repository/DecisionTablesDmnPaginateList.java
+++ b/modules/flowable-dmn-rest/src/main/java/org/flowable/rest/dmn/service/api/repository/DecisionTablesDmnPaginateList.java
@@ -14,13 +14,14 @@ package org.flowable.rest.dmn.service.api.repository;
 
 import java.util.List;
 
+import org.flowable.dmn.api.DmnDecisionTable;
 import org.flowable.rest.api.AbstractPaginateList;
 import org.flowable.rest.dmn.service.api.DmnRestResponseFactory;
 
 /**
  * @author Yvo Swillens
  */
-public class DecisionTablesDmnPaginateList extends AbstractPaginateList {
+public class DecisionTablesDmnPaginateList extends AbstractPaginateList<DecisionTableResponse, DmnDecisionTable> {
 
     protected DmnRestResponseFactory dmnRestResponseFactory;
 
@@ -28,9 +29,8 @@ public class DecisionTablesDmnPaginateList extends AbstractPaginateList {
         this.dmnRestResponseFactory = dmnRestResponseFactory;
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
-    protected List processList(List list) {
+    protected List<DecisionTableResponse> processList(List<DmnDecisionTable> list) {
         return dmnRestResponseFactory.createDecisionTableResponseList(list);
     }
 }

--- a/modules/flowable-dmn-rest/src/main/java/org/flowable/rest/dmn/service/api/repository/DmnDeploymentCollectionResource.java
+++ b/modules/flowable-dmn-rest/src/main/java/org/flowable/rest/dmn/service/api/repository/DmnDeploymentCollectionResource.java
@@ -84,7 +84,7 @@ public class DmnDeploymentCollectionResource {
             @ApiResponse(code = 200, message = "Indicates the request was successful."),
     })
     @RequestMapping(value = "/dmn-repository/deployments", method = RequestMethod.GET, produces = "application/json")
-    public DataResponse getDeployments(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams) {
+    public DataResponse<DmnDeploymentResponse> getDeployments(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams) {
         DmnDeploymentQuery deploymentQuery = dmnRepositoryService.createDeploymentQuery();
 
         // Apply filters
@@ -113,8 +113,7 @@ public class DmnDeploymentCollectionResource {
             }
         }
 
-        DataResponse response = new DmnDeploymentsPaginateList(dmnRestResponseFactory).paginateList(allRequestParams, deploymentQuery, "id", allowedSortProperties);
-        return response;
+        return new DmnDeploymentsPaginateList(dmnRestResponseFactory).paginateList(allRequestParams, deploymentQuery, "id", allowedSortProperties);
     }
 
     @ApiOperation(value = "Create a new decision table deployment", tags = {

--- a/modules/flowable-dmn-rest/src/main/java/org/flowable/rest/dmn/service/api/repository/DmnDeploymentsPaginateList.java
+++ b/modules/flowable-dmn-rest/src/main/java/org/flowable/rest/dmn/service/api/repository/DmnDeploymentsPaginateList.java
@@ -13,6 +13,7 @@
 
 package org.flowable.rest.dmn.service.api.repository;
 
+import org.flowable.dmn.api.DmnDeployment;
 import org.flowable.rest.api.AbstractPaginateList;
 import org.flowable.rest.dmn.service.api.DmnRestResponseFactory;
 
@@ -21,7 +22,7 @@ import java.util.List;
 /**
  * @author Yvo Swillens
  */
-public class DmnDeploymentsPaginateList extends AbstractPaginateList {
+public class DmnDeploymentsPaginateList extends AbstractPaginateList<DmnDeploymentResponse, DmnDeployment> {
 
     protected DmnRestResponseFactory restResponseFactory;
 
@@ -29,9 +30,8 @@ public class DmnDeploymentsPaginateList extends AbstractPaginateList {
         this.restResponseFactory = restResponseFactory;
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
-    protected List processList(List list) {
+    protected List<DmnDeploymentResponse> processList(List<DmnDeployment> list) {
         return restResponseFactory.createDmnDeploymentResponseList(list);
     }
 }

--- a/modules/flowable-form-rest/src/main/java/org/flowable/rest/form/service/api/form/BaseFormInstanceResource.java
+++ b/modules/flowable-form-rest/src/main/java/org/flowable/rest/form/service/api/form/BaseFormInstanceResource.java
@@ -41,7 +41,7 @@ public class BaseFormInstanceResource {
     @Autowired
     protected FormRestResponseFactory restResponseFactory;
 
-    protected DataResponse getQueryResponse(FormInstanceQueryRequest queryRequest, Map<String, String> requestParams) {
+    protected DataResponse<FormInstanceResponse> getQueryResponse(FormInstanceQueryRequest queryRequest, Map<String, String> requestParams) {
 
         FormInstanceQuery query = formService.createFormInstanceQuery();
 

--- a/modules/flowable-form-rest/src/main/java/org/flowable/rest/form/service/api/form/FormInstanceCollectionResource.java
+++ b/modules/flowable-form-rest/src/main/java/org/flowable/rest/form/service/api/form/FormInstanceCollectionResource.java
@@ -65,7 +65,7 @@ public class FormInstanceCollectionResource extends BaseFormInstanceResource {
             @ApiResponse(code = 404, message = "Indicates a parameter was passed in the wrong format . The status-message contains additional information.")
     })
     @RequestMapping(value = "/form/form-instances", method = RequestMethod.GET, produces = "application/json")
-    public DataResponse getFormInstances(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
+    public DataResponse<FormInstanceResponse> getFormInstances(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
         // Populate query based on request
         FormInstanceQueryRequest queryRequest = new FormInstanceQueryRequest();
 

--- a/modules/flowable-form-rest/src/main/java/org/flowable/rest/form/service/api/form/FormInstancePaginateList.java
+++ b/modules/flowable-form-rest/src/main/java/org/flowable/rest/form/service/api/form/FormInstancePaginateList.java
@@ -14,13 +14,14 @@ package org.flowable.rest.form.service.api.form;
 
 import java.util.List;
 
+import org.flowable.form.api.FormInstance;
 import org.flowable.rest.api.AbstractPaginateList;
 import org.flowable.rest.form.FormRestResponseFactory;
 
 /**
  * @author Yvo Swillens
  */
-public class FormInstancePaginateList extends AbstractPaginateList {
+public class FormInstancePaginateList extends AbstractPaginateList<FormInstanceResponse, FormInstance> {
 
     protected FormRestResponseFactory restResponseFactory;
 
@@ -28,9 +29,8 @@ public class FormInstancePaginateList extends AbstractPaginateList {
         this.restResponseFactory = restResponseFactory;
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
-    protected List processList(List list) {
+    protected List<FormInstanceResponse> processList(List<FormInstance> list) {
         return restResponseFactory.createFormInstanceResponse(list);
     }
 }

--- a/modules/flowable-form-rest/src/main/java/org/flowable/rest/form/service/api/form/FormInstanceQueryResource.java
+++ b/modules/flowable-form-rest/src/main/java/org/flowable/rest/form/service/api/form/FormInstanceQueryResource.java
@@ -45,7 +45,7 @@ public class FormInstanceQueryResource extends BaseFormInstanceResource {
             @ApiResponse(code = 400, message = "Indicates a parameter was passed in the wrong format . The status-message contains additional information.")
     })
     @RequestMapping(value = "/query/form-instances", method = RequestMethod.POST, produces = "application/json")
-    public DataResponse queryFormInstances(@RequestBody FormInstanceQueryRequest queryRequest, @ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
+    public DataResponse<FormInstanceResponse> queryFormInstances(@RequestBody FormInstanceQueryRequest queryRequest, @ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
 
         return getQueryResponse(queryRequest, allRequestParams);
     }

--- a/modules/flowable-form-rest/src/main/java/org/flowable/rest/form/service/api/repository/FormDefinitionCollectionResource.java
+++ b/modules/flowable-form-rest/src/main/java/org/flowable/rest/form/service/api/repository/FormDefinitionCollectionResource.java
@@ -91,7 +91,7 @@ public class FormDefinitionCollectionResource {
             @ApiResponse(code = 404, message = "Indicates a parameter was passed in the wrong format . The status-message contains additional information.")
     })
     @RequestMapping(value = "/form-repository/form-definitions", method = RequestMethod.GET, produces = "application/json")
-    public DataResponse getForms(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
+    public DataResponse<FormDefinitionResponse> getForms(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
         FormDefinitionQuery formDefinitionQuery = formRepositoryService.createFormDefinitionQuery();
 
         // Populate filter-parameters

--- a/modules/flowable-form-rest/src/main/java/org/flowable/rest/form/service/api/repository/FormDeploymentCollectionResource.java
+++ b/modules/flowable-form-rest/src/main/java/org/flowable/rest/form/service/api/repository/FormDeploymentCollectionResource.java
@@ -84,7 +84,7 @@ public class FormDeploymentCollectionResource {
             @ApiResponse(code = 200, message = "Indicates the request was successful."),
     })
     @RequestMapping(value = "/form-repository/deployments", method = RequestMethod.GET, produces = "application/json")
-    public DataResponse getDeployments(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams) {
+    public DataResponse<FormDeploymentResponse> getDeployments(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams) {
         FormDeploymentQuery deploymentQuery = formRepositoryService.createDeploymentQuery();
 
         // Apply filters
@@ -113,8 +113,7 @@ public class FormDeploymentCollectionResource {
             }
         }
 
-        DataResponse response = new FormDeploymentsPaginateList(formRestResponseFactory).paginateList(allRequestParams, deploymentQuery, "id", allowedSortProperties);
-        return response;
+        return new FormDeploymentsPaginateList(formRestResponseFactory).paginateList(allRequestParams, deploymentQuery, "id", allowedSortProperties);
     }
 
     @ApiOperation(value = "Create a new form deployment", tags = {

--- a/modules/flowable-form-rest/src/main/java/org/flowable/rest/form/service/api/repository/FormDeploymentsPaginateList.java
+++ b/modules/flowable-form-rest/src/main/java/org/flowable/rest/form/service/api/repository/FormDeploymentsPaginateList.java
@@ -14,13 +14,14 @@ package org.flowable.rest.form.service.api.repository;
 
 import java.util.List;
 
+import org.flowable.form.api.FormDeployment;
 import org.flowable.rest.api.AbstractPaginateList;
 import org.flowable.rest.form.FormRestResponseFactory;
 
 /**
  * @author Yvo Swillens
  */
-public class FormDeploymentsPaginateList extends AbstractPaginateList {
+public class FormDeploymentsPaginateList extends AbstractPaginateList<FormDeploymentResponse, FormDeployment> {
 
     protected FormRestResponseFactory formRestResponseFactory;
 
@@ -28,9 +29,8 @@ public class FormDeploymentsPaginateList extends AbstractPaginateList {
         this.formRestResponseFactory = formRestResponseFactory;
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
-    protected List processList(List list) {
+    protected List<FormDeploymentResponse> processList(List<FormDeployment> list) {
         return formRestResponseFactory.createFormDeploymentResponseList(list);
     }
 }

--- a/modules/flowable-form-rest/src/main/java/org/flowable/rest/form/service/api/repository/FormPaginateList.java
+++ b/modules/flowable-form-rest/src/main/java/org/flowable/rest/form/service/api/repository/FormPaginateList.java
@@ -14,13 +14,14 @@ package org.flowable.rest.form.service.api.repository;
 
 import java.util.List;
 
+import org.flowable.form.api.FormDefinition;
 import org.flowable.rest.api.AbstractPaginateList;
 import org.flowable.rest.form.FormRestResponseFactory;
 
 /**
  * @author Yvo Swillens
  */
-public class FormPaginateList extends AbstractPaginateList {
+public class FormPaginateList extends AbstractPaginateList<FormDefinitionResponse, FormDefinition> {
 
     protected FormRestResponseFactory formRestResponseFactory;
 
@@ -28,9 +29,8 @@ public class FormPaginateList extends AbstractPaginateList {
         this.formRestResponseFactory = formRestResponseFactory;
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
-    protected List processList(List list) {
+    protected List<FormDefinitionResponse> processList(List<FormDefinition> list) {
         return formRestResponseFactory.createFormResponseList(list);
     }
 }

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricActivityInstanceBaseResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricActivityInstanceBaseResource.java
@@ -51,7 +51,7 @@ public class HistoricActivityInstanceBaseResource {
     @Autowired
     protected HistoryService historyService;
 
-    protected DataResponse getQueryResponse(HistoricActivityInstanceQueryRequest queryRequest, Map<String, String> allRequestParams) {
+    protected DataResponse<HistoricActivityInstanceResponse> getQueryResponse(HistoricActivityInstanceQueryRequest queryRequest, Map<String, String> allRequestParams) {
         HistoricActivityInstanceQuery query = historyService.createHistoricActivityInstanceQuery();
 
         // Populate query based on request

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricActivityInstanceCollectionResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricActivityInstanceCollectionResource.java
@@ -58,7 +58,7 @@ public class HistoricActivityInstanceCollectionResource extends HistoricActivity
             @ApiImplicitParam(name = "withoutTenantId", dataType = "boolean", value = "If true, only returns instances without a tenantId set. If false, the withoutTenantId parameter is ignored.", paramType = "query")
     })
     @RequestMapping(value = "/history/historic-activity-instances", method = RequestMethod.GET, produces = "application/json")
-    public DataResponse getHistoricActivityInstances(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
+    public DataResponse<HistoricActivityInstanceResponse> getHistoricActivityInstances(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
         HistoricActivityInstanceQueryRequest query = new HistoricActivityInstanceQueryRequest();
 
         // Populate query based on request

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricActivityInstancePaginateList.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricActivityInstancePaginateList.java
@@ -15,13 +15,14 @@ package org.flowable.rest.service.api.history;
 
 import java.util.List;
 
+import org.flowable.engine.history.HistoricActivityInstance;
 import org.flowable.rest.api.AbstractPaginateList;
 import org.flowable.rest.service.api.RestResponseFactory;
 
 /**
  * @author Tijs Rademakers
  */
-public class HistoricActivityInstancePaginateList extends AbstractPaginateList {
+public class HistoricActivityInstancePaginateList extends AbstractPaginateList<HistoricActivityInstanceResponse, HistoricActivityInstance> {
 
     protected RestResponseFactory restResponseFactory;
 
@@ -29,9 +30,8 @@ public class HistoricActivityInstancePaginateList extends AbstractPaginateList {
         this.restResponseFactory = restResponseFactory;
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
-    protected List processList(List list) {
+    protected List<HistoricActivityInstanceResponse> processList(List<HistoricActivityInstance> list) {
         return restResponseFactory.createHistoricActivityInstanceResponseList(list);
     }
 }

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricActivityInstanceQueryResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricActivityInstanceQueryResource.java
@@ -44,7 +44,7 @@ public class HistoricActivityInstanceQueryResource extends HistoricActivityInsta
             @ApiResponse(code = 200, message = "Indicates request was successful and the activities are returned"),
             @ApiResponse(code = 400, message = "Indicates an parameter was passed in the wrong format. The status-message contains additional information") })
     @RequestMapping(value = "/query/historic-activity-instances", method = RequestMethod.POST, produces = "application/json")
-    public DataResponse queryActivityInstances(@RequestBody HistoricActivityInstanceQueryRequest queryRequest, @ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
+    public DataResponse<HistoricActivityInstanceResponse> queryActivityInstances(@RequestBody HistoricActivityInstanceQueryRequest queryRequest, @ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
 
         return getQueryResponse(queryRequest, allRequestParams);
     }

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricDetailBaseResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricDetailBaseResource.java
@@ -45,7 +45,7 @@ public class HistoricDetailBaseResource {
     @Autowired
     protected HistoryService historyService;
 
-    protected DataResponse getQueryResponse(HistoricDetailQueryRequest queryRequest, Map<String, String> allRequestParams) {
+    protected DataResponse<HistoricDetailResponse> getQueryResponse(HistoricDetailQueryRequest queryRequest, Map<String, String> allRequestParams) {
         HistoricDetailQuery query = historyService.createHistoricDetailQuery();
 
         // Populate query based on request

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricDetailCollectionResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricDetailCollectionResource.java
@@ -53,7 +53,7 @@ public class HistoricDetailCollectionResource extends HistoricDetailBaseResource
             @ApiResponse(code = 200, message = "Indicates that historic detail could be queried."),
             @ApiResponse(code = 400, message = "Indicates an parameter was passed in the wrong format. The status-message contains additional information.") })
     @RequestMapping(value = "/history/historic-detail", method = RequestMethod.GET, produces = "application/json")
-    public DataResponse getHistoricDetailInfo(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
+    public DataResponse<HistoricDetailResponse> getHistoricDetailInfo(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
         // Populate query based on request
         HistoricDetailQueryRequest queryRequest = new HistoricDetailQueryRequest();
 

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricDetailPaginateList.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricDetailPaginateList.java
@@ -15,13 +15,14 @@ package org.flowable.rest.service.api.history;
 
 import java.util.List;
 
+import org.flowable.engine.history.HistoricDetail;
 import org.flowable.rest.api.AbstractPaginateList;
 import org.flowable.rest.service.api.RestResponseFactory;
 
 /**
  * @author Tijs Rademakers
  */
-public class HistoricDetailPaginateList extends AbstractPaginateList {
+public class HistoricDetailPaginateList extends AbstractPaginateList<HistoricDetailResponse, HistoricDetail> {
 
     protected RestResponseFactory restResponseFactory;
 
@@ -29,9 +30,8 @@ public class HistoricDetailPaginateList extends AbstractPaginateList {
         this.restResponseFactory = restResponseFactory;
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
-    protected List processList(List list) {
+    protected List<HistoricDetailResponse> processList(List<HistoricDetail> list) {
         return restResponseFactory.createHistoricDetailResponse(list);
     }
 }

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricDetailQueryResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricDetailQueryResource.java
@@ -44,7 +44,7 @@ public class HistoricDetailQueryResource extends HistoricDetailBaseResource {
             @ApiResponse(code = 200, message = "Indicates request was successful and the historic details are returned"),
             @ApiResponse(code = 400, message = "Indicates an parameter was passed in the wrong format. The status-message contains additional information.") })
     @RequestMapping(value = "/query/historic-detail", method = RequestMethod.POST, produces = "application/json")
-    public DataResponse queryHistoricDetail(@RequestBody HistoricDetailQueryRequest queryRequest, @ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
+    public DataResponse<HistoricDetailResponse> queryHistoricDetail(@RequestBody HistoricDetailQueryRequest queryRequest, @ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
 
         return getQueryResponse(queryRequest, allRequestParams);
     }

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricProcessInstanceBaseResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricProcessInstanceBaseResource.java
@@ -52,7 +52,7 @@ public class HistoricProcessInstanceBaseResource {
     @Autowired
     protected HistoryService historyService;
 
-    protected DataResponse getQueryResponse(HistoricProcessInstanceQueryRequest queryRequest, Map<String, String> allRequestParams) {
+    protected DataResponse<HistoricProcessInstanceResponse> getQueryResponse(HistoricProcessInstanceQueryRequest queryRequest, Map<String, String> allRequestParams) {
         HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
 
         // Populate query based on request

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricProcessInstanceCollectionResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricProcessInstanceCollectionResource.java
@@ -64,7 +64,7 @@ public class HistoricProcessInstanceCollectionResource extends HistoricProcessIn
             @ApiResponse(code = 200, message = "Indicates that historic process instances could be queried."),
             @ApiResponse(code = 400, message = "Indicates an parameter was passed in the wrong format. The status-message contains additional information.") })
     @RequestMapping(value = "/history/historic-process-instances", method = RequestMethod.GET, produces = "application/json")
-    public DataResponse getHistoricProcessInstances(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
+    public DataResponse<HistoricProcessInstanceResponse> getHistoricProcessInstances(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
         // Populate query based on request
         HistoricProcessInstanceQueryRequest queryRequest = new HistoricProcessInstanceQueryRequest();
 

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricProcessInstancePaginateList.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricProcessInstancePaginateList.java
@@ -15,13 +15,14 @@ package org.flowable.rest.service.api.history;
 
 import java.util.List;
 
+import org.flowable.engine.history.HistoricProcessInstance;
 import org.flowable.rest.api.AbstractPaginateList;
 import org.flowable.rest.service.api.RestResponseFactory;
 
 /**
  * @author Tijs Rademakers
  */
-public class HistoricProcessInstancePaginateList extends AbstractPaginateList {
+public class HistoricProcessInstancePaginateList extends AbstractPaginateList<HistoricProcessInstanceResponse, HistoricProcessInstance> {
 
     protected RestResponseFactory restResponseFactory;
 
@@ -29,9 +30,8 @@ public class HistoricProcessInstancePaginateList extends AbstractPaginateList {
         this.restResponseFactory = restResponseFactory;
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
-    protected List processList(List list) {
+    protected List<HistoricProcessInstanceResponse> processList(List<HistoricProcessInstance> list) {
         return restResponseFactory.createHistoricProcessInstanceResponseList(list);
     }
 }

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricProcessInstanceQueryResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricProcessInstanceQueryResource.java
@@ -44,7 +44,7 @@ public class HistoricProcessInstanceQueryResource extends HistoricProcessInstanc
             @ApiResponse(code = 200, message = "Indicates request was successful and the process instances are returned"),
             @ApiResponse(code = 400, message = "Indicates an parameter was passed in the wrong format. The status-message contains additional information.") })
     @RequestMapping(value = "/query/historic-process-instances", method = RequestMethod.POST, produces = "application/json")
-    public DataResponse queryProcessInstances(@RequestBody HistoricProcessInstanceQueryRequest queryRequest, @ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
+    public DataResponse<HistoricProcessInstanceResponse> queryProcessInstances(@RequestBody HistoricProcessInstanceQueryRequest queryRequest, @ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
 
         return getQueryResponse(queryRequest, allRequestParams);
     }

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricTaskInstanceBaseResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricTaskInstanceBaseResource.java
@@ -63,7 +63,7 @@ public class HistoricTaskInstanceBaseResource {
     @Autowired
     protected HistoryService historyService;
 
-    protected DataResponse getQueryResponse(HistoricTaskInstanceQueryRequest queryRequest, Map<String, String> allRequestParams, String serverRootUrl) {
+    protected DataResponse<HistoricTaskInstanceResponse> getQueryResponse(HistoricTaskInstanceQueryRequest queryRequest, Map<String, String> allRequestParams, String serverRootUrl) {
         HistoricTaskInstanceQuery query = historyService.createHistoricTaskInstanceQuery();
 
         // Populate query based on request

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricTaskInstanceCollectionResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricTaskInstanceCollectionResource.java
@@ -90,7 +90,7 @@ public class HistoricTaskInstanceCollectionResource extends HistoricTaskInstance
             @ApiResponse(code = 200, message = "Indicates that historic task instances could be queried."),
             @ApiResponse(code = 404, message = "Indicates an parameter was passed in the wrong format. The status-message contains additional information.") })
     @RequestMapping(value = "/history/historic-task-instances", method = RequestMethod.GET, produces = "application/json")
-    public DataResponse getHistoricProcessInstances(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
+    public DataResponse<HistoricTaskInstanceResponse> getHistoricProcessInstances(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
         // Populate query based on request
         HistoricTaskInstanceQueryRequest queryRequest = new HistoricTaskInstanceQueryRequest();
 

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricTaskInstancePaginateList.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricTaskInstancePaginateList.java
@@ -17,11 +17,12 @@ import java.util.List;
 
 import org.flowable.rest.api.AbstractPaginateList;
 import org.flowable.rest.service.api.RestResponseFactory;
+import org.flowable.task.api.history.HistoricTaskInstance;
 
 /**
  * @author Tijs Rademakers
  */
-public class HistoricTaskInstancePaginateList extends AbstractPaginateList {
+public class HistoricTaskInstancePaginateList extends AbstractPaginateList<HistoricTaskInstanceResponse, HistoricTaskInstance> {
 
     protected RestResponseFactory restResponseFactory;
     protected String serverRootUrl;
@@ -31,9 +32,8 @@ public class HistoricTaskInstancePaginateList extends AbstractPaginateList {
         this.serverRootUrl = serverRootUrl;
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
-    protected List processList(List list) {
+    protected List<HistoricTaskInstanceResponse> processList(List<HistoricTaskInstance> list) {
         return restResponseFactory.createHistoricTaskInstanceResponseList(list);
     }
 }

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricTaskInstanceQueryResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricTaskInstanceQueryResource.java
@@ -45,7 +45,7 @@ public class HistoricTaskInstanceQueryResource extends HistoricTaskInstanceBaseR
             @ApiResponse(code = 404, message = "Indicates an parameter was passed in the wrong format. The status-message contains additional information.") })
     // FIXME Naming issue ?
     @RequestMapping(value = "/query/historic-task-instances", method = RequestMethod.POST, produces = "application/json")
-    public DataResponse queryProcessInstances(@RequestBody HistoricTaskInstanceQueryRequest queryRequest, @ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
+    public DataResponse<HistoricTaskInstanceResponse> queryProcessInstances(@RequestBody HistoricTaskInstanceQueryRequest queryRequest, @ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
 
         return getQueryResponse(queryRequest, allRequestParams, request.getRequestURL().toString().replace("/query/historic-task-instances", ""));
     }

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricVariableInstanceBaseResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricVariableInstanceBaseResource.java
@@ -45,7 +45,7 @@ public class HistoricVariableInstanceBaseResource {
     @Autowired
     protected HistoryService historyService;
 
-    protected DataResponse getQueryResponse(HistoricVariableInstanceQueryRequest queryRequest, Map<String, String> allRequestParams) {
+    protected DataResponse<HistoricVariableInstanceResponse> getQueryResponse(HistoricVariableInstanceQueryRequest queryRequest, Map<String, String> allRequestParams) {
         HistoricVariableInstanceQuery query = historyService.createHistoricVariableInstanceQuery();
 
         // Populate query based on request

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricVariableInstanceCollectionResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricVariableInstanceCollectionResource.java
@@ -51,7 +51,7 @@ public class HistoricVariableInstanceCollectionResource extends HistoricVariable
             @ApiResponse(code = 200, message = "Indicates that historic variable instances could be queried."),
             @ApiResponse(code = 400, message = "Indicates an parameter was passed in the wrong format. The status-message contains additional information.") })
     @RequestMapping(value = "/history/historic-variable-instances", method = RequestMethod.GET, produces = "application/json")
-    public DataResponse getHistoricActivityInstances(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
+    public DataResponse<HistoricVariableInstanceResponse> getHistoricActivityInstances(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
         HistoricVariableInstanceQueryRequest query = new HistoricVariableInstanceQueryRequest();
 
         // Populate query based on request

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricVariableInstancePaginateList.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricVariableInstancePaginateList.java
@@ -17,11 +17,12 @@ import java.util.List;
 
 import org.flowable.rest.api.AbstractPaginateList;
 import org.flowable.rest.service.api.RestResponseFactory;
+import org.flowable.variable.api.history.HistoricVariableInstance;
 
 /**
  * @author Tijs Rademakers
  */
-public class HistoricVariableInstancePaginateList extends AbstractPaginateList {
+public class HistoricVariableInstancePaginateList extends AbstractPaginateList<HistoricVariableInstanceResponse, HistoricVariableInstance> {
 
     protected RestResponseFactory restResponseFactory;
 
@@ -29,9 +30,8 @@ public class HistoricVariableInstancePaginateList extends AbstractPaginateList {
         this.restResponseFactory = restResponseFactory;
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
-    protected List processList(List list) {
+    protected List<HistoricVariableInstanceResponse> processList(List<HistoricVariableInstance> list) {
         return restResponseFactory.createHistoricVariableInstanceResponseList(list);
     }
 }

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricVariableInstanceQueryResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricVariableInstanceQueryResource.java
@@ -46,7 +46,7 @@ public class HistoricVariableInstanceQueryResource extends HistoricVariableInsta
             @ApiResponse(code = 200, message = "Indicates request was successful and the tasks are returned"),
             @ApiResponse(code = 400, message = "Indicates an parameter was passed in the wrong format. The status-message contains additional information.") })
     @RequestMapping(value = "/query/historic-variable-instances", method = RequestMethod.POST, produces = "application/json")
-    public DataResponse queryVariableInstances(@RequestBody HistoricVariableInstanceQueryRequest queryRequest, @ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams,
+    public DataResponse<HistoricVariableInstanceResponse> queryVariableInstances(@RequestBody HistoricVariableInstanceQueryRequest queryRequest, @ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams,
             HttpServletRequest request) {
 
         return getQueryResponse(queryRequest, allRequestParams);

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/identity/GroupCollectionResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/identity/GroupCollectionResource.java
@@ -80,7 +80,7 @@ public class GroupCollectionResource {
             @ApiResponse(code = 200, message = "Indicates the requested groups were returned.")
     })
     @GetMapping(value = "/identity/groups", produces = "application/json")
-    public DataResponse getGroups(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
+    public DataResponse<GroupResponse> getGroups(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
         GroupQuery query = identityService.createGroupQuery();
 
         if (allRequestParams.containsKey("id")) {

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/identity/GroupPaginateList.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/identity/GroupPaginateList.java
@@ -15,13 +15,14 @@ package org.flowable.rest.service.api.identity;
 
 import java.util.List;
 
+import org.flowable.idm.api.Group;
 import org.flowable.rest.api.AbstractPaginateList;
 import org.flowable.rest.service.api.RestResponseFactory;
 
 /**
  * @author Frederik Heremans
  */
-public class GroupPaginateList extends AbstractPaginateList {
+public class GroupPaginateList extends AbstractPaginateList<GroupResponse, Group> {
 
     protected RestResponseFactory restResponseFactory;
 
@@ -29,9 +30,8 @@ public class GroupPaginateList extends AbstractPaginateList {
         this.restResponseFactory = restResponseFactory;
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
-    protected List processList(List list) {
+    protected List<GroupResponse> processList(List<Group> list) {
         return restResponseFactory.createGroupResponseList(list);
     }
 }

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/identity/UserCollectionResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/identity/UserCollectionResource.java
@@ -84,7 +84,7 @@ public class UserCollectionResource {
             @ApiResponse(code = 200, message = "Indicates the group exists and is returned.")
     })
     @GetMapping(value = "/identity/users", produces = "application/json")
-    public DataResponse getUsers(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
+    public DataResponse<UserResponse> getUsers(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
         UserQuery query = identityService.createUserQuery();
 
         if (allRequestParams.containsKey("id")) {

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/identity/UserPaginateList.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/identity/UserPaginateList.java
@@ -15,13 +15,14 @@ package org.flowable.rest.service.api.identity;
 
 import java.util.List;
 
+import org.flowable.idm.api.User;
 import org.flowable.rest.api.AbstractPaginateList;
 import org.flowable.rest.service.api.RestResponseFactory;
 
 /**
  * @author Frederik Heremans
  */
-public class UserPaginateList extends AbstractPaginateList {
+public class UserPaginateList extends AbstractPaginateList<UserResponse, User> {
 
     protected RestResponseFactory restResponseFactory;
 
@@ -29,9 +30,8 @@ public class UserPaginateList extends AbstractPaginateList {
         this.restResponseFactory = restResponseFactory;
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
-    protected List processList(List list) {
+    protected List<UserResponse> processList(List<User> list) {
         return restResponseFactory.createUserResponseList(list, false);
     }
 }

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/management/DeadLetterJobCollectionResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/management/DeadLetterJobCollectionResource.java
@@ -76,7 +76,7 @@ public class DeadLetterJobCollectionResource {
             @ApiResponse(code = 400, message = "Indicates an illegal value has been used in a url query parameter or the both 'messagesOnly' and 'timersOnly' are used as parameters. Status description contains additional details about the error.")
     })
     @GetMapping(value = "/management/deadletter-jobs", produces = "application/json")
-    public DataResponse getJobs(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
+    public DataResponse<JobResponse> getJobs(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
         DeadLetterJobQuery query = managementService.createDeadLetterJobQuery();
 
         if (allRequestParams.containsKey("id")) {

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/management/JobCollectionResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/management/JobCollectionResource.java
@@ -77,7 +77,7 @@ public class JobCollectionResource {
             @ApiResponse(code = 400, message = "Indicates an illegal value has been used in a url query parameter or the both 'messagesOnly' and 'timersOnly' are used as parameters. Status description contains additional details about the error.")
     })
     @GetMapping(value = "/management/jobs", produces = "application/json")
-    public DataResponse getJobs(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
+    public DataResponse<JobResponse> getJobs(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
         JobQuery query = managementService.createJobQuery();
 
         if (allRequestParams.containsKey("id")) {

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/management/JobPaginateList.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/management/JobPaginateList.java
@@ -15,13 +15,14 @@ package org.flowable.rest.service.api.management;
 
 import java.util.List;
 
+import org.flowable.job.api.Job;
 import org.flowable.rest.api.AbstractPaginateList;
 import org.flowable.rest.service.api.RestResponseFactory;
 
 /**
  * @author Frederik Heremans
  */
-public class JobPaginateList extends AbstractPaginateList {
+public class JobPaginateList extends AbstractPaginateList<JobResponse, Job> {
 
     protected RestResponseFactory restResponseFactory;
 
@@ -29,9 +30,8 @@ public class JobPaginateList extends AbstractPaginateList {
         this.restResponseFactory = restResponseFactory;
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
-    protected List processList(List list) {
+    protected List<JobResponse> processList(List<Job> list) {
         return restResponseFactory.createJobResponseList(list);
     }
 }

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/management/SuspendedJobCollectionResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/management/SuspendedJobCollectionResource.java
@@ -77,7 +77,7 @@ public class SuspendedJobCollectionResource {
             @ApiResponse(code = 400, message = "Indicates an illegal value has been used in a url query parameter or the both 'messagesOnly' and 'timersOnly' are used as parameters. Status description contains additional details about the error.")
     })
     @GetMapping(value = "/management/suspended-jobs", produces = "application/json")
-    public DataResponse getJobs(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
+    public DataResponse<JobResponse> getJobs(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
         SuspendedJobQuery query = managementService.createSuspendedJobQuery();
 
         if (allRequestParams.containsKey("id")) {

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/management/TimerJobCollectionResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/management/TimerJobCollectionResource.java
@@ -77,7 +77,7 @@ public class TimerJobCollectionResource {
             @ApiResponse(code = 400, message = "Indicates an illegal value has been used in a url query parameter or the both 'messagesOnly' and 'timersOnly' are used as parameters. Status description contains additional details about the error.")
     })
     @GetMapping(value = "/management/timer-jobs", produces = "application/json")
-    public DataResponse getJobs(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
+    public DataResponse<JobResponse> getJobs(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
         TimerJobQuery query = managementService.createTimerJobQuery();
 
         if (allRequestParams.containsKey("id")) {

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/repository/DeploymentCollectionResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/repository/DeploymentCollectionResource.java
@@ -92,7 +92,7 @@ public class DeploymentCollectionResource {
             @ApiResponse(code = 200, message = "Indicates the request was successful."),
     })
     @GetMapping(value = "/repository/deployments", produces = "application/json")
-    public DataResponse getDeployments(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
+    public DataResponse<DeploymentResponse> getDeployments(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
         DeploymentQuery deploymentQuery = repositoryService.createDeploymentQuery();
 
         // Apply filters
@@ -121,8 +121,7 @@ public class DeploymentCollectionResource {
             }
         }
 
-        DataResponse response = new DeploymentsPaginateList(restResponseFactory).paginateList(allRequestParams, deploymentQuery, "id", allowedSortProperties);
-        return response;
+        return new DeploymentsPaginateList(restResponseFactory).paginateList(allRequestParams, deploymentQuery, "id", allowedSortProperties);
     }
 
     @ApiOperation(value = "Create a new deployment", tags = {

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/repository/DeploymentsPaginateList.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/repository/DeploymentsPaginateList.java
@@ -15,13 +15,14 @@ package org.flowable.rest.service.api.repository;
 
 import java.util.List;
 
+import org.flowable.engine.repository.Deployment;
 import org.flowable.rest.api.AbstractPaginateList;
 import org.flowable.rest.service.api.RestResponseFactory;
 
 /**
  * @author Tijs Rademakers
  */
-public class DeploymentsPaginateList extends AbstractPaginateList {
+public class DeploymentsPaginateList extends AbstractPaginateList<DeploymentResponse, Deployment> {
 
     protected RestResponseFactory restResponseFactory;
 
@@ -29,9 +30,8 @@ public class DeploymentsPaginateList extends AbstractPaginateList {
         this.restResponseFactory = restResponseFactory;
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
-    protected List processList(List list) {
+    protected List<DeploymentResponse> processList(List<Deployment> list) {
         return restResponseFactory.createDeploymentResponseList(list);
     }
 }

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/repository/ModelCollectionResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/repository/ModelCollectionResource.java
@@ -83,7 +83,7 @@ public class ModelCollectionResource extends BaseModelResource {
             @ApiResponse(code = 400, message = "Indicates a parameter was passed in the wrong format. The status-message contains additional information.")
     })
     @GetMapping(value = "/repository/models", produces = "application/json")
-    public DataResponse getModels(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
+    public DataResponse<ModelResponse> getModels(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
         ModelQuery modelQuery = repositoryService.createModelQuery();
 
         if (allRequestParams.containsKey("id")) {

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/repository/ModelsPaginateList.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/repository/ModelsPaginateList.java
@@ -15,13 +15,14 @@ package org.flowable.rest.service.api.repository;
 
 import java.util.List;
 
+import org.flowable.engine.repository.Model;
 import org.flowable.rest.api.AbstractPaginateList;
 import org.flowable.rest.service.api.RestResponseFactory;
 
 /**
  * @author Frederik Heremans
  */
-public class ModelsPaginateList extends AbstractPaginateList {
+public class ModelsPaginateList extends AbstractPaginateList<ModelResponse, Model> {
 
     protected RestResponseFactory restResponseFactory;
 
@@ -29,9 +30,8 @@ public class ModelsPaginateList extends AbstractPaginateList {
         this.restResponseFactory = restResponseFactory;
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
-    protected List processList(List list) {
+    protected List<ModelResponse> processList(List<Model> list) {
         return restResponseFactory.createModelResponseList(list);
     }
 }

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/repository/ProcessDefinitionCollectionResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/repository/ProcessDefinitionCollectionResource.java
@@ -86,7 +86,7 @@ public class ProcessDefinitionCollectionResource {
             @ApiResponse(code = 400, message = "Indicates a parameter was passed in the wrong format or that latest is used with other parameters other than key and keyLike. The status-message contains additional information.")
     })
     @GetMapping(value = "/repository/process-definitions", produces = "application/json")
-    public DataResponse getProcessDefinitions(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
+    public DataResponse<ProcessDefinitionResponse> getProcessDefinitions(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
         ProcessDefinitionQuery processDefinitionQuery = repositoryService.createProcessDefinitionQuery();
 
         // Populate filter-parameters

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/repository/ProcessDefinitionsPaginateList.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/repository/ProcessDefinitionsPaginateList.java
@@ -15,13 +15,14 @@ package org.flowable.rest.service.api.repository;
 
 import java.util.List;
 
+import org.flowable.engine.repository.ProcessDefinition;
 import org.flowable.rest.api.AbstractPaginateList;
 import org.flowable.rest.service.api.RestResponseFactory;
 
 /**
  * @author Frederik Heremans
  */
-public class ProcessDefinitionsPaginateList extends AbstractPaginateList {
+public class ProcessDefinitionsPaginateList extends AbstractPaginateList<ProcessDefinitionResponse, ProcessDefinition> {
 
     protected RestResponseFactory restResponseFactory;
 
@@ -29,9 +30,8 @@ public class ProcessDefinitionsPaginateList extends AbstractPaginateList {
         this.restResponseFactory = restResponseFactory;
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
-    protected List processList(List list) {
+    protected List<ProcessDefinitionResponse> processList(List<ProcessDefinition> list) {
         return restResponseFactory.createProcessDefinitionResponseList(list);
     }
 }

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/process/BaseProcessInstanceResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/process/BaseProcessInstanceResource.java
@@ -50,7 +50,7 @@ public class BaseProcessInstanceResource {
     @Autowired
     protected RuntimeService runtimeService;
 
-    protected DataResponse getQueryResponse(ProcessInstanceQueryRequest queryRequest, Map<String, String> requestParams) {
+    protected DataResponse<ProcessInstanceResponse> getQueryResponse(ProcessInstanceQueryRequest queryRequest, Map<String, String> requestParams) {
 
         ProcessInstanceQuery query = runtimeService.createProcessInstanceQuery();
 

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/process/EventSubscriptionCollectionResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/process/EventSubscriptionCollectionResource.java
@@ -69,7 +69,7 @@ public class EventSubscriptionCollectionResource {
             @ApiResponse(code = 400, message = "Indicates an illegal value has been used in a url query parameter. Status description contains additional details about the error.")
     })
     @RequestMapping(value = "/runtime/event-subscriptions", method = RequestMethod.GET, produces = "application/json")
-    public DataResponse getJobs(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
+    public DataResponse<EventSubscriptionResponse> getJobs(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
         EventSubscriptionQuery query = runtimeService.createEventSubscriptionQuery();
 
         if (allRequestParams.containsKey("id")) {

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/process/EventSubscriptionPaginateList.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/process/EventSubscriptionPaginateList.java
@@ -15,13 +15,14 @@ package org.flowable.rest.service.api.runtime.process;
 
 import java.util.List;
 
+import org.flowable.engine.runtime.EventSubscription;
 import org.flowable.rest.api.AbstractPaginateList;
 import org.flowable.rest.service.api.RestResponseFactory;
 
 /**
  * @author Tijs Rademakers
  */
-public class EventSubscriptionPaginateList extends AbstractPaginateList {
+public class EventSubscriptionPaginateList extends AbstractPaginateList<EventSubscriptionResponse, EventSubscription> {
 
     protected RestResponseFactory restResponseFactory;
 
@@ -29,9 +30,8 @@ public class EventSubscriptionPaginateList extends AbstractPaginateList {
         this.restResponseFactory = restResponseFactory;
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
-    protected List processList(List list) {
+    protected List<EventSubscriptionResponse> processList(List<EventSubscription> list) {
         return restResponseFactory.createEventSubscriptionResponseList(list);
     }
 }

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/process/ExecutionBaseResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/process/ExecutionBaseResource.java
@@ -51,7 +51,7 @@ public class ExecutionBaseResource {
     @Autowired
     protected RuntimeService runtimeService;
 
-    protected DataResponse getQueryResponse(ExecutionQueryRequest queryRequest, Map<String, String> requestParams, String serverRootUrl) {
+    protected DataResponse<ExecutionResponse> getQueryResponse(ExecutionQueryRequest queryRequest, Map<String, String> requestParams, String serverRootUrl) {
 
         ExecutionQuery query = runtimeService.createExecutionQuery();
 

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/process/ExecutionCollectionResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/process/ExecutionCollectionResource.java
@@ -64,7 +64,7 @@ public class ExecutionCollectionResource extends ExecutionBaseResource {
             @ApiResponse(code = 404, message = "Indicates a parameter was passed in the wrong format . The status-message contains additional information.")
     })
     @RequestMapping(value = "/runtime/executions", method = RequestMethod.GET, produces = "application/json")
-    public DataResponse getProcessInstances(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
+    public DataResponse<ExecutionResponse> getProcessInstances(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
         // Populate query based on request
         ExecutionQueryRequest queryRequest = new ExecutionQueryRequest();
 

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/process/ExecutionPaginateList.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/process/ExecutionPaginateList.java
@@ -15,13 +15,14 @@ package org.flowable.rest.service.api.runtime.process;
 
 import java.util.List;
 
+import org.flowable.engine.runtime.Execution;
 import org.flowable.rest.api.AbstractPaginateList;
 import org.flowable.rest.service.api.RestResponseFactory;
 
 /**
  * @author Frederik Heremans
  */
-public class ExecutionPaginateList extends AbstractPaginateList {
+public class ExecutionPaginateList extends AbstractPaginateList<ExecutionResponse, Execution> {
 
     protected RestResponseFactory restResponseFactory;
 
@@ -29,9 +30,8 @@ public class ExecutionPaginateList extends AbstractPaginateList {
         this.restResponseFactory = restResponseFactory;
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
-    protected List processList(List list) {
+    protected List<ExecutionResponse> processList(List<Execution> list) {
         return restResponseFactory.createExecutionResponseList(list);
     }
 }

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/process/ExecutionQueryResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/process/ExecutionQueryResource.java
@@ -47,7 +47,7 @@ public class ExecutionQueryResource extends ExecutionBaseResource {
             @ApiResponse(code = 404, message = "Indicates a parameter was passed in the wrong format . The status-message contains additional information.")
     })
     @RequestMapping(value = "/query/executions", method = RequestMethod.POST, produces = "application/json")
-    public DataResponse queryProcessInstances(@RequestBody ExecutionQueryRequest queryRequest, @ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
+    public DataResponse<ExecutionResponse> queryProcessInstances(@RequestBody ExecutionQueryRequest queryRequest, @ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
 
         return getQueryResponse(queryRequest, allRequestParams, request.getRequestURL().toString().replace("/query/executions", ""));
     }

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/process/ProcessInstanceCollectionResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/process/ProcessInstanceCollectionResource.java
@@ -82,7 +82,7 @@ public class ProcessInstanceCollectionResource extends BaseProcessInstanceResour
             @ApiResponse(code = 404, message = "Indicates a parameter was passed in the wrong format . The status-message contains additional information.")
     })
     @RequestMapping(value = "/runtime/process-instances", method = RequestMethod.GET, produces = "application/json")
-    public DataResponse getProcessInstances(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
+    public DataResponse<ProcessInstanceResponse> getProcessInstances(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams, HttpServletRequest request) {
         // Populate query based on request
         ProcessInstanceQueryRequest queryRequest = new ProcessInstanceQueryRequest();
 

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/process/ProcessInstancePaginateList.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/process/ProcessInstancePaginateList.java
@@ -15,13 +15,14 @@ package org.flowable.rest.service.api.runtime.process;
 
 import java.util.List;
 
+import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.rest.api.AbstractPaginateList;
 import org.flowable.rest.service.api.RestResponseFactory;
 
 /**
  * @author Frederik Heremans
  */
-public class ProcessInstancePaginateList extends AbstractPaginateList {
+public class ProcessInstancePaginateList extends AbstractPaginateList<ProcessInstanceResponse, ProcessInstance> {
 
     protected RestResponseFactory restResponseFactory;
 
@@ -29,9 +30,8 @@ public class ProcessInstancePaginateList extends AbstractPaginateList {
         this.restResponseFactory = restResponseFactory;
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
-    protected List processList(List list) {
+    protected List<ProcessInstanceResponse> processList(List<ProcessInstance> list) {
         return restResponseFactory.createProcessInstanceResponseList(list);
     }
 }

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/process/ProcessInstanceQueryResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/process/ProcessInstanceQueryResource.java
@@ -46,7 +46,7 @@ public class ProcessInstanceQueryResource extends BaseProcessInstanceResource {
             @ApiResponse(code = 400, message = "Indicates a parameter was passed in the wrong format . The status-message contains additional information.")
     })
     @RequestMapping(value = "/query/process-instances", method = RequestMethod.POST, produces = "application/json")
-    public DataResponse queryProcessInstances(@RequestBody ProcessInstanceQueryRequest queryRequest, @ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams,
+    public DataResponse<ProcessInstanceResponse> queryProcessInstances(@RequestBody ProcessInstanceQueryRequest queryRequest, @ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams,
             HttpServletRequest request) {
 
         return getQueryResponse(queryRequest, allRequestParams);

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/task/TaskBaseResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/task/TaskBaseResource.java
@@ -118,7 +118,7 @@ public class TaskBaseResource {
         }
     }
 
-    protected DataResponse getTasksFromQueryRequest(TaskQueryRequest request, Map<String, String> requestParams) {
+    protected DataResponse<TaskResponse> getTasksFromQueryRequest(TaskQueryRequest request, Map<String, String> requestParams) {
 
         TaskQuery taskQuery = taskService.createTaskQuery();
 

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/task/TaskCollectionResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/task/TaskCollectionResource.java
@@ -99,7 +99,7 @@ public class TaskCollectionResource extends TaskBaseResource {
             @ApiResponse(code = 404, message = "Indicates a parameter was passed in the wrong format or that delegationState has an invalid value (other than pending and resolved). The status-message contains additional information.")
     })
     @RequestMapping(value = "/runtime/tasks", method = RequestMethod.GET, produces = "application/json")
-    public DataResponse getTasks(@ApiParam(hidden = true) @RequestParam Map<String, String> requestParams, HttpServletRequest httpRequest) {
+    public DataResponse<TaskResponse> getTasks(@ApiParam(hidden = true) @RequestParam Map<String, String> requestParams, HttpServletRequest httpRequest) {
         // Create a Task query request
         TaskQueryRequest request = new TaskQueryRequest();
 

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/task/TaskPaginateList.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/task/TaskPaginateList.java
@@ -17,11 +17,12 @@ import java.util.List;
 
 import org.flowable.rest.api.AbstractPaginateList;
 import org.flowable.rest.service.api.RestResponseFactory;
+import org.flowable.task.api.Task;
 
 /**
  * @author Frederik Heremans
  */
-public class TaskPaginateList extends AbstractPaginateList {
+public class TaskPaginateList extends AbstractPaginateList<TaskResponse, Task> {
 
     protected RestResponseFactory restResponseFactory;
 
@@ -29,9 +30,8 @@ public class TaskPaginateList extends AbstractPaginateList {
         this.restResponseFactory = restResponseFactory;
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
-    protected List processList(List list) {
+    protected List<TaskResponse> processList(List<Task> list) {
         return restResponseFactory.createTaskResponseList(list);
     }
 }

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/task/TaskQueryResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/task/TaskQueryResource.java
@@ -45,7 +45,7 @@ public class TaskQueryResource extends TaskBaseResource {
             @ApiResponse(code = 400, message = "Indicates a parameter was passed in the wrong format or that delegationState has an invalid value (other than pending and resolved). The status-message contains additional information.")
     })
     @RequestMapping(value = "/query/tasks", method = RequestMethod.POST, produces = "application/json")
-    public DataResponse getQueryResult(@RequestBody TaskQueryRequest request, @ApiParam(hidden = true) @RequestParam Map<String, String> requestParams, HttpServletRequest httpRequest) {
+    public DataResponse<TaskResponse> getQueryResult(@RequestBody TaskQueryRequest request, @ApiParam(hidden = true) @RequestParam Map<String, String> requestParams, HttpServletRequest httpRequest) {
 
         return getTasksFromQueryRequest(request, requestParams);
     }


### PR DESCRIPTION
Use generics and type safety for the `DataResponse` and `XXXPaginateList`.

I am looking into adding spring rest docs so documentation is automatically generated in asciidoc, some improvements into the mappings and this is a step into that direction. This would also make it easier not to make a mistake when implementing some new stuff :)