### PR TITLE
WIP - Use spring rest docs and spring auto rest docs to generate rest documentation

### DIFF
--- a/modules/flowable-common-rest/pom.xml
+++ b/modules/flowable-common-rest/pom.xml
@@ -50,6 +50,32 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <id>generate-javadoc-json</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>javadoc-no-fork</goal>
+                        </goals>
+                        <configuration>
+                            <doclet>capital.scalable.restdocs.jsondoclet.ExtractDocumentationAsJsonDoclet</doclet>
+                            <docletArtifact>
+                                <groupId>capital.scalable</groupId>
+                                <artifactId>spring-auto-restdocs-json-doclet</artifactId>
+                                <version>${spring.auto.restdocs.version}</version>
+                            </docletArtifact>
+                            <destDir>generated-javadoc-json</destDir>
+                            <reportOutputDirectory>${project.build.directory}</reportOutputDirectory>
+                            <useStandardDocletOptions>false</useStandardDocletOptions>
+                            <show>package</show>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>

--- a/modules/flowable-rest/pom.xml
+++ b/modules/flowable-rest/pom.xml
@@ -49,6 +49,53 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <extensions>true</extensions>
+        <executions>
+          <execution>
+            <id>generate-javadoc-json</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>javadoc-no-fork</goal>
+            </goals>
+            <configuration>
+              <doclet>capital.scalable.restdocs.jsondoclet.ExtractDocumentationAsJsonDoclet</doclet>
+              <docletArtifact>
+                <groupId>capital.scalable</groupId>
+                <artifactId>spring-auto-restdocs-json-doclet</artifactId>
+                <version>${spring.auto.restdocs.version}</version>
+              </docletArtifact>
+              <destDir>generated-javadoc-json</destDir>
+              <reportOutputDirectory>${project.build.directory}</reportOutputDirectory>
+              <useStandardDocletOptions>false</useStandardDocletOptions>
+              <show>package</show>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.asciidoctor</groupId>
+        <artifactId>asciidoctor-maven-plugin</artifactId>
+        <version>1.5.6</version>
+        <executions>
+          <execution>
+            <id>generate-docs</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>process-asciidoc</goal>
+            </goals>
+            <configuration>
+              <backend>html</backend>
+              <doctype>book</doctype>
+              <attributes>
+                <snippets>${project.build.directory}/generated-snippets</snippets>
+              </attributes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
     <pluginManagement>
       <plugins>
@@ -124,7 +171,7 @@
     <dependency>
       <groupId>org.springframework.data</groupId>
       <artifactId>spring-data-jpa</artifactId>
-      <version>1.3.2.RELEASE</version>
+      <version>1.11.8.RELEASE</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -133,21 +180,52 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
-      <artifactId>hibernate-validator</artifactId>
-      <version>4.3.1.Final</version>
+      <groupId>org.springframework.restdocs</groupId>
+      <artifactId>spring-restdocs-mockmvc</artifactId>
+      <version>${spring.restdocs.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>capital.scalable</groupId>
+      <artifactId>spring-auto-restdocs-core</artifactId>
+      <version>${spring.auto.restdocs.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.jayway.jsonpath</groupId>
+      <artifactId>json-path</artifactId>
+      <version>2.3.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <version>1.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-validator</artifactId>
+      <version>5.4.2.Final</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- Needed because of spring-auto-rest-docs.
+    See https://github.com/ScaCap/spring-auto-restdocs/issues/124 -->
+    <dependency>
+      <groupId>org.glassfish</groupId>
+      <artifactId>javax.el</artifactId>
+      <version>3.0.1-b08</version>
+    </dependency>
+    <dependency>
+      <groupId>org.hibernate</groupId>
       <artifactId>hibernate-core</artifactId>
-      <version>4.1.9.Final</version>
+      <version>5.2.12.Final</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-entitymanager</artifactId>
-      <version>4.1.9.Final</version>
+      <version>5.2.12.Final</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/modules/flowable-rest/src/main/asciidoc/example-rest-userguide.adoc
+++ b/modules/flowable-rest/src/main/asciidoc/example-rest-userguide.adoc
@@ -1,0 +1,11 @@
+
+include::{snippets}/group-collection-resource-mvc-test/test-get-groups/1/auto-section.adoc[]
+
+include::{snippets}/group-collection-resource-mvc-test/test-get-groups/2/auto-section.adoc[]
+
+include::{snippets}/group-collection-resource-mvc-test/test-get-groups/3/auto-section.adoc[]
+
+include::{snippets}/group-collection-resource-mvc-test/test-get-groups/4/auto-section.adoc[]
+
+include::{snippets}/group-collection-resource-mvc-test/test-get-groups/5/auto-section.adoc[]
+

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/identity/GroupCollectionResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/identity/GroupCollectionResource.java
@@ -66,6 +66,9 @@ public class GroupCollectionResource {
     @Autowired
     protected IdentityService identityService;
 
+    /**
+     * Get a list of groups.
+     */
     @ApiOperation(value = "Get a list of groups", tags = { "Groups" }, produces = "application/json")
     @ApiImplicitParams({
             @ApiImplicitParam(name = "id", dataType = "string", value = "Only return group with the given id", paramType = "query"),

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/identity/GroupResponse.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/identity/GroupResponse.java
@@ -18,9 +18,21 @@ package org.flowable.rest.service.api.identity;
  */
 public class GroupResponse {
 
+    /**
+     * The id of the group.
+     */
     protected String id;
+    /**
+     * The URL for the group location.
+     */
     protected String url;
+    /**
+     * The name of the group.
+     */
     protected String name;
+    /**
+     * The type of the group.
+     */
     protected String type;
 
     public String getId() {

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/BaseSpringRestRule.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/BaseSpringRestRule.java
@@ -1,0 +1,34 @@
+package org.flowable.rest.service;
+
+import org.flowable.engine.test.FlowableRule;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class BaseSpringRestRule extends FlowableRule implements TestRule {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BaseSpringRestRule.class);
+
+    private Throwable exception;
+
+    @Override
+    protected void failed(Throwable e, Description description) {
+        super.failed(e, description);
+        if (e instanceof AssertionError) {
+            LOGGER.error("\n");
+            LOGGER.error("ASSERTION FAILED: {}", e, e);
+            exception = e;
+        } else if (e != null) {
+            LOGGER.error("\n");
+            LOGGER.error("EXCEPTION: {}", e, e);
+            exception = e;
+        }
+    }
+    public Throwable getException() {
+        return exception;
+    }
+}

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/BaseSpringRestTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/BaseSpringRestTest.java
@@ -1,0 +1,251 @@
+package org.flowable.rest.service;
+
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.flowable.engine.FormService;
+import org.flowable.engine.HistoryService;
+import org.flowable.engine.IdentityService;
+import org.flowable.engine.ManagementService;
+import org.flowable.engine.ProcessEngine;
+import org.flowable.engine.RepositoryService;
+import org.flowable.engine.RuntimeService;
+import org.flowable.engine.TaskService;
+import org.flowable.engine.common.impl.db.DbSchemaManager;
+import org.flowable.engine.common.impl.interceptor.Command;
+import org.flowable.engine.common.impl.interceptor.CommandContext;
+import org.flowable.engine.common.impl.interceptor.CommandExecutor;
+import org.flowable.engine.impl.ProcessEngineImpl;
+import org.flowable.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.flowable.engine.impl.util.CommandContextUtil;
+import org.flowable.idm.api.Group;
+import org.flowable.idm.api.User;
+import org.flowable.rest.DispatcherServletConfiguration;
+import org.flowable.rest.conf.ApplicationConfiguration;
+import org.flowable.rest.util.FlowableResponseFieldsSnippet;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.JUnitRestDocumentation;
+import org.springframework.restdocs.operation.preprocess.Preprocessors;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.method.HandlerMethod;
+
+import capital.scalable.restdocs.AutoDocumentation;
+import capital.scalable.restdocs.payload.JacksonResponseFieldSnippet;
+import capital.scalable.restdocs.response.ResponseModifyingPreprocessors;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import static capital.scalable.restdocs.jackson.JacksonResultHandlers.prepareJackson;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * @author Filip Hrisafov
+ */
+@WebAppConfiguration
+@ContextConfiguration(classes = {
+    ApplicationConfiguration.class,
+    BaseSpringRestTest.BaseTestSpringRestConfiguration.class,
+    DispatcherServletConfiguration.class
+})
+@RunWith(SpringRunner.class)
+public abstract class BaseSpringRestTest {
+
+    protected static final List<String> TABLENAMES_EXCLUDED_FROM_DB_CLEAN_CHECK = Arrays.asList("ACT_GE_PROPERTY", "ACT_ID_PROPERTY");
+
+    @Configuration
+    static class BaseTestSpringRestConfiguration {
+
+        @Bean
+        public BaseSpringRestRule restRule(ProcessEngine processEngine) {
+            BaseSpringRestRule restRule = new BaseSpringRestRule();
+            restRule.setProcessEngine(processEngine);
+            return restRule;
+        }
+    }
+
+    static class MyResponseFieldSnippet extends JacksonResponseFieldSnippet {
+
+        @Override
+        protected Type getType(HandlerMethod method) {
+            return method.getReturnType().getGenericParameterType();
+        }
+    }
+
+    protected final Logger LOGGER = LoggerFactory.getLogger(getClass());
+
+    @Rule
+    @Autowired
+    public BaseSpringRestRule restRule;
+
+    @Rule
+    public final JUnitRestDocumentation restDocumentation = new JUnitRestDocumentation();
+
+    @Autowired
+    private ProcessEngine processEngine;
+    @Autowired
+    protected ProcessEngineConfigurationImpl processEngineConfiguration;
+    @Autowired
+    protected RepositoryService repositoryService;
+    @Autowired
+    protected RuntimeService runtimeService;
+    @Autowired
+    protected TaskService taskService;
+    @Autowired
+    protected FormService formService;
+    @Autowired
+    protected HistoryService historyService;
+    @Autowired
+    protected IdentityService identityService;
+    @Autowired
+    protected ManagementService managementService;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+    @Autowired
+    protected WebApplicationContext webApplicationContext;
+    protected MockMvc mockMvc;
+
+    @BeforeClass
+    public static void setUpBeforeClass() {
+        System.setProperty("org.springframework.restdocs.javadocJsonDir","target/generated-javadoc-json,../flowable-common-rest/target/generated-javadoc-json");
+    }
+    @Before
+    public void setUp() {
+        createUsers();
+        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+            .alwaysDo(prepareJackson(objectMapper))
+            .alwaysDo(print())
+            .apply(documentationConfiguration(restDocumentation)
+                .snippets().withAdditionalDefaults(
+                    AutoDocumentation.description(),
+                    AutoDocumentation.methodAndPath(),
+                    AutoDocumentation.pathParameters(),
+                    AutoDocumentation.requestParameters(),
+                    AutoDocumentation.requestFields(),
+                    new FlowableResponseFieldsSnippet(),
+                    AutoDocumentation.section()
+                ))
+            .build();
+    }
+
+    protected void createUsers() {
+        User user = identityService.newUser("kermit");
+        user.setFirstName("Kermit");
+        user.setLastName("the Frog");
+        user.setPassword("kermit");
+        identityService.saveUser(user);
+
+        Group group = identityService.newGroup("admin");
+        group.setName("Administrators");
+        identityService.saveGroup(group);
+
+        identityService.createMembership(user.getId(), group.getId());
+    }
+
+    @After
+    public void tearDown() throws Throwable {
+        dropUsers();
+        assertAndEnsureCleanDb();
+        processEngineConfiguration.getClock().reset();
+    }
+
+    protected void dropUsers() {
+        IdentityService identityService = processEngine.getIdentityService();
+
+        identityService.deleteUser("kermit");
+        identityService.deleteGroup("admin");
+        identityService.deleteMembership("kermit", "admin");
+    }
+
+    /**
+     * Each test is assumed to clean up all DB content it entered. After a test method executed, this method scans all tables to see if the DB is completely clean. It throws AssertionFailed in case
+     * the DB is not clean. If the DB is not clean, it is cleaned by performing a create a drop.
+     */
+    protected void assertAndEnsureCleanDb() throws Throwable {
+        LOGGER.debug("verifying that db is clean after test");
+        Map<String, Long> tableCounts = managementService.getTableCount();
+        StringBuilder outputMessage = new StringBuilder();
+        for (String tableName : tableCounts.keySet()) {
+            String tableNameWithoutPrefix = tableName.replace(processEngineConfiguration.getDatabaseTablePrefix(), "");
+            if (!TABLENAMES_EXCLUDED_FROM_DB_CLEAN_CHECK.contains(tableNameWithoutPrefix)) {
+                Long count = tableCounts.get(tableName);
+                if (count != 0L) {
+                    outputMessage.append("  ").append(tableName).append(": ").append(count.toString()).append(" record(s) ");
+                }
+            }
+        }
+        if (outputMessage.length() > 0) {
+            outputMessage.insert(0, "DB NOT CLEAN: \n");
+            LOGGER.error("\n");
+            LOGGER.error(outputMessage.toString());
+
+            LOGGER.info("dropping and recreating db");
+
+            CommandExecutor commandExecutor = ((ProcessEngineImpl) processEngine).getProcessEngineConfiguration().getCommandExecutor();
+            commandExecutor.execute(new Command<Object>() {
+
+                @Override
+                public Object execute(CommandContext commandContext) {
+                    DbSchemaManager dbSchemaManager = CommandContextUtil.getProcessEngineConfiguration(commandContext).getDbSchemaManager();
+                    dbSchemaManager.dbSchemaDrop();
+                    dbSchemaManager.dbSchemaCreate();
+                    return null;
+                }
+            });
+
+            if (restRule.getException() != null) {
+                throw restRule.getException();
+            } else {
+                Assert.fail(outputMessage.toString());
+            }
+        } else {
+            LOGGER.info("database was clean");
+        }
+    }
+
+    /**
+     * Checks if the returned "data" array (child-node of root-json node returned by invoking a GET on the given url) contains entries with the given ID's.
+     */
+    protected void assertResultsPresentInDataResponse(String url, String... expectedResourceIds) throws Exception {
+        int numberOfResultsExpected = expectedResourceIds.length;
+
+        // Do the actual call
+        mockMvc.perform(get("/" + url))
+            // Check status and size
+            .andExpect(status().isOk())
+            .andDo(
+                document("{class-name}/{method-name}/{step}",
+                    Preprocessors.preprocessRequest(),
+                    Preprocessors.preprocessResponse(
+                        ResponseModifyingPreprocessors.replaceBinaryContent(),
+                        Preprocessors.prettyPrint()
+                    )
+                    ))
+//            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("data.[*]", hasSize(numberOfResultsExpected)))
+            .andExpect(jsonPath("data[*].id", containsInAnyOrder(expectedResourceIds)));
+    }
+}

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/identity/GroupCollectionResourceMvcTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/identity/GroupCollectionResourceMvcTest.java
@@ -1,0 +1,92 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.flowable.rest.service.api.identity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.flowable.engine.test.Deployment;
+import org.flowable.idm.api.Group;
+import org.flowable.rest.service.BaseSpringRestTest;
+import org.flowable.rest.service.BaseSpringRestTestCase;
+import org.flowable.rest.service.api.RestUrls;
+import org.junit.Assert;
+import org.junit.Test;
+
+import capital.scalable.restdocs.payload.JacksonResponseFieldSnippet;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class GroupCollectionResourceMvcTest extends BaseSpringRestTest {
+
+    /**
+     * Test getting all groups.
+     */
+    @Test
+    public void testGetGroups() throws Exception {
+        List<Group> savedGroups = new ArrayList<>();
+        try {
+            Group group1 = identityService.newGroup("testgroup1");
+            group1.setName("Test group");
+            group1.setType("Test type");
+            identityService.saveGroup(group1);
+            savedGroups.add(group1);
+
+            Group group2 = identityService.newGroup("testgroup2");
+            group2.setName("Another group");
+            group2.setType("Another type");
+            identityService.saveGroup(group2);
+            savedGroups.add(group2);
+
+            Group group3 = identityService.createGroupQuery().groupId("admin").singleResult();
+            Assert.assertNotNull(group3);
+
+            // Test filter-less
+            String url = RestUrls.createRelativeResourceUrl(RestUrls.URL_GROUP_COLLECTION);
+            assertResultsPresentInDataResponse(url, group1.getId(), group2.getId(), group3.getId());
+
+            // Test based on name
+            url = RestUrls.createRelativeResourceUrl(RestUrls.URL_GROUP_COLLECTION) + "?name=Test group";
+            assertResultsPresentInDataResponse(url, group1.getId());
+
+            // Test based on name like
+            url = RestUrls.createRelativeResourceUrl(RestUrls.URL_GROUP_COLLECTION) + "?nameLike=% group";
+            assertResultsPresentInDataResponse(url, group2.getId(), group1.getId());
+
+            // Test based on type
+            url = RestUrls.createRelativeResourceUrl(RestUrls.URL_GROUP_COLLECTION) + "?type=Another type";
+            assertResultsPresentInDataResponse(url, group2.getId());
+
+            // Test based on group member
+            url = RestUrls.createRelativeResourceUrl(RestUrls.URL_GROUP_COLLECTION) + "?member=kermit";
+            assertResultsPresentInDataResponse(url, group3.getId());
+
+        } finally {
+
+            // Delete groups after test passes or fails
+            if (!savedGroups.isEmpty()) {
+                for (Group group : savedGroups) {
+                    identityService.deleteGroup(group.getId());
+                }
+            }
+        }
+    }
+}

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/util/FlowableResponseFieldsSnippet.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/util/FlowableResponseFieldsSnippet.java
@@ -1,0 +1,36 @@
+package org.flowable.rest.util;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+
+import org.flowable.rest.api.DataResponse;
+import org.springframework.web.method.HandlerMethod;
+
+import capital.scalable.restdocs.payload.JacksonResponseFieldSnippet;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class FlowableResponseFieldsSnippet extends JacksonResponseFieldSnippet {
+
+    @Override
+    protected Type getType(HandlerMethod method) {
+        Type type = super.getType(method);
+        //TODO this will actually not work if the return type of the method was ResponseEntity, or HttpEntity
+        if (type != null && type.equals(DataResponse.class)) {
+            type = firstGenericType(method.getReturnType());
+        }
+        return type;
+    }
+
+    @Override
+    protected void enrichModel(Map<String, Object> model, HandlerMethod handlerMethod) {
+        super.enrichModel(model, handlerMethod);
+        model.put("isPageResponse", isPageResponse(handlerMethod));
+    }
+
+    private boolean isPageResponse(HandlerMethod handlerMethod) {
+        Type type = super.getType(handlerMethod);
+        return type instanceof Class && DataResponse.class.isAssignableFrom((Class<?>) type);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,10 @@
 		<flowable.osgi.remove.headers>Ignore-Package,Include-Resource,Private-Package,Bundle-DocURL</flowable.osgi.remove.headers>
 		<flowable.osgi.include.resource>{maven-resources}</flowable.osgi.include.resource>
 		<flowable.osgi.embed></flowable.osgi.embed>
+
+		<!-- REST properties -->
+		<spring.auto.restdocs.version>1.0.9</spring.auto.restdocs.version>
+		<spring.restdocs.version>1.2.2.RELEASE</spring.restdocs.version>
 	</properties>
 
 	<dependencyManagement>


### PR DESCRIPTION
This is a WIP and should **not be merged** yet. It is a proposal for using [spring-restdocs](https://github.com/spring-projects/spring-restdocs) and [spring-auto-restdocs](https://github.com/ScaCap/spring-auto-restdocs) which generated asciidoc documentation with example requests, descriptions from Javadoc.

I'll create a Forum topic for this as well.