### PR TITLE
LogInterceptor: remove logging of blank lines

### DIFF
--- a/modules/flowable-engine-common/src/main/java/org/flowable/engine/common/impl/interceptor/LogInterceptor.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/engine/common/impl/interceptor/LogInterceptor.java
@@ -29,7 +29,6 @@ public class LogInterceptor extends AbstractCommandInterceptor {
             // do nothing here if we cannot log
             return next.execute(config, command);
         }
-        LOGGER.debug("\n");
         LOGGER.debug("--- starting {} --------------------------------------------------------", command.getClass().getSimpleName());
         try {
 
@@ -37,7 +36,6 @@ public class LogInterceptor extends AbstractCommandInterceptor {
 
         } finally {
             LOGGER.debug("--- {} finished --------------------------------------------------------", command.getClass().getSimpleName());
-            LOGGER.debug("\n");
         }
     }
 }


### PR DESCRIPTION
The logging of new lines causes unnecessary and imho ugly blank lines like `2017-11-07 16:19:10,118 DEBUG [activiti-acquire-timer-jobs] org.activiti.engine.impl.interceptor.LogInterceptor -`