### PR TITLE
Support unicode filename when doing BPMN export

### DIFF
--- a/modules/flowable-ui-modeler/flowable-ui-modeler-rest/src/main/java/org/flowable/app/rest/editor/AbstractModelBpmnResource.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-rest/src/main/java/org/flowable/app/rest/editor/AbstractModelBpmnResource.java
@@ -15,6 +15,9 @@ package org.flowable.app.rest.editor;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+
+import java.net.URLEncoder;
 
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletResponse;
@@ -61,9 +64,10 @@ public class AbstractModelBpmnResource {
         generateBpmn20Xml(response, historicModel);
     }
 
-    protected void generateBpmn20Xml(HttpServletResponse response, AbstractModel model) {
-        String name = model.getName().replaceAll(" ", "_");
-        response.setHeader("Content-Disposition", "attachment; filename=" + name + ".bpmn20.xml");
+    protected void generateBpmn20Xml(HttpServletResponse response, AbstractModel model) throws UnsupportedEncodingException {
+        String name = model.getName().replaceAll(" ", "_") + ".bpmn20.xml";
+        String encodedName = "UTF-8''" + URLEncoder.encode(name, "UTF-8");
+        response.setHeader("Content-Disposition", "attachment; filename=" + name + "; filename*=" + encodedName);
         if (model.getModelEditorJson() != null) {
             try {
                 ServletOutputStream servletOutputStream = response.getOutputStream();


### PR DESCRIPTION
Add `filename*` parameter to `Content-Disposition` response header when
exporting BPMN file, in order to support unicode filename. See
https://tools.ietf.org/html/rfc6266 for more detail.

Tested in Firefox, Chrome and Edge.

P.S. I'm new to Java, so maybe I do something wrong.