### PR TITLE
Decision table without a parent deployment, but with the same key, are used as fallback.

### DIFF
--- a/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/cmd/AbstractExecuteDecisionCmd.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/cmd/AbstractExecuteDecisionCmd.java
@@ -32,7 +32,7 @@ public abstract class AbstractExecuteDecisionCmd implements Serializable {
     private static final long serialVersionUID = 1L;
 
     protected ExecuteDecisionInfo executeDecisionInfo = new ExecuteDecisionInfo();
-    
+
     public AbstractExecuteDecisionCmd(ExecuteDecisionBuilderImpl decisionBuilder) {
         executeDecisionInfo.setDecisionKey(decisionBuilder.getDecisionKey());
         executeDecisionInfo.setParentDeploymentId(decisionBuilder.getParentDeploymentId());
@@ -42,7 +42,7 @@ public abstract class AbstractExecuteDecisionCmd implements Serializable {
         executeDecisionInfo.setVariables(decisionBuilder.getVariables());
         executeDecisionInfo.setTenantId(decisionBuilder.getTenantId());
     }
-    
+
     public AbstractExecuteDecisionCmd(String decisionKey, Map<String, Object> variables) {
         executeDecisionInfo.setDecisionKey(decisionKey);
         executeDecisionInfo.setVariables(variables);
@@ -54,16 +54,32 @@ public abstract class AbstractExecuteDecisionCmd implements Serializable {
         if (StringUtils.isNotEmpty(getDecisionKey()) && StringUtils.isNotEmpty(getParentDeploymentId()) && StringUtils.isNotEmpty(getTenantId())) {
             decisionTable = deploymentManager.findDeployedLatestDecisionByKeyParentDeploymentIdAndTenantId(
                             getDecisionKey(), getParentDeploymentId(), getTenantId());
+
+            // Fall back
+            // If there is no decision table found linked to the deployment id, try to find one without a specific deployment id.
+            if(decisionTable == null){
+                decisionTable = deploymentManager.findDeployedLatestDecisionByKeyAndTenantId(getDecisionKey(), getTenantId());
+            }
+
             if (decisionTable == null) {
                 throw new FlowableObjectNotFoundException("No decision found for key: " + getDecisionKey() +
-                    ", parent deployment id " + getParentDeploymentId() + " and tenant id: " + getTenantId());
+                    ", parent deployment id " + getParentDeploymentId() + " and tenant id: " + getTenantId() +
+                    ". There was also no fall back decision table found without specifying the deployment id.");
             }
 
         } else if (StringUtils.isNotEmpty(getDecisionKey()) && StringUtils.isNotEmpty(getParentDeploymentId())) {
             decisionTable = deploymentManager.findDeployedLatestDecisionByKeyAndParentDeploymentId(getDecisionKey(), getParentDeploymentId());
+
+            // Fall back
+            // If there is no decision table found linked to the deployment id, try to find one without a specific deployment id.
+            if(decisionTable == null){
+                decisionTable = deploymentManager.findDeployedLatestDecisionByKey(getDecisionKey());
+            }
+
             if (decisionTable == null) {
                 throw new FlowableObjectNotFoundException("No decision found for key: " + getDecisionKey() +
-                    " and parent deployment id " + getParentDeploymentId());
+                    " and parent deployment id " + getParentDeploymentId() +
+                    ". There was also no fall back decision table found without specifying the deployment id.");
             }
 
         } else if (StringUtils.isNotEmpty(getDecisionKey()) && StringUtils.isNotEmpty(getTenantId())) {
@@ -82,7 +98,7 @@ public abstract class AbstractExecuteDecisionCmd implements Serializable {
         } else {
             throw new IllegalArgumentException("decisionKey is null");
         }
-        
+
         executeDecisionInfo.setDecisionDefinitionId(decisionTable.getId());
         executeDecisionInfo.setDeploymentId(decisionTable.getDeploymentId());
 
@@ -99,15 +115,15 @@ public abstract class AbstractExecuteDecisionCmd implements Serializable {
 
         return decision;
     }
-    
+
     protected String getDecisionKey() {
         return executeDecisionInfo.getDecisionKey();
     }
-    
+
     protected String getParentDeploymentId() {
         return executeDecisionInfo.getParentDeploymentId();
     }
-    
+
     protected String getTenantId() {
         return executeDecisionInfo.getTenantId();
     }

--- a/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/persistence/deploy/DeploymentManager.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/persistence/deploy/DeploymentManager.java
@@ -68,7 +68,8 @@ public class DeploymentManager {
         if (decisionTable == null) {
             decisionTable = engineConfig.getDecisionTableEntityManager().findById(decisionId);
             if (decisionTable == null) {
-                throw new FlowableObjectNotFoundException("no deployed decision found with id '" + decisionId + "'");
+                return null;
+//                throw new FlowableObjectNotFoundException("no deployed decision found with id '" + decisionId + "'");
             }
             decisionTable = resolveDecisionTable(decisionTable).getDecisionTableEntity();
         }
@@ -79,7 +80,8 @@ public class DeploymentManager {
         DecisionTableEntity decisionTable = decisionTableEntityManager.findLatestDecisionTableByKey(decisionKey);
 
         if (decisionTable == null) {
-            throw new FlowableObjectNotFoundException("no decisions deployed with key '" + decisionKey + "'");
+            return null;
+//            throw new FlowableObjectNotFoundException("no decisions deployed with key '" + decisionKey + "'");
         }
         decisionTable = resolveDecisionTable(decisionTable).getDecisionTableEntity();
         return decisionTable;
@@ -89,7 +91,8 @@ public class DeploymentManager {
         DecisionTableEntity decisionTable = decisionTableEntityManager.findLatestDecisionTableByKeyAndTenantId(decisionKey, tenantId);
 
         if (decisionTable == null) {
-            throw new FlowableObjectNotFoundException("no decisions deployed with key '" + decisionKey + "' for tenant identifier '" + tenantId + "'");
+            return null;
+//            throw new FlowableObjectNotFoundException("no decisions deployed with key '" + decisionKey + "' for tenant identifier '" + tenantId + "'");
         }
         decisionTable = resolveDecisionTable(decisionTable).getDecisionTableEntity();
         return decisionTable;
@@ -99,8 +102,9 @@ public class DeploymentManager {
         DecisionTableEntity decisionTable = decisionTableEntityManager.findLatestDecisionTableByKeyAndParentDeploymentId(decisionTableKey, parentDeploymentId);
 
         if (decisionTable == null) {
-            throw new FlowableObjectNotFoundException("no decisions deployed with key '" + decisionTableKey +
-                    "' for parent deployment id '" + parentDeploymentId + "'");
+            return null;
+//            throw new FlowableObjectNotFoundException("no decisions deployed with key '" + decisionTableKey +
+//                    "' for parent deployment id '" + parentDeploymentId + "'");
         }
         decisionTable = resolveDecisionTable(decisionTable).getDecisionTableEntity();
         return decisionTable;
@@ -113,8 +117,9 @@ public class DeploymentManager {
                 decisionTableKey, parentDeploymentId, tenantId);
 
         if (decisionTable == null) {
-            throw new FlowableObjectNotFoundException("no decisions deployed with key '" + decisionTableKey +
-                    "' for parent deployment id '" + parentDeploymentId + "' and tenant identifier " + tenantId);
+            return null;
+//            throw new FlowableObjectNotFoundException("no decisions deployed with key '" + decisionTableKey +
+//                    "' for parent deployment id '" + parentDeploymentId + "' and tenant identifier " + tenantId);
         }
         decisionTable = resolveDecisionTable(decisionTable).getDecisionTableEntity();
         return decisionTable;
@@ -124,7 +129,8 @@ public class DeploymentManager {
         DecisionTableEntity decisionTable = decisionTableEntityManager.findDecisionTableByKeyAndVersionAndTenantId(decisionKey, decisionVersion, tenantId);
 
         if (decisionTable == null) {
-            throw new FlowableObjectNotFoundException("no decisions deployed with key = '" + decisionKey + "' and version = '" + decisionVersion + "'");
+            return null;
+//            throw new FlowableObjectNotFoundException("no decisions deployed with key = '" + decisionKey + "' and version = '" + decisionVersion + "'");
         }
 
         decisionTable = resolveDecisionTable(decisionTable).getDecisionTableEntity();

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/GetDecisionTablesForProcessDefinitionCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/GetDecisionTablesForProcessDefinitionCmd.java
@@ -100,12 +100,6 @@ public class GetDecisionTablesForProcessDefinitionCmd implements Command<List<Dm
 
         if (decisionTable != null) {
             decisionTables.add(decisionTable);
-        } else {
-            decisionTable = decisionTableQuery.decisionTableKey(decisionTableKey).parentDeploymentId(null).latestVersion().singleResult();
-
-            if (decisionTable != null) {
-                decisionTables.add(decisionTable);
-            }
         }
     }
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/GetDecisionTablesForProcessDefinitionCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/GetDecisionTablesForProcessDefinitionCmd.java
@@ -100,6 +100,12 @@ public class GetDecisionTablesForProcessDefinitionCmd implements Command<List<Dm
 
         if (decisionTable != null) {
             decisionTables.add(decisionTable);
+        } else {
+            decisionTable = decisionTableQuery.decisionTableKey(decisionTableKey).parentDeploymentId(null).latestVersion().singleResult();
+
+            if (decisionTable != null) {
+                decisionTables.add(decisionTable);
+            }
         }
     }
 }


### PR DESCRIPTION
This addition of code allows deploying DMN decision tables without a parent deployment id, which are still found during the execution of a decision task.

A post on the forum will be created shortly where the benefits and drawbacks of this approach can be discussed.