### PR TITLE
Fix month off by one in rendered date fields (#636).

### DIFF
--- a/modules/flowable-ui-task/flowable-ui-task-app/src/main/webapp/workflow/scripts/controllers/render-form.js
+++ b/modules/flowable-ui-task/flowable-ui-task-app/src/main/webapp/workflow/scripts/controllers/render-form.js
@@ -305,7 +305,7 @@ angular.module('flowableApp')
                     } else if (field.type == 'date' && field.value && !field.readOnly) {
                         var dateArray = field.value.split('-');
                         if (dateArray && dateArray.length == 3) {
-                            field.value = new Date(dateArray[0],dateArray[1],dateArray[2]);
+                            field.value = new Date(dateArray[0],dateArray[1]-1,dateArray[2]);
                         }
                         
                     } else if (field.type == 'people' && field.value) {


### PR DESCRIPTION
Found the bug causing #636: in `render-form.js` the `Date` object is populated from a parsed ISO date without taking into account that JavaScript Date has zero-based months.