### PR TITLE
Throw a FlowableException when a decision task fails.

### DIFF
--- a/modules/flowable-cmmn-json-converter/src/main/java/org/flowable/cmmn/editor/constants/CmmnStencilConstants.java
+++ b/modules/flowable-cmmn-json-converter/src/main/java/org/flowable/cmmn/editor/constants/CmmnStencilConstants.java
@@ -84,6 +84,8 @@ public interface CmmnStencilConstants {
     String PROPERTY_DECISIONTABLE_REFERENCE_ID = "decisiontablereferenceid";
     String PROPERTY_DECISIONTABLE_REFERENCE_NAME = "decisiontablereferencename";
     String PROPERTY_DECISIONTABLE_REFERENCE_KEY = "decisionTableReferenceKey";
+    String PROPERTY_DECISIONTABLE_THROW_ERROR_NO_HITS = "decisiontaskthrowerroronnohits";
+    String PROPERTY_DECISIONTABLE_THROW_ERROR_NO_HITS_KEY = "decisiontaskThrowErrorOnNoHits";
     
     String PROPERTY_CASE_REFERENCE = "casetaskcasereference";
     

--- a/modules/flowable-cmmn-json-converter/src/main/java/org/flowable/cmmn/editor/json/converter/DecisionTaskJsonConverter.java
+++ b/modules/flowable-cmmn-json-converter/src/main/java/org/flowable/cmmn/editor/json/converter/DecisionTaskJsonConverter.java
@@ -71,6 +71,12 @@ public class DecisionTaskJsonConverter extends BaseCmmnJsonConverter implements 
             }
         }
 
+        boolean decisionTableThrowErrorOnNoHitsNode = getPropertyValueAsBoolean(PROPERTY_DECISIONTABLE_THROW_ERROR_NO_HITS, elementNode);
+        FieldExtension decisionTableThrowErrorOnNoHitsField = new FieldExtension();
+        decisionTableThrowErrorOnNoHitsField.setFieldName(PROPERTY_DECISIONTABLE_THROW_ERROR_NO_HITS_KEY);
+        decisionTableThrowErrorOnNoHitsField.setStringValue(decisionTableThrowErrorOnNoHitsNode ? "true" : "false");
+        serviceTask.getFieldExtensions().add(decisionTableThrowErrorOnNoHitsField);
+
         return serviceTask;
     }
 

--- a/modules/flowable-cmmn-json-converter/src/main/java/org/flowable/cmmn/editor/json/converter/ServiceTaskJsonConverter.java
+++ b/modules/flowable-cmmn-json-converter/src/main/java/org/flowable/cmmn/editor/json/converter/ServiceTaskJsonConverter.java
@@ -14,6 +14,7 @@ package org.flowable.cmmn.editor.json.converter;
 
 import java.util.Map;
 
+import com.fasterxml.jackson.databind.node.BooleanNode;
 import org.apache.commons.lang3.StringUtils;
 import org.flowable.cmmn.editor.constants.CmmnStencilConstants;
 import org.flowable.cmmn.editor.json.converter.CmmnJsonConverter.CmmnModelIdHelper;
@@ -32,7 +33,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
  * @author Tijs Rademakers
  */
 public class ServiceTaskJsonConverter extends BaseCmmnJsonConverter implements DecisionTableKeyAwareConverter {
-    
+
     protected Map<String, CmmnModelInfo> decisionTableKeyMap;
 
     public static void fillTypes(Map<String, Class<? extends BaseCmmnJsonConverter>> convertersToCmmnMap,
@@ -48,7 +49,7 @@ public class ServiceTaskJsonConverter extends BaseCmmnJsonConverter implements D
     public static void fillCmmnTypes(Map<Class<? extends BaseElement>, Class<? extends BaseCmmnJsonConverter>> convertersToJsonMap) {
         convertersToJsonMap.put(CaseTask.class, ServiceTaskJsonConverter.class);
     }
-    
+
     @Override
     protected String getStencilId(BaseElement baseElement) {
         return CmmnStencilConstants.STENCIL_TASK_SERVICE;
@@ -57,7 +58,7 @@ public class ServiceTaskJsonConverter extends BaseCmmnJsonConverter implements D
     @Override
     protected void convertElementToJson(ObjectNode elementNode, ObjectNode propertiesNode, ActivityProcessor processor,
                     BaseElement baseElement, CmmnModel cmmnModel) {
-        
+
         ServiceTask serviceTask = (ServiceTask) baseElement;
 
         if ("dmn".equalsIgnoreCase(serviceTask.getType())) {
@@ -72,6 +73,9 @@ public class ServiceTaskJsonConverter extends BaseCmmnJsonConverter implements D
                     decisionReferenceNode.put("id", modelInfo.getId());
                     decisionReferenceNode.put("name", modelInfo.getName());
                     decisionReferenceNode.put("key", modelInfo.getKey());
+                } else if (PROPERTY_DECISIONTABLE_THROW_ERROR_NO_HITS_KEY.equals(fieldExtension.getFieldName())) {
+                    propertiesNode.set(PROPERTY_DECISIONTABLE_THROW_ERROR_NO_HITS,
+                            BooleanNode.valueOf(Boolean.parseBoolean(fieldExtension.getStringValue())));
                 }
             }
 
@@ -110,7 +114,7 @@ public class ServiceTaskJsonConverter extends BaseCmmnJsonConverter implements D
     @Override
     protected BaseElement convertJsonToElement(JsonNode elementNode, JsonNode modelNode, ActivityProcessor processor,
                     BaseElement parentElement, Map<String, JsonNode> shapeMap, CmmnModel cmmnModel, CmmnModelIdHelper cmmnModelIdHelper) {
-        
+
         ServiceTask task = new ServiceTask();
         if (StringUtils.isNotEmpty(getPropertyValueAsString(PROPERTY_SERVICETASK_CLASS, elementNode))) {
             task.setImplementationType(ImplementationType.IMPLEMENTATION_TYPE_CLASS);

--- a/modules/flowable-json-converter/src/main/java/org/flowable/editor/constants/StencilConstants.java
+++ b/modules/flowable-json-converter/src/main/java/org/flowable/editor/constants/StencilConstants.java
@@ -253,6 +253,8 @@ public interface StencilConstants {
     final String PROPERTY_DECISIONTABLE_REFERENCE_ID = "decisiontablereferenceid";
     final String PROPERTY_DECISIONTABLE_REFERENCE_NAME = "decisiontablereferencename";
     final String PROPERTY_DECISIONTABLE_REFERENCE_KEY = "decisionTableReferenceKey";
+    final String PROPERTY_DECISIONTABLE_THROW_ERROR_NO_HITS = "decisiontaskthrowerroronnohits";
+    final String PROPERTY_DECISIONTABLE_THROW_ERROR_NO_HITS_KEY = "decisiontaskThrowErrorOnNoHits";
 
     final String PROPERTY_HTTPTASK_REQ_METHOD = "httptaskrequestmethod";
     final String PROPERTY_HTTPTASK_REQ_URL = "httptaskrequesturl";

--- a/modules/flowable-json-converter/src/main/java/org/flowable/editor/language/json/converter/DecisionTaskJsonConverter.java
+++ b/modules/flowable-json-converter/src/main/java/org/flowable/editor/language/json/converter/DecisionTaskJsonConverter.java
@@ -12,15 +12,14 @@
  */
 package org.flowable.editor.language.json.converter;
 
-import java.util.Map;
-
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.flowable.bpmn.model.BaseElement;
 import org.flowable.bpmn.model.FieldExtension;
 import org.flowable.bpmn.model.FlowElement;
 import org.flowable.bpmn.model.ServiceTask;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.Map;
 
 /**
  * @author Tijs Rademakers
@@ -31,7 +30,7 @@ public class DecisionTaskJsonConverter extends BaseBpmnJsonConverter implements 
     protected Map<String, String> decisionTableMap;
 
     public static void fillTypes(Map<String, Class<? extends BaseBpmnJsonConverter>> convertersToBpmnMap,
-            Map<Class<? extends BaseElement>, Class<? extends BaseBpmnJsonConverter>> convertersToJsonMap) {
+                                 Map<Class<? extends BaseElement>, Class<? extends BaseBpmnJsonConverter>> convertersToJsonMap) {
 
         fillJsonTypes(convertersToBpmnMap);
         fillBpmnTypes(convertersToJsonMap);
@@ -68,6 +67,12 @@ public class DecisionTaskJsonConverter extends BaseBpmnJsonConverter implements 
                 serviceTask.getFieldExtensions().add(decisionTableKeyField);
             }
         }
+
+        boolean decisionTableThrowErrorOnNoHitsNode = getPropertyValueAsBoolean(PROPERTY_DECISIONTABLE_THROW_ERROR_NO_HITS, elementNode);
+        FieldExtension decisionTableThrowErrorOnNoHitsField = new FieldExtension();
+        decisionTableThrowErrorOnNoHitsField.setFieldName(PROPERTY_DECISIONTABLE_THROW_ERROR_NO_HITS_KEY);
+        decisionTableThrowErrorOnNoHitsField.setStringValue(decisionTableThrowErrorOnNoHitsNode ? "true" : "false");
+        serviceTask.getFieldExtensions().add(decisionTableThrowErrorOnNoHitsField);
 
         return serviceTask;
     }

--- a/modules/flowable-json-converter/src/main/java/org/flowable/editor/language/json/converter/ServiceTaskJsonConverter.java
+++ b/modules/flowable-json-converter/src/main/java/org/flowable/editor/language/json/converter/ServiceTaskJsonConverter.java
@@ -14,6 +14,7 @@ package org.flowable.editor.language.json.converter;
 
 import java.util.Map;
 
+import com.fasterxml.jackson.databind.node.BooleanNode;
 import org.apache.commons.lang3.StringUtils;
 import org.flowable.bpmn.model.BaseElement;
 import org.flowable.bpmn.model.FieldExtension;
@@ -88,6 +89,9 @@ public class ServiceTaskJsonConverter extends BaseBpmnJsonConverter implements D
                     decisionReferenceNode.put("id", modelInfo.getId());
                     decisionReferenceNode.put("name", modelInfo.getName());
                     decisionReferenceNode.put("key", modelInfo.getKey());
+                } else if (PROPERTY_DECISIONTABLE_THROW_ERROR_NO_HITS_KEY.equals(fieldExtension.getFieldName())) {
+                    propertiesNode.set(PROPERTY_DECISIONTABLE_THROW_ERROR_NO_HITS,
+                            BooleanNode.valueOf(Boolean.parseBoolean(fieldExtension.getStringValue())));
                 }
             }
 

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/resources/stencilset_bpmn.json
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/resources/stencilset_bpmn.json
@@ -920,6 +920,16 @@
       "popular" : true
     } ]
   }, {
+    "name" : "decisiontaskThrowErrorOnNoHitspackage",
+    "properties" : [ {
+      "id" : "decisiontaskThrowErrorOnNoHits",
+      "type" : "Boolean",
+      "title" : "Throw error if no rules were hit",
+      "value" : "false",
+      "description" : "Should an error be thrown if no rules of the decision table were hit and consequently no result was found.",
+      "popular" : true
+    } ]
+  }, {
     "name" : "interruptingpackage",
     "properties" : [ {
       "id" : "interrupting",
@@ -1158,7 +1168,7 @@
     "view" : "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n<svg\n   xmlns=\"http://www.w3.org/2000/svg\"\n   xmlns:svg=\"http://www.w3.org/2000/svg\"\n   xmlns:oryx=\"http://www.b3mn.org/oryx\"\n   xmlns:xlink=\"http://www.w3.org/1999/xlink\"\n\n   width=\"102\"\n   height=\"82\"\n   version=\"1.0\">\n  <defs></defs>\n  <oryx:magnets>\n  \t<oryx:magnet oryx:cx=\"1\" oryx:cy=\"20\" oryx:anchors=\"left\" />\n  \t<oryx:magnet oryx:cx=\"1\" oryx:cy=\"40\" oryx:anchors=\"left\" />\n  \t<oryx:magnet oryx:cx=\"1\" oryx:cy=\"60\" oryx:anchors=\"left\" />\n  \t\n  \t<oryx:magnet oryx:cx=\"25\" oryx:cy=\"79\" oryx:anchors=\"bottom\" />\n  \t<oryx:magnet oryx:cx=\"50\" oryx:cy=\"79\" oryx:anchors=\"bottom\" />\n  \t<oryx:magnet oryx:cx=\"75\" oryx:cy=\"79\" oryx:anchors=\"bottom\" />\n  \t\n  \t<oryx:magnet oryx:cx=\"99\" oryx:cy=\"20\" oryx:anchors=\"right\" />\n  \t<oryx:magnet oryx:cx=\"99\" oryx:cy=\"40\" oryx:anchors=\"right\" />\n  \t<oryx:magnet oryx:cx=\"99\" oryx:cy=\"60\" oryx:anchors=\"right\" />\n  \t\n  \t<oryx:magnet oryx:cx=\"25\" oryx:cy=\"1\" oryx:anchors=\"top\" />\n  \t<oryx:magnet oryx:cx=\"50\" oryx:cy=\"1\" oryx:anchors=\"top\" />\n  \t<oryx:magnet oryx:cx=\"75\" oryx:cy=\"1\" oryx:anchors=\"top\" />\n  \t\n  \t<oryx:magnet oryx:cx=\"50\" oryx:cy=\"40\" oryx:default=\"yes\" />\n  </oryx:magnets>\n  <g pointer-events=\"fill\" oryx:minimumSize=\"50 40\">\n\t<rect id=\"text_frame\" oryx:anchors=\"bottom top right left\" x=\"1\" y=\"1\" width=\"94\" height=\"79\" rx=\"10\" ry=\"10\" stroke=\"none\" stroke-width=\"0\" fill=\"none\" />\n\t<rect id=\"bg_frame\" oryx:resize=\"vertical horizontal\" x=\"0\" y=\"0\" width=\"100\" height=\"80\" rx=\"10\" ry=\"10\" stroke=\"#bbbbbb\" stroke-width=\"1\" fill=\"#f9f9f9\" />\n\t\t<text \n\t\t\tfont-size=\"12\" \n\t\t\tid=\"text_name\" \n\t\t\tx=\"50\" \n\t\t\ty=\"40\" \n\t\t\toryx:align=\"middle center\"\n\t\t\toryx:fittoelem=\"text_frame\"\n\t\t\tstroke=\"#373e48\">\n\t\t</text>\n\t\n\t<g id=\"decisionTask\" transform=\"translate(4,3)\">\n\t\t<path oryx:anchors=\"top left\"\n\t\t\t d=\"m 1,2 0,14 16,0 0,-14 z m 1.45458,5.6000386 2.90906,0 0,2.7999224 -2.90906,0 z m 4.36364,0 8.72718,0 0,2.7999224 -8.72718,0 z m -4.36364,4.1998844 2.90906,0 0,2.800116 -2.90906,0 z m 4.36364,0 8.72718,0 0,2.800116 -8.72718,0 z\"\n     \t\tstyle=\"fill:#72a7d0;stroke:none\"\n\t\t/>\n\t</g>\n\n\t<g id=\"parallel\">\n\t\t<path oryx:anchors=\"bottom\" fill=\"none\" stroke=\"#bbbbbb\" d=\"M46 70 v8 M50 70 v8 M54 70 v8\" stroke-width=\"2\" />\n\t</g>\n\t\n\t<g id=\"sequential\">\n\t\t<path oryx:anchors=\"bottom\" fill=\"none\" stroke=\"#bbbbbb\" stroke-width=\"2\" d=\"M46,76h10M46,72h10 M46,68h10\"/>\n\t</g>\n\t\n\t<g id=\"compensation\">\n\t\t<path oryx:anchors=\"bottom\" fill=\"none\" stroke=\"#bbbbbb\" d=\"M 62 74 L 66 70 L 66 78 L 62 74 L 62 70 L 58 74 L 62 78 L 62 74\" stroke-width=\"1\" />\n\t</g>\n  </g>\n</svg>",
     "icon" : "activity/list/type.decision.png",
     "groups" : [ "Activities" ],
-    "propertyPackages" : [ "overrideidpackage", "namepackage", "documentationpackage", "asynchronousdefinitionpackage", "exclusivedefinitionpackage", "executionlistenerspackage", "multiinstance_typepackage", "multiinstance_cardinalitypackage", "multiinstance_collectionpackage", "multiinstance_variablepackage", "multiinstance_conditionpackage", "isforcompensationpackage", "decisiontaskdecisiontablereferencepackage" ],
+    "propertyPackages" : [ "overrideidpackage", "namepackage", "documentationpackage", "asynchronousdefinitionpackage", "exclusivedefinitionpackage", "executionlistenerspackage", "multiinstance_typepackage", "multiinstance_cardinalitypackage", "multiinstance_collectionpackage", "multiinstance_variablepackage", "multiinstance_conditionpackage", "isforcompensationpackage", "decisiontaskdecisiontablereferencepackage", "decisiontaskThrowErrorOnNoHitspackage" ],
     "hiddenPropertyPackages" : [ ],
     "roles" : [ "Activity", "sequence_start", "sequence_end", "ActivitiesMorph", "all" ]
   }, {

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/resources/stencilset_cmmn.json
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/resources/stencilset_cmmn.json
@@ -463,6 +463,16 @@
       "popular" : true
     } ]
   }, {
+    "name" : "decisiontaskThrowErrorOnNoHitspackage",
+    "properties" : [ {
+      "id" : "decisiontaskThrowErrorOnNoHits",
+      "type" : "Boolean",
+      "title" : "Throw error if no rules were hit",
+      "value" : "false",
+      "description" : "Should an error be thrown if no rules of the decision table were hit and consequently no result was found.",
+      "popular" : true
+    } ]
+  }{
     "name" : "casetaskcasereferencepackage",
     "properties" : [ {
       "id" : "casetaskcasereference",


### PR DESCRIPTION
At the moment, when executing a decision task from a BPMN process, the result does not distinguish between an empty response (aka, no rules matched) and an error during the execution. This PR remedies this by throwing a FlowableException when the decision task failed to execute.

A colleague of mine opened up a discussion linked to this on the forum: https://forum.flowable.org/t/decision-task-option-to-throw-error-when-no-rule-matched/1194

Thanks!