### PR TITLE
DatabaseConfiguration: fix c3po "bad pool size config" warning by set…

### DIFF
--- a/modules/flowable-ui-admin/flowable-ui-admin-conf/src/main/java/org/flowable/admin/conf/DatabaseConfiguration.java
+++ b/modules/flowable-ui-admin/flowable-ui-admin-conf/src/main/java/org/flowable/admin/conf/DatabaseConfiguration.java
@@ -140,6 +140,7 @@ public class DatabaseConfiguration {
 
             // Pool config: see http://www.mchange.com/projects/c3p0/#configuration
             ds.setMinPoolSize(minPoolSize);
+            ds.setInitialPoolSize(minPoolSize);
             ds.setMaxPoolSize(maxPoolSize);
             ds.setAcquireIncrement(acquireIncrement);
             if (preferredTestQuery != null) {

--- a/modules/flowable-ui-idm/flowable-ui-idm-conf/src/main/java/org/flowable/app/conf/DatabaseConfiguration.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-conf/src/main/java/org/flowable/app/conf/DatabaseConfiguration.java
@@ -120,6 +120,7 @@ public class DatabaseConfiguration {
 
             // Pool config: see http://www.mchange.com/projects/c3p0/#configuration
             ds.setMinPoolSize(minPoolSize);
+            ds.setInitialPoolSize(minPoolSize);
             ds.setMaxPoolSize(maxPoolSize);
             ds.setAcquireIncrement(acquireIncrement);
             if (preferredTestQuery != null) {

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-conf/src/main/java/org/flowable/app/conf/DatabaseConfiguration.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-conf/src/main/java/org/flowable/app/conf/DatabaseConfiguration.java
@@ -185,6 +185,7 @@ public class DatabaseConfiguration {
 
             // Pool config: see http://www.mchange.com/projects/c3p0/#configuration
             ds.setMinPoolSize(minPoolSize);
+            ds.setInitialPoolSize(minPoolSize);
             ds.setMaxPoolSize(maxPoolSize);
             ds.setAcquireIncrement(acquireIncrement);
             if (preferredTestQuery != null) {

--- a/modules/flowable-ui-task/flowable-ui-task-conf/src/main/java/org/flowable/app/conf/DatabaseConfiguration.java
+++ b/modules/flowable-ui-task/flowable-ui-task-conf/src/main/java/org/flowable/app/conf/DatabaseConfiguration.java
@@ -124,6 +124,7 @@ public class DatabaseConfiguration {
 
             // Pool config: see http://www.mchange.com/projects/c3p0/#configuration
             ds.setMinPoolSize(minPoolSize);
+            ds.setInitialPoolSize(minPoolSize);
             ds.setMaxPoolSize(maxPoolSize);
             ds.setAcquireIncrement(acquireIncrement);
             if (preferredTestQuery != null) {


### PR DESCRIPTION
…ting initialPoolSize to minPoolSize

Fixes ugly warn log messages `WARN  com.mchange.v2.resourcepool.BasicResourcePool  - Bad pool size config, start 3 < min 10. Using 10 as start.` when minPoolSize is greater than `3`, e.g. if the user does not configure `minPoolSize`.