### PR TITLE
flowable-groovy-script-static-engine: fix VariableScope package name …

### DIFF
--- a/modules/flowable-groovy-script-static-engine/src/main/java/org/flowable/engine/impl/scripting/GroovyStaticScriptEngine.java
+++ b/modules/flowable-groovy-script-static-engine/src/main/java/org/flowable/engine/impl/scripting/GroovyStaticScriptEngine.java
@@ -80,7 +80,7 @@ public class GroovyStaticScriptEngine extends GroovyScriptEngineImpl {
         ClassLoader ctxtLoader = Thread.currentThread().getContextClassLoader();
         try {
             Class<?> scriptClass = ctxtLoader.loadClass(Script.class.getName());
-            clazz = ctxtLoader.loadClass("org.flowable.engine.delegate.VariableScope");
+            clazz = ctxtLoader.loadClass("org.flowable.variable.api.delegate.VariableScope");
 
             if (scriptClass == Script.class) {
                 return ctxtLoader;

--- a/modules/flowable-groovy-script-static-engine/src/main/resources/EngineVariablesExtension.groovy
+++ b/modules/flowable-groovy-script-static-engine/src/main/resources/EngineVariablesExtension.groovy
@@ -7,7 +7,7 @@
  */
 
 import static org.flowable.engine.impl.scripting.GroovyStaticScriptEngine.*
-import org.flowable.engine.delegate.VariableScope
+import org.flowable.variable.api.delegate.VariableScope
 
 def typesOfVariables = COMPILE_OPTIONS.get()[VAR_TYPES]
 


### PR DESCRIPTION
…after recent engine refactoring

Recent refactoring broke the `flowable-groovy-script-static-engine` module. This can be replicated by running the tests, which fail with:

```
[ERROR] testGroovyStaticScriptEngine(org.flowable.examples.groovy.GroovyStaticScriptTest)  Time elapsed: 0.404 s  <<< ERROR!
java.lang.NullPointerException
```