### PR TITLE
flowable-http: Downgrade jetty test dependency to a java 7 compatible…

### DIFF
--- a/modules/flowable-http/pom.xml
+++ b/modules/flowable-http/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetty.version>9.4.4.v20170414</jetty.version>
+        <jetty.version>9.2.14.v20151106</jetty.version>
         <flowable.osgi.import.pkg>*</flowable.osgi.import.pkg>
         <flowable.artifact>
             org.flowable.http

--- a/modules/flowable-http/src/test/java/org/flowable/http/bpmn/HttpServiceTaskTest.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/bpmn/HttpServiceTaskTest.java
@@ -307,7 +307,7 @@ public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
         assertEquals("text/plain", headerMap.get("Content-Type"));
         assertEquals("623b94fc-14b8-4ee6-aed7-b16b9321e29f", headerMap.get("X-Request-ID"));
         assertEquals("localhost:7000", headerMap.get("Host"));
-        assertEquals("", headerMap.get("Test"));
+        assertEquals(null, headerMap.get("Test"));
 
         // Request assertions
         Map<String, Object> request = new HashMap<>();

--- a/modules/flowable-http/src/test/java/org/flowable/http/cmmn/CmmnHttpTaskTest.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/cmmn/CmmnHttpTaskTest.java
@@ -273,7 +273,7 @@ public class CmmnHttpTaskTest {
         assertEquals("text/plain", headerMap.get("Content-Type"));
         assertEquals("623b94fc-14b8-4ee6-aed7-b16b9321e29f", headerMap.get("X-Request-ID"));
         assertEquals("localhost:7000", headerMap.get("Host"));
-        assertEquals("", headerMap.get("Test"));
+        assertEquals(null, headerMap.get("Test"));
     }
 
     @Test
@@ -312,7 +312,7 @@ public class CmmnHttpTaskTest {
         assertEquals("text/plain", headerMap.get("Content-Type"));
         assertEquals("623b94fc-14b8-4ee6-aed7-b16b9321e29f", headerMap.get("X-Request-ID"));
         assertEquals("localhost:7000", headerMap.get("Host"));
-        assertEquals("", headerMap.get("Test"));
+        assertEquals(null, headerMap.get("Test"));
     }
 
     protected CaseInstance createCaseInstance() {

--- a/pom.xml
+++ b/pom.xml
@@ -1241,6 +1241,7 @@
 				<module>modules/flowable-content-rest</module>
 				<module>modules/flowable-jms-spring-executor</module>
 				<module>modules/flowable-ui-common</module>
+				<module>modules/flowable-http</module>
 			</modules>
 		</profile>
 		<profile>


### PR DESCRIPTION
… version (9.2.14.v20151106) and adjust tests for different HeaderMap behavior in this jetty version.