### PR TITLE
Fix bug with modeler that cannot save assignments for old models

### DIFF
--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/editor-app/configuration/properties-assignment-controller.js
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/webapp/editor-app/configuration/properties-assignment-controller.js
@@ -37,6 +37,9 @@ angular.module('flowableModeler').controller('FlowableAssignmentPopupCtrl',
         && $scope.property.value.assignment !== null) {
 
         $scope.assignment = $scope.property.value.assignment;
+        if (typeof $scope.assignment.type === 'undefined') {
+            $scope.assignment.type = 'static';
+        }
 
     } else {
         $scope.assignment = {type:'idm'};


### PR DESCRIPTION
see #697 for more information.

The fallback behaviour makes sure that old models will get automatically 'upgraded' to use the type property.