### PR TITLE
rerun failing tests (up to two times) to make build more stable

### DIFF
--- a/modules/flowable-cxf/pom.xml
+++ b/modules/flowable-cxf/pom.xml
@@ -59,7 +59,6 @@
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.7.1</version>
         <configuration>
          <forkMode>always</forkMode>
         </configuration>

--- a/modules/flowable-ui-admin/flowable-ui-admin-app/pom.xml
+++ b/modules/flowable-ui-admin/flowable-ui-admin-app/pom.xml
@@ -633,7 +633,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.16</version>
 				<configuration>
 					<argLine>-XX:MaxPermSize=128m -Xmx256m</argLine>
 					<forkCount>1</forkCount>

--- a/modules/flowable-ui-admin/pom.xml
+++ b/modules/flowable-ui-admin/pom.xml
@@ -89,7 +89,6 @@
 	  </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.16</version>
         <configuration>
 			<argLine>-XX:MaxPermSize=128m -Xmx256m</argLine>
 			<forkCount>1</forkCount>

--- a/modules/flowable-ui-idm/pom.xml
+++ b/modules/flowable-ui-idm/pom.xml
@@ -89,7 +89,6 @@
 	  </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.16</version>
         <configuration>
 			<argLine>-XX:MaxPermSize=128m -Xmx256m</argLine>
 			<forkCount>1</forkCount>

--- a/modules/flowable-ui-modeler/pom.xml
+++ b/modules/flowable-ui-modeler/pom.xml
@@ -83,7 +83,6 @@
 	  </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.16</version>
         <configuration>
 			<argLine>-XX:MaxPermSize=128m -Xmx256m</argLine>
 			<forkCount>1</forkCount>

--- a/modules/flowable-ui-task/pom.xml
+++ b/modules/flowable-ui-task/pom.xml
@@ -114,7 +114,6 @@
 	  </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.16</version>
         <configuration>
 			<argLine>-XX:MaxPermSize=128m -Xmx256m</argLine>
 			<forkCount>1</forkCount>

--- a/pom.xml
+++ b/pom.xml
@@ -989,7 +989,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.20</version>
+				<version>2.20.1</version>
 				<configuration>
 					<failIfNoTests>false</failIfNoTests>
 					<trimStackTrace>false</trimStackTrace>
@@ -998,6 +998,7 @@
 						<exclude>**/*TestCase.java</exclude>
 					</excludes>
 					<runOrder>alphabetical</runOrder>
+					<rerunFailingTestsCount>2</rerunFailingTestsCount>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
This could help to make the build more stable, as some asynchronous tests fail from time to time.

It only works for Junit 4 tests and only if the failed test does not affect state e.g. the running reused spring context, so I'm not sure how much it will help flowable. Enabling this feature made Apache Camel builds much more stable.