### PR TITLE
Update java-mail dependency version to 1.5.6

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -130,7 +130,7 @@ com.h2database                  h2                          1.4.196         The 
 com.fasterxml.uuid              java-uuid-generator         3.1.3           The Apache Software License, Version 2.0
 com.mchange                     mchange-commons-java        0.2.11          Eclipse Public License, Version 1.0
 com.mchange                     c3p0                        0.9.5.2         Eclipse Public License, Version 1.0
-com.sun.mail                    javax.mail                  1.5.2           CDDL/GPLv2+CE
+com.sun.mail                    javax.mail                  1.5.6           CDDL/GPLv2+CE
 commons-beanutils               commons-beanutils           1.8.3           The Apache Software License, Version 2.0
 commons-codec                   commons-codec               1.10            Apache License, Version 2.0
 commons-dbcp                    commons-dbcp                1.4             The Apache Software License, Version 2.0
@@ -148,7 +148,6 @@ io.swagger                      swagger-annotations         1.5.10          Apac
 io.swagger                      swagger-models              1.5.10          Apache License 2.0
 javax.activation                activation                  1.1.1           COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0
 javax.annotation                jsr250-api                  1.0             COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0
-javax.mail                      mail                        1.4.1           CDDL-GPLv2+CE
 joda-time                       joda-time                   2.9.9           Apache 2
 log4j                           log4j                       1.2.17          The Apache Software License, Version 2.0
 math.geom2d                     javaGeom                    0.11.1          Lesser General Public License version 2.0 (LGPLv2)

--- a/modules/flowable-ui-task/flowable-ui-task-app/pom.xml
+++ b/modules/flowable-ui-task/flowable-ui-task-app/pom.xml
@@ -249,8 +249,8 @@
 
         <!-- EMAIL -->
         <dependency>
-        	<groupId>javax.mail</groupId>
-        	<artifactId>mail</artifactId>
+            <groupId>com.sun.mail</groupId>
+            <artifactId>javax.mail</artifactId>
         </dependency>
         <dependency>
 			<groupId>commons-validator</groupId>

--- a/modules/flowable-ui-task/pom.xml
+++ b/modules/flowable-ui-task/pom.xml
@@ -72,9 +72,8 @@
             <version>2.3.20</version>
         </dependency>
         <dependency>
-        	<groupId>javax.mail</groupId>
-        	<artifactId>mail</artifactId>
-        	<version>1.4.7</version>
+            <groupId>com.sun.mail</groupId>
+            <artifactId>javax.mail</artifactId>
         </dependency>
         <dependency>
 			<groupId>commons-validator</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -160,9 +160,9 @@
 				<version>3.0.1</version>
 			</dependency>
 			<dependency>
-				<groupId>javax.mail</groupId>
-				<artifactId>mail</artifactId>
-				<version>1.4.1</version>
+				<groupId>com.sun.mail</groupId>
+				<artifactId>javax.mail</artifactId>
+				<version>1.5.6</version>
 			</dependency>
 			<dependency>
 				<groupId>javax.persistence</groupId>


### PR DESCRIPTION
Now the version of the direct java-mail dependency and the java-mail version used by the commons-email dependency are the same.