### PR TITLE
Change log level to debug in LogSqlExecutionTimePlugin.java.

### DIFF
--- a/modules/flowable-engine-common/src/main/java/org/flowable/engine/common/impl/db/LogSqlExecutionTimePlugin.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/engine/common/impl/db/LogSqlExecutionTimePlugin.java
@@ -61,7 +61,7 @@ public class LogSqlExecutionTimePlugin implements Interceptor {
         Object retVal = invocation.proceed();
         long endTime = System.currentTimeMillis();
         MappedStatement mappedStatement = (MappedStatement) invocation.getArgs()[0];
-        LOGGER.info("SQL Statement {} took {}ms", mappedStatement.getId(), endTime-startTime);
+        LOGGER.debug("SQL Statement {} took {}ms", mappedStatement.getId(), endTime-startTime);
         return retVal;
     }
 


### PR DESCRIPTION
Spring Boot Applications have a default log level of info. This results in the execution time of sql statements being logged when the plugin is enabled. Updating the plugin's log level to avoid this.