### PR TITLE
Issue #740 : Remove check that doesn't add "==" operator to export

### DIFF
--- a/modules/flowable-dmn-json-converter/src/main/java/org/flowable/editor/dmn/converter/DmnJsonConverter.java
+++ b/modules/flowable-dmn-json-converter/src/main/java/org/flowable/editor/dmn/converter/DmnJsonConverter.java
@@ -322,13 +322,10 @@ public class DmnJsonConverter {
                         expressionValue = expressionValueNode.asText();
                     }
 
-                    // don't add operator if it's ==
                     StringBuilder stringBuilder = new StringBuilder();
                     if (StringUtils.isNotEmpty(operatorValue)) {
-                        if (!"==".equals(operatorValue)) {
-                            stringBuilder = new StringBuilder(operatorValue);
-                            stringBuilder.append(" ");
-                        }
+                        stringBuilder = new StringBuilder(operatorValue);
+                        stringBuilder.append(" ");
                     }
 
                     // add quotes for string

--- a/modules/flowable-dmn-json-converter/src/test/java/org/flowable/editor/dmn/converter/DmnJsonConverterTest.java
+++ b/modules/flowable-dmn-json-converter/src/test/java/org/flowable/editor/dmn/converter/DmnJsonConverterTest.java
@@ -352,10 +352,10 @@ public class DmnJsonConverterTest {
         DecisionRule rule1 = decisionTable.getRules().get(0);
         DecisionRule rule2 = decisionTable.getRules().get(1);
 
-        assertEquals("\"TEST\"", rule1.getInputEntries().get(0).getInputEntry().getText());
-        assertEquals("100", rule1.getInputEntries().get(1).getInputEntry().getText());
-        assertEquals("true", rule1.getInputEntries().get(2).getInputEntry().getText());
-        assertEquals("date:toDate('2017-06-01')", rule1.getInputEntries().get(3).getInputEntry().getText());
+        assertEquals("== \"TEST\"", rule1.getInputEntries().get(0).getInputEntry().getText());
+        assertEquals("== 100", rule1.getInputEntries().get(1).getInputEntry().getText());
+        assertEquals("== true", rule1.getInputEntries().get(2).getInputEntry().getText());
+        assertEquals("== date:toDate('2017-06-01')", rule1.getInputEntries().get(3).getInputEntry().getText());
 
         assertEquals("\"WAS TEST\"", rule1.getOutputEntries().get(0).getOutputEntry().getText());
         assertEquals("100", rule1.getOutputEntries().get(1).getOutputEntry().getText());
@@ -364,7 +364,7 @@ public class DmnJsonConverterTest {
 
         assertEquals("!= \"TEST\"", rule2.getInputEntries().get(0).getInputEntry().getText());
         assertEquals("!= 100", rule2.getInputEntries().get(1).getInputEntry().getText());
-        assertEquals("false", rule2.getInputEntries().get(2).getInputEntry().getText());
+        assertEquals("== false", rule2.getInputEntries().get(2).getInputEntry().getText());
         assertEquals("!= date:toDate('2017-06-01')", rule2.getInputEntries().get(3).getInputEntry().getText());
 
         assertEquals("\"WASN'T TEST\"", rule2.getOutputEntries().get(0).getOutputEntry().getText());


### PR DESCRIPTION
Removed check on operator is "==" so that it gets added to the resulted dmn file when exporting.
And therefore fixed the issue with importing if the values contains a " "