### PR TITLE
Clean up junit dependency scope

### DIFF
--- a/modules/flowable-bpmn-converter/pom.xml
+++ b/modules/flowable-bpmn-converter/pom.xml
@@ -136,7 +136,6 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <scope>provided</scope>
     </dependency>
   </dependencies>
   

--- a/modules/flowable-bpmn-layout/pom.xml
+++ b/modules/flowable-bpmn-layout/pom.xml
@@ -107,7 +107,6 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <scope>provided</scope>
     </dependency>
   </dependencies>
 

--- a/modules/flowable-camel-cdi/pom.xml
+++ b/modules/flowable-camel-cdi/pom.xml
@@ -39,7 +39,6 @@
       <dependency>
           <groupId>junit</groupId>
           <artifactId>junit</artifactId>
-          <scope>test</scope>
       </dependency>
       <dependency>
           <groupId>com.h2database</groupId>

--- a/modules/flowable-camel/pom.xml
+++ b/modules/flowable-camel/pom.xml
@@ -49,7 +49,6 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/modules/flowable-cdi/pom.xml
+++ b/modules/flowable-cdi/pom.xml
@@ -125,7 +125,6 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.h2database</groupId>

--- a/modules/flowable-cmmn-converter/pom.xml
+++ b/modules/flowable-cmmn-converter/pom.xml
@@ -39,7 +39,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/modules/flowable-cmmn-engine-configurator/pom.xml
+++ b/modules/flowable-cmmn-engine-configurator/pom.xml
@@ -35,7 +35,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/modules/flowable-cmmn-engine/pom.xml
+++ b/modules/flowable-cmmn-engine/pom.xml
@@ -92,7 +92,8 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <scope>provided</scope>
+            <scope>compile</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>
@@ -133,8 +134,6 @@
             org.flowable.cmmn.db.mapping.entity
         </flowable.osgi.export.additional>
         <flowable.osgi.import.additional>
-            junit*;resolution:=optional,
-            org.junit*;resolution:=optional,
             com.sun*;resolution:=optional,
             javax.activation*;resolution:=optional,
             javax.persistence*;resolution:=optional,

--- a/modules/flowable-cmmn-image-generator/pom.xml
+++ b/modules/flowable-cmmn-image-generator/pom.xml
@@ -110,7 +110,6 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-            <scope>test</scope>
         </dependency>
 	</dependencies>
 

--- a/modules/flowable-cmmn-json-converter/pom.xml
+++ b/modules/flowable-cmmn-json-converter/pom.xml
@@ -119,7 +119,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/modules/flowable-cmmn-spring/pom.xml
+++ b/modules/flowable-cmmn-spring/pom.xml
@@ -117,7 +117,8 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <scope>provided</scope>
+            <scope>compile</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>

--- a/modules/flowable-content-engine/pom.xml
+++ b/modules/flowable-content-engine/pom.xml
@@ -94,7 +94,8 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <scope>provided</scope>
+            <scope>compile</scope>
+            <optional>true</optional>
         </dependency>
 
     </dependencies>

--- a/modules/flowable-content-rest/pom.xml
+++ b/modules/flowable-content-rest/pom.xml
@@ -144,7 +144,6 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>

--- a/modules/flowable-content-spring/pom.xml
+++ b/modules/flowable-content-spring/pom.xml
@@ -117,7 +117,8 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <scope>provided</scope>
+            <scope>compile</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>

--- a/modules/flowable-crystalball/pom.xml
+++ b/modules/flowable-crystalball/pom.xml
@@ -103,7 +103,6 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.h2database</groupId>

--- a/modules/flowable-cxf/pom.xml
+++ b/modules/flowable-cxf/pom.xml
@@ -109,7 +109,6 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.cxf</groupId>

--- a/modules/flowable-dmn-engine-configurator/pom.xml
+++ b/modules/flowable-dmn-engine-configurator/pom.xml
@@ -42,7 +42,6 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<scope>provided</scope>
 		</dependency>
         <dependency>
             <groupId>org.flowable</groupId>

--- a/modules/flowable-dmn-engine/pom.xml
+++ b/modules/flowable-dmn-engine/pom.xml
@@ -102,7 +102,8 @@
 		<dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <scope>provided</scope>
+            <scope>compile</scope>
+            <optional>true</optional>
         </dependency>
 
     </dependencies>

--- a/modules/flowable-dmn-json-converter/pom.xml
+++ b/modules/flowable-dmn-json-converter/pom.xml
@@ -38,7 +38,6 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>

--- a/modules/flowable-dmn-rest/pom.xml
+++ b/modules/flowable-dmn-rest/pom.xml
@@ -129,7 +129,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/modules/flowable-dmn-spring/pom.xml
+++ b/modules/flowable-dmn-spring/pom.xml
@@ -117,7 +117,8 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <scope>provided</scope>
+            <scope>compile</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>

--- a/modules/flowable-dmn-xml-converter/pom.xml
+++ b/modules/flowable-dmn-xml-converter/pom.xml
@@ -44,7 +44,6 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<scope>provided</scope>
 		</dependency>
 
 	</dependencies>

--- a/modules/flowable-engine/pom.xml
+++ b/modules/flowable-engine/pom.xml
@@ -101,7 +101,8 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <scope>provided</scope>
+            <scope>compile</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
@@ -220,8 +221,6 @@
             org.flowable.db.mapping.entity
         </flowable.osgi.export.additional>
         <flowable.osgi.import.additional>
-            junit*;resolution:=optional,
-            org.junit*;resolution:=optional,
             com.sun*;resolution:=optional,
             javax.activation*;resolution:=optional,
             javax.persistence*;resolution:=optional,

--- a/modules/flowable-form-engine-configurator/pom.xml
+++ b/modules/flowable-form-engine-configurator/pom.xml
@@ -38,7 +38,6 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<scope>provided</scope>
 		</dependency>
 	</dependencies>
 

--- a/modules/flowable-form-engine/pom.xml
+++ b/modules/flowable-form-engine/pom.xml
@@ -102,7 +102,8 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <scope>provided</scope>
+            <scope>compile</scope>
+            <optional>true</optional>
         </dependency>
 
     </dependencies>

--- a/modules/flowable-form-json-converter/pom.xml
+++ b/modules/flowable-form-json-converter/pom.xml
@@ -45,7 +45,6 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>

--- a/modules/flowable-form-rest/pom.xml
+++ b/modules/flowable-form-rest/pom.xml
@@ -131,7 +131,6 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>

--- a/modules/flowable-form-spring/pom.xml
+++ b/modules/flowable-form-spring/pom.xml
@@ -117,7 +117,8 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <scope>provided</scope>
+            <scope>compile</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>

--- a/modules/flowable-groovy-script-static-engine/pom.xml
+++ b/modules/flowable-groovy-script-static-engine/pom.xml
@@ -124,7 +124,6 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <scope>provided</scope>
     </dependency>
   </dependencies>
 

--- a/modules/flowable-http/pom.xml
+++ b/modules/flowable-http/pom.xml
@@ -168,7 +168,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/modules/flowable-identitylink-service/pom.xml
+++ b/modules/flowable-identitylink-service/pom.xml
@@ -50,7 +50,6 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.h2database</groupId>

--- a/modules/flowable-idm-engine/pom.xml
+++ b/modules/flowable-idm-engine/pom.xml
@@ -19,8 +19,6 @@
 			org.flowable.idm.engine
 		</flowable.artifact>
 		<flowable.osgi.import.additional>
-            junit*;resolution:=optional,
-            org.junit*;resolution:=optional,
 			org.springframework*;resolution:=optional,
             org.apache.commons.codec*;resolution:=optional,
 		</flowable.osgi.import.additional>
@@ -72,7 +70,8 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<scope>provided</scope>
+			<scope>compile</scope>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>com.h2database</groupId>

--- a/modules/flowable-idm-spring/pom.xml
+++ b/modules/flowable-idm-spring/pom.xml
@@ -124,7 +124,8 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <scope>provided</scope>
+            <scope>compile</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>

--- a/modules/flowable-image-generator/pom.xml
+++ b/modules/flowable-image-generator/pom.xml
@@ -110,7 +110,6 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-            <scope>test</scope>
         </dependency>
 	</dependencies>
 

--- a/modules/flowable-jmx/pom.xml
+++ b/modules/flowable-jmx/pom.xml
@@ -34,7 +34,6 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<scope>test</scope>
 		</dependency>
 	    <dependency>
 	      <groupId>org.slf4j</groupId>

--- a/modules/flowable-job-service/pom.xml
+++ b/modules/flowable-job-service/pom.xml
@@ -59,7 +59,6 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.h2database</groupId>

--- a/modules/flowable-json-converter/pom.xml
+++ b/modules/flowable-json-converter/pom.xml
@@ -118,7 +118,6 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/flowable-ldap-configurator/pom.xml
+++ b/modules/flowable-ldap-configurator/pom.xml
@@ -99,7 +99,6 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.h2database</groupId>

--- a/modules/flowable-mule/pom.xml
+++ b/modules/flowable-mule/pom.xml
@@ -119,7 +119,6 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>commons-logging</groupId>

--- a/modules/flowable-secure-javascript/pom.xml
+++ b/modules/flowable-secure-javascript/pom.xml
@@ -36,7 +36,6 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<scope>test</scope>
 		</dependency>
 
 		<!-- Specific to this module -->

--- a/modules/flowable-spring/pom.xml
+++ b/modules/flowable-spring/pom.xml
@@ -126,7 +126,8 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <scope>provided</scope>
+            <scope>compile</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>javax.persistence</groupId>

--- a/modules/flowable-task-service/pom.xml
+++ b/modules/flowable-task-service/pom.xml
@@ -53,7 +53,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>

--- a/modules/flowable-ui-admin/flowable-ui-admin-app/pom.xml
+++ b/modules/flowable-ui-admin/flowable-ui-admin-app/pom.xml
@@ -567,7 +567,6 @@
 		<dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <scope>test</scope>
         </dependency>
 		<dependency>
 			<groupId>com.jayway.jsonpath</groupId>

--- a/modules/flowable-variable-service/pom.xml
+++ b/modules/flowable-variable-service/pom.xml
@@ -50,7 +50,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>

--- a/modules/flowable5-camel-test/pom.xml
+++ b/modules/flowable5-camel-test/pom.xml
@@ -74,7 +74,6 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/modules/flowable5-compatibility-test/pom.xml
+++ b/modules/flowable5-compatibility-test/pom.xml
@@ -44,7 +44,6 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/modules/flowable5-cxf-test/pom.xml
+++ b/modules/flowable5-cxf-test/pom.xml
@@ -43,7 +43,6 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.cxf</groupId>

--- a/modules/flowable5-engine/pom.xml
+++ b/modules/flowable5-engine/pom.xml
@@ -50,7 +50,6 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.codehaus.groovy</groupId>
@@ -164,8 +163,6 @@
 			org.activiti.db.mapping.entity
 		</flowable.osgi.export.additional>
 		<flowable.osgi.import.additional>
-			junit*;resolution:=optional,
-			org.junit*;resolution:=optional,
 			com.sun*;resolution:=optional,
 			javax.persistence*;resolution:=optional,
 			org.apache.commons.mail*;resolution:=optional,

--- a/modules/flowable5-spring-test/pom.xml
+++ b/modules/flowable5-spring-test/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <scope>provided</scope>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>javax.persistence</groupId>

--- a/modules/flowable5-spring/pom.xml
+++ b/modules/flowable5-spring/pom.xml
@@ -118,7 +118,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>javax.persistence</groupId>

--- a/modules/flowable5-test/pom.xml
+++ b/modules/flowable5-test/pom.xml
@@ -43,7 +43,7 @@
 		<dependency>
       		<groupId>junit</groupId>
       		<artifactId>junit</artifactId>
-      		<scope>provided</scope>
+      		<scope>compile</scope>
     	</dependency>
 		<dependency>
 			<groupId>org.codehaus.groovy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -967,7 +967,7 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
-				<version>2.1.0</version>
+				<version>2.3.4</version>
 				<extensions>true</extensions>
 				<configuration>
 					<excludeDependencies>${flowable.osgi.exclude.dependencies}</excludeDependencies>


### PR DESCRIPTION
Inspired by https://github.com/flowable/flowable-engine/issues/744:

Update to maven-bundle-plugin version 3.5.0 which supports optional dependencies

engine/spring/test modules: change JUnit dependency to compile scope and make it optional (let the maven-bundle-plugin generate the optional OSGI resolution)

non-engine/-spring/-test modules: change JUnit dependency to test scope (inherit scope defined in parent pom)

Not ready to merge yet: OSGI tests currently fail on my box (have to investigate).