### PR TITLE
Update guava to version 23.6-android (latest java 7 compatible version)

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -125,7 +125,7 @@ com.fasterxml.jackson.core      jackson-databind            2.7.5           The 
 com.fasterxml.jackson.datatype  jackson-datatype-hppc       2.7.5           The Apache Software License, Version 2.0
 com.fasterxml.jackson.datatype  jackson-datatype-joda       2.7.5           The Apache Software License, Version 2.0
 com.fasterxml.jackson.datatype  jackson-datatype-json-org   2.7.5           The Apache Software License, Version 2.0
-com.google.guava                guava                       17.0            The Apache Software License, Version 2.0
+com.google.guava                guava                       23.6-android    The Apache Software License, Version 2.0
 com.h2database                  h2                          1.4.196         The H2 License, Version 1.0
 com.fasterxml.uuid              java-uuid-generator         3.1.3           The Apache Software License, Version 2.0
 com.mchange                     mchange-commons-java        0.2.11          Eclipse Public License, Version 1.0

--- a/pom.xml
+++ b/pom.xml
@@ -826,7 +826,7 @@
 			<dependency>
 				<groupId>com.google.guava</groupId>
 				<artifactId>guava</artifactId>
-				<version>17.0</version>
+				<version>23.6-android</version>
 			</dependency>
 			<!-- Flowable Modeler -->
 			<dependency>


### PR DESCRIPTION
Recent non android (nowadays called `jre` versions by the guava team) versions require java 8.