### PR TITLE
Allow remember me cookie's domain to be set from application properties

### DIFF
--- a/modules/flowable-ui-idm/flowable-ui-idm-conf/src/main/java/org/flowable/app/security/CustomPersistentRememberMeServices.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-conf/src/main/java/org/flowable/app/security/CustomPersistentRememberMeServices.java
@@ -75,6 +75,7 @@ public class CustomPersistentRememberMeServices extends AbstractRememberMeServic
     @Autowired
     private IdmIdentityService identityService;
 
+    private final String tokenDomain;
     private final int tokenMaxAgeInSeconds;
     private final long tokenMaxAgeInMilliseconds;
     private final long tokenRefreshDurationInMilliseconds;
@@ -93,6 +94,12 @@ public class CustomPersistentRememberMeServices extends AbstractRememberMeServic
         }
         tokenMaxAgeInSeconds = tokenMaxAgeSeconds;
         tokenMaxAgeInMilliseconds = tokenMaxAgeSeconds.longValue() * 1000L;
+
+        String domain = env.getProperty("security.cookie.domain", String.class);
+        if (domain != null) {
+            LOGGER.info("Cookie domain set to {}", domain);
+        }
+        tokenDomain = domain;
 
         Integer tokenRefreshSeconds = env.getProperty("security.cookie.refresh-age", Integer.class);
         if (tokenRefreshSeconds != null) {
@@ -217,6 +224,9 @@ public class CustomPersistentRememberMeServices extends AbstractRememberMeServic
         Cookie cookie = new Cookie(getCookieName(), cookieValue);
         cookie.setMaxAge(maxAge);
         cookie.setPath("/");
+        if (tokenDomain != null) {
+            cookie.setDomain(tokenDomain);
+        }
 
         cookie.setSecure(request.isSecure());
 


### PR DESCRIPTION
Resolves the issue described in https://forum.flowable.org/t/different-sub-domain-name-usage-per-ui-app/1308