### PR TITLE
Allow extension elements defined on a messageEventDefinition element to

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/parser/handler/MessageEventDefinitionParseHandler.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/parser/handler/MessageEventDefinitionParseHandler.java
@@ -12,9 +12,12 @@
  */
 package org.flowable.engine.impl.bpmn.parser.handler;
 
+import java.util.List;
+
 import org.flowable.bpmn.model.BaseElement;
 import org.flowable.bpmn.model.BoundaryEvent;
 import org.flowable.bpmn.model.BpmnModel;
+import org.flowable.bpmn.model.ExtensionElement;
 import org.flowable.bpmn.model.IntermediateCatchEvent;
 import org.flowable.bpmn.model.Message;
 import org.flowable.bpmn.model.MessageEventDefinition;
@@ -38,7 +41,12 @@ public class MessageEventDefinitionParseHandler extends AbstractBpmnParseHandler
         if (bpmnModel.containsMessageId(messageRef)) {
             Message message = bpmnModel.getMessage(messageRef);
             messageDefinition.setMessageRef(message.getName());
-            messageDefinition.setExtensionElements(message.getExtensionElements());
+
+            for(List<ExtensionElement> extensionElementList : message.getExtensionElements().values()) {
+                for(ExtensionElement extensionElement : extensionElementList) {
+                    messageDefinition.addExtensionElement(extensionElement);
+                }
+            }
         }
 
         if (bpmnParse.getCurrentFlowElement() instanceof IntermediateCatchEvent) {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/MessageEventDefinitionWithExtensionElementsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/MessageEventDefinitionWithExtensionElementsTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.bpmn.event;
 
+import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -32,20 +34,36 @@ public class MessageEventDefinitionWithExtensionElementsTest {
         MessageEventDefinition messageEventDefinitionMock = Mockito.mock(MessageEventDefinition.class);
         BpmnModel bpmnModelMock = Mockito.mock(BpmnModel.class);
         Message messageMock = Mockito.mock(Message.class);
+
         @SuppressWarnings("unchecked")
-        Map<String, List<ExtensionElement>> extensionElementMap = Mockito.mock(Map.class);
+        Map<String, List<ExtensionElement>> messageExtensionElementMapMock = Mockito.mock(Map.class);
+        Collection<List<ExtensionElement>> messageExtensionElementListCollectionMock = Mockito.mock(List.class);
+        Map<String, List<ExtensionElement>> messageDefinitionExtensionElementMapMock = Mockito.mock(Map.class);
+        Iterator<List<ExtensionElement>> collectionIteratorMock = Mockito.mock(Iterator.class);
+        List<ExtensionElement> messageExtensionElementListMock = Mockito.mock(List.class);
+        Iterator<ExtensionElement> extensionElementIteratorMock = Mockito.mock(Iterator.class);
+        ExtensionElement extensionElementMock = Mockito.mock(ExtensionElement.class);
 
         Mockito.when(bpmnParseMock.getBpmnModel()).thenReturn(bpmnModelMock);
         Mockito.when(messageEventDefinitionMock.getMessageRef()).thenReturn("messageId");
         Mockito.when(bpmnModelMock.containsMessageId("messageId")).thenReturn(true);
         Mockito.when(bpmnModelMock.getMessage("messageId")).thenReturn(messageMock);
         Mockito.when(messageMock.getName()).thenReturn("MessageWithExtensionElements");
-        Mockito.when(messageMock.getExtensionElements()).thenReturn(extensionElementMap);
+        Mockito.when(messageMock.getExtensionElements()).thenReturn(messageExtensionElementMapMock);
+        Mockito.when(messageExtensionElementMapMock.values()).thenReturn(messageExtensionElementListCollectionMock);
+
+        Mockito.when(messageExtensionElementListCollectionMock.iterator()).thenReturn(collectionIteratorMock);
+        Mockito.when(collectionIteratorMock.hasNext()).thenReturn(true, false);
+        Mockito.when(collectionIteratorMock.next()).thenReturn(messageExtensionElementListMock);
+        Mockito.when(collectionIteratorMock.next()).thenReturn(messageExtensionElementListMock);
+        Mockito.when(messageExtensionElementListMock.iterator()).thenReturn(extensionElementIteratorMock);
+        Mockito.when(extensionElementIteratorMock.hasNext()).thenReturn(true,false);
+        Mockito.when(extensionElementIteratorMock.next()).thenReturn(extensionElementMock);
 
         MessageEventDefinitionParseHandler handler = new MessageEventDefinitionParseHandler();
         handler.parse(bpmnParseMock, messageEventDefinitionMock);
 
         Mockito.verify(messageEventDefinitionMock).setMessageRef("MessageWithExtensionElements");
-        Mockito.verify(messageEventDefinitionMock).setExtensionElements(extensionElementMap);
+        Mockito.verify(messageEventDefinitionMock).addExtensionElement(extensionElementMock);
     }
 }


### PR DESCRIPTION
be used.

Currently the behavior of MessageEventDefinitionParseHandler overwrites
the extension elements on a messageEventDefinition element with the
extension elements from the associated message element. This update
changes the beavior to add the extension elements from the message
element to the messageEventDefinition's extension elements.

For example:

`<intermediateCatchEvent id="ID_91ee51f3-481d-439c-a62d-8b382a1cfddf" >
  <messageEventDefinition messageRef="ID_91ee51f3-481d-439c-a62d-8b382a1cfdde">
    <extensionElements>
      <xyzbpmn:promptDefinition promptRef="ID_91ee51f3-481d-439c-a62d-8b382a1cf7a1" required="true" defaultValueRef="ID_91ee51f3-481d-439c-a62d-8b382a1cf7a2">
        <xyzbpmn:promptValueDefinition promptValueRef="ID_91ee51f3-481d-439c-a62d-8b382a1cf7a2"/>
        <xyzbpmn:promptValueDefinition promptValueRef="ID_91ee51f3-481d-439c-a62d-8b382a1cf7a3"/>
      </xyzbpmn:promptDefinition>
    </extensionElements>
  </messageEventDefinition>
</intermediateCatchEvent>`


