### PR TITLE
Add support for saving result variable in the local scope #806

### DIFF
--- a/docs/userguide/src/en/bpmn/ch07b-BPMN-Constructs.adoc
+++ b/docs/userguide/src/en/bpmn/ch07b-BPMN-Constructs.adoc
@@ -2984,7 +2984,10 @@ public class TestExecutionListener implements ExecutionListener {
 
 ===== Service task results
 
-The return value of a service execution (for service task using expression only) can be assigned to an existing or to a new process variable by specifying the process variable name as a literal value for the _'flowable:resultVariable'_ attribute of a service task definition. Any existing value for a specific process variable will be overwritten by the result value of the service execution. When a result variable name is not specified, the service execution result value gets ignored.
+The return value of a service execution (for service task using expression only) can be assigned to an existing or to a new process variable by specifying the process variable name as a literal value for the _'flowable:resultVariable'_ attribute of a service task definition.
+Any existing value for a specific process variable will be overwritten by the result value of the service execution.
+If _`flowable:useLocalScopeForResultVariable'_ is used, then the variable will be assigned to a local variable.
+When a result variable name is not specified, the service execution result value gets ignored.
 
 [source,xml,linenums]
 ----

--- a/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/constants/BpmnXMLConstants.java
+++ b/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/constants/BpmnXMLConstants.java
@@ -191,6 +191,7 @@ public interface BpmnXMLConstants {
     public static final String ATTRIBUTE_TASK_SERVICE_RESULTVARIABLE = "resultVariableName";
     public static final String ATTRIBUTE_TASK_SERVICE_EXTENSIONID = "extensionId";
     public static final String ATTRIBUTE_TASK_SERVICE_SKIP_EXPRESSION = "skipExpression";
+    public static final String ATTRIBUTE_TASK_SERVICE_USE_LOCAL_SCOPE_FOR_RESULT_VARIABLE = "useLocalScopeForResultVariable";
 
     public static final String ATTRIBUTE_TASK_USER_ASSIGNEE = "assignee";
     public static final String ATTRIBUTE_TASK_USER_OWNER = "owner";

--- a/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/ServiceTaskXMLConverter.java
+++ b/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/ServiceTaskXMLConverter.java
@@ -75,6 +75,8 @@ public class ServiceTaskXMLConverter extends BaseBpmnXMLConverter {
             serviceTask.setResultVariableName(BpmnXMLUtil.getAttributeValue("resultVariable", xtr));
         }
 
+        serviceTask.setUseLocalScopeForResultVariable(Boolean.valueOf(BpmnXMLUtil.getAttributeValue(ATTRIBUTE_TASK_SERVICE_USE_LOCAL_SCOPE_FOR_RESULT_VARIABLE, xtr)));
+
         serviceTask.setType(serviceTaskType);
         serviceTask.setExtensionId(BpmnXMLUtil.getAttributeValue(ATTRIBUTE_TASK_SERVICE_EXTENSIONID, xtr));
 
@@ -110,6 +112,10 @@ public class ServiceTaskXMLConverter extends BaseBpmnXMLConverter {
         }
         if (StringUtils.isNotEmpty(serviceTask.getSkipExpression())) {
             writeQualifiedAttribute(ATTRIBUTE_TASK_SERVICE_SKIP_EXPRESSION, serviceTask.getSkipExpression(), xtw);
+        }
+
+        if (serviceTask.isUseLocalScopeForResultVariable()) {
+            writeQualifiedAttribute(ATTRIBUTE_TASK_SERVICE_USE_LOCAL_SCOPE_FOR_RESULT_VARIABLE, "true", xtw);
         }
     }
 

--- a/modules/flowable-bpmn-model/src/main/java/org/flowable/bpmn/model/ServiceTask.java
+++ b/modules/flowable-bpmn-model/src/main/java/org/flowable/bpmn/model/ServiceTask.java
@@ -33,6 +33,7 @@ public class ServiceTask extends TaskWithFieldExtensions {
     protected String extensionId;
     protected List<CustomProperty> customProperties = new ArrayList<>();
     protected String skipExpression;
+    protected boolean useLocalScopeForResultVariable;
 
     public String getImplementation() {
         return implementation;
@@ -102,6 +103,14 @@ public class ServiceTask extends TaskWithFieldExtensions {
         this.skipExpression = skipExpression;
     }
 
+    public boolean isUseLocalScopeForResultVariable() {
+        return useLocalScopeForResultVariable;
+    }
+
+    public void setUseLocalScopeForResultVariable(boolean useLocalScopeForResultVariable) {
+        this.useLocalScopeForResultVariable = useLocalScopeForResultVariable;
+    }
+
     @Override
     public ServiceTask clone() {
         ServiceTask clone = new ServiceTask();
@@ -118,6 +127,7 @@ public class ServiceTask extends TaskWithFieldExtensions {
         setOperationRef(otherElement.getOperationRef());
         setExtensionId(otherElement.getExtensionId());
         setSkipExpression(otherElement.getSkipExpression());
+        setUseLocalScopeForResultVariable(otherElement.isUseLocalScopeForResultVariable());
 
         fieldExtensions = new ArrayList<>();
         if (otherElement.getFieldExtensions() != null && !otherElement.getFieldExtensions().isEmpty()) {

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/ServiceTaskExpressionActivityBehavior.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/ServiceTaskExpressionActivityBehavior.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 import org.flowable.bpmn.model.MapExceptionEntry;
+import org.flowable.bpmn.model.ServiceTask;
 import org.flowable.engine.DynamicBpmnConstants;
 import org.flowable.engine.delegate.BpmnError;
 import org.flowable.engine.delegate.DelegateExecution;
@@ -37,6 +38,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
  * @author Frederik Heremans
  * @author Slawomir Wojtasiak (Patch for ACT-1159)
  * @author Falko Menge
+ * @author Filip Hrisafov
  */
 public class ServiceTaskExpressionActivityBehavior extends TaskActivityBehavior {
 
@@ -47,15 +49,16 @@ public class ServiceTaskExpressionActivityBehavior extends TaskActivityBehavior 
     protected Expression skipExpression;
     protected String resultVariable;
     protected List<MapExceptionEntry> mapExceptions;
+    protected boolean useLocalScopeForResultVariable;
 
-    public ServiceTaskExpressionActivityBehavior(String serviceTaskId, Expression expression,
-            Expression skipExpression, String resultVariable, List<MapExceptionEntry> mapExceptions) {
+    public ServiceTaskExpressionActivityBehavior(ServiceTask serviceTask, Expression expression, Expression skipExpression) {
 
-        this.serviceTaskId = serviceTaskId;
+        this.serviceTaskId = serviceTask.getId();
         this.expression = expression;
         this.skipExpression = skipExpression;
-        this.resultVariable = resultVariable;
-        this.mapExceptions = mapExceptions;
+        this.resultVariable = serviceTask.getResultVariableName();
+        this.mapExceptions = serviceTask.getMapExceptions();
+        this.useLocalScopeForResultVariable = serviceTask.isUseLocalScopeForResultVariable();
     }
 
     @Override
@@ -77,7 +80,11 @@ public class ServiceTaskExpressionActivityBehavior extends TaskActivityBehavior 
 
                 value = expression.getValue(execution);
                 if (resultVariable != null) {
-                    execution.setVariable(resultVariable, value);
+                    if (useLocalScopeForResultVariable) {
+                        execution.setVariableLocal(resultVariable, value);
+                    } else {
+                        execution.setVariable(resultVariable, value);
+                    }
                 }
             }
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/parser/factory/DefaultActivityBehaviorFactory.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/parser/factory/DefaultActivityBehaviorFactory.java
@@ -180,8 +180,7 @@ public class DefaultActivityBehaviorFactory extends AbstractBehaviorFactory impl
     @Override
     public ServiceTaskExpressionActivityBehavior createServiceTaskExpressionActivityBehavior(ServiceTask serviceTask) {
         Expression expression = expressionManager.createExpression(serviceTask.getImplementation());
-        return new ServiceTaskExpressionActivityBehavior(serviceTask.getId(), expression,
-                getSkipExpressionFromServiceTask(serviceTask), serviceTask.getResultVariableName(), serviceTask.getMapExceptions());
+        return new ServiceTaskExpressionActivityBehavior(serviceTask, expression, getSkipExpressionFromServiceTask(serviceTask));
     }
 
     @Override

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/validation/DefaultProcessValidatorTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/validation/DefaultProcessValidatorTest.java
@@ -59,7 +59,7 @@ public class DefaultProcessValidatorTest {
         Assert.assertNotNull(bpmnModel);
 
         List<ValidationError> allErrors = processValidator.validate(bpmnModel);
-        Assert.assertEquals(69, allErrors.size());
+        Assert.assertEquals(70, allErrors.size());
 
         String setName = ValidatorSetNames.FLOWABLE_EXECUTABLE_PROCESS; // shortening it a bit
 
@@ -123,6 +123,8 @@ public class DefaultProcessValidatorTest {
         problems = findErrors(allErrors, setName, Problems.SERVICE_TASK_MISSING_IMPLEMENTATION, 1);
         assertCommonProblemFieldForActivity(problems.get(0));
         problems = findErrors(allErrors, setName, Problems.SERVICE_TASK_WEBSERVICE_INVALID_OPERATION_REF, 1);
+        assertCommonProblemFieldForActivity(problems.get(0));
+        problems = findErrors(allErrors, setName, Problems.SERVICE_TASK_USE_LOCAL_SCOPE_FOR_RESULT_VAR_WITHOUT_RESULT_VARIABLE_NAME, 1);
         assertCommonProblemFieldForActivity(problems.get(0));
 
         // Send task

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/validation/invalidProcess.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/validation/invalidProcess.bpmn20.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+			 xmlns:flowable="http://flowable.org/bpmn"
 	xmlns:activiti="http://activiti.org/bpmn" targetNamespace="Examples">
 
 	<!-- Signals -->
@@ -67,6 +68,14 @@
 		</serviceTask>
 		<sequenceFlow id="flow2"
 			sourceRef="serviceTaskWithWrongResultVariableUsage" targetRef="userTask1" />
+
+		<!-- Service task with wrong usage of variable name and use local scope
+			(use local scope is ignored when result variable name is missing) -->
+		<serviceTask id="serviceTaskWithUseLocalScopeAndMissingResultVariableUsage"
+					 name="serviceTaskWithUseLocalScopeAndMissingResultVariableUsage"
+					 flowable:expression="#{true}"
+					 flowable:useLocalScopeForResultVariable ="true">
+		</serviceTask>
 
 		<!-- Service task without any implementation (class, expression, etc.) -->
 		<serviceTask id="serviceTask2" name="myService"></serviceTask>

--- a/modules/flowable-engine/src/test/resources/org/flowable/examples/bpmn/servicetask/ExpressionServiceTaskTest.testSetServiceLocalScopedResultWithParallelMultiInstance.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/examples/bpmn/servicetask/ExpressionServiceTaskTest.testSetServiceLocalScopedResultWithParallelMultiInstance.bpmn20.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:flowable="http://flowable.org/bpmn"
+             typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="Examples">
+    <process id="setServiceLocalScopedResultWithParallelMultiInstance" isExecutable="true">
+        <startEvent id="theStart"/>
+        <endEvent id="theEnd"/>
+        <subProcess id="subProcess" name="subProcess">
+            <multiInstanceLoopCharacteristics isSequential="false" flowable:collection="beans" flowable:elementVariable="bean"/>
+            <startEvent id="subProcessStart"/>
+            <serviceTask id="valueExpressionWithLocalResultVariableInSubProcess" flowable:expression="#{bean.value}" flowable:resultVariable="subProcessVar" flowable:useLocalScopeForResultVariable="true"/>
+            <userTask id="subProcessWaitState"/>
+            <exclusiveGateway id="gateway" default="defaultFlow"/>
+            <endEvent id="subProcessEnd"/>
+            <sequenceFlow id="flow2" sourceRef="subProcessStart" targetRef="valueExpressionWithLocalResultVariableInSubProcess"/>
+            <sequenceFlow id="flow3" sourceRef="valueExpressionWithLocalResultVariableInSubProcess" targetRef="gateway"/>
+            <sequenceFlow id="defaultFlow" sourceRef="gateway" targetRef="subProcessEnd"/>
+            <sequenceFlow id="flow5" sourceRef="subProcessWaitState" targetRef="subProcessEnd"/>
+            <sequenceFlow id="flow4" sourceRef="gateway" targetRef="subProcessWaitState">
+                <conditionExpression xsi:type="tFormalExpression"><![CDATA[#{subProcessVar == 'OK'}]]></conditionExpression>
+            </sequenceFlow>
+        </subProcess>
+        <userTask id="processWaitState"/>
+        <sequenceFlow id="flow7" sourceRef="processWaitState" targetRef="theEnd"/>
+        <sequenceFlow id="flow6" sourceRef="subProcess" targetRef="processWaitState"/>
+        <sequenceFlow id="flow1" sourceRef="theStart" targetRef="subProcess"/>
+    </process>
+</definitions>

--- a/modules/flowable-engine/src/test/resources/org/flowable/examples/bpmn/servicetask/ExpressionServiceTaskTest.testSetServiceResultWithParallelMultiInstance.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/examples/bpmn/servicetask/ExpressionServiceTaskTest.testSetServiceResultWithParallelMultiInstance.bpmn20.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:flowable="http://flowable.org/bpmn"
+             typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="Examples">
+    <process id="setServiceResultToWithParallelMultiInstance" isExecutable="true">
+        <startEvent id="theStart"/>
+        <endEvent id="theEnd"/>
+        <subProcess id="subProcess" name="subProcess">
+            <multiInstanceLoopCharacteristics isSequential="false" flowable:collection="beans" flowable:elementVariable="bean"/>
+            <startEvent id="subProcessStart"/>
+            <serviceTask id="valueExpressionWithResultVariableInSubProcess" flowable:expression="#{bean.value}" flowable:resultVariable="subProcessVar"/>
+            <userTask id="subProcessWaitState"/>
+            <exclusiveGateway id="gateway" default="defaultFlow"/>
+            <endEvent id="subProcessEnd"/>
+            <sequenceFlow id="flow2" sourceRef="subProcessStart" targetRef="valueExpressionWithResultVariableInSubProcess"/>
+            <sequenceFlow id="flow3" sourceRef="valueExpressionWithResultVariableInSubProcess" targetRef="gateway"/>
+            <sequenceFlow id="defaultFlow" sourceRef="gateway" targetRef="subProcessEnd"/>
+            <sequenceFlow id="flow5" sourceRef="subProcessWaitState" targetRef="subProcessEnd"/>
+            <sequenceFlow id="flow4" sourceRef="gateway" targetRef="subProcessWaitState">
+                <conditionExpression xsi:type="tFormalExpression"><![CDATA[#{subProcessVar == 'OK'}]]></conditionExpression>
+            </sequenceFlow>
+        </subProcess>
+        <userTask id="processWaitState"/>
+        <sequenceFlow id="flow7" sourceRef="processWaitState" targetRef="theEnd"/>
+        <sequenceFlow id="flow6" sourceRef="subProcess" targetRef="processWaitState"/>
+        <sequenceFlow id="flow1" sourceRef="theStart" targetRef="subProcess"/>
+    </process>
+</definitions>

--- a/modules/flowable-json-converter/src/main/java/org/flowable/editor/constants/StencilConstants.java
+++ b/modules/flowable-json-converter/src/main/java/org/flowable/editor/constants/StencilConstants.java
@@ -175,6 +175,7 @@ public interface StencilConstants {
     final String PROPERTY_SERVICETASK_FIELD_STRING_VALUE = "stringValue";
     final String PROPERTY_SERVICETASK_FIELD_STRING = "string";
     final String PROPERTY_SERVICETASK_FIELD_EXPRESSION = "expression";
+    final String PROPERTY_SERVICETASK_USE_LOCAL_SCOPE_FOR_RESULT_VARIABLE = "servicetaskUseLocalScopeForResultVariable";
 
     final String PROPERTY_FORM_PROPERTIES = "formproperties";
     final String PROPERTY_FORM_ID = "id";

--- a/modules/flowable-json-converter/src/main/java/org/flowable/editor/language/json/converter/ServiceTaskJsonConverter.java
+++ b/modules/flowable-json-converter/src/main/java/org/flowable/editor/language/json/converter/ServiceTaskJsonConverter.java
@@ -137,6 +137,10 @@ public class ServiceTaskJsonConverter extends BaseBpmnJsonConverter implements D
                 propertiesNode.put(PROPERTY_SERVICETASK_RESULT_VARIABLE, serviceTask.getResultVariableName());
             }
 
+            if (serviceTask.isUseLocalScopeForResultVariable()) {
+                propertiesNode.put(PROPERTY_SERVICETASK_USE_LOCAL_SCOPE_FOR_RESULT_VARIABLE, serviceTask.isUseLocalScopeForResultVariable());
+            }
+
             addFieldExtensions(serviceTask.getFieldExtensions(), propertiesNode);
         }
     }
@@ -159,6 +163,10 @@ public class ServiceTaskJsonConverter extends BaseBpmnJsonConverter implements D
 
         if (StringUtils.isNotEmpty(getPropertyValueAsString(PROPERTY_SERVICETASK_RESULT_VARIABLE, elementNode))) {
             task.setResultVariableName(getPropertyValueAsString(PROPERTY_SERVICETASK_RESULT_VARIABLE, elementNode));
+        }
+
+        if (getPropertyValueAsBoolean(PROPERTY_SERVICETASK_USE_LOCAL_SCOPE_FOR_RESULT_VARIABLE, elementNode)) {
+            task.setUseLocalScopeForResultVariable(true);
         }
 
         task.setSkipExpression(getPropertyValueAsString(PROPERTY_SKIP_EXPRESSION, elementNode));

--- a/modules/flowable-process-validation/src/main/java/org/flowable/validation/validator/Problems.java
+++ b/modules/flowable-process-validation/src/main/java/org/flowable/validation/validator/Problems.java
@@ -43,6 +43,7 @@ public interface Problems {
     String SERVICE_TASK_RESULT_VAR_NAME_WITH_DELEGATE = "flowable-servicetask-result-var-name-with-delegate";
     String SERVICE_TASK_MISSING_IMPLEMENTATION = "flowable-servicetask-missing-implementation";
     String SERVICE_TASK_WEBSERVICE_INVALID_OPERATION_REF = "flowable-servicetask-webservice-invalid-operation-ref";
+    String SERVICE_TASK_USE_LOCAL_SCOPE_FOR_RESULT_VAR_WITHOUT_RESULT_VARIABLE_NAME = "flowable-servicetask-use-local-scope-for-result-var-without-result-variable-name";
 
     String SEND_TASK_INVALID_IMPLEMENTATION = "flowable-sendtask-invalid-implementation";
     String SEND_TASK_INVALID_TYPE = "flowable-sendtask-invalid-type";

--- a/modules/flowable-process-validation/src/main/java/org/flowable/validation/validator/impl/ServiceTaskValidator.java
+++ b/modules/flowable-process-validation/src/main/java/org/flowable/validation/validator/impl/ServiceTaskValidator.java
@@ -79,6 +79,10 @@ public class ServiceTaskValidator extends ExternalInvocationTaskValidator {
                         .getImplementationType()))) {
             addError(errors, Problems.SERVICE_TASK_RESULT_VAR_NAME_WITH_DELEGATE, process, serviceTask, "'resultVariableName' not supported for service tasks using 'class' or 'delegateExpression");
         }
+
+        if (serviceTask.isUseLocalScopeForResultVariable() && StringUtils.isEmpty(serviceTask.getResultVariableName())) {
+            addWarning(errors, Problems.SERVICE_TASK_USE_LOCAL_SCOPE_FOR_RESULT_VAR_WITHOUT_RESULT_VARIABLE_NAME, process, serviceTask, "'useLocalScopeForResultVariable' is set, but no 'resultVariableName' is set. The property would not be used");
+        }
     }
 
     protected void verifyWebservice(BpmnModel bpmnModel, Process process, ServiceTask serviceTask, List<ValidationError> errors) {

--- a/modules/flowable-ui-admin/flowable-ui-admin-rest/src/main/java/org/flowable/admin/app/rest/client/modelinfo/bpmn/ServiceTaskInfoMapper.java
+++ b/modules/flowable-ui-admin/flowable-ui-admin-rest/src/main/java/org/flowable/admin/app/rest/client/modelinfo/bpmn/ServiceTaskInfoMapper.java
@@ -28,5 +28,6 @@ public class ServiceTaskInfoMapper extends AbstractInfoMapper {
             createPropertyNode("Delegate expression", serviceTask.getImplementation());
         }
         createPropertyNode("Result variable name", serviceTask.getResultVariableName());
+        createPropertyNode("Use local scope for result variable", serviceTask.isUseLocalScopeForResultVariable());
     }
 }

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/service/editor/mapper/ServiceTaskInfoMapper.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/service/editor/mapper/ServiceTaskInfoMapper.java
@@ -39,5 +39,6 @@ public class ServiceTaskInfoMapper extends AbstractInfoMapper {
         createPropertyNode("Result variable name", serviceTask.getResultVariableName());
         createFieldPropertyNodes("Field extensions", serviceTask.getFieldExtensions());
         createListenerPropertyNodes("Execution listeners", serviceTask.getExecutionListeners());
+        createPropertyNode("Use local scope for result variable", serviceTask.isUseLocalScopeForResultVariable());
     }
 }

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/resources/stencilset_bpmn.json
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/resources/stencilset_bpmn.json
@@ -274,6 +274,16 @@
       "popular" : true
     } ]
   }, {
+    "name" : "servicetaskresultvariablepackage",
+    "properties" : [ {
+      "id" : "servicetaskUseLocalScopeForResultVariable",
+      "type" : "Boolean",
+      "title" : "Use local scope for result variable",
+      "value" : "false",
+      "description" : "Flag that marks that the used resultVariable needs to be saved as a local variable",
+      "popular" : true
+    } ]
+  }, {
       "name": "scriptformatpackage",
     "properties" : [ {
           "id": "scriptformat",

--- a/modules/flowable-ui-task/flowable-ui-task-logic/src/main/java/org/flowable/app/service/editor/mapper/ServiceTaskInfoMapper.java
+++ b/modules/flowable-ui-task/flowable-ui-task-logic/src/main/java/org/flowable/app/service/editor/mapper/ServiceTaskInfoMapper.java
@@ -39,5 +39,6 @@ public class ServiceTaskInfoMapper extends AbstractInfoMapper {
         createPropertyNode("Result variable name", serviceTask.getResultVariableName());
         createFieldPropertyNodes("Field extensions", serviceTask.getFieldExtensions());
         createListenerPropertyNodes("Execution listeners", serviceTask.getExecutionListeners());
+        createPropertyNode("Use local scope for result variable", serviceTask.isUseLocalScopeForResultVariable());
     }
 }


### PR DESCRIPTION
Fixes #806 

I know that there are multiple tasks that have the result variable. I am doing it for ServiceTask only for now. However, I want to extract a common class for tasks with a result variable, there is quite duplication accross those tasks