### PR TITLE
Bring back commons-fileupload in apps that need it

### DIFF
--- a/modules/flowable-ui-admin/flowable-ui-admin-conf/pom.xml
+++ b/modules/flowable-ui-admin/flowable-ui-admin-conf/pom.xml
@@ -82,6 +82,10 @@
         </dependency>
         <!-- COMMON dependencies -->
         <dependency>
+            <groupId>commons-fileupload</groupId>
+            <artifactId>commons-fileupload</artifactId>
+        </dependency>
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-conf/pom.xml
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-conf/pom.xml
@@ -82,6 +82,10 @@
         </dependency>
         <!-- COMMON dependencies -->
         <dependency>
+            <groupId>commons-fileupload</groupId>
+            <artifactId>commons-fileupload</artifactId>
+        </dependency>
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>

--- a/modules/flowable-ui-task/flowable-ui-task-conf/pom.xml
+++ b/modules/flowable-ui-task/flowable-ui-task-conf/pom.xml
@@ -152,6 +152,10 @@
 
         <!-- COMMON dependencies -->
         <dependency>
+            <groupId>commons-fileupload</groupId>
+            <artifactId>commons-fileupload</artifactId>
+        </dependency>
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>


### PR DESCRIPTION
In #801 @PascalSchumacher removed the `commons-fileupload` from all `ui` modules. However, we need that in some of the modules (the ones that use the `CommonsMultipartResolver`)

I am bringing back that dependency only in the modules that actually use that Multipart resolver