### PR TITLE
Flowable Apps: Add date to log entries by using ISO-8601 date format.

### DIFF
--- a/modules/flowable-app-rest/src/main/resources/log4j.properties
+++ b/modules/flowable-app-rest/src/main/resources/log4j.properties
@@ -3,4 +3,4 @@ log4j.rootLogger=INFO, CA
 # ConsoleAppender
 log4j.appender.CA=org.apache.log4j.ConsoleAppender
 log4j.appender.CA.layout=org.apache.log4j.PatternLayout
-log4j.appender.CA.layout.ConversionPattern= %d{hh:mm:ss,SSS} [%t] %-5p %c %x - %m%n
+log4j.appender.CA.layout.ConversionPattern= %d{ISO8601} [%t] %-5p %c %x - %m%n

--- a/modules/flowable-ui-admin/flowable-ui-admin-app/src/main/resources/log4j.properties
+++ b/modules/flowable-ui-admin/flowable-ui-admin-app/src/main/resources/log4j.properties
@@ -3,7 +3,7 @@ log4j.rootLogger=INFO, CA
 # ConsoleAppender
 log4j.appender.CA=org.apache.log4j.ConsoleAppender
 log4j.appender.CA.layout=org.apache.log4j.PatternLayout
-log4j.appender.CA.layout.ConversionPattern= %d{hh:mm:ss,SSS} [%t] %-5p %c %x - %m%n
+log4j.appender.CA.layout.ConversionPattern= %d{ISO8601} [%t] %-5p %c %x - %m%n
 
 # Custom tweaks
 log4j.logger.org.apache.ibatis.level=INFO

--- a/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/resources/log4j.properties
+++ b/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/resources/log4j.properties
@@ -3,5 +3,5 @@ log4j.rootLogger=INFO, stdout
 # Console Appender
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern= %d{hh:mm:ss,SSS} [%t] %-5p %c %x - %m%n
+log4j.appender.stdout.layout.ConversionPattern= %d{ISO8601} [%t] %-5p %c %x - %m%n
 

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/resources/log4j.properties
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/resources/log4j.properties
@@ -3,5 +3,5 @@ log4j.rootLogger=INFO, stdout
 # Console Appender
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern= %d{hh:mm:ss,SSS} [%t] %-5p %c %x - %m%n
+log4j.appender.stdout.layout.ConversionPattern= %d{ISO8601} [%t] %-5p %c %x - %m%n
 

--- a/modules/flowable-ui-task/flowable-ui-task-app/src/main/resources/log4j.properties
+++ b/modules/flowable-ui-task/flowable-ui-task-app/src/main/resources/log4j.properties
@@ -3,7 +3,7 @@ log4j.rootLogger=INFO, stdout
 # Console Appender
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern= %d{hh:mm:ss,SSS} [%t] %-5p %c %x - %m%n
+log4j.appender.stdout.layout.ConversionPattern= %d{ISO8601} [%t] %-5p %c %x - %m%n
 
 # Custom tweaks
 log4j.logger.org.apache.ibatis.level=DEBUG


### PR DESCRIPTION
Logging the date in addition to the time is can be very helpful for non-development environments.