### PR TITLE
fixes JSON to DMN parsing issue with 'ignore expression value'

### DIFF
--- a/modules/flowable-dmn-json-converter/src/main/java/org/flowable/editor/dmn/converter/DmnJsonConverter.java
+++ b/modules/flowable-dmn-json-converter/src/main/java/org/flowable/editor/dmn/converter/DmnJsonConverter.java
@@ -328,38 +328,41 @@ public class DmnJsonConverter {
                         expressionValue = expressionValueNode.asText();
                     }
 
-                    StringBuilder stringBuilder = new StringBuilder();
-                    if (StringUtils.isNotEmpty(operatorValue)) {
-                        stringBuilder = new StringBuilder(operatorValue);
-                        stringBuilder.append(" ");
-                    }
-
-                    // add quotes for string
-                    if ("string".equals(ruleInputClauseContainer.getInputClause().getInputExpression().getTypeRef())
-                        && !"-".equals(expressionValue)
-                        && !expressionValue.startsWith("\"")
-                        && !expressionValue.endsWith("\"")) { // add quotes for string (with no surrounding quotes)
-                        
-                        stringBuilder.append("\"");
-                        stringBuilder.append(expressionValue);
-                        stringBuilder.append("\"");
-                        
-                    } else if ("date".equals(ruleInputClauseContainer.getInputClause().getInputExpression().getTypeRef())
-                        && !"-".equals(expressionValue) && StringUtils.isNotEmpty(expressionValue)){
-                        
-                        // wrap in built in toDate function
-                        stringBuilder.append("date:toDate('");
-                        stringBuilder.append(expressionValue);
-                        stringBuilder.append("')");
-                        
+                    if ("-".equals(expressionValue)) {
+                        inputEntry.setText(expressionValue);
                     } else {
-                        stringBuilder.append(expressionValue);
+                        StringBuilder stringBuilder = new StringBuilder();
+                        if (StringUtils.isNotEmpty(operatorValue)) {
+                            stringBuilder = new StringBuilder(operatorValue);
+                            stringBuilder.append(" ");
+                        }
+
+                        // add quotes for string
+                        if ("string".equals(ruleInputClauseContainer.getInputClause().getInputExpression().getTypeRef())
+                            && !"-".equals(expressionValue)
+                            && !expressionValue.startsWith("\"")
+                            && !expressionValue.endsWith("\"")) { // add quotes for string (with no surrounding quotes)
+
+                            stringBuilder.append("\"");
+                            stringBuilder.append(expressionValue);
+                            stringBuilder.append("\"");
+
+                        } else if ("date".equals(ruleInputClauseContainer.getInputClause().getInputExpression().getTypeRef())
+                            && !"-".equals(expressionValue) && StringUtils.isNotEmpty(expressionValue)) {
+
+                            // wrap in built in toDate function
+                            stringBuilder.append("date:toDate('");
+                            stringBuilder.append(expressionValue);
+                            stringBuilder.append("')");
+
+                        } else {
+                            stringBuilder.append(expressionValue);
+                        }
+                        inputEntry.setText(stringBuilder.toString());
                     }
 
-                    inputEntry.setText(stringBuilder.toString());
                     ruleInputClauseContainer.setInputEntry(inputEntry);
                     rule.addInputEntry(ruleInputClauseContainer);
-
                 }
                 for (String id : ruleOutputContainerMap.keySet()) {
                     RuleOutputClauseContainer ruleOutputClauseContainer = new RuleOutputClauseContainer();

--- a/modules/flowable-dmn-json-converter/src/test/java/org/flowable/editor/dmn/converter/DmnJsonConverterTest.java
+++ b/modules/flowable-dmn-json-converter/src/test/java/org/flowable/editor/dmn/converter/DmnJsonConverterTest.java
@@ -257,6 +257,12 @@ public class DmnJsonConverterTest {
         DmnDefinition dmnDefinition = new DmnJsonConverter().convertToDmn(testJsonResource, "abc", 1, new Date());
 
         assertNotNull(dmnDefinition);
+
+        DecisionTable decisionTable = (DecisionTable) dmnDefinition.getDecisions().get(0).getExpression();
+
+        assertEquals("-", decisionTable.getRules().get(0).getInputEntries().get(0).getInputEntry().getText());
+        assertEquals("-", decisionTable.getRules().get(1).getInputEntries().get(0).getInputEntry().getText());
+        assertEquals("-", decisionTable.getRules().get(2).getInputEntries().get(0).getInputEntry().getText());
     }
 
     @Test

--- a/modules/flowable-dmn-json-converter/src/test/resources/org/flowable/editor/dmn/converter/decisiontable_empty_expressions.json
+++ b/modules/flowable-dmn-json-converter/src/test/resources/org/flowable/editor/dmn/converter/decisiontable_empty_expressions.json
@@ -25,16 +25,19 @@
     ],
     "rules": [
         {
-            "3": "== \"TEST\"",
-            "4": "\"1\""
+            "3_operator": "==",
+            "3_expression": "-",
+            "4": "WAS IGNORE 1"
         },
         {
-            "3": "!= \"TEST\"",
-            "4": ""
+            "3_operator": "!=",
+            "3_expression": "-",
+            "4": "WAS IGNORE 2"
         },
         {
-            "3": "",
-            "4": "\"3\""
+            "3_operator": null,
+            "3_expression": "-",
+            "4": "WAS IGNORE 3"
         }
     ]
 }


### PR DESCRIPTION
Due to a recent change '==' was prefixed to a '-' expression value.
When the expression value is '-' additional parsing should be skipped.