### PR TITLE
Usage of c3p0 was removed in 9971a7ba5e2245a5ff8c256064fbebe642891c5a…

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -100,8 +100,6 @@ com.fasterxml.jackson.datatype  jackson-datatype-json-org   2.7.5           The 
 com.google.guava                guava                       23.6-android    The Apache Software License, Version 2.0
 com.h2database                  h2                          1.4.196         The H2 License, Version 1.0
 com.fasterxml.uuid              java-uuid-generator         3.1.3           The Apache Software License, Version 2.0
-com.mchange                     mchange-commons-java        0.2.11          Eclipse Public License, Version 1.0
-com.mchange                     c3p0                        0.9.5.2         Eclipse Public License, Version 1.0
 com.sun.mail                    javax.mail                  1.6.1           CDDL/GPLv2+CE
 commons-beanutils               commons-beanutils           1.8.3           The Apache Software License, Version 2.0
 commons-codec                   commons-codec               1.10            Apache License, Version 2.0

--- a/modules/flowable-ui-admin/flowable-ui-admin-app/src/main/resources/META-INF/flowable-app/flowable-app.properties
+++ b/modules/flowable-ui-admin/flowable-ui-admin-app/src/main/resources/META-INF/flowable-app/flowable-app.properties
@@ -36,7 +36,7 @@ datasource.password=flowable
 #datasource.jndi.resourceRef=true
 
 #
-# Connection pool (see http://www.mchange.com/projects/c3p0/#configuration)
+# Connection pool (see https://github.com/brettwooldridge/HikariCP#configuration-knobs-baby)
 #
 
 #datasource.min-pool-size=5

--- a/modules/flowable-ui-task/flowable-ui-task-app/src/main/resources/META-INF/flowable-app/flowable-app.properties
+++ b/modules/flowable-ui-task/flowable-ui-task-app/src/main/resources/META-INF/flowable-app/flowable-app.properties
@@ -42,7 +42,7 @@ datasource.password=flowable
 #datasource.jndi.resourceRef=true
 
 #
-# Connection pool (see http://www.mchange.com/projects/c3p0/#configuration)
+# Connection pool (see https://github.com/brettwooldridge/HikariCP#configuration-knobs-baby)
 #
 
 #datasource.min-pool-size=5


### PR DESCRIPTION
…, this commit some leftovers.

An alternative would be to just remove the links in the `flowable-app.properties` files (the `flowable-app.properties` of the other apps do not contains a link to the datasource configuration).

