### PR TITLE
Use latest Java 7 compatible version of HikariCP.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -666,8 +666,8 @@
             </dependency>
             <dependency>
                 <groupId>com.zaxxer</groupId>
-                <artifactId>HikariCP</artifactId>
-                <version>2.7.7</version>
+                <artifactId>HikariCP-java7</artifactId>
+                <version>2.4.13</version>
             </dependency>
 			<dependency>
 				<groupId>org.mockito</groupId>


### PR DESCRIPTION
HikariCP 2.5+ requires Java 8.

Just close this pull request if the next flowable version will require Java 8+.