### PR TITLE
Add capability to customize the WSDL importer of flowable-cxf

### DIFF
--- a/modules/flowable-cxf/src/main/java/org/flowable/engine/impl/webservice/CxfWSDLImporter.java
+++ b/modules/flowable-cxf/src/main/java/org/flowable/engine/impl/webservice/CxfWSDLImporter.java
@@ -82,7 +82,7 @@ public class CxfWSDLImporter implements XMLImporter {
     public void importFrom(Import theImport, String sourceSystemId) {
         this.namespace = theImport.getNamespace() == null ? "" : theImport.getNamespace() + ":";
         try {
-            final URIResolver uriResolver = new URIResolver(sourceSystemId, theImport.getLocation());
+            final URIResolver uriResolver = this.createUriResolver(sourceSystemId, theImport);
             if (uriResolver.isResolved()) {
                 if (uriResolver.getURI() != null) {
                     this.importFrom(uriResolver.getURI().toString());
@@ -98,6 +98,10 @@ public class CxfWSDLImporter implements XMLImporter {
         } catch (final IOException e) {
             throw new UncheckedException(e);
         }
+    }
+
+    protected URIResolver createUriResolver(String sourceSystemId, Import theImport) throws IOException {
+        return new URIResolver(sourceSystemId, theImport.getLocation());
     }
 
     public void importFrom(String url) {

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/WebServiceActivityBehavior.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/WebServiceActivityBehavior.java
@@ -265,10 +265,11 @@ public class WebServiceActivityBehavior extends AbstractBpmnActivityBehavior {
         if (!xmlImporterMap.containsKey(theImport.getNamespace())) {
 
             if (theImport.getImportType().equals("http://schemas.xmlsoap.org/wsdl/")) {
-                Class<?> wsdlImporterClass;
                 try {
-                    wsdlImporterClass = Class.forName("org.flowable.engine.impl.webservice.CxfWSDLImporter", true, Thread.currentThread().getContextClassLoader());
-                    XMLImporter importerInstance = (XMLImporter) wsdlImporterClass.newInstance();
+                    ProcessEngineConfigurationImpl processEngineConfig = CommandContextUtil.getProcessEngineConfiguration();
+                    XMLImporter importerInstance = processEngineConfig.getWsdlImporterFactory()
+                            .createXMLImporter(theImport);
+
                     xmlImporterMap.put(theImport.getNamespace(), importerInstance);
                     importerInstance.importFrom(theImport, sourceSystemId);
 
@@ -276,9 +277,8 @@ public class WebServiceActivityBehavior extends AbstractBpmnActivityBehavior {
                     wsServiceMap.putAll(importerInstance.getServices());
                     wsOperationMap.putAll(importerInstance.getOperations());
 
-                } catch (ClassNotFoundException e) {
-                    throw new FlowableException("Could not find importer class for type " + theImport.getImportType(),
-                            e);
+                } catch (FlowableException e) {
+                    throw e;
                 } catch (Exception e) {
                     throw new FlowableException(String.format("Error importing '%s' as '%s'", theImport.getLocation(),
                             theImport.getImportType()), e);

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/parser/factory/DefaultXMLImporterFactory.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/parser/factory/DefaultXMLImporterFactory.java
@@ -1,0 +1,45 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.engine.impl.bpmn.parser.factory;
+
+import org.flowable.bpmn.model.Import;
+import org.flowable.engine.common.api.FlowableException;
+import org.flowable.engine.impl.bpmn.parser.XMLImporter;
+import org.flowable.engine.impl.cfg.ProcessEngineConfigurationImpl;
+
+/**
+ * Default implementation of the {@link XMLImporterFactory}. Used when no custom {@link XMLImporterFactory} is injected
+ * on the {@link ProcessEngineConfigurationImpl}.
+ * 
+ * @author Christophe DENEUX
+ */
+public class DefaultXMLImporterFactory implements XMLImporterFactory {
+
+    // Name of the default XML Importer, provided by flowable-cxf
+    private static final String DEFAULT_XML_IMPORTER_FACTORY_CLASSNAME = "org.flowable.engine.impl.webservice.CxfWSDLImporter";
+
+    @Override
+    public XMLImporter createXMLImporter(Import theImport) throws FlowableException {
+
+        try {
+            Class<?> wsdlImporterClass = Class.forName(DEFAULT_XML_IMPORTER_FACTORY_CLASSNAME, true,
+                    Thread.currentThread().getContextClassLoader());
+            return (XMLImporter) wsdlImporterClass.newInstance();
+        } catch (ClassNotFoundException e) {
+            throw new FlowableException("Could not find importer class for type " + theImport.getImportType(), e);
+        } catch (Exception e) {
+            throw new FlowableException(String.format("Error instantiating XML importer '%s' for type '%s'",
+                    DEFAULT_XML_IMPORTER_FACTORY_CLASSNAME, theImport.getImportType()), e);
+        }
+    }
+}

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/parser/factory/XMLImporterFactory.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/parser/factory/XMLImporterFactory.java
@@ -1,0 +1,33 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.engine.impl.bpmn.parser.factory;
+
+import org.flowable.bpmn.model.Import;
+import org.flowable.engine.common.api.FlowableException;
+import org.flowable.engine.impl.bpmn.behavior.WebServiceActivityBehavior;
+import org.flowable.engine.impl.bpmn.parser.XMLImporter;
+import org.flowable.engine.impl.cfg.ProcessEngineConfigurationImpl;
+
+/**
+ * Factory class used by the {@link WebServiceActivityBehavior} to instantiate {@link XMLImporter}.
+ * 
+ * You can provide your own implementation of this class to provide your own XML/WSDL importer.
+ * 
+ * An instance of this interface can be injected in the {@link ProcessEngineConfigurationImpl} and its subclasses.
+ * 
+ * @author Christophe DENEUX
+ */
+public interface XMLImporterFactory {
+
+    public XMLImporter createXMLImporter(Import theImport) throws FlowableException;
+}

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -120,7 +120,9 @@ import org.flowable.engine.impl.bpmn.parser.factory.AbstractBehaviorFactory;
 import org.flowable.engine.impl.bpmn.parser.factory.ActivityBehaviorFactory;
 import org.flowable.engine.impl.bpmn.parser.factory.DefaultActivityBehaviorFactory;
 import org.flowable.engine.impl.bpmn.parser.factory.DefaultListenerFactory;
+import org.flowable.engine.impl.bpmn.parser.factory.DefaultXMLImporterFactory;
 import org.flowable.engine.impl.bpmn.parser.factory.ListenerFactory;
+import org.flowable.engine.impl.bpmn.parser.factory.XMLImporterFactory;
 import org.flowable.engine.impl.bpmn.parser.handler.AdhocSubProcessParseHandler;
 import org.flowable.engine.impl.bpmn.parser.handler.BoundaryEventParseHandler;
 import org.flowable.engine.impl.bpmn.parser.handler.BusinessRuleParseHandler;
@@ -341,6 +343,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     private static final Logger LOGGER = LoggerFactory.getLogger(ProcessEngineConfigurationImpl.class);
 
     public static final String DEFAULT_WS_SYNC_FACTORY = "org.flowable.engine.impl.webservice.CxfWebServiceClientFactory";
+
+    public static final String DEFAULT_WS_IMPORTER = "org.flowable.engine.impl.webservice.CxfWSDLImporter";
 
     public static final String DEFAULT_MYBATIS_MAPPING_FILE = "org/flowable/db/mapping/mappings.xml";
 
@@ -693,7 +697,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     protected int historicProcessInstancesQueryLimit = 20000;
 
     protected String wsSyncFactoryClassName = DEFAULT_WS_SYNC_FACTORY;
-    protected ConcurrentMap<QName, URL> wsOverridenEndpointAddresses = new ConcurrentHashMap<>();
+    protected XMLImporterFactory wsWsdlImporterFactory;
+    protected ConcurrentMap<QName, URL> wsOverridenEndpointAddresses = new ConcurrentHashMap<QName, URL>();
 
     protected DelegateInterceptor delegateInterceptor;
 
@@ -826,6 +831,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         initCommandExecutors();
         initServices();
         initIdGenerator();
+        initWsdlImporterFactory();
         initBehaviorFactory();
         initListenerFactory();
         initBpmnParser();
@@ -1525,6 +1531,13 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
             listenerFactory = defaultListenerFactory;
         } else if ((listenerFactory instanceof AbstractBehaviorFactory) && ((AbstractBehaviorFactory) listenerFactory).getExpressionManager() == null) {
             ((AbstractBehaviorFactory) listenerFactory).setExpressionManager(expressionManager);
+        }
+    }
+
+    public void initWsdlImporterFactory() {
+        if (wsWsdlImporterFactory == null) {
+            DefaultXMLImporterFactory defaultListenerFactory = new DefaultXMLImporterFactory();
+            wsWsdlImporterFactory = defaultListenerFactory;
         }
     }
 
@@ -2388,6 +2401,15 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     public ProcessEngineConfigurationImpl setWsSyncFactoryClassName(String wsSyncFactoryClassName) {
         this.wsSyncFactoryClassName = wsSyncFactoryClassName;
+        return this;
+    }
+
+    public XMLImporterFactory getWsdlImporterFactory() {
+        return wsWsdlImporterFactory;
+    }
+
+    public ProcessEngineConfigurationImpl setWsdlImporterFactory(XMLImporterFactory wsWsdlImporterFactory) {
+        this.wsWsdlImporterFactory = wsWsdlImporterFactory;
         return this;
     }
 


### PR DESCRIPTION
When using web-service task in my process definition, it is needed to import WSDL of invoked web-services.

I need to use a custom URI resolver to find WSDLs of my services. So I should be able to customize `flowable-cxf` with my own URI resolver through a custom WSDL importer.

Please find here my contribution to be able to configure the WSDL importer at process engine configuration.