### PR TITLE
The definitions location prefix should be optional

### DIFF
--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-starter-basic/src/main/java/org/flowable/spring/boot/FlowableProperties.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-starter-basic/src/main/java/org/flowable/spring/boot/FlowableProperties.java
@@ -41,7 +41,7 @@ public class FlowableProperties {
     private boolean isDbIdentityUsed = true;
     private boolean isDbHistoryUsed = true;
     private HistoryLevel historyLevel = HistoryLevel.AUDIT;
-    private String processDefinitionLocationPrefix = "classpath:/processes/";
+    private String processDefinitionLocationPrefix = "classpath*:/processes/";
     private List<String> processDefinitionLocationSuffixes = Arrays.asList("**.bpmn20.xml", "**.bpmn");
     private String restApiMapping = "/api/*";
     private String restApiServletName = "flowableRestApi";


### PR DESCRIPTION
When using classpath:location Spring expects the resources to exist and it fails if it doesn't find them.
However, when using classpath*:location Spring will not fail if the resources do not exist