### PR TITLE
flowable-camel: try to make AsyncProcessRevisitedTest more stable by imp…

### DIFF
--- a/modules/flowable-camel/src/test/java/org/flowable/camel/revisited/AsyncProcessRevisitedTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/revisited/AsyncProcessRevisitedTest.java
@@ -52,7 +52,8 @@ public class AsyncProcessRevisitedTest extends SpringFlowableTestCase {
 
     @Deployment(resources = { "process/revisited/async-revisited.bpmn20.xml" })
     public void testRunProcess() throws Exception {
-        NotifyBuilder oneExchangeSendToFlowable = new NotifyBuilder(camelContext).from("seda:continueAsync2").whenDone(1).create();
+        NotifyBuilder oneExchangeSendToFlowableReceive1 = new NotifyBuilder(camelContext).from("seda:continueAsync1").whenExactlyCompleted(1).create();
+        NotifyBuilder oneExchangeSendToFlowableReceive2 = new NotifyBuilder(camelContext).from("seda:continueAsync2").whenExactlyCompleted(1).create();
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("asyncCamelProcessRevisited");
 
@@ -60,7 +61,8 @@ public class AsyncProcessRevisitedTest extends SpringFlowableTestCase {
         assertEquals(3, executionList.size());
         waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(5000, 200);
 
-        assertTrue(oneExchangeSendToFlowable.matchesMockWaitTime());
+        assertTrue(oneExchangeSendToFlowableReceive1.matchesMockWaitTime());
+        assertTrue(oneExchangeSendToFlowableReceive2.matchesMockWaitTime());
         assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
     }
 }


### PR DESCRIPTION
…roving Camel NotifyBuilder usage

Test fails form time to time on travis, e.g.

https://api.travis-ci.org/v3/job/345715054/log.txt
https://api.travis-ci.org/v3/job/345892676/log.txt
https://api.travis-ci.org/v3/job/345715056/log.txt

This is me last try before resorting to `Thread.sleep` 😞 