### PR TITLE
Replace catch-exception with assertj and update mockito to latest from 1.x

### DIFF
--- a/modules/flowable-engine/pom.xml
+++ b/modules/flowable-engine/pom.xml
@@ -197,8 +197,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.googlecode.catch-exception</groupId>
-            <artifactId>catch-exception</artifactId>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/RuntimeServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/RuntimeServiceTest.java
@@ -44,8 +44,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static com.googlecode.catchexception.CatchException.catchException;
-import static com.googlecode.catchexception.CatchException.caughtException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
@@ -968,10 +967,8 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         Map<String, Object> params = new HashMap<>();
         params.put("var1", true);
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess", params);
-        catchException(runtimeService).getVariable(processInstance.getId(), "var1", String.class);
-        Exception e = caughtException();
-        assertNotNull(e);
-        assertTrue(e instanceof ClassCastException);
+        assertThatThrownBy(() -> runtimeService.getVariable(processInstance.getId(), "var1", String.class))
+            .isExactlyInstanceOf(ClassCastException.class);
     }
 
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
@@ -995,10 +992,8 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         Map<String, Object> params = new HashMap<>();
         params.put("var1", true);
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess", params);
-        catchException(runtimeService).getVariableLocal(processInstance.getId(), "var1", String.class);
-        Exception e = caughtException();
-        assertNotNull(e);
-        assertTrue(e instanceof ClassCastException);
+        assertThatThrownBy(() -> runtimeService.getVariableLocal(processInstance.getId(), "var1", String.class))
+            .isExactlyInstanceOf(ClassCastException.class);
     }
 
     // Test for https://activiti.atlassian.net/browse/ACT-2186

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskServiceTest.java
@@ -13,8 +13,7 @@
 
 package org.flowable.engine.test.api.task;
 
-import static com.googlecode.catchexception.CatchException.catchException;
-import static com.googlecode.catchexception.CatchException.caughtException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
@@ -1731,11 +1730,8 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
         taskService.setVariableLocal(currentTask.getId(), "variable1", "value1");
 
-        catchException(taskService).getVariableLocal(currentTask.getId(), "variable1", Boolean.class);
-
-        Exception e = caughtException();
-        assertNotNull(e);
-        assertTrue(e instanceof ClassCastException);
+        assertThatThrownBy(() -> taskService.getVariableLocal(currentTask.getId(), "variable1", Boolean.class))
+            .isExactlyInstanceOf(ClassCastException.class);
     }
 
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
@@ -1770,11 +1766,8 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
         taskService.setVariable(currentTask.getId(), "variable1", "value1");
 
-        catchException(taskService).getVariable(currentTask.getId(), "variable1", Boolean.class);
-
-        Exception e = caughtException();
-        assertNotNull(e);
-        assertTrue(e instanceof ClassCastException);
+        assertThatThrownBy(() -> taskService.getVariable(currentTask.getId(), "variable1", Boolean.class))
+            .isExactlyInstanceOf(ClassCastException.class);
     }
 
     public void testClaimTime() {

--- a/modules/flowable5-engine/pom.xml
+++ b/modules/flowable5-engine/pom.xml
@@ -141,8 +141,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.googlecode.catch-exception</groupId>
-			<artifactId>catch-exception</artifactId>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
 			<scope>test</scope>
 		</dependency>
 

--- a/modules/flowable5-test/pom.xml
+++ b/modules/flowable5-test/pom.xml
@@ -126,8 +126,8 @@
 			<artifactId>joda-time</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.googlecode.catch-exception</groupId>
-			<artifactId>catch-exception</artifactId>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
 			<scope>test</scope>
 		</dependency>
 

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/runtime/RuntimeServiceTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/runtime/RuntimeServiceTest.java
@@ -13,8 +13,7 @@
 
 package org.activiti.engine.test.api.runtime;
 
-import static com.googlecode.catchexception.CatchException.catchException;
-import static com.googlecode.catchexception.CatchException.caughtException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -973,10 +972,8 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         Map<String, Object> params = new HashMap<String, Object>();
         params.put("var1", true);
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess", params);
-        catchException(runtimeService).getVariable(processInstance.getId(), "var1", String.class);
-        Exception e = caughtException();
-        assertNotNull(e);
-        assertTrue(e instanceof ClassCastException);
+        assertThatThrownBy(() -> runtimeService.getVariable(processInstance.getId(), "var1", String.class))
+            .isExactlyInstanceOf(ClassCastException.class);
     }
 
     @Deployment(resources = {
@@ -1003,10 +1000,8 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         Map<String, Object> params = new HashMap<String, Object>();
         params.put("var1", true);
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess", params);
-        catchException(runtimeService).getVariableLocal(processInstance.getId(), "var1", String.class);
-        Exception e = caughtException();
-        assertNotNull(e);
-        assertTrue(e instanceof ClassCastException);
+        assertThatThrownBy(() -> runtimeService.getVariableLocal(processInstance.getId(), "var1", String.class))
+            .isExactlyInstanceOf(ClassCastException.class);
     }
 
     // Test for https://activiti.atlassian.net/browse/ACT-2186

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/task/TaskServiceTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/task/TaskServiceTest.java
@@ -13,8 +13,7 @@
 
 package org.activiti.engine.test.api.task;
 
-import static com.googlecode.catchexception.CatchException.catchException;
-import static com.googlecode.catchexception.CatchException.caughtException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
@@ -1502,11 +1501,8 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
         taskService.setVariableLocal(currentTask.getId(), "variable1", "value1");
 
-        catchException(taskService).getVariableLocal(currentTask.getId(), "variable1", Boolean.class);
-
-        Exception e = caughtException();
-        assertNotNull(e);
-        assertTrue(e instanceof ClassCastException);
+        assertThatThrownBy(() -> taskService.getVariableLocal(currentTask.getId(), "variable1", Boolean.class))
+            .isExactlyInstanceOf(ClassCastException.class);
     }
 
     @Deployment(resources = {
@@ -1544,10 +1540,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
         taskService.setVariable(currentTask.getId(), "variable1", "value1");
 
-        catchException(taskService).getVariable(currentTask.getId(), "variable1", Boolean.class);
-
-        Exception e = caughtException();
-        assertNotNull(e);
-        assertTrue(e instanceof ClassCastException);
+        assertThatThrownBy(() -> taskService.getVariable(currentTask.getId(), "variable1", Boolean.class))
+            .isExactlyInstanceOf(ClassCastException.class);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -672,7 +672,7 @@
 			<dependency>
 				<groupId>org.mockito</groupId>
 				<artifactId>mockito-core</artifactId>
-				<version>1.8.2</version>
+				<version>1.10.19</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>
@@ -903,9 +903,9 @@
 				<version>1.3.0</version>
 			</dependency>
 			<dependency>
-				<groupId>com.googlecode.catch-exception</groupId>
-				<artifactId>catch-exception</artifactId>
-				<version>1.2.0</version>
+				<groupId>org.assertj</groupId>
+				<artifactId>assertj-core</artifactId>
+				<version>3.9.1</version>
 				<scope>test</scope>
 			</dependency>
 		</dependencies>


### PR DESCRIPTION
catch-exception is not compatible with latest 1.10.19 from mockito

This also adds AssertJ which would allow us to write even better tests ;).