### PR TITLE
Extend JobExecutorFailRetryTest and other improvements

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/JobRetryCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/JobRetryCmd.java
@@ -41,7 +41,6 @@ import org.slf4j.LoggerFactory;
  * @author Saeid Mirzaei
  * @author Joram Barrez
  */
-
 public class JobRetryCmd implements Command<Object> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(JobRetryCmd.class.getName());
@@ -102,7 +101,7 @@ public class JobRetryCmd implements Command<Object> {
                 DurationHelper durationHelper = new DurationHelper(failedJobRetryTimeCycleValue, processEngineConfig.getClock());
                 int jobRetries = job.getRetries();
                 if (job.getExceptionMessage() == null) {
-                    // change default retries to the ones configured
+                    // this is the first failure; change default retries to the ones configured
                     jobRetries = durationHelper.getTimes();
                 }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/JobExecutorFailRetryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/JobExecutorFailRetryTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.jobexecutor;
 
+import static org.assertj.core.api.Assertions.*;
+
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
@@ -28,7 +30,7 @@ public class JobExecutorFailRetryTest extends PluggableFlowableTestCase {
         ProcessInstance instance1 = runtimeService.startProcessInstanceByKey("failedJobRetry");
 
         waitForJobExecutorToProcessAllJobs(1000, 200);
-        assertEquals(1, RetryFailingDelegate.getNumCalls()); // check number of calls of delegate
+        assertThat(RetryFailingDelegate.getNumCalls()).isEqualTo(1); // check number of calls of delegate
         
         assertProcessEnded(instance1.getId());
 
@@ -37,25 +39,20 @@ public class JobExecutorFailRetryTest extends PluggableFlowableTestCase {
         ProcessInstance instance2 = runtimeService.startProcessInstanceByKey("failedJobRetry");
 
         executeJobExecutorForTime(9000, 500);
-        assertEquals(3, RetryFailingDelegate.getNumCalls());
-        assertBetween(RetryFailingDelegate.getTimeDiff(), 3000, 5000); // check time difference between last 2 calls. Just roughly
+        assertThat(RetryFailingDelegate.getNumCalls()).isEqualTo(3);
+        assertThat(RetryFailingDelegate.getTimeDiff()).isBetween(3000L, 5000L); // check time difference between last 2 calls. Just roughly
         
         assertProcessEnded(instance2.getId());
 
         // process throws exception 3 times, with 3 seconds in between
-        RetryFailingDelegate.initialize(3); // throw exception 2 times
+        RetryFailingDelegate.initialize(3); // throw exception 3 times
         ProcessInstance instance3 = runtimeService.startProcessInstanceByKey("failedJobRetry");
 
         executeJobExecutorForTime(9000, 500);
-        assertEquals(3, RetryFailingDelegate.getNumCalls());
-        assertBetween(RetryFailingDelegate.getTimeDiff(), 3000, 5000);
+        assertThat(RetryFailingDelegate.getNumCalls()).isEqualTo(3);
+        assertThat(RetryFailingDelegate.getTimeDiff()).isBetween(3000L, 5000L);
         
         // since there are 3 retries, which all fail, the process should NOT be complete.
         assertEquals(1, processEngine.getRuntimeService().createProcessInstanceQuery().processInstanceId(instance3.getId()).count());
-    }
-
-    private static void assertBetween(long timeDiff, int lowerBound, int higherBound) {
-        assertTrue(timeDiff + " must be at least " + lowerBound, timeDiff >= lowerBound);
-        assertTrue(timeDiff + " must be at most " + higherBound, timeDiff <= higherBound);
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/RetryFailingDelegate.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/RetryFailingDelegate.java
@@ -18,25 +18,41 @@ import java.util.List;
 import org.flowable.engine.common.api.FlowableException;
 import org.flowable.engine.delegate.DelegateExecution;
 import org.flowable.engine.delegate.JavaDelegate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class RetryFailingDelegate implements JavaDelegate {
+    private static final Logger logger = LoggerFactory.getLogger(RetryFailingDelegate.class);
 
     public static final String EXCEPTION_MESSAGE = "Expected exception.";
 
-    public static boolean shallThrow;
-    public static List<Long> times;
+    private static int shallThrow;
+    private static List<Long> times;
 
-    public static void resetTimeList() {
+    public static void initialize(int num) {
+        shallThrow = num;
         times = new ArrayList<>();
+    }
+    
+    public static int getNumCalls() {
+        return times.size();
+    }
+    
+    public static long getTimeDiff() {
+        assert times.size() >= 2;
+        return times.get(1) - times.get(0);
     }
 
     @Override
     public void execute(DelegateExecution execution) {
-
         times.add(System.currentTimeMillis());
 
-        if (shallThrow) {
+        if (shallThrow > 0) {
+            logger.info("Throwing exception {} more times", shallThrow);
+            shallThrow--;
             throw new FlowableException(EXCEPTION_MESSAGE);
+        } else {
+            logger.info("Not throwing exception", shallThrow);
         }
     }
 }

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/cmd/FailedJobRetryCmdTest.testFailedServiceTask.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/cmd/FailedJobRetryCmdTest.testFailedServiceTask.bpmn20.xml
@@ -9,12 +9,12 @@
 		<startEvent id="theStart" />
 		<sequenceFlow id="flow1" sourceRef="theStart" targetRef="failingServiceTask" />
 
- 		<serviceTask id="failingServiceTask" activiti:async="true" activiti:class="org.flowable.engine.test.cmd.FailingDelegate">
+		<serviceTask id="failingServiceTask" activiti:async="true" activiti:class="org.flowable.engine.test.cmd.FailingDelegate">
 			<extensionElements>
-	       		<activiti:failedJobRetryTimeCycle>R5/PT5M</activiti:failedJobRetryTimeCycle>
-	       	</extensionElements>
+				<activiti:failedJobRetryTimeCycle>R5/PT5M</activiti:failedJobRetryTimeCycle>
+			</extensionElements>
 		</serviceTask>
-        
+
 		<sequenceFlow id="flow2" sourceRef="failingServiceTask" targetRef="theEnd" />
 		
 		<endEvent id="theEnd" />

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/jobexecutor/JobExecutorFailRetryTest.testFailedServiceTask.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/jobexecutor/JobExecutorFailRetryTest.testFailedServiceTask.bpmn20.xml
@@ -10,12 +10,12 @@
 		<startEvent id="theStart" />
 		<sequenceFlow id="flow1" sourceRef="theStart" targetRef="failingServiceTask" />
 
- 		<serviceTask id="failingServiceTask" activiti:async="true" activiti:class="org.flowable.engine.test.jobexecutor.RetryFailingDelegate">
+		<serviceTask id="failingServiceTask" activiti:async="true" activiti:class="org.flowable.engine.test.jobexecutor.RetryFailingDelegate">
 			<extensionElements>
-	       		<activiti:failedJobRetryTimeCycle>R2/PT6S</activiti:failedJobRetryTimeCycle>
-	       	</extensionElements>
+				<activiti:failedJobRetryTimeCycle>R3/PT3S</activiti:failedJobRetryTimeCycle>
+			</extensionElements>
 		</serviceTask>
-        
+
 		<sequenceFlow id="flow2" sourceRef="failingServiceTask" targetRef="theEnd" />
 		
 		<endEvent id="theEnd" />

--- a/modules/flowable-jms-spring-executor/src/test/java/org/flowable/test/spring/executor/jms/SpringJmsTest.java
+++ b/modules/flowable-jms-spring-executor/src/test/java/org/flowable/test/spring/executor/jms/SpringJmsTest.java
@@ -18,8 +18,6 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
-import javax.jms.ConnectionFactory;
-
 import org.flowable.engine.ProcessEngine;
 import org.flowable.job.service.impl.asyncexecutor.DefaultAsyncJobExecutor;
 import org.flowable.spring.impl.test.CleanTestExecutionListener;
@@ -42,9 +40,6 @@ public class SpringJmsTest {
 
     @Autowired
     private ProcessEngine processEngine;
-
-    @Autowired
-    private ConnectionFactory connectionFactory;
 
     @Test
     public void testMessageQueueAsyncExecutor() {

--- a/modules/flowable-jms-spring-executor/src/test/java/org/flowable/test/spring/executor/jms/config/SpringJmsConfig.java
+++ b/modules/flowable-jms-spring-executor/src/test/java/org/flowable/test/spring/executor/jms/config/SpringJmsConfig.java
@@ -64,6 +64,7 @@ public class SpringJmsConfig {
         configuration.setDatabaseSchemaUpdate(SpringProcessEngineConfiguration.DB_SCHEMA_UPDATE_TRUE);
         configuration.setAsyncExecutorMessageQueueMode(true);
         configuration.setAsyncExecutorActivate(true);
+        configuration.setAsyncExecutorDefaultTimerJobAcquireWaitTime(500);
         configuration.setJobManager(jobManager());
         return configuration;
     }

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/AbstractAsyncExecutor.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/AbstractAsyncExecutor.java
@@ -328,16 +328,6 @@ public abstract class AbstractAsyncExecutor implements AsyncExecutor {
     }
 
     @Override
-    public int getRetryWaitTimeInMillis() {
-        return retryWaitTimeInMillis;
-    }
-
-    @Override
-    public void setRetryWaitTimeInMillis(int retryWaitTimeInMillis) {
-        this.retryWaitTimeInMillis = retryWaitTimeInMillis;
-    }
-
-    @Override
     public int getResetExpiredJobsInterval() {
         return resetExpiredJobsInterval;
     }

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/AsyncExecutor.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/AsyncExecutor.java
@@ -81,10 +81,6 @@ public interface AsyncExecutor {
 
     void setMaxTimerJobsPerAcquisition(int maxJobs);
 
-    int getRetryWaitTimeInMillis();
-
-    void setRetryWaitTimeInMillis(int retryWaitTimeInMillis);
-
     int getResetExpiredJobsInterval();
 
     void setResetExpiredJobsInterval(int resetExpiredJobsInterval);

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/DefaultAsyncJobExecutor.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/DefaultAsyncJobExecutor.java
@@ -104,7 +104,7 @@ public class DefaultAsyncJobExecutor extends AbstractAsyncExecutor {
                 });
             }
 
-            // Job queue full, returning true so (if wanted) the acquiring can be throttled
+            // Job queue full, returning false so (if wanted) the acquiring can be throttled
             return false;
         }
     }

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/multitenant/ExecutorPerTenantAsyncExecutor.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/multitenant/ExecutorPerTenantAsyncExecutor.java
@@ -261,18 +261,6 @@ public class ExecutorPerTenantAsyncExecutor implements TenantAwareAsyncExecutor 
     }
 
     @Override
-    public int getRetryWaitTimeInMillis() {
-        return determineAsyncExecutor().getRetryWaitTimeInMillis();
-    }
-
-    @Override
-    public void setRetryWaitTimeInMillis(int retryWaitTimeInMillis) {
-        for (AsyncExecutor asyncExecutor : tenantExecutors.values()) {
-            asyncExecutor.setRetryWaitTimeInMillis(retryWaitTimeInMillis);
-        }
-    }
-
-    @Override
     public int getResetExpiredJobsInterval() {
         return determineAsyncExecutor().getResetExpiredJobsInterval();
     }


### PR DESCRIPTION
- JobExecutorFailRetryTest: verify that the process does not complete after 3 failing retries. 
- AsyncExecutor: remove unused and misleading property RetryWaitTimeInMillis. 
- Misc minor improvements.