### PR TITLE
Improve jaxb-api dependency management

### DIFF
--- a/modules/flowable-app-rest/pom.xml
+++ b/modules/flowable-app-rest/pom.xml
@@ -606,7 +606,6 @@
     <dependency>
         <groupId>javax.xml.bind</groupId> <!-- Needed for swagger doc generation -->
         <artifactId>jaxb-api</artifactId>
-        <version>2.3.0</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,11 @@
 				<scope>test</scope>
 			</dependency>
 			<dependency>
+				<groupId>javax.xml.bind</groupId>
+				<artifactId>jaxb-api</artifactId>
+				<version>2.3.0</version>
+			</dependency>
+			<dependency>
 				<groupId>com.sun.xml.bind</groupId>
 				<artifactId>jaxb-impl</artifactId>
 				<version>2.3.0</version>
@@ -175,11 +180,6 @@
 				<artifactId>javax.enterprise.concurrent-api</artifactId>
 				<version>1.0</version>
 				<scope>provided</scope>
-			</dependency>
-			<dependency>
-				<groupId>javax.xml.bind</groupId>
-				<artifactId>jaxb-api</artifactId>
-				<version>2.2.3</version>
 			</dependency>
 			<dependency>
 				<groupId>io.swagger</groupId>


### PR DESCRIPTION
Flowable-root: Update jaxb-api version to 2.3.0 to match the version of the other jaxb dependencies. Move the jaxb-api dependency above the other jaxb dependency declarations.

Flowable-app-rest: Use jaxb-api version from flowable root.