### PR TITLE
Added test case for repetition rule and exitCriterion on a task

### DIFF
--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/RepetitionRuleTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/RepetitionRuleTest.java
@@ -297,5 +297,26 @@ public class RepetitionRuleTest extends FlowableCmmnTestCase {
         // Ignoring second occur event
         assertEquals(1L, cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count());
     }
-    
+
+    @Test
+    @CmmnDeployment
+    public void testRepetitionRuleWithExitCriteria() {
+        //Completion of taskB will transition taskA to "exit", skipping the evaluation of the repetition rule (Table 8.8 of CMM 1.1 Spec)
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("testRepetitionRuleWithExitCriteria")
+                .variable("whileTrue", "true")
+                .start();
+
+        assertNotNull(caseInstance);
+
+        for (int i = 0; i < 3; i++) {
+            Task taskA = cmmnTaskService.createTaskQuery().active().taskDefinitionKey("taskA").singleResult();
+            cmmnTaskService.complete(taskA.getId());
+            assertCaseInstanceNotEnded(caseInstance);
+        }
+
+        Task taskB = cmmnTaskService.createTaskQuery().active().taskDefinitionKey("taskB").singleResult();
+        cmmnTaskService.complete(taskB.getId());
+        assertCaseInstanceEnded(caseInstance);
+    }
 }

--- a/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/itemcontrol/RepetitionRuleTest.testRepetitionRuleWithExitCriteria.cmmn
+++ b/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/itemcontrol/RepetitionRuleTest.testRepetitionRuleWithExitCriteria.cmmn
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/CMMN/20151109/MODEL"
+             targetNamespace="http://flowable.org/cmmn">
+    <case id="testRepetitionRuleWithExitCriteria" name="testRepetitionRuleWithExitCriteria">
+        <casePlanModel id="casePlanModel">
+
+            <planItem id="planItemStage" name="Stage One" definitionRef="stage1"/>
+
+            <stage id="stage1" name="Stage One">
+
+                <planItem id="planItemTaskA" name="Task A" definitionRef="taskA">
+                    <itemControl>
+                        <repetitionRule>
+                            <condition><![CDATA[${whileTrue}]]></condition>
+                        </repetitionRule>
+                    </itemControl>
+                    <exitCriterion sentryRef="onTaskBComplete"/>
+                </planItem>
+
+                <planItem id="planItemTaskB" name="Task B" definitionRef="taskB"/>
+
+                <sentry id="onTaskBComplete">
+                    <planItemOnPart sourceRef="planItemTaskB">
+                        <standardEvent>complete</standardEvent>
+                    </planItemOnPart>
+                </sentry>
+
+                <humanTask id="taskA" name="Task A"/>
+                <humanTask id="taskB" name="Task B"/>
+
+            </stage>
+
+        </casePlanModel>
+    </case>
+</definitions>


### PR DESCRIPTION
As discussed with @jbarrez there's no clear definition on the need to reevaluate repetition condition when a Plan Item transitions to exit (exitCriterion), although it is clear for complete and terminate.
This PR just adds a test that corroborates the current behavior of the engine, which we think it is correct for the moment, which is that "on-exit" it doesn't need to evaluate the repetion rule. 