### PR TITLE
Use jackson version 2.8.11(.1) which includes fixes for CVE-2017-17485 …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 		<jdk.version>1.8</jdk.version>
 		<spring.framework.version>4.3.14.RELEASE</spring.framework.version>
 		<spring.security.version>4.2.4.RELEASE</spring.security.version>
-		<jackson.version>2.9.3</jackson.version>
+		<jackson.version>2.8.11</jackson.version>
 		<mule.version>3.8.0</mule.version>
 		<camel.version>2.20.2</camel.version>
 		<cxf.version>3.2.2</cxf.version>
@@ -867,7 +867,7 @@
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-databind</artifactId>
-				<version>${jackson.version}</version>
+				<version>${jackson.version}.1</version>
 			</dependency>
 			<dependency>
 				<groupId>com.fasterxml.jackson.datatype</groupId>


### PR DESCRIPTION
…and CVE-2018-5968

For reference:

https://nvd.nist.gov/vuln/detail/CVE-2017-17485
https://nvd.nist.gov/vuln/detail/CVE-2018-5968

Jackson `2.9.4` also includes the fixes, but I believe the Spring Security version used by Flowable is not compatible with with Jackson `2.9.4` (see: https://github.com/spring-projects/spring-security/commit/8b7f77276144ef671726cf9bcb3882610f9a4e3f).

The `2.8.11.1` Jackson release included only `jackson-databind`.

Edit:
No sure if Flowable is affected by these vulnerabilities (see: https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062), but `git grep` did find some results for `@JsonTypeInfo(use = Id.CLASS`