### PR TITLE
Add environment post processor to disable Liquibase auto configuration

### DIFF
--- a/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-cmmn/src/main/resources/application.properties
+++ b/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-cmmn/src/main/resources/application.properties
@@ -1,3 +1,0 @@
-# Flowable does not need the Liquibase Configuration from Spring Boot.
-# If you are using liquibase in your own project, you need to enable this
-liquibase.enabled=false

--- a/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-content/src/main/resources/application.properties
+++ b/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-content/src/main/resources/application.properties
@@ -1,3 +1,0 @@
-# Flowable does not need the Liquibase Configuration from Spring Boot.
-# If you are using liquibase in your own project, you need to enable this
-liquibase.enabled=false

--- a/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-dmn/src/main/resources/application.properties
+++ b/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-dmn/src/main/resources/application.properties
@@ -1,3 +1,0 @@
-# Flowable does not need the Liquibase Configuration from Spring Boot.
-# If you are using liquibase in your own project, you need to enable this
-liquibase.enabled=false

--- a/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-form/src/main/resources/application.properties
+++ b/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-form/src/main/resources/application.properties
@@ -1,3 +1,0 @@
-# Flowable does not need the Liquibase Configuration from Spring Boot.
-# If you are using liquibase in your own project, you need to enable this
-liquibase.enabled=false

--- a/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-rest-api/src/main/resources/application.properties
+++ b/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-rest-api/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-liquibase.enabled=false

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/environment/FlowableLiquibaseEnvironmentPostProcessor.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/environment/FlowableLiquibaseEnvironmentPostProcessor.java
@@ -1,0 +1,50 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.spring.boot.environment;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.env.EnvironmentPostProcessor;
+import org.springframework.core.annotation.Order;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+
+/**
+ * When one of the engines that uses liquibase is pulled in with Spring Boot, it pulls the liquibase dependency
+ * and that activates {@link org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration}. However,
+ * this leads to issues, when the user doesn't actually use it. Therefore, we must disable it per default. In order
+ * to activate it, users need to set {@code liquibase.enabled=true} explicitly.
+ *
+ * @author Filip Hrisafov
+ */
+@Order(100)
+public class FlowableLiquibaseEnvironmentPostProcessor implements EnvironmentPostProcessor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FlowableLiquibaseEnvironmentPostProcessor.class);
+
+    @Override
+    public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
+        if (!environment.containsProperty("liquibase.enabled")) {
+            LOGGER.warn("Liquibase has not been explicitly enabled or disabled. Overriding default from Spring Boot from `true` to `false`. "
+                + "Flowable pulls in Liquibase, but does not use the Spring Boot configuration for it. "
+                + "If you are using it you would need to set `liquibase.enabled` to `true` by yourself");
+            Map<String, Object> source = new HashMap<>();
+            source.put("liquibase.enabled", false);
+            environment.getPropertySources().addLast(new MapPropertySource("flowable-liquibase-override", source));
+        }
+    }
+}

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,4 +1,7 @@
 
+org.springframework.boot.env.EnvironmentPostProcessor=\
+  org.flowable.spring.boot.environment.FlowableLiquibaseEnvironmentPostProcessor
+
 # Flowable auto-configurations
 
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\


### PR DESCRIPTION
Flowable engines pull Liquibase and Spring Boot starts the autoconfiguration which causes failures.
Therefore we are disabling Liquibase per default. Users have to explicitly enable it by setting liquibase.enabled to true