### PR TITLE
Use single property to configure the schema update of all engines in the same time

### DIFF
--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/FlowableProperties.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/FlowableProperties.java
@@ -39,6 +39,9 @@ public class FlowableProperties {
     private String mailServerDefaultFrom;
     private boolean mailServerUseSsl;
     private boolean mailServerUseTls;
+    /**
+     * The strategy that should be used for the database schema.
+     */
     private String databaseSchemaUpdate = "true";
     private String databaseSchema;
     /**

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/ProcessEngineAutoConfiguration.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/ProcessEngineAutoConfiguration.java
@@ -118,7 +118,6 @@ public class ProcessEngineAutoConfiguration extends AbstractEngineAutoConfigurat
         conf.setEnableSafeBpmnXml(processProperties.isEnableSafeXml());
 
         conf.setHistoryLevel(flowableProperties.getHistoryLevel());
-        conf.setDatabaseSchemaUpdate(processProperties.getDatabaseSchemaUpdate());
 
         processEngineConfigurationConfigurers.forEach(configurator -> configurator.configure(conf));
 

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/cmmn/CmmnEngineAutoConfiguration.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/cmmn/CmmnEngineAutoConfiguration.java
@@ -109,7 +109,6 @@ public class CmmnEngineAutoConfiguration extends AbstractEngineAutoConfiguration
         configuration.setHistoryLevel(flowableProperties.getHistoryLevel());
 
         configuration.setEnableSafeCmmnXml(cmmnProperties.isEnableSafeXml());
-        configuration.setDatabaseSchemaUpdate(cmmnProperties.getDatabaseSchemaUpdate());
 
         return configuration;
     }

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/cmmn/FlowableCmmnProperties.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/cmmn/FlowableCmmnProperties.java
@@ -62,11 +62,6 @@ public class FlowableCmmnProperties {
     private boolean enableSafeXml = true;
 
     /**
-     * The strategy that should be used for the database schema.
-     */
-    private String databaseSchemaUpdate = "true";
-
-    /**
      * The servlet configuration for the CMMN Rest API.
      */
     @NestedConfigurationProperty
@@ -118,14 +113,6 @@ public class FlowableCmmnProperties {
 
     public void setEnableSafeXml(boolean enableSafeXml) {
         this.enableSafeXml = enableSafeXml;
-    }
-
-    public String getDatabaseSchemaUpdate() {
-        return databaseSchemaUpdate;
-    }
-
-    public void setDatabaseSchemaUpdate(String databaseSchemaUpdate) {
-        this.databaseSchemaUpdate = databaseSchemaUpdate;
     }
 
     public FlowableServlet getServlet() {

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/dmn/DmnEngineAutoConfiguration.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/dmn/DmnEngineAutoConfiguration.java
@@ -88,7 +88,6 @@ public class DmnEngineAutoConfiguration extends AbstractEngineAutoConfiguration 
 
         configuration.setHistoryEnabled(dmnProperties.isHistoryEnabled());
         configuration.setEnableSafeDmnXml(dmnProperties.isEnableSafeXml());
-        configuration.setDatabaseSchemaUpdate(dmnProperties.getDatabaseSchemaUpdate());
 
         return configuration;
     }

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/dmn/FlowableDmnProperties.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/dmn/FlowableDmnProperties.java
@@ -67,11 +67,6 @@ public class FlowableDmnProperties {
     private boolean enableSafeXml = true;
 
     /**
-     * The strategy that should be used for the database schema.
-     */
-    private String databaseSchemaUpdate = "true";
-
-    /**
      * The servlet configuration for the DMN Rest API.
      */
     @NestedConfigurationProperty
@@ -131,14 +126,6 @@ public class FlowableDmnProperties {
 
     public void setEnableSafeXml(boolean enableSafeXml) {
         this.enableSafeXml = enableSafeXml;
-    }
-
-    public String getDatabaseSchemaUpdate() {
-        return databaseSchemaUpdate;
-    }
-
-    public void setDatabaseSchemaUpdate(String databaseSchemaUpdate) {
-        this.databaseSchemaUpdate = databaseSchemaUpdate;
     }
 
     public FlowableServlet getServlet() {

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/form/FlowableFormProperties.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/form/FlowableFormProperties.java
@@ -56,11 +56,6 @@ public class FlowableFormProperties {
     private boolean enabled = true;
 
     /**
-     * The strategy that should be used for the database schema.
-     */
-    private String databaseSchemaUpdate = "true";
-
-    /**
      * The servlet configuration for the Form Rest API.
      */
     @NestedConfigurationProperty
@@ -104,14 +99,6 @@ public class FlowableFormProperties {
 
     public void setEnabled(boolean enabled) {
         this.enabled = enabled;
-    }
-
-    public String getDatabaseSchemaUpdate() {
-        return databaseSchemaUpdate;
-    }
-
-    public void setDatabaseSchemaUpdate(String databaseSchemaUpdate) {
-        this.databaseSchemaUpdate = databaseSchemaUpdate;
     }
 
     public FlowableServlet getServlet() {

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/form/FormEngineAutoConfiguration.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/form/FormEngineAutoConfiguration.java
@@ -86,8 +86,6 @@ public class FormEngineAutoConfiguration extends AbstractEngineAutoConfiguration
         configureSpringEngine(configuration, platformTransactionManager);
         configureEngine(configuration, dataSource);
 
-        configuration.setDatabaseSchemaUpdate(formProperties.getDatabaseSchemaUpdate());
-
         return configuration;
     }
 

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/process/FlowableProcessProperties.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/process/FlowableProcessProperties.java
@@ -41,11 +41,6 @@ public class FlowableProcessProperties {
      */
     private boolean enableSafeXml = true;
 
-    /**
-     * The strategy that should be used for the database schema.
-     */
-    private String databaseSchemaUpdate = "true";
-
     public FlowableServlet getServlet() {
         return servlet;
     }
@@ -66,11 +61,4 @@ public class FlowableProcessProperties {
         this.enableSafeXml = enableSafeXml;
     }
 
-    public String getDatabaseSchemaUpdate() {
-        return databaseSchemaUpdate;
-    }
-
-    public void setDatabaseSchemaUpdate(String databaseSchemaUpdate) {
-        this.databaseSchemaUpdate = databaseSchemaUpdate;
-    }
 }

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -105,102 +105,27 @@
   ],
   "hints": [
     {
-      "name": "flowable.process.database-schema-update",
+      "name": "flowable.database-schema-update",
       "values": [
         {
           "value": "true",
-          "description": "Upon building of the process engine, a check is performed and an update of the schema is performed if it is necessary."
+          "description": "Upon building of the engine(s), a check is performed and an update of the schema is performed if it is necessary."
         },
         {
           "value": "drop-create",
-          "description": "The schema is dropped and then created during the process engine startup."
+          "description": "The schema is dropped and then created during the engine(s) startup."
         },
         {
           "value": "create-drop",
-          "description": "The schema is created during the process engine startup and dropped during the close of the engine."
+          "description": "The schema is created during the engine(s) startup and dropped during the close of the engine(s)."
         },
         {
           "value": "create",
-          "description": "The schema is created during the process engine startup."
+          "description": "The schema is created during the engine(s) startup."
         },
         {
           "value": "false",
-          "description": "Checks the version of the DB schema against the library when the process engine is being created and throws an exception if the versions don't match."
-        }
-      ]
-    },
-    {
-      "name": "flowable.cmmn.database-schema-update",
-      "values": [
-        {
-          "value": "true",
-          "description": "Upon building of the CMMN engine, a check is performed and an update of the schema is performed if it is necessary."
-        },
-        {
-          "value": "drop-create",
-          "description": "The schema is dropped and then created during the CMMN engine startup."
-        },
-        {
-          "value": "create-drop",
-          "description": "The schema is created during the CMMN engine startup and dropped during the close of the engine."
-        },
-        {
-          "value": "create",
-          "description": "The schema is created during the CMMN engine startup."
-        },
-        {
-          "value": "false",
-          "description": "Checks the version of the DB schema against the library when the CMMN engine is being created and throws an exception if the versions don't match."
-        }
-      ]
-    },
-    {
-      "name": "flowable.dmn.database-schema-update",
-      "values": [
-        {
-          "value": "true",
-          "description": "Upon building of the DMN engine, a check is performed and an update of the schema is performed if it is necessary."
-        },
-        {
-          "value": "drop-create",
-          "description": "The schema is dropped and then created during the DMN engine startup."
-        },
-        {
-          "value": "create-drop",
-          "description": "The schema is created during the DMN engine startup and dropped during the close of the engine."
-        },
-        {
-          "value": "create",
-          "description": "The schema is created during the DMN engine startup."
-        },
-        {
-          "value": "false",
-          "description": "Checks the version of the DB schema against the library when the DMN engine is being created and throws an exception if the versions don't match."
-        }
-      ]
-    },
-    {
-      "name": "flowable.form.database-schema-update",
-      "values": [
-        {
-          "value": "true",
-          "description": "Upon building of the form engine, a check is performed and an update of the schema is performed if it is necessary."
-        },
-        {
-          "value": "drop-create",
-          "description": "The schema is dropped and then created during the form engine startup."
-        },
-        {
-          "value": "create-drop",
-          "description": "The schema is created during the form engine startup and dropped during the close of the engine."
-        },
-        {
-          "value": "create",
-          "description": "The schema is created during the form engine startup."
-        },
-        {
-          "value": "false",
-          "description": "Checks the version of the DB schema against the library when the form engine is being created and throws an exception if the versions don't match."
+          "description": "Checks the version of the DB schema against the library when the engine(s) is(are) being created and throws an exception if the versions don't match."
         }
       ]
     }


### PR DESCRIPTION
I did a mistake in #885 when I added the property to all of the engines properties separately. 

The property was already there, in the FlowableProperties