### PR TITLE
fix-rtl-labeling-problem

### DIFF
--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/oryx-editor-code/scripts/Core/SVG/label.js
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/oryx-editor-code/scripts/Core/SVG/label.js
@@ -78,7 +78,7 @@ ORYX.Core.SVG.Label = Clazz.extend({
 		
 		
 		this.node.setAttributeNS(null, 'stroke-width', '0pt');
-		this.node.setAttributeNS(null, 'letter-spacing', '-0.01px');
+		this.node.setAttributeNS(null, 'letter-spacing', '0px');
 		
 		this.shapeId = options.shapeId;
 		


### PR DESCRIPTION
In modeler application, setting English character in name attribute for BPMN elements such as userTask, serviceTask,etc , all things are good. But, When using right-to-left alignment languages such as Persian (also know as Farsi), Arabic, Hebrew, showing output in UI were un-readble, because align is left-to-right and the alphabets were distinct from together. Changeling "letter-spacing" attribute from negative value to zero solved the problem.