### PR TITLE
Add modeler app multi tenancy support

### DIFF
--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/BaseSpringRestTestCase.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/BaseSpringRestTestCase.java
@@ -273,6 +273,10 @@ public class BaseSpringRestTestCase {
      * IMPORTANT: calling method is responsible for calling close() on returned {@link HttpResponse} to free the connection.
      */
     public CloseableHttpResponse executeBinaryRequest(HttpUriRequest request, int expectedStatusCode) {
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+        }
         return internalExecuteRequest(request, expectedStatusCode, false);
     }
 

--- a/modules/flowable-ui-common/src/main/java/org/flowable/app/tenant/DefaultTenantProvider.java
+++ b/modules/flowable-ui-common/src/main/java/org/flowable/app/tenant/DefaultTenantProvider.java
@@ -1,0 +1,57 @@
+package org.flowable.app.tenant;
+
+import org.apache.commons.lang3.StringUtils;
+import org.flowable.app.security.FlowableAppUser;
+import org.flowable.app.security.SecurityUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DefaultTenantProvider implements TenantProvider {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultTenantProvider.class);
+
+    private String tenantId;
+    
+    public DefaultTenantProvider(Environment environment) {
+        super();
+        String configuredTenantId = environment.getProperty("tenant.tenant_id");
+        if(! StringUtils.isBlank(configuredTenantId)) {
+            // trim whitespace as trailing whitespace are possible in properties files and easy to do
+            configuredTenantId = configuredTenantId.trim();
+            if(LOGGER.isDebugEnabled()) {
+                // quotes can help solve whitespace issues
+                LOGGER.debug("Found configured tenantId: '" + configuredTenantId + "'");
+            }
+            this.tenantId = configuredTenantId;
+        }
+    }
+
+    @Override
+    public String getTenantId() {
+        if(tenantId != null) {
+            if(LOGGER.isTraceEnabled()) {
+                LOGGER.trace("Using configured tenantId: '" + tenantId + "'");
+            }
+            return tenantId;
+        }
+        
+        FlowableAppUser appUser = SecurityUtils.getCurrentFlowableAppUser();
+        if(appUser != null) {
+            if(LOGGER.isTraceEnabled()) {
+                // quotes can help solve whitespace issues, trimming here would not 
+                // help solve the problem at source which is in user database
+                LOGGER.trace("Using user tenantId: '" + tenantId + "'");
+            }
+            return appUser.getUserObject().getTenantId();
+        }
+
+        if(LOGGER.isTraceEnabled()) {
+            LOGGER.trace("No tenantId");
+        }
+
+        return null;
+    }
+    
+}

--- a/modules/flowable-ui-common/src/main/java/org/flowable/app/tenant/TenantProvider.java
+++ b/modules/flowable-ui-common/src/main/java/org/flowable/app/tenant/TenantProvider.java
@@ -1,0 +1,6 @@
+package org.flowable.app.tenant;
+
+
+public interface TenantProvider {
+    public String getTenantId();
+}

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/resources/META-INF/flowable-app/flowable-app.properties
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/resources/META-INF/flowable-app/flowable-app.properties
@@ -62,6 +62,6 @@ rest.authentication.mode = verify-privilege
 # For the modeler this determines under which tenant_id to store and publish models
 # When not provided, empty or only contains whitespace it defaults to the user's tenant id if available 
 # otherwise it uses no tenant id
-tenant.tenant_id=demo
+#tenant.tenant_id=demo
 
 

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/resources/META-INF/flowable-app/flowable-app.properties
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/resources/META-INF/flowable-app/flowable-app.properties
@@ -57,3 +57,11 @@ rest.modeler-app.enabled=true
 # 'verify-privilege' : the user needs to exist, the password needs to match and the user needs to have the 'rest-api' privilege
 # If nothing set, defaults to 'verify-privilege'
 rest.authentication.mode = verify-privilege
+
+# Set the tenant_id 
+# For the modeler this determines under which tenant_id to store and publish models
+# When not provided, empty or only contains whitespace it defaults to the user's tenant id if available 
+# otherwise it uses no tenant id
+tenant.tenant_id=demo
+
+

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-conf/src/main/java/org/flowable/app/conf/ApplicationConfiguration.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-conf/src/main/java/org/flowable/app/conf/ApplicationConfiguration.java
@@ -39,6 +39,7 @@ import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
         "org.flowable.app.service",
         "org.flowable.app.filter",
         "org.flowable.app.security",
+        "org.flowable.app.tenant",
         "org.flowable.app.model.component" })
 public class ApplicationConfiguration {
 

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/domain/editor/AbstractModel.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/domain/editor/AbstractModel.java
@@ -34,6 +34,7 @@ public class AbstractModel {
     protected String modelEditorJson;
     protected String comment;
     protected Integer modelType;
+    protected String tenantId;
 
     public AbstractModel() {
         this.created = new Date();
@@ -135,4 +136,12 @@ public class AbstractModel {
         this.modelType = modelType;
     }
 
+    public String getTenantId() {
+        return tenantId;
+    }
+    
+    public void setTenantId(String tenantId) {
+        this.tenantId = tenantId;
+    }
+    
 }

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/model/editor/ModelRepresentation.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/model/editor/ModelRepresentation.java
@@ -37,6 +37,7 @@ public class ModelRepresentation extends AbstractRepresentation {
     protected int version;
     protected String comment;
     protected Integer modelType;
+    protected String tenantId;
 
     public ModelRepresentation(AbstractModel model) {
         initialize(model);
@@ -57,6 +58,7 @@ public class ModelRepresentation extends AbstractRepresentation {
         this.lastUpdatedBy = model.getLastUpdatedBy();
         this.comment = model.getComment();
         this.modelType = model.getModelType();
+        this.tenantId = model.getTenantId();
 
         // When based on a ProcessModel and not history, this is always the latest version
         if (model instanceof Model) {
@@ -152,6 +154,14 @@ public class ModelRepresentation extends AbstractRepresentation {
 
     public void setModelType(Integer modelType) {
         this.modelType = modelType;
+    }
+
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    public void setTenantId(String tenantId) {
+        this.tenantId = tenantId;
     }
 
     public Model toModel() {

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/repository/editor/ModelHistoryRepositoryImpl.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/repository/editor/ModelHistoryRepositoryImpl.java
@@ -18,6 +18,7 @@ import java.util.Map;
 
 import org.flowable.app.domain.editor.ModelHistory;
 import org.flowable.app.repository.UuidIdGenerator;
+import org.flowable.app.tenant.TenantProvider;
 import org.mybatis.spring.SqlSessionTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -32,6 +33,9 @@ public class ModelHistoryRepositoryImpl implements ModelHistoryRepository {
 
     @Autowired
     protected UuidIdGenerator idGenerator;
+    
+    @Autowired
+    protected TenantProvider tenantProvider;
 
     @Override
     public ModelHistory get(String id) {
@@ -42,6 +46,7 @@ public class ModelHistoryRepositoryImpl implements ModelHistoryRepository {
         Map<String, Object> params = new HashMap<>();
         params.put("modelType", modelType);
         params.put("createdBy", createdBy);
+        params.put("tenantId", tenantProvider.getTenantId());
         return sqlSessionTemplate.selectList(NAMESPACE + "selectModelHistoryByTypeAndCreatedBy", params);
     }
 
@@ -51,6 +56,7 @@ public class ModelHistoryRepositoryImpl implements ModelHistoryRepository {
 
     @Override
     public void save(ModelHistory modelHistory) {
+        modelHistory.setTenantId(tenantProvider.getTenantId());
         if (modelHistory.getId() == null) {
             modelHistory.setId(idGenerator.generateId());
             sqlSessionTemplate.insert(NAMESPACE + "insertModelHistory", modelHistory);

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/repository/editor/ModelRepositoryImpl.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/repository/editor/ModelRepositoryImpl.java
@@ -18,6 +18,7 @@ import java.util.Map;
 
 import org.flowable.app.domain.editor.Model;
 import org.flowable.app.repository.UuidIdGenerator;
+import org.flowable.app.tenant.TenantProvider;
 import org.mybatis.spring.SqlSessionTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -32,6 +33,9 @@ public class ModelRepositoryImpl implements ModelRepository {
 
     @Autowired
     protected UuidIdGenerator idGenerator;
+    
+    @Autowired
+    protected TenantProvider tenantProvider;
 
     @Override
     public Model get(String id) {
@@ -73,15 +77,18 @@ public class ModelRepositoryImpl implements ModelRepository {
         Map<String, Object> params = new HashMap<>();
         params.put("createdBy", createdBy);
         params.put("modelType", modelType);
+        params.put("tenantId", tenantProvider.getTenantId());
         return sqlSessionTemplate.selectOne(NAMESPACE + "countByModelTypeAndCreatedBy", params);
     }
 
     protected List<Model> findModelsByParameters(Map<String, Object> parameters) {
+        parameters.put("tenantId", tenantProvider.getTenantId());
         return sqlSessionTemplate.selectList(NAMESPACE + "selectModelByParameters", parameters);
     }
 
     @Override
     public void save(Model model) {
+        model.setTenantId(tenantProvider.getTenantId());
         if (model.getId() == null) {
             model.setId(idGenerator.generateId());
             sqlSessionTemplate.insert(NAMESPACE + "insertModel", model);

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/service/editor/ModelServiceImpl.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/app/service/editor/ModelServiceImpl.java
@@ -330,6 +330,7 @@ public class ModelServiceImpl implements ModelService {
         newModel.setModelEditorJson(editorJson);
         newModel.setLastUpdated(Calendar.getInstance().getTime());
         newModel.setLastUpdatedBy(createdBy.getId());
+        newModel.setTenantId(model.getTenantId());
 
         persistModel(newModel);
         return newModel;
@@ -830,6 +831,7 @@ public class ModelServiceImpl implements ModelService {
         historyModel.setVersion(model.getVersion());
         historyModel.setModelId(model.getId());
         historyModel.setComment(model.getComment());
+        historyModel.setTenantId(model.getTenantId());
 
         return historyModel;
     }
@@ -846,6 +848,7 @@ public class ModelServiceImpl implements ModelService {
         model.setModelType(basedOn.getModelType());
         model.setVersion(basedOn.getVersion());
         model.setComment(basedOn.getComment());
+        model.setTenantId(basedOn.getTenantId());
     }
 
     protected Map<String, String> convertToModelKeyMap(Map<String, Model> modelMap) {

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/resources/META-INF/liquibase/flowable-modeler-app-db-changelog.xml
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/resources/META-INF/liquibase/flowable-modeler-app-db-changelog.xml
@@ -141,4 +141,13 @@
         
     </changeSet>
 
+    <changeSet id="3" author="flowable">
+        <addColumn tableName="ACT_DE_MODEL">
+            <column  name="tenant_id" type="varchar(255)" />
+        </addColumn>
+        <addColumn tableName="ACT_DE_MODEL_HISTORY">
+            <column  name="tenant_id" type="varchar(255)" />
+        </addColumn>
+    </changeSet>
+
 </databaseChangeLog>

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/resources/META-INF/modeler-mybatis-mappings/Model.xml
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/resources/META-INF/modeler-mybatis-mappings/Model.xml
@@ -120,6 +120,9 @@
     <select id="countByModelTypeAndCreatedBy" parameterType="map">
        select count(m.id) from ${prefix}ACT_DE_MODEL m 
        where m.created_by = #{createdBy, jdbcType=VARCHAR} and m.model_type = #{modelType, jdbcType=INTEGER}
+      <if test="tenantId != null">
+         and tenant_id = #{tenantId, jdbcType=VARCHAR}
+      </if>
     </select>
 
     <delete id="deleteModel" parameterType="org.flowable.app.domain.editor.Model">

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/resources/META-INF/modeler-mybatis-mappings/Model.xml
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/resources/META-INF/modeler-mybatis-mappings/Model.xml
@@ -4,21 +4,22 @@
 
 <mapper namespace="org.flowable.app.domain.editor.Model">
 
-	<resultMap id="modelResultMap" type="org.flowable.app.domain.editor.Model">
-		<id property="id" column="id" jdbcType="VARCHAR" />
-		<result property="name" column="name" jdbcType="VARCHAR" />
-		<result property="key" column="model_key" jdbcType="VARCHAR" />
-		<result property="description" column="description" jdbcType="VARCHAR" />
-		<result property="comment" column="model_comment" jdbcType="VARCHAR" />
-		<result property="created" column="created" jdbcType="TIMESTAMP" />
-		<result property="createdBy" column="created_by" jdbcType="VARCHAR" />
-		<result property="lastUpdated" column="last_updated" jdbcType="TIMESTAMP" />
-		<result property="lastUpdatedBy" column="last_updated_by" jdbcType="VARCHAR" />
-		<result property="version" column="version" jdbcType="INTEGER" />
-		<result property="modelEditorJson" column="model_editor_json" jdbcType="VARCHAR" />
-		<result property="modelType" column="model_type" jdbcType="INTEGER" />
-		<result property="thumbnail" column="thumbnail" jdbcType="${blobType}" />
-	</resultMap>
+    <resultMap id="modelResultMap" type="org.flowable.app.domain.editor.Model">
+        <id property="id" column="id" jdbcType="VARCHAR" />
+        <result property="name" column="name" jdbcType="VARCHAR" />
+        <result property="key" column="model_key" jdbcType="VARCHAR" />
+        <result property="description" column="description" jdbcType="VARCHAR" />
+        <result property="comment" column="model_comment" jdbcType="VARCHAR" />
+        <result property="created" column="created" jdbcType="TIMESTAMP" />
+        <result property="createdBy" column="created_by" jdbcType="VARCHAR" />
+        <result property="lastUpdated" column="last_updated" jdbcType="TIMESTAMP" />
+        <result property="lastUpdatedBy" column="last_updated_by" jdbcType="VARCHAR" />
+        <result property="version" column="version" jdbcType="INTEGER" />
+        <result property="modelEditorJson" column="model_editor_json" jdbcType="VARCHAR" />
+        <result property="modelType" column="model_type" jdbcType="INTEGER" />
+        <result property="thumbnail" column="thumbnail" jdbcType="${blobType}" />
+        <result property="tenantId" column="tenantId" jdbcType="VARCHAR" />
+    </resultMap>
 
     <insert id="insertModel" parameterType="org.flowable.app.domain.editor.Model">
         insert into ${prefix}ACT_DE_MODEL (
@@ -34,7 +35,8 @@
             version,
             model_editor_json,
             model_type,
-            thumbnail) 
+            thumbnail,
+            tenant_id) 
          values (
             #{id, jdbcType=VARCHAR},
             #{name, jdbcType=VARCHAR},
@@ -48,7 +50,8 @@
             #{version, jdbcType=INTEGER},
             #{modelEditorJson, jdbcType=VARCHAR},
             #{modelType, jdbcType=INTEGER},
-            #{thumbnail, jdbcType=${blobType}}
+            #{thumbnail, jdbcType=${blobType}},
+            #{tenantId, jdbcType=VARCHAR}
           )
     </insert>
     
@@ -66,57 +69,61 @@
             version = #{version, jdbcType=INTEGER},
             model_editor_json = #{modelEditorJson, jdbcType=VARCHAR},
             model_type = #{modelType, jdbcType=INTEGER},
-            thumbnail = #{thumbnail, jdbcType=${blobType}}
+            thumbnail = #{thumbnail, jdbcType=${blobType}},
+            tenant_id = #{tenantId, jdbcType=VARCHAR}
         </set>
         where id = #{id, jdbcType=VARCHAR}
     </update>
     
-	<select id="selectModel" parameterType="string" resultMap="modelResultMap">
-		select * from ${prefix}ACT_DE_MODEL where id = #{id, jdbcType=VARCHAR}
-	</select>
-	
-	<select id="selectModelByParentModelId" parameterType="string" resultMap="modelResultMap">
-	   select model.* from ${prefix}ACT_DE_MODEL_RELATION modelrelation 
-	   inner join ${prefix}ACT_DE_MODEL model on modelrelation.model_id = model.id
-	   where modelrelation.parent_model_id = #{parentModelId, jdbcType=VARCHAR}
-	</select>
-	
-	<select id="selectModelByParameters" parameterType="map" resultMap="modelResultMap">
-		select * from ${prefix}ACT_DE_MODEL
-	   	<where> 
-		   	<if test="modelType != null">
-		       model_type = #{modelType, jdbcType=VARCHAR}
-		   	</if>
-		   	<if test="filter != null">
-	           and (lower(name) like #{filter, jdbcType=VARCHAR} or lower(description) like #{filter, jdbcType=VARCHAR}) 
-	      	</if>
-	      	<if test="key != null">
-	           and model_key = #{key, jdbcType=VARCHAR}
-	      	</if>
-      	</where>
-      	<if test="sort != null">
-	        <if test="sort == 'nameAsc'">
-	            order by name asc
-	        </if>
-	        <if test="sort == 'nameDesc'">
-	            order by name desc
-	        </if>
-	        <if test="sort == 'modifiedAsc'">
-	            order by last_updated asc
-	        </if>
-	        <if test="sort == 'modifiedDesc'">
-	            order by last_updated desc
-	        </if>
-      	</if>
-	</select>
-	
-	<select id="countByModelTypeAndCreatedBy" parameterType="map">
-	   select count(m.id) from ${prefix}ACT_DE_MODEL m 
-	   where m.created_by = #{createdBy, jdbcType=VARCHAR} and m.model_type = #{modelType, jdbcType=INTEGER}
-	</select>
+    <select id="selectModel" parameterType="string" resultMap="modelResultMap">
+        select * from ${prefix}ACT_DE_MODEL where id = #{id, jdbcType=VARCHAR}
+    </select>
+    
+    <select id="selectModelByParentModelId" parameterType="string" resultMap="modelResultMap">
+       select model.* from ${prefix}ACT_DE_MODEL_RELATION modelrelation 
+       inner join ${prefix}ACT_DE_MODEL model on modelrelation.model_id = model.id
+       where modelrelation.parent_model_id = #{parentModelId, jdbcType=VARCHAR}
+    </select>
+    
+    <select id="selectModelByParameters" parameterType="map" resultMap="modelResultMap">
+        select * from ${prefix}ACT_DE_MODEL
+        <where> 
+            <if test="modelType != null">
+               model_type = #{modelType, jdbcType=VARCHAR}
+            </if>
+            <if test="filter != null">
+               and (lower(name) like #{filter, jdbcType=VARCHAR} or lower(description) like #{filter, jdbcType=VARCHAR}) 
+            </if>
+            <if test="key != null">
+               and model_key = #{key, jdbcType=VARCHAR}
+            </if>
+            <if test="tenantId != null">
+               and tenant_id = #{tenantId, jdbcType=VARCHAR}
+            </if>
+        </where>
+        <if test="sort != null">
+            <if test="sort == 'nameAsc'">
+                order by name asc
+            </if>
+            <if test="sort == 'nameDesc'">
+                order by name desc
+            </if>
+            <if test="sort == 'modifiedAsc'">
+                order by last_updated asc
+            </if>
+            <if test="sort == 'modifiedDesc'">
+                order by last_updated desc
+            </if>
+        </if>
+    </select>
+    
+    <select id="countByModelTypeAndCreatedBy" parameterType="map">
+       select count(m.id) from ${prefix}ACT_DE_MODEL m 
+       where m.created_by = #{createdBy, jdbcType=VARCHAR} and m.model_type = #{modelType, jdbcType=INTEGER}
+    </select>
 
-	<delete id="deleteModel" parameterType="org.flowable.app.domain.editor.Model">
-		delete from ${prefix}ACT_DE_MODEL where id = #{id}
-	</delete>
+    <delete id="deleteModel" parameterType="org.flowable.app.domain.editor.Model">
+        delete from ${prefix}ACT_DE_MODEL where id = #{id}
+    </delete>
     
 </mapper>

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/resources/META-INF/modeler-mybatis-mappings/ModelHistory.xml
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/resources/META-INF/modeler-mybatis-mappings/ModelHistory.xml
@@ -87,7 +87,7 @@
        where created_by = #{createdBy, jdbcType=VARCHAR}
        and model_type = #{modelType, jdbcType=INTEGER}
        and removal_date is null
-      <if test="modelType != null">
+      <if test="tenantId != null">
        and tenant_id = #{tenantId, jdbcType=VARCHAR}
       </if>
     </select>

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/resources/META-INF/modeler-mybatis-mappings/ModelHistory.xml
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/resources/META-INF/modeler-mybatis-mappings/ModelHistory.xml
@@ -4,22 +4,23 @@
 
 <mapper namespace="org.flowable.app.domain.editor.ModelHistory">
 
-	<resultMap id="modelHistoryResultMap" type="org.flowable.app.domain.editor.ModelHistory">
-		<id property="id" column="id" jdbcType="VARCHAR" />
-		<result property="name" column="name" jdbcType="VARCHAR" />
-		<result property="key" column="model_key" jdbcType="VARCHAR" />
-		<result property="description" column="description" jdbcType="VARCHAR" />
-		<result property="comment" column="model_comment" jdbcType="VARCHAR" />
-		<result property="created" column="created" jdbcType="TIMESTAMP" />
-		<result property="createdBy" column="created_by" jdbcType="VARCHAR" />
-		<result property="lastUpdated" column="last_updated" jdbcType="TIMESTAMP" />
-		<result property="lastUpdatedBy" column="last_updated_by" jdbcType="VARCHAR" />
-		<result property="version" column="version" jdbcType="INTEGER" />
-		<result property="modelEditorJson" column="model_editor_json" jdbcType="VARCHAR" />
-		<result property="modelType" column="model_type" jdbcType="INTEGER" />
-		<result property="modelId" column="model_id" jdbcType="VARCHAR" />
-		<result property="removalDate" column="removal_date" jdbcType="TIMESTAMP" />
-	</resultMap>
+    <resultMap id="modelHistoryResultMap" type="org.flowable.app.domain.editor.ModelHistory">
+        <id property="id" column="id" jdbcType="VARCHAR" />
+        <result property="name" column="name" jdbcType="VARCHAR" />
+        <result property="key" column="model_key" jdbcType="VARCHAR" />
+        <result property="description" column="description" jdbcType="VARCHAR" />
+        <result property="comment" column="model_comment" jdbcType="VARCHAR" />
+        <result property="created" column="created" jdbcType="TIMESTAMP" />
+        <result property="createdBy" column="created_by" jdbcType="VARCHAR" />
+        <result property="lastUpdated" column="last_updated" jdbcType="TIMESTAMP" />
+        <result property="lastUpdatedBy" column="last_updated_by" jdbcType="VARCHAR" />
+        <result property="version" column="version" jdbcType="INTEGER" />
+        <result property="modelEditorJson" column="model_editor_json" jdbcType="VARCHAR" />
+        <result property="modelType" column="model_type" jdbcType="INTEGER" />
+        <result property="modelId" column="model_id" jdbcType="VARCHAR" />
+        <result property="removalDate" column="removal_date" jdbcType="TIMESTAMP" />
+        <result property="tenantId" column="tenant_id" jdbcType="VARCHAR" />
+    </resultMap>
 
     <insert id="insertModelHistory" parameterType="org.flowable.app.domain.editor.ModelHistory">
         insert into ${prefix}ACT_DE_MODEL_HISTORY (
@@ -36,7 +37,8 @@
             model_editor_json,
             model_type,
             model_id,
-            removal_date) 
+            removal_date,
+            tenant_id) 
          values (
              #{id, jdbcType=VARCHAR},
             #{name, jdbcType=VARCHAR},
@@ -51,7 +53,8 @@
             #{modelEditorJson, jdbcType=VARCHAR},
             #{modelType, jdbcType=INTEGER},
             #{modelId, jdbcType=VARCHAR},
-            #{removalDate, jdbcType=TIMESTAMP}
+            #{removalDate, jdbcType=TIMESTAMP},
+            #{tenantId, jdbcType=VARCHAR}
           )
     </insert>
     
@@ -69,23 +72,27 @@
             version = #{version, jdbcType=INTEGER},
             model_editor_json = #{modelEditorJson, jdbcType=VARCHAR},
             model_id = #{modelId, jdbcType=VARCHAR},
-            removal_date = #{removalDate, jdbcType=TIMESTAMP}
+            removal_date = #{removalDate, jdbcType=TIMESTAMP},
+            tenant_id = #{tenantId, jdbcType=VARCHAR}
         </set>
         where id = #{id, jdbcType=VARCHAR}
     </update>
 
-	<select id="selectModelHistory" parameterType="string" resultMap="modelHistoryResultMap">
-		select * from ${prefix}ACT_DE_MODEL_HISTORY where id = #{id, jdbcType=VARCHAR}
-	</select>
-	
-	<select id="selectModelHistoryByTypeAndCreatedBy" parameterType="map" resultMap="modelHistoryResultMap">
-	   select * from ${prefix}ACT_DE_MODEL_HISTORY 
-	   where created_by = #{createdBy, jdbcType=VARCHAR}
-	   and model_type = #{modelType, jdbcType=INTEGER}
-	   and removal_date is null
-	</select>
-	
-	<select id="selectModelHistoryByModelId" parameterType="string" resultMap="modelHistoryResultMap">
+    <select id="selectModelHistory" parameterType="string" resultMap="modelHistoryResultMap">
+        select * from ${prefix}ACT_DE_MODEL_HISTORY where id = #{id, jdbcType=VARCHAR}
+    </select>
+    
+    <select id="selectModelHistoryByTypeAndCreatedBy" parameterType="map" resultMap="modelHistoryResultMap">
+       select * from ${prefix}ACT_DE_MODEL_HISTORY 
+       where created_by = #{createdBy, jdbcType=VARCHAR}
+       and model_type = #{modelType, jdbcType=INTEGER}
+       and removal_date is null
+      <if test="modelType != null">
+       and tenant_id = #{tenantId, jdbcType=VARCHAR}
+      </if>
+    </select>
+    
+    <select id="selectModelHistoryByModelId" parameterType="string" resultMap="modelHistoryResultMap">
        select * from ${prefix}ACT_DE_MODEL_HISTORY 
        where model_id = #{modelId, jdbcType=VARCHAR}
        and removal_date is null
@@ -94,5 +101,5 @@
     <delete id="deleteModelHistory" parameterType="org.flowable.app.domain.editor.ModelHistory">
         delete from ${prefix}ACT_DE_MODEL_HISTORY where id = #{id, jdbcType=VARCHAR}
     </delete>
-	
+    
 </mapper>


### PR DESCRIPTION
This pull request adds tenant_id to modeler database tables and provides a TenantProvider interface through which the application access and applies tenancy.

The default tenant provider will look up the tenant id from the Environment (eg. app's properties file) and if not found uses the user's tenant_id (this was newly added by @martin-grofcik and is not yet supported in idm app) and uses null as last resort. This should be backwards compatible with existing installations which would neither have the tenant_id configuration property nor the user tenant_id. Also once tenant_id is implemented on users, the configuration property allows overriding this.

The mybatis xml files were updated to use spaces, as there was a mix of spaces and tabs in the file. Let me know if this is not ok.

I preferred adding tenant_id to both model and model_history as they are often queried separately and this avoids joining, but left it out from model_relation as joins are typically by id. In some situations like using Postgres RLS enforcement of tenancy it is simpler and safer to just add tenant_id to all tables, but I noticed this was not the general approach with other tables.


