### PR TITLE
Http task timeout best paired with socket timeout

### DIFF
--- a/modules/flowable-http/src/main/java/org/flowable/http/HttpActivityExecutor.java
+++ b/modules/flowable-http/src/main/java/org/flowable/http/HttpActivityExecutor.java
@@ -299,9 +299,9 @@ public class HttpActivityExecutor {
     protected void setConfig(final HttpRequestBase base, final HttpRequest requestInfo, int socketTimeout, int connectTimeout, int connectionRequestTimeout) {
         base.setConfig(RequestConfig.custom()
                 .setRedirectsEnabled(!requestInfo.isNoRedirects())
-                .setSocketTimeout(socketTimeout)
+                .setSocketTimeout(requestInfo.getTimeout() == 0 ? socketTimeout : requestInfo.getTimeout())
                 .setConnectTimeout(connectTimeout)
-                .setConnectionRequestTimeout(requestInfo.getTimeout() == 0 ? connectionRequestTimeout : requestInfo.getTimeout())
+                .setConnectionRequestTimeout(connectionRequestTimeout)
                 .build());
     }
 


### PR DESCRIPTION
See this pull request where the timeout was paired with connectionRequestTimeout. https://github.com/flowable/flowable-engine/pull/755

I left a comment there but it was after it had already been merged.

Referenced docs for http client:
https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/client/config/RequestConfig.html#getConnectionRequestTimeout()

Docs for connectionRequestTimeout: _"Returns the timeout in
milliseconds used when requesting a connection from the connection
manager."_

Docs for socketTimeout _"Defines the socket timeout (SO_TIMEOUT) in
milliseconds, which is the timeout for waiting for data or, put
differently, a maximum period inactivity between two consecutive data
packets)."_

So socket timeout more related to waiting for a response.