### PR TITLE
Add classifier for spring boot executable war archive

### DIFF
--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/pom.xml
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/pom.xml
@@ -259,6 +259,16 @@
                         spring-boot-configuration-processor
                     </excludeArtifactIds>
                 </configuration>
+                <executions>
+                  <execution>
+                    <goals>
+                      <goal>repackage</goal>
+                    </goals>
+                    <configuration>
+                      <classifier>exec</classifier>
+                    </configuration>
+                  </execution>
+                </executions>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
I am hoping you guys are ok with a classifier for the new spring boot executable war file.

The reason is that I use the war as a dependency and the maven dependency plugin can't unpack the spring boot repackaged war file.

This way one ends up with two archives:

[INFO] Installing xxxxxxxxxxxxxxxxxxxxxxxx/flowable-engine/modules/flowable-ui-modeler/flowable-ui-modeler-app/target/flowable-modeler.war to xxxxxxxxxxx/.m2/repository/org/flowable/flowable-ui-modeler-app/6.3.0-SNAPSHOT/**flowable-ui-modeler-app-6.3.0-SNAPSHOT.war**
[INFO] Installing xxxxxxxxxxxxxxxxxxxxxxxx/flowable-engine/modules/flowable-ui-modeler/flowable-ui-modeler-app/target/flowable-modeler-exec.war to xxxxxxxxxxx/.m2/repository/org/flowable/flowable-ui-modeler-app/6.3.0-SNAPSHOT/**flowable-ui-modeler-app-6.3.0-SNAPSHOT-exec.war**


For reference:
https://stackoverflow.com/questions/42515957/unpack-war-is-not-unpacking