### PR TITLE
Do not prepend a launch script to the Spring Boot jar / war

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1081,7 +1081,11 @@
 							</goals>
 							<configuration>
 								<mainClass>${start-class}</mainClass>
-								<executable>true</executable>
+								<!-- The generated Spring Boot jar / war should not be made executable be prepending a launch script to the jar / war
+								Such jars cause issues when being unpacked by maven dependency:unpack, it can also cause issues when deploying in a servlet container.
+								NB: The jar / war is still self contained and can be run with java -jar
+								-->
+								<executable>false</executable>
 							</configuration>
 						</execution>
 					</executions>


### PR DESCRIPTION
Such jars cause issues when being unpacked by maven dependency:unpack, it can also cause issues when deploying in a servlet container.
The jar / war is still self contained and can be run with java -jar and or deployed in a servlet container

As pointed out by @ruzkant prepending a launch script to the war can cause issues. For this reason this PR disables that.

The applications can still be run with `java -jar flowable-app.war` and / or be deployed in a servlet container which is sufficient.

If this PR is merged #926 can be closed without being merged