### PR TITLE
Process and CMMN Engines should use dedicated async executors

### DIFF
--- a/docs/userguide/src/en/bpmn/ch05a-Spring-Boot.adoc
+++ b/docs/userguide/src/en/bpmn/ch05a-Spring-Boot.adoc
@@ -664,6 +664,16 @@ flowable.process.servlet.load-on-startup=-1 # Load on startup of the Process dis
 flowable.process.servlet.name=Flowable BPMN Rest API # The name of the Process servlet.
 flowable.process.servlet.path=/process-api # The context path for the Process rest servlet.
 
+# Process Async Executor
+flowable.process.async-executor-activate=true # Whether the async executor should be activated.
+flowable.process.async.executor.async-job-lock-time-in-millis=300000 # The amount of time (in milliseconds) an async job is locked when acquired by the async executor. During this period of time, no other async executor will try to acquire and lock this job.
+flowable.process.async.executor.default-async-job-acquire-wait-time-in-millis=10000 # The time (in milliseconds) the async job acquisition thread will wait to execute the next acquirement query. This happens when no new async jobs were found or when less async jobs have been fetched. Default value = 10 seconds.
+flowable.process.async.executor.default-queue-size-full-wait-time-in-millis=0 # The time (in milliseconds) the async job (both timer and async continuations) acquisition thread will wait when the queue is full to execute the next query. By default set to 0 (for backwards compatibility)
+flowable.process.async.executor.default-timer-job-acquire-wait-time-in-millis=1000 # The time (in milliseconds) the timer job acquisition thread will wait to execute the next acquirement query. This happens when no new timer jobs were found or when less async jobs have been fetched. Default value = 10 seconds.
+flowable.process.async.executor.max-async-jobs-due-per-acquisition=1 # ???
+flowable.process.async.executor.retry-wait-time-in-millis=500 # ???
+flowable.process.async.executor.timer-lock-time-in-millis=300000 # The amount of time (in milliseconds) a timer job is locked when acquired by the async executor. During this period of time, no other async executor will try to acquire and lock this job.
+
 
 # CMMN {sc-flowable-boot}/cmmn/FlowableCmmnProperties.java[FlowableCmmnProperties]
 flowable.cmmn.deploy-resources=true # Whether to perform deployment of resources, default is 'true'.
@@ -676,15 +686,15 @@ flowable.cmmn.servlet.load-on-startup=-1 # Load on startup of the CMMN dispatche
 flowable.cmmn.servlet.name=Flowable CMMN Rest API # The name of the CMMN servlet.
 flowable.cmmn.servlet.path=/cmmn-api # The context path for the CMMN rest servlet.
 
-# Async Executor
-flowable.async-executor-activate=true # Whether the async executor should be activated.
-flowable.async.executor.async-job-lock-time-in-millis=300000 # The amount of time (in milliseconds) an async job is locked when acquired by the async executor. During this period of time, no other async executor will try to acquire and lock this job.
-flowable.async.executor.default-async-job-acquire-wait-time-in-millis=10000 # The time (in milliseconds) the async job acquisition thread will wait to execute the next acquirement query. This happens when no new async jobs were found or when less async jobs have been fetched. Default value = 10 seconds.
-flowable.async.executor.default-queue-size-full-wait-time-in-millis=0 # The time (in milliseconds) the async job (both timer and async continuations) acquisition thread will wait when the queue is full to execute the next query. By default set to 0 (for backwards compatibility)
-flowable.async.executor.default-timer-job-acquire-wait-time-in-millis=1000 # The time (in milliseconds) the timer job acquisition thread will wait to execute the next acquirement query. This happens when no new timer jobs were found or when less async jobs have been fetched. Default value = 10 seconds.
-flowable.async.executor.max-async-jobs-due-per-acquisition=1 # ???
-flowable.async.executor.retry-wait-time-in-millis=500 # ???
-flowable.async.executor.timer-lock-time-in-millis=300000 # The amount of time (in milliseconds) a timer job is locked when acquired by the async executor. During this period of time, no other async executor will try to acquire and lock this job.
+# CMMN Async Executor
+flowable.cmmn.async-executor-activate=true # Whether the async executor should be activated.
+flowable.cmmn.async.executor.async-job-lock-time-in-millis=300000 # The amount of time (in milliseconds) an async job is locked when acquired by the async executor. During this period of time, no other async executor will try to acquire and lock this job.
+flowable.cmmn.async.executor.default-async-job-acquire-wait-time-in-millis=10000 # The time (in milliseconds) the async job acquisition thread will wait to execute the next acquirement query. This happens when no new async jobs were found or when less async jobs have been fetched. Default value = 10 seconds.
+flowable.cmmn.async.executor.default-queue-size-full-wait-time-in-millis=0 # The time (in milliseconds) the async job (both timer and async continuations) acquisition thread will wait when the queue is full to execute the next query. By default set to 0 (for backwards compatibility)
+flowable.cmmn.async.executor.default-timer-job-acquire-wait-time-in-millis=1000 # The time (in milliseconds) the timer job acquisition thread will wait to execute the next acquirement query. This happens when no new timer jobs were found or when less async jobs have been fetched. Default value = 10 seconds.
+flowable.cmmn.async.executor.max-async-jobs-due-per-acquisition=1 # ???
+flowable.cmmn.async.executor.retry-wait-time-in-millis=500 # ???
+flowable.cmmn.async.executor.timer-lock-time-in-millis=300000 # The amount of time (in milliseconds) a timer job is locked when acquired by the async executor. During this period of time, no other async executor will try to acquire and lock this job.
 
 # Content {sc-flowable-boot}/content/FlowableContentProperties.java[FlowableContentProperties]
 flowable.content.enabled=true # Whether the content engine needs to be started.
@@ -910,6 +920,8 @@ Obviously, there is a lot about Spring Boot that hasn't been touched upon yet, l
 
 ==== Advanced Configuration
 
+===== Customizing Engine Configuration
+
 It's possible to get a hold of the engine configuration by implementing the _org.flowable.spring.boot.EngineConfigurationConfigurer<T>_ interface.
 Where _T_ is the Spring Type of the particular Engine Configuration.
 This can be useful for advanced configuration settings or simply because a property has not been exposed (yet).
@@ -932,6 +944,8 @@ By exposing an instance of this class as an _@Bean_ in the Spring Boot configura
 ====
 You can provide a custom implementation of a Flowable Service by using this. See {sc-flowable-boot}/ldap/FlowableLdapAutoConfiguration.java[FlowableLdapAutoConfiguration]
 ====
+
+===== Combining starters
 
 In case you need only a combination of the engines then you can add only the required depdenencies.
 For example to use the Process, CMMN, Form and IDM engine and use LDAP you need to add the following dependencies:
@@ -960,4 +974,40 @@ For example to use the Process, CMMN, Form and IDM engine and use LDAP you need 
 </dependency>
 ----
 
+===== Configuring Async Executors
+
+The Process and CMMN engines have dedicated `AsyncExecutor`(s) and they can be configured with the `flowable.{engine}.async.executor` property group.
+Where `engine` is either `process` or `cmmn`.
+
+The `AsyncExecutor`(s) per default share the same Spring `TaskExecutor` and `SpringRejectedJobsHandler`.
+In case you want to provide a dedicated executor for each of the engines you need define a qualified bean with `@Process` and `@Cmmn`.
+
+You can configure custom executors in the following way:
+
+[source,java,linenums]
+----
+@Configuration
+public class MyConfiguration {
+
+    @Process <1>
+    @Bean
+    public TaskExecutor processTaskExecutor() {
+        return new SimpleAsyncTaskExecutor();
+    }
+
+    @Cmmn <2>
+    @Bean
+    public TaskExecutor cmmnTaskExecutor() {
+        return new SyncTaskExecutor();
+    }
+}
+----
+<1> The Async Executor for the Process Engine would use a `SimpleAsyncTaskExecutor`
+<2> The Async Executor for the CMMN Engine would use a `SyncTaskExecutor`
+
+[IMPORTANT]
+======
+If you define a custom `TaskExecutor` bean the Flowable creation of the bean is not trigerred.
+Which means that if you define a bean qualified with `@Process` you have to define one with `@Cmmn` or `@Primary`, otherwise the Cmmn Async Executor will use the one for the Process
+======
 

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/test/FlowableCmmnRule.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/test/FlowableCmmnRule.java
@@ -89,6 +89,10 @@ public class FlowableCmmnRule implements TestRule {
         this.configurationResource = configurationResource;
     }
 
+    public FlowableCmmnRule(CmmnEngine cmmnEngine) {
+        setCmmnEngine(cmmnEngine);
+    }
+
     /**
      * Implementation based on {@link TestWatcher}.
      */
@@ -240,6 +244,11 @@ public class FlowableCmmnRule implements TestRule {
 
     public CmmnEngine getCmmnEngine() {
         return cmmnEngine;
+    }
+
+    public void setCmmnEngine(CmmnEngine cmmnEngine) {
+        this.cmmnEngine = cmmnEngine;
+        initializeServices();
     }
 
     public CmmnRepositoryService getCmmnRepositoryService() {

--- a/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-starter/pom.xml
+++ b/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-starter/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.flowable</groupId>
+        <artifactId>flowable-spring-boot-samples</artifactId>
+        <version>6.3.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>flowable-spring-boot-sample-starter</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.flowable</groupId>
+            <artifactId>flowable-spring-boot-starter</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-starter/src/main/java/flowable/FlowableStarterSampleApplication.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-starter/src/main/java/flowable/FlowableStarterSampleApplication.java
@@ -1,0 +1,27 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package flowable;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * @author Filip Hrisafov
+ */
+@SpringBootApplication
+public class FlowableStarterSampleApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(FlowableStarterSampleApplication.class, args);
+    }
+}

--- a/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-starter/src/main/resources/application.properties
+++ b/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-starter/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+flowable.cmmn.async.executor.default-async-job-acquire-wait-time-in-millis=1000
+flowable.process.async.executor.default-async-job-acquire-wait-time-in-millis=1000

--- a/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-starter/src/main/resources/stageAfterTimer.cmmn
+++ b/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-starter/src/main/resources/stageAfterTimer.cmmn
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:flowable="http://flowable.org/cmmn"
+             xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC"
+             xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" targetNamespace="http://www.flowable.org/casedef">
+    <case id="testStageAfterTimerEventListener" name="testStageAfterTimerEventListener" flowable:initiatorVariableName="initiator">
+        <casePlanModel id="casePlanModel">
+            <planItem id="planItem1" definitionRef="sid-0C9B53FA-D5A7-435E-A7C1-DD17BC00F729"/>
+            <planItem id="planItem4" definitionRef="sid-4DBD6FE0-C6FA-404E-BA87-A663B3B557AC">
+                <entryCriterion id="sid-C356A944-08F8-450E-943F-31F7C4155260" sentryRef="sentry1"/>
+            </planItem>
+            <sentry id="sentry1">
+                <planItemOnPart id="sentryOnPart1" sourceRef="planItem1">
+                    <standardEvent>occur</standardEvent>
+                </planItemOnPart>
+            </sentry>
+            <timerEventListener id="sid-0C9B53FA-D5A7-435E-A7C1-DD17BC00F729">
+                <timerExpression><![CDATA[P1D]]></timerExpression>
+            </timerEventListener>
+            <stage id="sid-4DBD6FE0-C6FA-404E-BA87-A663B3B557AC">
+                <planItem id="planItem2" name="A" definitionRef="sid-AF42AAD9-277F-4F5F-BD75-F14A7B2CEECE"/>
+                <planItem id="planItem3" name="B" definitionRef="sid-45C5DB26-A8DF-4318-9DC6-AADDC8ADB64C"/>
+                <humanTask id="sid-AF42AAD9-277F-4F5F-BD75-F14A7B2CEECE" name="A"/>
+                <humanTask id="sid-45C5DB26-A8DF-4318-9DC6-AADDC8ADB64C" name="B"/>
+            </stage>
+        </casePlanModel>
+    </case>
+    <cmmndi:CMMNDI>
+        <cmmndi:CMMNDiagram id="CMMNDiagram_testStageAfterTimerEventListener">
+            <cmmndi:CMMNShape id="CMMNShape_casePlanModel" cmmnElementRef="casePlanModel">
+                <dc:Bounds height="714.0" width="718.0" x="40.0" y="40.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_planItem1" cmmnElementRef="planItem1">
+                <dc:Bounds height="31.0" width="31.0" x="155.0" y="284.5"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_planItem4" cmmnElementRef="planItem4">
+                <dc:Bounds height="294.0" width="436.0" x="255.0" y="225.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_sid-C356A944-08F8-450E-943F-31F7C4155260" cmmnElementRef="sid-C356A944-08F8-450E-943F-31F7C4155260">
+                <dc:Bounds height="22.0" width="14.0" x="247.86016394391874" y="335.693754517856"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_planItem2" cmmnElementRef="planItem2">
+                <dc:Bounds height="80.0" width="100.0" x="333.5" y="318.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_planItem3" cmmnElementRef="planItem3">
+                <dc:Bounds height="80.0" width="100.0" x="488.5" y="318.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNEdge id="CMMNEdge_sid-1B32AB72-7163-457F-8D3C-AD30C7BA4812" cmmnElementRef="sid-C356A944-08F8-450E-943F-31F7C4155260"
+                             targetCMMNElementRef="planItem1">
+                <di:waypoint x="250.36757263004915" y="342.7535408682225"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNEdge>
+        </cmmndi:CMMNDiagram>
+    </cmmndi:CMMNDI>
+</definitions>

--- a/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-starter/src/main/resources/timerAfterStart.bpmn20.xml
+++ b/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-starter/src/main/resources/timerAfterStart.bpmn20.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC"
+             xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema"
+             xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://www.omg.org/spec/BPMN/2.0/20100501/BPMN20.xsd"
+             expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://www.flowable.org/processdef">
+    <process id="testTimerEvent" name="Test timer event" isExecutable="true">
+        <startEvent id="startEvent1"/>
+        <intermediateCatchEvent id="sid-61196880-6971-4AB6-B9D2-825D37E5CD00">
+            <timerEventDefinition>
+                <timeDuration>P1D</timeDuration>
+            </timerEventDefinition>
+        </intermediateCatchEvent>
+        <sequenceFlow id="sid-B31E0E07-E135-414F-809A-555D96F49BF0" sourceRef="startEvent1" targetRef="sid-61196880-6971-4AB6-B9D2-825D37E5CD00"/>
+        <userTask id="sid-EEEB09D3-93AA-462E-81B2-6F4DE3085543" name="Process User Task"/>
+        <sequenceFlow id="sid-B3475410-AE27-4399-9B30-C15F3C991BD5" sourceRef="sid-61196880-6971-4AB6-B9D2-825D37E5CD00"
+                      targetRef="sid-EEEB09D3-93AA-462E-81B2-6F4DE3085543"/>
+        <endEvent id="sid-AA5DADFA-8B2C-42C1-896A-90497499BC97"/>
+        <sequenceFlow id="sid-56B53A25-36FE-4B10-BED8-FA769D7665EC" sourceRef="sid-EEEB09D3-93AA-462E-81B2-6F4DE3085543"
+                      targetRef="sid-AA5DADFA-8B2C-42C1-896A-90497499BC97"/>
+    </process>
+    <bpmndi:BPMNDiagram id="BPMNDiagram_testTimerEvent">
+        <bpmndi:BPMNPlane bpmnElement="testTimerEvent" id="BPMNPlane_testTimerEvent">
+            <bpmndi:BPMNShape bpmnElement="startEvent1" id="BPMNShape_startEvent1">
+                <omgdc:Bounds height="30.0" width="30.0" x="100.0" y="163.0"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="sid-61196880-6971-4AB6-B9D2-825D37E5CD00" id="BPMNShape_sid-61196880-6971-4AB6-B9D2-825D37E5CD00">
+                <omgdc:Bounds height="31.0" width="31.0" x="165.0" y="150.0"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="sid-EEEB09D3-93AA-462E-81B2-6F4DE3085543" id="BPMNShape_sid-EEEB09D3-93AA-462E-81B2-6F4DE3085543">
+                <omgdc:Bounds height="80.0" width="100.0" x="251.0" y="138.0"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="sid-AA5DADFA-8B2C-42C1-896A-90497499BC97" id="BPMNShape_sid-AA5DADFA-8B2C-42C1-896A-90497499BC97">
+                <omgdc:Bounds height="28.0" width="28.0" x="396.0" y="164.0"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge bpmnElement="sid-B3475410-AE27-4399-9B30-C15F3C991BD5" id="BPMNEdge_sid-B3475410-AE27-4399-9B30-C15F3C991BD5">
+                <omgdi:waypoint x="196.94998922262772" y="166.0"/>
+                <omgdi:waypoint x="223.5" y="166.0"/>
+                <omgdi:waypoint x="223.5" y="178.0"/>
+                <omgdi:waypoint x="250.9999999999603" y="178.0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="sid-56B53A25-36FE-4B10-BED8-FA769D7665EC" id="BPMNEdge_sid-56B53A25-36FE-4B10-BED8-FA769D7665EC">
+                <omgdi:waypoint x="350.95000000000005" y="178.0"/>
+                <omgdi:waypoint x="396.0" y="178.0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="sid-B31E0E07-E135-414F-809A-555D96F49BF0" id="BPMNEdge_sid-B31E0E07-E135-414F-809A-555D96F49BF0">
+                <omgdi:waypoint x="129.71139533260344" y="175.31625500508352"/>
+                <omgdi:waypoint x="165.25536257417528" y="168.85371553344066"/>
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+    </bpmndi:BPMNDiagram>
+</definitions>

--- a/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-starter/src/test/java/flowable/MixedAsyncExecutorsTest.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-starter/src/test/java/flowable/MixedAsyncExecutorsTest.java
@@ -1,0 +1,94 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package flowable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Date;
+
+import org.flowable.cmmn.api.CmmnRuntimeService;
+import org.flowable.cmmn.api.CmmnTaskService;
+import org.flowable.cmmn.api.runtime.CaseInstance;
+import org.flowable.cmmn.engine.test.CmmnDeployment;
+import org.flowable.cmmn.engine.test.FlowableCmmnRule;
+import org.flowable.cmmn.engine.test.impl.CmmnJobTestHelper;
+import org.flowable.engine.impl.test.JobTestHelper;
+import org.flowable.engine.runtime.ProcessInstance;
+import org.flowable.engine.test.Deployment;
+import org.flowable.engine.test.FlowableRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+/**
+ * @author Filip Hrisafov
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class MixedAsyncExecutorsTest {
+
+    @Rule
+    @Autowired
+    public FlowableRule processRule;
+
+    @Rule
+    @Autowired
+    public FlowableCmmnRule cmmnRule;
+    private CmmnRuntimeService cmmnRuntimeService;
+    private CmmnTaskService cmmnTaskService;
+
+    @Before
+    public void setUp() {
+        cmmnRuntimeService = cmmnRule.getCmmnRuntimeService();
+        cmmnTaskService = cmmnRule.getCmmnEngine().getCmmnTaskService();
+    }
+
+    @CmmnDeployment(resources = "stageAfterTimer.cmmn")
+    @Deployment(resources = "timerAfterStart.bpmn20.xml")
+    @Test
+    public void mixedAsyncExecutor() {
+        Date startTime = new Date();
+        setClockTo(startTime);
+
+        // Start the Case instance
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testStageAfterTimerEventListener")
+            .start();
+
+        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(0);
+
+        // Start the Process instance
+        ProcessInstance processInstance = processRule.getRuntimeService().createProcessInstanceBuilder().processDefinitionKey("testTimerEvent").start();
+
+        assertThat(processRule.getTaskService().createTaskQuery().count()).isEqualTo(0);
+
+        // Timer fires after 1 day, so setting it to 1 day + 1 second
+        setClockTo(new Date(startTime.getTime() + (24 * 60 * 60 * 1000 + 1)));
+
+        CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnRule.getCmmnEngine(), 5000L, 200L, true);
+        JobTestHelper.waitForJobExecutorToProcessAllJobs(processRule, 5000L, 200L);
+
+        // User task should be active after the timer has triggered
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(2);
+        assertThat(processRule.getTaskService().createTaskQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(1);
+    }
+
+    protected void setClockTo(Date time) {
+        processRule.setCurrentTime(time);
+        cmmnRule.setCurrentTime(time);
+
+    }
+}

--- a/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-starter/src/test/java/flowable/TestConfiguration.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-starter/src/test/java/flowable/TestConfiguration.java
@@ -10,33 +10,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.flowable.spring.boot;
+package flowable;
 
-import org.flowable.spring.job.service.SpringCallerRunsRejectedJobsHandler;
-import org.flowable.spring.job.service.SpringRejectedJobsHandler;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.flowable.cmmn.engine.CmmnEngine;
+import org.flowable.cmmn.engine.test.FlowableCmmnRule;
+import org.flowable.engine.ProcessEngine;
+import org.flowable.engine.test.FlowableRule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.task.SimpleAsyncTaskExecutor;
-import org.springframework.core.task.TaskExecutor;
 
 /**
- * Common configuration for engines that need the job executions setup.
- *
  * @author Filip Hrisafov
  */
 @Configuration
-public class FlowableJobConfiguration {
+public class TestConfiguration {
 
     @Bean
-    @ConditionalOnMissingBean
-    public TaskExecutor taskExecutor() {
-        return new SimpleAsyncTaskExecutor();
+    public FlowableRule flowableProcessRule(ProcessEngine processEngine) {
+        return new FlowableRule(processEngine);
     }
 
     @Bean
-    @ConditionalOnMissingBean
-    public SpringRejectedJobsHandler springRejectedJobsHandler() {
-        return new SpringCallerRunsRejectedJobsHandler();
+    public FlowableCmmnRule flowableCmmnRule(CmmnEngine cmmnEngine) {
+        return new FlowableCmmnRule(cmmnEngine);
     }
 }

--- a/modules/flowable-spring-boot/flowable-spring-boot-samples/pom.xml
+++ b/modules/flowable-spring-boot/flowable-spring-boot-samples/pom.xml
@@ -28,6 +28,7 @@
         <module>flowable-spring-boot-sample-cmmn</module>
         <module>flowable-spring-boot-sample-ldap</module>
         <module>flowable-spring-boot-sample-rest-1.5.x</module>
+        <module>flowable-spring-boot-sample-starter</module>
     </modules>
     <dependencies>
         <dependency>

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/AbstractSpringEngineAutoConfiguration.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/AbstractSpringEngineAutoConfiguration.java
@@ -13,6 +13,7 @@
 package org.flowable.spring.boot;
 
 import org.flowable.spring.common.SpringEngineConfiguration;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.transaction.PlatformTransactionManager;
 
 /**
@@ -29,5 +30,75 @@ public abstract class AbstractSpringEngineAutoConfiguration extends AbstractEngi
 
     protected void configureSpringEngine(SpringEngineConfiguration engineConfiguration, PlatformTransactionManager transactionManager) {
         engineConfiguration.setTransactionManager(transactionManager);
+    }
+
+    /**
+     * Get the Object provided by the {@code availableProvider}, otherwise get a unique object from {@code uniqueProvider}.
+     * This can be used when we allow users to provide specific implementations per engine. For example to provide a specific
+     * {@link org.springframework.core.task.TaskExecutor} and / or {@link org.flowable.spring.job.service.SpringRejectedJobsHandler} for the CMMN Async
+     * Executor. Example:
+     * <pre><code>
+     * &#064;Configuration
+     * public class MyCustomConfiguration {
+     *
+     *     &#064;Bean
+     *     &#064;Cmmn
+     *     public TaskExecutor cmmnTaskExecutor() {
+     *         return new MyCustomTaskExecutor()
+     *     }
+     *
+     *     &#064;@Bean
+     *     &#064;Primary
+     *     public TaskExecutor primaryTaskExecutor() {
+     *         return new SimpleAsyncTaskExecutor()
+     *     }
+     *
+     * }
+     * </code></pre>
+     * Then when using:
+     * <pre><code>
+     * &#064;Configuration
+     * public class FlowableJobConfiguration {
+     *
+     *     public SpringAsyncExecutor cmmnAsyncExecutor(
+     *         ObjectProvider&lt;TaskExecutor&gt; taskExecutor,
+     *         &#064;Cmmn ObjectProvider&lt;TaskExecutor&gt; cmmnTaskExecutor
+     *     ) {
+     *         TaskExecutor executor = getIfAvailable(
+     *             cmmnTaskExecutor,
+     *             taskExecutor
+     *         );
+     *         // executor is an instance of MyCustomTaskExecutor
+     *     }
+     *
+     *     public SpringAsyncExecutor processAsyncExecutor(
+     *         ObjectProvider&lt;TaskExecutor&gt; taskExecutor,
+     *         &#064;Process ObjectProvider&lt;TaskExecutor&gt; processTaskExecutor
+     *     ) {
+     *         TaskExecutor executor = getIfAvailable(
+     *             processTaskExecutor,
+     *             taskExecutor
+     *         );
+     *         // executor is an instance of SimpleAsyncTaskExecutor
+     *     }
+     * }
+     * </code></pre>
+     *
+     * @param availableProvider
+     *     a provider that can provide an available object
+     * @param uniqueProvider
+     *     a provider that would be used if there is no available object, but only if it is unique
+     * @param <T>
+     *     the type of the object being provided
+     * @return the available object from {@code availableProvider} if there, otherwise the unique object from {@code uniqueProvider}
+     */
+    protected <T> T getIfAvailable(ObjectProvider<T> availableProvider, ObjectProvider<T> uniqueProvider) {
+        // This can be implemented by using availableProvider.getIfAvailable(() -> uniqueProvider.getIfUnique()). However, that is only there in Spring 5
+        // and we want to be support Spring 4 with the starters as well
+        T object = availableProvider.getIfAvailable();
+        if (object == null) {
+            object = uniqueProvider.getIfUnique();
+        }
+        return object;
     }
 }

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/ProcessEngineAutoConfiguration.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/ProcessEngineAutoConfiguration.java
@@ -33,15 +33,20 @@ import org.flowable.spring.SpringProcessEngineConfiguration;
 import org.flowable.spring.boot.condition.ConditionalOnProcessEngine;
 import org.flowable.spring.boot.idm.FlowableIdmProperties;
 import org.flowable.spring.boot.process.FlowableProcessProperties;
+import org.flowable.spring.boot.process.Process;
+import org.flowable.spring.job.service.SpringAsyncExecutor;
+import org.flowable.spring.job.service.SpringRejectedJobsHandler;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.Resource;
+import org.springframework.core.task.TaskExecutor;
 import org.springframework.transaction.PlatformTransactionManager;
 
 /**
@@ -81,10 +86,30 @@ public class ProcessEngineAutoConfiguration extends AbstractSpringEngineAutoConf
         this.mailProperties = mailProperties;
     }
 
+    /**
+     * The Async Executor must not be shared between the engines.
+     * Therefore a dedicated one is always created.
+     */
+    @Bean
+    @Process
+    @ConfigurationProperties(prefix = "flowable.process.async.executor")
+    @ConditionalOnMissingBean(name = "processAsyncExecutor")
+    public SpringAsyncExecutor processAsyncExecutor(
+        ObjectProvider<TaskExecutor> taskExecutor,
+        @Process ObjectProvider<TaskExecutor> processTaskExecutor,
+        ObjectProvider<SpringRejectedJobsHandler> rejectedJobsHandler,
+        @Process ObjectProvider<SpringRejectedJobsHandler> processRejectedJobsHandler
+    ) {
+        return new SpringAsyncExecutor(
+            getIfAvailable(processTaskExecutor, taskExecutor),
+            getIfAvailable(processRejectedJobsHandler, rejectedJobsHandler)
+        );
+    }
+
     @Bean
     @ConditionalOnMissingBean
     public SpringProcessEngineConfiguration springProcessEngineConfiguration(DataSource dataSource, PlatformTransactionManager platformTransactionManager,
-        ObjectProvider<AsyncExecutor> asyncExecutorProvider) throws IOException {
+        @Process ObjectProvider<AsyncExecutor> asyncExecutorProvider) throws IOException {
 
         SpringProcessEngineConfiguration conf = new SpringProcessEngineConfiguration();
 

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/cmmn/Cmmn.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/cmmn/Cmmn.java
@@ -1,0 +1,41 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.spring.boot.cmmn;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+
+/**
+ * Qualifier annotation for a CMMN beans that need to be injected for CMMN Configurations.
+ * <p>
+ * This can be used when one wants to provide a dedicated {@link org.springframework.core.task.TaskExecutor} or
+ * {@link org.flowable.spring.job.service.SpringRejectedJobsHandler} for the Cmmn {@link org.flowable.spring.job.service.SpringAsyncExecutor}.
+ *
+ * <b>IMPORTANT:</b> When using this for the {@code TaskExecutor} or the {@code RejectedJobsHandler}, one needs to define a {@code @Primary} bean as well,
+ * otherwise the Process Engine would use the one from the CMMN as well.
+ *
+ * @author Filip Hrisafov
+ */
+@Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.TYPE,
+    ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Qualifier
+public @interface Cmmn {
+
+}

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/process/Process.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/process/Process.java
@@ -1,0 +1,41 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.spring.boot.process;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+
+/**
+ * Qualifier annotation for a Process beans that need to be injected for Process Configurations.
+ * <p>
+ * This can be used when one wants to provide a dedicated {@link org.springframework.core.task.TaskExecutor} or
+ * {@link org.flowable.spring.job.service.SpringRejectedJobsHandler} for the Process {@link org.flowable.spring.job.service.SpringAsyncExecutor}.
+ *
+ * <b>IMPORTANT:</b> When using this for the {@code TaskExecutor} or the {@code RejectedJobsHandler}, one needs to define a {@code @Primary} bean as well,
+ * otherwise the CMMN Engine would use the one from the Process as well.
+ *
+ * @author Filip Hrisafov
+ */
+@Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.TYPE,
+    ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Qualifier
+public @interface Process {
+
+}

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/test/spring/boot/ProcessAndCmmnEngineAsyncExecutorTest.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/test/spring/boot/ProcessAndCmmnEngineAsyncExecutorTest.java
@@ -1,0 +1,312 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.test.spring.boot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.persistence.EntityManagerFactory;
+
+import org.flowable.cmmn.engine.CmmnEngine;
+import org.flowable.engine.ProcessEngine;
+import org.flowable.job.service.impl.asyncexecutor.AsyncExecutor;
+import org.flowable.spring.boot.FlowableTransactionAutoConfiguration;
+import org.flowable.spring.boot.ProcessEngineAutoConfiguration;
+import org.flowable.spring.boot.cmmn.Cmmn;
+import org.flowable.spring.boot.cmmn.CmmnEngineAutoConfiguration;
+import org.flowable.spring.boot.cmmn.CmmnEngineServicesAutoConfiguration;
+import org.flowable.spring.boot.process.Process;
+import org.flowable.spring.job.service.SpringAsyncExecutor;
+import org.flowable.spring.job.service.SpringRejectedJobsHandler;
+import org.junit.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.core.task.TaskExecutor;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class ProcessAndCmmnEngineAsyncExecutorTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(
+            ProcessEngineAutoConfiguration.class,
+            CmmnEngineAutoConfiguration.class,
+            CmmnEngineServicesAutoConfiguration.class,
+            FlowableTransactionAutoConfiguration.class,
+            DataSourceAutoConfiguration.class,
+            TransactionAutoConfiguration.class
+        ))
+        .withClassLoader(new FilteredClassLoader(EntityManagerFactory.class));
+
+    @Test
+    public void cmmnAndProcessEngineShouldUseDistinctAsyncExecutorsWithDefaultConfiguration() {
+        contextRunner.run((context -> {
+            assertThat(context).hasSingleBean(ProcessEngine.class);
+            assertThat(context).hasSingleBean(CmmnEngine.class);
+            assertThat(context).hasBean("taskExecutor");
+            assertThat(context).hasBean("springRejectedJobsHandler");
+            assertThat(context).hasBean("cmmnAsyncExecutor");
+            assertThat(context).hasBean("processAsyncExecutor");
+            AsyncExecutor processAsyncExecutor = context.getBean(ProcessEngine.class).getProcessEngineConfiguration().getAsyncExecutor();
+            AsyncExecutor cmmnAsyncExecutor = context.getBean(CmmnEngine.class).getCmmnEngineConfiguration().getAsyncExecutor();
+
+            assertThat(processAsyncExecutor)
+                .as("Process Engine Async Executor vs Cmmn Engine Async Executor")
+                .isNotSameAs(cmmnAsyncExecutor);
+            assertThat(processAsyncExecutor)
+                .as("Process Engine Async Executor")
+                .isInstanceOf(SpringAsyncExecutor.class);
+            assertThat(cmmnAsyncExecutor)
+                .as("Cmmn Engine Async Executor")
+                .isInstanceOf(SpringAsyncExecutor.class);
+
+            TaskExecutor taskExecutorBean = context.getBean("taskExecutor", TaskExecutor.class);
+            SpringRejectedJobsHandler rejectedJobsHandlerBean = context.getBean("springRejectedJobsHandler", SpringRejectedJobsHandler.class);
+
+            assertThat(((SpringAsyncExecutor) processAsyncExecutor).getRejectedJobsHandler())
+                .as("Process Async Rejected Jobs Handler")
+                .isSameAs(rejectedJobsHandlerBean);
+            assertThat(((SpringAsyncExecutor) cmmnAsyncExecutor).getRejectedJobsHandler())
+                .as("Cmmn Async Rejected Jobs Handler")
+                .isSameAs(rejectedJobsHandlerBean);
+
+            assertThat(((SpringAsyncExecutor) processAsyncExecutor).getTaskExecutor())
+                .as("Process Async Task Executor")
+                .isSameAs(taskExecutorBean);
+            assertThat(((SpringAsyncExecutor) cmmnAsyncExecutor).getTaskExecutor())
+                .as("Cmmn Async Task Executor")
+                .isSameAs(taskExecutorBean);
+        }));
+    }
+
+    @Test
+    public void cmmnAndProcessEngineShouldUseDistinctTaskExecutors() {
+        contextRunner.withUserConfiguration(DedicatedTaskExecutorsConfiguration.class)
+            .run((context -> {
+                AsyncExecutor processAsyncExecutor = context.getBean(ProcessEngine.class).getProcessEngineConfiguration().getAsyncExecutor();
+                AsyncExecutor cmmnAsyncExecutor = context.getBean(CmmnEngine.class).getCmmnEngineConfiguration().getAsyncExecutor();
+
+                assertThat(context)
+                    .doesNotHaveBean("taskExecutor")
+                    .hasBean("cmmnTaskExecutor")
+                    .hasBean("processTaskExecutor");
+                TaskExecutor cmmnTaskExecutorBean = context.getBean("cmmnTaskExecutor", TaskExecutor.class);
+                TaskExecutor processTaskExecutorBean = context.getBean("processTaskExecutor", TaskExecutor.class);
+
+                assertThat(((SpringAsyncExecutor) processAsyncExecutor).getTaskExecutor())
+                    .as("Process Async Task Executor")
+                    .isSameAs(processTaskExecutorBean)
+                    .isNotSameAs(((SpringAsyncExecutor) cmmnAsyncExecutor).getTaskExecutor());
+
+                assertThat(((SpringAsyncExecutor) cmmnAsyncExecutor).getTaskExecutor())
+                    .as("Cmmn Async Task Executor")
+                    .isSameAs(cmmnTaskExecutorBean);
+            }));
+    }
+
+    @Test
+    public void cmmnAndProcessEngineShouldUseDistinctTaskExecutorsWhenPrimaryIsPresent() {
+        contextRunner.withUserConfiguration(DedicatedTaskExecutorsConfiguration.class, PrimaryTaskExecutorConfiguration.class)
+            .run((context -> {
+                AsyncExecutor processAsyncExecutor = context.getBean(ProcessEngine.class).getProcessEngineConfiguration().getAsyncExecutor();
+                AsyncExecutor cmmnAsyncExecutor = context.getBean(CmmnEngine.class).getCmmnEngineConfiguration().getAsyncExecutor();
+
+                assertThat(context)
+                    .doesNotHaveBean("taskExecutor")
+                    .hasBean("primaryTaskExecutor")
+                    .hasBean("cmmnTaskExecutor")
+                    .hasBean("processTaskExecutor");
+
+                TaskExecutor primaryTaskExecutorBean = context.getBean("primaryTaskExecutor", TaskExecutor.class);
+                TaskExecutor cmmnTaskExecutorBean = context.getBean("cmmnTaskExecutor", TaskExecutor.class);
+                TaskExecutor processTaskExecutorBean = context.getBean("processTaskExecutor", TaskExecutor.class);
+
+                assertThat(((SpringAsyncExecutor) processAsyncExecutor).getTaskExecutor())
+                    .as("Process Async Task Executor")
+                    .isSameAs(processTaskExecutorBean)
+                    .isNotSameAs(((SpringAsyncExecutor) cmmnAsyncExecutor).getTaskExecutor())
+                    .as("Process Async Task Executor with primary")
+                    .isNotSameAs(primaryTaskExecutorBean);
+
+                assertThat(((SpringAsyncExecutor) cmmnAsyncExecutor).getTaskExecutor())
+                    .as("Cmmn Async Task Executor")
+                    .isSameAs(cmmnTaskExecutorBean)
+                    .as("Cmmn Async Task Executor with primary")
+                    .isNotSameAs(primaryTaskExecutorBean);
+            }));
+    }
+
+    @Test
+    public void cmmnShouldUsePrimaryAndProcessEngineShouldUseDedicatedTaskExecutor() {
+        contextRunner.withUserConfiguration(ProcessTaskExecutorConfiguration.class, PrimaryTaskExecutorConfiguration.class)
+            .run((context -> {
+                AsyncExecutor processAsyncExecutor = context.getBean(ProcessEngine.class).getProcessEngineConfiguration().getAsyncExecutor();
+                AsyncExecutor cmmnAsyncExecutor = context.getBean(CmmnEngine.class).getCmmnEngineConfiguration().getAsyncExecutor();
+
+                assertThat(context)
+                    .doesNotHaveBean("taskExecutor")
+                    .hasBean("primaryTaskExecutor")
+                    .hasBean("processTaskExecutor");
+
+                TaskExecutor prmiaryTaskExecutorBean = context.getBean("primaryTaskExecutor", TaskExecutor.class);
+                TaskExecutor processTaskExecutorBean = context.getBean("processTaskExecutor", TaskExecutor.class);
+
+                assertThat(((SpringAsyncExecutor) processAsyncExecutor).getTaskExecutor())
+                    .as("Process Async Task Executor")
+                    .isSameAs(processTaskExecutorBean)
+                    .isNotSameAs(((SpringAsyncExecutor) cmmnAsyncExecutor).getTaskExecutor());
+
+                assertThat(((SpringAsyncExecutor) cmmnAsyncExecutor).getTaskExecutor())
+                    .as("Cmmn Async Task Executor")
+                    .isSameAs(prmiaryTaskExecutorBean);
+            }));
+    }
+
+    @Test
+    public void cmmnAndProcessEngineShouldUseDistinctRejectedHandlers() {
+        contextRunner.withUserConfiguration(DedicatedRejectedHandlerConfiguration.class)
+            .run((context -> {
+                AsyncExecutor processAsyncExecutor = context.getBean(ProcessEngine.class).getProcessEngineConfiguration().getAsyncExecutor();
+                AsyncExecutor cmmnAsyncExecutor = context.getBean(CmmnEngine.class).getCmmnEngineConfiguration().getAsyncExecutor();
+
+                assertThat(context)
+                    .doesNotHaveBean("springRejectedJobsHandler")
+                    .hasBean("cmmnRejectedJobsHandler")
+                    .hasBean("processRejectedJobsHandler");
+
+                SpringRejectedJobsHandler processRejectedJobsHandlerBean = context.getBean("processRejectedJobsHandler", SpringRejectedJobsHandler.class);
+                SpringRejectedJobsHandler cmmnRejectedJobsHandlerBean = context.getBean("cmmnRejectedJobsHandler", SpringRejectedJobsHandler.class);
+
+                assertThat(((SpringAsyncExecutor) processAsyncExecutor).getRejectedJobsHandler())
+                    .as("Process Async Rejected Jobs Handler")
+                    .isSameAs(processRejectedJobsHandlerBean)
+                    .isNotSameAs(((SpringAsyncExecutor) cmmnAsyncExecutor).getRejectedJobsHandler());
+
+                assertThat(((SpringAsyncExecutor) cmmnAsyncExecutor).getRejectedJobsHandler())
+                    .as("Cmmn Async Rejected Jobs Handler")
+                    .isSameAs(cmmnRejectedJobsHandlerBean);
+            }));
+    }
+
+    @Test
+    public void cmmnShouldUseDedicatedAndProcessEngineShouldUsePrimaryRejectedHandler() {
+        contextRunner.withUserConfiguration(CmmnRejectedHandlerConfiguration.class, PrimaryRejectedHandlerConfiguration.class)
+            .run((context -> {
+                AsyncExecutor processAsyncExecutor = context.getBean(ProcessEngine.class).getProcessEngineConfiguration().getAsyncExecutor();
+                AsyncExecutor cmmnAsyncExecutor = context.getBean(CmmnEngine.class).getCmmnEngineConfiguration().getAsyncExecutor();
+
+                assertThat(context)
+                    .doesNotHaveBean("springRejectedJobsHandler")
+                    .hasBean("cmmnRejectedJobsHandler")
+                    .hasBean("primaryRejectedJobsHandler");
+
+                SpringRejectedJobsHandler primaryRejectedJobsHandlerBean = context.getBean("primaryRejectedJobsHandler", SpringRejectedJobsHandler.class);
+                SpringRejectedJobsHandler cmmnRejectedJobsHandlerBean = context.getBean("cmmnRejectedJobsHandler", SpringRejectedJobsHandler.class);
+
+                assertThat(((SpringAsyncExecutor) processAsyncExecutor).getRejectedJobsHandler())
+                    .as("Process Async Rejected Jobs Handler")
+                    .isSameAs(primaryRejectedJobsHandlerBean)
+                    .isNotSameAs(((SpringAsyncExecutor) cmmnAsyncExecutor).getRejectedJobsHandler());
+
+                assertThat(((SpringAsyncExecutor) cmmnAsyncExecutor).getRejectedJobsHandler())
+                    .as("Cmmn Async Rejected Jobs Handler")
+                    .isSameAs(cmmnRejectedJobsHandlerBean);
+            }));
+    }
+
+    @Import({ CmmnTaskExecutorConfiguration.class, ProcessTaskExecutorConfiguration.class })
+    @Configuration
+    static class DedicatedTaskExecutorsConfiguration {
+
+    }
+
+    @Configuration
+    static class CmmnTaskExecutorConfiguration {
+
+        @Cmmn
+        @Bean
+        public TaskExecutor cmmnTaskExecutor() {
+            return task -> {
+            };
+        }
+    }
+
+    @Configuration
+    static class ProcessTaskExecutorConfiguration {
+
+        @Process
+        @Bean
+        public TaskExecutor processTaskExecutor() {
+            return task -> {
+            };
+        }
+    }
+
+    @Configuration
+    static class PrimaryTaskExecutorConfiguration {
+
+        @Primary
+        @Bean
+        public TaskExecutor primaryTaskExecutor() {
+            return task -> {
+            };
+        }
+    }
+
+    @Import({ CmmnRejectedHandlerConfiguration.class, ProcessRejectedHandlerConfiguration.class })
+    @Configuration
+    static class DedicatedRejectedHandlerConfiguration {
+
+    }
+
+    @Configuration
+    static class CmmnRejectedHandlerConfiguration {
+
+        @Cmmn
+        @Bean
+        public SpringRejectedJobsHandler cmmnRejectedJobsHandler() {
+            return (asyncExecutor, job) -> {
+            };
+        }
+    }
+
+    @Configuration
+    static class ProcessRejectedHandlerConfiguration {
+
+        @Process
+        @Bean
+        public SpringRejectedJobsHandler processRejectedJobsHandler() {
+            return (asyncExecutor, job) -> {
+            };
+        }
+    }
+
+    @Configuration
+    static class PrimaryRejectedHandlerConfiguration {
+
+        @Primary
+        @Bean
+        public SpringRejectedJobsHandler primaryRejectedJobsHandler() {
+            return (asyncExecutor, job) -> {
+            };
+        }
+    }
+
+}

--- a/modules/flowable-ui-task/flowable-ui-task-app/src/main/resources/application.properties
+++ b/modules/flowable-ui-task/flowable-ui-task-app/src/main/resources/application.properties
@@ -86,8 +86,11 @@ spring.datasource.password=flowable
 
 flowable.process.definition-cache-limit=512
 #flowable.dmn.strict-mode=false
-flowable.async.executor.default-async-job-acquire-wait-time-in-millis=5000
-flowable.async.executor.default-timer-job-acquire-wait-time-in-millis=5000
+flowable.process.async.executor.default-async-job-acquire-wait-time-in-millis=5000
+flowable.process.async.executor.default-timer-job-acquire-wait-time-in-millis=5000
+
+flowable.cmmn.async.executor.default-async-job-acquire-wait-time-in-millis=5000
+flowable.cmmn.async.executor.default-timer-job-acquire-wait-time-in-millis=5000
 
 # The maximum file upload limit. Set to -1 to set to 'no limit'. Expressed in bytes
 spring.servlet.multipart.max-file-size=10MB


### PR DESCRIPTION
New @Process and @Cmmn qualifiers are added which allow providing custom TaskExecutor and SpringRejectedJobsHandler
for the Process and CMMN Async Executors.