### PR TITLE
The JMX beans should be created under the name of the application

### DIFF
--- a/modules/flowable-app-rest/src/main/resources/application.properties
+++ b/modules/flowable-app-rest/src/main/resources/application.properties
@@ -9,7 +9,11 @@ management.endpoint.health.show-details=when_authorized
 management.endpoint.health.roles=access-admin
 # Spring prefixes the roles with ROLE_. However, Flowable does not have that concept yet, so we need to override that with an empty string
 flowable.rest.app.role-prefix=
+spring.application.name=flowable-rest
 spring.banner.location=classpath:/org/flowable/spring/boot/flowable-banner.txt
+# The default domain for generating ObjectNames must be specified. Otherwise when multiple Spring Boot applications start in the same servlet container
+# all would be created with the same name (com.zaxxer.hikari:name=dataSource,type=HikariDataSource) for example
+spring.jmx.default-domain=${spring.application.name}
 # datasource
 spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.url=jdbc:h2:~/flowable-db/db;AUTO_SERVER=TRUE;AUTO_SERVER_PORT=9091;DB_CLOSE_DELAY=-1

--- a/modules/flowable-ui-admin/flowable-ui-admin-app/src/main/resources/application.properties
+++ b/modules/flowable-ui-admin/flowable-ui-admin-app/src/main/resources/application.properties
@@ -4,9 +4,13 @@ management.endpoints.jmx.unique-names=true
 # This is needed to force use of JDK proxies instead of using CGLIB
 spring.aop.proxy-target-class=false
 spring.aop.auto=false
+spring.application.name=flowable-ui-admin
 spring.liquibase.enabled=false
 spring.servlet.multipart.max-file-size=10MB
 spring.banner.location=classpath:/org/flowable/spring/boot/flowable-banner.txt
+# The default domain for generating ObjectNames must be specified. Otherwise when multiple Spring Boot applications start in the same servlet container
+# all would be created with the same name (com.zaxxer.hikari:name=dataSource,type=HikariDataSource) for example
+spring.jmx.default-domain=${spring.application.name}
 
 # Expose all actuator endpoints to the web
 # They are exposed, but only authenticated users can see /info and /health abd users with access-admin can see the others

--- a/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/resources/application.properties
+++ b/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/resources/application.properties
@@ -4,7 +4,11 @@ management.endpoints.jmx.unique-names=true
 # This is needed to force use of JDK proxies instead of using CGLIB
 spring.aop.proxy-target-class=false
 spring.aop.auto=false
+spring.application.name=flowable-ui-idm
 spring.banner.location=classpath:/org/flowable/spring/boot/flowable-banner.txt
+# The default domain for generating ObjectNames must be specified. Otherwise when multiple Spring Boot applications start in the same servlet container
+# all would be created with the same name (com.zaxxer.hikari:name=dataSource,type=HikariDataSource) for example
+spring.jmx.default-domain=${spring.application.name}
 
 # Expose all actuator endpoints to the web
 # They are exposed, but only authenticated users can see /info and /health abd users with access-admin can see the others

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/resources/application.properties
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/resources/application.properties
@@ -4,12 +4,16 @@ management.endpoints.jmx.unique-names=true
 # This is needed to force use of JDK proxies instead of using CGLIB
 spring.aop.proxy-target-class=false
 spring.aop.auto=false
+spring.application.name=flowable-ui-modeler
 #
 # SECURITY
 #
 spring.security.filter.dispatcher-types=REQUEST,FORWARD,ASYNC
 spring.liquibase.enabled=false
 spring.banner.location=classpath:/org/flowable/spring/boot/flowable-banner.txt
+# The default domain for generating ObjectNames must be specified. Otherwise when multiple Spring Boot applications start in the same servlet container
+# all would be created with the same name (com.zaxxer.hikari:name=dataSource,type=HikariDataSource) for example
+spring.jmx.default-domain=${spring.application.name}
 
 # Expose all actuator endpoints to the web
 # They are exposed, but only authenticated users can see /info and /health abd users with access-admin can see the others

--- a/modules/flowable-ui-task/flowable-ui-task-app/src/main/resources/application.properties
+++ b/modules/flowable-ui-task/flowable-ui-task-app/src/main/resources/application.properties
@@ -4,7 +4,11 @@ management.endpoints.jmx.unique-names=true
 # This is needed to force use of JDK proxies instead of using CGLIB
 spring.aop.proxy-target-class=false
 spring.aop.auto=false
+spring.application.name=flowable-ui-task
 spring.banner.location=classpath:/org/flowable/spring/boot/flowable-banner.txt
+# The default domain for generating ObjectNames must be specified. Otherwise when multiple Spring Boot applications start in the same servlet container
+# all would be created with the same name (com.zaxxer.hikari:name=dataSource,type=HikariDataSource) for example
+spring.jmx.default-domain=${spring.application.name}
 #
 # SECURITY
 #


### PR DESCRIPTION
When no JMX domain is given then each bean would be registered under the domain of name of the package of the class.
Each application should provide it's own domain which be default is the name of the application