### PR TITLE
Upgrade Mockito version to 2.18.0

### DIFF
--- a/modules/flowable-cmmn-spring/src/test/java/org/flowable/spring/test/autodeployment/AbstractAutoDeploymentStrategyTest.java
+++ b/modules/flowable-cmmn-spring/src/test/java/org/flowable/spring/test/autodeployment/AbstractAutoDeploymentStrategyTest.java
@@ -13,7 +13,7 @@
 
 package org.flowable.spring.test.autodeployment;
 
-import static org.mockito.Matchers.isA;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.when;
 
 import java.io.File;

--- a/modules/flowable-cmmn-spring/src/test/java/org/flowable/spring/test/autodeployment/DefaultAutoDeploymentStrategyTest.java
+++ b/modules/flowable-cmmn-spring/src/test/java/org/flowable/spring/test/autodeployment/DefaultAutoDeploymentStrategyTest.java
@@ -17,8 +17,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isA;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -32,13 +32,13 @@ import org.flowable.engine.common.api.FlowableException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.core.io.Resource;
 
 /**
  * @author Tiese Barrell
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class DefaultAutoDeploymentStrategyTest extends AbstractAutoDeploymentStrategyTest {
 
     private DefaultAutoDeploymentStrategy classUnderTest;

--- a/modules/flowable-cmmn-spring/src/test/java/org/flowable/spring/test/autodeployment/ResourceParentFolderAutoDeploymentStrategyTest.java
+++ b/modules/flowable-cmmn-spring/src/test/java/org/flowable/spring/test/autodeployment/ResourceParentFolderAutoDeploymentStrategyTest.java
@@ -16,8 +16,8 @@ package org.flowable.spring.test.autodeployment;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isA;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -33,7 +33,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.core.io.Resource;
 
 /**
@@ -146,11 +146,6 @@ public class ResourceParentFolderAutoDeploymentStrategyTest extends AbstractAuto
 
         final Resource[] resources = new Resource[] { resourceMock1, resourceMock2, resourceMock3 };
         classUnderTest.deployResources(deploymentNameHint, resources, repositoryServiceMock);
-
-        when(fileMock1.getParentFile()).thenReturn(null);
-        when(fileMock2.getParentFile()).thenReturn(parentFile2Mock);
-        when(parentFile2Mock.isDirectory()).thenReturn(false);
-        when(fileMock3.getParentFile()).thenReturn(null);
 
         verify(repositoryServiceMock, times(3)).createDeployment();
         verify(deploymentBuilderMock, times(1)).name(deploymentNameHint + "." + resourceName1);

--- a/modules/flowable-cmmn-spring/src/test/java/org/flowable/spring/test/autodeployment/SingleResourceAutoDeploymentStrategyTest.java
+++ b/modules/flowable-cmmn-spring/src/test/java/org/flowable/spring/test/autodeployment/SingleResourceAutoDeploymentStrategyTest.java
@@ -16,8 +16,8 @@ package org.flowable.spring.test.autodeployment;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isA;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -31,13 +31,13 @@ import org.flowable.engine.common.api.FlowableException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.core.io.Resource;
 
 /**
  * @author Tiese Barrell
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class SingleResourceAutoDeploymentStrategyTest extends AbstractAutoDeploymentStrategyTest {
 
     private SingleResourceAutoDeploymentStrategy classUnderTest;

--- a/modules/flowable-dmn-spring/src/test/java/org/flowable/spring/test/autodeployment/AbstractAutoDeploymentStrategyTest.java
+++ b/modules/flowable-dmn-spring/src/test/java/org/flowable/spring/test/autodeployment/AbstractAutoDeploymentStrategyTest.java
@@ -13,7 +13,7 @@
 
 package org.flowable.spring.test.autodeployment;
 
-import static org.mockito.Matchers.isA;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.when;
 
 import java.io.File;

--- a/modules/flowable-dmn-spring/src/test/java/org/flowable/spring/test/autodeployment/DefaultAutoDeploymentStrategyTest.java
+++ b/modules/flowable-dmn-spring/src/test/java/org/flowable/spring/test/autodeployment/DefaultAutoDeploymentStrategyTest.java
@@ -17,8 +17,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isA;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -32,13 +32,13 @@ import org.flowable.engine.common.api.FlowableException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.core.io.Resource;
 
 /**
  * @author Tiese Barrell
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class DefaultAutoDeploymentStrategyTest extends AbstractAutoDeploymentStrategyTest {
 
     private DefaultAutoDeploymentStrategy classUnderTest;

--- a/modules/flowable-dmn-spring/src/test/java/org/flowable/spring/test/autodeployment/ResourceParentFolderAutoDeploymentStrategyTest.java
+++ b/modules/flowable-dmn-spring/src/test/java/org/flowable/spring/test/autodeployment/ResourceParentFolderAutoDeploymentStrategyTest.java
@@ -16,8 +16,8 @@ package org.flowable.spring.test.autodeployment;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isA;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -33,7 +33,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.core.io.Resource;
 
 /**
@@ -150,11 +150,6 @@ public class ResourceParentFolderAutoDeploymentStrategyTest extends AbstractAuto
 
         final Resource[] resources = new Resource[] { resourceMock1, resourceMock2, resourceMock3 };
         classUnderTest.deployResources(deploymentNameHint, resources, repositoryServiceMock);
-
-        when(fileMock1.getParentFile()).thenReturn(null);
-        when(fileMock2.getParentFile()).thenReturn(parentFile2Mock);
-        when(parentFile2Mock.isDirectory()).thenReturn(false);
-        when(fileMock3.getParentFile()).thenReturn(null);
 
         verify(repositoryServiceMock, times(3)).createDeployment();
         verify(deploymentBuilderMock, times(3)).enableDuplicateFiltering();

--- a/modules/flowable-dmn-spring/src/test/java/org/flowable/spring/test/autodeployment/SingleResourceAutoDeploymentStrategyTest.java
+++ b/modules/flowable-dmn-spring/src/test/java/org/flowable/spring/test/autodeployment/SingleResourceAutoDeploymentStrategyTest.java
@@ -16,8 +16,8 @@ package org.flowable.spring.test.autodeployment;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isA;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -31,13 +31,13 @@ import org.flowable.engine.common.api.FlowableException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.core.io.Resource;
 
 /**
  * @author Tiese Barrell
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class SingleResourceAutoDeploymentStrategyTest extends AbstractAutoDeploymentStrategyTest {
 
     private SingleResourceAutoDeploymentStrategy classUnderTest;

--- a/modules/flowable-form-spring/src/test/java/org/flowable/spring/test/autodeployment/AbstractAutoDeploymentStrategyTest.java
+++ b/modules/flowable-form-spring/src/test/java/org/flowable/spring/test/autodeployment/AbstractAutoDeploymentStrategyTest.java
@@ -13,7 +13,7 @@
 
 package org.flowable.spring.test.autodeployment;
 
-import static org.mockito.Matchers.isA;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.when;
 
 import java.io.File;

--- a/modules/flowable-form-spring/src/test/java/org/flowable/spring/test/autodeployment/DefaultAutoDeploymentStrategyTest.java
+++ b/modules/flowable-form-spring/src/test/java/org/flowable/spring/test/autodeployment/DefaultAutoDeploymentStrategyTest.java
@@ -17,8 +17,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isA;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -32,13 +32,13 @@ import org.flowable.form.spring.autodeployment.DefaultAutoDeploymentStrategy;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.core.io.Resource;
 
 /**
  * @author Tiese Barrell
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class DefaultAutoDeploymentStrategyTest extends AbstractAutoDeploymentStrategyTest {
 
     private DefaultAutoDeploymentStrategy classUnderTest;

--- a/modules/flowable-form-spring/src/test/java/org/flowable/spring/test/autodeployment/ResourceParentFolderAutoDeploymentStrategyTest.java
+++ b/modules/flowable-form-spring/src/test/java/org/flowable/spring/test/autodeployment/ResourceParentFolderAutoDeploymentStrategyTest.java
@@ -16,8 +16,8 @@ package org.flowable.spring.test.autodeployment;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isA;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -33,7 +33,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.core.io.Resource;
 
 /**
@@ -150,11 +150,6 @@ public class ResourceParentFolderAutoDeploymentStrategyTest extends AbstractAuto
 
         final Resource[] resources = new Resource[] { resourceMock1, resourceMock2, resourceMock3 };
         classUnderTest.deployResources(deploymentNameHint, resources, repositoryServiceMock);
-
-        when(fileMock1.getParentFile()).thenReturn(null);
-        when(fileMock2.getParentFile()).thenReturn(parentFile2Mock);
-        when(parentFile2Mock.isDirectory()).thenReturn(false);
-        when(fileMock3.getParentFile()).thenReturn(null);
 
         verify(repositoryServiceMock, times(3)).createDeployment();
         verify(deploymentBuilderMock, times(3)).enableDuplicateFiltering();

--- a/modules/flowable-form-spring/src/test/java/org/flowable/spring/test/autodeployment/SingleResourceAutoDeploymentStrategyTest.java
+++ b/modules/flowable-form-spring/src/test/java/org/flowable/spring/test/autodeployment/SingleResourceAutoDeploymentStrategyTest.java
@@ -16,8 +16,8 @@ package org.flowable.spring.test.autodeployment;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isA;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -31,13 +31,13 @@ import org.flowable.form.spring.autodeployment.SingleResourceAutoDeploymentStrat
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.core.io.Resource;
 
 /**
  * @author Tiese Barrell
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class SingleResourceAutoDeploymentStrategyTest extends AbstractAutoDeploymentStrategyTest {
 
     private SingleResourceAutoDeploymentStrategy classUnderTest;

--- a/modules/flowable-spring/src/test/java/org/flowable/spring/test/autodeployment/AbstractAutoDeploymentStrategyTest.java
+++ b/modules/flowable-spring/src/test/java/org/flowable/spring/test/autodeployment/AbstractAutoDeploymentStrategyTest.java
@@ -13,7 +13,7 @@
 
 package org.flowable.spring.test.autodeployment;
 
-import static org.mockito.Matchers.isA;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.when;
 
 import java.io.File;

--- a/modules/flowable-spring/src/test/java/org/flowable/spring/test/autodeployment/DefaultAutoDeploymentStrategyTest.java
+++ b/modules/flowable-spring/src/test/java/org/flowable/spring/test/autodeployment/DefaultAutoDeploymentStrategyTest.java
@@ -17,8 +17,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isA;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -33,13 +33,13 @@ import org.flowable.spring.configurator.DefaultAutoDeploymentStrategy;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.core.io.Resource;
 
 /**
  * @author Tiese Barrell
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class DefaultAutoDeploymentStrategyTest extends AbstractAutoDeploymentStrategyTest {
 
     private DefaultAutoDeploymentStrategy classUnderTest;

--- a/modules/flowable-spring/src/test/java/org/flowable/spring/test/autodeployment/ResourceParentFolderAutoDeploymentStrategyTest.java
+++ b/modules/flowable-spring/src/test/java/org/flowable/spring/test/autodeployment/ResourceParentFolderAutoDeploymentStrategyTest.java
@@ -16,8 +16,8 @@ package org.flowable.spring.test.autodeployment;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isA;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -34,7 +34,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.core.io.Resource;
 
 /**
@@ -155,11 +155,6 @@ public class ResourceParentFolderAutoDeploymentStrategyTest extends AbstractAuto
 
         final Resource[] resources = new Resource[] { resourceMock1, resourceMock2, resourceMock3 };
         classUnderTest.deployResources(deploymentNameHint, resources, repositoryServiceMock);
-
-        when(fileMock1.getParentFile()).thenReturn(null);
-        when(fileMock2.getParentFile()).thenReturn(parentFile2Mock);
-        when(parentFile2Mock.isDirectory()).thenReturn(false);
-        when(fileMock3.getParentFile()).thenReturn(null);
 
         verify(repositoryServiceMock, times(3)).createDeployment();
         verify(deploymentBuilderMock, times(3)).enableDuplicateFiltering();

--- a/modules/flowable-spring/src/test/java/org/flowable/spring/test/autodeployment/SingleResourceAutoDeploymentStrategyTest.java
+++ b/modules/flowable-spring/src/test/java/org/flowable/spring/test/autodeployment/SingleResourceAutoDeploymentStrategyTest.java
@@ -16,8 +16,8 @@ package org.flowable.spring.test.autodeployment;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isA;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -32,13 +32,13 @@ import org.flowable.spring.configurator.SingleResourceAutoDeploymentStrategy;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.core.io.Resource;
 
 /**
  * @author Tiese Barrell
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class SingleResourceAutoDeploymentStrategyTest extends AbstractAutoDeploymentStrategyTest {
 
     private SingleResourceAutoDeploymentStrategy classUnderTest;

--- a/pom.xml
+++ b/pom.xml
@@ -688,7 +688,7 @@
 			<dependency>
 				<groupId>org.mockito</groupId>
 				<artifactId>mockito-core</artifactId>
-				<version>1.10.19</version>
+				<version>2.18.0</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
Unused stubbing is reported as an error by Mockito 2, so remove it were possible and make Mockito ignore it where easy removal is not possible.