### PR TITLE
Properties migrator should be compile dependency

### DIFF
--- a/modules/flowable-app-rest/pom.xml
+++ b/modules/flowable-app-rest/pom.xml
@@ -535,7 +535,6 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-properties-migrator</artifactId>
-      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.flowable</groupId>

--- a/modules/flowable-ui-admin/flowable-ui-admin-app/pom.xml
+++ b/modules/flowable-ui-admin/flowable-ui-admin-app/pom.xml
@@ -430,7 +430,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-properties-migrator</artifactId>
-            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.flowable</groupId>

--- a/modules/flowable-ui-idm/flowable-ui-idm-app/pom.xml
+++ b/modules/flowable-ui-idm/flowable-ui-idm-app/pom.xml
@@ -63,7 +63,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-properties-migrator</artifactId>
-            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.flowable</groupId>

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/pom.xml
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/pom.xml
@@ -58,7 +58,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-properties-migrator</artifactId>
-            <scope>runtime</scope>
         </dependency>
 
     	<dependency>

--- a/modules/flowable-ui-task/flowable-ui-task-app/pom.xml
+++ b/modules/flowable-ui-task/flowable-ui-task-app/pom.xml
@@ -63,7 +63,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-properties-migrator</artifactId>
-            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.flowable</groupId>


### PR DESCRIPTION
The property migrator should not be a runtime dependency as it is required for the migration path to the new Spring Boot properties of the apps

Fixes #957