### PR TITLE
Cockroach db compatibility

### DIFF
--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/resources/META-INF/liquibase/flowable-modeler-app-db-changelog.xml
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/resources/META-INF/liquibase/flowable-modeler-app-db-changelog.xml
@@ -23,13 +23,13 @@
 			<column name="model_comment" type="varchar(4000)">
 				<constraints nullable="true" />
 			</column>
-			<column name="created" type="datetime(6)">
+			<column name="created" type="datetime">
 				<constraints nullable="true" />
 			</column>
 			<column name="created_by" type="varchar(255)">
 				<constraints nullable="true" />
 			</column>
-			<column name="last_updated" type="datetime(6)">
+			<column name="last_updated" type="datetime">
 				<constraints nullable="true" />
 			</column>
 			<column name="last_updated_by" type="varchar(255)">
@@ -71,19 +71,19 @@
             <column name="model_comment" type="varchar(4000)">
                 <constraints nullable="true" />
             </column>
-            <column name="created" type="datetime(6)">
+            <column name="created" type="datetime">
                 <constraints nullable="true" />
             </column>
             <column name="created_by" type="varchar(255)">
                 <constraints nullable="true" />
             </column>
-            <column name="last_updated" type="datetime(6)">
+            <column name="last_updated" type="datetime">
                 <constraints nullable="true" />
             </column>
             <column name="last_updated_by" type="varchar(255)">
                 <constraints nullable="true" />
             </column>
-            <column name="removal_date" type="datetime(6)">
+            <column name="removal_date" type="datetime">
                 <constraints nullable="true" />
             </column>
             <column name="version" type="int">
@@ -115,15 +115,6 @@
             <column name="model_id" type="varchar(255)" />
             <column name="relation_type" type="varchar(255)" />
         </createTable>
-        
-        <addForeignKeyConstraint baseColumnNames="parent_model_id"
-			baseTableName="ACT_DE_MODEL_RELATION" constraintName="fk_relation_parent"
-			referencedColumnNames="id" referencedTableName="ACT_DE_MODEL" />
-			
-		<addForeignKeyConstraint baseColumnNames="model_id"
-			baseTableName="ACT_DE_MODEL_RELATION" constraintName="fk_relation_child"
-			referencedColumnNames="id" referencedTableName="ACT_DE_MODEL" />
-			
 	</changeSet>
     
     <!-- 
@@ -148,6 +139,44 @@
         <addColumn tableName="ACT_DE_MODEL_HISTORY">
             <column  name="tenant_id" type="varchar(255)" />
         </addColumn>
+    </changeSet>
+
+    <changeSet id="4" author="flowable">
+        <createIndex indexName="idx_mod_rel_parent"
+            tableName="ACT_DE_MODEL_RELATION" unique="false">
+            <column name="parent_model_id" />
+        </createIndex>
+
+        <createIndex indexName="idx_mod_rel_mod"
+            tableName="ACT_DE_MODEL_RELATION" unique="false">
+            <column name="model_id" />
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="5" author="flowable">
+        <!-- MARK_RAN so it won't keep trying to execute this changesetfor a dbms 
+            that doesn't need it because the FK's exist
+         -->
+        <preConditions onFail="MARK_RAN">
+            <!--  These foreign keys were part of changeset 1, but for 
+                cockroachdb 2.0.0 and earlier compatibility are being 
+                added here separated from index creation because in 
+                cockroachdb a foreign key:
+                  * must have an pre-existing index
+                  * can't create that index in same transaction as FK
+            -->
+            <not>
+                <foreignKeyConstraintExists foreignKeyName="fk_relation_parent"/>
+                <foreignKeyConstraintExists foreignKeyName="fk_relation_child"/>
+            </not>
+        </preConditions>
+        <addForeignKeyConstraint baseColumnNames="parent_model_id"
+            baseTableName="ACT_DE_MODEL_RELATION" constraintName="fk_relation_parent"
+            referencedColumnNames="id" referencedTableName="ACT_DE_MODEL" />
+            
+        <addForeignKeyConstraint baseColumnNames="model_id"
+            baseTableName="ACT_DE_MODEL_RELATION" constraintName="fk_relation_child"
+            referencedColumnNames="id" referencedTableName="ACT_DE_MODEL" />
     </changeSet>
 
 </databaseChangeLog>


### PR DESCRIPTION
[UPDATED]
This branch will attempt to add cockroachdb support to flowable.

 _I would like to get some feedback on preferences in regards to the implementation options._

Cockroachdb's core strategy seems to be to focus on being postgres compatible for ORM's and other tools. Although they may in future start supporting tools specifically so that cockroach's unique features can be better exploited.

I have run some tests with manually altered schema and this works, but automated schema upgrades present some challenges especially around transactions. 

**Implementation options**
**1. Create a new database in all places it is required, new scripts, new properties.**
This approach is challenging for the following reasons:
a. The JDBC driver returns product as postgresql and even the versions are postgres versions. The recommended way to detect cockroach over postgres is to run the following query: select version() from which CockroachDB can be extracted.

The posthres driver hardcodes product name, but could retrieve it from a handshake parameters called crdb_version as used by other cockroach tools like pgasync. I tested making this change to the driver, it's simple and works, but I am not sure if a pull request would be accepted for this, even though it seems more correct than hardcoding. I suspect it would break tools that work with the driver currently (it sounds like hibernate works to some extent).

b. Liquibase might need a custom extension as there is none yet. This is not particularly hard to do and it has the concept of priority when overriding databases. Need is maybe a strong word, because so far I have been able to make changes to changesets that do work on the postgres implementation.

c. More work is required to keep schemas up to date, especially the non-liquibase ones.

**2. Try to align postgres and cockroachdb implementations, to be compatible with each other.** 
This approach is challenging for its own reasons.
a. Foreign keys require indexes but you can't create them in the same transaction, not without postgres incompatible syntax. One option is to execute foreign keys in a second transaction which is not quite ideal (this approach is part of my initial commits). I opened an issue at cockroach here: https://github.com/cockroachdb/cockroach/issues/24578
So this may be resolved in future.

b. Other such issues may arise in future, and one the differentiation then becomes a bit more haphazard.

c. More care needs to go into postgres scripts to make sure they don't disobey cockroach semantics.

**Summary of issues found**
I opened issues at cockroach for the following:
1. A bug when calling jdbc metadata and then doing create table and insert queries in ddl scripts, sets off a sequence of events where it hangs.
https://github.com/cockroachdb/cockroach/issues/24578

This requires starting a fresh transaction right before ddl scripts are run.

2.  The issue with foreign keys and corresponding indexes not being allowed in the same transaction has had some discussion here where it seems it might be resolvable in a future update: https://github.com/cockroachdb/cockroach/issues/24626


**Comments**
* there is some advantage to making the scripts equal for postgres and cockroach, one could have a postgres backup database in the event of some  significant cockroachdb issue. I haven't tested it, but cockroach dumps claim to be loadable in other db's.
* I am not particularly happy with executing the sql ddl scripts in two transactions. 
* With liquibase the transaction issue is less of a concern as each changeset seems to execute in a transaction. 
* Moving the sql based migrations to liquibase is probably also an option, if that is a longer term goal for flowable.
* One can wait for some of the bugs to be resolved before taking this further
