### PR TITLE
Dev profiles

### DIFF
--- a/modules/flowable-app-rest/pom.xml
+++ b/modules/flowable-app-rest/pom.xml
@@ -21,15 +21,6 @@
   <build>
     <finalName>flowable-rest</finalName>
 
-    <resources>
-      <resource>
-        <directory>src/main/resources</directory>
-        <excludes>
-          <exclude>application-dev.properties</exclude>
-        </excludes>
-      </resource>
-    </resources>
-
     <plugins>
       <plugin>
 	    <groupId>org.apache.tomcat.maven</groupId>

--- a/modules/flowable-app-rest/src/main/java/org/flowable/rest/app/FlowableRestApplication.java
+++ b/modules/flowable-app-rest/src/main/java/org/flowable/rest/app/FlowableRestApplication.java
@@ -14,6 +14,7 @@ package org.flowable.rest.app;
 
 import org.flowable.rest.app.properties.RestAppProperties;
 import org.flowable.rest.conf.BootstrapConfiguration;
+import org.flowable.rest.conf.DevelopmentConfiguration;
 import org.flowable.rest.conf.SecurityConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -33,8 +34,8 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 })
 @Import({
     BootstrapConfiguration.class,
-    SecurityConfiguration.class
-
+    SecurityConfiguration.class,
+    DevelopmentConfiguration.class
 })
 @SpringBootApplication
 public class FlowableRestApplication extends SpringBootServletInitializer {

--- a/modules/flowable-app-rest/src/main/java/org/flowable/rest/conf/DevelopmentConfiguration.java
+++ b/modules/flowable-app-rest/src/main/java/org/flowable/rest/conf/DevelopmentConfiguration.java
@@ -1,0 +1,49 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.rest.conf;
+
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+
+import javax.sql.DataSource;
+
+/**
+ * Development @Profile specific datasource override
+ *
+ * @author Yvo Swillens
+ */
+@Configuration
+@Profile({"dev"})
+public class DevelopmentConfiguration {
+
+    protected static final String DATASOURCE_DRIVER_CLASS_NAME = "com.mysql.jdbc.Driver";
+    protected static final String DATASOURCE_URL = "jdbc:mysql://127.0.0.1:3306/flowable?characterEncoding=UTF-8";
+    protected static final String DATASOURCE_USERNAME = "flowable";
+    protected static final String DATASOURCE_PASSWORD = "flowable";
+
+    @Bean
+    @Primary
+    public DataSource developmentDataSource() {
+        return DataSourceBuilder
+            .create()
+            .driverClassName(DATASOURCE_DRIVER_CLASS_NAME)
+            .url(DATASOURCE_URL)
+            .username(DATASOURCE_USERNAME)
+            .password(DATASOURCE_PASSWORD)
+            .build();
+    }
+
+}

--- a/modules/flowable-app-rest/src/main/resources/application-dev.properties
+++ b/modules/flowable-app-rest/src/main/resources/application-dev.properties
@@ -1,4 +1,0 @@
-spring.datasource.driver-class-name=com.mysql.jdbc.Driver
-spring.datasource.url=jdbc:mysql://127.0.0.1:3306/flowable?characterEncoding=UTF-8
-spring.datasource.username=flowable
-spring.datasource.password=flowable

--- a/modules/flowable-ui-admin/flowable-ui-admin-conf/src/main/java/org/flowable/ui/admin/conf/ApplicationConfiguration.java
+++ b/modules/flowable-ui-admin/flowable-ui-admin-conf/src/main/java/org/flowable/ui/admin/conf/ApplicationConfiguration.java
@@ -20,18 +20,18 @@ import org.springframework.context.annotation.Import;
 
 @Configuration
 @ComponentScan(basePackages = {
-        "org.flowable.ui.admin.repository",
-        "org.flowable.ui.admin.service",
-        "org.flowable.ui.admin.filter",
-        "org.flowable.ui.admin.security",
-        "org.flowable.ui.common.conf",
-        "org.flowable.ui.common.repository",
-        "org.flowable.ui.common.service",
-        "org.flowable.ui.common.filter",
-        "org.flowable.ui.common.security"
+    "org.flowable.ui.admin.repository",
+    "org.flowable.ui.admin.service",
+    "org.flowable.ui.admin.security",
+    "org.flowable.ui.admin.conf",
+    "org.flowable.ui.common.conf",
+    "org.flowable.ui.common.repository",
+    "org.flowable.ui.common.service",
+    "org.flowable.ui.common.filter",
+    "org.flowable.ui.common.security"
 })
 @Import(value = {
-        SecurityConfiguration.class,
+    SecurityConfiguration.class,
     DatabaseConfiguration.class
 })
 @EnableConfigurationProperties(FlowableAdminAppProperties.class)

--- a/modules/flowable-ui-admin/flowable-ui-admin-conf/src/main/java/org/flowable/ui/admin/conf/ApplicationDevelopmentConfiguration.java
+++ b/modules/flowable-ui-admin/flowable-ui-admin-conf/src/main/java/org/flowable/ui/admin/conf/ApplicationDevelopmentConfiguration.java
@@ -1,0 +1,62 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.ui.admin.conf;
+
+import org.flowable.ui.admin.domain.EndpointType;
+import org.flowable.ui.admin.properties.FlowableAdminAppProperties;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+import javax.annotation.PostConstruct;
+
+/**
+ * Development @Profile specific datasource override
+ *
+ * @author Yvo Swillens
+ */
+@Profile({"dev"})
+@Configuration
+public class ApplicationDevelopmentConfiguration {
+
+    protected static final Integer FLOWABLE_ADMIN_APP_SERVER_CONFIG_PROCESS_PORT = 9999;
+    protected static final Integer FLOWABLE_ADMIN_APP_SERVER_CONFIG_CMMN_PORT = 9999;
+    protected static final Integer FLOWABLE_ADMIN_APP_SERVER_CONFIG_DMN_PORT = 9999;
+    protected static final Integer FLOWABLE_ADMIN_APP_SERVER_CONFIG_FORM_PORT = 9999;
+    protected static final Integer FLOWABLE_ADMIN_APP_SERVER_CONFIG_CONTENT_PORT = 9999;
+
+    @Autowired
+    private FlowableAdminAppProperties flowableAdminAppProperties;
+
+    @PostConstruct
+    public void postConstruct() {
+        if (flowableAdminAppProperties.getServerConfig() == null) {
+            return;
+        }
+        if (flowableAdminAppProperties.getServerConfig().get(EndpointType.PROCESS) != null) {
+            flowableAdminAppProperties.getServerConfig().get(EndpointType.PROCESS).setPort(FLOWABLE_ADMIN_APP_SERVER_CONFIG_PROCESS_PORT);
+        }
+        if (flowableAdminAppProperties.getServerConfig().get(EndpointType.CMMN) != null) {
+            flowableAdminAppProperties.getServerConfig().get(EndpointType.CMMN).setPort(FLOWABLE_ADMIN_APP_SERVER_CONFIG_CMMN_PORT);
+        }
+        if (flowableAdminAppProperties.getServerConfig().get(EndpointType.DMN) != null) {
+            flowableAdminAppProperties.getServerConfig().get(EndpointType.DMN).setPort(FLOWABLE_ADMIN_APP_SERVER_CONFIG_DMN_PORT);
+        }
+        if (flowableAdminAppProperties.getServerConfig().get(EndpointType.FORM) != null) {
+            flowableAdminAppProperties.getServerConfig().get(EndpointType.FORM).setPort(FLOWABLE_ADMIN_APP_SERVER_CONFIG_FORM_PORT);
+        }
+        if (flowableAdminAppProperties.getServerConfig().get(EndpointType.CONTENT) != null) {
+            flowableAdminAppProperties.getServerConfig().get(EndpointType.CONTENT).setPort(FLOWABLE_ADMIN_APP_SERVER_CONFIG_CONTENT_PORT);
+        }
+    }
+}

--- a/modules/flowable-ui-common/src/main/java/org/flowable/ui/common/conf/DevelopmentConfiguration.java
+++ b/modules/flowable-ui-common/src/main/java/org/flowable/ui/common/conf/DevelopmentConfiguration.java
@@ -1,0 +1,49 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.ui.common.conf;
+
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+
+import javax.sql.DataSource;
+
+/**
+ * Development @Profile specific datasource override
+ *
+ * @author Yvo Swillens
+ */
+@Configuration
+@Profile({"dev"})
+public class DevelopmentConfiguration {
+
+    protected static final String DATASOURCE_DRIVER_CLASS_NAME = "com.mysql.jdbc.Driver";
+    protected static final String DATASOURCE_URL = "jdbc:mysql://127.0.0.1:3306/flowable?characterEncoding=UTF-8";
+    protected static final String DATASOURCE_USERNAME = "flowable";
+    protected static final String DATASOURCE_PASSWORD = "flowable";
+
+    @Bean
+    @Primary
+    public DataSource developmentDataSource() {
+        return DataSourceBuilder
+            .create()
+            .driverClassName(DATASOURCE_DRIVER_CLASS_NAME)
+            .url(DATASOURCE_URL)
+            .username(DATASOURCE_USERNAME)
+            .password(DATASOURCE_PASSWORD)
+            .build();
+    }
+
+}

--- a/modules/flowable-ui-idm/flowable-ui-idm-app/pom.xml
+++ b/modules/flowable-ui-idm/flowable-ui-idm-app/pom.xml
@@ -190,7 +190,6 @@
                 </includes>
                 <excludes>
                     <exclude>static/fonts/**</exclude>
-                    <exclude>application-dev.properties</exclude>
                 </excludes>
             </resource>
             <resource>

--- a/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/resources/application-dev.properties
+++ b/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/resources/application-dev.properties
@@ -1,4 +1,0 @@
-spring.datasource.driver-class-name=com.mysql.jdbc.Driver
-spring.datasource.url=jdbc:mysql://127.0.0.1:3306/flowable?characterEncoding=UTF-8
-spring.datasource.username=flowable
-spring.datasource.password=flowable

--- a/modules/flowable-ui-idm/flowable-ui-idm-conf/src/main/java/org/flowable/ui/idm/conf/ApplicationConfiguration.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-conf/src/main/java/org/flowable/ui/idm/conf/ApplicationConfiguration.java
@@ -28,10 +28,11 @@ import org.springframework.web.servlet.DispatcherServlet;
 @Configuration
 @EnableConfigurationProperties(FlowableIdmAppProperties.class)
 @ComponentScan(basePackages = {
-        "org.flowable.ui.idm.conf",
-        "org.flowable.ui.idm.security",
-        "org.flowable.ui.idm.idm",
-        "org.flowable.ui.idm.service" }, excludeFilters = { @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, value = RemoteIdmServiceImpl.class) })
+    "org.flowable.ui.common.conf",
+    "org.flowable.ui.idm.conf",
+    "org.flowable.ui.idm.security",
+    "org.flowable.ui.idm.idm",
+    "org.flowable.ui.idm.service"}, excludeFilters = {@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, value = RemoteIdmServiceImpl.class)})
 public class ApplicationConfiguration {
 
     @Bean

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/pom.xml
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/pom.xml
@@ -239,7 +239,6 @@
                     <exclude>static/libs/bootstrap_3.1.1/fonts/**</exclude>
                     <exclude>static/editor-app/fonts/**</exclude>
 		            <exclude>static/libs/ui-grid_3.0.0/**</exclude>
-		            <exclude>application-dev.properties</exclude>
                 </excludes>
             </resource>
             <resource>

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/resources/application-dev.properties
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/resources/application-dev.properties
@@ -1,6 +1,0 @@
-spring.datasource.driver-class-name=com.mysql.jdbc.Driver
-spring.datasource.url=jdbc:mysql://127.0.0.1:3306/flowable?characterEncoding=UTF-8
-spring.datasource.username=flowable
-spring.datasource.password=flowable
-
-flowable.modeler.app.deployment-api-url=http://localhost:9999/flowable-task/process-api

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-conf/src/main/java/org/flowable/ui/modeler/conf/ApplicationConfiguration.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-conf/src/main/java/org/flowable/ui/modeler/conf/ApplicationConfiguration.java
@@ -30,6 +30,7 @@ import org.springframework.web.servlet.DispatcherServlet;
         "org.flowable.ui.modeler.repository",
         "org.flowable.ui.modeler.service",
         "org.flowable.ui.modeler.security",
+        "org.flowable.ui.common.conf",
         "org.flowable.ui.common.filter",
         "org.flowable.ui.common.service",
         "org.flowable.ui.common.repository",

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-conf/src/main/java/org/flowable/ui/modeler/conf/ApplicationDevelopmentConfiguration.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-conf/src/main/java/org/flowable/ui/modeler/conf/ApplicationDevelopmentConfiguration.java
@@ -1,0 +1,42 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.ui.modeler.conf;
+
+import org.flowable.ui.modeler.properties.FlowableModelerAppProperties;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+import javax.annotation.PostConstruct;
+
+/**
+ * Development @Profile specific configuration property overrides
+ *
+ * @author Yvo Swillens
+ */
+@Profile({"dev"})
+@Configuration
+public class ApplicationDevelopmentConfiguration {
+
+    protected static final boolean FLOWABLE_MODELER_REST_ENABLED = true;
+    protected static final String FLOWABLE_MODELER_DEPLOYMENT_URL = "http://localhost:9999/flowable-task/process-api";
+
+    @Autowired
+    private FlowableModelerAppProperties flowableModelerAppProperties;
+
+    @PostConstruct
+    public void postConstruct() {
+        flowableModelerAppProperties.setRestEnabled(FLOWABLE_MODELER_REST_ENABLED);
+        flowableModelerAppProperties.setDeploymentApiUrl(FLOWABLE_MODELER_DEPLOYMENT_URL);
+    }
+}

--- a/modules/flowable-ui-task/flowable-ui-task-app/pom.xml
+++ b/modules/flowable-ui-task/flowable-ui-task-app/pom.xml
@@ -297,7 +297,6 @@
                 <excludes>
                     <exclude>static/fonts/**</exclude>
                     <exclude>static/libs/ui-grid_3.0.0/**</exclude>
-                    <exclude>application-dev.properties</exclude>
                 </excludes>
             </resource>
             <resource>

--- a/modules/flowable-ui-task/flowable-ui-task-app/src/main/resources/application-dev.properties
+++ b/modules/flowable-ui-task/flowable-ui-task-app/src/main/resources/application-dev.properties
@@ -1,4 +1,0 @@
-spring.datasource.driver-class-name=com.mysql.jdbc.Driver
-spring.datasource.url=jdbc:mysql://127.0.0.1:3306/flowable?characterEncoding=UTF-8
-spring.datasource.username=flowable
-spring.datasource.password=flowable


### PR DESCRIPTION
Created development Spring profile configuration classes instead of dev property files.
This to avoid development specific file in the build artifacts.