### PR TITLE
bugFix Cmmn MilestoneQuery and HistoricMilestoneQuery 

### DIFF
--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/behavior/impl/MilestoneActivityBehavior.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/behavior/impl/MilestoneActivityBehavior.java
@@ -41,9 +41,7 @@ public class MilestoneActivityBehavior extends CoreCmmnActivityBehavior {
     protected MilestoneInstanceEntity createMilestoneInstance(PlanItemInstanceEntity planItemInstanceEntity, CommandContext commandContext) {
         MilestoneInstanceEntityManager milestoneInstanceEntityManager = CommandContextUtil.getMilestoneInstanceEntityManager(commandContext);
         MilestoneInstanceEntity milestoneInstanceEntity = milestoneInstanceEntityManager.create();
-        if (milestoneNameExpression != null) {
-            milestoneInstanceEntity.setName(milestoneNameExpression.getValue(planItemInstanceEntity).toString());
-        }
+        milestoneInstanceEntity.setName(milestoneNameExpression.getValue(planItemInstanceEntity).toString());
         milestoneInstanceEntity.setTimeStamp(CommandContextUtil.getCmmnEngineConfiguration(commandContext).getClock().getCurrentTime());
         milestoneInstanceEntity.setCaseInstanceId(planItemInstanceEntity.getCaseInstanceId());
         milestoneInstanceEntity.setCaseDefinitionId(planItemInstanceEntity.getCaseDefinitionId());

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/parser/DefaultCmmnActivityBehaviorFactory.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/parser/DefaultCmmnActivityBehaviorFactory.java
@@ -60,13 +60,13 @@ public class DefaultCmmnActivityBehaviorFactory implements CmmnActivityBehaviorF
 
     @Override
     public MilestoneActivityBehavior createMilestoneActivityBehavior(PlanItem planItem, Milestone milestone) {
-        Expression nameExpression = null;
-        if (StringUtils.isNotEmpty(planItem.getName())) {
-            nameExpression = expressionManager.createExpression(planItem.getName());
+        String name = null;
+        if (!StringUtils.isEmpty(planItem.getName())) {
+            name = planItem.getName();
         } else if (StringUtils.isNotEmpty(milestone.getName())) {
-            nameExpression = expressionManager.createExpression(milestone.getName());
+            name = milestone.getName();
         }
-        return new MilestoneActivityBehavior(nameExpression);
+        return new MilestoneActivityBehavior(expressionManager.createExpression(name));
     }
 
     @Override

--- a/modules/flowable-cmmn-engine/src/main/resources/org/flowable/cmmn/db/liquibase/flowable-cmmn-db-changelog.xml
+++ b/modules/flowable-cmmn-engine/src/main/resources/org/flowable/cmmn/db/liquibase/flowable-cmmn-db-changelog.xml
@@ -364,9 +364,6 @@
             <column name="TENANT_ID_" type="varchar(255)" defaultValue="" />
         </createTable>
 
-        <dropNotNullConstraint tableName="ACT_CMMN_HI_MIL_INST" columnName="NAME_" columnDataType="varchar(255)"/>
-        <dropNotNullConstraint tableName="ACT_CMMN_RU_MIL_INST" columnName="NAME_" columnDataType="varchar(255)"/>
-
     </changeSet>
 
 </databaseChangeLog>

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/history/MilestoneHistoryServiceTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/history/MilestoneHistoryServiceTest.java
@@ -94,12 +94,16 @@ public class MilestoneHistoryServiceTest extends FlowableCmmnTestCase {
         assertNotNull(xyzMilestone);
         assertEquals("xyzMilestone", xyzMilestone.getName());
 
-        //One Milestone has no name
+        HistoricMilestoneInstance one = cmmnHistoryService.createHistoricMilestoneInstanceQuery().milestoneInstanceName("1").singleResult();
+        assertNotNull(one);
+        assertEquals("1", one.getName());
+
         List<HistoricMilestoneInstance> list = cmmnHistoryService.createHistoricMilestoneInstanceQuery().orderByMilestoneName().asc().list();
         assertEquals(3, list.size());
-        assertNull(list.get(0).getName());
+        //assertNull(list.get(0).getName());
+        assertEquals("1", list.get(0).getName());
         assertEquals("abcMilestone", list.get(1).getName());
-        assertNotNull("xyzMilestone", list.get(2).getName());
+        assertEquals("xyzMilestone", list.get(2).getName());
 
         //Query timestamps
         HistoricMilestoneInstance milestone1 = cmmnHistoryService.createHistoricMilestoneInstanceQuery()

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/MilestoneQueryTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/MilestoneQueryTest.java
@@ -82,12 +82,17 @@ public class MilestoneQueryTest extends FlowableCmmnTestCase {
         assertNotNull(xyzMilestone);
         assertEquals("xyzMilestone", xyzMilestone.getName());
 
+        MilestoneInstance one = cmmnRuntimeService.createMilestoneInstanceQuery().milestoneInstanceName("1").singleResult();
+        assertNotNull(one);
+        assertEquals("1", one.getName());
+
         //One Milestone has no name
         List<MilestoneInstance> list = cmmnRuntimeService.createMilestoneInstanceQuery().orderByMilestoneName().asc().list();
         assertEquals(3, list.size());
-        assertNull(list.get(0).getName());
+        //assertNull(list.get(0).getName());
+        assertEquals("1", list.get(0).getName());
         assertEquals("abcMilestone", list.get(1).getName());
-        assertNotNull("xyzMilestone", list.get(2).getName());
+        assertEquals("xyzMilestone", list.get(2).getName());
 
         //Query timestamps
         MilestoneInstance milestone1 = cmmnRuntimeService.createMilestoneInstanceQuery()

--- a/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/history/MilestoneHistoryServiceTest.testMilestoneInstanceHistoryQuery.cmmn
+++ b/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/history/MilestoneHistoryServiceTest.testMilestoneInstanceHistoryQuery.cmmn
@@ -34,7 +34,7 @@
             </sentry>
             <milestone id="milestone1" name="xyzMilestone"/>
             <milestone id="milestone2"/>
-            <milestone id="milestone3"/>
+            <milestone id="milestone3" name="1"/>
             <userEventListener id="event1"/>
             <userEventListener id="event2"/>
             <userEventListener id="event3"/>

--- a/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/runtime/MilestoneQueryTest.testSimpleMilestoneInstanceQuery.cmmn
+++ b/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/runtime/MilestoneQueryTest.testSimpleMilestoneInstanceQuery.cmmn
@@ -34,7 +34,7 @@
             </sentry>
             <milestone id="milestone1" name="xyzMilestone"/>
             <milestone id="milestone2"/>
-            <milestone id="milestone3"/>
+            <milestone id="milestone3" name="1"/>
             <userEventListener id="event1"/>
             <userEventListener id="event2"/>
             <userEventListener id="event3"/>


### PR DESCRIPTION
bugFix Cmmn MilestoneQuery and HistoricMilestoneQuery criteria (reachedAfter condition typo and ElementId mapping)
bugFix DefaultCmmnActivityBehaviorFactory and MilestoneActivityBehavior were forcing the name of a milestone plan item to be not null in the case definition (xml). Not consistent with other planItems
Removed NotNull constraint (liquibase flowable-cmmn-db-changelog.xml) for NAME_ column of ACT_CMMN_HI_MIL_INST and ACT_CMMN_RU_MIL_INST tables
Added unitTest for MilestoneInstanceQuery and HistoricMilestoneIntanceQuery