### PR TITLE
#1028 FIX

### DIFF
--- a/modules/flowable-dmn-json-converter/src/main/java/org/flowable/editor/dmn/converter/DmnJsonConverter.java
+++ b/modules/flowable-dmn-json-converter/src/main/java/org/flowable/editor/dmn/converter/DmnJsonConverter.java
@@ -456,7 +456,7 @@ public class DmnJsonConverter {
                             expressionValue = expressionValueNode.asText();
                         }
 
-                        if (complexExpressionIds.contains(id)) {
+                        if (complexExpressionIds.contains(id) || expressionValue.startsWith("${") || expressionValue.startsWith("#{")) {
                             outputEntry.setText(expressionValue);
                         } else {
                             if ("string".equals(ruleOutputClauseContainer.getOutputClause().getTypeRef())

--- a/modules/flowable-dmn-json-converter/src/test/java/org/flowable/editor/dmn/converter/DmnJsonConverterTest.java
+++ b/modules/flowable-dmn-json-converter/src/test/java/org/flowable/editor/dmn/converter/DmnJsonConverterTest.java
@@ -59,7 +59,7 @@ public class DmnJsonConverterTest {
     private static final String JSON_RESOURCE_6 = "org/flowable/editor/dmn/converter/decisiontable_entries.json";
     private static final String JSON_RESOURCE_7 = "org/flowable/editor/dmn/converter/decisiontable_dates.json";
     private static final String JSON_RESOURCE_8 = "org/flowable/editor/dmn/converter/decisiontable_empty_operator.json";
-    private static final String JSON_RESOURCE_9 = "org/flowable/editor/dmn/converter/decisiontable_complex_output_expression.json";
+    private static final String JSON_RESOURCE_9 = "org/flowable/editor/dmn/converter/decisiontable_complex_output_expression_regression.json";
     private static final String JSON_RESOURCE_10 = "org/flowable/editor/dmn/converter/decisiontable_regression_model_v1.json";
     private static final String JSON_RESOURCE_11 = "org/flowable/editor/dmn/converter/decisiontable_regression_model_v1_no_type.json";
     private static final String JSON_RESOURCE_12 = "org/flowable/editor/dmn/converter/decisiontable_regression_model_v1_no_type2.json";
@@ -70,6 +70,8 @@ public class DmnJsonConverterTest {
     private static final String JSON_RESOURCE_17 = "org/flowable/editor/dmn/converter/decisiontable_custom_input_expression.json";
     private static final String JSON_RESOURCE_18 = "org/flowable/editor/dmn/converter/decisiontable_collections_collection_input.json";
     private static final String JSON_RESOURCE_19 = "org/flowable/editor/dmn/converter/decisiontable_collections_collection_compare.json";
+    private static final String JSON_RESOURCE_20 = "org/flowable/editor/dmn/converter/decisiontable_complex_output_expression.json";
+
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -369,12 +371,24 @@ public class DmnJsonConverterTest {
     }
 
     @Test
-    public void testConvertJsonToDmnComplexOutputExpression() {
+    public void testConvertJsonToDmnComplexOutputExpressionRegression() {
         JsonNode testJsonResource = parseJson(JSON_RESOURCE_9);
         DmnDefinition dmnDefinition = new DmnJsonConverter().convertToDmn(testJsonResource, "abc", 1, new Date());
 
         DecisionTable decisionTable = (DecisionTable) dmnDefinition.getDecisions().get(0).getExpression();
         assertEquals("refVar1 * refVar2", decisionTable.getRules().get(0).getOutputEntries().get(0).getOutputEntry().getText());
+
+        ObjectNode modelerJson = new DmnJsonConverter().convertToJson(dmnDefinition);
+        assertNotNull(modelerJson);
+    }
+
+    @Test
+    public void testConvertJsonToDmnComplexOutputExpression() {
+        JsonNode testJsonResource = parseJson(JSON_RESOURCE_20);
+        DmnDefinition dmnDefinition = new DmnJsonConverter().convertToDmn(testJsonResource, "abc", 1, new Date());
+
+        DecisionTable decisionTable = (DecisionTable) dmnDefinition.getDecisions().get(0).getExpression();
+        assertEquals("${refVar1 * refVar2}", decisionTable.getRules().get(0).getOutputEntries().get(0).getOutputEntry().getText());
 
         ObjectNode modelerJson = new DmnJsonConverter().convertToJson(dmnDefinition);
         assertNotNull(modelerJson);

--- a/modules/flowable-dmn-json-converter/src/test/resources/org/flowable/editor/dmn/converter/decisiontable_complex_output_expression_regression.json
+++ b/modules/flowable-dmn-json-converter/src/test/resources/org/flowable/editor/dmn/converter/decisiontable_complex_output_expression_regression.json
@@ -12,7 +12,8 @@
       "variableType": null,
       "type": "string",
       "label": "",
-      "entries": []
+      "entries": [],
+      "newVariable": false
     }
   ],
   "outputExpressions": [
@@ -22,19 +23,16 @@
       "variableType": null,
       "type": "string",
       "label": "",
-      "entries": []
+      "entries": [],
+      "newVariable": false,
+      "complexExpression": true
     }
   ],
   "rules": [
     {
-      "2": "${refVar1 * refVar2}",
+      "2": "refVar1 * refVar2",
       "1_operator": "==",
       "1_expression": "TEST"
-    },
-    {
-      "2": "#{refVar1 * refVar2}",
-      "1_operator": "==",
-      "1_expression": "TEST2"
     }
   ]
 }


### PR DESCRIPTION
When using expressions in string type output entries expression should not be surrounded by quotes.
This bug was introduced in 6.3 when the complex expression was removed in de decision table editor.