### PR TITLE
Change the locations of the controllers for the swagger-maven-plugin

### DIFF
--- a/docs/public-api/tools/flowable-oas-generator/pom.xml
+++ b/docs/public-api/tools/flowable-oas-generator/pom.xml
@@ -89,7 +89,7 @@
                         <apiSource>
                             <springmvc>true</springmvc>
                             <locations>
-                                <location>org.flowable.rest.dmn.service.api</location>
+                                <location>org.flowable.dmn.rest.service.api</location>
                             </locations>
                             <schemes>
                                 <scheme>http</scheme>
@@ -128,7 +128,7 @@
                         <apiSource>
                             <springmvc>true</springmvc>
                             <locations>
-                                <location>org.flowable.rest.form.service.api</location>
+                                <location>org.flowable.form.rest.service.api</location>
                             </locations>
                             <schemes>
                                 <scheme>http</scheme>
@@ -167,7 +167,7 @@
                         <apiSource>
                             <springmvc>true</springmvc>
                             <locations>
-                                <location>org.flowable.rest.content.service.api</location>
+                                <location>org.flowable.content.rest.service.api</location>
                             </locations>
                             <schemes>
                                 <scheme>http</scheme>

--- a/docs/public-api/tools/flowable-slate/slate/source/includes/_rest-header.md
+++ b/docs/public-api/tools/flowable-slate/slate/source/includes/_rest-header.md
@@ -187,6 +187,6 @@ When working with variables (execute decision), the REST API uses some common pr
 |date|Value is treated as a **java.util.Date**. When writing, the JSON text will be converted using ISO-8601 date format.
 
 
-It's possible to support additional variable-types with a custom JSON representation (either simple value or complex/nested JSON object). By extending the **initializeVariableConverters()** method on *org.flowable.rest.dmn.service.api.DmnRestResponseFactory**, you can add additional **org.flowable.rest.variable.RestVariableConverter* classes to support converting your POJOs to a format suitable for transferring through REST and converting the REST-value back to your POJO. The actual transformation to JSON is done by Jackson.
+It's possible to support additional variable-types with a custom JSON representation (either simple value or complex/nested JSON object). By extending the **initializeVariableConverters()** method on *org.flowable.dmn.rest.service.api.DmnRestResponseFactory**, you can add additional **org.flowable.rest.variable.RestVariableConverter* classes to support converting your POJOs to a format suitable for transferring through REST and converting the REST-value back to your POJO. The actual transformation to JSON is done by Jackson.
 
 

--- a/docs/userguide/src/en/base/header-rest.adoc
+++ b/docs/userguide/src/en/base/header-rest.adoc
@@ -237,4 +237,4 @@ When working with variables (execute decision), the REST API uses some common pr
 
 |===============
 
-It's possible to support additional variable-types with a custom JSON representation (either simple value or complex/nested JSON object). By extending the +initializeVariableConverters()+ method on +org.flowable.rest.dmn.service.api.DmnRestResponseFactory+, you can add additional +org.flowable.rest.variable.RestVariableConverter+ classes to support converting your POJOs to a format suitable for transferring through REST and converting the REST-value back to your POJO. The actual transformation to JSON is done by Jackson.
+It's possible to support additional variable-types with a custom JSON representation (either simple value or complex/nested JSON object). By extending the +initializeVariableConverters()+ method on +org.flowable.dmn.rest.service.api.DmnRestResponseFactory+, you can add additional +org.flowable.rest.variable.RestVariableConverter+ classes to support converting your POJOs to a format suitable for transferring through REST and converting the REST-value back to your POJO. The actual transformation to JSON is done by Jackson.

--- a/modules/flowable-app-rest/pom.xml
+++ b/modules/flowable-app-rest/pom.xml
@@ -172,7 +172,7 @@
                 <apiSource>
                   <springmvc>true</springmvc>
                   <locations>
-                    <location>org.flowable.rest.idm.service.api</location>
+                    <location>org.flowable.idm.rest.service.api</location>
                   </locations>
                   <schemes>
                     <scheme>http</scheme>
@@ -210,7 +210,7 @@
                 <apiSource>
                   <springmvc>true</springmvc>
                   <locations>
-                    <location>org.flowable.rest.dmn.service.api</location>
+                    <location>org.flowable.dmn.rest.service.api</location>
                   </locations>
                   <schemes>
                     <scheme>http</scheme>
@@ -248,7 +248,7 @@
                 <apiSource>
                   <springmvc>true</springmvc>
                   <locations>
-                    <location>org.flowable.rest.form.service.api</location>
+                    <location>org.flowable.form.rest.service.api</location>
                   </locations>
                   <schemes>
                     <scheme>http</scheme>
@@ -286,7 +286,7 @@
                 <apiSource>
                   <springmvc>true</springmvc>
                   <locations>
-                    <location>org.flowable.rest.content.service.api</location>
+                    <location>org.flowable.content.rest.service.api</location>
                   </locations>
                   <schemes>
                     <scheme>http</scheme>


### PR DESCRIPTION
The swagger documentation was missing because we didn't change the locations of the api sources in the swagger-maven-plugin.

I have also created a feature request for the swagger-maven-plugin https://github.com/kongchen/swagger-maven-plugin/issues/620 to add an option for configuring the plugin to fail the build in case no classes were found in the locations of an api source