### PR TITLE
Periodic code cleanups: remove duplicate addition of EndEvent

### DIFF
--- a/modules/flowable-cdi/src/main/java/org/flowable/cdi/impl/event/CdiEventSupportBpmnParseHandler.java
+++ b/modules/flowable-cdi/src/main/java/org/flowable/cdi/impl/event/CdiEventSupportBpmnParseHandler.java
@@ -70,7 +70,6 @@ public class CdiEventSupportBpmnParseHandler implements BpmnParseHandler {
         supportedTypes.add(Task.class);
         supportedTypes.add(ManualTask.class);
         supportedTypes.add(UserTask.class);
-        supportedTypes.add(EndEvent.class);
         supportedTypes.add(SubProcess.class);
         supportedTypes.add(EventSubProcess.class);
         supportedTypes.add(CallActivity.class);


### PR DESCRIPTION
The addition of a duplicate 'EndEvent' appears to be in error; removing second occurrence.