### PR TITLE
Periodic code cleanups: hasMoreFormProperties not updated in loop

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/history/async/json/transformer/FormPropertiesSubmittedHistoryJsonTransformer.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/history/async/json/transformer/FormPropertiesSubmittedHistoryJsonTransformer.java
@@ -48,10 +48,9 @@ public class FormPropertiesSubmittedHistoryJsonTransformer extends AbstractHisto
     @Override
     public void transformJson(HistoryJobEntity job, ObjectNode historicalData, CommandContext commandContext) {
         HistoricDetailDataManager historicDetailDataManager = CommandContextUtil.getProcessEngineConfiguration(commandContext).getHistoricDetailDataManager();
-        
-        boolean hasMoreFormProperties = true;
+
         int counter = 1;
-        while (hasMoreFormProperties) {
+        while (true) {
             
             String propertyId = getStringFromJson(historicalData, HistoryJsonConstants.FORM_PROPERTY_ID + counter);
             if (StringUtils.isEmpty(propertyId)) {


### PR DESCRIPTION
The variable `hasMoreFormProperties` is not updated inside of the loop; changed to a simple `true`.