### PR TITLE
#1075 Server errors when starting a process from a form not triggering Alert

### DIFF
--- a/modules/flowable-ui-task/flowable-ui-task-app/src/main/resources/static/workflow/scripts/controllers/processes.js
+++ b/modules/flowable-ui-task/flowable-ui-task-app/src/main/resources/static/workflow/scripts/controllers/processes.js
@@ -273,6 +273,9 @@ angular.module('flowableApp')
             $scope.selectDefaultDefinition();
         };
 
+        $scope.$on('process-started-error', function (event, data) {
+            $rootScope.addAlert(data.error.message, 'error');
+        });
 
         // Called after form is submitted
         $scope.$on('process-started', function (event, data) {


### PR DESCRIPTION
Create listener for the 'process-started-error' in static/workflow/scripts/controllers/processes.js which will create an alert.