### PR TITLE
Use correct path mapping for getting historic cmmn resource

### DIFF
--- a/modules/flowable-ui-modeler/flowable-ui-modeler-rest/src/main/java/org/flowable/ui/modeler/rest/app/ModelCmmnResource.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-rest/src/main/java/org/flowable/ui/modeler/rest/app/ModelCmmnResource.java
@@ -39,7 +39,7 @@ public class ModelCmmnResource extends AbstractModelCmmnResource {
     /**
      * GET /rest/models/{modelId}/history/{caseModelHistoryId}/cmmn -> Get CMMN 1.1 xml
      */
-    @RequestMapping(value = "/rest/models/{caseModelId}/history/{caseModelHistoryId}/bpmn20", method = RequestMethod.GET)
+    @RequestMapping(value = "/rest/models/{caseModelId}/history/{caseModelHistoryId}/cmmn", method = RequestMethod.GET)
     public void getHistoricProcessModelCmmnXml(HttpServletResponse response, @PathVariable String caseModelId, @PathVariable String caseModelHistoryId) throws IOException {
         super.getHistoricCaseModelCmmnXml(response, caseModelId, caseModelHistoryId);
     }


### PR DESCRIPTION
If this is not changed there is a clash with the path from the `ModelBpmnResource`