### PR TITLE
Change to dynamic context root for ui-idm-app #1022

### DIFF
--- a/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/resources/static/scripts/app-cfg.js
+++ b/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/resources/static/scripts/app-cfg.js
@@ -17,10 +17,12 @@
 
 var FLOWABLE = FLOWABLE || {};
 
+var pathname = window.location.pathname.replace(/\/$/, '');
+
 FLOWABLE.CONFIG = {
 	'onPremise' : true,
-	'contextRoot' : '/flowable-idm',
-	'webContextRoot' : '/flowable-idm',
+	'contextRoot' : pathname,
+	'webContextRoot' : pathname,
     'datesLocalization' : false
 };
 

--- a/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/resources/static/scripts/app-cfg.js
+++ b/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/resources/static/scripts/app-cfg.js
@@ -17,7 +17,7 @@
 
 var FLOWABLE = FLOWABLE || {};
 
-var pathname = window.location.pathname.replace(/\/$/, '');
+var pathname = window.location.pathname.replace(/^(\/[^\/]*)(\/.*)?\/$/, '$1');
 
 FLOWABLE.CONFIG = {
 	'onPremise' : true,

--- a/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/resources/static/scripts/app-cfg.js
+++ b/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/resources/static/scripts/app-cfg.js
@@ -17,7 +17,7 @@
 
 var FLOWABLE = FLOWABLE || {};
 
-var pathname = window.location.pathname.replace(/^(\/[^\/]*)(\/.*)?\/$/, '$1');
+var pathname = window.location.pathname.replace(/^(\/[^\/]*)(\/.*)?$/, '$1').replace(/\/$/, '');
 
 FLOWABLE.CONFIG = {
 	'onPremise' : true,

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/resources/static/scripts/app-cfg.js
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/resources/static/scripts/app-cfg.js
@@ -17,9 +17,11 @@
 
 var FLOWABLE = FLOWABLE || {};
 
+var pathname = window.location.pathname.replace(/^(\/[^\/]*)(\/.*)?\/$/, '$1');
+
 FLOWABLE.CONFIG = {
 	'onPremise' : true,
-	'contextRoot' : '/flowable-modeler',
-	'webContextRoot' : '/flowable-modeler',
+	'contextRoot' : pathname,
+	'webContextRoot' : pathname,
 	'datesLocalization' : false
 };

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/resources/static/scripts/app-cfg.js
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/resources/static/scripts/app-cfg.js
@@ -17,7 +17,7 @@
 
 var FLOWABLE = FLOWABLE || {};
 
-var pathname = window.location.pathname.replace(/^(\/[^\/]*)(\/.*)?\/$/, '$1');
+var pathname = window.location.pathname.replace(/^(\/[^\/]*)(\/.*)?$/, '$1').replace(/\/$/, '');
 
 FLOWABLE.CONFIG = {
 	'onPremise' : true,

--- a/modules/flowable-ui-task/flowable-ui-task-app/src/main/resources/static/scripts/app-cfg.js
+++ b/modules/flowable-ui-task/flowable-ui-task-app/src/main/resources/static/scripts/app-cfg.js
@@ -17,7 +17,7 @@
 
 var FLOWABLE = FLOWABLE || {};
 
-var pathname = window.location.pathname.replace(/^(\/[^\/]*)(\/.*)?\/$/, '$1');
+var pathname = window.location.pathname.replace(/^(\/[^\/]*)(\/.*)?$/, '$1').replace(/\/$/, '');
 
 FLOWABLE.CONFIG = {
 	'onPremise' : true,

--- a/modules/flowable-ui-task/flowable-ui-task-app/src/main/resources/static/scripts/app-cfg.js
+++ b/modules/flowable-ui-task/flowable-ui-task-app/src/main/resources/static/scripts/app-cfg.js
@@ -17,10 +17,12 @@
 
 var FLOWABLE = FLOWABLE || {};
 
+var pathname = window.location.pathname.replace(/^(\/[^\/]*)(\/.*)?\/$/, '$1');
+
 FLOWABLE.CONFIG = {
 	'onPremise' : true,
-	'contextRoot' : '/flowable-task',
-	'webContextRoot' : '/flowable-task',
+	'contextRoot' : pathname,
+	'webContextRoot' : pathname,
     'datesLocalization' : false
 };
 


### PR DESCRIPTION
Use current `window.location.pathname` to figure out the current context root instead of hardcoded context roots. Tested with Mozilla Firefox and Google Chrome.