### PR TITLE
Replace usages of deprecated method IOUtils#closeQuietly with try-wit…

### DIFF
--- a/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/ContentEngines.java
+++ b/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/ContentEngines.java
@@ -159,16 +159,12 @@ public abstract class ContentEngines {
     }
 
     protected static ContentEngine buildContentEngine(URL resource) {
-        InputStream inputStream = null;
-        try {
-            inputStream = resource.openStream();
+        try (InputStream inputStream = resource.openStream()) {
             ContentEngineConfiguration contentEngineConfiguration = ContentEngineConfiguration.createContentEngineConfigurationFromInputStream(inputStream);
             return contentEngineConfiguration.buildContentEngine();
 
         } catch (IOException e) {
             throw new FlowableException("couldn't open resource stream: " + e.getMessage(), e);
-        } finally {
-            IOUtils.closeQuietly(inputStream);
         }
     }
 

--- a/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/fs/FileSystemContentStorage.java
+++ b/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/fs/FileSystemContentStorage.java
@@ -128,9 +128,9 @@ public class FileSystemContentStorage implements ContentStorage {
             tempFileCreated = true;
 
             // Write the actual content to the file
-            FileOutputStream tempOutputStream = new FileOutputStream(tempContentFile);
-            length = IOUtils.copy(contentStream, tempOutputStream);
-            IOUtils.closeQuietly(tempOutputStream);
+            try (FileOutputStream tempOutputStream = new FileOutputStream(tempContentFile)) {
+                length = IOUtils.copy(contentStream, tempOutputStream);
+            }
 
             // Rename the content file first
             if (contentFile.renameTo(oldContentFile)) {

--- a/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/fs/SimpleFileSystemContentStorage.java
+++ b/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/fs/SimpleFileSystemContentStorage.java
@@ -149,9 +149,9 @@ public class SimpleFileSystemContentStorage implements ContentStorage {
             tempFileCreated = true;
 
             // Write the actual content to the file
-            FileOutputStream tempOutputStream = new FileOutputStream(tempContentFile);
-            length = IOUtils.copy(contentStream, tempOutputStream);
-            IOUtils.closeQuietly(tempOutputStream);
+            try (FileOutputStream tempOutputStream = new FileOutputStream(tempContentFile)) {
+                length = IOUtils.copy(contentStream, tempOutputStream);
+            }
 
             // Rename the content file first
             if (contentFile.renameTo(oldContentFile)) {

--- a/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/DmnEngines.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/DmnEngines.java
@@ -157,16 +157,12 @@ public abstract class DmnEngines {
     }
 
     protected static DmnEngine buildDmnEngine(URL resource) {
-        InputStream inputStream = null;
-        try {
-            inputStream = resource.openStream();
+        try (InputStream inputStream = resource.openStream()) {
             DmnEngineConfiguration dmnEngineConfiguration = DmnEngineConfiguration.createDmnEngineConfigurationFromInputStream(inputStream);
             return dmnEngineConfiguration.buildDmnEngine();
 
         } catch (IOException e) {
             throw new FlowableException("couldn't open resource stream: " + e.getMessage(), e);
-        } finally {
-            IOUtils.closeQuietly(inputStream);
         }
     }
 

--- a/modules/flowable-dmn-json-converter/src/test/java/org/flowable/editor/dmn/converter/DmnJsonConverterTest.java
+++ b/modules/flowable-dmn-json-converter/src/test/java/org/flowable/editor/dmn/converter/DmnJsonConverterTest.java
@@ -598,15 +598,11 @@ public class DmnJsonConverterTest {
 
     /* Helper methods */
     protected String readJsonToString(String resource) {
-        InputStream is = null;
-        try {
-            is = this.getClass().getClassLoader().getResourceAsStream(resource);
+        try (InputStream is = this.getClass().getClassLoader().getResourceAsStream(resource)) {
             return IOUtils.toString(is);
         } catch (IOException e) {
             fail("Could not read " + resource + " : " + e.getMessage());
             return null;
-        } finally {
-            IOUtils.closeQuietly(is);
         }
     }
 

--- a/modules/flowable-dmn-json-converter/src/test/java/org/flowable/editor/dmn/converter/DmnJsonConverterUtilTest.java
+++ b/modules/flowable-dmn-json-converter/src/test/java/org/flowable/editor/dmn/converter/DmnJsonConverterUtilTest.java
@@ -67,15 +67,11 @@ public class DmnJsonConverterUtilTest {
 
     /* Helper methods */
     protected String readJsonToString(String resource) {
-        InputStream is = null;
-        try {
-            is = this.getClass().getClassLoader().getResourceAsStream(resource);
+        try (InputStream is = this.getClass().getClassLoader().getResourceAsStream(resource)) {
             return IOUtils.toString(is);
         } catch (IOException e) {
             fail("Could not read " + resource + " : " + e.getMessage());
             return null;
-        } finally {
-            IOUtils.closeQuietly(is);
         }
     }
 

--- a/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/FormEngines.java
+++ b/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/FormEngines.java
@@ -157,16 +157,12 @@ public abstract class FormEngines {
     }
 
     protected static FormEngine buildFormEngine(URL resource) {
-        InputStream inputStream = null;
-        try {
-            inputStream = resource.openStream();
+        try (InputStream inputStream = resource.openStream()) {
             FormEngineConfiguration formEngineConfiguration = FormEngineConfiguration.createFormEngineConfigurationFromInputStream(inputStream);
             return formEngineConfiguration.buildFormEngine();
 
         } catch (IOException e) {
             throw new FlowableException("couldn't open resource stream: " + e.getMessage(), e);
-        } finally {
-            IOUtils.closeQuietly(inputStream);
         }
     }
 

--- a/modules/flowable-form-json-converter/src/test/java/org/flowable/editor/form/converter/FormJsonConverterTest.java
+++ b/modules/flowable-form-json-converter/src/test/java/org/flowable/editor/form/converter/FormJsonConverterTest.java
@@ -61,15 +61,11 @@ public class FormJsonConverterTest {
 
     /* Helper methods */
     protected String readJsonToString(String resource) {
-        InputStream is = null;
-        try {
-            is = this.getClass().getClassLoader().getResourceAsStream(resource);
+        try (InputStream is = this.getClass().getClassLoader().getResourceAsStream(resource)) {
             return IOUtils.toString(is, "utf-8");
         } catch (IOException e) {
             fail("Could not read " + resource + " : " + e.getMessage());
             return null;
-        } finally {
-            IOUtils.closeQuietly(is);
         }
     }
 

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/ui/modeler/service/BaseAppDefinitionService.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/ui/modeler/service/BaseAppDefinitionService.java
@@ -246,13 +246,9 @@ public class BaseAppDefinitionService {
     }
 
     protected byte[] createDeployZipArtifact(Map<String, byte[]> deployableAssets) {
-        ByteArrayOutputStream baos = null;
-        ZipOutputStream zos = null;
-        byte[] deployZipArtifact = null;
-        try {
-            baos = new ByteArrayOutputStream();
-            zos = new ZipOutputStream(baos);
 
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+             ZipOutputStream zos = new ZipOutputStream(baos)) {
             for (Map.Entry<String, byte[]> entry : deployableAssets.entrySet()) {
                 ZipEntry zipEntry = new ZipEntry(entry.getKey());
                 zipEntry.setSize(entry.getValue().length);
@@ -261,17 +257,11 @@ public class BaseAppDefinitionService {
                 zos.closeEntry();
             }
 
-            IOUtils.closeQuietly(zos);
-
             // this is the zip file as byte[]
-            deployZipArtifact = baos.toByteArray();
-
-            IOUtils.closeQuietly(baos);
+            return baos.toByteArray();
 
         } catch (IOException ioe) {
             throw new InternalServerErrorException("Could not create deploy zip artifact");
         }
-
-        return deployZipArtifact;
     }
 }

--- a/modules/flowable-ui-task/flowable-ui-task-rest/src/main/java/org/flowable/ui/task/rest/runtime/AbstractRelatedContentResource.java
+++ b/modules/flowable-ui-task/flowable-ui-task-rest/src/main/java/org/flowable/ui/task/rest/runtime/AbstractRelatedContentResource.java
@@ -201,17 +201,11 @@ public abstract class AbstractRelatedContentResource {
         }
 
         // Write content response
-        InputStream inputstream = contentService.getContentItemData(contentId);
-        try {
+        try (InputStream inputstream = contentService.getContentItemData(contentId)) {
             IOUtils.copy(inputstream, response.getOutputStream());
 
         } catch (IOException e) {
             throw new InternalServerErrorException("Error while writing raw content data for content: " + contentId, e);
-        } finally {
-            // Be sure to close the content object stream to free any resources that may be related to it
-            if (inputstream != null) {
-                IOUtils.closeQuietly(inputstream);
-            }
         }
     }
 


### PR DESCRIPTION
…h-resources statements.

Caveat: 

If only the close method throws an exception this now propagated instead of swallowed.

According to http://mail.openjdk.java.net/pipermail/coin-dev/2009-April/001503.html

>As a practical matter these [...] exceptions [...] rarely if ever occur, so a program will be no more robust if these exceptions are ignored. 

So this behavior change should be o.k.