### PR TITLE
Upgrade maven-surefire-plugin to version 2.22.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1006,7 +1006,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.21.0</version>
+				<version>2.22.0</version>
 				<configuration>
 					<failIfNoTests>false</failIfNoTests>
 					<trimStackTrace>false</trimStackTrace>


### PR DESCRIPTION
Not currently relevant for flowable, but this version supports running JUnit 5 tests out of the box (no additional configuration required).