### PR TITLE
Enhancement: Allow local variables to be set on executions via ChangeActivityStateBuilder

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/dynamic/DefaultDynamicStateManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/dynamic/DefaultDynamicStateManager.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -282,20 +283,23 @@ public class DefaultDynamicStateManager implements DynamicStateManager {
                 ExecutionEntity processInstanceExecution = defaultContinueParentExecution.getProcessInstance();
                 processInstanceExecution.setVariables(processVariables);
             }
-            
-            if (moveExecutionContainer.getMoveToFlowElements().size() == 1 && localVariables != null && localVariables.size() > 0) {
-                FlowElement moveToFlowElement = moveExecutionContainer.getMoveToFlowElements().iterator().next();
-                if (localVariables.containsKey(moveToFlowElement.getId())) {
-                    List<SubProcess> toCreateSubProcesses = moveExecutionContainer.getSubProcessesToCreateMap().get(moveToFlowElement.getId());
-                    if (toCreateSubProcesses != null && toCreateSubProcesses.size() > 0) {
-                        moveExecutionContainer.getNewSubProcessChildExecution(toCreateSubProcesses.get(0).getId())
-                            .setVariablesLocal(localVariables.get(moveToFlowElement.getId()));
-                    } else {
-                        newChildExecutions.get(0).setVariablesLocal(localVariables.get(moveToFlowElement.getId()));
+
+            if (localVariables != null && localVariables.size() > 0) {
+                Iterator<ExecutionEntity> newChildExecutionsIter = newChildExecutions.iterator();
+                while (newChildExecutionsIter.hasNext()) {
+                    ExecutionEntity execution = newChildExecutionsIter.next();
+                    while (null != execution) {
+                        if (null != execution.getActivityId()) {
+                            Map<String, Object> localVars = localVariables.get(execution.getActivityId());
+                            if (null != localVars) {
+                                execution.setVariablesLocal(localVars);
+                            }
+                        }
+                        execution = execution.getParent();
                     }
                 }
             }
-            
+
             for (ExecutionEntity newChildExecution : newChildExecutions) {
                 CommandContextUtil.getAgenda().planContinueProcessOperation(newChildExecution);
             }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/RuntimeServiceChangeStateTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/RuntimeServiceChangeStateTest.java
@@ -1082,6 +1082,69 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Deployment(resources = { "org/flowable/engine/test/api/oneTaskSubProcess.bpmn20.xml" })
+    public void testSetCurrentActivityInUnstartedSubProcessWithModeledDataObject() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("taskBefore","subTask")
+                .changeState();
+
+        org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertEquals("subTask", task.getTaskDefinitionKey());
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
+        assertEquals(3, executions.size());
+
+        Execution subProcessExecution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("subProcess").singleResult();
+        assertNotNull(runtimeService.getVariableLocal(subProcessExecution.getId(), "name", String.class));
+
+        DataObject nameDataObject = runtimeService.getDataObjectLocal(subProcessExecution.getId(), "name");
+        assertNotNull(nameDataObject);
+        assertEquals("John", nameDataObject.getValue());
+
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+    @Deployment(resources = { "org/flowable/engine/test/api/oneTaskSubProcess.bpmn20.xml" })
+    public void testSetCurrentActivityInUnstartedSubProcessWithLocalVariableOnSubProcess() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("taskBefore","subTask")
+                .localVariable("subProcess", "name", "Joe")
+                .changeState();
+
+        org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertEquals("subTask", task.getTaskDefinitionKey());
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
+        assertEquals(3, executions.size());
+
+        Execution subProcessExecution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("subProcess").singleResult();
+        assertNotNull(runtimeService.getVariableLocal(subProcessExecution.getId(), "name", String.class));
+
+        DataObject nameDataObject = runtimeService.getDataObjectLocal(subProcessExecution.getId(), "name");
+        assertNotNull(nameDataObject);
+        assertEquals("Joe", nameDataObject.getValue());
+
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
     @Deployment(resources = { "org/flowable/engine/test/api/parallelTask.bpmn20.xml" })
     public void testSetCurrentActivityToMultipleActivitiesForParallelGateway() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess");


### PR DESCRIPTION
Update the behavior of DefaultDynamicStateManager to support setting
local variables on any new child executions or one of its parents. This support is needed to ensure the value of a dataobject modeled on a subprocess can be set prior to planning the ContinueProcessOperation.