### PR TITLE
AbstractFlowableHttpHandler extensionElement support

### DIFF
--- a/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/child/FieldExtensionParser.java
+++ b/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/child/FieldExtensionParser.java
@@ -16,6 +16,7 @@ import javax.xml.stream.XMLStreamReader;
 
 import org.apache.commons.lang3.StringUtils;
 import org.flowable.bpmn.converter.util.BpmnXMLUtil;
+import org.flowable.bpmn.model.AbstractFlowableHttpHandler;
 import org.flowable.bpmn.model.FlowableListener;
 import org.flowable.bpmn.model.BaseElement;
 import org.flowable.bpmn.model.BpmnModel;
@@ -35,7 +36,7 @@ public class FieldExtensionParser extends BaseChildElementParser {
 
     @Override
     public boolean accepts(BaseElement element) {
-        return ((element instanceof FlowableListener) || (element instanceof ServiceTask) || (element instanceof SendTask));
+        return ((element instanceof FlowableListener) || (element instanceof ServiceTask) || (element instanceof SendTask) || (element instanceof AbstractFlowableHttpHandler));
     }
 
     @Override
@@ -78,8 +79,10 @@ public class FieldExtensionParser extends BaseChildElementParser {
             ((FlowableListener) parentElement).getFieldExtensions().add(extension);
         } else if (parentElement instanceof ServiceTask) {
             ((ServiceTask) parentElement).getFieldExtensions().add(extension);
-        } else {
+        } else if (parentElement instanceof SendTask) {
             ((SendTask) parentElement).getFieldExtensions().add(extension);
+        } else {
+            ((AbstractFlowableHttpHandler) parentElement).getFieldExtensions().add(extension);
         }
     }
 }

--- a/modules/flowable-http/src/test/java/org/flowable/http/bpmn/HttpServiceTaskTest.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/bpmn/HttpServiceTaskTest.java
@@ -87,6 +87,27 @@ public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
     }
 
     @Deployment
+    public void testGetWithParametrizedResponseHandler() {
+        String procId = runtimeService.startProcessInstanceByKey("simpleGetOnly").getId();
+        List<HistoricVariableInstance> variables = historyService.createHistoricVariableInstanceQuery().processInstanceId(procId).list();
+        assertEquals(2, variables.size());
+        String firstName = null;
+        String lastName = null;
+
+        for (HistoricVariableInstance historicVariableInstance : variables) {
+            if ("firstName".equals(historicVariableInstance.getVariableName())) {
+                firstName = (String) historicVariableInstance.getValue();
+            } else if ("lastName".equals(historicVariableInstance.getVariableName())) {
+                lastName = (String) historicVariableInstance.getValue();
+            }
+        }
+
+        assertEquals("John", firstName);
+        assertEquals("Doe", lastName);
+        assertProcessEnded(procId);
+    }
+
+    @Deployment
     public void testGetWithRequestHandler() {
         String procId = runtimeService.startProcessInstanceByKey("simpleGetOnly").getId();
         List<HistoricVariableInstance> variables = historyService.createHistoricVariableInstanceQuery().processInstanceId(procId).list();

--- a/modules/flowable-http/src/test/java/org/flowable/http/bpmn/ParametrizedHttpResponseHandler.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/bpmn/ParametrizedHttpResponseHandler.java
@@ -1,0 +1,49 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.http.bpmn;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Set;
+import org.flowable.common.engine.api.delegate.Expression;
+import org.flowable.common.engine.api.variable.VariableContainer;
+import org.flowable.http.HttpResponse;
+import org.flowable.http.delegate.HttpResponseHandler;
+
+import static org.flowable.http.ExpressionUtils.getStringFromField;
+import static org.flowable.http.ExpressionUtils.getStringSetFromField;
+
+public class ParametrizedHttpResponseHandler implements HttpResponseHandler {
+
+    protected Expression variableName;
+
+    private static final long serialVersionUID = 1L;
+    protected ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void handleHttpResponse(VariableContainer execution, HttpResponse httpResponse) {
+        try {
+            JsonNode responseNode = objectMapper.readTree(httpResponse.getBody());
+            String variableNameEvaluated = getStringFromField(this.variableName, execution);
+            Set<String> fields = getStringSetFromField(variableNameEvaluated);
+            for (final String field : fields) {
+              execution.setVariable(field, responseNode.get("name").get(field).asText());
+            }
+            httpResponse.setBodyResponseHandled(true);
+
+        } catch (Exception e) {
+            // test handler
+        }
+    }
+
+}

--- a/modules/flowable-http/src/test/resources/org/flowable/http/bpmn/HttpServiceTaskTest.testGetWithParametrizedResponseHandler.bpmn20.xml
+++ b/modules/flowable-http/src/test/resources/org/flowable/http/bpmn/HttpServiceTaskTest.testGetWithParametrizedResponseHandler.bpmn20.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:flowable="http://flowable.org/bpmn"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+             xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI"
+             typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath"
+             targetNamespace="http://www.flowable.org/processdef">
+  <process id="simpleGetOnly" name="Simple HTTP Get process">
+    <serviceTask id="httpGet" name="HTTP Get" flowable:type="http">
+      <extensionElements>
+        <flowable:field name="requestMethod">
+          <flowable:string><![CDATA[GET]]></flowable:string>
+        </flowable:field>
+        <flowable:field name="requestUrl">
+          <flowable:string><![CDATA[http://localhost:9798/test]]></flowable:string>
+        </flowable:field>
+        <flowable:httpResponseHandler class="org.flowable.http.bpmn.ParametrizedHttpResponseHandler">
+          <extensionElements>
+            <flowable:field name="variableName">
+              <flowable:string><![CDATA[firstName,lastName]]></flowable:string>
+            </flowable:field>
+          </extensionElements>
+        </flowable:httpResponseHandler>
+      </extensionElements>
+    </serviceTask>
+    <startEvent id="theStart" name="Start"></startEvent>
+    <endEvent id="theEnd" name="End"></endEvent>
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="httpGet"></sequenceFlow>
+    <sequenceFlow id="flow2" sourceRef="httpGet" targetRef="theEnd"></sequenceFlow>
+  </process>
+</definitions>


### PR DESCRIPTION
`FieldExtensionParser ` needs to handle `AbstractFlowableHttpHandler`, otherwise `AbstractFlowableHttpHandler` extensionElements don't get parsed.