### PR TITLE
Make sure Flowable Security auto configuration kicks in when the IdmIdentityService bean is present

### DIFF
--- a/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-rest-api-security/src/test/java/org/flowable/test/spring/boot/SecurityAutoConfigurationTest.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-rest-api-security/src/test/java/org/flowable/test/spring/boot/SecurityAutoConfigurationTest.java
@@ -5,7 +5,7 @@ import org.flowable.idm.api.IdmIdentityService;
 import org.flowable.idm.api.Privilege;
 import org.flowable.idm.api.User;
 import org.flowable.spring.boot.ProcessEngineAutoConfiguration;
-import org.flowable.spring.boot.SecurityAutoConfiguration;
+import org.flowable.spring.boot.FlowableSecurityAutoConfiguration;
 import org.flowable.spring.boot.idm.IdmEngineAutoConfiguration;
 import org.flowable.spring.boot.idm.IdmEngineServicesAutoConfiguration;
 import org.junit.After;
@@ -52,7 +52,7 @@ public class SecurityAutoConfigurationTest {
             ProcessEngineAutoConfiguration.class,
             IdmEngineServicesAutoConfiguration.class,
             org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration.class,
-            SecurityAutoConfiguration.class })
+            FlowableSecurityAutoConfiguration.class })
     public static class SecurityConfiguration {
 
         @Autowired

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/FlowableSecurityAutoConfiguration.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/FlowableSecurityAutoConfiguration.java
@@ -12,10 +12,9 @@
  */
 package org.flowable.spring.boot;
 
-import org.flowable.common.engine.impl.identity.Authentication;
 import org.flowable.common.engine.api.identity.AuthenticationContext;
+import org.flowable.common.engine.impl.identity.Authentication;
 import org.flowable.idm.api.IdmIdentityService;
-import org.flowable.spring.boot.condition.ConditionalOnIdmEngine;
 import org.flowable.spring.boot.idm.IdmEngineServicesAutoConfiguration;
 import org.flowable.spring.security.FlowableAuthenticationProvider;
 import org.flowable.spring.security.FlowableUserDetailsService;
@@ -25,6 +24,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
@@ -41,19 +41,21 @@ import org.springframework.security.core.userdetails.UserDetailsService;
  * @author Josh Long
  */
 @Configuration
-@ConditionalOnIdmEngine
 @ConditionalOnClass({
     AuthenticationManager.class,
+    IdmIdentityService.class,
+    FlowableAuthenticationProvider.class,
     GlobalAuthenticationConfigurerAdapter.class
 })
+@ConditionalOnBean(IdmIdentityService.class)
 @AutoConfigureBefore(org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration.class)
 @AutoConfigureAfter({
     IdmEngineServicesAutoConfiguration.class,
     ProcessEngineAutoConfiguration.class
 })
-public class SecurityAutoConfiguration {
+public class FlowableSecurityAutoConfiguration {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(SecurityAutoConfiguration.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(FlowableSecurityAutoConfiguration.class);
 
     @Configuration
     public static class UserDetailsServiceConfiguration

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/RestApiAutoConfiguration.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/RestApiAutoConfiguration.java
@@ -72,7 +72,7 @@ import org.springframework.context.annotation.Configuration;
 @AutoConfigureAfter({
     //FIXME in order to support both 1.5.x and 2.0 we can't use MultipartAutoConfiguration (the package is changed)
     //MultipartAutoConfiguration.class,
-    SecurityAutoConfiguration.class,
+    FlowableSecurityAutoConfiguration.class,
     AppEngineServicesAutoConfiguration.class,
     ProcessEngineServicesAutoConfiguration.class,
     CmmnEngineServicesAutoConfiguration.class,

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/ldap/FlowableLdapAutoConfiguration.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/ldap/FlowableLdapAutoConfiguration.java
@@ -19,7 +19,7 @@ import org.flowable.ldap.LDAPIdentityServiceImpl;
 import org.flowable.ldap.LDAPQueryBuilder;
 import org.flowable.spring.boot.EngineConfigurationConfigurer;
 import org.flowable.spring.boot.ProcessEngineServicesAutoConfiguration;
-import org.flowable.spring.boot.SecurityAutoConfiguration;
+import org.flowable.spring.boot.FlowableSecurityAutoConfiguration;
 import org.flowable.spring.boot.condition.ConditionalOnLdap;
 import org.flowable.spring.boot.idm.IdmEngineServicesAutoConfiguration;
 import org.springframework.beans.factory.ObjectProvider;
@@ -36,7 +36,7 @@ import org.springframework.context.annotation.Configuration;
  */
 @ConditionalOnLdap
 @AutoConfigureBefore({
-    SecurityAutoConfiguration.class,
+    FlowableSecurityAutoConfiguration.class,
     IdmEngineServicesAutoConfiguration.class,
     ProcessEngineServicesAutoConfiguration.class
 })

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -25,4 +25,4 @@ org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
     org.flowable.spring.boot.cmmn.CmmnEngineAutoConfiguration,\
     org.flowable.spring.boot.cmmn.CmmnEngineServicesAutoConfiguration,\
     org.flowable.spring.boot.ldap.FlowableLdapAutoConfiguration,\
-    org.flowable.spring.boot.SecurityAutoConfiguration
+    org.flowable.spring.boot.FlowableSecurityAutoConfiguration

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/test/spring/boot/FlowableSecurityAutoConfigurationTest.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/test/spring/boot/FlowableSecurityAutoConfigurationTest.java
@@ -1,0 +1,121 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.test.spring.boot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.flowable.common.engine.impl.identity.Authentication;
+import org.flowable.idm.api.IdmIdentityService;
+import org.flowable.spring.boot.FlowableSecurityAutoConfiguration;
+import org.flowable.spring.boot.idm.IdmEngineAutoConfiguration;
+import org.flowable.spring.boot.idm.IdmEngineServicesAutoConfiguration;
+import org.flowable.spring.security.FlowableAuthenticationProvider;
+import org.flowable.spring.security.FlowableUserDetailsService;
+import org.flowable.spring.security.SpringSecurityAuthenticationContext;
+import org.junit.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration;
+import org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.configuration.GlobalAuthenticationConfigurerAdapter;
+import org.springframework.security.core.userdetails.UserDetailsService;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class FlowableSecurityAutoConfigurationTest {
+
+    private static final AutoConfigurations IDM_CONFIGURATION = AutoConfigurations.of(
+        DataSourceAutoConfiguration.class,
+        DataSourceTransactionManagerAutoConfiguration.class,
+        TransactionAutoConfiguration.class,
+        IdmEngineAutoConfiguration.class,
+        IdmEngineServicesAutoConfiguration.class
+    );
+
+    private ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(
+            FlowableSecurityAutoConfiguration.class,
+            org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration.class
+        ));
+
+    @Test
+    public void withMissingAuthenticationManager() {
+        contextRunner
+            .withConfiguration(IDM_CONFIGURATION)
+            .withClassLoader(new FilteredClassLoader(AuthenticationManager.class))
+            .run(context -> assertThat(context)
+                .hasSingleBean(IdmIdentityService.class)
+                .doesNotHaveBean(FlowableSecurityAutoConfiguration.class));
+    }
+
+    @Test
+    public void withMissingIdmIdentityService() {
+        contextRunner
+            .withConfiguration(IDM_CONFIGURATION)
+            .withClassLoader(new FilteredClassLoader(IdmIdentityService.class))
+            .run(context -> assertThat(context)
+                .hasSingleBean(IdmIdentityService.class)
+                .doesNotHaveBean(FlowableSecurityAutoConfiguration.class));
+    }
+
+    @Test
+    public void withMissingFlowableAuthenticationProvider() {
+        contextRunner
+            .withConfiguration(IDM_CONFIGURATION)
+            .withClassLoader(new FilteredClassLoader(FlowableAuthenticationProvider.class))
+            .run(context -> assertThat(context)
+                .hasSingleBean(IdmIdentityService.class)
+                .doesNotHaveBean(FlowableSecurityAutoConfiguration.class));
+    }
+
+    @Test
+    public void withMissingGlobalAuthenticationConfigurerAdapter() {
+        contextRunner
+            .withConfiguration(IDM_CONFIGURATION)
+            .withClassLoader(new FilteredClassLoader(GlobalAuthenticationConfigurerAdapter.class))
+            .run(context -> assertThat(context)
+                .hasSingleBean(IdmIdentityService.class)
+                .doesNotHaveBean(FlowableSecurityAutoConfiguration.class));
+    }
+
+    @Test
+    public void withMissingIdmIdentityServiceBean() {
+        contextRunner
+            .run(context -> assertThat(context)
+                .doesNotHaveBean(IdmIdentityService.class)
+                .doesNotHaveBean(FlowableSecurityAutoConfiguration.class));
+    }
+
+    @Test
+    public void securityConfigurationShouldUseFlowableSecurity() {
+        contextRunner
+            .withConfiguration(IDM_CONFIGURATION)
+            .run(context -> {
+                    assertThat(context)
+                        .hasSingleBean(IdmIdentityService.class)
+                        .hasSingleBean(FlowableSecurityAutoConfiguration.class)
+                        .hasSingleBean(UserDetailsService.class)
+                        .hasSingleBean(AuthenticationProvider.class);
+                    assertThat(context.getBean(UserDetailsService.class)).isInstanceOf(FlowableUserDetailsService.class);
+                    assertThat(context.getBean(AuthenticationProvider.class)).isInstanceOf(FlowableAuthenticationProvider.class);
+
+                    assertThat(Authentication.getAuthenticationContext()).isInstanceOf(SpringSecurityAuthenticationContext.class);
+                }
+            );
+    }
+}


### PR DESCRIPTION

Rename the flowable SecurityAutoConfiguration to FlowableSecurityAutoConfiguration in order to be able to test it properly.
For some reason when used in tests the bean was being overriden by the Spring Boot SecurityAutoConfiguration