### PR TITLE
HttpResponseHandler & HttpRequestHandler BpmnError propagation

### DIFF
--- a/modules/flowable-http/src/main/java/org/flowable/http/HttpActivityExecutor.java
+++ b/modules/flowable-http/src/main/java/org/flowable/http/HttpActivityExecutor.java
@@ -40,6 +40,9 @@ import org.apache.http.util.EntityUtils;
 import org.flowable.bpmn.model.MapExceptionEntry;
 import org.flowable.common.engine.api.FlowableException;
 import org.flowable.common.engine.api.variable.VariableContainer;
+import org.flowable.engine.delegate.BpmnError;
+import org.flowable.engine.delegate.DelegateExecution;
+import org.flowable.engine.impl.bpmn.helper.ErrorPropagation;
 import org.flowable.http.delegate.HttpRequestHandler;
 import org.flowable.http.delegate.HttpResponseHandler;
 import org.slf4j.Logger;
@@ -205,6 +208,11 @@ public class HttpActivityExecutor {
                 httpRequestHandler.handleHttpRequest(execution, requestInfo, client);
             }
         } catch (Exception e) {
+            if (e instanceof BpmnError) {
+                ErrorPropagation.propagateError(((BpmnError) e), ((DelegateExecution) execution));
+                return null;
+            }
+
             throw new FlowableException("Exception while invoking HttpRequestHandler: " + e.getMessage(), e);
         }
 
@@ -274,6 +282,11 @@ public class HttpActivityExecutor {
                     httpResponseHandler.handleHttpResponse(execution, responseInfo);
                 }
             } catch (Exception e) {
+                if (e instanceof BpmnError) {
+                    ErrorPropagation.propagateError(((BpmnError) e), ((DelegateExecution) execution));
+                    return null;
+                }
+
                 throw new FlowableException("Exception while invoking HttpResponseHandler: " + e.getMessage(), e);
             }
 

--- a/modules/flowable-http/src/test/java/org/flowable/http/bpmn/BpmnThrowingRequestHandler.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/bpmn/BpmnThrowingRequestHandler.java
@@ -1,0 +1,17 @@
+package org.flowable.http.bpmn;
+
+import org.apache.http.client.HttpClient;
+import org.flowable.common.engine.api.variable.VariableContainer;
+import org.flowable.engine.delegate.BpmnError;
+import org.flowable.http.HttpRequest;
+import org.flowable.http.delegate.HttpRequestHandler;
+
+public class BpmnThrowingRequestHandler implements HttpRequestHandler {
+
+  private static final long serialVersionUID = 1L;
+
+  @Override
+  public void handleHttpRequest(final VariableContainer execution, final HttpRequest httpRequest, final HttpClient client) {
+      throw new BpmnError("httpRequestHandlerError");
+  }
+}

--- a/modules/flowable-http/src/test/java/org/flowable/http/bpmn/BpmnThrowingResponseHandler.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/bpmn/BpmnThrowingResponseHandler.java
@@ -1,0 +1,16 @@
+package org.flowable.http.bpmn;
+
+import org.flowable.common.engine.api.variable.VariableContainer;
+import org.flowable.engine.delegate.BpmnError;
+import org.flowable.http.HttpResponse;
+import org.flowable.http.delegate.HttpResponseHandler;
+
+public class BpmnThrowingResponseHandler implements HttpResponseHandler {
+
+  private static final long serialVersionUID = 1L;
+
+  @Override
+  public void handleHttpResponse(final VariableContainer execution, final HttpResponse httpResponse) {
+      throw new BpmnError("httpResponseHandlerError");
+  }
+}

--- a/modules/flowable-http/src/test/java/org/flowable/http/bpmn/HttpServiceTaskTest.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/bpmn/HttpServiceTaskTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.flowable.common.engine.api.FlowableException;
+import org.flowable.engine.history.HistoricProcessInstance;
 import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
@@ -115,6 +116,28 @@ public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
         assertEquals("httpGetResponseBody", variables.get(0).getVariableName());
         String variableValue = variables.get(0).getValue().toString();
         assertTrue(variableValue.contains("firstName") && variableValue.contains("John"));
+        assertProcessEnded(procId);
+    }
+
+    @Deployment
+    public void testGetWithBpmnThrowingResponseHandler() {
+        String procId = runtimeService.startProcessInstanceByKey("simpleGetOnly").getId();
+        final HistoricProcessInstance processInstance = historyService.createHistoricProcessInstanceQuery()
+            .processInstanceId(procId)
+            .singleResult();
+
+        assertEquals("theEnd2", processInstance.getEndActivityId());
+        assertProcessEnded(procId);
+    }
+
+    @Deployment
+    public void testGetWithBpmnThrowingRequestHandler() {
+        String procId = runtimeService.startProcessInstanceByKey("simpleGetOnly").getId();
+        final HistoricProcessInstance processInstance = historyService.createHistoricProcessInstanceQuery()
+            .processInstanceId(procId)
+            .singleResult();
+
+        assertEquals("theEnd2", processInstance.getEndActivityId());
         assertProcessEnded(procId);
     }
 

--- a/modules/flowable-http/src/test/resources/org/flowable/http/bpmn/HttpServiceTaskTest.testGetWithBpmnThrowingRequestHandler.bpmn20.xml
+++ b/modules/flowable-http/src/test/resources/org/flowable/http/bpmn/HttpServiceTaskTest.testGetWithBpmnThrowingRequestHandler.bpmn20.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:flowable="http://flowable.org/bpmn"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+             xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI"
+             typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath"
+             targetNamespace="http://www.flowable.org/processdef">
+  <process id="simpleGetOnly" name="Simple HTTP Get process">
+    <serviceTask id="httpGet" name="HTTP Get" flowable:type="http">
+      <extensionElements>
+        <flowable:field name="requestMethod">
+          <flowable:string><![CDATA[GET]]></flowable:string>
+        </flowable:field>
+        <flowable:field name="requestUrl">
+          <flowable:string><![CDATA[http://localhost:9798/test]]></flowable:string>
+        </flowable:field>
+        <flowable:httpRequestHandler class="org.flowable.http.bpmn.BpmnThrowingRequestHandler"/>
+      </extensionElements>
+    </serviceTask>
+    <startEvent id="theStart" name="Start"></startEvent>
+    <endEvent id="theEnd" name="End"></endEvent>
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="httpGet"></sequenceFlow>
+    <sequenceFlow id="flow2" sourceRef="httpGet" targetRef="theEnd"></sequenceFlow>
+
+    <boundaryEvent id="httpRequestHandlerErrorEvent" attachedToRef="httpGet">
+      <errorEventDefinition errorRef="httpRequestHandlerError"/>
+    </boundaryEvent>
+    <endEvent id="theEnd2" name="End 2"></endEvent>
+    <sequenceFlow id="flow3" sourceRef="httpRequestHandlerErrorEvent" targetRef="theEnd2"></sequenceFlow>
+  </process>
+</definitions>

--- a/modules/flowable-http/src/test/resources/org/flowable/http/bpmn/HttpServiceTaskTest.testGetWithBpmnThrowingResponseHandler.bpmn20.xml
+++ b/modules/flowable-http/src/test/resources/org/flowable/http/bpmn/HttpServiceTaskTest.testGetWithBpmnThrowingResponseHandler.bpmn20.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:flowable="http://flowable.org/bpmn"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+             xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI"
+             typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath"
+             targetNamespace="http://www.flowable.org/processdef">
+  <process id="simpleGetOnly" name="Simple HTTP Get process">
+    <serviceTask id="httpGet" name="HTTP Get" flowable:type="http">
+      <extensionElements>
+        <flowable:field name="requestMethod">
+          <flowable:string><![CDATA[GET]]></flowable:string>
+        </flowable:field>
+        <flowable:field name="requestUrl">
+          <flowable:string><![CDATA[http://localhost:9798/test]]></flowable:string>
+        </flowable:field>
+        <flowable:httpResponseHandler class="org.flowable.http.bpmn.BpmnThrowingResponseHandler"/>
+      </extensionElements>
+    </serviceTask>
+    <startEvent id="theStart" name="Start"></startEvent>
+    <endEvent id="theEnd" name="End"></endEvent>
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="httpGet"></sequenceFlow>
+    <sequenceFlow id="flow2" sourceRef="httpGet" targetRef="theEnd"></sequenceFlow>
+
+    <boundaryEvent id="httpResponseHandlerErrorEvent" attachedToRef="httpGet">
+      <errorEventDefinition errorRef="httpResponseHandlerError"/>
+    </boundaryEvent>
+    <endEvent id="theEnd2" name="End 2"></endEvent>
+    <sequenceFlow id="flow3" sourceRef="httpResponseHandlerErrorEvent" targetRef="theEnd2"></sequenceFlow>
+  </process>
+</definitions>


### PR DESCRIPTION
Maybe I am mistaken, but it seems like `BpmnError`s thrown by `HttpRequestHandler` or `HttpResponseHandler` should be propagated instead of wrapped as `FlowableException` to allow custom implementations of these interfaces to affect the flow. Catching all `FlowableException`s with `<flowable:mapException>` does not seem like the proper solution since we cannot differentiate between different reasons that caused them to be thrown if we want to handle them differently: 

- Exception while invoking HttpRequestHandler
- Exception while invoking HttpResponseHandler
- HTTP exception occurred
- IO exception occurred
- Invalid URL exception occurred

Another way of catching exceptions from `HttpRequestHandler` or `HttpResponseHandler` would be to make a new `FlowableException` superclass, but according to the [documentation](https://flowable.org/docs/userguide/index.html#_exception_strategy), this is not the preferred way in order to avoid a big exception hierarchy.