### PR TITLE
DOCS: Fixed typos in CDI documentation

### DIFF
--- a/docs/userguide/src/en/bpmn/ch15-Cdi.adoc
+++ b/docs/userguide/src/en/bpmn/ch15-Cdi.adoc
@@ -3,11 +3,11 @@
 == CDI integration
 
 The flowable-cdi modules leverages both the configurability of Flowable and the extensibility of cdi. The most prominent features of flowable-cdi are:
-   
-* Support for @BusinessProcessScoped beans (Cdi beans the lifecycle of which is bound to a process instance),
-* A custom El-Resolver for resolving Cdi beans (including EJBs) from the process,
+
+* Support for @BusinessProcessScoped beans (CDI beans whose lifecycle is bound to a process instance),
+* A custom El-Resolver for resolving CDI beans (including EJBs) from the process,
 * Declarative control over a process instance using annotations,
-* Flowable is hooked-up to the cdi event bus,
+* Flowable is hooked-up to the CDI event bus,
 * Works with both Java EE and Java SE, works with Spring,
 * Support for unit testing.
 
@@ -22,15 +22,15 @@ The flowable-cdi modules leverages both the configurability of Flowable and the 
 
 === Setting up flowable-cdi
 
-Flowable cdi can be setup in different environments. In this section we briefly walk through the configuration options.    
-    
+Flowable-cdi can be set up in different environments. In this section we briefly walk through the configuration options.
+
 
 ==== Looking up a Process Engine
 
-The cdi extension needs to get access to a ProcessEngine. To achieve this, an implementation of the interface +org.flowable.cdi.spi.ProcessEngineLookup+ is looked up at runtime. The cdi module ships with a default implementation named +org.flowable.cdi.impl.LocalProcessEngineLookup+, which uses  the ++ProcessEngines++-Utility class for looking up the ProcessEngine. In the default configuration +$$ProcessEngines#NAME_DEFAULT$$+ is used to lookup the ProcessEngine. This class might be subclassed to set a custom name. NOTE: needs an +flowable.cfg.xml+ configuration on the classpath.		 
-    	
-Flowable cdi uses a java.util.ServiceLoader SPI for resolving an instance of +org.flowable.cdi.spi.ProcessEngineLookup+. In order to provide a custom implementation of the interface, we need to add a plain text file named  +META-INF/services/org.flowable.cdi.spi.ProcessEngineLookup+ to our deployment, in which we specify the fully qualified classname of the implementation. 
-    	
+The CDI extension needs to get access to a +ProcessEngine+. To achieve this, an implementation of the interface +org.flowable.cdi.spi.ProcessEngineLookup+ is looked up at runtime. The CDI module ships with a default implementation named +org.flowable.cdi.impl.LocalProcessEngineLookup+, which uses the ++ProcessEngines++-Utility class for looking up the ProcessEngine. In the default configuration +$$ProcessEngines#NAME_DEFAULT$$+ is used to look up the +ProcessEngine+. This class might be subclassed to set a custom name. NOTE: You need a +flowable.cfg.xml+ configuration on the classpath.
+	
+Flowable-cdi uses a +java.util.ServiceLoader+ SPI for resolving an instance of +org.flowable.cdi.spi.ProcessEngineLookup+. In order to provide a custom implementation of the interface, we need to add a plain text file named +META-INF/services/org.flowable.cdi.spi.ProcessEngineLookup+ to our deployment, in which we specify the fully qualified class name of the implementation. 
+
 [NOTE]
 ====
 If you do not provide a custom +org.flowable.cdi.spi.ProcessEngineLookup+ implementation, Flowable will use the default +LocalProcessEngineLookup+ implementation. In that case, all you need to do is providing a flowable.cfg.xml file on the classpath (see next section).
@@ -39,13 +39,13 @@ If you do not provide a custom +org.flowable.cdi.spi.ProcessEngineLookup+ implem
 
 ==== Configuring the Process Engine
 
-Configuration depends on the selected ProcessEngineLookup-Strategy (cf. previous section). Here, we focus on the configuration options available in combination with the LocalProcessEngineLookup, which requires us to provide  a Spring flowable.cfg.xml file on the classpath.
+Configuration depends on the selected +ProcessEngineLookup+-Strategy (cf. previous section). Here, we focus on the configuration options available in combination with the +LocalProcessEngineLookup+, which requires us to provide a Spring +flowable.cfg.xml+ file on the classpath.
 
-Flowable offers different ProcessEngineConfiguration implementations mostly dependent on the underlying transaction management strategy. The flowable-cdi module is not concerned with transactions, which means that potentially any transaction management strategy  can be used (even the Spring transaction abstraction). As a convenience, the cdi-module provides two custom ProcessEngineConfiguration implementations: 
-     	
-* ++org.flowable.cdi.CdiJtaProcessEngineConfiguration++: a subclass of the Flowable JtaProcessEngineConfiguration,  can be used if JTA-managed transactions should be used for Flowable
-* ++org.flowable.cdi.CdiStandaloneProcessEngineConfiguration++: a subclass of the Flowable StandaloneProcessEngineConfiguration,  can be used if plain JDBC transactions should be used for Flowable. The following is an example flowable.cfg.xml file for JBoss 7:
-     
+Flowable offers different +ProcessEngineConfiguration+ implementations mostly dependent on the underlying transaction management strategy. The flowable-cdi module is not concerned with transactions, which means that potentially any transaction management strategy  can be used (even the Spring transaction abstraction). As a convenience, the CDI module provides two custom +ProcessEngineConfiguration+ implementations: 
+
+* ++org.flowable.cdi.CdiJtaProcessEngineConfiguration++: a subclass of the Flowable JtaProcessEngineConfiguration can be used if JTA-managed transactions should be used for Flowable
+* ++org.flowable.cdi.CdiStandaloneProcessEngineConfiguration++: a subclass of the Flowable +StandaloneProcessEngineConfiguration+ can be used if plain JDBC transactions should be used for Flowable. The following is an example +flowable.cfg.xml+ file for JBoss 7:
+
 [source,xml,linenums]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
@@ -74,7 +74,7 @@ Flowable offers different ProcessEngineConfiguration implementations mostly depe
      	
 ----
 
-And this is how it would look like for Glassfish 3.1.1 (assuming a datasource named jdbc/flowable is properly configured):
+And this is how it would look like for Glassfish 3.1.1 (assuming a datasource named +jdbc/flowable+ is properly configured):
 
 [source,xml,linenums]     	
 ----
@@ -113,11 +113,11 @@ Note that the above configuration requires the "spring-context" module:
 </dependency>
 ----
 
-The configuration in a Java SE environment looks exactly  like the examples provided in section <<configuration,Creating a ProcessEngine>>, substitute "CdiStandaloneProcessEngineConfiguration" for "StandaloneProcessEngineConfiguration".     	 
+The configuration in a Java SE environment looks exactly like the examples provided in section <<configuration,Creating a ProcessEngine>>, substitute +CdiStandaloneProcessEngineConfiguration+ for +StandaloneProcessEngineConfiguration+. 	 
      	
 ==== Deploying Processes
 
-Processes can be deployed using standard Flowable API (++RepositoryService++). In addition, flowable-cdi offers the possibility to  auto-deploy processes listed in a file named ++processes.xml++ located top-level in the classpath. This is an example processes.xml file:
+Processes can be deployed using the standard Flowable API (+RepositoryService+). In addition, flowable-cdi offers the possibility to auto-deploy processes listed in a file named +processes.xml+ located top-level in the classpath. This is an example +processes.xml+ file:
      
 [source,xml,linenums]
 ----
@@ -125,40 +125,40 @@ Processes can be deployed using standard Flowable API (++RepositoryService++). I
 <!-- list the processes to be deployed -->
 <processes>
 	<process resource="diagrams/myProcess.bpmn20.xml" />
-	<process resource="diagrams/myOtherProcess.bpmn20.xml" />  
+	<process resource="diagrams/myOtherProcess.bpmn20.xml" />
 </processes> 
 ----
 
      
-===Contextual Process Execution with CDI
+=== Contextual Process Execution with CDI
 
-In this section we briefly look at the contextual process execution model used by the Flowable CDI extension. A BPMN business process is typically a long-running interaction, comprised of both user and system tasks. At runtime, a process is split-up into a set of individual units of work, performed by users and/or  application logic. In flowable-cdi, a process instance can be associated with a cdi scope, the association representing a  unit of work. This is particularly useful, if a unit of work is complex, for instance if the implementation of  a UserTask is a complex sequence of different forms and "non-process-scoped" state needs to be kept during this interaction.
+In this section we briefly look at the contextual process execution model used by the Flowable CDI extension. A BPMN business process is typically a long-running interaction, comprised of both user and system tasks. At runtime, a process is split-up into a set of individual units of work, performed by users and/or application logic. In flowable-cdi, a process instance can be associated with a CDI scope, the association representing a unit of work. This is particularly useful, if a unit of work is complex, for instance if the implementation of a user task is a complex sequence of different forms and "non-process-scoped" state needs to be kept during this interaction.
 
-In the default configuration, process instances are associated with the "broadest" active scope, starting with  the conversation and falling back to the request if the conversation context is not active.	 
+In the default configuration, process instances are associated with the "broadest" active scope, starting with the conversation and falling back to the request if the conversation context is not active.	 
 
 ==== Associating a Conversation with a Process Instance 
 	
-When resolving @BusinessProcessScoped beans, or injecting process variables, we rely on an existing association  between an active cdi scope and a process instance. flowable-cdi provides the +org.flowable.cdi.BusinessProcess+ bean  for controlling the association, most prominently:
+When resolving @BusinessProcessScoped beans, or injecting process variables, we rely on an existing association between an active CDI scope and a process instance. flowable-cdi provides the +org.flowable.cdi.BusinessProcess+ bean for controlling the association, most prominently:
 		
-* the _startProcessBy(...)_ methods, mirroring the respective methods exposed by the Flowable +RuntimeService+ allowing to start and subsequently associating a business process,
-* +resumeProcessById(String processInstanceId)+, allowing to associate the process instance with the provided id,
-* +resumeTaskById(String taskId)+, allowing to associate the task with the provided id (and by extension, the corresponding process instance),		  
+* The _startProcessBy(...)_ methods, mirroring the respective methods exposed by the Flowable +RuntimeService+ allowing to start and subsequently associating a business process.
+* +resumeProcessById(String processInstanceId)+, allowing to associate the process instance with the provided id.
+* +resumeTaskById(String taskId)+, allowing to associate the task with the provided id (and by extension, the corresponding process instance).
 
-Once a unit of work (for example a UserTask) is completed, the +completeTask()+ method can be called to disassociate the  conversation/request from the process instance. This signals Flowable that the current task is completed and makes  the process instance proceed.
+Once a unit of work (for example a user task) is completed, the +completeTask()+ method can be called to disassociate the conversation/request from the process instance. This signals the engine that the current task is completed and makes the process instance proceed.
 
-Note that the ++BusinessProcess++-bean is a +@Named+ bean, which means that the exposed methods can  be invoked using expression language, for example from a JSF page. The following JSF2 snippet begins a new conversation and associates it  with a user task instance, the id of which is passed as a request parameter (e.g. ++pageName.jsf?taskId=XX++):
+Note that the +BusinessProcess+ bean is a ++@Named++ bean, which means that the exposed methods can be invoked using expression language, for example from a JSF page. The following JSF2 snippet begins a new conversation and associates it with a user task instance, the id of which is passed as a request parameter (e.g. ++pageName.jsf?taskId=XX++):
 
 [source,xml,linenums]
 ----
 <f:metadata>
-<f:viewParam name="taskId" />
-<f:event type="preRenderView" listener="#{businessProcess.startTask(taskId, true)}" />
+	<f:viewParam name="taskId" />
+	<f:event type="preRenderView" listener="#{businessProcess.startTask(taskId, true)}" />
 </f:metadata>
 ----
 
 ==== Declaratively controlling the Process
 
-Flowable-cdi allows declaratively starting process instances and completing tasks using annotations. The  +@org.flowable.cdi.annotation.StartProcess+ annotation allows to start a process instance  either by "key" or by "name".  Note that the process instance is started _after_ the annotated method returns. Example:
+Flowable-cdi allows declaratively starting process instances and completing tasks using annotations. The ++@org.flowable.cdi.annotation.StartProcess++ annotation allows to start a process instance either by "key" or by "name". Note that the process instance is started _after_ the annotated method returns. Example:
 		
 [source,java,linenums]
 ----
@@ -169,7 +169,7 @@ public String submitRequest(BusinessTripRequest request) {
 }			
 ----
 
-Depending on the configuration of Flowable, the code of the annotated method and the starting of the  process instance will be combined in the same transaction. The ++@org.flowable.cdi.annotation.CompleteTask++-annotation works in the same way:
+Depending on the configuration of Flowable, the code of the annotated method and the starting of the process instance will be combined in the same transaction. The ++@org.flowable.cdi.annotation.CompleteTask++-annotation works in the same way:
 
 [source,java,linenums]
 ----
@@ -180,7 +180,7 @@ public String authorizeBusinessTrip() {
 }
 ----
 
-The ++@CompleteTask++ annotation offers the possibility to end the current conversation. The  default behavior is to end the conversation after the call to Flowable returns. Ending the conversation can be disabled,  as shown in the example above.
+The ++@CompleteTask++ annotation offers the possibility to end the current conversation. The default behavior is to end the conversation after the call to Flowable returns. Ending the conversation can be disabled, as shown in the example above.
 
 
 ==== Referencing Beans from the Process
@@ -193,7 +193,7 @@ Flowable-cdi exposes CDI beans to Flowable El, using a custom resolver. This mak
 			flowable:assignee="#{authorizingManager.account.username}" />
 ----
 
-Where "authorizingManager" could be a bean provided by a producer method:
+Where +authorizingManager+ could be a bean provided by a producer method:
 
 [source,java,linenums]
 ----
@@ -214,7 +214,7 @@ We can use the same feature to call a business method of an EJB in a service tas
 
 ==== Working with @BusinessProcessScoped beans
 
-Using flowable-cdi, the lifecycle of a bean can be bound to a process instance. To this extend, a custom context implementation is provided, namely the BusinessProcessContext. Instances of BusinessProcessScoped beans are stored as process variables in the current process instance. BusinessProcessScoped beans need to be PassivationCapable (for example Serializable). The following is an example of a process scoped bean:
+Using flowable-cdi, the lifecycle of a bean can be bound to a process instance. To this extent, a custom context implementation is provided, namely the +BusinessProcessContext+. Instances of +BusinessProcessScoped+ beans are stored as process variables in the current process instance. +BusinessProcessScoped+ beans need to be +PassivationCapable+ (for example +Serializable+). The following is an example of a process scoped bean:
 
 [source,java,linenums]
 ----
@@ -228,12 +228,12 @@ public class BusinessTripRequest implements Serializable {
 }
 ----
 
-Sometimes, we want to work with process scoped beans, in the absence of an association with a process instance, for example before starting a process. If no process instance is currently active, instances of BusinessProcessScoped beans are temporarily stored in a local scope (I.e. the Conversation or the Request, depending on the context. If this scope is later associated with a business process instance, the bean instances are flushed to the process instance.
+Sometimes, we want to work with process scoped beans, in the absence of an association with a process instance, for example before starting a process. If no process instance is currently active, instances of +BusinessProcessScoped+ beans are temporarily stored in a local scope, i.e. the +Conversation+ or the +Request+, depending on the context. If this scope is later associated with a business process instance, the bean instances are flushed to the process instance.
 
 ==== Injecting Process Variables
 
 Process variables are available for injection. flowable-cdi supports 
-	  	
+ 	
 * type-safe injection of +@BusinessProcessScoped+ beans using +@Inject \[additional qualifiers\] Type fieldName+
 * unsafe injection of other process variables using the +@ProcessVariable(name?)+ qualifier: 
 
@@ -243,8 +243,8 @@ Process variables are available for injection. flowable-cdi supports
 @Inject @ProcessVariable("accountNumber") Object account
 ----
 
-In order to reference process variables using EL, we have similar options:
-	  	
+In order to reference process variables using EL, there are similar options:
+
 * +@Named @BusinessProcessScoped+ beans can be referenced directly,
 * other process variables can be referenced using the ++ProcessVariables++-bean:
 
@@ -255,7 +255,7 @@ In order to reference process variables using EL, we have similar options:
 
 ==== Receiving Process Events
 
-Flowable can be hooked-up to the CDI event-bus. This allows us to be notified of process events using standard CDI event mechanisms.  In order to enable CDI event support for Flowable, enable the corresponding parse listener in the configuration:
+Flowable can be hooked-up to the CDI event bus. This allows us to be notified of process events using standard CDI event mechanisms. In order to enable CDI event support for Flowable, enable the corresponding parse listener in the configuration:
 
 [source,xml,linenums]
 ----
@@ -281,45 +281,43 @@ public void onProcessEvent(@Observes BusinessProcessEvent businessProcessEvent) 
 
 This observer would be notified of all events. If we want to restrict the set of events the observer receives, we can add qualifier annotations:
 		
-* ++@BusinessProcess++: restricts the set of events to a certain  process definition. Example: +@Observes @BusinessProcess("billingProcess") BusinessProcessEvent evt+
-* ++@StartActivity++: restricts the set of events by a certain activity. For example:  +@Observes @StartActivity("shipGoods") BusinessProcessEvent evt+ is invoke whenever an activity with the  id "shipGoods" is entered. 	  		
-* ++@EndActivity++: restricts the set of events by a certain activity. For example:  +@Observes @EndActivity("shipGoods") BusinessProcessEvent evt+ is invoke whenever an activity with the  id "shipGoods" is left. 	  		
+* ++@BusinessProcess++: restricts the set of events to a certain process definition. Example: +@Observes @BusinessProcess("billingProcess") BusinessProcessEvent evt+
+* ++@StartActivity++: restricts the set of events by a certain activity. For example: +@Observes @StartActivity("shipGoods") BusinessProcessEvent evt+ is invoke whenever an activity with the id "shipGoods" is entered.
+* ++@EndActivity++: restricts the set of events by a certain activity. For example: +@Observes @EndActivity("shipGoods") BusinessProcessEvent evt+ is invoke whenever an activity with the id "shipGoods" is left.	
 * ++@TakeTransition++: restricts the set of events by a certain transition.
 * ++@CreateTask++: restricts the set of events by a certain task's creation.
 * ++@DeleteTask++: restricts the set of events by a certain task's deletion.
 * ++@AssignTask++: restricts the set of events by a certain task's assignment.
 * ++@CompleteTask++: restricts the set of events by a certain task's completion.
-	  		
-The qualifiers named above can be combined freely. For example, in order to receive all events generated when  leaving the "shipGoods" activity in the "shipmentProcess", we could write the following observer method:
+	
+The qualifiers named above can be combined freely. For example, in order to receive all events generated when leaving the "shipGoods" activity in the "shipmentProcess", we could write the following observer method:
 
 [source,java,linenums]
 ----
 public void beforeShippingGoods(@Observes @BusinessProcess("shippingProcess") @EndActivity("shipGoods") BusinessProcessEvent evt) {
 	// handle event
-}	  	  	
+}
 ----
 
-In the default configuration, event listeners are invoked synchronously and in the context of the same transaction. CDI transactional observers (only available in combination with JavaEE / EJB), allow to control  when the event is handed to the observer method. Using transactional observers, we can for example assure that an observer is only  notified if the transaction in which the event is fired succeeds: 
+In the default configuration, event listeners are invoked synchronously and in the context of the same transaction. CDI transactional observers (only available in combination with JavaEE/EJB), allow to control when the event is handed to the observer method. Using transactional observers, we can for example assure that an observer is only notified if the transaction in which the event is fired succeeds: 
 
 [source,java,linenums]
 ----
 public void onShipmentSuceeded(@Observes(during=TransactionPhase.AFTER_SUCCESS) @BusinessProcess("shippingProcess") @EndActivity("shipGoods") BusinessProcessEvent evt) {
 	// send email to customer.
-}	  	
+}	
 ----
 
 
 ==== Additional Features
 
 
-* The ProcessEngine as well as the services are available for injection: +@Inject ProcessEngine, RepositoryService, TaskService+, ...
+* The +ProcessEngine+ as well as the services are available for injection: +@Inject ProcessEngine, RepositoryService, TaskService+, ...
 * The current process instance and task can be injected: +@Inject ProcessInstance, Task+,
-* The current business key can be injected:  +@Inject @BusinessKey String businessKey+,
-* The current process instance id be injected:  +@Inject @ProcessInstanceId String pid+,
+* The current business key can be injected: +@Inject @BusinessKey String businessKey+,
+* The current process instance id be injected: +@Inject @ProcessInstanceId String pid+,
 
 === Known Limitations
 
 
-Although flowable-cdi is implemented against the SPI and designed to be a "portable-extension" it is only tested using Weld.	  	 
-	  	
-
+Although flowable-cdi is implemented against the SPI and designed to be a "portable-extension" it is only tested using Weld.


### PR DESCRIPTION
Applied unified spelling (Cdi, cdi, CDI -> CDI)
Corrected minor grammar mistakes
Unified formatting and marked technical terms with + / ++