### PR TITLE
Feature: rootCause filtering on mapException

### DIFF
--- a/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/constants/BpmnXMLConstants.java
+++ b/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/constants/BpmnXMLConstants.java
@@ -325,5 +325,6 @@ public interface BpmnXMLConstants {
     public static final String MAP_EXCEPTION = "mapException";
     public static final String MAP_EXCEPTION_ERRORCODE = "errorCode";
     public static final String MAP_EXCEPTION_ANDCHILDREN = "includeChildExceptions";
+    public static final String MAP_EXCEPTION_ROOTCAUSE = "rootCause";
 
 }

--- a/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/child/FlowableMapExceptionParser.java
+++ b/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/child/FlowableMapExceptionParser.java
@@ -39,6 +39,7 @@ public class FlowableMapExceptionParser extends BaseChildElementParser {
 
         String errorCode = xtr.getAttributeValue(null, MAP_EXCEPTION_ERRORCODE);
         String andChildren = xtr.getAttributeValue(null, MAP_EXCEPTION_ANDCHILDREN);
+        String rootCause = xtr.getAttributeValue(null, MAP_EXCEPTION_ROOTCAUSE);
         String exceptionClass = xtr.getElementText();
         boolean hasChildrenBool = false;
 
@@ -54,6 +55,6 @@ public class FlowableMapExceptionParser extends BaseChildElementParser {
             throw new XMLException("No errorCode defined mapException with errorCode=" + errorCode + " and class=" + exceptionClass);
         }
 
-        ((Activity) parentElement).getMapExceptions().add(new MapExceptionEntry(errorCode, exceptionClass, hasChildrenBool));
+        ((Activity) parentElement).getMapExceptions().add(new MapExceptionEntry(errorCode, exceptionClass, hasChildrenBool, rootCause));
     }
 }

--- a/modules/flowable-bpmn-model/src/main/java/org/flowable/bpmn/model/MapExceptionEntry.java
+++ b/modules/flowable-bpmn-model/src/main/java/org/flowable/bpmn/model/MapExceptionEntry.java
@@ -21,11 +21,13 @@ public class MapExceptionEntry {
     protected String errorCode;
     protected String className;
     protected boolean andChildren;
+    protected String rootCause;
 
-    public MapExceptionEntry(String errorCode, String className, boolean andChildren) {
+    public MapExceptionEntry(String errorCode, String className, boolean andChildren, String rootCause) {
         this.errorCode = errorCode;
         this.className = className;
         this.andChildren = andChildren;
+        this.rootCause = rootCause;
     }
 
     public String getErrorCode() {
@@ -50,6 +52,14 @@ public class MapExceptionEntry {
 
     public void setAndChildren(boolean andChildren) {
         this.andChildren = andChildren;
+    }
+
+    public String getRootCause() {
+        return rootCause;
+    }
+
+    public void setRootCause(String rootCause) {
+        this.rootCause = rootCause;
     }
 
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/helper/ErrorPropagation.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/helper/ErrorPropagation.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.flowable.bpmn.model.BoundaryEvent;
 import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.bpmn.model.CallActivity;
@@ -324,11 +325,20 @@ public class ErrorPropagation {
         for (MapExceptionEntry me : exceptionMap) {
             String exceptionClass = me.getClassName();
             String errorCode = me.getErrorCode();
+            String rootCause = me.getRootCause();
 
             // save the first mapping with no exception class as default map
             if (StringUtils.isNotEmpty(errorCode) && StringUtils.isEmpty(exceptionClass) && defaultExceptionMapping == null) {
-                defaultExceptionMapping = errorCode;
-                continue;
+                // if rootCause is set, check if it matches the exception
+                if (StringUtils.isNotEmpty(rootCause)) {
+                    if (ExceptionUtils.getRootCause(e).getClass().getName().equals(rootCause)) {
+                        defaultExceptionMapping = errorCode;
+                        continue;
+                    }
+                } else {
+                    defaultExceptionMapping = errorCode;
+                    continue;
+                }
             }
 
             // ignore if error code or class are not defined
@@ -337,13 +347,25 @@ public class ErrorPropagation {
             }
 
             if (e.getClass().getName().equals(exceptionClass)) {
+                if (StringUtils.isNotEmpty(rootCause)) {
+                    if (ExceptionUtils.getRootCause(e).getClass().getName().equals(rootCause)) {
+                        return errorCode;
+                    }
+                    continue;
+                }
                 return errorCode;
             }
             
             if (me.isAndChildren()) {
                 Class<?> exceptionClassClass = ReflectUtil.loadClass(exceptionClass);
                 if (exceptionClassClass.isAssignableFrom(e.getClass())) {
-                    return errorCode;
+                    if (StringUtils.isNotEmpty(rootCause)) {
+                        if (ExceptionUtils.getRootCause(e).getClass().getName().equals(rootCause)) {
+                            return errorCode;
+                        }
+                    } else {
+                        return errorCode;
+                    }
                 }
             }
         }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/error/mapError/BoundaryErrorMapTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/error/mapError/BoundaryErrorMapTest.java
@@ -55,6 +55,17 @@ public class BoundaryErrorMapTest extends PluggableFlowableTestCase {
         assertTrue(FlagDelegate.isVisited());
     }
 
+    @Deployment
+    public void testRootCauseSingleDirectMap() {
+        FlagDelegate.reset();
+        Map<String, Object> vars = new HashMap<>();
+        vars.put("exceptionClass", BoundaryErrorParentException.class.getName());
+        vars.put("nestedExceptionClass", IllegalArgumentException.class.getName());
+
+        runtimeService.startProcessInstanceByKey("processWithSingleExceptionMap", vars);
+        assertTrue(FlagDelegate.isVisited());
+    }
+
     // exception does not match the single mapping
     @Deployment(resources = "org/flowable/engine/test/bpmn/event/error/mapError/BoundaryErrorMapTest.testClassDelegateSingleDirectMap.bpmn20.xml")
     public void testClassDelegateSingleDirectMapNotMatchingException() {
@@ -104,11 +115,58 @@ public class BoundaryErrorMapTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Deployment(resources = "org/flowable/engine/test/bpmn/event/error/mapError/BoundaryErrorMapTest.testRootCauseSingleDirectMap.bpmn20.xml")
+    public void testRootCauseSingleDirectMapNotMatchingException() {
+        FlagDelegate.reset();
+
+        Map<String, Object> vars = new HashMap<>();
+        vars.put("exceptionClass", BoundaryErrorParentException.class.getName());
+        vars.put("nestedExceptionClass", IllegalStateException.class.getName());
+        assertEquals(0, ServiceTaskTestMock.CALL_COUNT.get());
+
+        try {
+            runtimeService.startProcessInstanceByKey("processWithSingleExceptionMap", vars);
+            fail("exception expected, as there is no matching exception map");
+        } catch (Exception e) {
+            assertFalse(FlagDelegate.isVisited());
+        }
+    }
+
+    // exception matches by inheritance
+    @Deployment(resources = "org/flowable/engine/test/bpmn/event/error/mapError/BoundaryErrorMapTest.testClassDelegateSingleInheritedMapWithRootCause.bpmn20.xml")
+    public void testClassDelegateSingleInheritedMapWithRootCauseNotMatchingException() {
+        FlagDelegate.reset();
+
+        Map<String, Object> vars = new HashMap<>();
+        vars.put("exceptionClass", BoundaryEventChildException.class.getName());
+        vars.put("nestedExceptionClass", IllegalStateException.class.getName());
+        assertEquals(0, ServiceTaskTestMock.CALL_COUNT.get());
+
+        try {
+            runtimeService.startProcessInstanceByKey("processWithSingleExceptionMap", vars);
+            fail("exception expected, as there is no matching exception map");
+        } catch (Exception e) {
+            assertFalse(FlagDelegate.isVisited());
+        }
+    }
+
     // exception matches by inheritance
     @Deployment
     public void testClassDelegateSingleInheritedMap() {
         Map<String, Object> vars = new HashMap<>();
         vars.put("exceptionClass", BoundaryEventChildException.class.getName());
+        FlagDelegate.reset();
+
+        runtimeService.startProcessInstanceByKey("processWithSingleExceptionMap", vars);
+        assertTrue(FlagDelegate.isVisited());
+    }
+
+    // exception matches by inheritance
+    @Deployment
+    public void testClassDelegateSingleInheritedMapWithRootCause() {
+        Map<String, Object> vars = new HashMap<>();
+        vars.put("exceptionClass", BoundaryEventChildException.class.getName());
+        vars.put("nestedExceptionClass", IllegalArgumentException.class.getName());
         FlagDelegate.reset();
 
         runtimeService.startProcessInstanceByKey("processWithSingleExceptionMap", vars);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/error/mapError/BoundaryErrorParentException.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/error/mapError/BoundaryErrorParentException.java
@@ -20,4 +20,10 @@ public class BoundaryErrorParentException extends RuntimeException {
 
     private static final long serialVersionUID = 1L;
 
+    public BoundaryErrorParentException() {
+    }
+
+    public BoundaryErrorParentException(Throwable cause) {
+        super(cause);
+    }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/error/mapError/BoundaryEventChildException.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/error/mapError/BoundaryEventChildException.java
@@ -18,4 +18,10 @@ package org.flowable.engine.test.bpmn.event.error.mapError;
 
 public class BoundaryEventChildException extends BoundaryErrorParentException {
 
+    public BoundaryEventChildException() {
+    }
+
+    public BoundaryEventChildException(Throwable cause) {
+        super(cause);
+    }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/error/mapError/ThrowNestedCustomExceptionDelegate.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/error/mapError/ThrowNestedCustomExceptionDelegate.java
@@ -1,0 +1,48 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.engine.test.bpmn.event.error.mapError;
+
+import org.apache.commons.lang3.StringUtils;
+import org.flowable.common.engine.api.FlowableException;
+import org.flowable.engine.delegate.DelegateExecution;
+import org.flowable.engine.delegate.JavaDelegate;
+
+/**
+ * @author Saeid Mirzaei
+ */
+public class ThrowNestedCustomExceptionDelegate implements JavaDelegate {
+
+    @Override
+    public void execute(DelegateExecution execution) {
+        Object exceptionClassVar = execution.getVariable("exceptionClass");
+        Object nestedExceptionClassVar = execution.getVariable("nestedExceptionClass");
+        if (exceptionClassVar == null)
+            return;
+
+        String exceptionClassName = exceptionClassVar.toString();
+        String nestedExceptionClassName = nestedExceptionClassVar.toString();
+
+        if (StringUtils.isNotEmpty(exceptionClassName) && StringUtils.isNotEmpty(nestedExceptionClassName)) {
+            RuntimeException exception = null;
+            RuntimeException nestedException = null;
+            try {
+                nestedException = (RuntimeException) Class.forName(nestedExceptionClassName).newInstance();
+                exception = (RuntimeException) Class.forName(exceptionClassName).getConstructor(Throwable.class).newInstance(nestedException);
+
+            } catch (Exception e) {
+                throw new FlowableException("Class not found", e);
+            }
+            throw exception;
+        }
+    }
+}

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/event/error/mapError/BoundaryErrorMapTest.testClassDelegateSingleInheritedMapWithRootCause.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/event/error/mapError/BoundaryErrorMapTest.testClassDelegateSingleInheritedMapWithRootCause.bpmn20.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://www.activiti.org/test">
+  <error id="myError" errorCode="myErrorCode1" />
+  <process id="processWithSingleExceptionMap" isExecutable="true">
+    <startEvent id="theStart"></startEvent>
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="serviceTask"></sequenceFlow>
+    <serviceTask id="serviceTask" activiti:class="org.flowable.engine.test.bpmn.event.error.mapError.ThrowNestedCustomExceptionDelegate">
+      <extensionElements>
+        <activiti:mapException xmlns:activiti="http://activiti.org/bpmn" errorCode="myErrorCode1" rootCause="java.lang.IllegalArgumentException" includeChildExceptions="true">org.flowable.engine.test.bpmn.event.error.mapError.BoundaryErrorParentException</activiti:mapException>
+      </extensionElements>
+    </serviceTask>
+    <boundaryEvent id="catchError" attachedToRef="serviceTask">
+      <errorEventDefinition errorRef="myErrorCode1" />
+    </boundaryEvent>
+    <sequenceFlow id="flow4" sourceRef="serviceTask" targetRef="theEnd"></sequenceFlow>
+    <endEvent id="theEnd"></endEvent>
+    <serviceTask id="flagTask" name="Set Flag" activiti:class="org.flowable.engine.test.bpmn.event.error.mapError.FlagDelegate"></serviceTask>
+    <sequenceFlow id="flow5" sourceRef="catchError" targetRef="flagTask"></sequenceFlow>
+    <sequenceFlow id="flow6" sourceRef="flagTask" targetRef="theEnd"></sequenceFlow>
+  </process>
+</definitions>

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/event/error/mapError/BoundaryErrorMapTest.testRootCauseSingleDirectMap.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/event/error/mapError/BoundaryErrorMapTest.testRootCauseSingleDirectMap.bpmn20.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:flowable="http://flowable.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://www.flowable.org/test">
+  <error id="myError" errorCode="myErrorCode1" />
+  <process id="processWithSingleExceptionMap" isExecutable="true">
+    <startEvent id="theStart"></startEvent>
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="serviceTask"></sequenceFlow>
+    <serviceTask id="serviceTask" flowable:class="org.flowable.engine.test.bpmn.event.error.mapError.ThrowNestedCustomExceptionDelegate">
+      <extensionElements>
+        <flowable:mapException errorCode="myErrorCode1" rootCause="java.lang.IllegalArgumentException">org.flowable.engine.test.bpmn.event.error.mapError.BoundaryErrorParentException</flowable:mapException>
+      </extensionElements>
+    </serviceTask>
+    <boundaryEvent id="catchError" attachedToRef="serviceTask">
+      <errorEventDefinition errorRef="myErrorCode1" />
+    </boundaryEvent>
+    <sequenceFlow id="flow4" sourceRef="serviceTask" targetRef="theEnd"></sequenceFlow>
+    <endEvent id="theEnd"></endEvent>
+    <serviceTask id="flagTask" name="Set Flag" flowable:class="org.flowable.engine.test.bpmn.event.error.mapError.FlagDelegate"></serviceTask>
+    <sequenceFlow id="flow5" sourceRef="catchError" targetRef="flagTask"></sequenceFlow>
+    <sequenceFlow id="flow6" sourceRef="flagTask" targetRef="theEnd"></sequenceFlow>
+  </process>
+</definitions>

--- a/modules/flowable-http/src/main/java/org/flowable/http/HttpActivityExecutor.java
+++ b/modules/flowable-http/src/main/java/org/flowable/http/HttpActivityExecutor.java
@@ -40,6 +40,9 @@ import org.apache.http.util.EntityUtils;
 import org.flowable.bpmn.model.MapExceptionEntry;
 import org.flowable.common.engine.api.FlowableException;
 import org.flowable.common.engine.api.variable.VariableContainer;
+import org.flowable.engine.delegate.BpmnError;
+import org.flowable.engine.delegate.DelegateExecution;
+import org.flowable.engine.impl.bpmn.helper.ErrorPropagation;
 import org.flowable.http.delegate.HttpRequestHandler;
 import org.flowable.http.delegate.HttpResponseHandler;
 import org.slf4j.Logger;
@@ -205,6 +208,11 @@ public class HttpActivityExecutor {
                 httpRequestHandler.handleHttpRequest(execution, requestInfo, client);
             }
         } catch (Exception e) {
+            if (e instanceof BpmnError) {
+                ErrorPropagation.propagateError(((BpmnError) e), ((DelegateExecution) execution));
+                return null;
+            }
+
             throw new FlowableException("Exception while invoking HttpRequestHandler: " + e.getMessage(), e);
         }
 
@@ -274,6 +282,11 @@ public class HttpActivityExecutor {
                     httpResponseHandler.handleHttpResponse(execution, responseInfo);
                 }
             } catch (Exception e) {
+                if (e instanceof BpmnError) {
+                    ErrorPropagation.propagateError(((BpmnError) e), ((DelegateExecution) execution));
+                    return null;
+                }
+
                 throw new FlowableException("Exception while invoking HttpResponseHandler: " + e.getMessage(), e);
             }
 

--- a/modules/flowable-http/src/test/java/org/flowable/http/bpmn/BpmnThrowingRequestHandler.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/bpmn/BpmnThrowingRequestHandler.java
@@ -1,0 +1,17 @@
+package org.flowable.http.bpmn;
+
+import org.apache.http.client.HttpClient;
+import org.flowable.common.engine.api.variable.VariableContainer;
+import org.flowable.engine.delegate.BpmnError;
+import org.flowable.http.HttpRequest;
+import org.flowable.http.delegate.HttpRequestHandler;
+
+public class BpmnThrowingRequestHandler implements HttpRequestHandler {
+
+  private static final long serialVersionUID = 1L;
+
+  @Override
+  public void handleHttpRequest(final VariableContainer execution, final HttpRequest httpRequest, final HttpClient client) {
+      throw new BpmnError("httpRequestHandlerError");
+  }
+}

--- a/modules/flowable-http/src/test/java/org/flowable/http/bpmn/BpmnThrowingResponseHandler.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/bpmn/BpmnThrowingResponseHandler.java
@@ -1,0 +1,16 @@
+package org.flowable.http.bpmn;
+
+import org.flowable.common.engine.api.variable.VariableContainer;
+import org.flowable.engine.delegate.BpmnError;
+import org.flowable.http.HttpResponse;
+import org.flowable.http.delegate.HttpResponseHandler;
+
+public class BpmnThrowingResponseHandler implements HttpResponseHandler {
+
+  private static final long serialVersionUID = 1L;
+
+  @Override
+  public void handleHttpResponse(final VariableContainer execution, final HttpResponse httpResponse) {
+      throw new BpmnError("httpResponseHandlerError");
+  }
+}

--- a/modules/flowable-http/src/test/java/org/flowable/http/bpmn/HttpServiceTaskTest.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/bpmn/HttpServiceTaskTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.flowable.common.engine.api.FlowableException;
+import org.flowable.engine.history.HistoricProcessInstance;
 import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
@@ -115,6 +116,28 @@ public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
         assertEquals("httpGetResponseBody", variables.get(0).getVariableName());
         String variableValue = variables.get(0).getValue().toString();
         assertTrue(variableValue.contains("firstName") && variableValue.contains("John"));
+        assertProcessEnded(procId);
+    }
+
+    @Deployment
+    public void testGetWithBpmnThrowingResponseHandler() {
+        String procId = runtimeService.startProcessInstanceByKey("simpleGetOnly").getId();
+        final HistoricProcessInstance processInstance = historyService.createHistoricProcessInstanceQuery()
+            .processInstanceId(procId)
+            .singleResult();
+
+        assertEquals("theEnd2", processInstance.getEndActivityId());
+        assertProcessEnded(procId);
+    }
+
+    @Deployment
+    public void testGetWithBpmnThrowingRequestHandler() {
+        String procId = runtimeService.startProcessInstanceByKey("simpleGetOnly").getId();
+        final HistoricProcessInstance processInstance = historyService.createHistoricProcessInstanceQuery()
+            .processInstanceId(procId)
+            .singleResult();
+
+        assertEquals("theEnd2", processInstance.getEndActivityId());
         assertProcessEnded(procId);
     }
 

--- a/modules/flowable-http/src/test/resources/org/flowable/http/bpmn/HttpServiceTaskTest.testGetWithBpmnThrowingRequestHandler.bpmn20.xml
+++ b/modules/flowable-http/src/test/resources/org/flowable/http/bpmn/HttpServiceTaskTest.testGetWithBpmnThrowingRequestHandler.bpmn20.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:flowable="http://flowable.org/bpmn"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+             xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI"
+             typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath"
+             targetNamespace="http://www.flowable.org/processdef">
+  <process id="simpleGetOnly" name="Simple HTTP Get process">
+    <serviceTask id="httpGet" name="HTTP Get" flowable:type="http">
+      <extensionElements>
+        <flowable:field name="requestMethod">
+          <flowable:string><![CDATA[GET]]></flowable:string>
+        </flowable:field>
+        <flowable:field name="requestUrl">
+          <flowable:string><![CDATA[http://localhost:9798/test]]></flowable:string>
+        </flowable:field>
+        <flowable:httpRequestHandler class="org.flowable.http.bpmn.BpmnThrowingRequestHandler"/>
+      </extensionElements>
+    </serviceTask>
+    <startEvent id="theStart" name="Start"></startEvent>
+    <endEvent id="theEnd" name="End"></endEvent>
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="httpGet"></sequenceFlow>
+    <sequenceFlow id="flow2" sourceRef="httpGet" targetRef="theEnd"></sequenceFlow>
+
+    <boundaryEvent id="httpRequestHandlerErrorEvent" attachedToRef="httpGet">
+      <errorEventDefinition errorRef="httpRequestHandlerError"/>
+    </boundaryEvent>
+    <endEvent id="theEnd2" name="End 2"></endEvent>
+    <sequenceFlow id="flow3" sourceRef="httpRequestHandlerErrorEvent" targetRef="theEnd2"></sequenceFlow>
+  </process>
+</definitions>

--- a/modules/flowable-http/src/test/resources/org/flowable/http/bpmn/HttpServiceTaskTest.testGetWithBpmnThrowingResponseHandler.bpmn20.xml
+++ b/modules/flowable-http/src/test/resources/org/flowable/http/bpmn/HttpServiceTaskTest.testGetWithBpmnThrowingResponseHandler.bpmn20.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:flowable="http://flowable.org/bpmn"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+             xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI"
+             typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath"
+             targetNamespace="http://www.flowable.org/processdef">
+  <process id="simpleGetOnly" name="Simple HTTP Get process">
+    <serviceTask id="httpGet" name="HTTP Get" flowable:type="http">
+      <extensionElements>
+        <flowable:field name="requestMethod">
+          <flowable:string><![CDATA[GET]]></flowable:string>
+        </flowable:field>
+        <flowable:field name="requestUrl">
+          <flowable:string><![CDATA[http://localhost:9798/test]]></flowable:string>
+        </flowable:field>
+        <flowable:httpResponseHandler class="org.flowable.http.bpmn.BpmnThrowingResponseHandler"/>
+      </extensionElements>
+    </serviceTask>
+    <startEvent id="theStart" name="Start"></startEvent>
+    <endEvent id="theEnd" name="End"></endEvent>
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="httpGet"></sequenceFlow>
+    <sequenceFlow id="flow2" sourceRef="httpGet" targetRef="theEnd"></sequenceFlow>
+
+    <boundaryEvent id="httpResponseHandlerErrorEvent" attachedToRef="httpGet">
+      <errorEventDefinition errorRef="httpResponseHandlerError"/>
+    </boundaryEvent>
+    <endEvent id="theEnd2" name="End 2"></endEvent>
+    <sequenceFlow id="flow3" sourceRef="httpResponseHandlerErrorEvent" targetRef="theEnd2"></sequenceFlow>
+  </process>
+</definitions>

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/helper/ErrorPropagation.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/helper/ErrorPropagation.java
@@ -35,6 +35,7 @@ import org.activiti.engine.impl.pvm.runtime.AtomicOperation;
 import org.activiti.engine.impl.pvm.runtime.InterpretableExecution;
 import org.activiti.engine.impl.util.ReflectUtil;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.flowable.bpmn.model.MapExceptionEntry;
 import org.flowable.common.engine.api.delegate.event.FlowableEngineEventType;
 import org.slf4j.Logger;
@@ -215,11 +216,20 @@ public class ErrorPropagation {
         for (MapExceptionEntry me : exceptionMap) {
             String exceptionClass = me.getClassName();
             String errorCode = me.getErrorCode();
+            String rootCause = me.getRootCause();
 
             // save the first mapping with no exception class as default map
             if (StringUtils.isNotEmpty(errorCode) && StringUtils.isEmpty(exceptionClass) && defaultMap == null) {
-                defaultMap = errorCode;
-                continue;
+                // if rootCause is set, check if it matches the exception
+                if (StringUtils.isNotEmpty(rootCause)) {
+                    if (ExceptionUtils.getRootCause(e).getClass().getName().equals(rootCause)) {
+                        defaultMap = errorCode;
+                        continue;
+                    }
+                } else {
+                    defaultMap = errorCode;
+                    continue;
+                }
             }
 
             // ignore if error code or class are not defined
@@ -227,14 +237,27 @@ public class ErrorPropagation {
                 continue;
 
             if (e.getClass().getName().equals(exceptionClass)) {
+                if (StringUtils.isNotEmpty(rootCause)) {
+                    if (ExceptionUtils.getRootCause(e).getClass().getName().equals(rootCause)) {
+                        propagateError(errorCode, execution);
+                    }
+                    continue;
+                }
                 propagateError(errorCode, execution);
                 return true;
             }
             if (me.isAndChildren()) {
                 Class<?> exceptionClassClass = ReflectUtil.loadClass(exceptionClass);
                 if (exceptionClassClass.isAssignableFrom(e.getClass())) {
-                    propagateError(errorCode, execution);
-                    return true;
+                    if (StringUtils.isNotEmpty(rootCause)) {
+                        if (ExceptionUtils.getRootCause(e).getClass().getName().equals(rootCause)) {
+                            propagateError(errorCode, execution);
+                            return true;
+                        }
+                    } else {
+                        propagateError(errorCode, execution);
+                        return true;
+                    }
                 }
             }
         }


### PR DESCRIPTION
New feature as discussed [here](https://forum.flowable.org/t/extending-mapexception-to-allow-filtering-based-on-rootcause/2147).

This PR adds support for additional `mapException` filtering through a new attribute called `rootCause`. Only exceptions that were caused by the configured `rootCause` will be caught by the error `boundaryEvent`. 

Flag `includeChildExceptions` is still respected, so the combination of a specific exception to catch, what root cause of the exception to handle and whether child exceptions will be caught should all be compatible.