### PR TITLE
Http request body encoding

### DIFF
--- a/modules/flowable-http/src/main/java/org/flowable/http/HttpActivityExecutor.java
+++ b/modules/flowable-http/src/main/java/org/flowable/http/HttpActivityExecutor.java
@@ -226,14 +226,22 @@ public class HttpActivityExecutor {
                 case "POST": {
                     HttpPost post = new HttpPost(uri.toString());
                     if (requestInfo.getBody() != null) {
-                        post.setEntity(new StringEntity(requestInfo.getBody()));
+                        if (StringUtils.isNotEmpty(requestInfo.getBodyEncoding())) {
+                            post.setEntity(new StringEntity(requestInfo.getBody(), requestInfo.getBodyEncoding()));
+                        } else {
+                            post.setEntity(new StringEntity(requestInfo.getBody()));
+                        }
                     }
                     request = post;
                     break;
                 }
                 case "PUT": {
                     HttpPut put = new HttpPut(uri.toString());
-                    put.setEntity(new StringEntity(requestInfo.getBody()));
+                    if (StringUtils.isNotEmpty(requestInfo.getBodyEncoding())) {
+                        put.setEntity(new StringEntity(requestInfo.getBody(), requestInfo.getBodyEncoding()));
+                    } else {
+                        put.setEntity(new StringEntity(requestInfo.getBody()));
+                    }
                     request = put;
                     break;
                 }

--- a/modules/flowable-http/src/main/java/org/flowable/http/HttpRequest.java
+++ b/modules/flowable-http/src/main/java/org/flowable/http/HttpRequest.java
@@ -23,6 +23,7 @@ public class HttpRequest {
     protected String url;
     protected String headers;
     protected String body;
+    protected String bodyEncoding;
     protected int timeout;
     protected boolean noRedirects;
     protected Set<String> failCodes;
@@ -64,6 +65,14 @@ public class HttpRequest {
 
     public void setBody(String body) {
         this.body = body;
+    }
+
+    public String getBodyEncoding() {
+        return bodyEncoding;
+    }
+
+    public void setBodyEncoding(String bodyEncoding) {
+        this.bodyEncoding = bodyEncoding;
     }
 
     public int getTimeout() {

--- a/modules/flowable-http/src/main/java/org/flowable/http/bpmn/impl/HttpActivityBehaviorImpl.java
+++ b/modules/flowable-http/src/main/java/org/flowable/http/bpmn/impl/HttpActivityBehaviorImpl.java
@@ -77,6 +77,8 @@ public class HttpActivityBehaviorImpl extends AbstractBpmnActivityBehavior {
     protected Expression requestHeaders;
     // HttpRequest body expression (Optional)
     protected Expression requestBody;
+    // HttpRequest body encoding expression, for example UTF-8 (Optional)
+    protected Expression requestBodyEncoding;
     // Timeout in seconds for the body (Optional)
     protected Expression requestTimeout;
     // HttpRequest retry disable HTTP redirects (Optional)
@@ -148,6 +150,7 @@ public class HttpActivityBehaviorImpl extends AbstractBpmnActivityBehavior {
             request.setUrl(getStringFromField(requestUrl, execution));
             request.setHeaders(getStringFromField(requestHeaders, execution));
             request.setBody(getStringFromField(requestBody, execution));
+            request.setBodyEncoding(getStringFromField(requestBodyEncoding, execution));
             request.setTimeout(getIntFromField(requestTimeout, execution));
             request.setNoRedirects(getBooleanFromField(disallowRedirects, execution));
             request.setIgnoreErrors(getBooleanFromField(ignoreException, execution));

--- a/modules/flowable-http/src/test/java/org/flowable/http/bpmn/HttpServiceTaskTest.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/bpmn/HttpServiceTaskTest.java
@@ -331,7 +331,7 @@ public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
         ProcessInstance process = runtimeService.startProcessInstanceByKey("testHttpPost2XX");
         assertFalse(process.isEnded());
 
-        String body = "{\"test\":\"sample\",\"result\":true}";
+        String body = "{\"test\":\"Alen Turković\",\"result\":true}";
         // Request assertions
         Map<String, Object> request = new HashMap<>();
         request.put("httpPostRequestMethod", "POST");
@@ -360,6 +360,29 @@ public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
         Map<String, Object> response = new HashMap<>();
         response.put("httpPostResponseStatusCode", 302);
         assertEquals(process.getId(), response);
+        continueProcess(process);
+    }
+
+    @Deployment
+    public void testHttpPostBodyEncoding() throws Exception {
+        ProcessInstance process = runtimeService.startProcessInstanceByKey("testHttpPostBodyEncoding");
+        assertFalse(process.isEnded());
+
+        // Request assertions
+        Map<String, Object> request = new HashMap<>();
+        request.put("httpPostRequestMethod", "POST");
+        request.put("httpPostRequestUrl", "http://localhost:9798/hello");
+        request.put("httpPostRequestHeaders", "Content-Type: application/json; charset=utf-8");
+        request.put("httpPostRequestBody", "{\"name\":\"Alen Turković\"}");
+        assertEquals(process.getId(), request);
+        // Response assertions
+        Map<String, Object> response = new HashMap<>();
+        response.put("httpPostResponseStatusCode", 200);
+        assertEquals(process.getId(), response);
+        // Response body assertions
+        String responseBody = (String) runtimeService.getVariable(process.getId(), "httpPostResponseBody");
+        assertNotNull(responseBody);
+        assertEquals("{\"result\":\"Hello Alen Turković\"}", responseBody.trim());
         continueProcess(process);
     }
 

--- a/modules/flowable-http/src/test/resources/org/flowable/http/bpmn/HttpServiceTaskTest.testHttpPostBodyEncoding.bpmn20.xml
+++ b/modules/flowable-http/src/test/resources/org/flowable/http/bpmn/HttpServiceTaskTest.testHttpPostBodyEncoding.bpmn20.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:flowable="http://flowable.org/bpmn"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+             xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI"
+             typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath"
+             targetNamespace="http://www.flowable.org/processdef">
+  <process id="testHttpPostBodyEncoding" name="HTTP Post process" isExecutable="true">
+    <serviceTask id="httpPost" name="HTTP Post Body Encoding" flowable:type="http">
+      <extensionElements>
+        <flowable:field name="requestMethod">
+          <flowable:string><![CDATA[POST]]></flowable:string>
+        </flowable:field>
+        <flowable:field name="requestUrl">
+          <flowable:string><![CDATA[http://localhost:9798/hello]]></flowable:string>
+        </flowable:field>
+        <flowable:field name="requestHeaders">
+          <flowable:string><![CDATA[Content-Type: application/json; charset=utf-8]]></flowable:string>
+        </flowable:field>
+        <flowable:field name="requestBody">
+          <flowable:string><![CDATA[{"name":"Alen Turković"}]]></flowable:string>
+        </flowable:field>
+        <flowable:field name="requestBodyEncoding">
+          <flowable:string><![CDATA[UTF-8]]></flowable:string>
+        </flowable:field>
+        <flowable:field name="saveRequestVariables">
+          <flowable:string><![CDATA[true]]></flowable:string>
+        </flowable:field>
+        <flowable:field name="saveResponseParameters">
+          <flowable:string><![CDATA[true]]></flowable:string>
+        </flowable:field>
+      </extensionElements>
+    </serviceTask>
+    <startEvent id="theStart" name="Start"></startEvent>
+    <endEvent id="theEnd" name="End"></endEvent>
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="httpPost"></sequenceFlow>
+    <receiveTask id="wait" name="Wait"></receiveTask>
+    <sequenceFlow id="sid-62E5CF14-207F-40C8-B00D-8571FEBA3947" sourceRef="wait" targetRef="theEnd"></sequenceFlow>
+    <sequenceFlow id="flow2" sourceRef="httpPost" targetRef="wait"></sequenceFlow>
+  </process>
+</definitions>


### PR DESCRIPTION
Http request body should be encoded with a configurable charset instead of using the default one from StringEntity