### PR TITLE
Remove prerequisites elements of flowable-ui-* POMs to fix "The projec…

### DIFF
--- a/modules/flowable-ui-admin/flowable-ui-admin-app/pom.xml
+++ b/modules/flowable-ui-admin/flowable-ui-admin-app/pom.xml
@@ -297,10 +297,6 @@
 
 	</profiles>
 
-	<prerequisites>
-		<maven>3.0.0</maven>
-	</prerequisites>
-
 	<dependencies>
 
         <dependency>

--- a/modules/flowable-ui-admin/pom.xml
+++ b/modules/flowable-ui-admin/pom.xml
@@ -21,10 +21,6 @@
         <tomcat.version>7.0.53</tomcat.version>
     </properties>
 
-    <prerequisites>
-        <maven>3.0.0</maven>
-    </prerequisites>
-
     <modules>
         <module>flowable-ui-admin-logic</module>
         <module>flowable-ui-admin-rest</module>

--- a/modules/flowable-ui-common/pom.xml
+++ b/modules/flowable-ui-common/pom.xml
@@ -12,10 +12,6 @@
     <version>6.3.2-SNAPSHOT</version>
   </parent>
 
-  <prerequisites>
-    <maven>3.0.0</maven>
-  </prerequisites>
-
   <dependencies>
 
     <dependency>

--- a/modules/flowable-ui-idm/pom.xml
+++ b/modules/flowable-ui-idm/pom.xml
@@ -17,10 +17,6 @@
         <tomcat.version>7.0.53</tomcat.version>
     </properties>
 
-    <prerequisites>
-        <maven>3.0.0</maven>
-    </prerequisites>
-
     <modules>
         <module>flowable-ui-idm-logic</module>
         <module>flowable-ui-idm-rest</module>

--- a/modules/flowable-ui-modeler/pom.xml
+++ b/modules/flowable-ui-modeler/pom.xml
@@ -17,10 +17,6 @@
 		<!-- Web container version -->		<tomcat.version>7.0.53</tomcat.version>
   </properties>
 
-	<prerequisites>
-		<maven>3.0.0</maven>
-	</prerequisites>
-	
 	<modules>
 		<module>flowable-ui-modeler-logic</module>
 		<module>flowable-ui-modeler-rest</module>

--- a/modules/flowable-ui-task/pom.xml
+++ b/modules/flowable-ui-task/pom.xml
@@ -13,10 +13,6 @@
         <version>6.3.2-SNAPSHOT</version>
     </parent>
 
-    <prerequisites>
-        <maven>3.0.0</maven>
-    </prerequisites>
-
     <modules>
         <module>flowable-ui-task-logic</module>
         <module>flowable-ui-task-rest</module>


### PR DESCRIPTION
…t * uses prerequisites which is only intended for maven-plugin projects" maven warnings.

An alternative solution would be to define a maven enforcer check in the root pom.