### PR TITLE
Fix the the problem of method enableDuplicateFiltering() sometime will be invalid.

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/DeployCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/DeployCmd.java
@@ -88,7 +88,7 @@ public class DeployCmd<T> implements Command<Deployment>, Serializable {
                 
             } else {
                 List<Deployment> deploymentList = processEngineConfiguration.getRepositoryService().createDeploymentQuery().deploymentName(deployment.getName())
-                        .deploymentTenantId(deployment.getTenantId()).orderByDeploymentId().desc().list();
+                        .deploymentTenantId(deployment.getTenantId()).orderByDeploymenTime().desc().list();
 
                 if (!deploymentList.isEmpty()) {
                     existingDeployments.addAll(deploymentList);


### PR DESCRIPTION
When I use StrongUuidGenerator to generate uuid,orderByDeploymentId() may be wrong.
You used orderByDeploymenTime() in [if] at line 83,but used orderByDeploymentId() in [else] at line 91.