### PR TITLE
Add support for forcing a TO address when using the MailTask

### DIFF
--- a/docs/userguide/src/en/bpmn/ch05a-Spring-Boot.adoc
+++ b/docs/userguide/src/en/bpmn/ch05a-Spring-Boot.adoc
@@ -763,6 +763,7 @@ flowable.idm.ldap.user-base-dn= # The base 'distinguished name' (DN) from which 
 
 # Flowable Mail {sc-flowable-boot}/FlowableMailProperties.java[FlowableMailProperties]
 flowable.mail.server.default-from=flowable@localhost # The default from address that needs to be used when sending emails.
+flowable.mail.server.force-to= # The force to address(es) that would be used when sending out emails. IMPORTANT: If this is send then all emails will be send to defined addresses instead of the address configured in the MailActivity.
 flowable.mail.server.host=localhost # The host of the mail server.
 flowable.mail.server.password= # The password for the mail server authentication.
 flowable.mail.server.port=1025 # The port of the mail server.

--- a/docs/userguide/src/en/bpmn/ch07b-BPMN-Constructs.adoc
+++ b/docs/userguide/src/en/bpmn/ch07b-BPMN-Constructs.adoc
@@ -3450,6 +3450,7 @@ The Flowable engine sends e-mails trough an external mail server with SMTP capab
 |Property|Required?|Description
 |mailServerHost|no|The hostname of your mail server (for example, mail.mycorp.com). Default is +localhost+
 |mailServerPort|yes, if not on the default port|The port for SMTP traffic on the mail server. The default is _25_
+|mailServerForceTo|no|If set it will be used as a replacement of the configured to, cc and / or bcc in the Mail Task when sending out emails.
 |mailServerDefaultFrom|no|The default e-mail address of the sender of e-mails, when none is provided by the user. By default this is _flowable@flowable.org_
 |mailServerUsername|if applicable for your server|Some mail servers require credentials for sending e-mail. By default not set.
 |mailServerPassword|if applicable for your server|Some mail servers require credentials for sending e-mail. By default not set.

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/ProcessEngineConfiguration.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/ProcessEngineConfiguration.java
@@ -94,6 +94,7 @@ public abstract class ProcessEngineConfiguration extends AbstractEngineConfigura
     protected boolean useSSL;
     protected boolean useTLS;
     protected String mailServerDefaultFrom = "flowable@localhost";
+    protected String mailServerForceTo;
     protected String mailSessionJndi;
     protected Map<String, MailServerInfo> mailServers = new HashMap<>();
     protected Map<String, String> mailSessionsJndi = new HashMap<>();
@@ -302,6 +303,15 @@ public abstract class ProcessEngineConfiguration extends AbstractEngineConfigura
 
     public ProcessEngineConfiguration setMailServerDefaultFrom(String mailServerDefaultFrom) {
         this.mailServerDefaultFrom = mailServerDefaultFrom;
+        return this;
+    }
+
+    public String getMailServerForceTo() {
+        return mailServerForceTo;
+    }
+
+    public ProcessEngineConfiguration setMailServerForceTo(String mailServerForceTo) {
+        this.mailServerForceTo = mailServerForceTo;
         return this;
     }
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/cfg/MailServerInfo.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/cfg/MailServerInfo.java
@@ -19,6 +19,7 @@ package org.flowable.engine.cfg;
 public class MailServerInfo {
 
     protected String mailServerDefaultFrom;
+    protected String mailServerForceTo;
     protected String mailServerHost;
     protected int mailServerPort;
     protected String mailServerUsername;
@@ -32,6 +33,14 @@ public class MailServerInfo {
 
     public void setMailServerDefaultFrom(String mailServerDefaultFrom) {
         this.mailServerDefaultFrom = mailServerDefaultFrom;
+    }
+
+    public String getMailServerForceTo() {
+        return mailServerForceTo;
+    }
+
+    public void setMailServerForceTo(String mailServerForceTo) {
+        this.mailServerForceTo = mailServerForceTo;
     }
 
     public String getMailServerHost() {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/mail/EmailServiceTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/mail/EmailServiceTaskTest.java
@@ -13,6 +13,10 @@
 
 package org.flowable.engine.test.bpmn.mail;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
+
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -71,6 +75,28 @@ public class EmailServiceTaskTest extends EmailTestCase {
         deleteDeployments();
     }
 
+    @Deployment(resources = "org/flowable/engine/test/bpmn/mail/EmailSendTaskTest.testSimpleTextMail.bpmn20.xml", tenantId = "forceToEmailTenant")
+    public void testSimpleTextMailWhenMultiTenantWithForceTo() throws Exception {
+        String tenantId = "forceToEmailTenant";
+
+        String procId = runtimeService.startProcessInstanceByKeyAndTenantId("simpleTextOnly", tenantId).getId();
+
+        List<WiserMessage> messages = wiser.getMessages();
+        assertEquals(1, messages.size());
+
+        WiserMessage message = messages.get(0);
+        assertEmailSend(message, false, "Hello Kermit!", "This a text only e-mail.", "flowable@myTenant.com", Collections.singletonList(
+            "no-reply@myTenant.com"), null);
+
+        assertThat(messages)
+            .extracting(WiserMessage::getEnvelopeSender, WiserMessage::getEnvelopeReceiver)
+            .containsExactlyInAnyOrder(
+                tuple("flowable@myTenant.com", "no-reply@myTenant.com")
+            );
+
+        assertProcessEnded(procId);
+    }
+
     public void testSimpleTextMailForNonExistentTenant() throws Exception {
         String tenantId = "nonExistentTenant";
 
@@ -85,6 +111,26 @@ public class EmailServiceTaskTest extends EmailTestCase {
         WiserMessage message = messages.get(0);
         assertEmailSend(message, false, "Hello Kermit!", "This a text only e-mail.", "flowable@localhost", Collections.singletonList(
                 "kermit@activiti.org"), null);
+        assertProcessEnded(procId);
+
+        deleteDeployments();
+    }
+
+    public void testSimpleTextMailForNonExistentTenantWithForceTo() throws Exception {
+        processEngineConfiguration.setMailServerForceTo("no-reply@flowable.org");
+        String tenantId = "nonExistentTenant";
+
+        repositoryService.createDeployment()
+            .addClasspathResource("org/flowable/engine/test/bpmn/mail/EmailSendTaskTest.testSimpleTextMail.bpmn20.xml")
+            .tenantId(tenantId).deploy();
+        String procId = runtimeService.startProcessInstanceByKeyAndTenantId("simpleTextOnly", tenantId).getId();
+
+        List<WiserMessage> messages = wiser.getMessages();
+        assertEquals(1, messages.size());
+
+        WiserMessage message = messages.get(0);
+        assertEmailSend(message, false, "Hello Kermit!", "This a text only e-mail.", "flowable@localhost", Collections.singletonList(
+            "no-reply@flowable.org"), null);
         assertProcessEnded(procId);
 
         deleteDeployments();
@@ -108,6 +154,20 @@ public class EmailServiceTaskTest extends EmailTestCase {
         assertEquals("fozzie@activiti.org", recipients.get(0));
         assertEquals("kermit@activiti.org", recipients.get(1));
         assertEquals("mispiggy@activiti.org", recipients.get(2));
+    }
+
+    @Deployment(resources = "org/flowable/engine/test/bpmn/mail/EmailServiceTaskTest.testSimpleTextMailMultipleRecipients.bpmn20.xml")
+    public void testSimpleTextMailMultipleRecipientsAndForceTo() {
+        processEngineConfiguration.setMailServerForceTo("no-reply@flowable.org, no-reply2@flowable.org");
+        runtimeService.startProcessInstanceByKey("simpleTextOnlyMultipleRecipients");
+
+        List<WiserMessage> messages = wiser.getMessages();
+        assertThat(messages)
+            .extracting(WiserMessage::getEnvelopeSender, WiserMessage::getEnvelopeReceiver)
+            .containsExactlyInAnyOrder(
+                tuple("flowable@localhost", "no-reply@flowable.org"),
+                tuple("flowable@localhost", "no-reply2@flowable.org")
+            );
     }
 
     @Deployment
@@ -142,10 +202,31 @@ public class EmailServiceTaskTest extends EmailTestCase {
         assertEmailSend(messages.get(0), false, "Hello world", "This is the content", "flowable@localhost", Collections.singletonList(
                 "kermit@activiti.org"), Collections.singletonList("fozzie@activiti.org"));
 
-        // Bcc is not stored in the header (obviously)
-        // so the only way to verify the bcc, is that there are three messages
-        // send.
-        assertEquals(3, messages.size());
+        assertThat(messages)
+            .extracting(WiserMessage::getEnvelopeSender, WiserMessage::getEnvelopeReceiver)
+            .containsExactlyInAnyOrder(
+                tuple("flowable@localhost", "kermit@activiti.org"),
+                tuple("flowable@localhost", "fozzie@activiti.org"),
+                tuple("flowable@localhost", "mispiggy@activiti.org")
+            );
+    }
+
+    @Deployment(resources = "org/flowable/engine/test/bpmn/mail/EmailServiceTaskTest.testCcAndBcc.bpmn20.xml")
+    public void testCcAndBccWithForceTo() throws Exception {
+        processEngineConfiguration.setMailServerForceTo("no-reply@flowable");
+        runtimeService.startProcessInstanceByKey("ccAndBcc");
+
+        List<WiserMessage> messages = wiser.getMessages();
+        assertEmailSend(messages.get(0), false, "Hello world", "This is the content", "flowable@localhost", Collections.singletonList("no-reply@flowable"),
+            Collections.singletonList("no-reply@flowable"));
+
+        assertThat(messages)
+            .extracting(WiserMessage::getEnvelopeSender, WiserMessage::getEnvelopeReceiver)
+            .containsExactlyInAnyOrder(
+                tuple("flowable@localhost", "no-reply@flowable"),
+                tuple("flowable@localhost", "no-reply@flowable"),
+                tuple("flowable@localhost", "no-reply@flowable")
+            );
     }
 
     @Deployment
@@ -295,6 +376,21 @@ public class EmailServiceTaskTest extends EmailTestCase {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             assertNull(historyService.createHistoricVariableInstanceQuery().processInstanceId(piId).variableName("emailError").singleResult());
         }
+    }
+
+    @Deployment
+    public void testMissingToAddress() {
+        assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("missingToAddress"))
+            .isInstanceOf(FlowableException.class)
+            .hasMessage("No recipient could be found for sending email");
+    }
+
+    @Deployment(resources = "org/flowable/engine/test/bpmn/mail/EmailServiceTaskTest.testMissingToAddress.bpmn20.xml")
+    public void testMissingToAddressWithForceTo() {
+        processEngineConfiguration.setMailServerForceTo("no-reply@flowable.org");
+        assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("missingToAddress"))
+            .isInstanceOf(FlowableException.class)
+            .hasMessage("No recipient could be found for sending email");
     }
 
     // Helper

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/mail/EmailTestCase.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/mail/EmailTestCase.java
@@ -22,11 +22,13 @@ import org.subethamail.wiser.Wiser;
 public abstract class EmailTestCase extends PluggableFlowableTestCase {
 
     protected Wiser wiser;
+    private String initialForceTo;
 
     @Override
     protected void setUp() throws Exception {
         super.setUp();
 
+        initialForceTo = processEngineConfiguration.getMailServerForceTo();
         boolean serverUpAndRunning = false;
         while (!serverUpAndRunning) {
             wiser = new Wiser();
@@ -51,6 +53,7 @@ public abstract class EmailTestCase extends PluggableFlowableTestCase {
         Thread.sleep(250L);
 
         super.tearDown();
+        processEngineConfiguration.setMailServerForceTo(initialForceTo);
     }
 
 }

--- a/modules/flowable-engine/src/test/resources/flowable.cfg.xml
+++ b/modules/flowable-engine/src/test/resources/flowable.cfg.xml
@@ -43,6 +43,18 @@
             <property name="mailServerPassword" value="password" />
           </bean>
         </entry>
+        <entry key="forceToEmailTenant">
+          <bean class="org.flowable.engine.cfg.MailServerInfo">
+            <property name="mailServerHost" value="localhost" />
+            <property name="mailServerPort" value="5025" />
+            <property name="mailServerUseSSL" value="false" />
+            <property name="mailServerUseTLS" value="false" />
+            <property name="mailServerDefaultFrom" value="flowable@myTenant.com" />
+            <property name="mailServerForceTo" value="no-reply@myTenant.com" />
+            <property name="mailServerUsername" value="flowable@myTenant.com" />
+            <property name="mailServerPassword" value="password" />
+          </bean>
+        </entry>
       </map>
     </property>
     

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/mail/EmailSendTaskTest.testMissingToAddress.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/mail/EmailSendTaskTest.testMissingToAddress.bpmn20.xml
@@ -1,0 +1,23 @@
+<definitions
+        xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+        xmlns:flowable="http://flowable.org/bpmn"
+        targetNamespace="Examples">
+
+    <process id="missingToAddress">
+        <startEvent id="theStart"/>
+        <sequenceFlow sourceRef="theStart" targetRef="sendMail"/>
+        <sendTask id="sendMail" flowable:type="mail">
+            <extensionElements>
+                <flowable:field name="to"/>
+                <flowable:field name="subject">
+                    <flowable:string>Hello Kermit!</flowable:string>
+                </flowable:field>
+                <flowable:field name="text">
+                    <flowable:string>This a text only e-mail.</flowable:string>
+                </flowable:field>
+            </extensionElements>
+        </sendTask>
+        <sequenceFlow sourceRef="sendMail" targetRef="theEnd"/>
+        <endEvent id="theEnd"/>
+    </process>
+</definitions>

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/mail/EmailServiceTaskTest.testMissingToAddress.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/mail/EmailServiceTaskTest.testMissingToAddress.bpmn20.xml
@@ -1,0 +1,23 @@
+<definitions
+        xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+        xmlns:flowable="http://flowable.org/bpmn"
+        targetNamespace="Examples">
+
+    <process id="missingToAddress">
+        <startEvent id="theStart"/>
+        <sequenceFlow sourceRef="theStart" targetRef="sendMail"/>
+        <serviceTask id="sendMail" flowable:type="mail">
+            <extensionElements>
+                <flowable:field name="to"/>
+                <flowable:field name="subject">
+                    <flowable:string>Hello Kermit!</flowable:string>
+                </flowable:field>
+                <flowable:field name="text">
+                    <flowable:string>This a text only e-mail.</flowable:string>
+                </flowable:field>
+            </extensionElements>
+        </serviceTask>
+        <sequenceFlow sourceRef="sendMail" targetRef="theEnd"/>
+        <endEvent id="theEnd"/>
+    </process>
+</definitions>

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/FlowableMailProperties.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/FlowableMailProperties.java
@@ -49,6 +49,13 @@ public class FlowableMailProperties {
     private String defaultFrom = "flowable@localhost";
 
     /**
+     * The force to address(es) that would be used when sending out emails.
+     * IMPORTANT: If this is send then all emails will be send to defined addresses instead of the address
+     * configured in the MailActivity.
+     */
+    private String forceTo;
+
+    /**
      * Sets whether SSL/TLS encryption should be enabled for the SMTP transport upon connection (SMTPS/POPS).
      */
     private boolean useSsl;
@@ -96,6 +103,14 @@ public class FlowableMailProperties {
 
     public void setDefaultFrom(String defaultFrom) {
         this.defaultFrom = defaultFrom;
+    }
+
+    public String getForceTo() {
+        return forceTo;
+    }
+
+    public void setForceTo(String forceTo) {
+        this.forceTo = forceTo;
     }
 
     public boolean isUseSsl() {

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/ProcessEngineAutoConfiguration.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/ProcessEngineAutoConfiguration.java
@@ -176,6 +176,7 @@ public class ProcessEngineAutoConfiguration extends AbstractSpringEngineAutoConf
         conf.setMailServerUsername(mailProperties.getUsername());
         conf.setMailServerPassword(mailProperties.getPassword());
         conf.setMailServerDefaultFrom(mailProperties.getDefaultFrom());
+        conf.setMailServerForceTo(mailProperties.getForceTo());
         conf.setMailServerUseSSL(mailProperties.isUseSsl());
         conf.setMailServerUseTLS(mailProperties.isUseTls());
 


### PR DESCRIPTION

The mailServerForceTo can be used when testing processes without the need to adapt the BPMN model itself