### PR TITLE
Make sure the EmailServiceTaskTest can run green on all DBs

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/mail/EmailServiceTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/mail/EmailServiceTaskTest.java
@@ -78,6 +78,7 @@ public class EmailServiceTaskTest extends EmailTestCase {
     @Deployment(resources = "org/flowable/engine/test/bpmn/mail/EmailSendTaskTest.testSimpleTextMail.bpmn20.xml", tenantId = "forceToEmailTenant")
     public void testSimpleTextMailWhenMultiTenantWithForceTo() throws Exception {
         String tenantId = "forceToEmailTenant";
+        addMailServer(tenantId, "flowable@myTenant.com", "no-reply@myTenant.com");
 
         String procId = runtimeService.startProcessInstanceByKeyAndTenantId("simpleTextOnly", tenantId).getId();
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/mail/EmailTestCase.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/mail/EmailTestCase.java
@@ -13,6 +13,10 @@
 
 package org.flowable.engine.test.bpmn.mail;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import org.flowable.engine.cfg.MailServerInfo;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.subethamail.wiser.Wiser;
 
@@ -23,12 +27,15 @@ public abstract class EmailTestCase extends PluggableFlowableTestCase {
 
     protected Wiser wiser;
     private String initialForceTo;
+    private Map<String, MailServerInfo> initialMailServers;
 
     @Override
     protected void setUp() throws Exception {
         super.setUp();
 
         initialForceTo = processEngineConfiguration.getMailServerForceTo();
+        Map<String, MailServerInfo> mailServers = processEngineConfiguration.getMailServers();
+        initialMailServers = mailServers == null ? null : new HashMap<>(mailServers);
         boolean serverUpAndRunning = false;
         while (!serverUpAndRunning) {
             wiser = new Wiser();
@@ -54,6 +61,21 @@ public abstract class EmailTestCase extends PluggableFlowableTestCase {
 
         super.tearDown();
         processEngineConfiguration.setMailServerForceTo(initialForceTo);
+        processEngineConfiguration.setMailServers(initialMailServers);
+    }
+
+    protected void addMailServer(String tenantId, String defaultFrom, String forceTo) {
+        MailServerInfo mailServerInfo = new MailServerInfo();
+        mailServerInfo.setMailServerHost("localhost");
+        mailServerInfo.setMailServerPort(5025);
+        mailServerInfo.setMailServerUseSSL(false);
+        mailServerInfo.setMailServerUseTLS(false);
+        mailServerInfo.setMailServerDefaultFrom(defaultFrom);
+        mailServerInfo.setMailServerForceTo(forceTo);
+        mailServerInfo.setMailServerUsername(defaultFrom);
+        mailServerInfo.setMailServerPassword("password");
+
+        processEngineConfiguration.getMailServers().put(tenantId, mailServerInfo);
     }
 
 }

--- a/modules/flowable-engine/src/test/resources/flowable.cfg.xml
+++ b/modules/flowable-engine/src/test/resources/flowable.cfg.xml
@@ -43,18 +43,6 @@
             <property name="mailServerPassword" value="password" />
           </bean>
         </entry>
-        <entry key="forceToEmailTenant">
-          <bean class="org.flowable.engine.cfg.MailServerInfo">
-            <property name="mailServerHost" value="localhost" />
-            <property name="mailServerPort" value="5025" />
-            <property name="mailServerUseSSL" value="false" />
-            <property name="mailServerUseTLS" value="false" />
-            <property name="mailServerDefaultFrom" value="flowable@myTenant.com" />
-            <property name="mailServerForceTo" value="no-reply@myTenant.com" />
-            <property name="mailServerUsername" value="flowable@myTenant.com" />
-            <property name="mailServerPassword" value="password" />
-          </bean>
-        </entry>
       </map>
     </property>
     


### PR DESCRIPTION
* Remove the forceToEmailTenant from the test flowable.cfg.xml
* Create the required MailServerInfo within the needed tests
* Make sure that the initial mailServerInfo is reset after the Email tests (in case it was modified)