### PR TITLE
Update ch05a-Spring-Boot.adoc

### DIFF
--- a/docs/userguide/src/en/bpmn/ch05a-Spring-Boot.adoc
+++ b/docs/userguide/src/en/bpmn/ch05a-Spring-Boot.adoc
@@ -17,7 +17,7 @@ The Flowable starters are also puling spring boot starter transitively, which me
 
 ==== Getting started
 
-Spring Boot is all about convention over configuration. To get started, simply add the _flowable-spring-boot-starter_ or _flowable-spring-boot-starter-rest_ dependency to your project.
+Spring Boot is all about convention over configuration. To get started, simply add the _flowable-spring-boot-starter_ or _flowable-spring-boot-starter-rest_ dependency to your Spring Boot project.
 In case you don't need all the engines see the other <<springBootFlowableStarter, Flowable starters>>.
 For example for Maven:
 


### PR DESCRIPTION
Changed

"To get started, simply add the _flowable-spring-boot-starter_ or _flowable-spring-boot-starter-rest_ dependency to your project."

to 

"To get started, simply add the _flowable-spring-boot-starter_ or _flowable-spring-boot-starter-rest_ dependency to your Spring Boot project."

to avoid the misunderstanding that it is enough to add the flowable-spring-boot-starter to a non-Spring Boot project.