### PR TITLE
Do no wrap a FlowableException into a new FlowableException

### DIFF
--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/el/JuelExpression.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/el/JuelExpression.java
@@ -50,6 +50,8 @@ public class JuelExpression implements Expression {
             throw new FlowableException("Unknown property used in expression: " + expressionText, pnfe);
         } catch (MethodNotFoundException mnfe) {
             throw new FlowableException("Unknown method used in expression: " + expressionText, mnfe);
+        } catch (FlowableException ex) {
+            throw ex;
         } catch (Exception e) {
             throw new FlowableException("Error while evaluating expression: " + expressionText, e);
         }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/ServiceTaskDelegateExpressionActivityBehavior.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/ServiceTaskDelegateExpressionActivityBehavior.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -39,7 +39,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * {@link ActivityBehavior} used when 'delegateExpression' is used for a serviceTask.
- * 
+ *
  * @author Joram Barrez
  * @author Josh Long
  * @author Slawomir Wojtasiak (Patch for ACT-1159)
@@ -110,7 +110,7 @@ public class ServiceTaskDelegateExpressionActivityBehavior extends TaskActivityB
                 } else {
                     throw new FlowableIllegalArgumentException("Delegate expression " + expression + " did neither resolve to an implementation of " + ActivityBehavior.class + " nor " + JavaDelegate.class);
                 }
-                
+
             } else {
                 leave(execution);
             }
@@ -133,6 +133,8 @@ public class ServiceTaskDelegateExpressionActivityBehavior extends TaskActivityB
 
             if (error != null) {
                 ErrorPropagation.propagateError(error, execution);
+            } else if (exc instanceof FlowableException) {
+                throw exc;
             } else {
                 throw new FlowableException(exc.getMessage(), exc);
             }


### PR DESCRIPTION
If it's already a FlowableException do not wrap it into a new FlowableException. Until now when you throw a FlowableIllegalArgumentException it ends up in a 500 internal error.