### PR TITLE
Add FlowableUserDetails interface for extending the Spring Security UserDetails

### DIFF
--- a/modules/flowable-spring-security/pom.xml
+++ b/modules/flowable-spring-security/pom.xml
@@ -39,6 +39,16 @@
 
         <!-- Test dependencies -->
         <dependency>
+            <groupId>org.flowable</groupId>
+            <artifactId>flowable-idm-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/modules/flowable-spring-security/src/main/java/org/flowable/spring/security/FlowableUser.java
+++ b/modules/flowable-spring-security/src/main/java/org/flowable/spring/security/FlowableUser.java
@@ -26,7 +26,7 @@ import org.springframework.security.core.GrantedAuthority;
  *
  * @author Filip Hrisafov
  */
-public class FlowableUser extends org.springframework.security.core.userdetails.User {
+public class FlowableUser extends org.springframework.security.core.userdetails.User implements FlowableUserDetails {
 
     private static final long serialVersionUID = 1L;
 
@@ -36,22 +36,53 @@ public class FlowableUser extends org.springframework.security.core.userdetails.
 
     protected final List<Privilege> privileges;
 
-    public FlowableUser(User user, boolean active, List<Group> groups, List<Privilege> privileges, Collection<? extends GrantedAuthority> authorities) {
+    /**
+     * @deprecated Privileges are no longer required use {@link #FlowableUser(User, boolean, List, Collection)} instead
+     */
+    @Deprecated
+    public FlowableUser(User user, boolean active, List<? extends Group> groups, List<? extends Privilege> privileges,
+        Collection<? extends GrantedAuthority> authorities) {
         super(user.getId(), user.getPassword() == null ? "" : user.getPassword(), active, active, active, active, authorities);
         this.user = user;
         this.groups = Collections.unmodifiableList(groups);
         this.privileges = Collections.unmodifiableList(privileges);
     }
 
+    public FlowableUser(User user, boolean active, List<? extends Group> groups, Collection<? extends GrantedAuthority> authorities) {
+        this(user, active, groups, Collections.emptyList(), authorities);
+    }
+
+    public FlowableUser(User user, String username, boolean enabled,
+        List<? extends Group> groups, Collection<? extends GrantedAuthority> authorities) {
+        super(username, user.getPassword() == null ? "" : user.getPassword(), enabled, true, true, true, authorities);
+        this.user = user;
+        this.groups = Collections.unmodifiableList(groups);
+        this.privileges = Collections.emptyList();
+    }
+
+    @Override
     public User getUser() {
         return user;
     }
 
+    @Override
     public List<Group> getGroups() {
         return groups;
     }
 
+    /**
+     * The privileges are as {@link GrantedAuthority}. THey can be extracted through {@link #getAuthorities()}
+     *
+     * @@deprecated use {@link #getAuthorities()} instead
+     */
+    @Deprecated
     public List<Privilege> getPrivileges() {
         return privileges;
+    }
+
+    @Override
+    public void eraseCredentials() {
+        super.eraseCredentials();
+        user.setPassword(null);
     }
 }

--- a/modules/flowable-spring-security/src/main/java/org/flowable/spring/security/FlowableUserDetails.java
+++ b/modules/flowable-spring-security/src/main/java/org/flowable/spring/security/FlowableUserDetails.java
@@ -19,7 +19,7 @@ import org.flowable.idm.api.User;
 import org.springframework.security.core.userdetails.UserDetails;
 
 /**
- * Provides core core user information within a Flowable application.
+ * Provides core user information within a Flowable application.
  *
  * @author Filip Hrisafov
  * @see UserDetails

--- a/modules/flowable-spring-security/src/main/java/org/flowable/spring/security/FlowableUserDetails.java
+++ b/modules/flowable-spring-security/src/main/java/org/flowable/spring/security/FlowableUserDetails.java
@@ -1,0 +1,42 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.spring.security;
+
+import java.util.List;
+
+import org.flowable.idm.api.Group;
+import org.flowable.idm.api.User;
+import org.springframework.security.core.userdetails.UserDetails;
+
+/**
+ * Provides core core user information within a Flowable application.
+ *
+ * @author Filip Hrisafov
+ * @see UserDetails
+ */
+public interface FlowableUserDetails extends UserDetails {
+
+    /**
+     * The user object containing the information for the Flowable IDM User.
+     * If not using the default FlowableUserDetailsService make sure that you are not reusing the User returned by the IDM and that you
+     * use a correct serializable User. For example use {@link UserDto}
+     */
+    User getUser();
+
+    /**
+     * The groups of the Flowable IDM User.
+     * If not using the default FlowableUserDetailsService make sure that you are not reusing the Groups returned by the IDM and that you
+     * use a correct serializable Group. For example use {@link GroupDetails}
+     */
+    List<Group> getGroups();
+}

--- a/modules/flowable-spring-security/src/main/java/org/flowable/spring/security/FlowableUserDetailsService.java
+++ b/modules/flowable-spring-security/src/main/java/org/flowable/spring/security/FlowableUserDetailsService.java
@@ -85,6 +85,6 @@ public class FlowableUserDetailsService
             }
         }
 
-        return new FlowableUser(user, true, groups, userPrivileges, grantedAuthorities);
+        return new FlowableUser(UserDto.create(user), true, GroupDetails.create(groups), userPrivileges, grantedAuthorities);
     }
 }

--- a/modules/flowable-spring-security/src/main/java/org/flowable/spring/security/FlowableUserDetailsService.java
+++ b/modules/flowable-spring-security/src/main/java/org/flowable/spring/security/FlowableUserDetailsService.java
@@ -85,6 +85,9 @@ public class FlowableUserDetailsService
             }
         }
 
+        // We have to create new UserDto as the User returned by IDM is not serialized properly
+        // (it extends AbstractEntity which is not serializable) and leads to the id not being serialized
+        // We have to create new GroupDetails as Group returned bby IDM is not serialized properly. Same reasoning as with the User
         return new FlowableUser(UserDto.create(user), true, GroupDetails.create(groups), userPrivileges, grantedAuthorities);
     }
 }

--- a/modules/flowable-spring-security/src/main/java/org/flowable/spring/security/GroupDetails.java
+++ b/modules/flowable-spring-security/src/main/java/org/flowable/spring/security/GroupDetails.java
@@ -19,6 +19,7 @@ import java.util.List;
 import org.flowable.idm.api.Group;
 
 /**
+ * An immutable serializable implementation of {@link Group}
  * @author Filip Hrisafov
  */
 public class GroupDetails implements Group, Serializable {

--- a/modules/flowable-spring-security/src/main/java/org/flowable/spring/security/GroupDetails.java
+++ b/modules/flowable-spring-security/src/main/java/org/flowable/spring/security/GroupDetails.java
@@ -1,0 +1,80 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.spring.security;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.flowable.idm.api.Group;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class GroupDetails implements Group, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    protected final String id;
+    protected final String name;
+    protected final String type;
+
+    protected GroupDetails(String id, String name, String type) {
+        this.id = id;
+        this.name = name;
+        this.type = type;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(String id) {
+        // Not supported
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setName(String name) {
+        // Not supported
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+
+    @Override
+    public void setType(String string) {
+        // Not supported
+
+    }
+
+    public static GroupDetails create(Group group) {
+        return new GroupDetails(group.getId(), group.getName(), group.getType());
+    }
+
+    public static List<GroupDetails> create(List<Group> groups) {
+        List<GroupDetails> groupDetails = new ArrayList<>(groups.size());
+        for (Group group : groups) {
+            groupDetails.add(create(group));
+        }
+        return groupDetails;
+    }
+}

--- a/modules/flowable-spring-security/src/main/java/org/flowable/spring/security/UserDto.java
+++ b/modules/flowable-spring-security/src/main/java/org/flowable/spring/security/UserDto.java
@@ -1,0 +1,123 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.spring.security;
+
+import java.io.Serializable;
+
+import org.flowable.idm.api.User;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class UserDto implements User, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    protected final String id;
+    protected String password;
+    protected final String firstName;
+    protected final String lastName;
+    protected final String displayName;
+    protected final String email;
+    protected final String tenantId;
+
+    protected UserDto(String id, String password, String firstName, String lastName, String displayName, String email, String tenantId) {
+        this.id = id;
+        this.password = password;
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.displayName = displayName;
+        this.email = email;
+        this.tenantId = tenantId;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(String id) {
+        // Not supported
+    }
+
+    @Override
+    public String getFirstName() {
+        return firstName;
+    }
+
+    @Override
+    public void setFirstName(String firstName) {
+        // Not supported
+    }
+
+    @Override
+    public String getLastName() {
+        return lastName;
+    }
+
+    @Override
+    public void setLastName(String lastName) {
+        // Not supported
+    }
+
+    @Override
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    @Override
+    public void setDisplayName(String displayName) {
+        // Not supported
+    }
+
+    @Override
+    public String getEmail() {
+        return email;
+    }
+
+    @Override
+    public void setEmail(String email) {
+        // Not supported
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    @Override
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    @Override
+    public void setTenantId(String tenantId) {
+        // Not supported
+    }
+
+    @Override
+    public boolean isPictureSet() {
+        return false;
+    }
+
+    public static UserDto create(User user) {
+        return new UserDto(user.getId(), user.getPassword(), user.getFirstName(), user.getLastName(), user.getDisplayName(), user.getEmail(),
+            user.getTenantId());
+    }
+}

--- a/modules/flowable-spring-security/src/main/java/org/flowable/spring/security/UserDto.java
+++ b/modules/flowable-spring-security/src/main/java/org/flowable/spring/security/UserDto.java
@@ -17,6 +17,8 @@ import java.io.Serializable;
 import org.flowable.idm.api.User;
 
 /**
+ * An immutable serializable implementation of {@link User}. This implementation allows mutation only for the password,
+ * in order for it to be removed by Spring Security when the credentials are erased.
  * @author Filip Hrisafov
  */
 public class UserDto implements User, Serializable {

--- a/modules/flowable-spring-security/src/test/java/org/flowable/spring/security/FlowableUserDetailsServiceTest.java
+++ b/modules/flowable-spring-security/src/test/java/org/flowable/spring/security/FlowableUserDetailsServiceTest.java
@@ -1,0 +1,285 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.spring.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import org.flowable.idm.api.Group;
+import org.flowable.idm.api.Privilege;
+import org.flowable.idm.api.User;
+import org.flowable.idm.engine.test.PluggableFlowableIdmTestCase;
+import org.springframework.security.core.CredentialsContainer;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class FlowableUserDetailsServiceTest extends PluggableFlowableIdmTestCase {
+
+    private UserDetailsService userDetailsService;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+
+        createGroup("admins", "Admins", "user");
+        createGroup("sales", "Sales", "user");
+        createGroup("engineering", "Engineering", "tech");
+
+        createUser("kermit", "Kermit", "the Frog", "Kermit the Frog", "kermit@muppetshow.com");
+        createUser("fozzie", "Fozzie", "Bear", "Fozzie Bear", "fozzie@muppetshow.com");
+
+        idmIdentityService.createMembership("kermit", "admins");
+        idmIdentityService.createMembership("kermit", "sales");
+        idmIdentityService.createMembership("kermit", "engineering");
+        idmIdentityService.createMembership("fozzie", "sales");
+
+        String adminPrivilegename = "access admin application";
+        Privilege adminPrivilege = idmIdentityService.createPrivilege(adminPrivilegename);
+        idmIdentityService.addGroupPrivilegeMapping(adminPrivilege.getId(), "admins");
+
+        String modelerPrivilegeName = "access modeler application";
+        Privilege modelerPrivilege = idmIdentityService.createPrivilege(modelerPrivilegeName);
+        idmIdentityService.addGroupPrivilegeMapping(modelerPrivilege.getId(), "admins");
+        idmIdentityService.addGroupPrivilegeMapping(modelerPrivilege.getId(), "engineering");
+        idmIdentityService.addUserPrivilegeMapping(modelerPrivilege.getId(), "kermit");
+
+        String startProcessesPrivilegename = "start processes";
+        Privilege startProcessesPrivilege = idmIdentityService.createPrivilege(startProcessesPrivilegename);
+        idmIdentityService.addGroupPrivilegeMapping(startProcessesPrivilege.getId(), "sales");
+
+        userDetailsService = new FlowableUserDetailsService(idmIdentityService);
+    }
+
+    private User createUser(String id, String firstName, String lastName, String displayName, String email) {
+        User user = idmIdentityService.newUser(id);
+        user.setFirstName(firstName);
+        user.setLastName(lastName);
+        user.setDisplayName(displayName);
+        user.setEmail(email);
+        user.setPassword(id);
+        idmIdentityService.saveUser(user);
+        return user;
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        clearAllUsersAndGroups();
+        super.tearDown();
+    }
+
+    public void testLoadingByUnknownUserShouldThrowException() {
+        assertThatThrownBy(() -> userDetailsService.loadUserByUsername("unknown"))
+            .isInstanceOf(UsernameNotFoundException.class)
+            .hasMessage("user (unknown) could not be found");
+    }
+
+    public void testLoadingByNullUserShouldIgnoreFlowableException() {
+        assertThatThrownBy(() -> userDetailsService.loadUserByUsername(null))
+            .isInstanceOf(UsernameNotFoundException.class)
+            .hasMessage("user (null) could not be found");
+    }
+
+    public void testLoadingKnownUserWithAllPrivileges() {
+        UserDetails kermit = userDetailsService.loadUserByUsername("kermit");
+
+        assertThat(kermit).isNotNull();
+        assertThat(kermit.isCredentialsNonExpired()).as("credentialsNonExpired").isTrue();
+        assertThat(kermit.isAccountNonLocked()).as("accountNonLocked").isTrue();
+        assertThat(kermit.isAccountNonExpired()).as("accountNonExpired").isTrue();
+        assertThat(kermit.isEnabled()).as("enabled").isTrue();
+        assertThat(kermit.getUsername()).as("username").isEqualTo("kermit");
+        assertThat(kermit.getPassword()).as("password").isEqualTo("kermit");
+        assertThat(kermit.getAuthorities())
+            .extracting(GrantedAuthority::getAuthority)
+            .as("granted authorities")
+            .containsExactly(
+                "access admin application",
+                "access modeler application",
+                "start processes"
+            );
+
+        assertThat(kermit).isInstanceOf(FlowableUserDetails.class);
+
+        FlowableUserDetails kermitFlowable = (FlowableUserDetails) kermit;
+
+        User user = kermitFlowable.getUser();
+        assertThat(user.getId()).isEqualTo("kermit");
+        assertThat(user.getFirstName()).isEqualTo("Kermit");
+        assertThat(user.getLastName()).isEqualTo("the Frog");
+        assertThat(user.getDisplayName()).isEqualTo("Kermit the Frog");
+        assertThat(user.getEmail()).isEqualTo("kermit@muppetshow.com");
+        assertThat(user.getPassword()).isEqualTo("kermit");
+
+        user.setId("test");
+        user.setFirstName("test");
+        user.setLastName("test");
+        user.setDisplayName("test");
+        user.setEmail("test");
+
+        assertThat(user.getId()).isEqualTo("kermit");
+        assertThat(user.getFirstName()).isEqualTo("Kermit");
+        assertThat(user.getLastName()).isEqualTo("the Frog");
+        assertThat(user.getDisplayName()).isEqualTo("Kermit the Frog");
+        assertThat(user.getEmail()).isEqualTo("kermit@muppetshow.com");
+
+        assertThat(kermitFlowable.getGroups())
+            .extracting(Group::getId, Group::getName, Group::getType)
+            .as("Groups")
+            .containsExactlyInAnyOrder(
+                tuple("admins", "Admins", "user"),
+                tuple("sales", "Sales", "user"),
+                tuple("engineering", "Engineering", "tech")
+            );
+
+        kermitFlowable.getGroups().forEach(group -> {
+            group.setId("test");
+            group.setType("test");
+            group.setName("test");
+        });
+
+        assertThat(kermitFlowable.getGroups())
+            .extracting(Group::getId, Group::getName, Group::getType)
+            .as("Groups")
+            .containsExactlyInAnyOrder(
+                tuple("admins", "Admins", "user"),
+                tuple("sales", "Sales", "user"),
+                tuple("engineering", "Engineering", "tech")
+            );
+
+        assertThat(kermit).isInstanceOf(CredentialsContainer.class);
+        CredentialsContainer container = (CredentialsContainer) kermit;
+        container.eraseCredentials();
+        assertThat(kermit.getPassword()).as("Password after erase").isNull();
+        assertThat(kermitFlowable.getUser().getPassword()).as("User password after erase").isNull();
+    }
+
+    public void testLoadingUserShouldBeCaseSensitive() {
+        assertThatThrownBy(() -> userDetailsService.loadUserByUsername("kErMiT"))
+            .isInstanceOf(UsernameNotFoundException.class)
+            .hasMessage("user (kErMiT) could not be found");
+    }
+
+    public void testLoadingKnownUserWithSomePrivileges() {
+        UserDetails fozzie = userDetailsService.loadUserByUsername("fozzie");
+
+        assertThat(fozzie).isNotNull();
+        assertThat(fozzie.isCredentialsNonExpired()).as("credentialsNonExpired").isTrue();
+        assertThat(fozzie.isAccountNonLocked()).as("accountNonLocked").isTrue();
+        assertThat(fozzie.isAccountNonExpired()).as("accountNonExpired").isTrue();
+        assertThat(fozzie.isEnabled()).as("enabled").isTrue();
+        assertThat(fozzie.getUsername()).as("username").isEqualTo("fozzie");
+        assertThat(fozzie.getPassword()).as("password").isEqualTo("fozzie");
+        assertThat(fozzie.getAuthorities())
+            .extracting(GrantedAuthority::getAuthority)
+            .as("granted authorities")
+            .containsExactly(
+                "start processes"
+            );
+
+        assertThat(fozzie).isInstanceOf(FlowableUserDetails.class);
+
+        FlowableUserDetails fozzieFlowable = (FlowableUserDetails) fozzie;
+
+        User user = fozzieFlowable.getUser();
+        assertThat(user.getId()).isEqualTo("fozzie");
+        assertThat(user.getFirstName()).isEqualTo("Fozzie");
+        assertThat(user.getLastName()).isEqualTo("Bear");
+        assertThat(user.getDisplayName()).isEqualTo("Fozzie Bear");
+        assertThat(user.getEmail()).isEqualTo("fozzie@muppetshow.com");
+        assertThat(user.getPassword()).isEqualTo("fozzie");
+
+        user.setId("test");
+        user.setFirstName("test");
+        user.setLastName("test");
+        user.setDisplayName("test");
+        user.setEmail("test");
+
+        assertThat(user.getId()).isEqualTo("fozzie");
+        assertThat(user.getFirstName()).isEqualTo("Fozzie");
+        assertThat(user.getLastName()).isEqualTo("Bear");
+        assertThat(user.getDisplayName()).isEqualTo("Fozzie Bear");
+        assertThat(user.getEmail()).isEqualTo("fozzie@muppetshow.com");
+
+        assertThat(fozzieFlowable.getGroups())
+            .extracting(Group::getId, Group::getName, Group::getType)
+            .as("Groups")
+            .containsExactlyInAnyOrder(
+                tuple("sales", "Sales", "user")
+            );
+    }
+
+    public void testSerializingUserDetailsShouldWorkCorrectly() throws IOException, ClassNotFoundException {
+        UserDetails kermit = userDetailsService.loadUserByUsername("kermit");
+
+        byte[] serialized;
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        ObjectOutputStream outputStream = new ObjectOutputStream(buffer);
+        outputStream.writeObject(kermit);
+        outputStream.close();
+        serialized = buffer.toByteArray();
+
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(serialized);
+        ObjectInputStream stream = new ObjectInputStream(inputStream);
+        Object deserialized = stream.readObject();
+        stream.close();
+
+        assertThat(deserialized).isInstanceOf(FlowableUserDetails.class);
+
+        kermit = (UserDetails) deserialized;
+        assertThat(kermit.isCredentialsNonExpired()).as("credentialsNonExpired").isTrue();
+        assertThat(kermit.isAccountNonLocked()).as("accountNonLocked").isTrue();
+        assertThat(kermit.isAccountNonExpired()).as("accountNonExpired").isTrue();
+        assertThat(kermit.isEnabled()).as("enabled").isTrue();
+        assertThat(kermit.getUsername()).as("username").isEqualTo("kermit");
+        assertThat(kermit.getPassword()).as("password").isEqualTo("kermit");
+        assertThat(kermit.getAuthorities())
+            .extracting(GrantedAuthority::getAuthority)
+            .as("granted authorities")
+            .containsExactly(
+                "access admin application",
+                "access modeler application",
+                "start processes"
+            );
+
+        FlowableUserDetails kermitFlowable = (FlowableUserDetails) kermit;
+
+        User user = kermitFlowable.getUser();
+        assertThat(user.getId()).isEqualTo("kermit");
+        assertThat(user.getFirstName()).isEqualTo("Kermit");
+        assertThat(user.getLastName()).isEqualTo("the Frog");
+        assertThat(user.getDisplayName()).isEqualTo("Kermit the Frog");
+        assertThat(user.getEmail()).isEqualTo("kermit@muppetshow.com");
+        assertThat(user.getPassword()).isEqualTo("kermit");
+
+        assertThat(kermitFlowable.getGroups())
+            .extracting(Group::getId, Group::getName, Group::getType)
+            .as("Groups")
+            .containsExactlyInAnyOrder(
+                tuple("admins", "Admins", "user"),
+                tuple("sales", "Sales", "user"),
+                tuple("engineering", "Engineering", "tech")
+            );
+    }
+}

--- a/modules/flowable-spring-security/src/test/resources/flowable.idm.cfg.xml
+++ b/modules/flowable-spring-security/src/test/resources/flowable.idm.cfg.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans   http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <bean id="idmEngineConfiguration" class="org.flowable.idm.engine.impl.cfg.StandaloneIdmEngineConfiguration">
+
+        <property name="jdbcUrl" value="jdbc:h2:mem:flowableidm;DB_CLOSE_DELAY=1000" />
+        <property name="jdbcDriver" value="org.h2.Driver" />
+        <property name="jdbcUsername" value="sa" />
+        <property name="jdbcPassword" value="" />
+        
+        <!-- Database configurations -->
+    	<property name="databaseSchemaUpdate" value="drop-create" />
+    </bean>
+</beans>

--- a/modules/flowable-spring-security/src/test/resources/log4j.properties
+++ b/modules/flowable-spring-security/src/test/resources/log4j.properties
@@ -1,0 +1,8 @@
+log4j.rootLogger=ERROR, CA
+
+# ConsoleAppender
+log4j.appender.CA=org.apache.log4j.ConsoleAppender
+log4j.appender.CA.layout=org.apache.log4j.PatternLayout
+log4j.appender.CA.layout.ConversionPattern= %d{hh:mm:ss,SSS} [%t] %-5p %c %x - %m%n
+
+log4j.logger.org.flowable.idm.engine=DEBUG


### PR DESCRIPTION

* Add test for testing the FlowableUserDetailsService
* Add UserDto and GroupDetails which are complying with Serializable
* Deprecate FlowableUser#getPrivileges as it is not required and returns only the User privileges and not the group ones