### PR TITLE
Swagger for the CMMN REST API should be part of the flowable-rest documentation

### DIFF
--- a/modules/flowable-app-rest/pom.xml
+++ b/modules/flowable-app-rest/pom.xml
@@ -356,6 +356,44 @@
                   <swaggerFileName>flowable</swaggerFileName>
                   <swaggerDirectory>${basedir}/src/main/resources/static/docs/specfile/app</swaggerDirectory>
                 </apiSource>
+                <!-- ++++++++++ -->
+                <!-- CMMN -->
+                <!-- ++++++++++ -->
+                <apiSource>
+                  <springmvc>true</springmvc>
+                  <locations>
+                    <location>org.flowable.cmmn.rest.service.api</location>
+                  </locations>
+                  <schemes>
+                    <scheme>http</scheme>
+                    <scheme>https</scheme>
+                  </schemes>
+                  <host>${swagger.host}</host>
+                  <basePath>/flowable-rest/cmmn-api</basePath>
+                  <info>
+                    <title>Flowable CMMN REST API</title>
+                    <version>v1</version>
+                    <contact>
+                      <email></email>
+                      <name>Flowable</name>
+                      <url>http://www.flowable.org/</url>
+                    </contact>
+                    <license>
+                      <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+                      <name>Apache 2.0</name>
+                    </license>
+                  </info>
+                  <securityDefinitions>
+                    <securityDefinition>
+                      <name>basicAuth</name>
+                      <type>basic</type>
+                    </securityDefinition>
+                  </securityDefinitions>
+                  <descriptionFile>${basedir}/src/main/resources/swagger/info.txt</descriptionFile>
+                  <outputFormats>json,yaml</outputFormats>
+                  <swaggerFileName>flowable</swaggerFileName>
+                  <swaggerDirectory>${basedir}/src/main/resources/static/docs/specfile/cmmn</swaggerDirectory>
+                </apiSource>
               </apiSources>
             </configuration>
             <executions>

--- a/modules/flowable-app-rest/src/main/resources/static/docs/index.html
+++ b/modules/flowable-app-rest/src/main/resources/static/docs/index.html
@@ -47,6 +47,9 @@
           case "specfile/dmn/flowable.json":
               api = "dmn";
               break;
+          case "specfile/cmmn/flowable.json":
+              api = "cmmn";
+              break;
           case "specfile/form/flowable.json":
               api = "form";
               break;
@@ -114,6 +117,9 @@
               case "dmn":
                   specFile = "specfile/dmn/flowable.json";
                   break;
+              case "cmmn":
+                  specFile = "specfile/cmmn/flowable.json";
+                  break;
               case "form":
                   specFile = "specfile/form/flowable.json";
                   break;
@@ -147,6 +153,7 @@
           <option value="process">Process</option>
           <option value="idm">IDM</option>
           <option value="dmn">DMN</option>
+          <option value="cmmn">CMMN</option>
           <option value="form">Form</option>
           <option value="content">Content</option>
           <option value="app">App</option>


### PR DESCRIPTION
The Swagger REST resources were missing from the flowable-rest application