### PR TITLE
Support for JUnit Jupiter in the flowable-engine

### DIFF
--- a/modules/flowable-app-engine-spring/pom.xml
+++ b/modules/flowable-app-engine-spring/pom.xml
@@ -124,6 +124,21 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>

--- a/modules/flowable-app-engine/pom.xml
+++ b/modules/flowable-app-engine/pom.xml
@@ -75,6 +75,21 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>

--- a/modules/flowable-bpmn-converter/pom.xml
+++ b/modules/flowable-bpmn-converter/pom.xml
@@ -138,6 +138,21 @@
       <artifactId>junit</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   
   <profiles>

--- a/modules/flowable-bpmn-layout/pom.xml
+++ b/modules/flowable-bpmn-layout/pom.xml
@@ -109,6 +109,21 @@
       <artifactId>junit</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/modules/flowable-camel/pom.xml
+++ b/modules/flowable-camel/pom.xml
@@ -51,6 +51,21 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>com.h2database</groupId>

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/AsyncPingTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/AsyncPingTest.java
@@ -23,12 +23,16 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.spring.impl.test.SpringFlowableTestCase;
 import org.junit.Assert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
  * @author Saeid Mirzaei
  */
+@Tag("camel")
 @ContextConfiguration("classpath:generic-camel-flowable-context.xml")
 public class AsyncPingTest extends SpringFlowableTestCase {
 
@@ -38,7 +42,7 @@ public class AsyncPingTest extends SpringFlowableTestCase {
     @Autowired
     protected RuntimeService runtimeService;
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         camelContext.addRoutes(new RouteBuilder() {
 
@@ -50,7 +54,7 @@ public class AsyncPingTest extends SpringFlowableTestCase {
         });
     }
 
-    @Override
+    @Test
     public void tearDown() throws Exception {
         List<Route> routes = camelContext.getRoutes();
         for (Route r : routes) {
@@ -59,6 +63,7 @@ public class AsyncPingTest extends SpringFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "process/asyncPing.bpmn20.xml" })
     public void testRunProcess() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("asyncPingProcess");

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/AsyncProcessTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/AsyncProcessTest.java
@@ -22,19 +22,24 @@ import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.spring.impl.test.SpringFlowableTestCase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
  * @author Saeid Mirzaei
  */
+@Tag("camel")
 @ContextConfiguration("classpath:generic-camel-flowable-context.xml")
 public class AsyncProcessTest extends SpringFlowableTestCase {
 
     @Autowired
     protected CamelContext camelContext;
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         camelContext.addRoutes(new RouteBuilder() {
 
@@ -51,7 +56,7 @@ public class AsyncProcessTest extends SpringFlowableTestCase {
         });
     }
 
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
         List<Route> routes = camelContext.getRoutes();
         for (Route r : routes) {
@@ -60,6 +65,7 @@ public class AsyncProcessTest extends SpringFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "process/async.bpmn20.xml" })
     public void testRunProcess() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("asyncCamelProcess");

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/CamelVariableBodyMapTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/CamelVariableBodyMapTest.java
@@ -25,9 +25,14 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.spring.impl.test.SpringFlowableTestCase;
 import org.flowable.task.api.Task;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 
+@Tag("camel")
 @ContextConfiguration("classpath:generic-camel-flowable-context.xml")
 public class CamelVariableBodyMapTest extends SpringFlowableTestCase {
 
@@ -36,7 +41,7 @@ public class CamelVariableBodyMapTest extends SpringFlowableTestCase {
     @Autowired
     protected CamelContext camelContext;
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         camelContext.addRoutes(new RouteBuilder() {
 
@@ -50,7 +55,7 @@ public class CamelVariableBodyMapTest extends SpringFlowableTestCase {
         service1.reset();
     }
 
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
         List<Route> routes = camelContext.getRoutes();
         for (Route r : routes) {
@@ -59,6 +64,7 @@ public class CamelVariableBodyMapTest extends SpringFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = {"process/HelloCamelBodyMap.bpmn20.xml"})
     public void testCamelBody() throws Exception {
         Map<String, Object> varMap = new HashMap<>();

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/CamelVariableBodyTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/CamelVariableBodyTest.java
@@ -25,9 +25,14 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.spring.impl.test.SpringFlowableTestCase;
 import org.flowable.task.api.Task;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 
+@Tag("camel")
 @ContextConfiguration("classpath:generic-camel-flowable-context.xml")
 public class CamelVariableBodyTest extends SpringFlowableTestCase {
 
@@ -36,7 +41,7 @@ public class CamelVariableBodyTest extends SpringFlowableTestCase {
 
     protected MockEndpoint service1;
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         camelContext.addRoutes(new RouteBuilder() {
 
@@ -49,7 +54,7 @@ public class CamelVariableBodyTest extends SpringFlowableTestCase {
         service1.reset();
     }
 
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
         List<Route> routes = camelContext.getRoutes();
         for (Route r : routes) {
@@ -58,6 +63,7 @@ public class CamelVariableBodyTest extends SpringFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = {"process/HelloCamelBody.bpmn20.xml"})
     public void testCamelBody() throws Exception {
         service1.expectedBodiesReceived("hello world");

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/CustomContextTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/CustomContextTest.java
@@ -25,9 +25,14 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.flowable.engine.test.Deployment;
 import org.flowable.spring.impl.test.SpringFlowableTestCase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 
+@Tag("camel")
 @ContextConfiguration("classpath:generic-camel-flowable-context.xml")
 public class CustomContextTest extends SpringFlowableTestCase {
 
@@ -38,7 +43,7 @@ public class CustomContextTest extends SpringFlowableTestCase {
 
     protected MockEndpoint service2;
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
 
         camelContext.addRoutes(new RouteBuilder() {
@@ -61,7 +66,7 @@ public class CustomContextTest extends SpringFlowableTestCase {
         service2.reset();
     }
 
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
         List<Route> routes = camelContext.getRoutes();
         for (Route r : routes) {
@@ -70,6 +75,7 @@ public class CustomContextTest extends SpringFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "process/custom.bpmn20.xml" })
     public void testRunProcess() throws Exception {
         CamelContext ctx = applicationContext.getBean(CamelContext.class);

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/EmptyProcessTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/EmptyProcessTest.java
@@ -23,18 +23,21 @@ import org.apache.camel.builder.RouteBuilder;
 import org.flowable.engine.test.Deployment;
 import org.flowable.spring.impl.test.SpringFlowableTestCase;
 import org.flowable.variable.api.history.HistoricVariableInstance;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 
+@Tag("camel")
 @ContextConfiguration("classpath:generic-camel-flowable-context.xml")
 public class EmptyProcessTest extends SpringFlowableTestCase {
 
     @Autowired
     protected CamelContext camelContext;
 
-    @BeforeClass
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         camelContext.addRoutes(new RouteBuilder() {
 
@@ -47,7 +50,7 @@ public class EmptyProcessTest extends SpringFlowableTestCase {
         });
     }
 
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
         List<Route> routes = camelContext.getRoutes();
         for (Route r : routes) {
@@ -56,6 +59,7 @@ public class EmptyProcessTest extends SpringFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "process/empty.bpmn20.xml" })
     public void testRunProcessWithHeader() throws Exception {
         CamelContext ctx = applicationContext.getBean(CamelContext.class);
@@ -75,6 +79,7 @@ public class EmptyProcessTest extends SpringFlowableTestCase {
         assertEquals("Foo", var.getValue());
     }
 
+    @Test
     @Deployment(resources = { "process/empty.bpmn20.xml" })
     public void testObjectAsVariable() throws Exception {
         CamelContext ctx = applicationContext.getBean(CamelContext.class);
@@ -90,6 +95,7 @@ public class EmptyProcessTest extends SpringFlowableTestCase {
         assertEquals(expectedObj, var.getValue());
     }
 
+    @Test
     @Deployment(resources = { "process/empty.bpmn20.xml" })
     public void testObjectAsStringVariable() throws Exception {
         CamelContext ctx = applicationContext.getBean(CamelContext.class);

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/ErrorHandlingTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/ErrorHandlingTest.java
@@ -20,6 +20,8 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
 import org.flowable.spring.impl.test.SpringFlowableTestCase;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
@@ -27,6 +29,7 @@ import org.springframework.test.context.ContextConfiguration;
  *
  * @author stefan.schulze@accelsis.biz
  */
+@Tag("camel")
 @ContextConfiguration("classpath:error-camel-flowable-context.xml")
 public class ErrorHandlingTest extends SpringFlowableTestCase {
 
@@ -40,6 +43,7 @@ public class ErrorHandlingTest extends SpringFlowableTestCase {
      *
      * @throws Exception
      */
+    @Test
     @Deployment(resources = {"process/errorHandling.bpmn20.xml"})
     public void testCamelRouteWorksAsIntended() throws Exception {
         Map<String, Object> variables = new HashMap<>();
@@ -61,6 +65,7 @@ public class ErrorHandlingTest extends SpringFlowableTestCase {
      *
      * @throws Exception
      */
+    @Test
     @Deployment(resources = {"process/errorHandling.bpmn20.xml"})
     public void testRollbackOnException() throws Exception {
         Map<String, Object> variables = new HashMap<>();
@@ -78,6 +83,7 @@ public class ErrorHandlingTest extends SpringFlowableTestCase {
      *
      * @throws Exception
      */
+    @Test
     @Deployment(resources = {"process/errorHandling.bpmn20.xml"})
     public void testErrorHandledByCamel() throws Exception {
         Map<String, Object> variables = new HashMap<>();

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/ErrorMapExceptionTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/ErrorMapExceptionTest.java
@@ -18,18 +18,22 @@ import org.apache.camel.builder.RouteBuilder;
 import org.flowable.camel.util.FlagJavaDelegate;
 import org.flowable.engine.test.Deployment;
 import org.flowable.spring.impl.test.SpringFlowableTestCase;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
  * @author Saeid Mirzaei
  */
+@Tag("camel")
 @ContextConfiguration("classpath:generic-camel-flowable-context.xml")
 public class ErrorMapExceptionTest extends SpringFlowableTestCase {
 
     @Autowired
     protected CamelContext camelContext;
 
+    @Test
     @Deployment(resources = { "process/mapExceptionSingleMap.bpmn20.xml" })
     public void testCamelSingleDirectMap() throws Exception {
         camelContext.addRoutes(new RouteBuilder() {
@@ -45,6 +49,7 @@ public class ErrorMapExceptionTest extends SpringFlowableTestCase {
         assertTrue(FlagJavaDelegate.isFlagSet());
     }
 
+    @Test
     @Deployment(resources = { "process/mapExceptionDefaultMap.bpmn20.xml" })
     public void testCamelDefaultMap() throws Exception {
         camelContext.addRoutes(new RouteBuilder() {
@@ -59,6 +64,7 @@ public class ErrorMapExceptionTest extends SpringFlowableTestCase {
         assertTrue(FlagJavaDelegate.isFlagSet());
     }
 
+    @Test
     @Deployment(resources = { "process/mapExceptionParentMap.bpmn20.xml" })
     public void testCamelParentMap() throws Exception {
         camelContext.addRoutes(new RouteBuilder() {

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/MultipleInstanceRoute.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/MultipleInstanceRoute.java
@@ -19,16 +19,21 @@ import org.apache.camel.Route;
 import org.apache.camel.builder.RouteBuilder;
 import org.flowable.engine.test.Deployment;
 import org.flowable.spring.impl.test.SpringFlowableTestCase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 
+@Tag("camel")
 @ContextConfiguration("classpath:generic-camel-flowable-context.xml")
 public class MultipleInstanceRoute extends SpringFlowableTestCase {
 
     @Autowired
     protected CamelContext camelContext;
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         camelContext.addRoutes(new RouteBuilder() {
 
@@ -39,7 +44,7 @@ public class MultipleInstanceRoute extends SpringFlowableTestCase {
         });
     }
 
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
         List<Route> routes = camelContext.getRoutes();
         for (Route r : routes) {
@@ -48,6 +53,7 @@ public class MultipleInstanceRoute extends SpringFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "process/multiInstanceCamel.bpmn20.xml" })
     public void testCamelBody() throws Exception {
         runtimeService.startProcessInstanceByKey("multiInstanceCamelProcess");

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/ParallelProcessTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/ParallelProcessTest.java
@@ -21,16 +21,21 @@ import org.apache.camel.builder.RouteBuilder;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.spring.impl.test.SpringFlowableTestCase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 
+@Tag("camel")
 @ContextConfiguration("classpath:generic-camel-flowable-context.xml")
 public class ParallelProcessTest extends SpringFlowableTestCase {
 
     @Autowired
     protected CamelContext camelContext;
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         camelContext.addRoutes(new RouteBuilder() {
 
@@ -45,7 +50,7 @@ public class ParallelProcessTest extends SpringFlowableTestCase {
         });
     }
 
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
         List<Route> routes = camelContext.getRoutes();
         for (Route r : routes) {
@@ -54,6 +59,7 @@ public class ParallelProcessTest extends SpringFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "process/parallel.bpmn20.xml" })
     public void testRunProcess() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("parallelCamelProcess");

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/SimpleProcessTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/SimpleProcessTest.java
@@ -25,9 +25,14 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.flowable.engine.test.Deployment;
 import org.flowable.spring.impl.test.SpringFlowableTestCase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 
+@Tag("camel")
 @ContextConfiguration("classpath:generic-camel-flowable-context.xml")
 public class SimpleProcessTest extends SpringFlowableTestCase {
 
@@ -38,7 +43,7 @@ public class SimpleProcessTest extends SpringFlowableTestCase {
 
     protected MockEndpoint service2;
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         service1 = (MockEndpoint) camelContext.getEndpoint("mock:service1");
         service1.reset();
@@ -56,7 +61,7 @@ public class SimpleProcessTest extends SpringFlowableTestCase {
         });
     }
 
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
         List<Route> routes = camelContext.getRoutes();
         for (Route r : routes) {
@@ -65,6 +70,7 @@ public class SimpleProcessTest extends SpringFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "process/example.bpmn20.xml" })
     public void testRunProcess() throws Exception {
         CamelContext ctx = applicationContext.getBean(CamelContext.class);
@@ -86,6 +92,7 @@ public class SimpleProcessTest extends SpringFlowableTestCase {
         assertEquals("var2", m.get("var2"));
     }
 
+    @Test
     @Deployment(resources = { "process/example.bpmn20.xml" })
     public void testRunProcessByKey() throws Exception {
         CamelContext ctx = applicationContext.getBean(CamelContext.class);

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/SimpleSpringProcessTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/SimpleSpringProcessTest.java
@@ -25,9 +25,14 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.flowable.engine.test.Deployment;
 import org.flowable.spring.impl.test.SpringFlowableTestCase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 
+@Tag("camel")
 @ContextConfiguration("classpath:generic-camel-flowable-context.xml")
 public class SimpleSpringProcessTest extends SpringFlowableTestCase {
 
@@ -38,7 +43,7 @@ public class SimpleSpringProcessTest extends SpringFlowableTestCase {
 
     protected MockEndpoint service2;
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         camelContext.addRoutes(new RouteBuilder() {
 
@@ -60,7 +65,7 @@ public class SimpleSpringProcessTest extends SpringFlowableTestCase {
         service2.reset();
     }
 
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
         List<Route> routes = camelContext.getRoutes();
         for (Route r : routes) {
@@ -69,6 +74,7 @@ public class SimpleSpringProcessTest extends SpringFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "process/example.bpmn20.xml" })
     public void testRunProcess() throws Exception {
         CamelContext ctx = applicationContext.getBean(CamelContext.class);
@@ -91,6 +97,7 @@ public class SimpleSpringProcessTest extends SpringFlowableTestCase {
 
     }
 
+    @Test
     @Deployment(resources = { "process/example.bpmn20.xml" })
     public void testRunProcessByKey() throws Exception {
         CamelContext ctx = applicationContext.getBean(CamelContext.class);

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/TestReturnValueFromFlowable.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/TestReturnValueFromFlowable.java
@@ -25,6 +25,10 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.flowable.engine.RuntimeService;
 import org.flowable.engine.test.Deployment;
 import org.flowable.spring.impl.test.SpringFlowableTestCase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 
@@ -32,6 +36,7 @@ import org.springframework.test.context.ContextConfiguration;
  * @author Saeid Mirzaei
  */
 
+@Tag("camel")
 @ContextConfiguration("classpath:generic-camel-flowable-context.xml")
 public class TestReturnValueFromFlowable extends SpringFlowableTestCase {
     @Autowired
@@ -46,7 +51,7 @@ public class TestReturnValueFromFlowable extends SpringFlowableTestCase {
     @Produce(uri = "direct:startReturnResultTest")
     protected ProducerTemplate template;
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
 
         camelContext.addRoutes(new RouteBuilder() {
@@ -58,7 +63,7 @@ public class TestReturnValueFromFlowable extends SpringFlowableTestCase {
         });
     }
 
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
         List<Route> routes = camelContext.getRoutes();
         for (Route r : routes) {
@@ -67,6 +72,7 @@ public class TestReturnValueFromFlowable extends SpringFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testReturnResultFromNewProcess() throws Exception {
         resultEndpoint.expectedPropertyReceived("exampleCamelReturnValue", "hello world.");

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/examples/initiator/InitiatorCamelCallTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/examples/initiator/InitiatorCamelCallTest.java
@@ -19,16 +19,20 @@ import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.RouteBuilder;
 import org.flowable.engine.test.Deployment;
 import org.flowable.spring.impl.test.SpringFlowableTestCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 
+@Tag("camel")
 @ContextConfiguration("classpath:generic-camel-flowable-context.xml")
 public class InitiatorCamelCallTest extends SpringFlowableTestCase {
 
     @Autowired
     protected CamelContext camelContext;
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         camelContext.addRoutes(new RouteBuilder() {
 
@@ -40,6 +44,7 @@ public class InitiatorCamelCallTest extends SpringFlowableTestCase {
         });
     }
 
+    @Test
     @Deployment
     public void testInitiatorCamelCall() throws Exception {
         CamelContext ctx = applicationContext.getBean(CamelContext.class);

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/examples/multiinstance/MultiInstanceTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/examples/multiinstance/MultiInstanceTest.java
@@ -21,19 +21,23 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
 import org.flowable.spring.impl.test.SpringFlowableTestCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
  * @author Saeid Mirzaei
  */
+@Tag("camel")
 @ContextConfiguration("classpath:generic-camel-flowable-context.xml")
 public class MultiInstanceTest extends SpringFlowableTestCase {
 
     @Autowired
     protected CamelContext camelContext;
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         camelContext.addRoutes(new RouteBuilder() {
 
@@ -45,6 +49,7 @@ public class MultiInstanceTest extends SpringFlowableTestCase {
         });
     }
 
+    @Test
     @Deployment(resources = { "process/multiinstanceReceive.bpmn20.xml" })
     public void testRunProcess() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("miProcessExample");

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/examples/ping/PingPongTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/examples/ping/PingPongTest.java
@@ -19,19 +19,23 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.builder.RouteBuilder;
 import org.flowable.engine.test.Deployment;
 import org.flowable.spring.impl.test.SpringFlowableTestCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
  * @author Saeid Mirzaei
  */
+@Tag("camel")
 @ContextConfiguration("classpath:generic-camel-flowable-context.xml")
 public class PingPongTest extends SpringFlowableTestCase {
 
     @Autowired
     protected CamelContext camelContext;
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         camelContext.addRoutes(new RouteBuilder() {
 
@@ -42,6 +46,7 @@ public class PingPongTest extends SpringFlowableTestCase {
         });
     }
 
+    @Test
     @Deployment
     public void testPingPong() {
         Map<String, Object> variables = new HashMap<>();

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/examples/simple/SimpleCamelCallTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/examples/simple/SimpleCamelCallTest.java
@@ -17,16 +17,20 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.builder.RouteBuilder;
 import org.flowable.engine.test.Deployment;
 import org.flowable.spring.impl.test.SpringFlowableTestCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 
+@Tag("camel")
 @ContextConfiguration("classpath:generic-camel-flowable-context.xml")
 public class SimpleCamelCallTest extends SpringFlowableTestCase {
 
     @Autowired
     protected CamelContext camelContext;
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         camelContext.addRoutes(new RouteBuilder() {
 
@@ -37,6 +41,7 @@ public class SimpleCamelCallTest extends SpringFlowableTestCase {
         });
     }
 
+    @Test
     @Deployment
     public void testSimpleCamelCall() {
         runtimeService.startProcessInstanceByKey("SimpleCamelCallProcess");

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/exception/CamelExceptionTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/exception/CamelExceptionTest.java
@@ -28,12 +28,17 @@ import org.flowable.engine.impl.test.JobTestHelper;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
 import org.flowable.spring.impl.test.SpringFlowableTestCase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
  * @author Saeid Mirzaei
  */
+@Tag("camel")
 @ContextConfiguration("classpath:generic-camel-flowable-context.xml")
 public class CamelExceptionTest extends SpringFlowableTestCase {
 
@@ -46,7 +51,7 @@ public class CamelExceptionTest extends SpringFlowableTestCase {
     @Autowired
     protected ManagementService managementService;
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         ExceptionServiceMock.reset();
         NoExceptionServiceMock.reset();
@@ -59,7 +64,7 @@ public class CamelExceptionTest extends SpringFlowableTestCase {
         });
     }
 
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
         List<Route> routes = camelContext.getRoutes();
         for (Route r : routes) {
@@ -69,6 +74,7 @@ public class CamelExceptionTest extends SpringFlowableTestCase {
     }
 
     // check happy path in synchronouse camel call
+    @Test
     @Deployment(resources = { "org/flowable/camel/exception/bpmnExceptionInRouteSynchronous.bpmn20.xml" })
     public void testHappyPathSynchronous() {
         // Signal ThrowBpmnExceptionBean to throw no exception
@@ -80,6 +86,7 @@ public class CamelExceptionTest extends SpringFlowableTestCase {
     }
 
     // Check Non BPMN error in synchronouse camel call
+    @Test
     @Deployment(resources = { "org/flowable/camel/exception/bpmnExceptionInRouteSynchronous.bpmn20.xml" })
     public void testNonBpmnExceptionInCamel() {
         // Signal ThrowBpmnExceptionBean to throw a non BPMN Exception
@@ -100,6 +107,7 @@ public class CamelExceptionTest extends SpringFlowableTestCase {
     }
 
     // check Bpmn Exception in synchronous camel call
+    @Test
     @Deployment(resources = { "org/flowable/camel/exception/bpmnExceptionInRouteSynchronous.bpmn20.xml" })
     public void testBpmnExceptionInCamel() {
         // Signal ThrowBpmnExceptionBean to throw a BPMN Exception
@@ -116,6 +124,7 @@ public class CamelExceptionTest extends SpringFlowableTestCase {
     }
 
     // check happy path in asynchronous camel call
+    @Test
     @Deployment(resources = { "org/flowable/camel/exception/bpmnExceptionInRouteAsynchronous.bpmn20.xml" })
     public void testHappyPathAsynchronous() {
 
@@ -133,6 +142,7 @@ public class CamelExceptionTest extends SpringFlowableTestCase {
     }
 
     // check non bpmn exception in asynchronouse camel call
+    @Test
     @Deployment(resources = { "org/flowable/camel/exception/bpmnExceptionInRouteAsynchronous.bpmn20.xml" })
     public void testNonBpmnPathAsynchronous() {
 

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/revisited/AsyncProcessRevisitedTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/revisited/AsyncProcessRevisitedTest.java
@@ -22,20 +22,23 @@ import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.spring.impl.test.SpringFlowableTestCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
  * @author Saeid Mirzaei
  */
-
+@Tag("camel")
 @ContextConfiguration("classpath:generic-camel-flowable-context.xml")
 public class AsyncProcessRevisitedTest extends SpringFlowableTestCase {
 
     @Autowired
     protected CamelContext camelContext;
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         camelContext.addRoutes(new RouteBuilder() {
 
@@ -50,6 +53,7 @@ public class AsyncProcessRevisitedTest extends SpringFlowableTestCase {
         });
     }
 
+    @Test
     @Deployment(resources = { "process/revisited/async-revisited.bpmn20.xml" })
     public void testRunProcess() throws Exception {
         NotifyBuilder oneExchangeSendToFlowableReceive1 = new NotifyBuilder(camelContext).from("seda:continueAsync1").whenExactlyCompleted(1).create();

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/revisited/ParallelProcessRevisitedTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/revisited/ParallelProcessRevisitedTest.java
@@ -18,16 +18,20 @@ import org.apache.camel.builder.RouteBuilder;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.spring.impl.test.SpringFlowableTestCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 
+@Tag("camel")
 @ContextConfiguration("classpath:generic-camel-flowable-context.xml")
 public class ParallelProcessRevisitedTest extends SpringFlowableTestCase {
 
     @Autowired
     protected CamelContext camelContext;
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         camelContext.addRoutes(new RouteBuilder() {
 
@@ -39,6 +43,7 @@ public class ParallelProcessRevisitedTest extends SpringFlowableTestCase {
         });
     }
 
+    @Test
     @Deployment(resources = { "process/revisited/parallel-revisited.bpmn20.xml" })
     public void testRunProcess() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("parallelCamelProcessRevisited");

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/variables/CamelVariableTransferTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/variables/CamelVariableTransferTest.java
@@ -25,6 +25,10 @@ import org.flowable.engine.TaskService;
 import org.flowable.engine.test.Deployment;
 import org.flowable.spring.impl.test.SpringFlowableTestCase;
 import org.flowable.task.api.Task;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 
@@ -32,6 +36,7 @@ import org.springframework.test.context.ContextConfiguration;
  * 
  * @author Saeid Mirzaei
  */
+@Tag("camel")
 @ContextConfiguration("classpath:generic-camel-flowable-context.xml")
 public class CamelVariableTransferTest extends SpringFlowableTestCase {
     @Autowired
@@ -42,7 +47,7 @@ public class CamelVariableTransferTest extends SpringFlowableTestCase {
 
     protected MockEndpoint service1;
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         camelContext.addRoutes(new RouteBuilder() {
 
@@ -95,7 +100,7 @@ public class CamelVariableTransferTest extends SpringFlowableTestCase {
         });
     }
 
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
         List<Route> routes = camelContext.getRoutes();
         for (Route r : routes) {
@@ -105,6 +110,7 @@ public class CamelVariableTransferTest extends SpringFlowableTestCase {
     }
 
     // check that at least all properties are passed from camel to activiti when copyVariablesFromProperties=true is simply true
+    @Test
     @Deployment
     public void testCamelPropertiesAll() throws Exception {
         ProducerTemplate tpl = camelContext.createProducerTemplate();
@@ -123,6 +129,7 @@ public class CamelVariableTransferTest extends SpringFlowableTestCase {
     }
 
     // check that body will be copied into variables even if copyVariablesFromProperties=true
+    @Test
     @Deployment(resources = { "org/flowable/camel/variables/CamelVariableTransferTest.testCamelPropertiesAll.bpmn20.xml" })
     public void testCamelPropertiesAndBody() throws Exception {
         ProducerTemplate tpl = camelContext.createProducerTemplate();
@@ -142,6 +149,7 @@ public class CamelVariableTransferTest extends SpringFlowableTestCase {
         assertEquals("sampleBody", variables.get("camelBody"));
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/camel/variables/CamelVariableTransferTest.testCamelPropertiesAll.bpmn20.xml" })
     public void testCamelPropertiesFiltered() throws Exception {
         ProducerTemplate tpl = camelContext.createProducerTemplate();
@@ -159,6 +167,7 @@ public class CamelVariableTransferTest extends SpringFlowableTestCase {
         assertNull(variables.get("property3"));
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/camel/variables/CamelVariableTransferTest.testCamelPropertiesAll.bpmn20.xml" })
     public void testCamelPropertiesNone() throws Exception {
         ProducerTemplate tpl = camelContext.createProducerTemplate();
@@ -176,6 +185,7 @@ public class CamelVariableTransferTest extends SpringFlowableTestCase {
         assertNull(variables.get("property3"));
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/camel/variables/CamelVariableTransferTest.testCamelPropertiesAll.bpmn20.xml" })
     public void testCamelHeadersAll() throws Exception {
         ProducerTemplate tpl = camelContext.createProducerTemplate();
@@ -193,6 +203,7 @@ public class CamelVariableTransferTest extends SpringFlowableTestCase {
         assertEquals("sampleValueForProperty3", variables.get("property3"));
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/camel/variables/CamelVariableTransferTest.testCamelPropertiesAll.bpmn20.xml" })
     public void testCamelHeadersFiltered() throws Exception {
         ProducerTemplate tpl = camelContext.createProducerTemplate();
@@ -210,6 +221,7 @@ public class CamelVariableTransferTest extends SpringFlowableTestCase {
         assertNull(variables.get("property3"));
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/camel/variables/CamelVariableTransferTest.testCamelPropertiesAll.bpmn20.xml" })
     public void testCamelHeadersNone() throws Exception {
         ProducerTemplate tpl = camelContext.createProducerTemplate();

--- a/modules/flowable-cmmn-engine/pom.xml
+++ b/modules/flowable-cmmn-engine/pom.xml
@@ -99,6 +99,21 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>

--- a/modules/flowable-cmmn-json-converter/pom.xml
+++ b/modules/flowable-cmmn-json-converter/pom.xml
@@ -122,6 +122,21 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/modules/flowable-cmmn-spring/pom.xml
+++ b/modules/flowable-cmmn-spring/pom.xml
@@ -128,6 +128,21 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>

--- a/modules/flowable-content-engine/pom.xml
+++ b/modules/flowable-content-engine/pom.xml
@@ -96,6 +96,21 @@
             <artifactId>junit</artifactId>
             <scope>provided</scope>
         </dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
 
     </dependencies>
 

--- a/modules/flowable-content-spring/pom.xml
+++ b/modules/flowable-content-spring/pom.xml
@@ -120,6 +120,21 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>

--- a/modules/flowable-crystalball/pom.xml
+++ b/modules/flowable-crystalball/pom.xml
@@ -106,6 +106,21 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
       <scope>test</scope>

--- a/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/examples/tutorial/step01/FirstSimulationRunTest.java
+++ b/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/examples/tutorial/step01/FirstSimulationRunTest.java
@@ -15,9 +15,9 @@ package org.flowable.crystalball.examples.tutorial.step01;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
-import org.flowable.engine.ProcessEngines;
 import org.flowable.engine.impl.test.ResourceFlowableTestCase;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * This class provides the first insight into simulation run driven by process definition
@@ -30,6 +30,7 @@ public class FirstSimulationRunTest extends ResourceFlowableTestCase {
         super("org/flowable/crystalball/examples/tutorial/step01/FirstSimulationRunTest.cfg.xml");
     }
 
+    @Test
     @Deployment
     public void testSimulationRun() {
         runtimeService.startProcessInstanceByKey("basicSimulationRun");
@@ -40,9 +41,4 @@ public class FirstSimulationRunTest extends ResourceFlowableTestCase {
         assertThat(Counter.value.get(), is(1l));
     }
 
-    @Override
-    protected void closeDownProcessEngine() {
-        super.closeDownProcessEngine();
-        ProcessEngines.destroy();
-    }
 }

--- a/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/process/SimulationRunTaskTest.java
+++ b/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/process/SimulationRunTaskTest.java
@@ -12,9 +12,9 @@
  */
 package org.flowable.crystalball.process;
 
-import org.flowable.engine.ProcessEngines;
 import org.flowable.engine.impl.test.ResourceFlowableTestCase;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * This class provides the first insight into simulation run driven by process definition
@@ -27,6 +27,7 @@ public class SimulationRunTaskTest extends ResourceFlowableTestCase {
         super("org/flowable/crystalball/process/SimulationRunTaskTest.cfg.xml");
     }
 
+    @Test
     @Deployment
     public void testBasicSimulationRun() {
         runtimeService.startProcessInstanceByKey("basicSimulationRun");
@@ -34,9 +35,4 @@ public class SimulationRunTaskTest extends ResourceFlowableTestCase {
         assertEquals(0, runtimeService.createExecutionQuery().count());
     }
 
-    @Override
-    protected void closeDownProcessEngine() {
-        super.closeDownProcessEngine();
-        ProcessEngines.destroy();
-    }
 }

--- a/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/impl/MultiInstanceScriptEventHandlerTest.java
+++ b/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/impl/MultiInstanceScriptEventHandlerTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.core.Is.is;
 import org.flowable.engine.impl.test.ResourceFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * This class tests ScriptEventHandler with multi instance simulation run.
@@ -18,6 +19,7 @@ public class MultiInstanceScriptEventHandlerTest extends ResourceFlowableTestCas
         super("org/flowable/crystalball/simulator/impl/MultiInstanceScriptEventHandlerTest.cfg.xml");
     }
 
+    @Test
     @Deployment
     public void testSequentialSimulationRun() throws Exception {
         ProcessInstance simulationExperiment = runtimeService.startProcessInstanceByKey("multiInstanceResultVariablesSimulationRun");

--- a/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/impl/ScriptEventHandlerTest.java
+++ b/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/impl/ScriptEventHandlerTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.core.Is.is;
 import org.flowable.engine.impl.test.ResourceFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * This class tests ScriptEventHandler
@@ -18,6 +19,7 @@ public class ScriptEventHandlerTest extends ResourceFlowableTestCase {
         super("org/flowable/crystalball/simulator/impl/ScriptEventHandlerTest.cfg.xml");
     }
 
+    @Test
     @Deployment
     public void testSimpleScriptExecution() throws Exception {
         ProcessInstance simulationExperiment = runtimeService.startProcessInstanceByKey("resultVariableSimulationRun");

--- a/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/impl/playback/AbstractPlaybackTest.java
+++ b/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/impl/playback/AbstractPlaybackTest.java
@@ -39,23 +39,28 @@ import org.flowable.crystalball.simulator.impl.SimulationProcessEngineFactory;
 import org.flowable.crystalball.simulator.impl.StartProcessByIdEventHandler;
 import org.flowable.crystalball.simulator.impl.clock.DefaultClockFactory;
 import org.flowable.crystalball.simulator.impl.clock.ThreadLocalClock;
+import org.flowable.engine.HistoryService;
+import org.flowable.engine.ProcessEngine;
 import org.flowable.engine.ProcessEngineConfiguration;
 import org.flowable.engine.ProcessEngines;
+import org.flowable.engine.RuntimeService;
+import org.flowable.engine.TaskService;
 import org.flowable.engine.impl.ProcessEngineImpl;
 import org.flowable.engine.impl.cfg.ProcessEngineConfigurationImpl;
-import org.flowable.engine.impl.test.AbstractFlowableTestCase;
 import org.flowable.engine.impl.test.TestHelper;
 import org.flowable.variable.service.impl.el.NoExecutionVariableScope;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.FactoryBean;
 
+import junit.framework.TestCase;
+
 /**
  * This class is supper class for all Playback tests
  *
  * @author martin.grofcik
  */
-public abstract class AbstractPlaybackTest extends AbstractFlowableTestCase {
+public abstract class AbstractPlaybackTest extends TestCase {
     // Process instance start event
     private static final String PROCESS_INSTANCE_START_EVENT_TYPE = "PROCESS_INSTANCE_START";
     private static final String PROCESS_DEFINITION_ID_KEY = "processDefinitionId";
@@ -65,11 +70,20 @@ public abstract class AbstractPlaybackTest extends AbstractFlowableTestCase {
 
     private static final String BUSINESS_KEY = "testBusinessKey";
 
+    private static final String EMPTY_LINE = "\n";
+
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractPlaybackTest.class);
 
     protected InMemoryRecordFlowableEventListener listener = new InMemoryRecordFlowableEventListener(getTransformers());
+    protected String deploymentIdFromDeploymentAnnotation;
+    protected Throwable exception;
 
-    @Override
+    protected ProcessEngine processEngine;
+    protected ProcessEngineConfiguration processEngineConfiguration;
+    protected RuntimeService runtimeService;
+    protected TaskService taskService;
+    protected HistoryService historyService;
+
     protected void initializeProcessEngine() {
         Clock clock = new DefaultClockImpl();
 
@@ -78,6 +92,13 @@ public abstract class AbstractPlaybackTest extends AbstractFlowableTestCase {
 
         this.processEngine = (new RecordableProcessEngineFactory(
                 (ProcessEngineConfigurationImpl) processEngineConfiguration, listener)).getObject();
+    }
+
+    protected void initializeServices() {
+        this.processEngineConfiguration = processEngine.getProcessEngineConfiguration();
+        this.runtimeService = processEngine.getRuntimeService();
+        this.taskService = processEngine.getTaskService();
+        this.historyService = processEngine.getHistoryService();
     }
 
     @Override
@@ -137,7 +158,6 @@ public abstract class AbstractPlaybackTest extends AbstractFlowableTestCase {
             if (simDebugger != null) {
                 TestHelper.annotationDeploymentTearDown(processEngine, deploymentIdFromDeploymentAnnotation, getClass(), getName());
                 simDebugger.close();
-                assertAndEnsureCleanDb();
             }
             this.processEngineConfiguration.getClock().reset();
 
@@ -177,7 +197,7 @@ public abstract class AbstractPlaybackTest extends AbstractFlowableTestCase {
 
     private void recordEvents() throws Throwable {
         initializeProcessEngine();
-        if (repositoryService == null) {
+        if (runtimeService == null) {
             initializeServices();
         }
 
@@ -219,7 +239,6 @@ public abstract class AbstractPlaybackTest extends AbstractFlowableTestCase {
 
         } finally {
             TestHelper.annotationDeploymentTearDown(processEngine, deploymentIdFromDeploymentAnnotation, getClass(), getName());
-            assertAndEnsureCleanDb();
             LOGGER.info("dropping and recreating db");
 
             this.processEngineConfiguration.getClock().reset();
@@ -230,7 +249,6 @@ public abstract class AbstractPlaybackTest extends AbstractFlowableTestCase {
         }
     }
 
-    @Override
     protected void closeDownProcessEngine() {
         ProcessEngines.destroy();
     }

--- a/modules/flowable-cxf/pom.xml
+++ b/modules/flowable-cxf/pom.xml
@@ -130,6 +130,21 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
       <scope>test</scope>

--- a/modules/flowable-cxf/src/test/java/org/flowable/engine/impl/webservice/AbstractWebServiceTaskTest.java
+++ b/modules/flowable-cxf/src/test/java/org/flowable/engine/impl/webservice/AbstractWebServiceTaskTest.java
@@ -17,6 +17,9 @@ import org.apache.cxf.interceptor.LoggingInInterceptor;
 import org.apache.cxf.interceptor.LoggingOutInterceptor;
 import org.apache.cxf.jaxws.JaxWsServerFactoryBean;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 
 /**
  * An abstract class for unit test of web-service task
@@ -24,6 +27,7 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
  * @author <a href="mailto:gnodet@gmail.com">Guillaume Nodet</a>
  * @author Christophe DENEUX
  */
+@Tag("webservice")
 public abstract class AbstractWebServiceTaskTest extends PluggableFlowableTestCase {
 
     public static final String WEBSERVICE_MOCK_ADDRESS = "http://localhost:63081/webservicemock";
@@ -32,9 +36,8 @@ public abstract class AbstractWebServiceTaskTest extends PluggableFlowableTestCa
 
     protected Server server;
 
-    @Override
-    protected void initializeProcessEngine() {
-        super.initializeProcessEngine();
+    @BeforeEach
+    protected void setUp() {
 
         webServiceMock = new WebServiceMockImpl();
         JaxWsServerFactoryBean svrFactory = new JaxWsServerFactoryBean();
@@ -47,9 +50,8 @@ public abstract class AbstractWebServiceTaskTest extends PluggableFlowableTestCa
         server.start();
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
         server.stop();
     }
 

--- a/modules/flowable-cxf/src/test/java/org/flowable/engine/impl/webservice/AbstractWebServiceTaskTest.java
+++ b/modules/flowable-cxf/src/test/java/org/flowable/engine/impl/webservice/AbstractWebServiceTaskTest.java
@@ -13,13 +13,11 @@
 package org.flowable.engine.impl.webservice;
 
 import org.apache.cxf.endpoint.Server;
-import org.apache.cxf.interceptor.LoggingInInterceptor;
-import org.apache.cxf.interceptor.LoggingOutInterceptor;
-import org.apache.cxf.jaxws.JaxWsServerFactoryBean;
-import org.flowable.engine.impl.test.PluggableFlowableTestCase;
-import org.junit.jupiter.api.AfterEach;
+import org.flowable.engine.impl.test.AbstractFlowableTestCase;
+import org.flowable.engine.impl.test.PluggableFlowableExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * An abstract class for unit test of web-service task
@@ -28,7 +26,10 @@ import org.junit.jupiter.api.Tag;
  * @author Christophe DENEUX
  */
 @Tag("webservice")
-public abstract class AbstractWebServiceTaskTest extends PluggableFlowableTestCase {
+@Tag("pluggable")
+@ExtendWith(MockWebServiceExtension.class)
+@ExtendWith(PluggableFlowableExtension.class)
+public abstract class AbstractWebServiceTaskTest extends AbstractFlowableTestCase {
 
     public static final String WEBSERVICE_MOCK_ADDRESS = "http://localhost:63081/webservicemock";
 
@@ -37,22 +38,9 @@ public abstract class AbstractWebServiceTaskTest extends PluggableFlowableTestCa
     protected Server server;
 
     @BeforeEach
-    protected void setUp() {
-
-        webServiceMock = new WebServiceMockImpl();
-        JaxWsServerFactoryBean svrFactory = new JaxWsServerFactoryBean();
-        svrFactory.setServiceClass(WebServiceMock.class);
-        svrFactory.setAddress(WEBSERVICE_MOCK_ADDRESS);
-        svrFactory.setServiceBean(webServiceMock);
-        svrFactory.getInInterceptors().add(new LoggingInInterceptor());
-        svrFactory.getOutInterceptors().add(new LoggingOutInterceptor());
-        server = svrFactory.create();
-        server.start();
-    }
-
-    @AfterEach
-    protected void tearDown() throws Exception {
-        server.stop();
+    protected void setUp(WebServiceMock webServiceMock, Server server) {
+        this.webServiceMock = webServiceMock;
+        this.server = server;
     }
 
 }

--- a/modules/flowable-cxf/src/test/java/org/flowable/engine/impl/webservice/MockWebServiceExtension.java
+++ b/modules/flowable-cxf/src/test/java/org/flowable/engine/impl/webservice/MockWebServiceExtension.java
@@ -1,0 +1,102 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.engine.impl.webservice;
+
+import static org.flowable.engine.impl.webservice.AbstractWebServiceTaskTest.WEBSERVICE_MOCK_ADDRESS;
+
+import org.apache.cxf.endpoint.Server;
+import org.apache.cxf.interceptor.LoggingInInterceptor;
+import org.apache.cxf.interceptor.LoggingOutInterceptor;
+import org.apache.cxf.jaxws.JaxWsServerFactoryBean;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+/**
+ * Extension is needed, as we need to have the we service run before we start deploying to the flowable engine.
+ *
+ * @author Filip Hrisafov
+ */
+public class MockWebServiceExtension implements BeforeEachCallback, AfterEachCallback, ParameterResolver {
+
+    private static final ExtensionContext.Namespace NAMESPACE = ExtensionContext.Namespace.create(MockWebServiceExtension.class);
+
+    @Override
+    public void beforeEach(ExtensionContext context) {
+        getMockWebServiceContext(context).server.start();
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) {
+        getMockWebServiceContext(context).stopIfStarted();
+    }
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+        Class<?> parameterType = parameterContext.getParameter().getType();
+        return WebServiceMock.class.equals(parameterType) || Server.class.equals(parameterType);
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+        Class<?> parameterType = parameterContext.getParameter().getType();
+        if (WebServiceMock.class.equals(parameterType)) {
+            return getMockWebServiceContext(extensionContext).webServiceMock;
+        } else if (Server.class.equals(parameterType)) {
+            return getMockWebServiceContext(extensionContext).server;
+        }
+        throw new ParameterResolutionException("Cannot resolve parameter for parameter context: " + parameterContext);
+    }
+
+    private static MockWebServiceContext getMockWebServiceContext(ExtensionContext context) {
+        return getStore(context).getOrComputeIfAbsent(context.getUniqueId(), key -> create(), MockWebServiceContext.class);
+
+    }
+
+    private static ExtensionContext.Store getStore(ExtensionContext context) {
+        return context.getRoot().getStore(NAMESPACE);
+    }
+
+    private static class MockWebServiceContext {
+
+        protected final WebServiceMock webServiceMock;
+        protected final Server server;
+
+        private MockWebServiceContext(WebServiceMock webServiceMock, Server server) {
+            this.webServiceMock = webServiceMock;
+            this.server = server;
+        }
+
+        private void stopIfStarted() {
+            if (server.isStarted()) {
+                server.stop();
+                server.destroy();
+            }
+        }
+    }
+
+    private static MockWebServiceContext create() {
+        WebServiceMock webServiceMock = new WebServiceMockImpl();
+        JaxWsServerFactoryBean svrFactory = new JaxWsServerFactoryBean();
+        svrFactory.setServiceClass(WebServiceMock.class);
+        svrFactory.setAddress(WEBSERVICE_MOCK_ADDRESS);
+        svrFactory.setServiceBean(webServiceMock);
+        svrFactory.getInInterceptors().add(new LoggingInInterceptor());
+        svrFactory.getOutInterceptors().add(new LoggingOutInterceptor());
+        Server server = svrFactory.create();
+        return new MockWebServiceContext(webServiceMock, server);
+    }
+}

--- a/modules/flowable-cxf/src/test/java/org/flowable/engine/impl/webservice/WebServiceImportTest.java
+++ b/modules/flowable-cxf/src/test/java/org/flowable/engine/impl/webservice/WebServiceImportTest.java
@@ -13,6 +13,7 @@
 package org.flowable.engine.impl.webservice;
 
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * An integration test for CXF based web services
@@ -21,6 +22,7 @@ import org.flowable.engine.test.Deployment;
  */
 public class WebServiceImportTest extends AbstractWebServiceTaskTest {
 
+    @Test
     @Deployment
     public void testImport() throws Exception {
 
@@ -29,6 +31,7 @@ public class WebServiceImportTest extends AbstractWebServiceTaskTest {
 
     }
 
+    @Test
     @Deployment
     public void testImport_DifferentDirectories() throws Exception {
 

--- a/modules/flowable-cxf/src/test/java/org/flowable/engine/impl/webservice/WebServiceTaskTest.java
+++ b/modules/flowable-cxf/src/test/java/org/flowable/engine/impl/webservice/WebServiceTaskTest.java
@@ -28,6 +28,7 @@ import org.flowable.engine.delegate.BpmnError;
 import org.flowable.engine.history.HistoricProcessInstance;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * An integration test for CXF based web services
@@ -36,6 +37,7 @@ import org.flowable.engine.test.Deployment;
  */
 public class WebServiceTaskTest extends AbstractWebServiceTaskTest {
 
+    @Test
     @Deployment
     public void testWebServiceInvocation() throws Exception {
 
@@ -48,6 +50,7 @@ public class WebServiceTaskTest extends AbstractWebServiceTaskTest {
         assertTrue(processInstance.isEnded());
     }
 
+    @Test
     @Deployment
     public void testWebServiceInvocationDataStructure() throws Exception {
 
@@ -63,6 +66,7 @@ public class WebServiceTaskTest extends AbstractWebServiceTaskTest {
         assertTrue(processInstance.isEnded());
     }
 
+    @Test
     @Deployment
     public void testFaultManagement() throws Exception {
 
@@ -103,6 +107,7 @@ public class WebServiceTaskTest extends AbstractWebServiceTaskTest {
         }
     }
 
+    @Test
     @Deployment
     public void testFaultManagementREatWSClientLevel() throws Exception {
 
@@ -116,6 +121,7 @@ public class WebServiceTaskTest extends AbstractWebServiceTaskTest {
         }
     }
 
+    @Test
     @Deployment
     public void testWebServiceInvocationWithEndpointAddressConfigured() throws Exception {
 

--- a/modules/flowable-cxf/src/test/java/org/flowable/engine/test/bpmn/sendtask/WebServiceSimplisticTest.java
+++ b/modules/flowable-cxf/src/test/java/org/flowable/engine/test/bpmn/sendtask/WebServiceSimplisticTest.java
@@ -17,6 +17,7 @@ import java.util.Map;
 
 import org.flowable.engine.test.Deployment;
 import org.flowable.engine.test.bpmn.servicetask.AbstractWebServiceTaskTest;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Esteban Robles Luna
@@ -29,6 +30,7 @@ public class WebServiceSimplisticTest extends AbstractWebServiceTaskTest {
         return false;
     }
 
+    @Test
     @Deployment
     public void testAsyncInvocationWithSimplisticDataFlow() throws Exception {
         assertEquals(-1, webServiceMock.getCount());

--- a/modules/flowable-cxf/src/test/java/org/flowable/engine/test/bpmn/sendtask/WebServiceTest.java
+++ b/modules/flowable-cxf/src/test/java/org/flowable/engine/test/bpmn/sendtask/WebServiceTest.java
@@ -14,6 +14,7 @@ package org.flowable.engine.test.bpmn.sendtask;
 
 import org.flowable.engine.test.Deployment;
 import org.flowable.engine.test.bpmn.servicetask.AbstractWebServiceTaskTest;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Esteban Robles Luna
@@ -21,6 +22,7 @@ import org.flowable.engine.test.bpmn.servicetask.AbstractWebServiceTaskTest;
  */
 public class WebServiceTest extends AbstractWebServiceTaskTest {
 
+    @Test
     @Deployment
     public void testAsyncInvocationWithoutDataFlow() throws Exception {
         assertEquals(-1, webServiceMock.getCount());

--- a/modules/flowable-cxf/src/test/java/org/flowable/engine/test/bpmn/servicetask/AbstractWebServiceTaskTest.java
+++ b/modules/flowable-cxf/src/test/java/org/flowable/engine/test/bpmn/servicetask/AbstractWebServiceTaskTest.java
@@ -19,6 +19,8 @@ import org.apache.cxf.jaxws.JaxWsServerFactoryBean;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.impl.webservice.WebServiceMock;
 import org.flowable.engine.impl.webservice.WebServiceMockImpl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * @author Esteban Robles Luna
@@ -29,9 +31,8 @@ public abstract class AbstractWebServiceTaskTest extends
     protected WebServiceMock webServiceMock;
     private Server server;
 
-    @Override
-    protected void initializeProcessEngine() {
-        super.initializeProcessEngine();
+    @BeforeEach
+    protected void setUp() {
 
         webServiceMock = new WebServiceMockImpl();
         JaxWsServerFactoryBean svrFactory = new JaxWsServerFactoryBean();
@@ -44,9 +45,8 @@ public abstract class AbstractWebServiceTaskTest extends
         server.start();
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
         server.stop();
         server.destroy();
     }

--- a/modules/flowable-cxf/src/test/java/org/flowable/engine/test/bpmn/servicetask/AbstractWebServiceTaskTest.java
+++ b/modules/flowable-cxf/src/test/java/org/flowable/engine/test/bpmn/servicetask/AbstractWebServiceTaskTest.java
@@ -12,43 +12,29 @@
  */
 package org.flowable.engine.test.bpmn.servicetask;
 
-import org.apache.cxf.endpoint.Server;
-import org.apache.cxf.interceptor.LoggingInInterceptor;
-import org.apache.cxf.interceptor.LoggingOutInterceptor;
-import org.apache.cxf.jaxws.JaxWsServerFactoryBean;
-import org.flowable.engine.impl.test.PluggableFlowableTestCase;
+import org.flowable.engine.impl.test.AbstractFlowableTestCase;
+import org.flowable.engine.impl.test.PluggableFlowableExtension;
+import org.flowable.engine.impl.webservice.MockWebServiceExtension;
 import org.flowable.engine.impl.webservice.WebServiceMock;
-import org.flowable.engine.impl.webservice.WebServiceMockImpl;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @author Esteban Robles Luna
  */
+@Tag("webservice")
+@Tag("pluggable")
+@ExtendWith(MockWebServiceExtension.class)
+@ExtendWith(PluggableFlowableExtension.class)
 public abstract class AbstractWebServiceTaskTest extends
-        PluggableFlowableTestCase {
+    AbstractFlowableTestCase {
 
     protected WebServiceMock webServiceMock;
-    private Server server;
 
     @BeforeEach
-    protected void setUp() {
-
-        webServiceMock = new WebServiceMockImpl();
-        JaxWsServerFactoryBean svrFactory = new JaxWsServerFactoryBean();
-        svrFactory.setServiceClass(WebServiceMock.class);
-        svrFactory.setAddress("http://localhost:63081/webservicemock");
-        svrFactory.setServiceBean(webServiceMock);
-        svrFactory.getInInterceptors().add(new LoggingInInterceptor());
-        svrFactory.getOutInterceptors().add(new LoggingOutInterceptor());
-        server = svrFactory.create();
-        server.start();
-    }
-
-    @AfterEach
-    protected void tearDown() throws Exception {
-        server.stop();
-        server.destroy();
+    protected void setUp(WebServiceMock webServiceMock) {
+        this.webServiceMock = webServiceMock;
     }
 
     // @Override

--- a/modules/flowable-cxf/src/test/java/org/flowable/engine/test/bpmn/servicetask/WebServiceSimplisticTest.java
+++ b/modules/flowable-cxf/src/test/java/org/flowable/engine/test/bpmn/servicetask/WebServiceSimplisticTest.java
@@ -17,6 +17,7 @@ import java.util.Map;
 
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Esteban Robles Luna
@@ -28,6 +29,7 @@ public class WebServiceSimplisticTest extends AbstractWebServiceTaskTest {
         return false;
     }
 
+    @Test
     @Deployment
     public void testWebServiceInvocationWithSimplisticDataFlow() throws Exception {
         Map<String, Object> variables = new HashMap<>();
@@ -41,6 +43,7 @@ public class WebServiceSimplisticTest extends AbstractWebServiceTaskTest {
         assertEquals("The counter has the value -1. Good news", response);
     }
 
+    @Test
     @Deployment
     public void testWebResponseNoName() throws Exception {
         Map<String, Object> variables = new HashMap<>();
@@ -54,6 +57,7 @@ public class WebServiceSimplisticTest extends AbstractWebServiceTaskTest {
         assertEquals("The counter has the value -1. Good news (NO NAME)", response);
     }
 
+    @Test
     @Deployment
     public void testWebResponseKeywordName() throws Exception {
         Map<String, Object> variables = new HashMap<>();

--- a/modules/flowable-cxf/src/test/java/org/flowable/engine/test/bpmn/servicetask/WebServiceTaskTest.java
+++ b/modules/flowable-cxf/src/test/java/org/flowable/engine/test/bpmn/servicetask/WebServiceTaskTest.java
@@ -13,12 +13,14 @@
 package org.flowable.engine.test.bpmn.servicetask;
 
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Esteban Robles Luna
  */
 public class WebServiceTaskTest extends AbstractWebServiceTaskTest {
 
+    @Test
     @Deployment
     public void testWebServiceInvocationWithoutDataFlow() throws Exception {
         assertEquals(-1, webServiceMock.getCount());

--- a/modules/flowable-dmn-engine-configurator/pom.xml
+++ b/modules/flowable-dmn-engine-configurator/pom.xml
@@ -44,6 +44,21 @@
 			<artifactId>junit</artifactId>
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
         <dependency>
             <groupId>org.flowable</groupId>
             <artifactId>flowable-cmmn-engine</artifactId>

--- a/modules/flowable-dmn-engine/pom.xml
+++ b/modules/flowable-dmn-engine/pom.xml
@@ -104,6 +104,21 @@
             <artifactId>junit</artifactId>
             <scope>provided</scope>
         </dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
 
     </dependencies>
 

--- a/modules/flowable-dmn-spring-configurator/pom.xml
+++ b/modules/flowable-dmn-spring-configurator/pom.xml
@@ -52,6 +52,21 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>

--- a/modules/flowable-dmn-spring-configurator/src/test/java/org/flowable/dmn/spring/configurator/test/DecisionTaskWithSpringBeanTest.java
+++ b/modules/flowable-dmn-spring-configurator/src/test/java/org/flowable/dmn/spring/configurator/test/DecisionTaskWithSpringBeanTest.java
@@ -20,6 +20,7 @@ import org.flowable.dmn.api.DmnDeployment;
 import org.flowable.dmn.engine.DmnEngineConfiguration;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
@@ -28,6 +29,7 @@ import org.springframework.test.context.ContextConfiguration;
 @ContextConfiguration("classpath:flowable-context.xml")
 public class DecisionTaskWithSpringBeanTest extends SpringDmnFlowableTestCase {
 
+    @Test
     @Deployment(resources = { "org/flowable/dmn/spring/configurator/test/oneDecisionTaskProcess.bpmn20.xml",
         "org/flowable/dmn/spring/configurator/test/simple.dmn" })
     public void testDecisionTask() {

--- a/modules/flowable-dmn-spring-configurator/src/test/java/org/flowable/dmn/spring/configurator/test/SpringDmnFlowableTestCase.java
+++ b/modules/flowable-dmn-spring-configurator/src/test/java/org/flowable/dmn/spring/configurator/test/SpringDmnFlowableTestCase.java
@@ -12,57 +12,31 @@
  */
 package org.flowable.dmn.spring.configurator.test;
 
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
-import org.flowable.engine.ProcessEngine;
 import org.flowable.engine.impl.test.AbstractFlowableTestCase;
+import org.flowable.engine.impl.test.EnsureCleanDb;
+import org.flowable.spring.impl.test.InternalFlowableSpringExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestContextManager;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /**
  * @author Joram Barrez
  * @author Josh Long
  */
+@EnsureCleanDb(excludeTables = {
+    "ACT_GE_PROPERTY",
+    "ACT_ID_PROPERTY",
+    "ACT_DMN_DATABASECHANGELOGLOCK",
+    "ACT_DMN_DATABASECHANGELOG"
+})
+@ExtendWith(InternalFlowableSpringExtension.class)
+@ExtendWith(SpringExtension.class)
 public abstract class SpringDmnFlowableTestCase extends AbstractFlowableTestCase implements ApplicationContextAware {
-
-    // we need a data structure to store all the resolved ProcessEngines and map them to something
-    protected Map<Object, ProcessEngine> cachedProcessEngines = new ConcurrentHashMap<>();
-    
-    static {
-        TABLENAMES_EXCLUDED_FROM_DB_CLEAN_CHECK.add("ACT_DMN_DATABASECHANGELOGLOCK");
-        TABLENAMES_EXCLUDED_FROM_DB_CLEAN_CHECK.add("ACT_DMN_DATABASECHANGELOG");
-    }
-
-    protected TestContextManager testContextManager;
 
     @Autowired
     protected ApplicationContext applicationContext;
-
-    public SpringDmnFlowableTestCase() {
-        this.testContextManager = new TestContextManager(getClass());
-    }
-
-    @Override
-    public void runBare() throws Throwable {
-        testContextManager.prepareTestInstance(this); // this will initialize all dependencies
-        super.runBare();
-    }
-
-    @Override
-    protected void initializeProcessEngine() {
-        ContextConfiguration contextConfiguration = getClass().getAnnotation(ContextConfiguration.class);
-        String[] value = contextConfiguration.value();
-        boolean hasOneArg = value != null && value.length == 1;
-        String key = hasOneArg ? value[0] : ProcessEngine.class.getName();
-        ProcessEngine engine = this.cachedProcessEngines.containsKey(key) ? this.cachedProcessEngines.get(key) : this.applicationContext.getBean(ProcessEngine.class);
-
-        this.cachedProcessEngines.put(key, engine);
-        this.processEngine = engine;
-    }
 
     @Override
     public void setApplicationContext(ApplicationContext applicationContext) {

--- a/modules/flowable-dmn-spring/pom.xml
+++ b/modules/flowable-dmn-spring/pom.xml
@@ -124,6 +124,21 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>

--- a/modules/flowable-dmn-xml-converter/pom.xml
+++ b/modules/flowable-dmn-xml-converter/pom.xml
@@ -46,6 +46,21 @@
 			<artifactId>junit</artifactId>
 			<scope>provided</scope>
 		</dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
 
 	</dependencies>
 

--- a/modules/flowable-engine/pom.xml
+++ b/modules/flowable-engine/pom.xml
@@ -104,6 +104,21 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
             <scope>provided</scope>

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/test/AbstractFlowableTestCase.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/test/AbstractFlowableTestCase.java
@@ -27,18 +27,14 @@ import org.flowable.bpmn.model.EndEvent;
 import org.flowable.bpmn.model.SequenceFlow;
 import org.flowable.bpmn.model.StartEvent;
 import org.flowable.bpmn.model.UserTask;
-import org.flowable.common.engine.impl.db.DbSchemaManager;
 import org.flowable.common.engine.impl.history.HistoryLevel;
-import org.flowable.common.engine.impl.interceptor.Command;
-import org.flowable.common.engine.impl.interceptor.CommandConfig;
-import org.flowable.common.engine.impl.interceptor.CommandContext;
-import org.flowable.common.engine.impl.interceptor.CommandExecutor;
 import org.flowable.engine.DynamicBpmnService;
 import org.flowable.engine.FormService;
 import org.flowable.engine.HistoryService;
 import org.flowable.engine.IdentityService;
 import org.flowable.engine.ManagementService;
 import org.flowable.engine.ProcessEngine;
+import org.flowable.engine.ProcessEngineConfiguration;
 import org.flowable.engine.RepositoryService;
 import org.flowable.engine.RuntimeService;
 import org.flowable.engine.TaskService;
@@ -48,33 +44,28 @@ import org.flowable.engine.impl.ProcessEngineImpl;
 import org.flowable.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.flowable.engine.impl.history.DefaultHistoryManager;
 import org.flowable.engine.impl.history.HistoryManager;
-import org.flowable.engine.impl.util.CommandContextUtil;
 import org.flowable.engine.repository.Deployment;
 import org.flowable.engine.repository.ProcessDefinition;
 import org.flowable.engine.runtime.ProcessInstance;
-import org.flowable.job.api.HistoryJob;
 import org.flowable.task.api.Task;
 import org.flowable.task.api.history.HistoricTaskInstance;
-import org.junit.Assert;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * @author Tom Baeyens
  * @author Joram Barrez
+ * @author Filip Hrisafov
  */
+@EnsureCleanDb(excludeTables = {
+    "ACT_GE_PROPERTY",
+    "ACT_ID_PROPERTY"
+})
 public abstract class AbstractFlowableTestCase extends AbstractTestCase {
-
-    protected static final List<String> TABLENAMES_EXCLUDED_FROM_DB_CLEAN_CHECK = new ArrayList<>();
-
-    static {
-        TABLENAMES_EXCLUDED_FROM_DB_CLEAN_CHECK.add("ACT_GE_PROPERTY");
-        TABLENAMES_EXCLUDED_FROM_DB_CLEAN_CHECK.add("ACT_ID_PROPERTY");
-    }
 
     protected ProcessEngine processEngine;
 
-    protected String deploymentIdFromDeploymentAnnotation;
     protected List<String> deploymentIdsForAutoCleanup = new ArrayList<>();
-    protected Throwable exception;
 
     protected ProcessEngineConfigurationImpl processEngineConfiguration;
     protected RepositoryService repositoryService;
@@ -86,104 +77,31 @@ public abstract class AbstractFlowableTestCase extends AbstractTestCase {
     protected ManagementService managementService;
     protected DynamicBpmnService dynamicBpmnService;
 
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
-
-        // Always reset authenticated user to avoid any mistakes
-        identityService.setAuthenticatedUserId(null);
+    @BeforeEach
+    public final void initializeServices(ProcessEngine processEngine) {
+        processEngineConfiguration = ((ProcessEngineImpl) processEngine).getProcessEngineConfiguration();
+        this.processEngine = processEngine;
+        repositoryService = processEngine.getRepositoryService();
+        runtimeService = processEngine.getRuntimeService();
+        taskService = processEngine.getTaskService();
+        formService = processEngine.getFormService();
+        historyService = processEngine.getHistoryService();
+        identityService = processEngine.getIdentityService();
+        managementService = processEngine.getManagementService();
+        dynamicBpmnService = processEngine.getDynamicBpmnService();
     }
 
-    protected abstract void initializeProcessEngine();
-
-    // Default: do nothing
-    protected void closeDownProcessEngine() {
-    }
-
-    protected void nullifyServices() {
-        processEngineConfiguration = null;
-        repositoryService = null;
-        runtimeService = null;
-        taskService = null;
-        formService = null;
-        historyService = null;
-        identityService = null;
-        managementService = null;
-        dynamicBpmnService = null;
-    }
-
-    @Override
-    public void runBare() throws Throwable {
-        initializeProcessEngine();
-        initializeServices();
-
-        try {
-
-            deploymentIdFromDeploymentAnnotation = TestHelper.annotationDeploymentSetUp(processEngine, getClass(), getName());
-
-            super.runBare();
-
-            validateHistoryData();
-
-        } catch (AssertionError e) {
-            LOGGER.error(EMPTY_LINE);
-            LOGGER.error("ASSERTION FAILED: {}", e, e);
-            exception = e;
-            throw e;
-
-        } catch (Throwable e) {
-            LOGGER.error(EMPTY_LINE);
-            LOGGER.error("EXCEPTION: {}", e, e);
-            exception = e;
-            throw e;
-
-        } finally {
-            
-            boolean isAsyncHistoryEnabled = processEngineConfiguration.isAsyncHistoryEnabled();
-            
-            if (isAsyncHistoryEnabled) {
-                List<HistoryJob> jobs = managementService.createHistoryJobQuery().list();
-                for (HistoryJob job : jobs) {
-                    managementService.deleteHistoryJob(job.getId());
-                }
-            }
-            
-            HistoryManager asyncHistoryManager = null;
-            try {
-                if (isAsyncHistoryEnabled) {
-                    processEngineConfiguration.setAsyncHistoryEnabled(false);
-                    asyncHistoryManager = processEngineConfiguration.getHistoryManager();
-                    processEngineConfiguration.setHistoryManager(new DefaultHistoryManager(processEngineConfiguration, processEngineConfiguration.getHistoryLevel()));
-                }
-    
-                if (deploymentIdFromDeploymentAnnotation != null) {
-                    TestHelper.annotationDeploymentTearDown(processEngine, deploymentIdFromDeploymentAnnotation, getClass(), getName());
-                    deploymentIdFromDeploymentAnnotation = null;
-                }
-    
-                for (String autoDeletedDeploymentId : deploymentIdsForAutoCleanup) {
-                    repositoryService.deleteDeployment(autoDeletedDeploymentId, true);
-                }
-                deploymentIdsForAutoCleanup.clear();
-    
-                assertAndEnsureCleanDb();
-                
-            } finally {
-            
-                if (isAsyncHistoryEnabled) {
-                    processEngineConfiguration.setAsyncHistoryEnabled(true);
-                    processEngineConfiguration.setHistoryManager(asyncHistoryManager);
-                }
-                
-                processEngineConfiguration.getClock().reset();
-            }
-
-            // Can't do this in the teardown, as the teardown will be called as part of the super.runBare
-            closeDownProcessEngine();
+    @AfterEach
+    public final void cleanDeployments() {
+        for (String autoDeletedDeploymentId : deploymentIdsForAutoCleanup) {
+            repositoryService.deleteDeployment(autoDeletedDeploymentId, true);
         }
+        deploymentIdsForAutoCleanup.clear();
     }
 
-    protected void validateHistoryData() {
+    protected static void validateHistoryData(ProcessEngine processEngine) {
+        ProcessEngineConfiguration processEngineConfiguration = processEngine.getProcessEngineConfiguration();
+        HistoryService historyService = processEngine.getHistoryService();
         if (processEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.AUDIT)) {
 
             List<HistoricProcessInstance> historicProcessInstances = historyService.createHistoricProcessInstanceQuery().finished().list();
@@ -241,64 +159,6 @@ public abstract class AbstractFlowableTestCase extends AbstractTestCase {
         }
     }
 
-    /**
-     * Each test is assumed to clean up all DB content it entered. After a test method executed, this method scans all tables to see if the DB is completely clean. It throws AssertionFailed in case
-     * the DB is not clean. If the DB is not clean, it is cleaned by performing a create a drop.
-     */
-    protected void assertAndEnsureCleanDb() throws Throwable {
-        LOGGER.debug("verifying that db is clean after test");
-        Map<String, Long> tableCounts = managementService.getTableCount();
-        StringBuilder outputMessage = new StringBuilder();
-        for (String tableName : tableCounts.keySet()) {
-            String tableNameWithoutPrefix = tableName.replace(processEngineConfiguration.getDatabaseTablePrefix(), "");
-            if (!TABLENAMES_EXCLUDED_FROM_DB_CLEAN_CHECK.contains(tableNameWithoutPrefix)) {
-                Long count = tableCounts.get(tableName);
-                if (count != 0L) {
-                    outputMessage.append("  ").append(tableName).append(": ").append(count).append(" record(s) ");
-                }
-            }
-        }
-        if (outputMessage.length() > 0) {
-            outputMessage.insert(0, "DB NOT CLEAN: \n");
-            LOGGER.error(EMPTY_LINE);
-            LOGGER.error(outputMessage.toString());
-
-            LOGGER.info("dropping and recreating db");
-
-            CommandExecutor commandExecutor = processEngineConfiguration.getCommandExecutor();
-            CommandConfig config = new CommandConfig().transactionNotSupported();
-            commandExecutor.execute(config, new Command<Object>() {
-                @Override
-                public Object execute(CommandContext commandContext) {
-                    DbSchemaManager dbSchemaManager = CommandContextUtil.getProcessEngineConfiguration(commandContext).getDbSchemaManager();
-                    dbSchemaManager.dbSchemaDrop();
-                    dbSchemaManager.dbSchemaCreate();
-                    return null;
-                }
-            });
-
-            if (exception != null) {
-                throw exception;
-            } else {
-                Assert.fail(outputMessage.toString());
-            }
-        } else {
-            LOGGER.info("database was clean");
-        }
-    }
-
-    protected void initializeServices() {
-        processEngineConfiguration = ((ProcessEngineImpl) processEngine).getProcessEngineConfiguration();
-        repositoryService = processEngine.getRepositoryService();
-        runtimeService = processEngine.getRuntimeService();
-        taskService = processEngine.getTaskService();
-        formService = processEngine.getFormService();
-        historyService = processEngine.getHistoryService();
-        identityService = processEngine.getIdentityService();
-        managementService = processEngine.getManagementService();
-        dynamicBpmnService = processEngine.getDynamicBpmnService();
-    }
-    
     public void assertProcessEnded(final String processInstanceId) {
         assertProcessEnded(processInstanceId, 10000);
     }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/test/AbstractTestCase.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/test/AbstractTestCase.java
@@ -13,21 +13,15 @@
 
 package org.flowable.engine.impl.test;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import junit.framework.TestCase;
+import org.junit.Assert;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @author Tom Baeyens
+ * @author Filip Hrisafov
  */
-public abstract class AbstractTestCase extends TestCase {
-
-    protected static final String EMPTY_LINE = "\n";
-
-    protected static final Logger LOGGER = LoggerFactory.getLogger(AbstractTestCase.class);
-
-    protected boolean isEmptyLinesEnabled = true;
+@ExtendWith(LoggingExtension.class)
+public abstract class AbstractTestCase {
 
     /**
      * Asserts if the provided text is part of some text.
@@ -45,32 +39,253 @@ public abstract class AbstractTestCase extends TestCase {
         assertTextPresent(expected.toLowerCase(), actual.toLowerCase());
     }
 
-    @Override
-    protected void runTest() throws Throwable {
-        if (LOGGER.isDebugEnabled()) {
-            if (isEmptyLinesEnabled) {
-                LOGGER.debug(EMPTY_LINE);
-            }
-            LOGGER.debug("#### START {}.{} ###########################################################", this.getClass().getSimpleName(), getName());
-        }
+    // Asserts are taken from TestCase in order not to perform a migration of the assertions in all tests
 
-        try {
+    /**
+     * Asserts that a condition is true. If it isn't it throws
+     * an AssertionFailedError with the given message.
+     */
+    public static void assertTrue(String message, boolean condition) {
+        Assert.assertTrue(message, condition);
+    }
 
-            super.runTest();
+    /**
+     * Asserts that a condition is true. If it isn't it throws
+     * an AssertionFailedError.
+     */
+    public static void assertTrue(boolean condition) {
+        Assert.assertTrue(condition);
+    }
 
-        } catch (AssertionError e) {
-            LOGGER.error(EMPTY_LINE);
-            LOGGER.error("ASSERTION FAILED: {}", e, e);
-            throw e;
+    /**
+     * Asserts that a condition is false. If it isn't it throws
+     * an AssertionFailedError.
+     */
+    public static void assertFalse(boolean condition) {
+        Assert.assertFalse(condition);
+    }
 
-        } catch (Throwable e) {
-            LOGGER.error(EMPTY_LINE);
-            LOGGER.error("EXCEPTION: {}", e, e);
-            throw e;
+    /**
+     * Asserts that a condition is false. If it isn't it throws
+     * an AssertionFailedError with the given message.
+     */
+    public static void assertFalse(String message, boolean condition) {
+        Assert.assertFalse(message, condition);
+    }
 
-        } finally {
-            LOGGER.debug("#### END {}.{} #############################################################", this.getClass().getSimpleName(), getName());
-        }
+    /**
+     * Fails a test with the given message.
+     */
+    public static void fail(String message) {
+        Assert.fail(message);
+    }
+
+    /**
+     * Fails a test with no message.
+     */
+    public static void fail() {
+        Assert.fail();
+    }
+
+    /**
+     * Asserts that two objects are equal. If they are not
+     * an AssertionFailedError is thrown with the given message.
+     */
+    public static void assertEquals(String message, Object expected, Object actual) {
+        Assert.assertEquals(message, expected, actual);
+    }
+
+    /**
+     * Asserts that two objects are equal. If they are not
+     * an AssertionFailedError is thrown.
+     */
+    public static void assertEquals(Object expected, Object actual) {
+        Assert.assertEquals(expected, actual);
+    }
+
+    /**
+     * Asserts that two Strings are equal.
+     */
+    public static void assertEquals(String message, String expected, String actual) {
+        Assert.assertEquals(message, expected, actual);
+    }
+
+    /**
+     * Asserts that two Strings are equal.
+     */
+    public static void assertEquals(String expected, String actual) {
+        Assert.assertEquals(expected, actual);
+    }
+
+    /**
+     * Asserts that two doubles are equal concerning a delta.  If they are not
+     * an AssertionFailedError is thrown with the given message.  If the expected
+     * value is infinity then the delta value is ignored.
+     */
+    public static void assertEquals(String message, double expected, double actual, double delta) {
+        Assert.assertEquals(message, expected, actual, delta);
+    }
+
+    /**
+     * Asserts that two doubles are equal concerning a delta. If the expected
+     * value is infinity then the delta value is ignored.
+     */
+    public static void assertEquals(double expected, double actual, double delta) {
+        Assert.assertEquals(expected, actual, delta);
+    }
+
+    /**
+     * Asserts that two floats are equal concerning a positive delta. If they
+     * are not an AssertionFailedError is thrown with the given message. If the
+     * expected value is infinity then the delta value is ignored.
+     */
+    public static void assertEquals(String message, float expected, float actual, float delta) {
+        Assert.assertEquals(message, expected, actual, delta);
+    }
+
+    /**
+     * Asserts that two floats are equal concerning a delta. If the expected
+     * value is infinity then the delta value is ignored.
+     */
+    public static void assertEquals(float expected, float actual, float delta) {
+        Assert.assertEquals(expected, actual, delta);
+    }
+
+    /**
+     * Asserts that two longs are equal. If they are not
+     * an AssertionFailedError is thrown with the given message.
+     */
+    public static void assertEquals(String message, long expected, long actual) {
+        Assert.assertEquals(message, expected, actual);
+    }
+
+    /**
+     * Asserts that two longs are equal.
+     */
+    public static void assertEquals(long expected, long actual) {
+        Assert.assertEquals(expected, actual);
+    }
+
+    /**
+     * Asserts that two booleans are equal. If they are not
+     * an AssertionFailedError is thrown with the given message.
+     */
+    public static void assertEquals(String message, boolean expected, boolean actual) {
+        Assert.assertEquals(message, expected, actual);
+    }
+
+    /**
+     * Asserts that two booleans are equal.
+     */
+    public static void assertEquals(boolean expected, boolean actual) {
+        Assert.assertEquals(expected, actual);
+    }
+
+    /**
+     * Asserts that two bytes are equal. If they are not
+     * an AssertionFailedError is thrown with the given message.
+     */
+    public static void assertEquals(String message, byte expected, byte actual) {
+        Assert.assertEquals(message, expected, actual);
+    }
+
+    /**
+     * Asserts that two bytes are equal.
+     */
+    public static void assertEquals(byte expected, byte actual) {
+        Assert.assertEquals(expected, actual);
+    }
+
+    /**
+     * Asserts that two chars are equal. If they are not
+     * an AssertionFailedError is thrown with the given message.
+     */
+    public static void assertEquals(String message, char expected, char actual) {
+        Assert.assertEquals(message, expected, actual);
+    }
+
+    /**
+     * Asserts that two chars are equal.
+     */
+    public static void assertEquals(char expected, char actual) {
+        Assert.assertEquals(expected, actual);
+    }
+
+    /**
+     * Asserts that two shorts are equal. If they are not
+     * an AssertionFailedError is thrown with the given message.
+     */
+    public static void assertEquals(String message, short expected, short actual) {
+        Assert.assertEquals(message, expected, actual);
+    }
+
+    /**
+     * Asserts that two shorts are equal.
+     */
+    public static void assertEquals(short expected, short actual) {
+        Assert.assertEquals(expected, actual);
+    }
+
+    /**
+     * Asserts that two ints are equal. If they are not
+     * an AssertionFailedError is thrown with the given message.
+     */
+    public static void assertEquals(String message, int expected, int actual) {
+        Assert.assertEquals(message, expected, actual);
+    }
+
+    /**
+     * Asserts that two ints are equal.
+     */
+    public static void assertEquals(int expected, int actual) {
+        Assert.assertEquals(expected, actual);
+    }
+
+    protected static void assertNotNull(Object object) {
+        Assert.assertNotNull(object);
+    }
+
+    /**
+     * Asserts that an object isn't null. If it is
+     * an AssertionFailedError is thrown with the given message.
+     */
+    public static void assertNotNull(String message, Object object) {
+        Assert.assertNotNull(message, object);
+    }
+
+    /**
+     * Asserts that an object is null. If it isn't an {@link AssertionError} is
+     * thrown.
+     * Message contains: Expected: <null> but was: object
+     *
+     * @param object Object to check or <code>null</code>
+     */
+    public static void assertNull(Object object) {
+        Assert.assertNull(object);
+    }
+
+    /**
+     * Asserts that an object is null.  If it is not
+     * an AssertionFailedError is thrown with the given message.
+     */
+    public static void assertNull(String message, Object object) {
+        Assert.assertNull(message, object);
+    }
+
+    /**
+     * Asserts that two objects do not refer to the same object. If they do
+     * refer to the same object an AssertionFailedError is thrown.
+     */
+    public static void assertNotSame(Object expected, Object actual) {
+        Assert.assertNotSame(expected, actual);
+    }
+
+    /**
+     * Asserts that two objects refer to the same object. If they are not
+     * the same an AssertionFailedError is thrown.
+     */
+    public static void assertSame(Object expected, Object actual) {
+        Assert.assertSame(expected, actual);
     }
 
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/test/CleanTest.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/test/CleanTest.java
@@ -1,0 +1,40 @@
+package org.flowable.engine.impl.test;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation that instructs the {@link InternalFlowableExtension} to clean all deployments
+ * of a test.
+ * When used on a test class it will remove all deployments after each method. When used on a method it will remove the deployments only for that method.
+ * This annotation is handled different depending on the {@link org.junit.jupiter.api.TestInstance.Lifecycle TestInstance.Lifecycle} and it's location.
+ * <ul>
+ *      <li>
+ *          Class annotated and {@link org.junit.jupiter.api.TestInstance.Lifecycle#PER_CLASS TestInstance.Lifecycle#PER_CLASS}
+ *          - the clean would happen after all tests have run
+ *      </li>
+ *      <li>
+ *          Class annotated and {@link org.junit.jupiter.api.TestInstance.Lifecycle#PER_METHOD TestInstance.Lifecycle#PER_METHOD} or no lifecycle
+ *          - the clean would happen after each test has run
+ *      </li>
+ *      <li>
+ *          Method annotated - the clean would happen after the test has run
+ *      </li>
+ * </ul>
+ *
+ * @author Filip Hrisafov
+ */
+@Target({
+    ElementType.TYPE,
+    ElementType.METHOD
+})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+public @interface CleanTest {
+
+}

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/test/EnsureCleanDb.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/test/EnsureCleanDb.java
@@ -1,0 +1,34 @@
+package org.flowable.engine.impl.test;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation that instructs the {@link InternalFlowableExtension} to assert a clean DB (scans all tables to see if the DB is completely clean).
+ * It throws {@link AssertionError} in case the DB is not clean. If the DB is not clean, it would be cleaned by performing a create and drop.
+ * Dropping the DB can be disabled by setting {@link EnsureCleanDb#dropDb()} to {@code false}.
+ * If the {@link org.junit.jupiter.api.TestInstance.Lifecycle TestInstance.Lifecycle} is set to
+ * {@link org.junit.jupiter.api.TestInstance.Lifecycle#PER_CLASS TestInstance.Lifecycle#PER_CLASS} then the assertion will happen after all tests have run.
+ *
+ * @author Filip Hrisafov
+ */
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+public @interface EnsureCleanDb {
+
+    /**
+     * The names of the tables that should be excluded from a check
+     *
+     * @return the table names that should be excluded when doing the check
+     */
+    String[] excludeTables() default {};
+
+    boolean dropDb() default true;
+
+}

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/test/InternalFlowableExtension.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/test/InternalFlowableExtension.java
@@ -1,0 +1,238 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.engine.impl.test;
+
+import static org.flowable.engine.impl.test.TestHelper.EMPTY_LINE;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.flowable.common.engine.api.FlowableOptimisticLockingException;
+import org.flowable.common.engine.impl.db.DbSchemaManager;
+import org.flowable.common.engine.impl.interceptor.Command;
+import org.flowable.common.engine.impl.interceptor.CommandConfig;
+import org.flowable.common.engine.impl.interceptor.CommandContext;
+import org.flowable.common.engine.impl.interceptor.CommandExecutor;
+import org.flowable.engine.ManagementService;
+import org.flowable.engine.ProcessEngine;
+import org.flowable.engine.ProcessEngineConfiguration;
+import org.flowable.engine.RepositoryService;
+import org.flowable.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.flowable.engine.impl.history.DefaultHistoryManager;
+import org.flowable.engine.impl.history.HistoryManager;
+import org.flowable.engine.impl.util.CommandContextUtil;
+import org.flowable.engine.test.Deployment;
+import org.flowable.engine.test.DeploymentId;
+import org.flowable.job.api.HistoryJob;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.platform.commons.support.AnnotationSupport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Base internal extension for JUnit Jupiter. This is a basis for other internal extensions. It allows:
+ * <ul>
+ *     <li>
+ *         Performs a deployment before each test when a test method is annotated with {@link Deployment}
+ *     </li>
+ *     <li>
+ *         Validates the history data after each test
+ *     </li>
+ *     <li>
+ *         Delete history jobs and deployment after each test
+ *     </li>
+ *     <li>
+ *         Assert and ensure a clean db after each test or after all tests (depending on the {@link TestInstance.Lifecycle}.
+ *     </li>
+ *     <li>
+ *         Support for injecting the {@link ProcessEngine}, services, {@link ProcessEngineConfiguration} and the id of the deployment done via
+ *         {@link Deployment} into test methods and lifecycle methods within tests.
+ *     </li>
+ * </ul>
+ * @author Filip Hrisafov
+ */
+public abstract class InternalFlowableExtension implements AfterEachCallback, BeforeEachCallback, AfterAllCallback, ParameterResolver {
+
+    protected static final String ANNOTATION_DEPLOYMENT_ID_KEY = "deploymentIdFromDeploymentAnnotation";
+
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
+
+    @Override
+    public void beforeEach(ExtensionContext context) {
+        ProcessEngine processEngine = getProcessEngine(context);
+
+        AnnotationSupport.findAnnotation(context.getTestMethod(), Deployment.class)
+            .ifPresent(deployment -> {
+                String deploymentIdFromDeploymentAnnotation = TestHelper
+                    .annotationDeploymentSetUp(processEngine, context.getRequiredTestClass(), context.getRequiredTestMethod(), deployment);
+                getStore(context).put(context.getUniqueId() + ANNOTATION_DEPLOYMENT_ID_KEY, deploymentIdFromDeploymentAnnotation);
+            });
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        ProcessEngine processEngine = getProcessEngine(context);
+        // Always reset authenticated user to avoid any mistakes
+        processEngine.getIdentityService().setAuthenticatedUserId(null);
+
+        AbstractFlowableTestCase.validateHistoryData(processEngine);
+        doFinally(context, TestInstance.Lifecycle.PER_METHOD);
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) throws Exception {
+        doFinally(context, TestInstance.Lifecycle.PER_CLASS);
+    }
+
+    protected void doFinally(ExtensionContext context, TestInstance.Lifecycle lifecycleForClean) {
+        ProcessEngine processEngine = getProcessEngine(context);
+        ProcessEngineConfigurationImpl processEngineConfiguration = (ProcessEngineConfigurationImpl) processEngine.getProcessEngineConfiguration();
+        boolean isAsyncHistoryEnabled = processEngineConfiguration.isAsyncHistoryEnabled();
+
+        if (isAsyncHistoryEnabled) {
+            ManagementService managementService = processEngine.getManagementService();
+            List<HistoryJob> jobs = managementService.createHistoryJobQuery().list();
+            for (HistoryJob job : jobs) {
+                managementService.deleteHistoryJob(job.getId());
+            }
+        }
+
+        HistoryManager asyncHistoryManager = null;
+        try {
+            if (isAsyncHistoryEnabled) {
+                processEngineConfiguration.setAsyncHistoryEnabled(false);
+                asyncHistoryManager = processEngineConfiguration.getHistoryManager();
+                processEngineConfiguration
+                    .setHistoryManager(new DefaultHistoryManager(processEngineConfiguration, processEngineConfiguration.getHistoryLevel()));
+            }
+
+            String annotationDeploymentKey = context.getUniqueId() + ANNOTATION_DEPLOYMENT_ID_KEY;
+            String deploymentIdFromDeploymentAnnotation = getStore(context).get(annotationDeploymentKey, String.class);
+            if (deploymentIdFromDeploymentAnnotation != null) {
+                TestHelper.annotationDeploymentTearDown(processEngine, deploymentIdFromDeploymentAnnotation, context.getRequiredTestClass(),
+                    context.getRequiredTestMethod().getName());
+                getStore(context).remove(annotationDeploymentKey);
+            }
+
+            AnnotationSupport.findAnnotation(context.getTestMethod(), CleanTest.class)
+                .ifPresent(cleanTest -> removeDeployments(processEngine.getRepositoryService()));
+            if (context.getTestInstanceLifecycle().orElse(TestInstance.Lifecycle.PER_METHOD) == lifecycleForClean) {
+                cleanTestAndAssertAndEnsureCleanDb(context, processEngine);
+            }
+
+        } finally {
+
+            if (isAsyncHistoryEnabled) {
+                processEngineConfiguration.setAsyncHistoryEnabled(true);
+                processEngineConfiguration.setHistoryManager(asyncHistoryManager);
+            }
+
+            processEngineConfiguration.getClock().reset();
+        }
+    }
+
+    protected void cleanTestAndAssertAndEnsureCleanDb(ExtensionContext context, ProcessEngine processEngine) {
+        AnnotationSupport.findAnnotation(context.getRequiredTestClass(), CleanTest.class)
+            .ifPresent(cleanTest -> removeDeployments(getProcessEngine(context).getRepositoryService()));
+        AnnotationSupport.findAnnotation(context.getRequiredTestClass(), EnsureCleanDb.class)
+            .ifPresent(ensureCleanDb -> assertAndEnsureCleanDb(processEngine, context, ensureCleanDb));
+    }
+
+    /**
+     * Each test is assumed to clean up all DB content it entered. After a test method executed, this method scans all tables to see if the DB is completely clean. It throws AssertionFailed in case
+     * the DB is not clean. If the DB is not clean, it is cleaned by performing a create a drop.
+     */
+    protected void assertAndEnsureCleanDb(ProcessEngine processEngine, ExtensionContext context, EnsureCleanDb ensureCleanDb) {
+        logger.debug("verifying that db is clean after test");
+        Set<String> tableNamesExcludedFromDbCleanCheck = new HashSet<>(Arrays.asList(ensureCleanDb.excludeTables()));
+        ManagementService managementService = processEngine.getManagementService();
+        ProcessEngineConfiguration processEngineConfiguration = processEngine.getProcessEngineConfiguration();
+        Map<String, Long> tableCounts = managementService.getTableCount();
+        StringBuilder outputMessage = new StringBuilder();
+        for (String tableName : tableCounts.keySet()) {
+            String tableNameWithoutPrefix = tableName.replace(processEngineConfiguration.getDatabaseTablePrefix(), "");
+            if (!tableNamesExcludedFromDbCleanCheck.contains(tableNameWithoutPrefix)) {
+                Long count = tableCounts.get(tableName);
+                if (count != 0L) {
+                    outputMessage.append("  ").append(tableName).append(": ").append(count).append(" record(s) ");
+                }
+            }
+        }
+        if (outputMessage.length() > 0) {
+            outputMessage.insert(0, "DB NOT CLEAN: \n");
+            logger.error(EMPTY_LINE);
+            logger.error(outputMessage.toString());
+
+            logger.info("dropping and recreating db");
+
+            if (ensureCleanDb.dropDb()) {
+                CommandExecutor commandExecutor = processEngineConfiguration.getCommandExecutor();
+                CommandConfig config = new CommandConfig().transactionNotSupported();
+                commandExecutor.execute(config, new Command<Object>() {
+
+                    @Override
+                    public Object execute(CommandContext commandContext) {
+                        DbSchemaManager dbSchemaManager = CommandContextUtil.getProcessEngineConfiguration(commandContext).getDbSchemaManager();
+                        dbSchemaManager.dbSchemaDrop();
+                        dbSchemaManager.dbSchemaCreate();
+                        return null;
+                    }
+                });
+            }
+
+            if (!context.getExecutionException().isPresent()) {
+                throw new AssertionError(outputMessage.toString());
+            }
+        } else {
+            logger.info("database was clean");
+        }
+    }
+
+    protected void removeDeployments(RepositoryService repositoryService) {
+        for (org.flowable.engine.repository.Deployment deployment : repositoryService.createDeploymentQuery().list()) {
+            try {
+                repositoryService.deleteDeployment(deployment.getId(), true);
+            } catch (FlowableOptimisticLockingException flowableOptimisticLockingException) {
+                logger.warn("Caught exception, retrying", flowableOptimisticLockingException);
+                repositoryService.deleteDeployment(deployment.getId(), true);
+            }
+        }
+    }
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext context) {
+        Class<?> parameterType = parameterContext.getParameter().getType();
+        return ProcessEngine.class.equals(parameterType) || parameterContext.isAnnotated(DeploymentId.class);
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext context) {
+        if (parameterContext.isAnnotated(DeploymentId.class)) {
+            return getStore(context).get(context.getUniqueId() + ANNOTATION_DEPLOYMENT_ID_KEY, String.class);
+        }
+        return getProcessEngine(context);
+    }
+
+    protected abstract ProcessEngine getProcessEngine(ExtensionContext context);
+
+    protected abstract ExtensionContext.Store getStore(ExtensionContext context);
+}

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/test/LoggingExtension.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/test/LoggingExtension.java
@@ -1,0 +1,54 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.engine.impl.test;
+
+import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
+import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class LoggingExtension implements BeforeTestExecutionCallback, AfterTestExecutionCallback {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LoggingExtension.class);
+    private static final String EMPTY_LINE = "\n";
+
+    @Override
+    public void beforeTestExecution(ExtensionContext context) throws Exception {
+        LOGGER.debug(EMPTY_LINE);
+        LOGGER.debug("#### START {}.{} ###########################################################", context.getRequiredTestClass().getSimpleName(),
+            context.getRequiredTestMethod().getName());
+    }
+
+    @Override
+    public void afterTestExecution(ExtensionContext context) throws Exception {
+        context.getExecutionException().ifPresent(LoggingExtension::logExecutionException);
+
+        LOGGER.debug("#### END {}.{} ###########################################################", context.getRequiredTestClass().getSimpleName(),
+            context.getRequiredTestMethod().getName());
+        LOGGER.debug(EMPTY_LINE);
+    }
+
+    protected static void logExecutionException(Throwable ex) {
+        if (ex instanceof AssertionError) {
+            LOGGER.error(EMPTY_LINE);
+            LOGGER.error("ASSERTION FAILED: {}", ex, ex);
+        } else {
+            LOGGER.error(EMPTY_LINE);
+            LOGGER.error("EXCEPTION: {}", ex, ex);
+        }
+    }
+}

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/test/PluggableFlowableExtension.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/test/PluggableFlowableExtension.java
@@ -1,0 +1,110 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.engine.impl.test;
+
+import org.flowable.common.engine.api.FlowableException;
+import org.flowable.common.engine.impl.cfg.CommandExecutorImpl;
+import org.flowable.common.engine.impl.interceptor.CommandExecutor;
+import org.flowable.common.engine.impl.interceptor.CommandInterceptor;
+import org.flowable.engine.ProcessEngine;
+import org.flowable.engine.ProcessEngines;
+import org.flowable.engine.impl.interceptor.CommandInvoker;
+import org.flowable.engine.impl.interceptor.LoggingExecutionTreeCommandInvoker;
+import org.flowable.engine.test.EnableVerboseExecutionTreeLogging;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.commons.support.AnnotationSupport;
+
+/**
+ * An extension which uses the {@link ProcessEngines#getDefaultProcessEngine()} and is cached within the entire context
+ * (i.e. it would be reused by all users of the extension).
+ * <p>
+ * This extension also activates {@link EnableVerboseExecutionTreeLogging} if a class is annotated with it.
+ *
+ * @author Filip Hrisafov
+ */
+public class PluggableFlowableExtension extends InternalFlowableExtension {
+
+    private static final ExtensionContext.Namespace NAMESPACE = ExtensionContext.Namespace.create(PluggableFlowableExtension.class);
+    private static final String PROCESS_ENGINE = "cachedProcessEngine";
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        try {
+            super.afterEach(context);
+        } finally {
+            if (AnnotationSupport.isAnnotated(context.getRequiredTestClass(), EnableVerboseExecutionTreeLogging.class)) {
+                swapCommandInvoker(getProcessEngine(context), false);
+            }
+        }
+    }
+
+    @Override
+    protected ProcessEngine getProcessEngine(ExtensionContext context) {
+        ProcessEngine processEngine = getStore(context).getOrComputeIfAbsent(PROCESS_ENGINE, key -> initializeProcessEngine(), ProcessEngine.class);
+
+        // Enable verbose execution tree debugging if needed
+        Class<?> testClass = context.getRequiredTestClass();
+        if (AnnotationSupport.isAnnotated(testClass, EnableVerboseExecutionTreeLogging.class)) {
+            swapCommandInvoker(processEngine, true);
+        }
+        return processEngine;
+    }
+
+    protected ProcessEngine initializeProcessEngine() {
+        logger.info("No cached process engine found for test. Retrieving the default engine.");
+        ProcessEngines.destroy(); // Just to be sure we're not getting any previously cached version
+
+        ProcessEngine processEngine = ProcessEngines.getDefaultProcessEngine();
+        if (processEngine == null) {
+            throw new FlowableException("no default process engine available");
+        }
+        return processEngine;
+    }
+
+    protected void swapCommandInvoker(ProcessEngine processEngine, boolean debug) {
+        CommandExecutor commandExecutor = processEngine.getProcessEngineConfiguration().getCommandExecutor();
+        if (commandExecutor instanceof CommandExecutorImpl) {
+            CommandExecutorImpl commandExecutorImpl = (CommandExecutorImpl) commandExecutor;
+
+            CommandInterceptor previousCommandInterceptor = null;
+            CommandInterceptor commandInterceptor = commandExecutorImpl.getFirst();
+
+            while (commandInterceptor != null) {
+
+                boolean matches = debug ? (commandInterceptor instanceof CommandInvoker) : (commandInterceptor instanceof LoggingExecutionTreeCommandInvoker);
+                if (matches) {
+
+                    CommandInterceptor commandInvoker = debug ? new LoggingExecutionTreeCommandInvoker() : new CommandInvoker();
+                    if (previousCommandInterceptor != null) {
+                        previousCommandInterceptor.setNext(commandInvoker);
+                    } else {
+                        commandExecutorImpl.setFirst(previousCommandInterceptor);
+                    }
+                    break;
+
+                } else {
+                    previousCommandInterceptor = commandInterceptor;
+                    commandInterceptor = commandInterceptor.getNext();
+                }
+            }
+
+        } else {
+            logger.warn("Not using {}, ignoring the {} annotation", CommandExecutorImpl.class, EnableVerboseExecutionTreeLogging.class);
+        }
+    }
+
+    @Override
+    protected ExtensionContext.Store getStore(ExtensionContext context) {
+        return context.getRoot().getStore(NAMESPACE);
+    }
+}

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/test/PluggableFlowableTestCase.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/test/PluggableFlowableTestCase.java
@@ -13,18 +13,8 @@
 
 package org.flowable.engine.impl.test;
 
-import org.flowable.common.engine.api.FlowableException;
-import org.flowable.common.engine.impl.cfg.CommandExecutorImpl;
-import org.flowable.common.engine.impl.interceptor.CommandExecutor;
-import org.flowable.common.engine.impl.interceptor.CommandInterceptor;
-import org.flowable.engine.ProcessEngine;
-import org.flowable.engine.ProcessEngines;
-import org.flowable.engine.impl.ProcessEngineImpl;
-import org.flowable.engine.impl.interceptor.CommandInvoker;
-import org.flowable.engine.impl.interceptor.LoggingExecutionTreeCommandInvoker;
-import org.flowable.engine.test.EnableVerboseExecutionTreeLogging;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Base class for the flowable test cases.
@@ -36,74 +26,9 @@ import org.slf4j.LoggerFactory;
  * @author Tom Baeyens
  * @author Joram Barrez
  */
+@Tag("pluggable")
+@ExtendWith(PluggableFlowableExtension.class)
 public abstract class PluggableFlowableTestCase extends AbstractFlowableTestCase {
 
-    private static final Logger pluggableActivitiTestCaseLogger = LoggerFactory.getLogger(PluggableFlowableTestCase.class);
-
-    protected static ProcessEngine cachedProcessEngine;
-
-    @Override
-    protected void initializeProcessEngine() {
-        if (cachedProcessEngine == null) {
-            pluggableActivitiTestCaseLogger.info("No cached process engine found for test. Retrieving the default engine.");
-            ProcessEngines.destroy(); // Just to be sure we're not getting any previously cached version
-
-            cachedProcessEngine = ProcessEngines.getDefaultProcessEngine();
-            if (cachedProcessEngine == null) {
-                throw new FlowableException("no default process engine available");
-            }
-        }
-
-        processEngine = cachedProcessEngine;
-        processEngineConfiguration = ((ProcessEngineImpl) processEngine).getProcessEngineConfiguration();
-
-        // Enable verbose execution tree debugging if needed
-        if (this.getClass().isAnnotationPresent(EnableVerboseExecutionTreeLogging.class)) {
-            swapCommandInvoker(true);
-        }
-
-    }
-
-    @Override
-    protected void closeDownProcessEngine() {
-        super.closeDownProcessEngine();
-
-        // Reset command invoker
-        if (this.getClass().isAnnotationPresent(EnableVerboseExecutionTreeLogging.class)) {
-            swapCommandInvoker(false);
-        }
-    }
-
-    protected void swapCommandInvoker(boolean debug) {
-        CommandExecutor commandExecutor = processEngineConfiguration.getCommandExecutor();
-        if (commandExecutor instanceof CommandExecutorImpl) {
-            CommandExecutorImpl commandExecutorImpl = (CommandExecutorImpl) commandExecutor;
-
-            CommandInterceptor previousCommandInterceptor = null;
-            CommandInterceptor commandInterceptor = commandExecutorImpl.getFirst();
-
-            while (commandInterceptor != null) {
-
-                boolean matches = debug ? (commandInterceptor instanceof CommandInvoker) : (commandInterceptor instanceof LoggingExecutionTreeCommandInvoker);
-                if (matches) {
-
-                    CommandInterceptor commandInvoker = debug ? new LoggingExecutionTreeCommandInvoker() : new CommandInvoker();
-                    if (previousCommandInterceptor != null) {
-                        previousCommandInterceptor.setNext(commandInvoker);
-                    } else {
-                        commandExecutorImpl.setFirst(previousCommandInterceptor);
-                    }
-                    break;
-
-                } else {
-                    previousCommandInterceptor = commandInterceptor;
-                    commandInterceptor = commandInterceptor.getNext();
-                }
-            }
-
-        } else {
-            pluggableActivitiTestCaseLogger.warn("Not using {}, ignoring the {} annotation", CommandExecutorImpl.class, EnableVerboseExecutionTreeLogging.class);
-        }
-    }
 
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/test/ResourceFlowableExtension.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/test/ResourceFlowableExtension.java
@@ -1,0 +1,82 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.engine.impl.test;
+
+import java.util.function.Consumer;
+
+import org.flowable.engine.ProcessEngine;
+import org.flowable.engine.ProcessEngineConfiguration;
+import org.flowable.engine.ProcessEngines;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * An extension that uses the configured resource to create a {@link ProcessEngine}.
+ * This extension needs to be registered via {@link org.junit.jupiter.api.extension.RegisterExtension RegisterExtension}. It additionally allows for
+ * customizing the {@link ProcessEngineConfiguration}
+ * A new {@link ProcessEngine} will be created for each test.
+ *
+ * @author Filip Hrisafov
+ */
+public class ResourceFlowableExtension extends InternalFlowableExtension {
+
+    private static final ExtensionContext.Namespace NAMESPACE = ExtensionContext.Namespace.create(ResourceFlowableExtension.class);
+    protected final String configurationResource;
+    protected final String processEngineName;
+    protected final Consumer<ProcessEngineConfiguration> configurationConsumer;
+
+    public ResourceFlowableExtension(String configurationResource, Consumer<ProcessEngineConfiguration> configurationConsumer) {
+        this(configurationResource, null, configurationConsumer);
+    }
+
+    public ResourceFlowableExtension(String configurationResource, String processEngineName, Consumer<ProcessEngineConfiguration> configurationConsumer) {
+        this.configurationResource = configurationResource;
+        this.processEngineName = processEngineName;
+        this.configurationConsumer = configurationConsumer;
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        super.afterEach(context);
+        ProcessEngine processEngine = getProcessEngine(context);
+        ProcessEngines.unregister(processEngine);
+    }
+
+    @Override
+    protected ProcessEngine getProcessEngine(ExtensionContext context) {
+        return getStore(context).getOrComputeIfAbsent(context.getUniqueId(), key -> initializeProcessEngine(), ProcessEngine.class);
+    }
+
+    protected ProcessEngine initializeProcessEngine() {
+        ProcessEngineConfiguration config = ProcessEngineConfiguration.createProcessEngineConfigurationFromResource(configurationResource);
+        if (processEngineName != null) {
+            logger.info("Initializing process engine with name '{}'", processEngineName);
+            config.setEngineName(processEngineName);
+        }
+        configurationConsumer.accept(config);
+        ProcessEngine processEngine = config.buildProcessEngine();
+        ProcessEngines.setInitialized(true);
+        return processEngine;
+    }
+
+    @Override
+    protected ExtensionContext.Store getStore(ExtensionContext context) {
+        return context.getRoot().getStore(NAMESPACE);
+    }
+
+    public ProcessEngine rebootEngine() {
+        String engineName = processEngineName != null ? processEngineName : ProcessEngines.NAME_DEFAULT;
+        ProcessEngine processEngine = ProcessEngines.getProcessEngine(engineName);
+        ProcessEngines.unregister(processEngine);
+        return initializeProcessEngine();
+    }
+}

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/test/ResourceFlowableTestCase.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/test/ResourceFlowableTestCase.java
@@ -14,7 +14,8 @@
 package org.flowable.engine.impl.test;
 
 import org.flowable.engine.ProcessEngineConfiguration;
-import org.flowable.engine.ProcessEngines;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,9 +23,13 @@ import org.slf4j.LoggerFactory;
  * @author Tom Baeyens
  * @author Joram Barrez
  */
+@Tag("resource")
 public abstract class ResourceFlowableTestCase extends AbstractFlowableTestCase {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ResourceFlowableTestCase.class);
+
+    @RegisterExtension
+    protected final ResourceFlowableExtension extension;
 
     protected String activitiConfigurationResource;
     protected String processEngineName;
@@ -36,29 +41,15 @@ public abstract class ResourceFlowableTestCase extends AbstractFlowableTestCase 
     public ResourceFlowableTestCase(String activitiConfigurationResource, String processEngineName) {
         this.activitiConfigurationResource = activitiConfigurationResource;
         this.processEngineName = processEngineName;
-    }
-
-    @Override
-    protected void closeDownProcessEngine() {
-        super.closeDownProcessEngine();
-        ProcessEngines.unregister(processEngine);
-        processEngine = null;
-        nullifyServices();
-    }
-
-    @Override
-    protected void initializeProcessEngine() {
-        ProcessEngineConfiguration config = ProcessEngineConfiguration.createProcessEngineConfigurationFromResource(activitiConfigurationResource);
-        if (processEngineName != null) {
-            LOGGER.info("Initializing process engine with name '{}'", processEngineName);
-            config.setEngineName(processEngineName);
-        }
-        additionalConfiguration(config);
-        processEngine = config.buildProcessEngine();
+        this.extension = new ResourceFlowableExtension(activitiConfigurationResource, processEngineName, this::additionalConfiguration);
     }
 
     protected void additionalConfiguration(ProcessEngineConfiguration processEngineConfiguration) {
 
+    }
+
+    protected void rebootEngine() {
+        initializeServices(extension.rebootEngine());
     }
 
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/test/TestHelper.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/test/TestHelper.java
@@ -69,7 +69,6 @@ public abstract class TestHelper {
     // Test annotation support /////////////////////////////////////////////
 
     public static String annotationDeploymentSetUp(ProcessEngine processEngine, Class<?> testClass, String methodName) {
-        String deploymentId = null;
         Method method = null;
         try {
             method = testClass.getMethod(methodName, (Class<?>[]) null);
@@ -77,7 +76,17 @@ public abstract class TestHelper {
             LOGGER.warn("Could not get method by reflection. This could happen if you are using @Parameters in combination with annotations.", e);
             return null;
         }
+        return annotationDeploymentSetUp(processEngine, testClass, method);
+    }
+
+    public static String annotationDeploymentSetUp(ProcessEngine processEngine, Class<?> testClass, Method method) {
         Deployment deploymentAnnotation = method.getAnnotation(Deployment.class);
+        return annotationDeploymentSetUp(processEngine, testClass, method, deploymentAnnotation);
+    }
+
+    public static String annotationDeploymentSetUp(ProcessEngine processEngine, Class<?> testClass, Method method, Deployment deploymentAnnotation) {
+        String deploymentId = null;
+        String methodName = method.getName();
         if (deploymentAnnotation != null) {
             LOGGER.debug("annotation @Deployment creates deployment for {}.{}", testClass.getSimpleName(), methodName);
             String[] resources = deploymentAnnotation.resources();

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/test/TestHelper.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/test/TestHelper.java
@@ -148,8 +148,21 @@ public abstract class TestHelper {
         }
     }
 
-    protected static void handleMockServiceTaskAnnotation(FlowableMockSupport mockSupport, MockServiceTask mockedServiceTask) {
-        mockSupport.mockServiceTaskWithClassDelegate(mockedServiceTask.originalClassName(), mockedServiceTask.mockedClassName());
+    public static void handleMockServiceTaskAnnotation(FlowableMockSupport mockSupport, MockServiceTask mockedServiceTask) {
+        String originalClassName = mockedServiceTask.originalClassName();
+        mockSupport.mockServiceTaskWithClassDelegate(originalClassName, mockedServiceTask.mockedClassName());
+        Class<?> mockedClass = mockedServiceTask.mockedClass();
+        if (!Void.class.equals(mockedClass)) {
+            mockSupport.mockServiceTaskWithClassDelegate(originalClassName, mockedClass);
+        }
+
+        String id = mockedServiceTask.id();
+        if (!id.isEmpty()) {
+            mockSupport.mockServiceTaskByIdWithClassDelegate(id, mockedServiceTask.mockedClassName());
+            if (!Void.class.equals(mockedClass)) {
+                mockSupport.mockServiceTaskByIdWithClassDelegate(id, mockedClass);
+            }
+        }
     }
 
     protected static void handleMockServiceTasksAnnotation(FlowableMockSupport mockSupport, Method method) {
@@ -164,7 +177,12 @@ public abstract class TestHelper {
     protected static void handleNoOpServiceTasksAnnotation(FlowableMockSupport mockSupport, Method method) {
         NoOpServiceTasks noOpServiceTasks = method.getAnnotation(NoOpServiceTasks.class);
         if (noOpServiceTasks != null) {
+            handleNoOpServiceTasksAnnotation(mockSupport, noOpServiceTasks);
+        }
+    }
 
+    public static void handleNoOpServiceTasksAnnotation(FlowableMockSupport mockSupport, NoOpServiceTasks noOpServiceTasks) {
+        if (noOpServiceTasks != null) {
             String[] ids = noOpServiceTasks.ids();
             Class<?>[] classes = noOpServiceTasks.classes();
             String[] classNames = noOpServiceTasks.classNames();
@@ -192,7 +210,6 @@ public abstract class TestHelper {
                 }
 
             }
-
         }
     }
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/test/DeploymentId.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/test/DeploymentId.java
@@ -1,0 +1,21 @@
+package org.flowable.engine.test;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation that can be used on test methods, lifecycle method to inject the id of the deployment deployed via {@link Deployment}.
+ *
+ * <b>NB:</b> This only works for the tests with JUnit Jupiter.
+ *
+ * @author Filip Hrisafov
+ */
+@Target({ ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface DeploymentId {
+
+}

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/test/FlowableExtension.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/test/FlowableExtension.java
@@ -1,0 +1,206 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.engine.test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.flowable.engine.FormService;
+import org.flowable.engine.HistoryService;
+import org.flowable.engine.IdentityService;
+import org.flowable.engine.ManagementService;
+import org.flowable.engine.ProcessEngine;
+import org.flowable.engine.ProcessEngineConfiguration;
+import org.flowable.engine.RepositoryService;
+import org.flowable.engine.RuntimeService;
+import org.flowable.engine.TaskService;
+import org.flowable.engine.impl.test.TestHelper;
+import org.flowable.engine.test.mock.FlowableMockSupport;
+import org.flowable.engine.test.mock.MockServiceTask;
+import org.flowable.engine.test.mock.NoOpServiceTasks;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.platform.commons.support.AnnotationSupport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * JUnit Jupiter extension for the Flowable ProcessEngine and services initialization.
+ *
+ * <p>
+ * Usage:
+ * </p>
+ *
+ * <pre>
+ * &#64;FlowableTest
+ * class YourTest {
+ *
+ *   &#64;BeforeEach
+ *   void setUp(ProcessEngine processEngine) {
+ *       ...
+ *   }
+ *
+ *   &#64;Test
+ *   void myTest(RuntimeService runtimeService) {
+ *       ...
+ *   }
+ *
+ *   ...
+ * }
+ * </pre>
+ *
+ * <p>
+ * The ProcessEngine and the services will be made available to the test class through the parameter resolution (BeforeEach, AfterEach, test methods).
+ * The ProcessEngine will be initialized by default with the flowable.cfg.xml resource on the classpath.
+ * To specify a different configuration file, pass the resource location in {@link #FlowableExtension(String) the appropriate constructor}.
+ * If a custom resource is needed then {@link org.junit.jupiter.api.extension.RegisterExtension RegisterExtension} should be used.
+ * Process engines will be cached as part of the JUnit Jupiter Extension context.
+ * Right before the first time the setUp is called for a given configuration resource, the process engine will be constructed.
+ * </p>
+ *
+ * <p>
+ * You can declare a deployment with the {@link Deployment} annotation. This extension will make sure that this deployment gets deployed before the setUp and
+ * {@link RepositoryService#deleteDeployment(String, boolean) cascade deleted} after the tearDown.
+ * The id of the deployment can be accessed by using {@link DeploymentId} in a test method.
+ * </p>
+ *
+ * <p>
+ * {@link FlowableTestHelper#setCurrentTime(Date) can be used to set the current time used by the process engine}
+ * This can be handy to control the exact time that is used by the engine in order to verify e.g. e.g. due dates of timers.
+ * Or start, end and duration times in the history service. In the tearDown, the internal clock will automatically be reset to use the current system
+ * time rather then the time that was set during a test method.
+ * </p>
+ *
+ * @author Filip Hrisafov
+ */
+public class FlowableExtension implements ParameterResolver, BeforeEachCallback, AfterEachCallback {
+
+    private static final ExtensionContext.Namespace NAMESPACE = ExtensionContext.Namespace.create(FlowableExtension.class);
+
+    private static final Set<Class<?>> SUPPORTED_PARAMETERS = new HashSet<>(Arrays.asList(
+        ProcessEngineConfiguration.class,
+        ProcessEngine.class,
+        RepositoryService.class,
+        RuntimeService.class,
+        TaskService.class,
+        HistoryService.class,
+        IdentityService.class,
+        ManagementService.class,
+        FormService.class
+    ));
+
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
+    protected final String configurationResource;
+
+    public FlowableExtension() {
+        this("flowable.cfg.xml");
+    }
+
+    public FlowableExtension(String configurationResource) {
+        this.configurationResource = configurationResource;
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext context) throws Exception {
+        FlowableTestHelper flowableTestHelper = getTestHelper(context);
+        FlowableMockSupport mockSupport = flowableTestHelper.getMockSupport();
+
+        if (mockSupport != null) {
+            AnnotationSupport.findRepeatableAnnotations(context.getRequiredTestClass(), MockServiceTask.class)
+                .forEach(mockServiceTask -> TestHelper.handleMockServiceTaskAnnotation(mockSupport, mockServiceTask));
+            AnnotationSupport.findRepeatableAnnotations(context.getRequiredTestMethod(), MockServiceTask.class)
+                .forEach(mockServiceTask -> TestHelper.handleMockServiceTaskAnnotation(mockSupport, mockServiceTask));
+            AnnotationSupport.findAnnotation(context.getRequiredTestMethod(), NoOpServiceTasks.class)
+                .ifPresent(noOpServiceTasks -> TestHelper.handleNoOpServiceTasksAnnotation(mockSupport, noOpServiceTasks));
+        }
+
+        AnnotationSupport.findAnnotation(context.getTestMethod(), Deployment.class)
+            .ifPresent(deployment -> {
+                String deploymentIdFromDeploymentAnnotation = TestHelper
+                    .annotationDeploymentSetUp(flowableTestHelper.getProcessEngine(), context.getRequiredTestClass(), context.getRequiredTestMethod(),
+                        deployment);
+                flowableTestHelper.setDeploymentIdFromDeploymentAnnotation(deploymentIdFromDeploymentAnnotation);
+            });
+
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        FlowableTestHelper flowableTestHelper = getTestHelper(context);
+        ProcessEngine processEngine = flowableTestHelper.getProcessEngine();
+        String deploymentIdFromDeploymentAnnotation = flowableTestHelper.getDeploymentIdFromDeploymentAnnotation();
+        if (deploymentIdFromDeploymentAnnotation != null) {
+            TestHelper.annotationDeploymentTearDown(processEngine, deploymentIdFromDeploymentAnnotation, context.getRequiredTestClass(),
+                context.getRequiredTestMethod().getName());
+            flowableTestHelper.setDeploymentIdFromDeploymentAnnotation(null);
+        }
+
+        processEngine.getProcessEngineConfiguration().getClock().reset();
+
+        FlowableMockSupport mockSupport = flowableTestHelper.getMockSupport();
+        if (mockSupport != null) {
+            TestHelper.annotationMockSupportTeardown(mockSupport);
+        }
+    }
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext context) {
+        Class<?> parameterType = parameterContext.getParameter().getType();
+        return SUPPORTED_PARAMETERS.contains(parameterType) || FlowableTestHelper.class.equals(parameterType) || FlowableMockSupport.class.equals(parameterType)
+            || parameterContext.isAnnotated(DeploymentId.class);
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext context) {
+        FlowableTestHelper flowableTestHelper = getTestHelper(context);
+        if (parameterContext.isAnnotated(DeploymentId.class)) {
+            return flowableTestHelper.getDeploymentIdFromDeploymentAnnotation();
+        }
+
+        Class<?> parameterType = parameterContext.getParameter().getType();
+        ProcessEngine processEngine = flowableTestHelper.getProcessEngine();
+        if (parameterType.isInstance(processEngine)) {
+            return processEngine;
+        } else if (FlowableTestHelper.class.equals(parameterType)) {
+            return flowableTestHelper;
+        } else if (FlowableMockSupport.class.equals(parameterType)) {
+            return flowableTestHelper.getMockSupport();
+        }
+
+        try {
+            return ProcessEngine.class.getDeclaredMethod("get" + parameterType.getSimpleName()).invoke(processEngine);
+        } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException ex) {
+            throw new ParameterResolutionException("Could not find service " + parameterType, ex);
+        }
+    }
+
+    protected FlowableTestHelper getTestHelper(ExtensionContext context) {
+        return getStore(context)
+            .getOrComputeIfAbsent(context.getRequiredTestClass(), key -> new FlowableTestHelper(createProcessEngine(context)), FlowableTestHelper.class);
+    }
+
+    protected ProcessEngine createProcessEngine(ExtensionContext context) {
+        return TestHelper.getProcessEngine(configurationResource);
+    }
+
+    protected ExtensionContext.Store getStore(ExtensionContext context) {
+        return context.getRoot().getStore(NAMESPACE);
+    }
+}

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/test/FlowableTest.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/test/FlowableTest.java
@@ -1,0 +1,82 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.flowable.engine.test;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Date;
+
+import org.flowable.engine.RepositoryService;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Convenience for annotation that activates the {@link FlowableExtension} JUnit Jupiter annotation.
+ *
+ * <p>
+ * Usage:
+ * </p>
+ *
+ * <pre>
+ * &#64;FlowableTest
+ * class YourTest {
+ *
+ *   &#64;BeforeEach
+ *   void setUp(ProcessEngine processEngine) {
+ *       ...
+ *   }
+ *
+ *   &#64;Test
+ *   void myTest(RuntimeService runtimeService) {
+ *       ...
+ *   }
+ *
+ *   ...
+ * }
+ * </pre>
+ *
+ * <p>
+ * The ProcessEngine and the services will be made available to the test class through the parameter resolution (BeforeEach, AfterEach, test moethds).
+ * The processEngine will be initialized by default with the flowable.cfg.xml resource on the classpath.
+ * To specify a different configuration file, pass the resource location in {@link FlowableExtension#FlowableExtension(String) the apropriate constructor}.
+ * Process engines will be cached as part of the JUnit Jupiter Extension context.
+ * Right before the first time the setUp is called for a given configuration resource, the process engine will be constructed.
+ * </p>
+ *
+ * <p>
+ * You can declare a deployment with the {@link Deployment} annotation. The extension will make sure that this deployment gets deployed before the setUp and
+ * {@link RepositoryService#deleteDeployment(String, boolean) cascade deleted} after the tearDown.
+ * The id of the deployment can be accessed by using {@link DeploymentId} in a test method.
+ * </p>
+ *
+ * <p>
+ * {@link FlowableTestHelper#setCurrentTime(Date) can be used to set the current time used by the process engine}
+ * This can be handy to control the exact time that is used by the engine in order to verify e.g. e.g. due dates of timers.
+ * Or start, end and duration times in the history service. In the tearDown, the internal clock will automatically be reset to use the current system
+ * time rather then the time that was set during a test method.
+ * </p>
+ *
+ * @author Filip Hrisafov
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@ExtendWith(FlowableExtension.class)
+public @interface FlowableTest {
+
+}

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/test/FlowableTestHelper.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/test/FlowableTestHelper.java
@@ -1,0 +1,73 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.engine.test;
+
+import java.time.Instant;
+import java.util.Date;
+
+import org.flowable.engine.ProcessEngine;
+import org.flowable.engine.impl.test.JobTestHelper;
+import org.flowable.engine.test.mock.FlowableMockSupport;
+
+/**
+ * A Helper for the Flowable {@link FlowableExtension} that can be used within the JUnit Jupiter context store
+ * and users can use it in the tests for easy modifying of the {@link ProcessEngine} time and easy access for waiting on the job executor.
+ *
+ * @author Filip Hrisafov
+ */
+public class FlowableTestHelper {
+
+    protected final ProcessEngine processEngine;
+    protected final FlowableMockSupport mockSupport;
+    protected String deploymentIdFromDeploymentAnnotation;
+
+    public FlowableTestHelper(ProcessEngine processEngine) {
+        this.processEngine = processEngine;
+        if (FlowableMockSupport.isMockSupportPossible(this.processEngine)) {
+            this.mockSupport = new FlowableMockSupport(this.processEngine);
+        } else {
+            this.mockSupport = null;
+        }
+    }
+
+    public ProcessEngine getProcessEngine() {
+        return processEngine;
+    }
+
+    public String getDeploymentIdFromDeploymentAnnotation() {
+        return deploymentIdFromDeploymentAnnotation;
+    }
+
+    public void setDeploymentIdFromDeploymentAnnotation(String deploymentIdFromDeploymentAnnotation) {
+        this.deploymentIdFromDeploymentAnnotation = deploymentIdFromDeploymentAnnotation;
+    }
+
+    public FlowableMockSupport getMockSupport() {
+        return mockSupport;
+    }
+
+    public void waitForJobExecutorToProcessAllJobs(long maxMillisToWait, long intervalMillis) {
+        JobTestHelper
+            .waitForJobExecutorToProcessAllJobs(processEngine.getProcessEngineConfiguration(), processEngine.getManagementService(), maxMillisToWait,
+                intervalMillis);
+    }
+
+    public void setCurrentTime(Date date) {
+        processEngine.getProcessEngineConfiguration().getClock().setCurrentTime(date);
+    }
+
+    public void setCurrentTime(Instant instant) {
+        processEngine.getProcessEngineConfiguration().getClock().setCurrentTime(instant == null ? null : Date.from(instant));
+    }
+
+}

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/test/TestActivityBehaviorFactory.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/test/TestActivityBehaviorFactory.java
@@ -114,6 +114,7 @@ public class TestActivityBehaviorFactory extends AbstractBehaviorFactory impleme
 
     protected boolean allServiceTasksNoOp;
     protected Map<String, String> mockedClassDelegatesMapping = new HashMap<>();
+    protected Map<String, String> mockedClassTaskIdDelegatesMapping = new HashMap<>();
     protected Set<String> noOpServiceTaskIds = new HashSet<>();
     protected Set<String> noOpServiceTaskClassNames = new HashSet<>();
 
@@ -169,6 +170,8 @@ public class TestActivityBehaviorFactory extends AbstractBehaviorFactory impleme
 
             return new ClassDelegate(mockedClassDelegatesMapping.get(serviceTask.getImplementation()), createFieldDeclarations(serviceTask.getFieldExtensions()));
 
+        } else if (serviceTask.getId() != null && mockedClassTaskIdDelegatesMapping.containsKey(serviceTask.getId())) {
+            return new ClassDelegate(mockedClassTaskIdDelegatesMapping.get(serviceTask.getId()), createFieldDeclarations(serviceTask.getFieldExtensions()));
         }
 
         return wrappedActivityBehaviorFactory.createClassDelegateServiceTask(serviceTask);
@@ -432,6 +435,14 @@ public class TestActivityBehaviorFactory extends AbstractBehaviorFactory impleme
 
     public void addClassDelegateMock(String originalClassFqn, String mockedClassFqn) {
         mockedClassDelegatesMapping.put(originalClassFqn, mockedClassFqn);
+    }
+
+    public void addClassDelegateMockByTaskId(String serviceTaskId, Class<?> mockedClass) {
+        addClassDelegateMockByTaskId(serviceTaskId, mockedClass.getName());
+    }
+
+    public void addClassDelegateMockByTaskId(String serviceTaskId, String mockedClassFqn) {
+        mockedClassTaskIdDelegatesMapping.put(serviceTaskId, mockedClassFqn);
     }
 
     public void addNoOpServiceTaskById(String id) {

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/test/mock/FlowableMockSupport.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/test/mock/FlowableMockSupport.java
@@ -54,6 +54,14 @@ public class FlowableMockSupport {
         testActivityBehaviorFactory.addClassDelegateMock(originalClassFqn, mockedClassFqn);
     }
 
+    public void mockServiceTaskByIdWithClassDelegate(String taskId, Class<?> mockedClass) {
+        testActivityBehaviorFactory.addClassDelegateMockByTaskId(taskId, mockedClass);
+    }
+
+    public void mockServiceTaskByIdWithClassDelegate(String taskId, String mockedClassFqn) {
+        testActivityBehaviorFactory.addClassDelegateMockByTaskId(taskId, mockedClassFqn);
+    }
+
     public void setAllServiceTasksNoOp() {
         testActivityBehaviorFactory.setAllServiceTasksNoOp();
     }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/test/mock/MockServiceTask.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/test/mock/MockServiceTask.java
@@ -13,6 +13,7 @@
 
 package org.flowable.engine.test.mock;
 
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
@@ -20,6 +21,7 @@ import java.lang.annotation.RetentionPolicy;
  * @author Joram Barrez
  */
 @Retention(RetentionPolicy.RUNTIME)
+@Repeatable(MockServiceTasks.class)
 public @interface MockServiceTask {
 
     public String id() default "";
@@ -27,5 +29,7 @@ public @interface MockServiceTask {
     public String originalClassName() default "";
 
     public String mockedClassName() default "";
+
+    Class<?> mockedClass() default Void.class;
 
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/app/AppResourceDeploymentTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/app/AppResourceDeploymentTest.java
@@ -19,12 +19,14 @@ import org.flowable.engine.app.AppModel;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.repository.Deployment;
 import org.flowable.engine.repository.ProcessDefinition;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tijs Rademakers
  */
 public class AppResourceDeploymentTest extends PluggableFlowableTestCase {
 
+    @Test
     public void testSingleAppResource() {
         InputStream inputStream = this.getClass().getClassLoader().getResourceAsStream("org/flowable/engine/test/api/app/test.app");
         Deployment deployment = repositoryService.createDeployment().addInputStream("test.app", inputStream).deploy();
@@ -50,6 +52,7 @@ public class AppResourceDeploymentTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testAppResourceWithProcessDefinition() {
         InputStream appInputStream = this.getClass().getClassLoader().getResourceAsStream("org/flowable/engine/test/api/app/test.app");
         InputStream bpmnInputStream = this.getClass().getClassLoader().getResourceAsStream("org/flowable/engine/test/repository/one.bpmn20.xml");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/deletereason/DeleteReasonTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/deletereason/DeleteReasonTest.java
@@ -24,12 +24,14 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
 import org.flowable.task.api.history.HistoricTaskInstance;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
  */
 public class DeleteReasonTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testDeleteProcessInstance() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("deleteReasonProcess");
@@ -60,6 +62,7 @@ public class DeleteReasonTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testDeleteProcessInstanceWithCustomDeleteReason() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("deleteReasonProcess");
@@ -94,6 +97,7 @@ public class DeleteReasonTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testRegularProcessInstanceEnd() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("deleteReasonProcess");
@@ -122,6 +126,7 @@ public class DeleteReasonTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testDeleteProcessInstanceWithReceiveTask() {
         // First case: one receive task
@@ -166,6 +171,7 @@ public class DeleteReasonTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testInterruptingBoundaryEvent() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("deleteReasonProcess");
@@ -186,6 +192,7 @@ public class DeleteReasonTest extends PluggableFlowableTestCase {
         assertHistoricActivitiesDeleteReason(processInstance, DeleteReason.BOUNDARY_EVENT_INTERRUPTING, "B", "C", "D", "theSubprocess");
     }
 
+    @Test
     @Deployment
     public void testInterruptingBoundaryEvent2() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("deleteReasonReceiveTask");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ActivityEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ActivityEventsTest.java
@@ -38,6 +38,9 @@ import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test case for all {@link FlowableEvent}s related to activities.
@@ -51,16 +54,17 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
 
     protected EventLogger databaseEventLogger;
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
+        listener = new TestFlowableActivityEventListener(true);
+        processEngineConfiguration.getEventDispatcher().addEventListener(listener);
 
         // Database event logger setup
         databaseEventLogger = new EventLogger(processEngineConfiguration.getClock(), processEngineConfiguration.getObjectMapper());
         runtimeService.addEventListener(databaseEventLogger);
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
 
         if (listener != null) {
@@ -76,21 +80,13 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
         // Database event logger teardown
         runtimeService.removeEventListener(databaseEventLogger);
 
-        super.tearDown();
-    }
-
-    @Override
-    protected void initializeServices() {
-        super.initializeServices();
-
-        listener = new TestFlowableActivityEventListener(true);
-        processEngineConfiguration.getEventDispatcher().addEventListener(listener);
     }
 
     /**
      * Test starting and completed events for activity. Since these events are dispatched in the core of the PVM, not all individual activity-type is tested. Rather, we test the main types (tasks,
      * gateways, events, subprocesses).
      */
+    @Test
     @Deployment
     public void testActivityEvents() throws Exception {
         // We're interested in the raw events, alter the listener to keep those as well
@@ -223,6 +219,7 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
     /**
      * Test events related to signalling
      */
+    @Test
     @Deployment
     public void testActivitySignalEvents() throws Exception {
         // Two paths are active in the process, one receive-task and one intermediate catching signal-event
@@ -281,6 +278,7 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
     /**
      * Test to verify if signals coming from an intermediate throw-event trigger the right events to be dispatched.
      */
+    @Test
     @Deployment
     public void testActivitySignalEventsWithinProcess() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("signalProcess");
@@ -318,6 +316,7 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
     /**
      * Test events related to message events, called from the API.
      */
+    @Test
     @Deployment
     public void testActivityMessageEvents() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("messageProcess");
@@ -357,6 +356,7 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
     /**
      * Test events related to message events, called from the API, targeting an event-subprocess.
      */
+    @Test
     @Deployment
     public void testActivityMessageEventsInEventSubprocess() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("messageProcess");
@@ -400,6 +400,7 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
     /**
      * Test events related to message events, called from the API, targeting an event-subprocess.
      */
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/event/ActivityEventsTest.testActivityMessageEventsInEventSubprocess.bpmn20.xml")
     public void testActivityMessageEventsInEventSubprocessForCancel() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("messageProcess");
@@ -445,6 +446,7 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
     /**
      * Test events related to compensation events.
      */
+    @Test
     @Deployment
     public void testActivityCompensationEvents() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("compensationProcess");
@@ -480,6 +482,7 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
     /**
      * Test events related to error-events
      */
+    @Test
     @Deployment
     public void testActivityErrorEvents() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("errorProcess");
@@ -514,6 +517,7 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
     /**
      * Test events related to error-events, thrown from within process-execution (eg. service-task).
      */
+    @Test
     @Deployment
     public void testActivityErrorEventsFromBPMNError() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("errorProcess");
@@ -545,6 +549,7 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
         assertFalse(processInstance.getId().equals(errorEvent.getExecutionId()));
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/event/JobEventsTest.testJobEntityEvents.bpmn20.xml")
     public void testActivityTimeOutEvent() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testJobEvents");
@@ -567,6 +572,7 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
         assertTrue("Boundary timer is the cause of the cancellation", boundaryEvent.getEventDefinitions().get(0) instanceof TimerEventDefinition);
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventTest.testTimerOnNestingOfSubprocesses.bpmn20.xml")
     public void testActivityTimeOutEventInSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("timerOnNestedSubprocesses");
@@ -595,6 +601,7 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
         assertTrue(eventIdList.indexOf("innerSubprocess") >= 0);
     }
 
+    @Test
     @Deployment
     public void testActivityTimeOutEventInCallActivity() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("timerOnCallActivity");
@@ -627,6 +634,7 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
     /**
      * Test events related to message events, called from the API.
      */
+    @Test
     @Deployment
     public void testActivityMessageBoundaryEventsOnUserTask() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("messageOnUserTaskProcess");
@@ -679,6 +687,7 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
     /**
      * Test events related to message events, called from the API.
      */
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/event/ActivityEventsTest.testActivityMessageBoundaryEventsOnUserTask.bpmn20.xml")
     public void testActivityMessageBoundaryEventsOnUserTaskForCancel() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("messageOnUserTaskProcess");
@@ -721,6 +730,7 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
     /**
      * Test events related to message events, called from the API.
      */
+    @Test
     @Deployment
     public void testActivityMessageBoundaryEventsOnSubProcess() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("messageOnSubProcess");
@@ -785,6 +795,7 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
     /** 
      * Test events related to message events, called from the API.
      */
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/event/ActivityEventsTest.testActivityMessageBoundaryEventsOnSubProcess.bpmn20.xml")
     public void testActivityMessageBoundaryEventsOnSubProcessForCancel() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("messageOnSubProcess");
@@ -823,6 +834,7 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
         assertDatabaseEventPresent(FlowableEngineEventType.ACTIVITY_MESSAGE_WAITING);
     }
 
+    @Test
     @Deployment
     public void testActivitySignalBoundaryEventsOnSubProcess() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("signalOnSubProcess");
@@ -878,6 +890,7 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
         assertEquals("signalName", repositoryService.getBpmnModel(cancelEvent.getProcessDefinitionId()).getSignal(signalEventDefinition.getSignalRef()).getName());
     }
 
+    @Test
     @Deployment
     public void testActivitySignalBoundaryEventsOnUserTask() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("signalOnUserTask");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/AttachmentEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/AttachmentEventsTest.java
@@ -24,6 +24,10 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.task.Attachment;
 import org.flowable.engine.test.Deployment;
+import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test case for all {@link FlowableEvent}s related to attachments.
@@ -37,6 +41,7 @@ public class AttachmentEventsTest extends PluggableFlowableTestCase {
     /**
      * Test create, update and delete events of attachments on a task/process.
      */
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testAttachmentEntityEvents() throws Exception {
 
@@ -116,6 +121,7 @@ public class AttachmentEventsTest extends PluggableFlowableTestCase {
     /**
      * Test create, update and delete events of users.
      */
+    @Test
     public void testAttachmentEntityEventsStandaloneTask() throws Exception {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             org.flowable.task.api.Task task = null;
@@ -189,6 +195,7 @@ public class AttachmentEventsTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testAttachmentEntityEventsOnHistoricTaskDelete() throws Exception {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             org.flowable.task.api.Task task = null;
@@ -223,16 +230,14 @@ public class AttachmentEventsTest extends PluggableFlowableTestCase {
         }
     }
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
         listener = new TestFlowableEntityEventListener(Attachment.class);
         processEngineConfiguration.getEventDispatcher().addEventListener(listener);
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
 
         if (listener != null) {
             processEngineConfiguration.getEventDispatcher().removeEventListener(listener);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/CallActivityTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/CallActivityTest.java
@@ -22,6 +22,9 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.task.service.impl.persistence.entity.TaskEntity;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class CallActivityTest extends PluggableFlowableTestCase {
 
@@ -29,9 +32,10 @@ public class CallActivityTest extends PluggableFlowableTestCase {
 
     protected EventLogger databaseEventLogger;
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
+        listener = new CallActivityEventListener();
+        processEngineConfiguration.getEventDispatcher().addEventListener(listener);
 
         // Database event logger setup
         databaseEventLogger = new EventLogger(processEngineConfiguration.getClock(),
@@ -39,7 +43,7 @@ public class CallActivityTest extends PluggableFlowableTestCase {
         runtimeService.addEventListener(databaseEventLogger);
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
 
         if (listener != null) {
@@ -55,17 +59,9 @@ public class CallActivityTest extends PluggableFlowableTestCase {
         // Database event logger teardown
         runtimeService.removeEventListener(databaseEventLogger);
 
-        super.tearDown();
     }
 
-    @Override
-    protected void initializeServices() {
-        super.initializeServices();
-
-        listener = new CallActivityEventListener();
-        processEngineConfiguration.getEventDispatcher().addEventListener(listener);
-    }
-
+    @Test
     @Deployment(resources = {
             "org/flowable/engine/test/api/event/CallActivityTest.testCallActivity.bpmn20.xml",
             "org/flowable/engine/test/api/event/CallActivityTest.testCalledActivity.bpmn20.xml" })
@@ -249,6 +245,7 @@ public class CallActivityTest extends PluggableFlowableTestCase {
         assertEquals(26, mylistener.getEventsReceived().size());
     }
     
+    @Test
     @Deployment(resources = {
             "org/flowable/engine/test/api/event/CallActivityTest.testCallActivity.bpmn20.xml",
             "org/flowable/engine/test/api/event/CallActivityTest.testCalledActivity.bpmn20.xml" })
@@ -371,6 +368,7 @@ public class CallActivityTest extends PluggableFlowableTestCase {
         assertEquals(17, mylistener.getEventsReceived().size());
     }
 
+    @Test
     @Deployment(resources = {
             "org/flowable/engine/test/api/event/CallActivityTest.testCallActivityTerminateEnd.bpmn20.xml",
             "org/flowable/engine/test/api/event/CallActivityTest.testCalledActivityTerminateEnd.bpmn20.xml" })
@@ -554,6 +552,7 @@ public class CallActivityTest extends PluggableFlowableTestCase {
         assertEquals(idx, mylistener.getEventsReceived().size());
     }
     
+    @Test
     @Deployment(resources = {
             "org/flowable/engine/test/api/event/CallActivityTest.testCallActivity.bpmn20.xml",
             "org/flowable/engine/test/api/event/CallActivityTest.testCalledActivity.bpmn20.xml" })
@@ -596,6 +595,7 @@ public class CallActivityTest extends PluggableFlowableTestCase {
         System.out.println("the end");
     }
     
+    @Test
     @Deployment(resources = {
             "org/flowable/engine/test/api/event/CallActivityTest.testCallActivityProcessInstanceName.bpmn20.xml",
             "org/flowable/engine/test/api/event/CallActivityTest.testCalledActivity.bpmn20.xml"

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/CancelCallActivityTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/CancelCallActivityTest.java
@@ -34,6 +34,9 @@ import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.task.service.impl.persistence.entity.TaskEntity;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class CancelCallActivityTest extends PluggableFlowableTestCase {
 
@@ -41,9 +44,10 @@ public class CancelCallActivityTest extends PluggableFlowableTestCase {
 
     protected EventLogger databaseEventLogger;
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
+        listener = new CallActivityEventListener();
+        processEngineConfiguration.getEventDispatcher().addEventListener(listener);
 
         // Database event logger setup
         databaseEventLogger = new EventLogger(processEngineConfiguration.getClock(),
@@ -51,7 +55,7 @@ public class CancelCallActivityTest extends PluggableFlowableTestCase {
         runtimeService.addEventListener(databaseEventLogger);
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
 
         if (listener != null) {
@@ -67,17 +71,9 @@ public class CancelCallActivityTest extends PluggableFlowableTestCase {
         // Database event logger teardown
         runtimeService.removeEventListener(databaseEventLogger);
 
-        super.tearDown();
     }
 
-    @Override
-    protected void initializeServices() {
-        super.initializeServices();
-
-        listener = new CallActivityEventListener();
-        processEngineConfiguration.getEventDispatcher().addEventListener(listener);
-    }
-
+    @Test
     @Deployment(resources = {
             "org/flowable/engine/test/api/event/CancelCallActivityTest.testActivityMessageBoundaryEventsOnCallActivity.bpmn20.xml",
             "org/flowable/engine/test/api/event/CancelCallActivityTest.testActivityMessageBoundaryEventsCalledActivity.bpmn20.xml" })

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/CancelUserTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/CancelUserTaskTest.java
@@ -33,30 +33,25 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.task.api.Task;
 import org.flowable.task.service.impl.persistence.entity.TaskEntity;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class CancelUserTaskTest extends PluggableFlowableTestCase {
 
     private UserActivityEventListener testListener;
 
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
-    }
-
-    @Override
-    protected void tearDown() throws Exception {
+    @AfterEach
+    public void tearDown() throws Exception {
 
         if (testListener != null) {
             testListener.clearEventsReceived();
             processEngineConfiguration.getEventDispatcher().removeEventListener(testListener);
         }
-
-        super.tearDown();
     }
 
-    @Override
-    protected void initializeServices() {
-        super.initializeServices();
+    @BeforeEach
+    protected void setUp() {
         testListener = new UserActivityEventListener();
         processEngineConfiguration.getEventDispatcher().addEventListener(testListener);
     }
@@ -64,6 +59,7 @@ public class CancelUserTaskTest extends PluggableFlowableTestCase {
     /**
      * User task cancelled by terminate end event.
      */
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/event/CancelUserTaskEventsTest.bpmn20.xml" })
     public void testUserTaskCancelledWhenFlowToTerminateEnd() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("cancelUserTaskEvents");
@@ -164,6 +160,7 @@ public class CancelUserTaskTest extends PluggableFlowableTestCase {
     /**
      * User task cancelled by message boundary event.
      */
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/event/CancelUserTaskEventsTest.bpmn20.xml" })
     public void testUserTaskCancelledByMessageBoundaryEvent() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("cancelUserTaskEvents");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/CommentEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/CommentEventsTest.java
@@ -21,6 +21,9 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.task.Comment;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test case for all {@link FlowableEvent}s related to comments.
@@ -34,6 +37,7 @@ public class CommentEventsTest extends PluggableFlowableTestCase {
     /**
      * Test create, update and delete events of comments on a task/process.
      */
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testCommentEntityEvents() throws Exception {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
@@ -70,6 +74,7 @@ public class CommentEventsTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testCommentEntityEventsStandaloneTask() throws Exception {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             org.flowable.task.api.Task task = null;
@@ -113,16 +118,14 @@ public class CommentEventsTest extends PluggableFlowableTestCase {
         }
     }
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
         listener = new TestFlowableEntityEventListener(Comment.class);
         processEngineConfiguration.getEventDispatcher().addEventListener(listener);
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
 
         if (listener != null) {
             processEngineConfiguration.getEventDispatcher().removeEventListener(listener);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/DatabaseEventLoggerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/DatabaseEventLoggerTest.java
@@ -27,6 +27,9 @@ import org.flowable.engine.impl.event.logger.handler.Fields;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -42,24 +45,23 @@ public class DatabaseEventLoggerTest extends PluggableFlowableTestCase {
 
     protected ObjectMapper objectMapper = new ObjectMapper();
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
 
         // Database event logger setup
         databaseEventLogger = new EventLogger(processEngineConfiguration.getClock(), processEngineConfiguration.getObjectMapper());
         runtimeService.addEventListener(databaseEventLogger);
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
 
         // Database event logger teardown
         runtimeService.removeEventListener(databaseEventLogger);
 
-        super.tearDown();
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/event/DatabaseEventLoggerProcess.bpmn20.xml" })
     public void testDatabaseEvents() throws IOException {
 
@@ -437,6 +439,7 @@ public class DatabaseEventLoggerTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     public void testDatabaseEventsNoTenant() throws IOException {
 
         String deploymentId = repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/api/event/DatabaseEventLoggerProcess.bpmn20.xml").deploy().getId();
@@ -535,6 +538,7 @@ public class DatabaseEventLoggerTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     public void testStandaloneTaskEvents() throws JsonParseException, JsonMappingException, IOException {
 
         org.flowable.task.api.Task task = taskService.newTask();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/DeploymentEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/DeploymentEventsTest.java
@@ -17,6 +17,9 @@ import org.flowable.common.engine.api.delegate.event.FlowableEntityEvent;
 import org.flowable.common.engine.api.delegate.event.FlowableEvent;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.repository.Deployment;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test case for all {@link FlowableEvent}s related to deployments.
@@ -30,6 +33,7 @@ public class DeploymentEventsTest extends PluggableFlowableTestCase {
     /**
      * Test create, update and delete events of deployment entities.
      */
+    @Test
     public void testDeploymentEvents() throws Exception {
         Deployment deployment = null;
         try {
@@ -80,16 +84,14 @@ public class DeploymentEventsTest extends PluggableFlowableTestCase {
         }
     }
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
         listener = new TestFlowableEntityEventListener(Deployment.class);
         processEngineConfiguration.getEventDispatcher().addEventListener(listener);
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
 
         if (listener != null) {
             processEngineConfiguration.getEventDispatcher().removeEventListener(listener);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ErrorThrowingEventListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ErrorThrowingEventListenerTest.java
@@ -19,6 +19,7 @@ import org.flowable.engine.impl.bpmn.helper.ErrorThrowingEventListener;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test case for all {@link FlowableEventListener}s that throws an error BPMN event when an {@link FlowableEvent} has been dispatched.
@@ -27,6 +28,7 @@ import org.flowable.engine.test.Deployment;
  */
 public class ErrorThrowingEventListenerTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testThrowError() throws Exception {
         ErrorThrowingEventListener listener = null;
@@ -55,6 +57,7 @@ public class ErrorThrowingEventListenerTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testThrowErrorDefinedInProcessDefinition() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testError");
@@ -74,6 +77,7 @@ public class ErrorThrowingEventListenerTest extends PluggableFlowableTestCase {
         waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
     }
 
+    @Test
     @Deployment
     public void testThrowErrorWithErrorcode() throws Exception {
         ErrorThrowingEventListener listener = null;
@@ -118,6 +122,7 @@ public class ErrorThrowingEventListenerTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testThrowErrorWithErrorcodeDefinedInProcessDefinition() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testError");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ExecutionEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ExecutionEventsTest.java
@@ -19,6 +19,9 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test case for all {@link FlowableEvent}s related to executions.
@@ -32,6 +35,7 @@ public class ExecutionEventsTest extends PluggableFlowableTestCase {
     /**
      * Test create, update and delete events of process instances.
      */
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testExecutionEvents() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -127,17 +131,15 @@ public class ExecutionEventsTest extends PluggableFlowableTestCase {
         listener.clearEventsReceived();
     }
 
-    @Override
-    protected void initializeServices() {
-        super.initializeServices();
+    @BeforeEach
+    protected void setUp() {
 
         listener = new TestFlowableEntityEventListener(Execution.class);
         processEngineConfiguration.getEventDispatcher().addEventListener(listener);
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
 
         if (listener != null) {
             listener.clearEventsReceived();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/FlowableEventDispatcherTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/FlowableEventDispatcherTest.java
@@ -26,6 +26,8 @@ import org.flowable.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.flowable.engine.impl.persistence.entity.ExecutionEntityImpl;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.task.service.TaskServiceConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * 
@@ -35,9 +37,8 @@ public class FlowableEventDispatcherTest extends PluggableFlowableTestCase {
 
     protected FlowableEventDispatcher dispatcher;
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
 
         dispatcher = new FlowableEventDispatcherImpl();
     }
@@ -45,6 +46,7 @@ public class FlowableEventDispatcherTest extends PluggableFlowableTestCase {
     /**
      * Test adding a listener and check if events are sent to it. Also checks that after removal, no events are received.
      */
+    @Test
     public void testAddAndRemoveEventListenerAllEvents() throws Exception {
         // Create a listener that just adds the events to a list
         TestFlowableEventListener newListener = new TestFlowableEventListener();
@@ -77,6 +79,7 @@ public class FlowableEventDispatcherTest extends PluggableFlowableTestCase {
     /**
      * Test adding a listener and check if events are sent to it, for the types it was registered for. Also checks that after removal, no events are received.
      */
+    @Test
     public void testAddAndRemoveEventListenerTyped() throws Exception {
         // Create a listener that just adds the events to a list
         TestFlowableEventListener newListener = new TestFlowableEventListener();
@@ -111,6 +114,7 @@ public class FlowableEventDispatcherTest extends PluggableFlowableTestCase {
     /**
      * Test that adding a listener with a null-type is never called.
      */
+    @Test
     public void testAddAndRemoveEventListenerTypedNullType() throws Exception {
 
         // Create a listener that just adds the events to a list
@@ -133,6 +137,7 @@ public class FlowableEventDispatcherTest extends PluggableFlowableTestCase {
     /**
      * Test the {@link BaseEntityEventListener} shipped with Flowable.
      */
+    @Test
     public void testBaseEntityEventListener() throws Exception {
         TestBaseEntityEventListener listener = new TestBaseEntityEventListener();
 
@@ -197,6 +202,7 @@ public class FlowableEventDispatcherTest extends PluggableFlowableTestCase {
     /**
      * Test dispatching behavior when an exception occurs in the listener
      */
+    @Test
     public void testExceptionInListener() throws Exception {
         // Create listener that doesn't force the dispatching to fail
         TestExceptionFlowableEventListener listener = new TestExceptionFlowableEventListener(false);
@@ -240,6 +246,7 @@ public class FlowableEventDispatcherTest extends PluggableFlowableTestCase {
      * Test conversion of string-value (and list) in list of {@link FlowableEngineEventType}s, used in configuration of process-engine
      * {@link ProcessEngineConfigurationImpl#setTypedEventListeners(java.util.Map)} .
      */
+    @Test
     public void testActivitiEventTypeParsing() throws Exception {
         // Check with empty null
         FlowableEngineEventType[] types = FlowableEngineEventType.getTypesFromString(null);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/FlowableProcessTerminatedEventImplTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/FlowableProcessTerminatedEventImplTest.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.when;
 
 import org.flowable.engine.delegate.event.impl.FlowableProcessTerminatedEventImpl;
 import org.flowable.engine.impl.persistence.entity.ExecutionEntity;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 /**

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/GroupEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/GroupEventsTest.java
@@ -19,6 +19,9 @@ import org.flowable.idm.api.Group;
 import org.flowable.idm.api.User;
 import org.flowable.idm.api.event.FlowableIdmEventType;
 import org.flowable.idm.api.event.FlowableIdmMembershipEvent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test case for all {@link FlowableEvent}s related to groups.
@@ -32,6 +35,7 @@ public class GroupEventsTest extends PluggableFlowableTestCase {
     /**
      * Test create, update and delete events of Groups.
      */
+    @Test
     public void testGroupEntityEvents() throws Exception {
         Group group = null;
         try {
@@ -84,6 +88,7 @@ public class GroupEventsTest extends PluggableFlowableTestCase {
     /**
      * Test create, update and delete events of Groups.
      */
+    @Test
     public void testGroupMembershipEvents() throws Exception {
         TestFlowableEventListener membershipListener = new TestFlowableEventListener();
         processEngineConfiguration.getEventDispatcher().addEventListener(membershipListener);
@@ -141,16 +146,14 @@ public class GroupEventsTest extends PluggableFlowableTestCase {
         }
     }
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
         listener = new TestFlowableEntityEventListener(Group.class);
         processEngineConfiguration.getEventDispatcher().addEventListener(listener);
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
 
         if (listener != null) {
             processEngineConfiguration.getEventDispatcher().removeEventListener(listener);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/HistoricActivityEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/HistoricActivityEventsTest.java
@@ -23,6 +23,9 @@ import org.flowable.engine.impl.test.HistoryTestHelper;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test case for all {@link FlowableEvent}s related to activities.
@@ -34,28 +37,26 @@ public class HistoricActivityEventsTest extends PluggableFlowableTestCase {
 
     private TestHistoricActivityEventListener listener;
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
 
         this.listener = new TestHistoricActivityEventListener();
         processEngineConfiguration.getEventDispatcher().addEventListener(listener);
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
 
         if (listener != null) {
             listener.clearEventsReceived();
             processEngineConfiguration.getEventDispatcher().removeEventListener(listener);
         }
-
-        super.tearDown();
     }
 
     /**
      * Test added to assert the historic activity instance event
      */
+    @Test
     @Deployment
     public void testHistoricActivityEventDispatched() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/IdentityLinkEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/IdentityLinkEventsTest.java
@@ -20,6 +20,9 @@ import org.flowable.engine.repository.ProcessDefinition;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.identitylink.api.IdentityLink;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test case for all {@link FlowableEvent}s related to process definitions.
@@ -33,6 +36,7 @@ public class IdentityLinkEventsTest extends PluggableFlowableTestCase {
     /**
      * Check identity links on process definitions.
      */
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testProcessDefinitionIdentityLinkEvents() throws Exception {
         ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().processDefinitionKey("oneTaskProcess").singleResult();
@@ -79,6 +83,7 @@ public class IdentityLinkEventsTest extends PluggableFlowableTestCase {
     /**
      * Check identity links on process instances.
      */
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testProcessInstanceIdentityLinkEvents() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -117,6 +122,7 @@ public class IdentityLinkEventsTest extends PluggableFlowableTestCase {
     /**
      * Check identity links on process instances.
      */
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testTaskIdentityLinks() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -177,6 +183,7 @@ public class IdentityLinkEventsTest extends PluggableFlowableTestCase {
     /**
      * Check deletion of links on process instances.
      */
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testProcessInstanceIdentityDeleteCandidateGroupEvents() throws Exception {
 
@@ -201,17 +208,15 @@ public class IdentityLinkEventsTest extends PluggableFlowableTestCase {
         assertEquals(1, listener.getEventsReceived().size());
     }
 
-    @Override
-    protected void initializeServices() {
-        super.initializeServices();
+    @BeforeEach
+    protected void setUp() {
 
         listener = new TestFlowableEntityEventListener(IdentityLink.class);
         processEngineConfiguration.getEventDispatcher().addEventListener(listener);
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
 
         if (listener != null) {
             listener.clearEventsReceived();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/JobEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/JobEventsTest.java
@@ -30,6 +30,9 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test case for all {@link FlowableEvent}s related to jobs.
@@ -43,6 +46,7 @@ public class JobEventsTest extends PluggableFlowableTestCase {
     /**
      * Test create, update and delete events of jobs entities.
      */
+    @Test
     @Deployment
     public void testJobEntityEvents() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testJobEvents");
@@ -117,6 +121,7 @@ public class JobEventsTest extends PluggableFlowableTestCase {
     /**
      * Test job canceled and timer scheduled events for reschedule.
      */
+    @Test
     @Deployment
     public void testJobEntityEventsForRescheduleTimer() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testJobEventsForReschedule");
@@ -219,6 +224,7 @@ public class JobEventsTest extends PluggableFlowableTestCase {
     /**
      * Timer repetition
      */
+    @Test
     @Deployment
     public void testRepetitionJobEntityEvents() throws Exception {
         Clock previousClock = processEngineConfiguration.getClock();
@@ -300,6 +306,7 @@ public class JobEventsTest extends PluggableFlowableTestCase {
         processEngineConfiguration.setClock(previousClock);
     }
 
+    @Test
     @Deployment
     public void testJobCanceledEventOnBoundaryEvent() throws Exception {
         Clock testClock = new DefaultClockImpl();
@@ -317,6 +324,7 @@ public class JobEventsTest extends PluggableFlowableTestCase {
         checkEventCount(1, FlowableEngineEventType.JOB_CANCELED);
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/event/JobEventsTest.testJobCanceledEventOnBoundaryEvent.bpmn20.xml")
     public void testJobCanceledEventByManagementService() throws Exception {
         // GIVEN
@@ -333,6 +341,7 @@ public class JobEventsTest extends PluggableFlowableTestCase {
         checkEventCount(1, FlowableEngineEventType.JOB_CANCELED);
     }
 
+    @Test
     public void testJobCanceledAndTimerStartEventOnProcessRedeploy() throws Exception {
         // GIVEN deploy process definition
         String deployment1 = repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/api/event/JobEventsTest.testTimerFiredForTimerStart.bpmn20.xml").deploy().getId();
@@ -386,6 +395,7 @@ public class JobEventsTest extends PluggableFlowableTestCase {
     /**
      * /** Test TIMER_FIRED event for timer start bpmn event.
      */
+    @Test
     @Deployment
     public void testTimerFiredForTimerStart() throws Exception {
         // there should be one job after process definition deployment
@@ -416,6 +426,7 @@ public class JobEventsTest extends PluggableFlowableTestCase {
     /**
      * Test TIMER_FIRED event for intermediate timer bpmn event.
      */
+    @Test
     @Deployment
     public void testTimerFiredForIntermediateTimer() throws Exception {
         runtimeService.startProcessInstanceByKey("testTimerFiredForIntermediateTimer");
@@ -434,6 +445,7 @@ public class JobEventsTest extends PluggableFlowableTestCase {
     /**
      * Test create, update and delete events of jobs entities.
      */
+    @Test
     @Deployment
     public void testJobEntityEventsException() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testJobEvents");
@@ -505,6 +517,7 @@ public class JobEventsTest extends PluggableFlowableTestCase {
         checkEventContext(event, theJob);
     }
 
+    @Test
     @Deployment
     public void testTerminateEndEvent() throws Exception {
         Clock previousClock = processEngineConfiguration.getClock();
@@ -568,16 +581,14 @@ public class JobEventsTest extends PluggableFlowableTestCase {
         assertEquals(entity.getId(), ((Job) entityEvent.getEntity()).getId());
     }
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
         listener = new TestFlowableEntityEventListener(Job.class);
         processEngineConfiguration.getEventDispatcher().addEventListener(listener);
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
 
         if (listener != null) {
             processEngineConfiguration.getEventDispatcher().removeEventListener(listener);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/MessageThrowingEventListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/MessageThrowingEventListenerTest.java
@@ -19,6 +19,7 @@ import org.flowable.engine.impl.bpmn.helper.MessageThrowingEventListener;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test case for all {@link FlowableEventListener}s that throw a message BPMN event when an {@link FlowableEvent} has been dispatched.
@@ -27,6 +28,7 @@ import org.flowable.engine.test.Deployment;
  */
 public class MessageThrowingEventListenerTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testThrowMessage() throws Exception {
         MessageThrowingEventListener listener = null;
@@ -59,6 +61,7 @@ public class MessageThrowingEventListenerTest extends PluggableFlowableTestCase 
         }
     }
 
+    @Test
     @Deployment
     public void testThrowMessageDefinedInProcessDefinition() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testMessage");
@@ -79,6 +82,7 @@ public class MessageThrowingEventListenerTest extends PluggableFlowableTestCase 
         assertNotNull(boundaryTask);
     }
 
+    @Test
     @Deployment
     public void testThrowMessageInterrupting() throws Exception {
         MessageThrowingEventListener listener = null;

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ModelEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ModelEventsTest.java
@@ -17,6 +17,9 @@ import org.flowable.common.engine.api.delegate.event.FlowableEntityEvent;
 import org.flowable.common.engine.api.delegate.event.FlowableEvent;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.repository.Model;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test case for all {@link FlowableEvent}s related to models.
@@ -30,6 +33,7 @@ public class ModelEventsTest extends PluggableFlowableTestCase {
     /**
      * Test create, update and delete events of model entities.
      */
+    @Test
     public void testModelEvents() throws Exception {
         Model model = null;
         try {
@@ -78,16 +82,14 @@ public class ModelEventsTest extends PluggableFlowableTestCase {
         }
     }
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
         listener = new TestFlowableEntityEventListener(Model.class);
         processEngineConfiguration.getEventDispatcher().addEventListener(listener);
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
 
         if (listener != null) {
             processEngineConfiguration.getEventDispatcher().removeEventListener(listener);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.java
@@ -38,17 +38,15 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.task.api.Task;
 import org.flowable.task.service.impl.persistence.entity.TaskEntity;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
 
     private MultiInstanceUserActivityEventListener testListener;
 
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
-    }
-
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
 
         if (testListener != null) {
@@ -56,12 +54,10 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
             processEngineConfiguration.getEventDispatcher().removeEventListener(testListener);
         }
 
-        super.tearDown();
     }
 
-    @Override
-    protected void initializeServices() {
-        super.initializeServices();
+    @BeforeEach
+    protected void setUp() {
         testListener = new MultiInstanceUserActivityEventListener();
         processEngineConfiguration.getEventDispatcher().addEventListener(testListener);
     }
@@ -69,6 +65,7 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
     /**
      * Multi-instance user task cancelled by terminate end event.
      */
+    @Test
     @Deployment(resources = {"org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.bpmn20.xml"})
     public void testMultiInstanceCancelledWhenFlowToTerminateEnd() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("multiInstanceUserTaskEvents");
@@ -223,6 +220,7 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
     /**
      * Multi-instance user task cancelled by terminate end event.
      */
+    @Test
     @Deployment(resources = {"org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.testMultiInstanceCompleteCondition.bpmn20.xml"})
     public void testMultiInstanceCompleteCondition() throws Exception {
         Map<String,Object> variables = new HashMap<>();
@@ -327,6 +325,7 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
     /**
      * Multi-instance user task cancelled by terminate end event.
      */
+    @Test
     @Deployment(resources = {"org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.testMultiInstanceCompleteCondition.bpmn20.xml"})
     public void testMultiInstanceComplete() throws Exception {
         Map<String,Object> variables = new HashMap<>();
@@ -444,6 +443,7 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
      * Multi-instance user task cancelled by message boundary event defined on
      * multi-instance user task.
      */
+    @Test
     @Deployment(resources = {"org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.bpmn20.xml"})
     public void testMultiInstanceCancelledByMessageBoundaryEvent() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("multiInstanceUserTaskEvents");
@@ -591,6 +591,7 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
      * Multi-instance user task defined in external subprocess. The multi-instance user tasks
      * are cancelled by message boundary event defined on multi-instance user task.
      */
+    @Test
     @Deployment(resources = {
             "org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.testCallActivityTerminateEnd.bpmn20.xml",
             "org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.testCalledActivityTerminateEnd.bpmn20.xml"})
@@ -736,6 +737,7 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
      * Multi-instance user task defined in external subprocess. The external subprocess and
      * the multi-instance user tasks are cancelled when parent flows to terminate end event.
      */
+    @Test
     @Deployment(resources = {
             "org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.testCallActivityTerminateEnd.bpmn20.xml",
             "org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.testCalledActivityTerminateEnd.bpmn20.xml"})
@@ -899,6 +901,7 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
         assertEquals(idx, testListener.getEventsReceived().size());
     }
 
+    @Test
     @Deployment(resources = {
             "org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.testEmbeddedSubprocess.bpmn20.xml"})
     public void testMultiInstanceInSubprocessCancelledWhenFlowToTerminateEnd() throws Exception {
@@ -1061,6 +1064,7 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
         assertEquals(idx, testListener.getEventsReceived().size());
     }
 
+    @Test
     @Deployment(resources = {
             "org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.testMultiInstanceSequentialUserTaskEventsWithNormalCompletion.bpmn20.xml"})
     public void testMultiInstanceSequentialUserTaskEventsWithNormalCompletion() {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ProcessDefinitionEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ProcessDefinitionEventsTest.java
@@ -22,6 +22,9 @@ import org.flowable.engine.impl.util.ProcessDefinitionUtil;
 import org.flowable.engine.repository.ProcessDefinition;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.service.impl.persistence.entity.TimerJobEntity;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test case for all {@link FlowableEvent}s related to process definitions.
@@ -30,13 +33,12 @@ import org.flowable.job.service.impl.persistence.entity.TimerJobEntity;
  */
 public class ProcessDefinitionEventsTest extends PluggableFlowableTestCase {
 
-    private TestMultipleFlowableEventListener listener;
-
     /**
      * Test create, update and delete events of process definitions.
      */
-    @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
+    @Test
     public void testProcessDefinitionEvents() throws Exception {
+        repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml").deploy();
         ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().processDefinitionKey("oneTaskProcess").singleResult();
 
         assertNotNull(processDefinition);
@@ -80,7 +82,6 @@ public class ProcessDefinitionEventsTest extends PluggableFlowableTestCase {
 
         // Check delete event when category is updated
         repositoryService.deleteDeployment(processDefinition.getDeploymentId(), true);
-        deploymentIdFromDeploymentAnnotation = null;
 
         assertEquals(1, listener.getEventsReceived().size());
         assertTrue(listener.getEventsReceived().get(0) instanceof FlowableEntityEvent);
@@ -91,11 +92,18 @@ public class ProcessDefinitionEventsTest extends PluggableFlowableTestCase {
         listener.clearEventsReceived();
     }
 
+    private TestMultipleFlowableEventListener listener;
+
     /**
      * test sequence of events for process definition with timer start event
      */
-    @Deployment(resources = { "org/flowable/engine/test/bpmn/event/timer/StartTimerEventTest.testDurationStartTimerEvent.bpmn20.xml" })
+    @Test
     public void testTimerStartEventDeployment() {
+        deploymentIdsForAutoCleanup
+            .add(repositoryService.createDeployment()
+                .addClasspathResource("org/flowable/engine/test/bpmn/event/timer/StartTimerEventTest.testDurationStartTimerEvent.bpmn20.xml")
+                .deploy()
+                .getId());
         ProcessDefinitionEntity processDefinition = (ProcessDefinitionEntity) repositoryService.createProcessDefinitionQuery().processDefinitionKey("startTimerEventExample").singleResult();
         FlowableEntityEvent processDefinitionCreated = FlowableEventBuilder.createEntityEvent(FlowableEngineEventType.ENTITY_CREATED, processDefinition);
 
@@ -132,10 +140,8 @@ public class ProcessDefinitionEventsTest extends PluggableFlowableTestCase {
         return false;
     }
 
-    @Override
-    protected void initializeServices() {
-        super.initializeServices();
-
+    @BeforeEach
+    public void setUp() {
         listener = new ProcessDefinitionEventsListener();
         listener.setEventClasses(FlowableEntityEvent.class);
         listener.setEntityClasses(ProcessDefinition.class, TimerJobEntity.class);
@@ -143,10 +149,8 @@ public class ProcessDefinitionEventsTest extends PluggableFlowableTestCase {
         processEngineConfiguration.getEventDispatcher().addEventListener(listener);
     }
 
-    @Override
-    protected void tearDown() throws Exception {
-        super.tearDown();
-
+    @AfterEach
+    public void tearDown() throws Exception {
         if (listener != null) {
             listener.clearEventsReceived();
             processEngineConfiguration.getEventDispatcher().removeEventListener(listener);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ProcessDefinitionScopedEventListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ProcessDefinitionScopedEventListenerTest.java
@@ -20,6 +20,8 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.repository.ProcessDefinition;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.flowable.engine.test.DeploymentId;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for event-listeners that are registered on a process-definition scope, rather than on the global engine-wide scope.
@@ -34,8 +36,9 @@ public class ProcessDefinitionScopedEventListenerTest extends PluggableFlowableT
     /**
      * Test to verify listeners on a process-definition are only called for events related to that definition.
      */
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml", "org/flowable/engine/test/api/event/simpleProcess.bpmn20.xml" })
-    public void testProcessDefinitionScopedListener() throws Exception {
+    public void testProcessDefinitionScopedListener(@DeploymentId String deploymentIdFromDeploymentAnnotation) throws Exception {
         ProcessDefinition firstDefinition = repositoryService.createProcessDefinitionQuery().deploymentId(deploymentIdFromDeploymentAnnotation).processDefinitionKey("oneTaskProcess").singleResult();
         assertNotNull(firstDefinition);
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ProcessInstanceEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ProcessInstanceEventsTest.java
@@ -37,6 +37,9 @@ import org.flowable.engine.repository.ProcessDefinition;
 import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test case for all {@link FlowableEvent}s related to process instances.
@@ -50,6 +53,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
     /**
      * Test create, update and delete events of process instances.
      */
+    @Test
     @Deployment
     public void testProcessInstanceEvents() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -224,6 +228,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
     /**
      * Test create, update and delete events of process instances.
      */
+    @Test
     @Deployment(resources = {"org/flowable/engine/test/api/runtime/nestedSubProcess.bpmn20.xml", "org/flowable/engine/test/api/runtime/subProcess.bpmn20.xml"})
     public void testSubProcessInstanceEvents() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("nestedSimpleSubProcess");
@@ -330,6 +335,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
     /**
      * Test process with signals start.
      */
+    @Test
     @Deployment(resources = {"org/flowable/engine/test/bpmn/event/signal/SignalEventTest.testSignalWithGlobalScope.bpmn20.xml"})
     public void testSignalProcessInstanceStart() throws Exception {
         this.runtimeService.startProcessInstanceByKey("processWithSignalCatch");
@@ -342,6 +348,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
     /**
      * Test Start->End process on PROCESS_COMPLETED event
      */
+    @Test
     @Deployment(resources = {"org/flowable/engine/test/api/event/ProcessInstanceEventsTest.noneTaskProcess.bpmn20.xml"})
     public void testProcessCompleted_StartEnd() throws Exception {
         this.runtimeService.startProcessInstanceByKey("noneTaskProcess");
@@ -352,6 +359,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
     /**
      * Test Start->User org.flowable.task.service.Task process on PROCESS_COMPLETED event
      */
+    @Test
     @Deployment(resources = {"org/flowable/engine/test/api/event/ProcessInstanceEventsTest.noEndProcess.bpmn20.xml"})
     public void testProcessCompleted_NoEnd() throws Exception {
         ProcessInstance noEndProcess = this.runtimeService.startProcessInstanceByKey("noEndProcess");
@@ -366,6 +374,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
      * <p>
      * process on PROCESS_COMPLETED event
      */
+    @Test
     @Deployment(resources = {"org/flowable/engine/test/api/event/ProcessInstanceEventsTest.parallelGatewayNoEndProcess.bpmn20.xml"})
     public void testProcessCompleted_ParallelGatewayNoEnd() throws Exception {
         this.runtimeService.startProcessInstanceByKey("noEndProcess");
@@ -378,6 +387,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
      * <p/>
      * process on PROCESS_COMPLETED event
      */
+    @Test
     @Deployment(resources = {"org/flowable/engine/test/api/event/ProcessInstanceEventsTest.parallelGatewayTwoEndsProcess.bpmn20.xml"})
     public void testProcessCompleted_ParallelGatewayTwoEnds() throws Exception {
         this.runtimeService.startProcessInstanceByKey("noEndProcess");
@@ -386,6 +396,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
         assertEquals("ActivitiEventType.PROCESS_COMPLETED was expected 1 time.", 1, events.size());
     }
 
+    @Test
     @Deployment(resources = {
             "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateInCallActivityMulitInstance.bpmn",
             "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.subProcessTerminateTerminateAll.bpmn20.xml"})
@@ -396,6 +407,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
         assertEquals("FlowableEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT was expected 6 times.", 6, events.size());
     }
 
+    @Test
     @Deployment(resources = {"org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
     public void testProcessInstanceCancelledEvents_cancel() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -422,6 +434,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
         listener.clearEventsReceived();
     }
 
+    @Test
     @Deployment(resources = {"org/flowable/engine/test/api/runtime/nestedSubProcess.bpmn20.xml", "org/flowable/engine/test/api/runtime/subProcess.bpmn20.xml"})
     public void testProcessInstanceCancelledEvents_cancelProcessHierarchy() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("nestedSimpleSubProcess");
@@ -464,6 +477,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
         listener.clearEventsReceived();
     }
 
+    @Test
     @Deployment(resources = {"org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
     public void testProcessInstanceCancelledEvents_complete() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -479,6 +493,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment(resources = {"org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
     public void testProcessInstanceTerminatedEvents_complete() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -491,6 +506,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
         assertEquals("There should be no FlowableEventType.PROCESS_TERMINATED event after process complete.", 0, processTerminatedEvents.size());
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testProcessTerminate.bpmn")
     public void testProcessInstanceTerminatedEvents() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
@@ -522,6 +538,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment(resources = {"org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateInCallActivity.bpmn",
             "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.subProcessTerminate.bpmn"})
     public void testProcessInstanceTerminatedEvents_callActivity() throws Exception {
@@ -540,6 +557,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment(resources = {"org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateInSubProcessWithBoundaryTerminateAll.bpmn20.xml"})
     public void testTerminateAllInSubProcess() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventWithBoundary");
@@ -556,6 +574,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment(resources = {"org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateInParentProcess.bpmn",
             "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
     public void testProcessInstanceTerminatedEvents_terminateInParentProcess() throws Exception {
@@ -596,6 +615,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment(resources = {
             "org/flowable/engine/test/bpmn/event/error/BoundaryErrorEventTest.testCatchErrorOnCallActivity-parent.bpmn20.xml",
             "org/flowable/engine/test/bpmn/event/error/BoundaryErrorEventTest.subprocess.bpmn20.xml"
@@ -626,6 +646,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
         assertProcessEnded(pi.getId());
     }
 
+    @Test
     @Deployment(resources = {
             "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testParallelCallActivity.bpmn20.xml",
             "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml"})
@@ -644,6 +665,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
         assertEquals(0, taskService.createTaskQuery().count());
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/runtime/subProcessWithTerminateEnd.bpmn20.xml")
     public void testProcessInstanceTerminatedEventInSubProcess() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("subProcessWithTerminateEndTest");
@@ -684,6 +706,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
     }
 
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/runtime/multipleSubprocessTerminateEnd.bpmn20.xml")
     public void testProcessInstanceWithMultipleSubprocessAndTerminateEnd2() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("multiplesubProcessWithTerminateEndTest");
@@ -760,17 +783,15 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
 
     }
 
-    @Override
-    protected void initializeServices() {
-        super.initializeServices();
+    @BeforeEach
+    protected void setUp() {
         this.listener = new TestInitializedEntityEventListener();
         processEngineConfiguration.getEventDispatcher().addEventListener(this.listener);
         FilteredStaticTestFlowableEventListener.clearEventsReceived();
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
 
         if (listener != null) {
             listener.clearEventsReceived();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ProcessInstanceNameListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ProcessInstanceNameListenerTest.java
@@ -28,6 +28,10 @@ import org.flowable.engine.delegate.event.AbstractFlowableEngineEventListener;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link FlowableEngineEventType#PROCESS_CREATED} event.
@@ -38,6 +42,7 @@ public class ProcessInstanceNameListenerTest extends PluggableFlowableTestCase {
 
     private TestInitializedEntityEventListener listener;
 
+    @Test
     @Deployment(resources = {"org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
     public void testProcessCreateProcessNameEvent() throws Exception {
         ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().
@@ -51,6 +56,7 @@ public class ProcessInstanceNameListenerTest extends PluggableFlowableTestCase {
                 listener.getProcessName(), is("oneTaskProcessInstanceName"));
     }
 
+    @Test
     public void testCallActivityProcessCreatedDefinitionName() throws Exception {
         BpmnModel mainBpmnModel = loadBPMNModel("org/flowable/engine/test/bpmn/subprocess/SubProcessTest.testSuspendedProcessCallActivity_mainProcess.bpmn.xml");
         BpmnModel childBpmnModel = loadBPMNModel("org/flowable/engine/test/bpmn/subprocess/SubProcessTest.testSuspendedProcessCallActivity_childProcess.bpmn.xml");
@@ -69,16 +75,14 @@ public class ProcessInstanceNameListenerTest extends PluggableFlowableTestCase {
         repositoryService.deleteDeployment(childDeployment.getId());
     }
 
-    @Override
-    protected void initializeServices() {
-        super.initializeServices();
+    @BeforeEach
+    protected void setUp() {
         this.listener = new TestInitializedEntityEventListener();
         processEngineConfiguration.getEventDispatcher().addEventListener(this.listener, FlowableEngineEventType.PROCESS_CREATED);
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
 
         if (listener != null) {
             processEngineConfiguration.getEventDispatcher().removeEventListener(listener);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/SignalThrowingEventListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/SignalThrowingEventListenerTest.java
@@ -21,6 +21,7 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test case for all {@link FlowableEventListener}s that throws a signal BPMN event when an {@link FlowableEvent} has been dispatched.
@@ -29,6 +30,7 @@ import org.flowable.job.api.Job;
  */
 public class SignalThrowingEventListenerTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testThrowSignal() throws Exception {
         SignalThrowingEventListener listener = null;
@@ -62,6 +64,7 @@ public class SignalThrowingEventListenerTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testThrowSignalDefinedInProcessDefinition() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testSignal");
@@ -83,6 +86,7 @@ public class SignalThrowingEventListenerTest extends PluggableFlowableTestCase {
         assertNotNull(boundaryTask);
     }
 
+    @Test
     @Deployment
     public void testThrowSignalInterrupting() throws Exception {
         SignalThrowingEventListener listener = null;
@@ -118,6 +122,7 @@ public class SignalThrowingEventListenerTest extends PluggableFlowableTestCase {
     /**
      * Test signal throwing when a job failed and the retries are decremented, effectively starting a new transaction.
      */
+    @Test
     @Deployment
     public void testThrowSignalInNewTransaction() throws Exception {
         SignalThrowingEventListener listener = null;
@@ -163,6 +168,7 @@ public class SignalThrowingEventListenerTest extends PluggableFlowableTestCase {
     /**
      * Test signal throwing when a job failed, signaling will happen in the rolled back transaction, not doing anything in the end...
      */
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/event/SignalThrowingEventListenerTest.testThrowSignalInNewTransaction.bpmn20.xml" })
     public void testThrowSignalInRolledbackTransaction() throws Exception {
         SignalThrowingEventListener listener = null;
@@ -209,6 +215,7 @@ public class SignalThrowingEventListenerTest extends PluggableFlowableTestCase {
     /**
      * Test if an engine-wide signal is thrown as response to a dispatched event.
      */
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/event/SignalThrowingEventListenerTest.globalSignal.bpmn20.xml",
             "org/flowable/engine/test/api/event/SignalThrowingEventListenerTest.globalSignalExternalProcess.bpmn20.xml" })
     public void testGlobalSignal() throws Exception {
@@ -253,6 +260,7 @@ public class SignalThrowingEventListenerTest extends PluggableFlowableTestCase {
     /**
      * Test if an engine-wide signal is thrown as response to a dispatched event.
      */
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/event/SignalThrowingEventListenerTest.globalSignalDefinedInProcessDefinition.bpmn20.xml",
             "org/flowable/engine/test/api/event/SignalThrowingEventListenerTest.globalSignalExternalProcess.bpmn20.xml" })
     public void testGlobalSignalDefinedInProcessDefinition() throws Exception {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/TaskEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/TaskEventsTest.java
@@ -24,6 +24,9 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.task.service.impl.persistence.entity.TaskEntity;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test case for all {@link FlowableEvent}s related to tasks.
@@ -37,6 +40,7 @@ public class TaskEventsTest extends PluggableFlowableTestCase {
     /**
      * Check create, update and delete events for a task.
      */
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testTaskEventsInProcess() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -116,6 +120,7 @@ public class TaskEventsTest extends PluggableFlowableTestCase {
         waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testTaskAssignmentEventInProcess() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -185,6 +190,7 @@ public class TaskEventsTest extends PluggableFlowableTestCase {
     /**
      * Check events related to process instance delete and standalone task delete.
      */
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testDeleteEventDoesNotDispathComplete() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -243,6 +249,7 @@ public class TaskEventsTest extends PluggableFlowableTestCase {
      * This method checks to ensure that the task.fireEvent(TaskListener.EVENTNAME_CREATE), fires before the dispatchEvent FlowableEventType.TASK_CREATED. A ScriptTaskListener updates the priority and
      * assignee before the dispatchEvent() takes place.
      */
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/event/TaskEventsTest.testEventFiring.bpmn20.xml" })
     public void testEventFiringOrdering() {
         // We need to add a special listener that copies the org.flowable.task.service.Task values - to record its state when the event fires,
@@ -290,6 +297,7 @@ public class TaskEventsTest extends PluggableFlowableTestCase {
     /**
      * Check all events for tasks not related to a process-instance
      */
+    @Test
     public void testStandaloneTaskEvents() throws Exception {
 
         org.flowable.task.api.Task task = null;
@@ -394,16 +402,14 @@ public class TaskEventsTest extends PluggableFlowableTestCase {
         assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
     }
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
         listener = new TestFlowableEntityEventListener(org.flowable.task.api.Task.class);
         processEngineConfiguration.getEventDispatcher().addEventListener(listener);
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
 
         if (listener != null) {
             processEngineConfiguration.getEventDispatcher().removeEventListener(listener);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/TransactionEventListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/TransactionEventListenerTest.java
@@ -26,20 +26,22 @@ import org.flowable.engine.delegate.DelegateExecution;
 import org.flowable.engine.delegate.JavaDelegate;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TransactionEventListenerTest extends PluggableFlowableTestCase {
 
     protected TestTransactionEventListener onCommitListener;
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
 
         onCommitListener = new TestTransactionEventListener(TransactionState.COMMITTED.name());
         processEngineConfiguration.getEventDispatcher().addEventListener(onCommitListener);
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
         TestTransactionEventListener.eventsReceived.clear();
         if (onCommitListener != null) {
@@ -47,9 +49,9 @@ public class TransactionEventListenerTest extends PluggableFlowableTestCase {
             onCommitListener = null;
         }
 
-        super.tearDown();
     }
 
+    @Test
     public void testRegularProcessExecution() {
 
         assertEquals(0, TestTransactionEventListener.eventsReceived.size());
@@ -80,6 +82,7 @@ public class TransactionEventListenerTest extends PluggableFlowableTestCase {
         assertEquals(1, TestTransactionEventListener.eventsReceived.get(FlowableEngineEventType.PROCESS_COMPLETED.name()).size());
     }
 
+    @Test
     @Deployment
     public void testProcessExecutionWithRollback() {
 
@@ -102,6 +105,7 @@ public class TransactionEventListenerTest extends PluggableFlowableTestCase {
         assertEquals(1, runtimeService.createProcessInstanceQuery().count());
     }
 
+    @Test
     @Deployment
     public void testProcessDefinitionDefinedEventListener() {
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/UncaughtErrorEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/UncaughtErrorEventTest.java
@@ -16,6 +16,9 @@ import org.flowable.common.engine.api.delegate.event.FlowableEvent;
 import org.flowable.engine.delegate.BpmnError;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link FlowableEvent} thrown when a BPMNError is not caught in the process.
@@ -29,6 +32,7 @@ public class UncaughtErrorEventTest extends PluggableFlowableTestCase {
     /**
      * Test events related to error-events, thrown from within process-execution (eg. service-task).
      */
+    @Test
     @Deployment
     public void testUncaughtError() throws Exception {
         try {
@@ -39,17 +43,15 @@ public class UncaughtErrorEventTest extends PluggableFlowableTestCase {
         }
     }
 
-    @Override
-    protected void initializeServices() {
-        super.initializeServices();
+    @BeforeEach
+    public void setUp() {
 
         listener = new TestFlowableEventListener();
         processEngineConfiguration.getEventDispatcher().addEventListener(listener);
     }
 
-    @Override
-    protected void tearDown() throws Exception {
-        super.tearDown();
+    @AfterEach
+    public void tearDown() throws Exception {
 
         if (listener != null) {
             listener.clearEventsReceived();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/UserEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/UserEventsTest.java
@@ -17,6 +17,9 @@ import org.flowable.common.engine.api.delegate.event.FlowableEvent;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.idm.api.User;
 import org.flowable.idm.api.event.FlowableIdmEventType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test case for all {@link FlowableEvent}s related to users.
@@ -30,6 +33,7 @@ public class UserEventsTest extends PluggableFlowableTestCase {
     /**
      * Test create, update and delete events of users.
      */
+    @Test
     public void testUserEntityEvents() throws Exception {
         User user = null;
         try {
@@ -79,16 +83,14 @@ public class UserEventsTest extends PluggableFlowableTestCase {
         }
     }
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
         listener = new TestFlowableEntityEventListener(User.class);
         processEngineConfiguration.getEventDispatcher().addEventListener(listener);
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
 
         if (listener != null) {
             processEngineConfiguration.getEventDispatcher().removeEventListener(listener);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/VariableEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/VariableEventsTest.java
@@ -31,6 +31,9 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.variable.api.event.FlowableVariableEvent;
 import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test case for all {@link FlowableEvent}s related to variables.
@@ -44,6 +47,7 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
     /**
      * Test create, update and delete variables on a process-instance, using the API.
      */
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testProcessInstanceVariableEvents() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -112,6 +116,7 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
         assertTrue(listener.getEventsReceived().isEmpty());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testStartEndProcessInstanceVariableEvents() throws Exception {
         Map<String, Object> variables = new HashMap<>();
@@ -131,6 +136,7 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
     /**
      * Test create event of variables when process is started with variables passed in.
      */
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testProcessInstanceVariableEventsOnStart() throws Exception {
 
@@ -156,6 +162,7 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
     /**
      * Test create, update and delete variables locally on a child-execution of the process instance.
      */
+    @Test
     @Deployment
     public void testProcessInstanceVariableEventsOnChildExecution() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("variableProcess");
@@ -175,6 +182,7 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
         assertEquals(processInstance.getId(), event.getProcessInstanceId());
     }
 
+    @Test
     @Deployment
     public void testProcessInstanceVariableEventsOnCallActivity() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("callVariableProcess",
@@ -239,6 +247,7 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
     /**
      * Test variable events when done within a process (eg. execution-listener)
      */
+    @Test
     @Deployment
     public void testProcessInstanceVariableEventsWithinProcess() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("variableProcess");
@@ -281,6 +290,7 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
     /**
      * Test create, update and delete of task-local variables.
      */
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testTaskVariableEvents() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -326,6 +336,7 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
     /**
      * Test variable events when done within a process (eg. execution-listener)
      */
+    @Test
     @Deployment
     public void testTaskVariableEventsWithinProcess() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("variableProcess");
@@ -369,6 +380,7 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
     /**
      * Test to check create, update an delete behavior for variables on a task not related to a process.
      */
+    @Test
     public void testTaskVariableStandalone() throws Exception {
         org.flowable.task.api.Task newTask = taskService.newTask();
         try {
@@ -422,6 +434,7 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/processVariableEvent.bpmn20.xml" })
     public void testProcessInstanceVariableEventsForModeledDataObjectOnStart() throws Exception {
 
@@ -457,6 +470,7 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
     /**
      * Test variables event for modeled data objects on callActivity.
      */
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/callActivity.bpmn20.xml", "org/flowable/engine/test/api/runtime/calledActivity.bpmn20.xml" })
     public void testProcessInstanceVariableEventsForModeledDataObjectOnCallActivityStart() throws Exception {
 
@@ -500,18 +514,14 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
         assertEquals("var1 value", event.getVariableValue());
     }
 
-    @Override
-    protected void initializeServices() {
-        super.initializeServices();
-
+    @BeforeEach
+    public void setUp() {
         listener = new TestVariableEventListener();
         processEngineConfiguration.getEventDispatcher().addEventListener(listener);
     }
 
-    @Override
-    protected void tearDown() throws Exception {
-        super.tearDown();
-
+    @AfterEach
+    public void tearDown() throws Exception {
         if (listener != null) {
             listener.clearEventsReceived();
             processEngineConfiguration.getEventDispatcher().removeEventListener(listener);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/form/FormPropertyDefaultValueTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/form/FormPropertyDefaultValueTest.java
@@ -22,9 +22,11 @@ import org.flowable.engine.form.TaskFormData;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 public class FormPropertyDefaultValueTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testDefaultValue() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("FormPropertyDefaultValueTest.testDefaultValue");
@@ -59,6 +61,7 @@ public class FormPropertyDefaultValueTest extends PluggableFlowableTestCase {
         assertEquals(1L, runtimeService.getVariable(processInstance.getId(), "longExpressionProperty"));
     }
 
+    @Test
     @Deployment
     public void testStartFormDefaultValue() throws Exception {
         String processDefinitionId = repositoryService.createProcessDefinitionQuery().processDefinitionKey("FormPropertyDefaultValueTest.testDefaultValue").latestVersion().singleResult().getId();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/form/FormServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/form/FormServiceTest.java
@@ -32,6 +32,8 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.repository.ProcessDefinition;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.flowable.engine.test.DeploymentId;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
@@ -41,6 +43,7 @@ import org.flowable.engine.test.Deployment;
  */
 public class FormServiceTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment(resources = { "org/flowable/examples/taskforms/VacationRequest_deprecated_forms.bpmn20.xml", "org/flowable/examples/taskforms/approve.form",
             "org/flowable/examples/taskforms/request.form", "org/flowable/examples/taskforms/adjustRequest.form" })
     public void testGetStartFormByProcessDefinitionId() {
@@ -52,6 +55,7 @@ public class FormServiceTest extends PluggableFlowableTestCase {
         assertNotNull(startForm);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testGetStartFormByProcessDefinitionIdWithoutStartform() {
         List<ProcessDefinition> processDefinitions = repositoryService.createProcessDefinitionQuery().list();
@@ -62,6 +66,7 @@ public class FormServiceTest extends PluggableFlowableTestCase {
         assertNull(startForm);
     }
 
+    @Test
     public void testGetStartFormByKeyNullKey() {
         try {
             formService.getRenderedStartForm(null);
@@ -71,6 +76,7 @@ public class FormServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testGetStartFormByIdNullId() {
         try {
             formService.getRenderedStartForm(null);
@@ -80,6 +86,7 @@ public class FormServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testGetStartFormByIdUnexistingProcessDefinitionId() {
         try {
             formService.getRenderedStartForm("unexistingId");
@@ -90,6 +97,7 @@ public class FormServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testGetTaskFormNullTaskId() {
         try {
             formService.getRenderedTaskForm(null);
@@ -99,6 +107,7 @@ public class FormServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testGetTaskFormUnexistingTaskId() {
         try {
             formService.getRenderedTaskForm("unexistingtask");
@@ -109,8 +118,9 @@ public class FormServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/form/FormsProcess.bpmn20.xml", "org/flowable/engine/test/api/form/start.form", "org/flowable/engine/test/api/form/task.form" })
-    public void testTaskFormPropertyDefaultsAndFormRendering() {
+    public void testTaskFormPropertyDefaultsAndFormRendering(@DeploymentId String deploymentIdFromDeploymentAnnotation) {
         String procDefId = repositoryService.createProcessDefinitionQuery().singleResult().getId();
         StartFormData startForm = formService.getStartFormData(procDefId);
         assertNotNull(startForm);
@@ -156,6 +166,7 @@ public class FormServiceTest extends PluggableFlowableTestCase {
         assertEquals(expectedVariables, variables);
     }
 
+    @Test
     @Deployment
     public void testFormPropertyHandling() {
         Map<String, String> properties = new HashMap<>();
@@ -247,6 +258,7 @@ public class FormServiceTest extends PluggableFlowableTestCase {
         assertEquals(expectedVariables, variables);
     }
 
+    @Test
     @Deployment
     public void testFormPropertyExpression() {
         Map<String, Object> varMap = new HashMap<>();
@@ -276,6 +288,7 @@ public class FormServiceTest extends PluggableFlowableTestCase {
     }
 
     @SuppressWarnings("unchecked")
+    @Test
     @Deployment
     public void testFormPropertyDetails() {
         String procDefId = repositoryService.createProcessDefinitionQuery().singleResult().getId();
@@ -322,6 +335,7 @@ public class FormServiceTest extends PluggableFlowableTestCase {
         assertEquals(expectedValues, values);
     }
 
+    @Test
     @Deployment
     public void testInvalidFormKeyReference() {
         try {
@@ -332,6 +346,7 @@ public class FormServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testSubmitStartFormDataWithBusinessKey() {
         Map<String, String> properties = new HashMap<>();
@@ -345,6 +360,7 @@ public class FormServiceTest extends PluggableFlowableTestCase {
         assertEquals(processInstance.getId(), runtimeService.createProcessInstanceQuery().processInstanceBusinessKey("123").singleResult().getId());
     }
 
+    @Test
     public void testGetStartFormKeyEmptyArgument() {
         try {
             formService.getStartFormKey(null);
@@ -361,6 +377,7 @@ public class FormServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/form/FormsProcess.bpmn20.xml")
     public void testGetStartFormKey() {
         String processDefinitionId = repositoryService.createProcessDefinitionQuery().singleResult().getId();
@@ -369,6 +386,7 @@ public class FormServiceTest extends PluggableFlowableTestCase {
         assertEquals(expectedFormKey, actualFormKey);
     }
 
+    @Test
     public void testGetTaskFormKeyEmptyArguments() {
         try {
             formService.getTaskFormKey(null, "23");
@@ -399,6 +417,7 @@ public class FormServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/form/FormsProcess.bpmn20.xml")
     public void testGetTaskFormKey() {
         String processDefinitionId = repositoryService.createProcessDefinitionQuery().singleResult().getId();
@@ -410,6 +429,7 @@ public class FormServiceTest extends PluggableFlowableTestCase {
         assertEquals(expectedFormKey, actualFormKey);
     }
 
+    @Test
     @Deployment
     public void testGetTaskFormKeyWithExpression() {
         runtimeService.startProcessInstanceByKey("FormsProcess", CollectionUtil.singletonMap("dynamicKey", "test"));
@@ -418,6 +438,7 @@ public class FormServiceTest extends PluggableFlowableTestCase {
         assertEquals("test", formService.getTaskFormData(task.getId()).getFormKey());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testSubmitTaskFormData() {
         List<ProcessDefinition> processDefinitions = repositoryService.createProcessDefinitionQuery().list();
@@ -440,6 +461,7 @@ public class FormServiceTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testSaveFormData() {
         List<ProcessDefinition> processDefinitions = repositoryService.createProcessDefinitionQuery().list();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricProcessInstanceAndVariablesQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricProcessInstanceAndVariablesQueryTest.java
@@ -22,6 +22,9 @@ import org.flowable.engine.history.HistoricProcessInstance;
 import org.flowable.engine.history.HistoricProcessInstanceQuery;
 import org.flowable.engine.impl.test.HistoryTestHelper;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tijs Rademakers
@@ -39,9 +42,8 @@ public class HistoricProcessInstanceAndVariablesQueryTest extends PluggableFlowa
     /**
      * Setup starts 4 process instances of oneTaskProcess and 1 instance of oneTaskProcess2
      */
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
         repositoryService.createDeployment()
                 .addClasspathResource("org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml")
                 .addClasspathResource("org/flowable/engine/test/api/runtime/oneTaskProcess2.bpmn20.xml")
@@ -68,13 +70,13 @@ public class HistoricProcessInstanceAndVariablesQueryTest extends PluggableFlowa
         processInstanceIds.add(runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY_3, "1", startMap).getId());
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
         deleteDeployments();
         
-        super.tearDown();
     }
 
+    @Test
     public void testQuery() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             HistoricProcessInstance processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().variableValueEquals("anothertest", 123).singleResult();
@@ -184,6 +186,7 @@ public class HistoricProcessInstanceAndVariablesQueryTest extends PluggableFlowa
         }
     }
 
+    @Test
     public void testQueryByprocessDefinition() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // DeploymentId
@@ -224,6 +227,7 @@ public class HistoricProcessInstanceAndVariablesQueryTest extends PluggableFlowa
         }
     }
     
+    @Test
     public void testQueryByVariableExist() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // DeploymentId
@@ -254,6 +258,7 @@ public class HistoricProcessInstanceAndVariablesQueryTest extends PluggableFlowa
         }
     }
 
+    @Test
     public void testOrQuery() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             HistoricProcessInstance processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().or().variableValueEquals("anothertest", 123)
@@ -374,6 +379,7 @@ public class HistoricProcessInstanceAndVariablesQueryTest extends PluggableFlowa
         }
     }
 
+    @Test
     public void testOrQueryMultipleVariableValues() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             HistoricProcessInstanceQuery query0 = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().or();
@@ -425,6 +431,7 @@ public class HistoricProcessInstanceAndVariablesQueryTest extends PluggableFlowa
         }
     }
 
+    @Test
     public void testOrQueryByprocessDefinition() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // DeploymentId

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricProcessInstanceQueryAndWithExceptionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricProcessInstanceQueryAndWithExceptionTest.java
@@ -21,6 +21,9 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.job.api.Job;
 import org.flowable.job.api.TimerJobQuery;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class HistoricProcessInstanceQueryAndWithExceptionTest extends PluggableFlowableTestCase {
 
@@ -28,9 +31,8 @@ public class HistoricProcessInstanceQueryAndWithExceptionTest extends PluggableF
     private static final String PROCESS_DEFINITION_KEY_WITH_EXCEPTION_1 = "JobErrorCheck";
     private static final String PROCESS_DEFINITION_KEY_WITH_EXCEPTION_2 = "JobErrorDoubleCheck";
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
         repositoryService.createDeployment()
                 .addClasspathResource("org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml")
                 .addClasspathResource("org/flowable/engine/test/api/runtime/JobErrorCheck.bpmn20.xml")
@@ -38,12 +40,12 @@ public class HistoricProcessInstanceQueryAndWithExceptionTest extends PluggableF
                 .deploy();
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
         deleteDeployments();
-        super.tearDown();
     }
 
+    @Test
     public void testQueryWithException() throws InterruptedException {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             ProcessInstance processNoException = runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY_NO_EXCEPTION);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricProcessInstanceQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricProcessInstanceQueryTest.java
@@ -20,11 +20,13 @@ import org.flowable.engine.impl.test.HistoryTestHelper;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 public class HistoricProcessInstanceQueryTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testLocalization() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("historicProcessLocalization");
@@ -84,6 +86,7 @@ public class HistoricProcessInstanceQueryTest extends PluggableFlowableTestCase 
         }
     }
     
+    @Test
     public void testQueryByDeploymentId() {
         deployOneTaskTestProcess();
         String deploymentId = repositoryService.createDeploymentQuery().singleResult().getId();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricProcessInstanceQueryVersionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricProcessInstanceQueryVersionTest.java
@@ -19,15 +19,17 @@ import org.flowable.common.engine.impl.history.HistoryLevel;
 import org.flowable.engine.history.HistoricProcessInstance;
 import org.flowable.engine.impl.test.HistoryTestHelper;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class HistoricProcessInstanceQueryVersionTest extends PluggableFlowableTestCase {
 
     private static final String PROCESS_DEFINITION_KEY = "oneTaskProcess";
     private static final String DEPLOYMENT_FILE_PATH = "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml";
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
         repositoryService.createDeployment()
                 .addClasspathResource(DEPLOYMENT_FILE_PATH)
                 .deploy();
@@ -47,11 +49,12 @@ public class HistoricProcessInstanceQueryVersionTest extends PluggableFlowableTe
         waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
         deleteDeployments();
     }
 
+    @Test
     public void testHistoricProcessInstanceQueryByProcessDefinitionVersion() {
         assertEquals(1, historyService.createHistoricProcessInstanceQuery().processDefinitionVersion(1).list().get(0).getProcessDefinitionVersion().intValue());
         assertEquals(2, historyService.createHistoricProcessInstanceQuery().processDefinitionVersion(2).list().get(0).getProcessDefinitionVersion().intValue());
@@ -82,6 +85,7 @@ public class HistoricProcessInstanceQueryVersionTest extends PluggableFlowableTe
         }
     }
 
+    @Test
     public void testHistoricProcessInstanceQueryByProcessDefinitionVersionAndKey() {
         assertEquals(1, historyService.createHistoricProcessInstanceQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(1).count());
         assertEquals(1, historyService.createHistoricProcessInstanceQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(2).count());
@@ -93,6 +97,7 @@ public class HistoricProcessInstanceQueryVersionTest extends PluggableFlowableTe
         assertEquals(0, historyService.createHistoricProcessInstanceQuery().processDefinitionKey("undefined").processDefinitionVersion(2).list().size());
     }
 
+    @Test
     public void testHistoricProcessInstanceOrQueryByProcessDefinitionVersion() {
         assertEquals(1, historyService.createHistoricProcessInstanceQuery().or().processDefinitionVersion(1).processDefinitionId("undefined").endOr().count());
         assertEquals(1, historyService.createHistoricProcessInstanceQuery().or().processDefinitionVersion(2).processDefinitionId("undefined").endOr().count());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricTaskAndVariablesQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricTaskAndVariablesQueryTest.java
@@ -29,6 +29,9 @@ import org.flowable.identitylink.api.IdentityLinkInfo;
 import org.flowable.identitylink.api.IdentityLinkType;
 import org.flowable.task.api.history.HistoricTaskInstance;
 import org.flowable.task.api.history.HistoricTaskInstanceQuery;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tijs Rademakers
@@ -37,7 +40,7 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
 
     private List<String> taskIds;
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
 
         identityService.saveUser(identityService.newUser("kermit"));
@@ -54,7 +57,7 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
         taskIds = generateTestTasks();
     }
 
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
         identityService.deleteGroup("accountancy");
         identityService.deleteGroup("management");
@@ -64,6 +67,7 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
         taskService.deleteTasks(taskIds, true);
     }
 
+    @Test
     @Deployment
     public void testQuery() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
@@ -179,6 +183,7 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
         }
     }
 
+    @Test
     @Deployment
     public void testOrQuery() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
@@ -339,6 +344,7 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
         }
     }
 
+    @Test
     @Deployment
     public void testOrQueryMultipleVariableValues() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
@@ -371,6 +377,7 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
         }
     }
 
+    @Test
     @Deployment
     public void testCandidate() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
@@ -432,6 +439,7 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
         }
     }
     
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/history/HistoricTaskAndVariablesQueryTest.testCandidate.bpmn20.xml" })
     public void testIgnoreAssigneeValue() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
@@ -475,6 +483,7 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
         }
     }
 
+    @Test
     @Deployment(resources = {"org/flowable/engine/test/api/history/HistoricTaskAndVariablesQueryTest.testCandidate.bpmn20.xml"})
     public void testIgnoreAssigneeValueOr() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
@@ -510,6 +519,7 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
         }
     }
 
+    @Test
     public void testQueryWithPagingAndVariables() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             List<HistoricTaskInstance> tasks = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().includeTaskLocalVariables().orderByTaskPriority().desc().listPage(0, 1);
@@ -541,6 +551,7 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
         }
     }
 
+    @Test
     public void testQueryWithPagingVariablesAndIdentityLinks() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             
@@ -594,6 +605,7 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
         }
     }
     
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/history/HistoricTaskAndVariablesQueryTest.testCandidate.bpmn20.xml" })
     public void testQueryVariableExists() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
@@ -656,6 +668,7 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml" })
     public void testWithoutDueDateQuery() throws Exception {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
@@ -690,6 +703,7 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
     }
 
     // Unit test for https://activiti.atlassian.net/browse/ACT-4152
+    @Test
     public void testQueryWithIncludeTaskVariableAndTaskCategory() {
         List<HistoricTaskInstance> tasks = historyService.createHistoricTaskInstanceQuery().taskAssignee("gonzo").list();
         for (HistoricTaskInstance task : tasks) {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoryLevelServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoryLevelServiceTest.java
@@ -26,6 +26,7 @@ import org.flowable.engine.test.Deployment;
 import org.flowable.task.api.Task;
 import org.flowable.task.api.history.HistoricTaskInstance;
 import org.flowable.variable.api.history.HistoricVariableInstance;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tijs Rademakers
@@ -33,6 +34,7 @@ import org.flowable.variable.api.history.HistoricVariableInstance;
 public class HistoryLevelServiceTest extends PluggableFlowableTestCase {
 
   @Deployment(resources = { "org/flowable/engine/test/api/history/oneTaskHistoryLevelNoneProcess.bpmn20.xml" })
+  @Test
   public void testNoneHistoryLevel() {
     // With a clean ProcessEngine, no instances should be available
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -62,6 +64,7 @@ public class HistoryLevelServiceTest extends PluggableFlowableTestCase {
   }
   
   @Deployment(resources = { "org/flowable/engine/test/api/history/oneTaskHistoryLevelActivityProcess.bpmn20.xml" })
+  @Test
   public void testActivityHistoryLevel() {
     // With a clean ProcessEngine, no instances should be available
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -119,6 +122,7 @@ public class HistoryLevelServiceTest extends PluggableFlowableTestCase {
   }
   
   @Deployment(resources = { "org/flowable/engine/test/api/history/oneTaskHistoryLevelAuditProcess.bpmn20.xml" })
+  @Test
   public void testAuditHistoryLevel() {
     // With a clean ProcessEngine, no instances should be available
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -184,6 +188,7 @@ public class HistoryLevelServiceTest extends PluggableFlowableTestCase {
   }
   
   @Deployment(resources = { "org/flowable/engine/test/api/history/oneTaskHistoryLevelFullProcess.bpmn20.xml" })
+  @Test
   public void testFullHistoryLevel() {
     // With a clean ProcessEngine, no instances should be available
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoryServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoryServiceTest.java
@@ -36,6 +36,9 @@ import org.flowable.engine.test.api.runtime.ProcessInstanceQueryTest;
 import org.flowable.task.api.TaskQuery;
 import org.flowable.task.api.history.HistoricTaskInstance;
 import org.flowable.task.api.history.HistoricTaskInstanceQuery;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -45,6 +48,9 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
  */
 public class HistoryServiceTest extends PluggableFlowableTestCase {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(HistoryServiceTest.class);
+
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testHistoricProcessInstanceQuery() {
         // With a clean ProcessEngine, no instances should be available
@@ -65,6 +71,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         assertEquals(1, historyService.createHistoricProcessInstanceQuery().count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testHistoricProcessInstanceQueryOrderBy() {
         // With a clean ProcessEngine, no instances should be available
@@ -94,6 +101,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         historyService.createHistoricTaskInstanceQuery().orderByTaskPriority().asc().list();
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testHistoricProcessInstanceUserIdAndActivityId() {
         identityService.setAuthenticatedUserId("johndoe");
@@ -115,6 +123,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         assertEquals("theEnd", historicProcessInstance.getEndActivityId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/examples/bpmn/callactivity/orderProcess.bpmn20.xml", "org/flowable/examples/bpmn/callactivity/checkCreditProcess.bpmn20.xml" })
     public void testOrderProcessWithCallActivity() {
         // After the process has started, the 'verify credit history' task should be active
@@ -135,6 +144,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         assertTrue(historicProcessInstance.getProcessDefinitionId().contains("checkCreditProcess"));
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/examples/bpmn/callactivity/orderProcess.bpmn20.xml", "org/flowable/examples/bpmn/callactivity/checkCreditProcess.bpmn20.xml" })
     public void testExcludeSubprocesses() {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("orderProcess");
@@ -149,6 +159,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         assertEquals(2, instanceList.size());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml", "org/flowable/examples/bpmn/callactivity/orderProcess.bpmn20.xml",
             "org/flowable/examples/bpmn/callactivity/checkCreditProcess.bpmn20.xml" })
     public void testHistoricProcessInstanceQueryByProcessDefinitionKey() {
@@ -178,6 +189,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         assertEquals(historicProcessInstanceSuper.getId(), historicProcessInstanceSub.getSuperProcessInstanceId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml", "org/flowable/engine/test/api/runtime/oneTaskProcess2.bpmn20.xml" })
     public void testHistoricProcessInstanceQueryByProcessInstanceIds() {
         HashSet<String> processInstanceIds = new HashSet<>();
@@ -203,6 +215,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testHistoricProcessInstanceQueryByProcessInstanceIdsEmpty() {
         try {
             historyService.createHistoricProcessInstanceQuery().processInstanceIds(new HashSet<>());
@@ -212,6 +225,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testHistoricProcessInstanceQueryByProcessInstanceIdsNull() {
         try {
             historyService.createHistoricProcessInstanceQuery().processInstanceIds(null);
@@ -221,6 +235,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testHistoricProcessInstanceQueryForDelete() {
         String processInstanceId = runtimeService.startProcessInstanceByKey("oneTaskProcess").getId();
@@ -271,6 +286,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         assertEquals(0, processInstanceQuery.count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml", "org/flowable/engine/test/api/runtime/oneTaskProcess2.bpmn20.xml" })
     public void testHistoricProcessInstanceQueryByDeploymentId() {
         org.flowable.engine.repository.Deployment deployment = repositoryService.createDeploymentQuery().singleResult();
@@ -293,6 +309,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         assertEquals(0, processInstanceQuery.count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml", "org/flowable/engine/test/api/runtime/oneTaskProcess2.bpmn20.xml" })
     public void testHistoricProcessInstanceQueryByDeploymentIdIn() {
         org.flowable.engine.repository.Deployment deployment = repositoryService.createDeploymentQuery().singleResult();
@@ -319,6 +336,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         assertEquals(0, processInstanceQuery.count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml", "org/flowable/engine/test/api/runtime/oneTaskProcess2.bpmn20.xml" })
     public void testHistoricTaskInstanceQueryByDeploymentId() {
         org.flowable.engine.repository.Deployment deployment = repositoryService.createDeploymentQuery().singleResult();
@@ -340,6 +358,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         assertEquals(0, taskInstanceQuery.count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml", "org/flowable/engine/test/api/runtime/oneTaskProcess2.bpmn20.xml" })
     public void testHistoricTaskInstanceQueryByDeploymentIdIn() {
         org.flowable.engine.repository.Deployment deployment = repositoryService.createDeploymentQuery().singleResult();
@@ -369,6 +388,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         assertEquals(0, taskInstanceQuery.count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml", "org/flowable/engine/test/api/runtime/oneTaskProcess2.bpmn20.xml" })
     public void testHistoricTaskInstanceOrQueryByDeploymentId() {
         org.flowable.engine.repository.Deployment deployment = repositoryService.createDeploymentQuery().singleResult();
@@ -454,6 +474,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         assertEquals(0, taskInstanceQuery.count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml", "org/flowable/engine/test/api/runtime/oneTaskProcess2.bpmn20.xml" })
     public void testHistoricTaskInstanceOrQueryByDeploymentIdIn() {
         org.flowable.engine.repository.Deployment deployment = repositoryService.createDeploymentQuery().singleResult();
@@ -489,6 +510,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         assertEquals(0, taskInstanceQuery.count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testLocalizeTasks() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -537,6 +559,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         assertNull(task.getDescription());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/concurrentExecution.bpmn20.xml" })
     public void testHistoricVariableInstancesOnParallelExecution() {
         Map<String, Object> vars = new HashMap<>();
@@ -566,6 +589,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
     /**
      * basically copied from {@link ProcessInstanceQueryTest}
      */
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testQueryStringVariable() {
         Map<String, Object> vars = new HashMap<>();
@@ -675,6 +699,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 5000, 200);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testQueryEqualsIgnoreCase() {
         Map<String, Object> vars = new HashMap<>();
@@ -723,6 +748,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
      * Only do one second type, as the logic is same as in {@link ProcessInstanceQueryTest} and I do not want to duplicate all test case logic here. Basically copied from
      * {@link ProcessInstanceQueryTest}
      */
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testQueryDateVariable() throws Exception {
         Map<String, Object> vars = new HashMap<>();
@@ -838,6 +864,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 5000, 200);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testNativeHistoricProcessInstanceTest() {
         // just test that the query will be constructed and executed, details are tested in the TaskQueryTest
@@ -849,6 +876,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         // managementService.getTableName(HistoricProcessInstance.class)).listPage(0, 1).size());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testNativeHistoricTaskInstanceTest() {
         runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -858,6 +886,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         assertEquals(1, historyService.createNativeHistoricTaskInstanceQuery().sql("SELECT * FROM " + managementService.getTableName(HistoricProcessInstance.class)).listPage(0, 1).size());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testNativeHistoricActivityInstanceTest() {
         runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -867,6 +896,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         assertEquals(1, historyService.createNativeHistoricActivityInstanceQuery().sql("SELECT * FROM " + managementService.getTableName(HistoricProcessInstance.class)).listPage(0, 1).size());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testHistoricProcessInstanceQueryByProcessDefinitionName() {
 
@@ -886,6 +916,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         assertEquals(1, historyService.createHistoricProcessInstanceQuery().or().processDefinitionName(processDefinitionName).processDefinitionId("invalid").endOr().count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testHistoricProcessInstanceQueryByProcessDefinitionCategory() {
         String processDefinitionKey = "oneTaskProcess";

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/NonCascadeDeleteTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/NonCascadeDeleteTest.java
@@ -16,6 +16,7 @@ import org.flowable.common.engine.impl.history.HistoryLevel;
 import org.flowable.engine.history.HistoricProcessInstance;
 import org.flowable.engine.impl.test.HistoryTestHelper;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
+import org.junit.jupiter.api.Test;
 
 public class NonCascadeDeleteTest extends PluggableFlowableTestCase {
 
@@ -25,16 +26,7 @@ public class NonCascadeDeleteTest extends PluggableFlowableTestCase {
 
     private String processInstanceId;
 
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
-    }
-
-    @Override
-    protected void tearDown() throws Exception {
-        super.tearDown();
-    }
-
+    @Test
     public void testHistoricProcessInstanceQuery() {
         deploymentId = repositoryService.createDeployment()
                 .addClasspathResource("org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml")

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/ProcessInstanceLogQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/ProcessInstanceLogQueryTest.java
@@ -26,6 +26,9 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.task.Comment;
 import org.flowable.task.api.history.HistoricTaskInstance;
 import org.flowable.variable.api.history.HistoricVariableInstance;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
@@ -34,9 +37,8 @@ public class ProcessInstanceLogQueryTest extends PluggableFlowableTestCase {
 
     protected String processInstanceId;
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
 
         // Deploy test process
         deployTwoTasksTestProcess();
@@ -63,16 +65,16 @@ public class ProcessInstanceLogQueryTest extends PluggableFlowableTestCase {
         waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
 
         for (Comment comment : taskService.getProcessInstanceComments(processInstanceId)) {
             taskService.deleteComment(comment.getId());
         }
 
-        super.tearDown();
     }
 
+    @Test
     public void testBaseProperties() {
         ProcessInstanceHistoryLog log = historyService.createProcessInstanceHistoryLogQuery(processInstanceId).singleResult();
         assertNotNull(log.getId());
@@ -83,6 +85,7 @@ public class ProcessInstanceLogQueryTest extends PluggableFlowableTestCase {
         assertNotNull(log.getStartTime());
     }
 
+    @Test
     public void testIncludeTasks() {
         ProcessInstanceHistoryLog log = historyService.createProcessInstanceHistoryLogQuery(processInstanceId).includeTasks().singleResult();
         List<HistoricData> events = log.getHistoricData();
@@ -93,6 +96,7 @@ public class ProcessInstanceLogQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testIncludeComments() {
         ProcessInstanceHistoryLog log = historyService.createProcessInstanceHistoryLogQuery(processInstanceId).includeComments().singleResult();
         List<HistoricData> events = log.getHistoricData();
@@ -103,6 +107,7 @@ public class ProcessInstanceLogQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testIncludeTasksAndComments() {
         ProcessInstanceHistoryLog log = historyService.createProcessInstanceHistoryLogQuery(processInstanceId).includeTasks().includeComments().singleResult();
         List<HistoricData> events = log.getHistoricData();
@@ -123,6 +128,7 @@ public class ProcessInstanceLogQueryTest extends PluggableFlowableTestCase {
         assertEquals(3, commentCounter);
     }
 
+    @Test
     public void testIncludeActivities() {
         ProcessInstanceHistoryLog log = historyService.createProcessInstanceHistoryLogQuery(processInstanceId).includeActivities().singleResult();
         List<HistoricData> events = log.getHistoricData();
@@ -133,6 +139,7 @@ public class ProcessInstanceLogQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testIncludeVariables() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.FULL, processEngineConfiguration)) {
             ProcessInstanceHistoryLog log = historyService.createProcessInstanceHistoryLogQuery(processInstanceId).includeVariables().singleResult();
@@ -145,6 +152,7 @@ public class ProcessInstanceLogQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testIncludeVariableUpdates() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.FULL, processEngineConfiguration)) {
             ProcessInstanceHistoryLog log = historyService.createProcessInstanceHistoryLogQuery(processInstanceId).includeVariableUpdates().singleResult();
@@ -157,6 +165,7 @@ public class ProcessInstanceLogQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testEverything() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.FULL, processEngineConfiguration)) {
             ProcessInstanceHistoryLog log = historyService.createProcessInstanceHistoryLogQuery(processInstanceId).includeTasks().includeActivities().includeComments().includeVariables()

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/identity/GroupQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/identity/GroupQueryTest.java
@@ -20,15 +20,17 @@ import org.flowable.common.engine.api.FlowableIllegalArgumentException;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.idm.api.Group;
 import org.flowable.idm.api.GroupQuery;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
  */
 public class GroupQueryTest extends PluggableFlowableTestCase {
 
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
+    @BeforeEach
+    public void setUp() throws Exception {
 
         createGroup("muppets", "Muppet show characters", "user");
         createGroup("frogs", "Famous frogs", "user");
@@ -60,8 +62,8 @@ public class GroupQueryTest extends PluggableFlowableTestCase {
         return group;
     }
 
-    @Override
-    protected void tearDown() throws Exception {
+    @AfterEach
+    public void tearDown() throws Exception {
         identityService.deleteUser("kermit");
         identityService.deleteUser("fozzie");
         identityService.deleteUser("mispiggy");
@@ -71,14 +73,15 @@ public class GroupQueryTest extends PluggableFlowableTestCase {
         identityService.deleteGroup("frogs");
         identityService.deleteGroup("admin");
 
-        super.tearDown();
     }
 
+    @Test
     public void testQueryById() {
         GroupQuery query = identityService.createGroupQuery().groupId("muppets");
         verifyQueryResults(query, 1);
     }
 
+    @Test
     public void testQueryByInvalidId() {
         GroupQuery query = identityService.createGroupQuery().groupId("invalid");
         verifyQueryResults(query, 0);
@@ -90,6 +93,7 @@ public class GroupQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByName() {
         GroupQuery query = identityService.createGroupQuery().groupName("Muppet show characters");
         verifyQueryResults(query, 1);
@@ -98,6 +102,7 @@ public class GroupQueryTest extends PluggableFlowableTestCase {
         verifyQueryResults(query, 1);
     }
 
+    @Test
     public void testQueryByInvalidName() {
         GroupQuery query = identityService.createGroupQuery().groupName("invalid");
         verifyQueryResults(query, 0);
@@ -109,6 +114,7 @@ public class GroupQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByNameLike() {
         GroupQuery query = identityService.createGroupQuery().groupNameLike("%Famous%");
         verifyQueryResults(query, 2);
@@ -120,6 +126,7 @@ public class GroupQueryTest extends PluggableFlowableTestCase {
         verifyQueryResults(query, 1);
     }
 
+    @Test
     public void testQueryByInvalidNameLike() {
         GroupQuery query = identityService.createGroupQuery().groupNameLike("%invalid%");
         verifyQueryResults(query, 0);
@@ -131,6 +138,7 @@ public class GroupQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByType() {
         GroupQuery query = identityService.createGroupQuery().groupType("user");
         verifyQueryResults(query, 3);
@@ -139,6 +147,7 @@ public class GroupQueryTest extends PluggableFlowableTestCase {
         verifyQueryResults(query, 0);
     }
 
+    @Test
     public void testQueryByInvalidType() {
         GroupQuery query = identityService.createGroupQuery().groupType("invalid");
         verifyQueryResults(query, 0);
@@ -150,6 +159,7 @@ public class GroupQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByMember() {
         GroupQuery query = identityService.createGroupQuery().groupMember("fozzie");
         verifyQueryResults(query, 2);
@@ -171,6 +181,7 @@ public class GroupQueryTest extends PluggableFlowableTestCase {
         assertEquals("muppets", groups.get(1).getId());
     }
 
+    @Test
     public void testQueryByInvalidMember() {
         GroupQuery query = identityService.createGroupQuery().groupMember("invalid");
         verifyQueryResults(query, 0);
@@ -182,6 +193,7 @@ public class GroupQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQuerySorting() {
         // asc
         assertEquals(4, identityService.createGroupQuery().orderByGroupId().asc().count());
@@ -209,6 +221,7 @@ public class GroupQueryTest extends PluggableFlowableTestCase {
         assertEquals("frogs", groups.get(3).getId());
     }
 
+    @Test
     public void testQueryInvalidSortingUsage() {
         try {
             identityService.createGroupQuery().orderByGroupId().list();
@@ -244,6 +257,7 @@ public class GroupQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testNativeQuery() {
         String baseQuerySql = "SELECT * FROM ACT_ID_GROUP";
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/identity/IdentityServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/identity/IdentityServiceTest.java
@@ -27,12 +27,14 @@ import org.flowable.idm.engine.IdmEngineConfiguration;
 import org.flowable.idm.engine.IdmEngines;
 import org.flowable.idm.engine.impl.authentication.ApacheDigester;
 import org.flowable.idm.engine.impl.authentication.ClearTextPasswordEncoder;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Frederik Heremans
  */
 public class IdentityServiceTest extends PluggableFlowableTestCase {
 
+    @Test
     public void testUserInfo() {
         User user = identityService.newUser("testuser");
         identityService.saveUser(user);
@@ -49,6 +51,7 @@ public class IdentityServiceTest extends PluggableFlowableTestCase {
         identityService.deleteUser(user.getId());
     }
 
+    @Test
     public void testCreateExistingUser() {
         User user = identityService.newUser("testuser");
         identityService.saveUser(user);
@@ -64,6 +67,7 @@ public class IdentityServiceTest extends PluggableFlowableTestCase {
         identityService.deleteUser(user.getId());
     }
 
+    @Test
     public void testUpdateUser() {
         // First, create a new user
         User user = identityService.newUser("johndoe");
@@ -90,6 +94,7 @@ public class IdentityServiceTest extends PluggableFlowableTestCase {
         identityService.deleteUser(user.getId());
     }
 
+    @Test
     public void testCreateUserWithoutTenantId() {
         // First, create a new user
         User user = identityService.newUser("johndoe");
@@ -108,6 +113,7 @@ public class IdentityServiceTest extends PluggableFlowableTestCase {
         identityService.deleteUser(user.getId());
     }
 
+    @Test
     public void testUserPicture() {
         // First, create a new user
         User user = identityService.newUser("johndoe");
@@ -133,6 +139,7 @@ public class IdentityServiceTest extends PluggableFlowableTestCase {
         identityService.deleteUser(user.getId());
     }
 
+    @Test
     public void testUpdateGroup() {
         Group group = identityService.newGroup("sales");
         group.setName("Sales");
@@ -148,16 +155,19 @@ public class IdentityServiceTest extends PluggableFlowableTestCase {
         identityService.deleteGroup(group.getId());
     }
 
+    @Test
     public void testFindUserByUnexistingId() {
         User user = identityService.createUserQuery().userId("unexistinguser").singleResult();
         assertNull(user);
     }
 
+    @Test
     public void testFindGroupByUnexistingId() {
         Group group = identityService.createGroupQuery().groupId("unexistinggroup").singleResult();
         assertNull(group);
     }
 
+    @Test
     public void testCreateMembershipUnexistingGroup() {
         User johndoe = identityService.newUser("johndoe");
         identityService.saveUser(johndoe);
@@ -172,6 +182,7 @@ public class IdentityServiceTest extends PluggableFlowableTestCase {
         identityService.deleteUser(johndoe.getId());
     }
 
+    @Test
     public void testCreateMembershipUnexistingUser() {
         Group sales = identityService.newGroup("sales");
         identityService.saveGroup(sales);
@@ -186,6 +197,7 @@ public class IdentityServiceTest extends PluggableFlowableTestCase {
         identityService.deleteGroup(sales.getId());
     }
 
+    @Test
     public void testCreateMembershipAlreadyExisting() {
         Group sales = identityService.newGroup("sales");
         identityService.saveGroup(sales);
@@ -205,6 +217,7 @@ public class IdentityServiceTest extends PluggableFlowableTestCase {
         identityService.deleteUser(johndoe.getId());
     }
 
+    @Test
     public void testSaveGroupNullArgument() {
         try {
             identityService.saveGroup(null);
@@ -214,6 +227,7 @@ public class IdentityServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testSaveUserNullArgument() {
         try {
             identityService.saveUser(null);
@@ -223,6 +237,7 @@ public class IdentityServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testFindGroupByIdNullArgument() {
         try {
             identityService.createGroupQuery().groupId(null).singleResult();
@@ -232,6 +247,7 @@ public class IdentityServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testCreateMembershipNullArguments() {
         try {
             identityService.createMembership(null, "group");
@@ -248,6 +264,7 @@ public class IdentityServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testFindGroupsByUserIdNullArguments() {
         try {
             identityService.createGroupQuery().groupMember(null).singleResult();
@@ -257,12 +274,14 @@ public class IdentityServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testFindUsersByGroupUnexistingGroup() {
         List<User> users = identityService.createUserQuery().memberOfGroup("unexistinggroup").list();
         assertNotNull(users);
         assertTrue(users.isEmpty());
     }
 
+    @Test
     public void testDeleteGroupNullArguments() {
         try {
             identityService.deleteGroup(null);
@@ -272,6 +291,7 @@ public class IdentityServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testDeleteMembership() {
         Group sales = identityService.newGroup("sales");
         identityService.saveGroup(sales);
@@ -294,6 +314,7 @@ public class IdentityServiceTest extends PluggableFlowableTestCase {
         identityService.deleteUser("johndoe");
     }
 
+    @Test
     public void testDeleteMembershipWhenUserIsNoMember() {
         Group sales = identityService.newGroup("sales");
         identityService.saveGroup(sales);
@@ -308,6 +329,7 @@ public class IdentityServiceTest extends PluggableFlowableTestCase {
         identityService.deleteUser("johndoe");
     }
 
+    @Test
     public void testDeleteMembershipUnexistingGroup() {
         User johndoe = identityService.newUser("johndoe");
         identityService.saveUser(johndoe);
@@ -316,6 +338,7 @@ public class IdentityServiceTest extends PluggableFlowableTestCase {
         identityService.deleteUser(johndoe.getId());
     }
 
+    @Test
     public void testDeleteMembershipUnexistingUser() {
         Group sales = identityService.newGroup("sales");
         identityService.saveGroup(sales);
@@ -324,6 +347,7 @@ public class IdentityServiceTest extends PluggableFlowableTestCase {
         identityService.deleteGroup(sales.getId());
     }
 
+    @Test
     public void testDeleteMemberschipNullArguments() {
         try {
             identityService.deleteMembership(null, "group");
@@ -340,6 +364,7 @@ public class IdentityServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testDeleteUserNullArguments() {
         try {
             identityService.deleteUser(null);
@@ -349,18 +374,21 @@ public class IdentityServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testDeleteUserUnexistingUserId() {
         // No exception should be thrown. Deleting an unexisting user should
         // be ignored silently
         identityService.deleteUser("unexistinguser");
     }
 
+    @Test
     public void testCheckPasswordNullSafe() {
         assertFalse(identityService.checkPassword("userId", null));
         assertFalse(identityService.checkPassword(null, "passwd"));
         assertFalse(identityService.checkPassword(null, null));
     }
 
+    @Test
     public void testChangePassword() {
 
         IdmEngineConfiguration idmEngineConfiguration = IdmEngines.getDefaultIdmEngine().getIdmEngineConfiguration();
@@ -396,6 +424,7 @@ public class IdentityServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testUserOptimisticLockingException() {
         User user = identityService.newUser("kermit");
         identityService.saveUser(user);
@@ -419,6 +448,7 @@ public class IdentityServiceTest extends PluggableFlowableTestCase {
         identityService.deleteUser(user.getId());
     }
 
+    @Test
     public void testGroupOptimisticLockingException() {
         Group group = identityService.newGroup("group");
         identityService.saveGroup(group);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/identity/IdmTransactionsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/identity/IdmTransactionsTest.java
@@ -24,13 +24,15 @@ import org.flowable.engine.test.Deployment;
 import org.flowable.idm.api.Group;
 import org.flowable.idm.api.User;
 import org.flowable.task.service.delegate.DelegateTask;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
  */
 public class IdmTransactionsTest extends PluggableFlowableTestCase {
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
 
         List<User> allUsers = identityService.createUserQuery().list();
@@ -42,10 +44,9 @@ public class IdmTransactionsTest extends PluggableFlowableTestCase {
         for (Group group : allGroups) {
             identityService.deleteGroup(group.getId());
         }
-
-        super.tearDown();
     }
 
+    @Test
     @Deployment
     public void testCommitOnNoException() {
 
@@ -60,6 +61,7 @@ public class IdmTransactionsTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment
     public void testTransactionRolledBackOnException() {
 
@@ -87,6 +89,7 @@ public class IdmTransactionsTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment
     public void testMultipleIdmCallsInDelegate() {
         runtimeService.startProcessInstanceByKey("multipleServiceInvocations");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/identity/ProcessInstanceIdentityLinkTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/identity/ProcessInstanceIdentityLinkTest.java
@@ -15,6 +15,7 @@ package org.flowable.engine.test.api.identity;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
@@ -25,6 +26,7 @@ public class ProcessInstanceIdentityLinkTest extends PluggableFlowableTestCase {
     // https://jira.codehaus.org/browse/ACT-1591
     // (Referential integrity constraint violation on PROC_INST and
     // IDENTITY_LINK)
+    @Test
     @Deployment
     public void testSetAuthenticatedUserAndCompleteLastTask() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("identityLinktest");
@@ -47,6 +49,7 @@ public class ProcessInstanceIdentityLinkTest extends PluggableFlowableTestCase {
     // https://jira.codehaus.org/browse/ACT-1591
     // (Referential integrity constraint violation on PROC_INST and
     // IDENTITY_LINK)
+    @Test
     @Deployment
     public void testSetAuthenticatedUserWithNoWaitStates() {
         identityService.setAuthenticatedUserId("kermit");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/identity/UserQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/identity/UserQueryTest.java
@@ -20,6 +20,9 @@ import org.flowable.common.engine.api.FlowableIllegalArgumentException;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.idm.api.User;
 import org.flowable.idm.api.UserQuery;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertThat;
@@ -29,9 +32,8 @@ import static org.junit.Assert.assertThat;
  */
 public class UserQueryTest extends PluggableFlowableTestCase {
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
 
         createUser("kermit", "Kermit", "Thefrog", "kermit@muppetshow.com", "flowable");
         createUser("fozzie", "Fozzie", "Bear", "fozzie@muppetshow.com", "flowable");
@@ -57,7 +59,7 @@ public class UserQueryTest extends PluggableFlowableTestCase {
         return user;
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
         identityService.deleteUser("kermit");
         identityService.deleteUser("fozzie");
@@ -67,19 +69,21 @@ public class UserQueryTest extends PluggableFlowableTestCase {
         identityService.deleteGroup("muppets");
         identityService.deleteGroup("frogs");
 
-        super.tearDown();
     }
 
+    @Test
     public void testQueryByNoCriteria() {
         UserQuery query = identityService.createUserQuery();
         verifyQueryResults(query, 4);
     }
 
+    @Test
     public void testQueryById() {
         UserQuery query = identityService.createUserQuery().userId("kermit");
         verifyQueryResults(query, 1);
     }
 
+    @Test
     public void testQueryByInvalidId() {
         UserQuery query = identityService.createUserQuery().userId("invalid");
         verifyQueryResults(query, 0);
@@ -91,6 +95,7 @@ public class UserQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByFirstName() {
         UserQuery query = identityService.createUserQuery().userFirstName("Gonzo");
         verifyQueryResults(query, 1);
@@ -99,6 +104,7 @@ public class UserQueryTest extends PluggableFlowableTestCase {
         assertEquals("gonzo", result.getId());
     }
 
+    @Test
     public void testQueryByInvalidFirstName() {
         UserQuery query = identityService.createUserQuery().userFirstName("invalid");
         verifyQueryResults(query, 0);
@@ -110,6 +116,7 @@ public class UserQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByFirstNameLike() {
         UserQuery query = identityService.createUserQuery().userFirstNameLike("%o%");
         verifyQueryResults(query, 3);
@@ -118,6 +125,7 @@ public class UserQueryTest extends PluggableFlowableTestCase {
         verifyQueryResults(query, 1);
     }
 
+    @Test
     public void testQueryByInvalidFirstNameLike() {
         UserQuery query = identityService.createUserQuery().userFirstNameLike("%mispiggy%");
         verifyQueryResults(query, 0);
@@ -129,6 +137,7 @@ public class UserQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByLastName() {
         UserQuery query = identityService.createUserQuery().userLastName("Bear");
         verifyQueryResults(query, 1);
@@ -137,6 +146,7 @@ public class UserQueryTest extends PluggableFlowableTestCase {
         assertEquals("fozzie", result.getId());
     }
 
+    @Test
     public void testQueryByInvalidLastName() {
         UserQuery query = identityService.createUserQuery().userLastName("invalid");
         verifyQueryResults(query, 0);
@@ -148,6 +158,7 @@ public class UserQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByLastNameLike() {
         UserQuery query = identityService.createUserQuery().userLastNameLike("%rog%");
         verifyQueryResults(query, 1);
@@ -156,6 +167,7 @@ public class UserQueryTest extends PluggableFlowableTestCase {
         verifyQueryResults(query, 2);
     }
 
+    @Test
     public void testQueryByFullNameLike() {
         UserQuery query = identityService.createUserQuery().userFullNameLike("%erm%");
         verifyQueryResults(query, 1);
@@ -167,6 +179,7 @@ public class UserQueryTest extends PluggableFlowableTestCase {
         verifyQueryResults(query, 4);
     }
 
+    @Test
     public void testQueryByInvalidLastNameLike() {
         UserQuery query = identityService.createUserQuery().userLastNameLike("%invalid%");
         verifyQueryResults(query, 0);
@@ -178,11 +191,13 @@ public class UserQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByEmail() {
         UserQuery query = identityService.createUserQuery().userEmail("kermit@muppetshow.com");
         verifyQueryResults(query, 1);
     }
 
+    @Test
     public void testQueryByInvalidEmail() {
         UserQuery query = identityService.createUserQuery().userEmail("invalid");
         verifyQueryResults(query, 0);
@@ -194,6 +209,7 @@ public class UserQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByEmailLike() {
         UserQuery query = identityService.createUserQuery().userEmailLike("%muppetshow.com");
         verifyQueryResults(query, 3);
@@ -202,6 +218,7 @@ public class UserQueryTest extends PluggableFlowableTestCase {
         verifyQueryResults(query, 1);
     }
 
+    @Test
     public void testQueryByInvalidEmailLike() {
         UserQuery query = identityService.createUserQuery().userEmailLike("%invalid%");
         verifyQueryResults(query, 0);
@@ -213,6 +230,7 @@ public class UserQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQuerySorting() {
         // asc
         assertEquals(4, identityService.createUserQuery().orderByUserId().asc().count());
@@ -234,6 +252,7 @@ public class UserQueryTest extends PluggableFlowableTestCase {
         assertEquals("Gonzo", users.get(1).getFirstName());
     }
 
+    @Test
     public void testQueryInvalidSortingUsage() {
         try {
             identityService.createUserQuery().orderByUserId().list();
@@ -248,6 +267,7 @@ public class UserQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByMemberOf() {
         UserQuery query = identityService.createUserQuery().memberOfGroup("muppets");
         verifyQueryResults(query, 3);
@@ -259,6 +279,7 @@ public class UserQueryTest extends PluggableFlowableTestCase {
         assertEquals("kermit", result.getId());
     }
 
+    @Test
     public void testQueryByInvalidMemberOf() {
         UserQuery query = identityService.createUserQuery().memberOfGroup("invalid");
         verifyQueryResults(query, 0);
@@ -270,6 +291,7 @@ public class UserQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByTenantId() {
         UserQuery query = identityService.createUserQuery().tenantId("flowable");
         verifyQueryResults(query, 3);
@@ -278,11 +300,13 @@ public class UserQueryTest extends PluggableFlowableTestCase {
         verifyQueryResults(query, 1);
     }
 
+    @Test
     public void testQueryByInvalidTenantId() {
         UserQuery query = identityService.createUserQuery().tenantId("invalidTenantId");
         verifyQueryResults(query, 0);
     }
 
+    @Test
     public void testQueryByNullTenantId() {
         try {
             identityService.createUserQuery().tenantId(null);
@@ -313,6 +337,7 @@ public class UserQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testNativeQuery() {
         String baseQuerySql = "SELECT * FROM ACT_ID_USER";
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/mgmt/JobQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/mgmt/JobQueryTest.java
@@ -34,6 +34,9 @@ import org.flowable.job.api.JobQuery;
 import org.flowable.job.api.TimerJobQuery;
 import org.flowable.job.service.impl.cmd.CancelJobsCmd;
 import org.flowable.job.service.impl.persistence.entity.JobEntity;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
@@ -62,9 +65,8 @@ public class JobQueryTest extends PluggableFlowableTestCase {
     /**
      * Setup will create - 3 process instances, each with one timer, each firing at t1/t2/t3 + 1 hour (see process) - 1 message
      */
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
 
         this.commandExecutor = processEngineConfiguration.getCommandExecutor();
 
@@ -108,13 +110,13 @@ public class JobQueryTest extends PluggableFlowableTestCase {
         });
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
         repositoryService.deleteDeployment(deploymentId, true);
         commandExecutor.execute(new CancelJobsCmd(messageId));
-        super.tearDown();
     }
 
+    @Test
     public void testQueryByNoCriteria() {
         JobQuery query = managementService.createJobQuery();
         verifyQueryResults(query, 1);
@@ -123,11 +125,13 @@ public class JobQueryTest extends PluggableFlowableTestCase {
         verifyQueryResults(timerQuery, 3);
     }
 
+    @Test
     public void testQueryByProcessInstanceId() {
         TimerJobQuery query = managementService.createTimerJobQuery().processInstanceId(processInstanceIdOne);
         verifyQueryResults(query, 1);
     }
 
+    @Test
     public void testQueryByInvalidProcessInstanceId() {
         TimerJobQuery query = managementService.createTimerJobQuery().processInstanceId("invalid");
         verifyQueryResults(query, 0);
@@ -139,6 +143,7 @@ public class JobQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByExecutionId() {
         Job job = managementService.createTimerJobQuery().processInstanceId(processInstanceIdOne).singleResult();
         TimerJobQuery query = managementService.createTimerJobQuery().executionId(job.getExecutionId());
@@ -146,6 +151,7 @@ public class JobQueryTest extends PluggableFlowableTestCase {
         verifyQueryResults(query, 1);
     }
 
+    @Test
     public void testQueryByInvalidExecutionId() {
         JobQuery query = managementService.createJobQuery().executionId("invalid");
         verifyQueryResults(query, 0);
@@ -166,6 +172,7 @@ public class JobQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByHandlerType() {
         final JobEntity job = (JobEntity) managementService.createJobQuery().singleResult();
         job.setJobHandlerType("test");
@@ -183,6 +190,7 @@ public class JobQueryTest extends PluggableFlowableTestCase {
         assertNotNull(handlerTypeJob);
     }
 
+    @Test
     public void testQueryByInvalidJobType() {
         JobQuery query = managementService.createJobQuery().handlerType("invalid");
         verifyQueryResults(query, 0);
@@ -203,6 +211,7 @@ public class JobQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByRetriesLeft() {
         JobQuery query = managementService.createJobQuery();
         verifyQueryResults(query, 1);
@@ -219,6 +228,7 @@ public class JobQueryTest extends PluggableFlowableTestCase {
         verifyQueryResults(timerQuery, 2);
     }
 
+    @Test
     public void testQueryByExecutable() {
         processEngineConfiguration.getClock().setCurrentTime(new Date(timerThreeFireTime.getTime() + ONE_SECOND)); // all obs should be executable at t3 + 1hour.1second
         JobQuery query = managementService.createJobQuery();
@@ -247,6 +257,7 @@ public class JobQueryTest extends PluggableFlowableTestCase {
         verifyQueryResults(timerQuery, 0);
     }
 
+    @Test
     public void testQueryByOnlyTimers() {
         JobQuery query = managementService.createJobQuery().timers();
         verifyQueryResults(query, 0);
@@ -255,11 +266,13 @@ public class JobQueryTest extends PluggableFlowableTestCase {
         verifyQueryResults(timerQuery, 3);
     }
 
+    @Test
     public void testQueryByOnlyMessages() {
         JobQuery query = managementService.createJobQuery().messages();
         verifyQueryResults(query, 1);
     }
 
+    @Test
     public void testInvalidOnlyTimersUsage() {
         try {
             managementService.createJobQuery().timers().messages().list();
@@ -269,6 +282,7 @@ public class JobQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByDuedateLowerThan() {
         JobQuery query = managementService.createJobQuery().duedateLowerThan(testStartTime);
         verifyQueryResults(query, 0);
@@ -286,6 +300,7 @@ public class JobQueryTest extends PluggableFlowableTestCase {
         verifyQueryResults(timerQuery, 3);
     }
 
+    @Test
     public void testQueryByDuedateHigherThan() {
         JobQuery query = managementService.createJobQuery().duedateHigherThan(testStartTime);
         verifyQueryResults(query, 0);
@@ -309,6 +324,7 @@ public class JobQueryTest extends PluggableFlowableTestCase {
         verifyQueryResults(timerQuery, 0);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/mgmt/ManagementServiceTest.testGetJobExceptionStacktrace.bpmn20.xml" })
     public void testQueryByException() {
         TimerJobQuery query = managementService.createTimerJobQuery().withException();
@@ -320,6 +336,7 @@ public class JobQueryTest extends PluggableFlowableTestCase {
         verifyFailedJob(query, processInstance);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/mgmt/ManagementServiceTest.testGetJobExceptionStacktrace.bpmn20.xml" })
     public void testQueryByExceptionMessage() {
         TimerJobQuery query = managementService.createTimerJobQuery().exceptionMessage(EXCEPTION_MESSAGE);
@@ -331,6 +348,7 @@ public class JobQueryTest extends PluggableFlowableTestCase {
         verifyFailedJob(query, processInstance);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/mgmt/ManagementServiceTest.testGetJobExceptionStacktrace.bpmn20.xml" })
     public void testQueryByExceptionMessageEmpty() {
         JobQuery query = managementService.createJobQuery().exceptionMessage("");
@@ -342,6 +360,7 @@ public class JobQueryTest extends PluggableFlowableTestCase {
         verifyQueryResults(query, 0);
     }
 
+    @Test
     public void testQueryByExceptionMessageNull() {
         try {
             managementService.createJobQuery().exceptionMessage(null);
@@ -351,6 +370,7 @@ public class JobQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testJobQueryWithExceptions() throws Throwable {
 
         createJobWithoutExceptionMsg();
@@ -379,6 +399,7 @@ public class JobQueryTest extends PluggableFlowableTestCase {
 
     // sorting //////////////////////////////////////////
 
+    @Test
     public void testQuerySorting() {
         // asc
         assertEquals(1, managementService.createJobQuery().orderByJobId().asc().count());
@@ -424,6 +445,7 @@ public class JobQueryTest extends PluggableFlowableTestCase {
         assertEquals(processInstanceIdOne, jobs.get(2).getProcessInstanceId());
     }
 
+    @Test
     public void testQueryInvalidSortingUsage() {
         try {
             managementService.createJobQuery().orderByJobId().list();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/mgmt/ManagementServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/mgmt/ManagementServiceTest.java
@@ -28,6 +28,7 @@ import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
 import org.flowable.job.api.JobNotFoundException;
 import org.flowable.job.service.impl.cmd.AcquireTimerJobsCmd;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Frederik Heremans
@@ -37,11 +38,13 @@ import org.flowable.job.service.impl.cmd.AcquireTimerJobsCmd;
  */
 public class ManagementServiceTest extends PluggableFlowableTestCase {
 
+    @Test
     public void testGetMetaDataForUnexistingTable() {
         TableMetaData metaData = managementService.getTableMetaData("unexistingtable");
         assertNull(metaData);
     }
 
+    @Test
     public void testGetMetaDataNullTableName() {
         try {
             managementService.getTableMetaData(null);
@@ -51,6 +54,7 @@ public class ManagementServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testExecuteJobNullJobId() {
         try {
             managementService.executeJob(null);
@@ -60,6 +64,7 @@ public class ManagementServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testExecuteJobUnexistingJob() {
         try {
             managementService.executeJob("unexistingjob");
@@ -70,6 +75,7 @@ public class ManagementServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testGetJobExceptionStacktrace() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("exceptionInJobExecution");
@@ -101,6 +107,7 @@ public class ManagementServiceTest extends PluggableFlowableTestCase {
         assertTextPresent("This is an exception thrown from scriptTask", exceptionStack);
     }
 
+    @Test
     public void testgetJobExceptionStacktraceUnexistingJobId() {
         try {
             managementService.getJobExceptionStacktrace("unexistingjob");
@@ -111,6 +118,7 @@ public class ManagementServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testgetJobExceptionStacktraceNullJobId() {
         try {
             managementService.getJobExceptionStacktrace(null);
@@ -120,6 +128,7 @@ public class ManagementServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/mgmt/ManagementServiceTest.testGetJobExceptionStacktrace.bpmn20.xml" })
     public void testSetJobRetries() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("exceptionInJobExecution");
@@ -139,6 +148,7 @@ public class ManagementServiceTest extends PluggableFlowableTestCase {
         assertEquals(duedate, timerJob.getDuedate());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/mgmt/ManagementServiceTest.testFailingAsyncJob.bpmn20.xml" })
     public void testAsyncJobWithNoRetriesLeft() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("exceptionInJobExecution");
@@ -197,6 +207,7 @@ public class ManagementServiceTest extends PluggableFlowableTestCase {
         assertEquals(5, asyncJob.getRetries());
     }
 
+    @Test
     public void testSetJobRetriesUnexistingJobId() {
         try {
             managementService.setJobRetries("unexistingjob", 5);
@@ -207,6 +218,7 @@ public class ManagementServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testSetJobRetriesEmptyJobId() {
         try {
             managementService.setJobRetries("", 5);
@@ -216,6 +228,7 @@ public class ManagementServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testSetJobRetriesJobIdNull() {
         try {
             managementService.setJobRetries(null, 5);
@@ -225,6 +238,7 @@ public class ManagementServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testSetJobRetriesNegativeNumberOfRetries() {
         try {
             managementService.setJobRetries("unexistingjob", -1);
@@ -234,6 +248,7 @@ public class ManagementServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testDeleteJobNullJobId() {
         try {
             managementService.deleteJob(null);
@@ -243,6 +258,7 @@ public class ManagementServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testDeleteJobUnexistingJob() {
         try {
             managementService.deleteJob("unexistingjob");
@@ -253,6 +269,7 @@ public class ManagementServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/mgmt/timerOnTask.bpmn20.xml" })
     public void testDeleteJobDeletion() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("timerOnTask");
@@ -265,6 +282,7 @@ public class ManagementServiceTest extends PluggableFlowableTestCase {
         assertNull("There should be no job now. It was deleted", timerJob);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/mgmt/timerOnTask.bpmn20.xml" })
     public void testDeleteJobThatWasAlreadyAcquired() {
         processEngineConfiguration.getClock().setCurrentTime(new Date());
@@ -296,6 +314,7 @@ public class ManagementServiceTest extends PluggableFlowableTestCase {
 
     // https://jira.codehaus.org/browse/ACT-1816:
     // ManagementService doesn't seem to give actual table Name for EventSubscriptionEntity.class
+    @Test
     public void testGetTableName() {
         String table = managementService.getTableName(EventSubscriptionEntity.class);
         assertEquals("ACT_RU_EVENT_SUBSCR", table);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/mgmt/TimerJobQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/mgmt/TimerJobQueryTest.java
@@ -22,6 +22,9 @@ import org.flowable.engine.repository.Deployment;
 import org.flowable.engine.runtime.Execution;
 import org.flowable.job.api.Job;
 import org.flowable.job.service.impl.persistence.entity.TimerJobEntity;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
@@ -31,22 +34,21 @@ public class TimerJobQueryTest extends PluggableFlowableTestCase {
     private Date testStartTime;
     private String processInstanceId;
     
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
         this.testStartTime = new Date();
         repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/api/mgmt/TimerJobQueryTest.bpmn20.xml").deploy();
         this.processInstanceId = runtimeService.startProcessInstanceByKey("timerJobQueryTest").getId();
     }
     
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
         for (Deployment deployment : repositoryService.createDeploymentQuery().list()) {
             repositoryService.deleteDeployment(deployment.getId(), true);
         }
-        super.tearDown();
     }
     
+    @Test
     public void testByJobId() {
         List<Job> timerJobs = managementService.createTimerJobQuery().list();
         assertEquals(3, timerJobs.size());
@@ -58,10 +60,12 @@ public class TimerJobQueryTest extends PluggableFlowableTestCase {
         }
     }
     
+    @Test
     public void testByProcessInstanceId() {
         assertEquals(3, managementService.createTimerJobQuery().processInstanceId(processInstanceId).list().size());
     }
     
+    @Test
     public void testByExecutionId() {
         for (String id : Arrays.asList("timerA", "timerB", "timerC")) {
             Execution execution = runtimeService.createExecutionQuery().activityId(id).singleResult();
@@ -70,12 +74,14 @@ public class TimerJobQueryTest extends PluggableFlowableTestCase {
         }
     }
     
+    @Test
     public void testByProcessDefinitionId() {
         String processDefinitionid = repositoryService.createProcessDefinitionQuery().singleResult().getId();
         assertEquals(3, managementService.createTimerJobQuery().processDefinitionId(processDefinitionid).count());
         assertEquals(3, managementService.createTimerJobQuery().processDefinitionId(processDefinitionid).list().size());
     }
     
+    @Test
     public void testByExecutable() {
         assertEquals(0, managementService.createTimerJobQuery().executable().count());
         assertEquals(0, managementService.createTimerJobQuery().executable().list().size());
@@ -84,12 +90,14 @@ public class TimerJobQueryTest extends PluggableFlowableTestCase {
         assertEquals(3, managementService.createTimerJobQuery().executable().list().size());
     }
     
+    @Test
     public void testByHandlerType() {
         assertEquals(3, managementService.createTimerJobQuery().handlerType(TriggerTimerEventJobHandler.TYPE).count());
         assertEquals(3, managementService.createTimerJobQuery().handlerType(TriggerTimerEventJobHandler.TYPE).list().size());
         assertEquals(0, managementService.createTimerJobQuery().handlerType("invalid").count());
     }
     
+    @Test
     public void testByJobType() {
         assertEquals(3, managementService.createTimerJobQuery().timers().count());
         assertEquals(3, managementService.createTimerJobQuery().timers().list().size());
@@ -114,12 +122,14 @@ public class TimerJobQueryTest extends PluggableFlowableTestCase {
         assertEquals(1, managementService.createTimerJobQuery().withException().list().size());
     }
     
+    @Test
     public void testByduedateLowerThan() {
         Date date = new Date(testStartTime.getTime() + (10 * 60 * 1000 * 1000));
         assertEquals(3, managementService.createTimerJobQuery().timers().duedateLowerThan(date).count());
         assertEquals(3, managementService.createTimerJobQuery().timers().duedateLowerThan(date).list().size());
     }
     
+    @Test
     public void testByDuedateHigherThan() {
         assertEquals(0, managementService.createTimerJobQuery().timers().duedateLowerThan(testStartTime).count());
         assertEquals(0, managementService.createTimerJobQuery().timers().duedateLowerThan(testStartTime).list().size());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/nonpublic/EventSubscriptionQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/nonpublic/EventSubscriptionQueryTest.java
@@ -29,12 +29,14 @@ import org.flowable.engine.runtime.EventSubscriptionQuery;
 import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Daniel Meyer
  */
 public class EventSubscriptionQueryTest extends PluggableFlowableTestCase {
 
+    @Test
     public void testQueryByEventName() {
 
         processEngineConfiguration.getCommandExecutor().execute(new Command<Void>() {
@@ -67,6 +69,7 @@ public class EventSubscriptionQueryTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     public void testQueryByEventType() {
 
         processEngineConfiguration.getCommandExecutor().execute(new Command<Void>() {
@@ -99,6 +102,7 @@ public class EventSubscriptionQueryTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     public void testQueryByActivityId() {
 
         processEngineConfiguration.getCommandExecutor().execute(new Command<Void>() {
@@ -134,6 +138,7 @@ public class EventSubscriptionQueryTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     public void testQueryByEventSubscriptionId() {
 
         processEngineConfiguration.getCommandExecutor().execute(new Command<Void>() {
@@ -167,6 +172,7 @@ public class EventSubscriptionQueryTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment
     public void testQueryByExecutionId() {
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/repository/DeployInvalidXmlTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/repository/DeployInvalidXmlTest.java
@@ -16,25 +16,27 @@ import org.flowable.bpmn.exceptions.XMLException;
 import org.flowable.engine.RepositoryService;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.repository.ProcessDefinition;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
  */
 public class DeployInvalidXmlTest extends PluggableFlowableTestCase {
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
 
         processEngineConfiguration.setEnableSafeBpmnXml(true); // Needs to be enabled to test this
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
         processEngineConfiguration.setEnableSafeBpmnXml(false); // set back to default
-        super.tearDown();
     }
 
+    @Test
     public void testDeployNonSchemaConformantXml() {
         try {
             repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/api/repository/nonSchemaConformantXml.bpmn20.xml").deploy().getId();
@@ -45,6 +47,7 @@ public class DeployInvalidXmlTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     public void testDeployWithMissingWaypointsForSequenceflowInDiagramInterchange() {
         try {
             repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/api/repository/noWayPointsForSequenceFlowInDiagramInterchange.bpmn20.xml").deploy().getId();
@@ -68,6 +71,7 @@ public class DeployInvalidXmlTest extends PluggableFlowableTestCase {
             + " <userTask id='theTask' name='my task' />" + " <sequenceFlow id='flow2' sourceRef='theTask' targetRef='theEnd' />" + " <endEvent id='theEnd' />" + "</process>" + "</definitions>";
 
     // See https://activiti.atlassian.net/browse/ACT-1579?focusedCommentId=319886#comment-319886
+    @Test
     public void testProcessEngineDenialOfServiceAttackUsingUnsafeXmlTest() throws InterruptedException {
 
         // Putting this in a Runnable so we can time it out
@@ -108,6 +112,7 @@ public class DeployInvalidXmlTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     public void testExternalEntityResolvingTest() {
         String deploymentId = repositoryService.createDeployment()
                 .addClasspathResource("org/flowable/engine/test/api/repository/DeployInvalidXmlTest.testExternalEntityResolvingTest.bpmn20.xml")

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/repository/DeployNonExecutableProcessDefinitionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/repository/DeployNonExecutableProcessDefinitionTest.java
@@ -15,6 +15,7 @@ package org.flowable.engine.test.api.repository;
 import org.flowable.common.engine.api.FlowableException;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author jbarrez
@@ -26,6 +27,7 @@ public class DeployNonExecutableProcessDefinitionTest extends PluggableFlowableT
      * 
      * In this test, a process definition is deployed together with one that is not executable. The none-executable should not be startable.
      */
+    @Test
     @Deployment
     public void testDeployNonExecutableProcessDefinition() {
         try {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/repository/DeploymentCategoryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/repository/DeploymentCategoryTest.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.repository.Deployment;
 import org.flowable.engine.repository.DeploymentQuery;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tom Baeyens
@@ -27,6 +28,7 @@ import org.flowable.engine.repository.DeploymentQuery;
  */
 public class DeploymentCategoryTest extends PluggableFlowableTestCase {
 
+    @Test
     public void testDeploymentCategory() {
         String noCategoryDeploymentId = null;
         String deploymentOneId = null;
@@ -82,6 +84,7 @@ public class DeploymentCategoryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testDeploymentKey() {
         String noKeyDeploymentId = null;
         String deploymentOneId = null;

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/repository/DeploymentQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/repository/DeploymentQueryTest.java
@@ -21,6 +21,9 @@ import org.flowable.engine.impl.persistence.entity.DeploymentEntity;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.repository.Deployment;
 import org.flowable.engine.repository.DeploymentQuery;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tom Baeyens
@@ -31,7 +34,7 @@ public class DeploymentQueryTest extends PluggableFlowableTestCase {
 
     private String deploymentTwoId;
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
         deploymentOneId = repositoryService.createDeployment().name("org/flowable/engine/test/repository/one.bpmn20.xml").category("testCategory")
                 .addClasspathResource("org/flowable/engine/test/repository/one.bpmn20.xml").deploy().getId();
@@ -39,16 +42,15 @@ public class DeploymentQueryTest extends PluggableFlowableTestCase {
         deploymentTwoId = repositoryService.createDeployment().name("org/flowable/engine/test/repository/two.bpmn20.xml").addClasspathResource("org/flowable/engine/test/repository/two.bpmn20.xml")
                 .deploy().getId();
 
-        super.setUp();
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
         repositoryService.deleteDeployment(deploymentOneId, true);
         repositoryService.deleteDeployment(deploymentTwoId, true);
     }
 
+    @Test
     public void testQueryNoCriteria() {
         DeploymentQuery query = repositoryService.createDeploymentQuery();
         assertEquals(2, query.list().size());
@@ -61,6 +63,7 @@ public class DeploymentQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByDeploymentId() {
         DeploymentQuery query = repositoryService.createDeploymentQuery().deploymentId(deploymentOneId);
         assertNotNull(query.singleResult());
@@ -68,6 +71,7 @@ public class DeploymentQueryTest extends PluggableFlowableTestCase {
         assertEquals(1, query.count());
     }
 
+    @Test
     public void testQueryByInvalidDeploymentId() {
         DeploymentQuery query = repositoryService.createDeploymentQuery().deploymentId("invalid");
         assertNull(query.singleResult());
@@ -81,6 +85,7 @@ public class DeploymentQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByName() {
         DeploymentQuery query = repositoryService.createDeploymentQuery().deploymentName("org/flowable/engine/test/repository/two.bpmn20.xml");
         assertNotNull(query.singleResult());
@@ -88,6 +93,7 @@ public class DeploymentQueryTest extends PluggableFlowableTestCase {
         assertEquals(1, query.count());
     }
 
+    @Test
     public void testQueryByInvalidName() {
         DeploymentQuery query = repositoryService.createDeploymentQuery().deploymentName("invalid");
         assertNull(query.singleResult());
@@ -101,6 +107,7 @@ public class DeploymentQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByNameLike() {
         DeploymentQuery query = repositoryService.createDeploymentQuery().deploymentNameLike("%flowable%");
         assertEquals(2, query.list().size());
@@ -113,6 +120,7 @@ public class DeploymentQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByInvalidNameLike() {
         DeploymentQuery query = repositoryService.createDeploymentQuery().deploymentNameLike("invalid");
         assertNull(query.singleResult());
@@ -126,6 +134,7 @@ public class DeploymentQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByNameAndCategory() {
         DeploymentQuery query = repositoryService.createDeploymentQuery().deploymentCategory("testCategory").deploymentNameLike("%flowable%");
         assertEquals(1, query.list().size());
@@ -133,6 +142,7 @@ public class DeploymentQueryTest extends PluggableFlowableTestCase {
         assertNotNull(query.singleResult());
     }
 
+    @Test
     public void testQueryByProcessDefinitionKey() {
         DeploymentQuery query = repositoryService.createDeploymentQuery().processDefinitionKey("one");
         assertEquals(1, query.list().size());
@@ -140,18 +150,21 @@ public class DeploymentQueryTest extends PluggableFlowableTestCase {
         assertNotNull(query.singleResult());
     }
 
+    @Test
     public void testQueryByProcessDefinitionKeyLike() {
         DeploymentQuery query = repositoryService.createDeploymentQuery().processDefinitionKeyLike("%o%");
         assertEquals(2, query.list().size());
         assertEquals(2, query.count());
     }
 
+    @Test
     public void testQueryByInvalidProcessDefinitionKeyLike() {
         DeploymentQuery query = repositoryService.createDeploymentQuery().processDefinitionKeyLike("invalid");
         assertEquals(0, query.list().size());
         assertEquals(0, query.count());
     }
 
+    @Test
     public void testVerifyDeploymentProperties() {
         List<Deployment> deployments = repositoryService.createDeploymentQuery().orderByDeploymentName().asc().list();
 
@@ -174,6 +187,7 @@ public class DeploymentQueryTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     public void testNativeQuery() {
         assertEquals("ACT_RE_DEPLOYMENT", managementService.getTableName(Deployment.class));
         assertEquals("ACT_RE_DEPLOYMENT", managementService.getTableName(DeploymentEntity.class));

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/repository/LaneExtensionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/repository/LaneExtensionTest.java
@@ -24,12 +24,14 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.repository.ProcessDefinition;
 import org.flowable.engine.test.Deployment;
 import org.junit.Assert;
+import org.junit.jupiter.api.Test;
 
 /**
  * Created by P3700487 on 2/19/2015.
  */
 public class LaneExtensionTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testLaneExtensionElement() {
         ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().processDefinitionKey("swimlane-extension").singleResult();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/repository/ModelQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/repository/ModelQueryTest.java
@@ -21,6 +21,9 @@ import org.flowable.engine.repository.Deployment;
 import org.flowable.engine.repository.Model;
 import org.flowable.engine.repository.ModelQuery;
 import org.junit.Assert;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tijs Rademakers
@@ -29,7 +32,7 @@ public class ModelQueryTest extends PluggableFlowableTestCase {
 
     private String modelOneId;
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
         Model model = repositoryService.newModel();
         model.setName("my model");
@@ -40,15 +43,14 @@ public class ModelQueryTest extends PluggableFlowableTestCase {
 
         repositoryService.addModelEditorSource(modelOneId, "bytes".getBytes("utf-8"));
 
-        super.setUp();
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
         repositoryService.deleteModel(modelOneId);
     }
 
+    @Test
     public void testModelProperties() {
         ModelQuery query = repositoryService.createModelQuery();
         Model model = query.singleResult();
@@ -61,12 +63,14 @@ public class ModelQueryTest extends PluggableFlowableTestCase {
         assertNotNull(model.getLastUpdateTime());
     }
 
+    @Test
     public void testQueryNoCriteria() {
         ModelQuery query = repositoryService.createModelQuery();
         assertEquals(1, query.list().size());
         assertEquals(1, query.count());
     }
 
+    @Test
     public void testQueryByName() throws Exception {
         ModelQuery query = repositoryService.createModelQuery().modelName("my model");
         Model model = query.singleResult();
@@ -76,6 +80,7 @@ public class ModelQueryTest extends PluggableFlowableTestCase {
         assertEquals(1, query.count());
     }
 
+    @Test
     public void testQueryByInvalidName() {
         ModelQuery query = repositoryService.createModelQuery().modelName("invalid");
         assertNull(query.singleResult());
@@ -83,6 +88,7 @@ public class ModelQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, query.count());
     }
 
+    @Test
     public void testQueryByNameLike() throws Exception {
         ModelQuery query = repositoryService.createModelQuery().modelNameLike("%model%");
         Model model = query.singleResult();
@@ -92,6 +98,7 @@ public class ModelQueryTest extends PluggableFlowableTestCase {
         assertEquals(1, query.count());
     }
 
+    @Test
     public void testQueryByInvalidNameLike() {
         ModelQuery query = repositoryService.createModelQuery().modelNameLike("%invalid%");
         assertNull(query.singleResult());
@@ -99,6 +106,7 @@ public class ModelQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, query.count());
     }
 
+    @Test
     public void testQueryByKey() {
         ModelQuery query = repositoryService.createModelQuery().modelName("my model").modelKey("someKey");
         Model model = query.singleResult();
@@ -107,6 +115,7 @@ public class ModelQueryTest extends PluggableFlowableTestCase {
         assertEquals(1, query.count());
     }
 
+    @Test
     public void testQueryByNameAndKey() {
         ModelQuery query = repositoryService.createModelQuery().modelKey("someKey");
         Model model = query.singleResult();
@@ -115,6 +124,7 @@ public class ModelQueryTest extends PluggableFlowableTestCase {
         assertEquals(1, query.count());
     }
 
+    @Test
     public void testQueryByInvalidKey() {
         ModelQuery query = repositoryService.createModelQuery().modelKey("invalid");
         assertNull(query.singleResult());
@@ -122,12 +132,14 @@ public class ModelQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, query.count());
     }
 
+    @Test
     public void testQueryByCategory() {
         ModelQuery query = repositoryService.createModelQuery().modelCategory("test");
         assertEquals(1, query.list().size());
         assertEquals(1, query.count());
     }
 
+    @Test
     public void testQueryByInvalidCategory() {
         ModelQuery query = repositoryService.createModelQuery().modelCategory("invalid");
         assertNull(query.singleResult());
@@ -135,12 +147,14 @@ public class ModelQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, query.count());
     }
 
+    @Test
     public void testQueryByCategoryLike() {
         ModelQuery query = repositoryService.createModelQuery().modelCategoryLike("%te%");
         assertEquals(1, query.list().size());
         assertEquals(1, query.count());
     }
 
+    @Test
     public void testQueryByInvalidCategoryLike() {
         ModelQuery query = repositoryService.createModelQuery().modelCategoryLike("%invalid%");
         assertNull(query.singleResult());
@@ -148,18 +162,21 @@ public class ModelQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, query.count());
     }
 
+    @Test
     public void testQueryByCategoryNotEquals() {
         ModelQuery query = repositoryService.createModelQuery().modelCategoryNotEquals("aap");
         assertEquals(1, query.list().size());
         assertEquals(1, query.count());
     }
 
+    @Test
     public void testQueryByVersion() {
         ModelQuery query = repositoryService.createModelQuery().modelVersion(1);
         assertEquals(1, query.list().size());
         assertEquals(1, query.count());
     }
 
+    @Test
     public void testByDeploymentId() {
         Deployment deployment = repositoryService.createDeployment().addString("test", "test").deploy();
 
@@ -185,18 +202,21 @@ public class ModelQueryTest extends PluggableFlowableTestCase {
         assertEquals(1, repositoryService.createModelQuery().count());
     }
 
+    @Test
     public void testByInvalidDeploymentId() {
         ModelQuery query = repositoryService.createModelQuery().deploymentId("invalid");
         assertNull(query.singleResult());
         assertEquals(0, query.count());
     }
 
+    @Test
     public void testNotDeployed() {
         ModelQuery query = repositoryService.createModelQuery().notDeployed();
         assertEquals(1, query.count());
         assertEquals(1, query.list().size());
     }
 
+    @Test
     public void testOrderBy() {
         ModelQuery query = repositoryService.createModelQuery();
         assertEquals(1, query.orderByCreateTime().asc().count());
@@ -208,6 +228,7 @@ public class ModelQueryTest extends PluggableFlowableTestCase {
         assertEquals(1, query.orderByModelKey().desc().count());
     }
 
+    @Test
     public void testByLatestVersion() {
         ModelQuery query = repositoryService.createModelQuery().latestVersion().modelKey("someKey");
         Model model = query.singleResult();
@@ -230,6 +251,7 @@ public class ModelQueryTest extends PluggableFlowableTestCase {
         repositoryService.deleteModel(model.getId());
     }
 
+    @Test
     public void testVerifyModelProperties() {
         List<Model> models = repositoryService.createModelQuery().orderByModelName().asc().list();
 
@@ -245,6 +267,7 @@ public class ModelQueryTest extends PluggableFlowableTestCase {
         assertEquals(1, repositoryService.createModelQuery().orderByModelId().asc().list().size());
     }
 
+    @Test
     public void testNativeQuery() {
         assertEquals("ACT_RE_MODEL", managementService.getTableName(Model.class));
         assertEquals("ACT_RE_MODEL", managementService.getTableName(ModelEntity.class));
@@ -260,6 +283,7 @@ public class ModelQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, repositoryService.createNativeProcessDefinitionQuery().sql(baseQuerySql).listPage(1, 5).size());
     }
 
+    @Test
     public void testKeyAndLatest() throws Exception {
 
         ModelEntity model1 = null;

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/repository/ProcessDefinitionCategoryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/repository/ProcessDefinitionCategoryTest.java
@@ -18,12 +18,14 @@ import java.util.List;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.repository.Deployment;
 import org.flowable.engine.repository.ProcessDefinition;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
  */
 public class ProcessDefinitionCategoryTest extends PluggableFlowableTestCase {
 
+    @Test
     public void testQueryByCategoryNotEquals() {
         Deployment deployment = repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/api/repository/processCategoryOne.bpmn20.xml")
                 .addClasspathResource("org/flowable/engine/test/api/repository/processCategoryTwo.bpmn20.xml").addClasspathResource("org/flowable/engine/test/api/repository/processCategoryThree.bpmn20.xml")
@@ -52,6 +54,7 @@ public class ProcessDefinitionCategoryTest extends PluggableFlowableTestCase {
         return processDefinitionNames;
     }
 
+    @Test
     @org.flowable.engine.test.Deployment
     public void testSetProcessDefinitionCategory() {
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/repository/ProcessDefinitionQueryByLatestTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/repository/ProcessDefinitionQueryByLatestTest.java
@@ -19,20 +19,11 @@ import java.util.List;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.repository.ProcessDefinition;
 import org.flowable.engine.repository.ProcessDefinitionQuery;
+import org.junit.jupiter.api.Test;
 
 public class ProcessDefinitionQueryByLatestTest extends PluggableFlowableTestCase {
 
     private static final String XML_FILE_PATH = "org/flowable/engine/test/repository/latest/";
-
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
-    }
-
-    @Override
-    protected void tearDown() throws Exception {
-        super.tearDown();
-    }
 
     protected List<String> deploy(List<String> xmlFileNameList) throws Exception {
         List<String> deploymentIdList = new ArrayList<>();
@@ -54,6 +45,7 @@ public class ProcessDefinitionQueryByLatestTest extends PluggableFlowableTestCas
         }
     }
 
+    @Test
     public void testQueryByLatestAndId() throws Exception {
         // Deploy
         List<String> xmlFileNameList = Arrays.asList("name_testProcess1_one.bpmn20.xml",
@@ -84,6 +76,7 @@ public class ProcessDefinitionQueryByLatestTest extends PluggableFlowableTestCas
         unDeploy(deploymentIdList);
     }
 
+    @Test
     public void testQueryByLatestAndName() throws Exception {
         // Deploy
         List<String> xmlFileNameList = Arrays.asList("name_testProcess1_one.bpmn20.xml",
@@ -108,6 +101,7 @@ public class ProcessDefinitionQueryByLatestTest extends PluggableFlowableTestCas
         unDeploy(deploymentIdList);
     }
 
+    @Test
     public void testQueryByLatestAndVersion() throws Exception {
         // Deploy
         List<String> xmlFileNameList = Arrays.asList("version_testProcess1_one.bpmn20.xml",
@@ -124,6 +118,7 @@ public class ProcessDefinitionQueryByLatestTest extends PluggableFlowableTestCas
         unDeploy(deploymentIdList);
     }
 
+    @Test
     public void testQueryByLatestAndDeploymentId() throws Exception {
         // Deploy
         List<String> xmlFileNameList = Arrays.asList("name_testProcess1_one.bpmn20.xml",

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/repository/ProcessDefinitionQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/repository/ProcessDefinitionQueryTest.java
@@ -24,6 +24,9 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.repository.Deployment;
 import org.flowable.engine.repository.ProcessDefinition;
 import org.flowable.engine.repository.ProcessDefinitionQuery;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
@@ -33,7 +36,7 @@ public class ProcessDefinitionQueryTest extends PluggableFlowableTestCase {
     private String deploymentOneId;
     private String deploymentTwoId;
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
         deploymentOneId = repositoryService.createDeployment().name("org/flowable/engine/test/repository/one.bpmn20.xml").addClasspathResource("org/flowable/engine/test/repository/one.bpmn20.xml")
                 .addClasspathResource("org/flowable/engine/test/repository/two.bpmn20.xml").deploy().getId();
@@ -41,16 +44,15 @@ public class ProcessDefinitionQueryTest extends PluggableFlowableTestCase {
         deploymentTwoId = repositoryService.createDeployment().name("org/flowable/engine/test/repository/one.bpmn20.xml").addClasspathResource("org/flowable/engine/test/repository/one.bpmn20.xml")
                 .deploy().getId();
 
-        super.setUp();
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
         repositoryService.deleteDeployment(deploymentOneId, true);
         repositoryService.deleteDeployment(deploymentTwoId, true);
     }
 
+    @Test
     public void testProcessDefinitionProperties() {
         List<ProcessDefinition> processDefinitions = repositoryService.createProcessDefinitionQuery().orderByProcessDefinitionName().asc().orderByProcessDefinitionVersion().asc()
                 .orderByProcessDefinitionCategory().asc().list();
@@ -74,11 +76,13 @@ public class ProcessDefinitionQueryTest extends PluggableFlowableTestCase {
         assertEquals("Examples2", processDefinition.getCategory());
     }
 
+    @Test
     public void testQueryByDeploymentId() {
         ProcessDefinitionQuery query = repositoryService.createProcessDefinitionQuery().deploymentId(deploymentOneId);
         verifyQueryResults(query, 2);
     }
 
+    @Test
     public void testQueryByInvalidDeploymentId() {
         ProcessDefinitionQuery query = repositoryService.createProcessDefinitionQuery().deploymentId("invalid");
         verifyQueryResults(query, 0);
@@ -90,6 +94,7 @@ public class ProcessDefinitionQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByName() {
         ProcessDefinitionQuery query = repositoryService.createProcessDefinitionQuery().processDefinitionName("Two");
         verifyQueryResults(query, 1);
@@ -98,6 +103,7 @@ public class ProcessDefinitionQueryTest extends PluggableFlowableTestCase {
         verifyQueryResults(query, 2);
     }
 
+    @Test
     public void testQueryByInvalidName() {
         ProcessDefinitionQuery query = repositoryService.createProcessDefinitionQuery().processDefinitionName("invalid");
         verifyQueryResults(query, 0);
@@ -109,16 +115,19 @@ public class ProcessDefinitionQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByNameLike() {
         ProcessDefinitionQuery query = repositoryService.createProcessDefinitionQuery().processDefinitionNameLike("%w%");
         verifyQueryResults(query, 1);
     }
 
+    @Test
     public void testQueryByInvalidNameLike() {
         ProcessDefinitionQuery query = repositoryService.createProcessDefinitionQuery().processDefinitionNameLike("%invalid%");
         verifyQueryResults(query, 0);
     }
 
+    @Test
     public void testQueryByKey() {
         // process one
         ProcessDefinitionQuery query = repositoryService.createProcessDefinitionQuery().processDefinitionKey("one");
@@ -129,6 +138,7 @@ public class ProcessDefinitionQueryTest extends PluggableFlowableTestCase {
         verifyQueryResults(query, 1);
     }
 
+    @Test
     public void testQueryByInvalidKey() {
         ProcessDefinitionQuery query = repositoryService.createProcessDefinitionQuery().processDefinitionKey("invalid");
         verifyQueryResults(query, 0);
@@ -140,11 +150,13 @@ public class ProcessDefinitionQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByKeyLike() {
         ProcessDefinitionQuery query = repositoryService.createProcessDefinitionQuery().processDefinitionKeyLike("%o%");
         verifyQueryResults(query, 3);
     }
 
+    @Test
     public void testQueryByInvalidKeyLike() {
         ProcessDefinitionQuery query = repositoryService.createProcessDefinitionQuery().processDefinitionKeyLike("%invalid%");
         verifyQueryResults(query, 0);
@@ -156,11 +168,13 @@ public class ProcessDefinitionQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByCategory() {
         ProcessDefinitionQuery query = repositoryService.createProcessDefinitionQuery().processDefinitionCategory("Examples");
         verifyQueryResults(query, 2);
     }
 
+    @Test
     public void testQueryByCategoryLike() {
         ProcessDefinitionQuery query = repositoryService.createProcessDefinitionQuery().processDefinitionCategoryLike("%Example%");
         verifyQueryResults(query, 3);
@@ -169,6 +183,7 @@ public class ProcessDefinitionQueryTest extends PluggableFlowableTestCase {
         verifyQueryResults(query, 1);
     }
 
+    @Test
     public void testQueryByVersion() {
         ProcessDefinitionQuery query = repositoryService.createProcessDefinitionQuery().processDefinitionVersion(2);
         verifyQueryResults(query, 1);
@@ -177,6 +192,7 @@ public class ProcessDefinitionQueryTest extends PluggableFlowableTestCase {
         verifyQueryResults(query, 2);
     }
 
+    @Test
     public void testQueryByInvalidVersion() {
         ProcessDefinitionQuery query = repositoryService.createProcessDefinitionQuery().processDefinitionVersion(3);
         verifyQueryResults(query, 0);
@@ -194,6 +210,7 @@ public class ProcessDefinitionQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByKeyAndVersion() {
         ProcessDefinitionQuery query = repositoryService.createProcessDefinitionQuery().processDefinitionKey("one").processDefinitionVersion(1);
         verifyQueryResults(query, 1);
@@ -205,6 +222,7 @@ public class ProcessDefinitionQueryTest extends PluggableFlowableTestCase {
         verifyQueryResults(query, 0);
     }
 
+    @Test
     public void testQueryByLatest() {
         ProcessDefinitionQuery query = repositoryService.createProcessDefinitionQuery().latestVersion();
         verifyQueryResults(query, 2);
@@ -216,6 +234,7 @@ public class ProcessDefinitionQueryTest extends PluggableFlowableTestCase {
         verifyQueryResults(query, 1);
     }
 
+    @Test
     public void testQuerySorting() {
 
         // asc
@@ -280,6 +299,7 @@ public class ProcessDefinitionQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByMessageSubscription() {
         Deployment deployment = repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/api/repository/processWithNewBookingMessage.bpmn20.xml")
                 .addClasspathResource("org/flowable/engine/test/api/repository/processWithNewInvoiceMessage.bpmn20.xml").deploy();
@@ -293,6 +313,7 @@ public class ProcessDefinitionQueryTest extends PluggableFlowableTestCase {
         repositoryService.deleteDeployment(deployment.getId());
     }
 
+    @Test
     public void testNativeQuery() {
         assertEquals("ACT_RE_PROCDEF", managementService.getTableName(ProcessDefinition.class));
         assertEquals("ACT_RE_PROCDEF", managementService.getTableName(ProcessDefinitionEntity.class));
@@ -310,6 +331,7 @@ public class ProcessDefinitionQueryTest extends PluggableFlowableTestCase {
         assertEquals(2, repositoryService.createNativeProcessDefinitionQuery().sql(baseQuerySql).listPage(1, 3).size());
     }
 
+    @Test
     public void testQueryByProcessDefinitionIds() {
         List<ProcessDefinition> processDefinitions = repositoryService.createProcessDefinitionQuery().list();
         Set<String> ids = new HashSet<>();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/repository/ProcessDefinitionSuspensionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/repository/ProcessDefinitionSuspensionTest.java
@@ -21,6 +21,7 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.repository.ProcessDefinition;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Daniel Meyer
@@ -28,12 +29,14 @@ import org.flowable.engine.test.Deployment;
  */
 public class ProcessDefinitionSuspensionTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/db/processOne.bpmn20.xml" })
     public void testProcessDefinitionActiveByDefault() {
         ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
         assertFalse(processDefinition.isSuspended());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/db/processOne.bpmn20.xml" })
     public void testSuspendActivateProcessDefinitionById() {
 
@@ -51,6 +54,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableFlowableTestCase {
         assertFalse(processDefinition.isSuspended());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/db/processOne.bpmn20.xml" })
     public void testSuspendActivateProcessDefinitionByKey() {
 
@@ -68,6 +72,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableFlowableTestCase {
         assertFalse(processDefinition.isSuspended());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/db/processOne.bpmn20.xml" })
     public void testCannotActivateActiveProcessDefinition() {
 
@@ -83,6 +88,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/db/processOne.bpmn20.xml" })
     public void testCannotSuspendActiveProcessDefinition() {
 
@@ -99,6 +105,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/db/processOne.bpmn20.xml", "org/flowable/engine/test/db/processTwo.bpmn20.xml" })
     public void testQueryForActiveDefinitions() {
 
@@ -114,6 +121,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableFlowableTestCase {
         assertEquals(1, repositoryService.createProcessDefinitionQuery().active().count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/db/processOne.bpmn20.xml", "org/flowable/engine/test/db/processTwo.bpmn20.xml" })
     public void testQueryForSuspendedDefinitions() {
 
@@ -130,6 +138,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableFlowableTestCase {
         assertEquals(1, repositoryService.createProcessDefinitionQuery().suspended().count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/db/processOne.bpmn20.xml" })
     public void testStartProcessInstanceForSuspendedProcessDefinition() {
         ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
@@ -152,6 +161,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testContinueProcessAfterProcessDefinitionSuspend() {
 
@@ -172,6 +182,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createProcessInstanceQuery().count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testSuspendProcessInstancesDuringProcessDefinitionSuspend() {
 
@@ -219,6 +230,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createProcessInstanceQuery().active().count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testSubmitStartFormAfterProcessDefinitionSuspend() {
         ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
@@ -241,6 +253,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment
     public void testJobIsExecutedOnProcessDefinitionSuspend() {
 
@@ -263,6 +276,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableFlowableTestCase {
         assertEquals(0, managementService.createTimerJobQuery().count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testDelayedSuspendProcessDefinition() {
 
@@ -311,6 +325,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableFlowableTestCase {
         assertEquals(0, repositoryService.createProcessDefinitionQuery().suspended().count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testDelayedSuspendProcessDefinitionIncludingProcessInstances() {
 
@@ -372,6 +387,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableFlowableTestCase {
         assertEquals(0, repositoryService.createProcessDefinitionQuery().suspended().count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testDelayedActivateProcessDefinition() {
 
@@ -408,6 +424,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableFlowableTestCase {
         assertEquals(0, repositoryService.createProcessDefinitionQuery().suspended().count());
     }
 
+    @Test
     public void testSuspendMultipleProcessDefinitionsByKey() {
 
         // Deploy three processes
@@ -449,6 +466,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testDelayedSuspendMultipleProcessDefinitionsByKey() {
 
         Date startTime = new Date();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/repository/RepositoryServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/repository/RepositoryServiceTest.java
@@ -33,6 +33,7 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.repository.Model;
 import org.flowable.engine.repository.ProcessDefinition;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Frederik Heremans
@@ -40,6 +41,7 @@ import org.flowable.engine.test.Deployment;
  */
 public class RepositoryServiceTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testStartProcessInstanceById() {
         List<ProcessDefinition> processDefinitions = repositoryService.createProcessDefinitionQuery().list();
@@ -50,6 +52,7 @@ public class RepositoryServiceTest extends PluggableFlowableTestCase {
         assertNotNull(processDefinition.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testFindProcessDefinitionById() {
         List<ProcessDefinition> definitions = repositoryService.createProcessDefinitionQuery().list();
@@ -65,6 +68,7 @@ public class RepositoryServiceTest extends PluggableFlowableTestCase {
         assertEquals("This is a process for testing purposes", processDefinition.getDescription());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testDeleteDeploymentWithRunningInstances() {
         List<ProcessDefinition> processDefinitions = repositoryService.createProcessDefinitionQuery().list();
@@ -82,6 +86,7 @@ public class RepositoryServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testDeleteDeploymentNullDeploymentId() {
         try {
             repositoryService.deleteDeployment(null);
@@ -91,6 +96,7 @@ public class RepositoryServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testDeleteDeploymentCascadeNullDeploymentId() {
         try {
             repositoryService.deleteDeployment(null, true);
@@ -100,6 +106,7 @@ public class RepositoryServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testDeleteDeploymentNonExistentDeploymentId() {
         try {
             repositoryService.deleteDeployment("foobar");
@@ -111,6 +118,7 @@ public class RepositoryServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testDeleteDeploymentCascadeNonExistentDeploymentId() {
         try {
             repositoryService.deleteDeployment("foobar", true);
@@ -122,6 +130,7 @@ public class RepositoryServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testDeleteDeploymentCascadeWithRunningInstances() {
         List<ProcessDefinition> processDefinitions = repositoryService.createProcessDefinitionQuery().list();
@@ -134,6 +143,7 @@ public class RepositoryServiceTest extends PluggableFlowableTestCase {
         repositoryService.deleteDeployment(processDefinition.getDeploymentId(), true);
     }
 
+    @Test
     public void testFindDeploymentResourceNamesNullDeploymentId() {
         try {
             repositoryService.getDeploymentResourceNames(null);
@@ -143,6 +153,7 @@ public class RepositoryServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testDeploymentWithDelayedProcessDefinitionActivation() {
 
         Date startTime = new Date();
@@ -185,6 +196,7 @@ public class RepositoryServiceTest extends PluggableFlowableTestCase {
         repositoryService.deleteDeployment(deployment.getId(), true);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testGetResourceAsStreamUnexistingResourceInExistingDeployment() {
         // Get hold of the deployment id
@@ -199,6 +211,7 @@ public class RepositoryServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testGetResourceAsStreamUnexistingDeployment() {
 
@@ -211,6 +224,7 @@ public class RepositoryServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testGetResourceAsStreamNullArguments() {
         try {
             repositoryService.getResourceAsStream(null, "resource");
@@ -227,6 +241,7 @@ public class RepositoryServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testNewModelPersistence() {
         Model model = repositoryService.newModel();
         assertNotNull(model);
@@ -248,6 +263,7 @@ public class RepositoryServiceTest extends PluggableFlowableTestCase {
         repositoryService.deleteModel(model.getId());
     }
 
+    @Test
     public void testNewModelWithSource() throws Exception {
         Model model = repositoryService.newModel();
         model.setName("Test model");
@@ -267,6 +283,7 @@ public class RepositoryServiceTest extends PluggableFlowableTestCase {
         repositoryService.deleteModel(model.getId());
     }
 
+    @Test
     public void testUpdateModelPersistence() throws Exception {
         Model model = repositoryService.newModel();
         assertNotNull(model);
@@ -303,6 +320,7 @@ public class RepositoryServiceTest extends PluggableFlowableTestCase {
         repositoryService.deleteModel(model.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testProcessDefinitionEntitySerializable() {
         String procDefId = repositoryService.createProcessDefinitionQuery().singleResult().getId();
@@ -320,6 +338,7 @@ public class RepositoryServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testGetBpmnModel() {
         ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
@@ -373,6 +392,7 @@ public class RepositoryServiceTest extends PluggableFlowableTestCase {
      * 
      * See https://blogs.oracle.com/xuemingshen/entry/non_utf_8_encoding_in
      */
+    @Test
     public void testDeployZipFile() {
         InputStream inputStream = this.getClass().getClassLoader().getResourceAsStream("org/flowable/engine/test/api/repository/test-processes.zip");
         assertNotNull(inputStream);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ExecutionAndProcessInstanceQueryVersionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ExecutionAndProcessInstanceQueryVersionTest.java
@@ -13,6 +13,9 @@
 package org.flowable.engine.test.api.runtime;
 
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ExecutionAndProcessInstanceQueryVersionTest extends PluggableFlowableTestCase {
 
@@ -22,9 +25,8 @@ public class ExecutionAndProcessInstanceQueryVersionTest extends PluggableFlowab
     private org.flowable.engine.repository.Deployment oldDeployment;
     private org.flowable.engine.repository.Deployment newDeployment;
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
         oldDeployment = repositoryService.createDeployment()
                 .addClasspathResource(DEPLOYMENT_FILE_PATH)
                 .deploy();
@@ -38,12 +40,13 @@ public class ExecutionAndProcessInstanceQueryVersionTest extends PluggableFlowab
         runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY).getId();
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
         repositoryService.deleteDeployment(oldDeployment.getId(), true);
         repositoryService.deleteDeployment(newDeployment.getId(), true);
     }
 
+    @Test
     public void testProcessInstanceQueryByProcessDefinitionVersion() {
         assertEquals(1, runtimeService.createProcessInstanceQuery().processDefinitionVersion(1).count());
         assertEquals(1, runtimeService.createProcessInstanceQuery().processDefinitionVersion(2).count());
@@ -53,6 +56,7 @@ public class ExecutionAndProcessInstanceQueryVersionTest extends PluggableFlowab
         assertEquals(0, runtimeService.createProcessInstanceQuery().processDefinitionVersion(3).list().size());
     }
 
+    @Test
     public void testProcessInstanceQueryByProcessDefinitionVersionAndKey() {
         assertEquals(1, runtimeService.createProcessInstanceQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(1).count());
         assertEquals(1, runtimeService.createProcessInstanceQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(2).count());
@@ -64,6 +68,7 @@ public class ExecutionAndProcessInstanceQueryVersionTest extends PluggableFlowab
         assertEquals(0, runtimeService.createProcessInstanceQuery().processDefinitionKey("undefined").processDefinitionVersion(2).list().size());
     }
 
+    @Test
     public void testProcessInstanceOrQueryByProcessDefinitionVersion() {
         assertEquals(1, runtimeService.createProcessInstanceQuery().or().processDefinitionVersion(1).processDefinitionId("undefined").endOr().count());
         assertEquals(1, runtimeService.createProcessInstanceQuery().or().processDefinitionVersion(2).processDefinitionId("undefined").endOr().count());
@@ -73,6 +78,7 @@ public class ExecutionAndProcessInstanceQueryVersionTest extends PluggableFlowab
         assertEquals(0, runtimeService.createProcessInstanceQuery().or().processDefinitionVersion(3).processDefinitionId("undefined").endOr().list().size());
     }
 
+    @Test
     public void testExecutionQueryByProcessDefinitionVersion() {
         assertEquals(2, runtimeService.createExecutionQuery().processDefinitionVersion(1).count());
         assertEquals(2, runtimeService.createExecutionQuery().processDefinitionVersion(2).count());
@@ -82,6 +88,7 @@ public class ExecutionAndProcessInstanceQueryVersionTest extends PluggableFlowab
         assertEquals(0, runtimeService.createExecutionQuery().processDefinitionVersion(3).list().size());
     }
 
+    @Test
     public void testExecutionQueryByProcessDefinitionVersionAndKey() {
         assertEquals(2, runtimeService.createExecutionQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(1).count());
         assertEquals(2, runtimeService.createExecutionQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(2).count());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ExecutionQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ExecutionQueryTest.java
@@ -46,6 +46,9 @@ import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ExecutionQuery;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -65,9 +68,8 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
     private List<String> concurrentProcessInstanceIds;
     private List<String> sequentialProcessInstanceIds;
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
         repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml")
                 .addClasspathResource("org/flowable/engine/test/api/runtime/concurrentExecution.bpmn20.xml").deploy();
 
@@ -80,20 +82,21 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         sequentialProcessInstanceIds.add(runtimeService.startProcessInstanceByKey(SEQUENTIAL_PROCESS_KEY).getId());
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
         for (org.flowable.engine.repository.Deployment deployment : repositoryService.createDeploymentQuery().list()) {
             repositoryService.deleteDeployment(deployment.getId(), true);
         }
-        super.tearDown();
     }
 
+    @Test
     public void testQueryByProcessDefinitionKey() {
         // Concurrent process with 3 executions for each process instance
         assertEquals(12, runtimeService.createExecutionQuery().processDefinitionKey(CONCURRENT_PROCESS_KEY).list().size());
         assertEquals(2, runtimeService.createExecutionQuery().processDefinitionKey(SEQUENTIAL_PROCESS_KEY).list().size());
     }
 
+    @Test
     public void testQueryByProcessDefinitionKeyIn() {
         Set<String> includeIds = new HashSet<>();
         assertEquals(14, runtimeService.createExecutionQuery().processDefinitionKeys(includeIds).list().size());
@@ -109,6 +112,7 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createExecutionQuery().processDefinitionKeys(includeIds).list().size());
     }
 
+    @Test
     public void testQueryByInvalidProcessDefinitionKey() {
         ExecutionQuery query = runtimeService.createExecutionQuery().processDefinitionKey("invalid");
         assertNull(query.singleResult());
@@ -116,12 +120,14 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, query.count());
     }
 
+    @Test
     public void testQueryByProcessDefinitionCategory() {
         // Concurrent process with 3 executions for each process instance
         assertEquals(12, runtimeService.createExecutionQuery().processDefinitionCategory(CONCURRENT_PROCESS_CATEGORY).list().size());
         assertEquals(2, runtimeService.createExecutionQuery().processDefinitionCategory(SEQUENTIAL_PROCESS_CATEGORY).list().size());
     }
 
+    @Test
     public void testQueryByInvalidProcessDefinitionCategory() {
         ExecutionQuery query = runtimeService.createExecutionQuery().processDefinitionCategory("invalid");
         assertNull(query.singleResult());
@@ -129,12 +135,14 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, query.count());
     }
 
+    @Test
     public void testQueryByProcessDefinitionName() {
         // Concurrent process with 3 executions for each process instance
         assertEquals(12, runtimeService.createExecutionQuery().processDefinitionName(CONCURRENT_PROCESS_NAME).list().size());
         assertEquals(2, runtimeService.createExecutionQuery().processDefinitionName(SEQUENTIAL_PROCESS_NAME).list().size());
     }
 
+    @Test
     public void testQueryByInvalidProcessDefinitionName() {
         ExecutionQuery query = runtimeService.createExecutionQuery().processDefinitionName("invalid");
         assertNull(query.singleResult());
@@ -142,6 +150,7 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, query.count());
     }
 
+    @Test
     public void testQueryByProcessInstanceId() {
         for (String processInstanceId : concurrentProcessInstanceIds) {
             ExecutionQuery query = runtimeService.createExecutionQuery().processInstanceId(processInstanceId);
@@ -151,6 +160,7 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         assertEquals(2, runtimeService.createExecutionQuery().processInstanceId(sequentialProcessInstanceIds.get(0)).list().size());
     }
 
+    @Test
     public void testQueryByRootProcessInstanceId() {
         for (String processInstanceId : concurrentProcessInstanceIds) {
             ExecutionQuery query = runtimeService.createExecutionQuery().rootProcessInstanceId(processInstanceId);
@@ -160,6 +170,7 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         assertEquals(2, runtimeService.createExecutionQuery().rootProcessInstanceId(sequentialProcessInstanceIds.get(0)).list().size());
     }
 
+    @Test
     public void testQueryByParentId() {
         // Concurrent processes fork into 2 child-executions. Should be found
         // when parentId is used
@@ -170,6 +181,7 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByInvalidProcessInstanceId() {
         ExecutionQuery query = runtimeService.createExecutionQuery().processInstanceId("invalid");
         assertNull(query.singleResult());
@@ -177,11 +189,13 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, query.count());
     }
 
+    @Test
     public void testQueryExecutionId() {
         List<Execution> executions = runtimeService.createExecutionQuery().processDefinitionKey(SEQUENTIAL_PROCESS_KEY).list();
         assertEquals(2, executions.size());
     }
 
+    @Test
     public void testQueryByInvalidExecutionId() {
         ExecutionQuery query = runtimeService.createExecutionQuery().executionId("invalid");
         assertNull(query.singleResult());
@@ -189,6 +203,7 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, query.count());
     }
 
+    @Test
     public void testQueryByActivityId() {
         ExecutionQuery query = runtimeService.createExecutionQuery().activityId("receivePayment");
         assertEquals(4, query.list().size());
@@ -201,6 +216,7 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByInvalidActivityId() {
         ExecutionQuery query = runtimeService.createExecutionQuery().activityId("invalid");
         assertNull(query.singleResult());
@@ -211,6 +227,7 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
     /**
      * Validate fix for ACT-1896
      */
+    @Test
     public void testQueryByActivityIdAndBusinessKeyWithChildren() {
         ExecutionQuery query = runtimeService.createExecutionQuery().activityId("receivePayment").processInstanceBusinessKey("BUSINESS-KEY-1", true);
         assertEquals(1, query.list().size());
@@ -221,6 +238,7 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         assertEquals("receivePayment", execution.getActivityId());
     }
 
+    @Test
     public void testQueryPaging() {
         assertEquals(14, runtimeService.createExecutionQuery().count());
         assertEquals(4, runtimeService.createExecutionQuery().processDefinitionKey(CONCURRENT_PROCESS_KEY).listPage(0, 4).size());
@@ -229,6 +247,7 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         assertEquals(12, runtimeService.createExecutionQuery().processDefinitionKey(CONCURRENT_PROCESS_KEY).listPage(0, 20).size());
     }
 
+    @Test
     public void testQuerySorting() {
 
         // 13 executions: 3 for each concurrent, 1 for the sequential
@@ -246,6 +265,7 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         assertEquals(12, runtimeService.createExecutionQuery().processDefinitionKey(CONCURRENT_PROCESS_KEY).orderByProcessDefinitionKey().asc().orderByProcessInstanceId().desc().list().size());
     }
 
+    @Test
     public void testQueryInvalidSorting() {
         try {
             runtimeService.createExecutionQuery().orderByProcessDefinitionKey().list();
@@ -255,18 +275,21 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByBusinessKey() {
         assertEquals(1, runtimeService.createExecutionQuery().processDefinitionKey(CONCURRENT_PROCESS_KEY).processInstanceBusinessKey("BUSINESS-KEY-1").list().size());
         assertEquals(1, runtimeService.createExecutionQuery().processDefinitionKey(CONCURRENT_PROCESS_KEY).processInstanceBusinessKey("BUSINESS-KEY-2").list().size());
         assertEquals(0, runtimeService.createExecutionQuery().processDefinitionKey(CONCURRENT_PROCESS_KEY).processInstanceBusinessKey("NON-EXISTING").list().size());
     }
 
+    @Test
     public void testQueryByBusinessKeyIncludingChildExecutions() {
         assertEquals(3, runtimeService.createExecutionQuery().processDefinitionKey(CONCURRENT_PROCESS_KEY).processInstanceBusinessKey("BUSINESS-KEY-1", true).list().size());
         assertEquals(3, runtimeService.createExecutionQuery().processDefinitionKey(CONCURRENT_PROCESS_KEY).processInstanceBusinessKey("BUSINESS-KEY-2", true).list().size());
         assertEquals(0, runtimeService.createExecutionQuery().processDefinitionKey(CONCURRENT_PROCESS_KEY).processInstanceBusinessKey("NON-EXISTING", true).list().size());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testQueryStringVariable() {
         Map<String, Object> vars = new HashMap<>();
@@ -369,6 +392,7 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         runtimeService.deleteProcessInstance(processInstance3.getId(), "test");
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testQueryEqualsIgnoreCase() {
         Map<String, Object> vars = new HashMap<>();
@@ -438,6 +462,7 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testQueryLike() {
         Map<String, Object> vars = new HashMap<>();
@@ -471,6 +496,7 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testQueryLikeIgnoreCase() {
         Map<String, Object> vars = new HashMap<>();
@@ -513,6 +539,7 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = {
             "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testQueryLongVariable() {
@@ -607,6 +634,7 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         runtimeService.deleteProcessInstance(processInstance3.getId(), "test");
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testQueryDoubleVariable() {
         Map<String, Object> vars = new HashMap<>();
@@ -700,6 +728,7 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         runtimeService.deleteProcessInstance(processInstance3.getId(), "test");
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testQueryIntegerVariable() {
         Map<String, Object> vars = new HashMap<>();
@@ -793,6 +822,7 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         runtimeService.deleteProcessInstance(processInstance3.getId(), "test");
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testQueryShortVariable() {
         Map<String, Object> vars = new HashMap<>();
@@ -889,6 +919,7 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         runtimeService.deleteProcessInstance(processInstance3.getId(), "test");
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testQueryDateVariable() throws Exception {
         Map<String, Object> vars = new HashMap<>();
@@ -1000,6 +1031,7 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         runtimeService.deleteProcessInstance(processInstance3.getId(), "test");
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testBooleanVariable() throws Exception {
 
@@ -1075,6 +1107,7 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         runtimeService.deleteProcessInstance(processInstance2.getId(), "test");
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testQueryVariablesUpdatedToNullValue() {
         // Start process instance with different types of variables
@@ -1112,6 +1145,7 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         assertNull(notQuery.singleResult());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testQueryNullVariable() throws Exception {
         Map<String, Object> vars = new HashMap<>();
@@ -1201,6 +1235,7 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         assertNull(execution);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testQueryInvalidTypes() throws Exception {
         Map<String, Object> vars = new HashMap<>();
@@ -1226,6 +1261,7 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         runtimeService.deleteProcessInstance(processInstance.getId(), "test");
     }
 
+    @Test
     public void testQueryVariablesNullNameArgument() {
         try {
             runtimeService.createExecutionQuery().variableValueEquals(null, "value");
@@ -1271,6 +1307,7 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testQueryAllVariableTypes() throws Exception {
         Map<String, Object> vars = new HashMap<>();
@@ -1295,6 +1332,7 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         runtimeService.deleteProcessInstance(processInstance.getId(), "test");
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testClashingValues() throws Exception {
         Map<String, Object> vars = new HashMap<>();
@@ -1316,6 +1354,7 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         runtimeService.deleteProcessInstance(processInstance2.getId(), "test");
     }
     
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testVariableExistsQuery() {
         Map<String, Object> vars = new HashMap<>();
@@ -1370,6 +1409,7 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, executions.size());
     }
 
+    @Test
     @Deployment
     public void testQueryBySignalSubscriptionName() {
         runtimeService.startProcessInstanceByKey("catchSignal");
@@ -1387,6 +1427,7 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         assertEquals(2, runtimeService.createExecutionQuery().signalEventSubscriptionName("alert").count());
     }
 
+    @Test
     @Deployment
     public void testQueryBySignalSubscriptionNameBoundary() {
         runtimeService.startProcessInstanceByKey("signalProces");
@@ -1404,6 +1445,7 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         assertEquals(2, runtimeService.createExecutionQuery().signalEventSubscriptionName("Test signal").count());
     }
 
+    @Test
     public void testNativeQuery() {
         // just test that the query will be constructed and executed, details
         // are tested in the TaskQueryTest
@@ -1415,11 +1457,13 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         assertEquals(executionCount, runtimeService.createNativeExecutionQuery().sql("SELECT count(*) FROM " + managementService.getTableName(Execution.class)).count());
     }
 
+    @Test
     public void testNativeQueryPaging() {
         assertEquals(5, runtimeService.createNativeExecutionQuery().sql("SELECT * FROM " + managementService.getTableName(Execution.class)).listPage(1, 5).size());
         assertEquals(1, runtimeService.createNativeExecutionQuery().sql("SELECT * FROM " + managementService.getTableName(Execution.class)).listPage(2, 1).size());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/concurrentExecution.bpmn20.xml" })
     public void testExecutionQueryWithProcessVariable() {
         Map<String, Object> variables = new HashMap<>();
@@ -1459,6 +1503,7 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/executionLocalization.bpmn20.xml" })
     public void testLocalizeExecution() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("executionLocalization");
@@ -1656,6 +1701,7 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         assertEquals("SubProcess Description 'en-US'", execution.getDescription());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testQueryStartedBefore() throws Exception {
         Calendar calendar = new GregorianCalendar();
@@ -1680,6 +1726,7 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         assertEquals(2, executions.size());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testQueryStartedAfter() throws Exception {
         Calendar calendar = new GregorianCalendar();
@@ -1704,6 +1751,7 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         assertEquals(2, executions.size());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testQueryStartedBy() throws Exception {
         final String authenticatedUser = "user1";
@@ -1715,6 +1763,7 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         assertEquals(1, executions.size());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/multipleSubProcess.bpmn20.xml",
             "org/flowable/engine/test/api/runtime/subProcess.bpmn20.xml" })
     public void testOnlySubProcessExecutions() throws Exception {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/InstanceInvolvementTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/InstanceInvolvementTest.java
@@ -26,25 +26,30 @@ import org.flowable.engine.test.Deployment;
 import org.flowable.identitylink.api.IdentityLink;
 import org.flowable.identitylink.api.IdentityLinkType;
 import org.flowable.idm.api.Group;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Marcus Klimstra
  */
 public class InstanceInvolvementTest extends PluggableFlowableTestCase {
 
+    @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         Group testGroup = identityService.newGroup("testGroup");
         identityService.saveGroup(testGroup);
         testGroup = identityService.newGroup("testGroup2");
         identityService.saveGroup(testGroup);
     }
 
+    @AfterEach
     public void tearDown() {
         identityService.deleteGroup("testGroup");
         identityService.deleteGroup("testGroup2");
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/threeParallelTasks.bpmn20.xml" })
     public void testInvolvements() {
         // "user1", "user2", "user3" and "user4 should not be involved with any process instance
@@ -106,6 +111,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/threeParallelTasks.bpmn20.xml" })
     public void testInstanceRemoval() {
         String instanceId = startProcessAsUser("threeParallelTasks", "user1");
@@ -119,6 +125,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
     /**
      * Test for ACT-1686
      */
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testUserMultipleTimesinvolvedWithProcessInstance() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -130,6 +137,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         assertEquals(1L, runtimeService.createProcessInstanceQuery().involvedUser("kermit").count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testInvolvedGroupsWithProcessInstance() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -140,6 +148,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         assertEquals(processInstance.getId(), runtimeService.createProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testOneInvolvedGroupsInTwo() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -151,6 +160,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         assertEquals(processInstance.getId(), runtimeService.createProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testTwoInvolvedGroupsInTwo() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -162,6 +172,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         assertEquals(processInstance.getId(), runtimeService.createProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testTwoInvolvedGroupsInOne() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -172,6 +183,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         assertEquals(processInstance.getId(), runtimeService.createProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testNoInvolvedGroupsInTwo() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -182,6 +194,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         assertEquals(0L, runtimeService.createProcessInstanceQuery().involvedGroups(Collections.singleton("nonInvolvedGroup")).count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testOneInvolvedGroupsInMultiple() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -195,6 +208,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
             runtimeService.createProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testOneInvolvedGroupInNone() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -205,6 +219,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         assertEquals(0L, runtimeService.createProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testOrInvolvedGroupsWithProcessInstance() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -216,6 +231,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         assertEquals(processInstance.getId(), runtimeService.createProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testOrOneInvolvedGroupsInTwo() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -228,6 +244,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         assertEquals(processInstance.getId(), runtimeService.createProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testOrTwoInvolvedGroupsInTwo() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -240,6 +257,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         assertEquals(processInstance.getId(), runtimeService.createProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testOrTwoInvolvedGroupsInOne() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -252,6 +270,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
             or().processInstanceId("undefinedId").involvedGroups(Collections.singleton("testGroup")).endOr().list().get(0).getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testOrNoInvolvedGroupsInTwo() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -263,6 +282,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
             or().processInstanceId("undefinedId").involvedGroups(Collections.singleton("nonInvolvedGroup")).endOr().count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testOrOneInvolvedGroupsInMultiple() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -278,6 +298,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
                 or().processInstanceId("undefinedId").involvedGroups(Collections.singleton("testGroup")).endOr().list().get(0).getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testOrOneInvolvedGroupInNone() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -289,6 +310,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
             or().processInstanceId("undefinedId").involvedGroups(Collections.singleton("testGroup")).endOr().count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testOrOneInvolvedGroupWithUser() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -300,6 +322,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
             or().involvedUser("kermit").involvedGroups(Collections.singleton("testGroup")).endOr().count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testOneInvolvedGroupWithUser() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -311,6 +334,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
             involvedUser("kermit").involvedGroups(Collections.singleton("testGroup")).count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testOneInvolvedGroupTogetherWithUser() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -321,6 +345,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
             involvedUser("kermit").involvedGroups(Collections.singleton("testGroup")).count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testOneInvolvedUserTogetherWithGroup() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -331,6 +356,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
             involvedUser("kermit").involvedGroups(Collections.singleton("testGroup")).count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testOrOneInvolvedUserTogetherWithGroup() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -344,6 +370,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
             count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testInvolvedGroupsWithHistoricProcessInstance() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -356,6 +383,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testHistoryOneInvolvedGroupsInTwo() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -370,6 +398,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testHistoryTwoInvolvedGroupsInTwo() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -384,6 +413,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testHistoryTwoInvolvedGroupsInOne() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -396,6 +426,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testHistoryNoInvolvedGroupsInTwo() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -408,6 +439,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testHistoryOneInvolvedGroupsInMultiple() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -423,6 +455,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testHistoryOneInvolvedGroupInNone() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -435,6 +468,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testHistoryOrInvolvedGroupsWithProcessInstance() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -448,6 +482,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testHistoryOrOneInvolvedGroupsInTwo() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -462,6 +497,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testHistoryOrTwoInvolvedGroupsInTwo() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -476,6 +512,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testHistoryOrTwoInvolvedGroupsInOne() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -490,6 +527,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testHistoryOrNoInvolvedGroupsInTwo() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -503,6 +541,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testHistoryOrOneInvolvedGroupsInMultiple() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -520,6 +559,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testHistoryOrOneInvolvedGroupInNone() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -533,6 +573,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testHistoryOrOneInvolvedGroupWithUser() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -546,6 +587,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testHistoryOneInvolvedGroupWithUser() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -559,6 +601,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testHistoryOneInvolvedGroupTogetherWithUser() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -571,6 +614,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testHistoryOneInvolvedUserTogetherWithGroup() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -583,6 +627,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testHistoryOrOneInvolvedUserTogetherWithGroup() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ProcessInstanceAndVariablesQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ProcessInstanceAndVariablesQueryTest.java
@@ -19,6 +19,9 @@ import java.util.Map;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.runtime.ProcessInstanceQuery;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tijs Rademakers
@@ -32,9 +35,8 @@ public class ProcessInstanceAndVariablesQueryTest extends PluggableFlowableTestC
     /**
      * Setup starts 4 process instances of oneTaskProcess and 1 instance of oneTaskProcess2
      */
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
         repositoryService.createDeployment()
                 .addClasspathResource("org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml")
                 .addClasspathResource("org/flowable/engine/test/api/runtime/oneTaskProcess2.bpmn20.xml")
@@ -57,14 +59,14 @@ public class ProcessInstanceAndVariablesQueryTest extends PluggableFlowableTestC
         runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY_3, "1", startMap);
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
         for (org.flowable.engine.repository.Deployment deployment : repositoryService.createDeploymentQuery().list()) {
             repositoryService.deleteDeployment(deployment.getId(), true);
         }
-        super.tearDown();
     }
 
+    @Test
     public void testQuery() {
         ProcessInstance processInstance = runtimeService.createProcessInstanceQuery().includeProcessVariables().variableValueEquals("anothertest", 123).singleResult();
         Map<String, Object> variableMap = processInstance.getProcessVariables();
@@ -131,6 +133,7 @@ public class ProcessInstanceAndVariablesQueryTest extends PluggableFlowableTestC
         assertEquals(0, instanceList.size());
     }
 
+    @Test
     public void testOrQuery() {
         ProcessInstance processInstance = runtimeService.createProcessInstanceQuery().includeProcessVariables()
                 .or().variableValueEquals("undefined", 999).variableValueEquals("anothertest", 123).endOr().singleResult();
@@ -159,6 +162,7 @@ public class ProcessInstanceAndVariablesQueryTest extends PluggableFlowableTestC
         assertEquals(123, variableMap.get("anothertest"));
     }
 
+    @Test
     public void testOrQueryMultipleVariableValues() {
         ProcessInstanceQuery query0 = runtimeService.createProcessInstanceQuery().includeProcessVariables().or();
         for (int i = 0; i < 20; i++) {
@@ -204,6 +208,7 @@ public class ProcessInstanceAndVariablesQueryTest extends PluggableFlowableTestC
         assertEquals(123, variableMap.get("anothertest"));
     }
 
+    @Test
     public void testOrProcessVariablesLikeIgnoreCase() {
         List<ProcessInstance> instanceList = runtimeService
                 .createProcessInstanceQuery().or()

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ProcessInstanceCommentTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ProcessInstanceCommentTest.java
@@ -21,12 +21,14 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.task.Comment;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
  */
 public class ProcessInstanceCommentTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testAddCommentToProcessInstance() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ProcessInstanceIdentityLinksTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ProcessInstanceIdentityLinksTest.java
@@ -22,12 +22,14 @@ import org.flowable.engine.task.Event;
 import org.flowable.engine.test.Deployment;
 import org.flowable.identitylink.api.IdentityLink;
 import org.flowable.identitylink.api.IdentityLinkType;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Wendel Kerr
  */
 public class ProcessInstanceIdentityLinksTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/runtime/IdentityLinksProcess.bpmn20.xml")
     public void testParticipantUserLink() {
         runtimeService.startProcessInstanceByKey("IdentityLinksProcess");
@@ -51,6 +53,7 @@ public class ProcessInstanceIdentityLinksTest extends PluggableFlowableTestCase 
         assertEquals(0, runtimeService.getIdentityLinksForProcessInstance(processInstanceId).size());
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/runtime/IdentityLinksProcess.bpmn20.xml")
     public void testCandidateGroupLink() {
         runtimeService.startProcessInstanceByKey("IdentityLinksProcess");
@@ -105,6 +108,7 @@ public class ProcessInstanceIdentityLinksTest extends PluggableFlowableTestCase 
         throw new AssertionError("no process instance event found with action " + action);
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/runtime/IdentityLinksProcess.bpmn20.xml")
     public void testCustomTypeUserLink() {
         runtimeService.startProcessInstanceByKey("IdentityLinksProcess");
@@ -128,6 +132,7 @@ public class ProcessInstanceIdentityLinksTest extends PluggableFlowableTestCase 
         assertEquals(0, runtimeService.getIdentityLinksForProcessInstance(processInstanceId).size());
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/runtime/IdentityLinksProcess.bpmn20.xml")
     public void testCustomLinkGroupLink() {
         runtimeService.startProcessInstanceByKey("IdentityLinksProcess");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ProcessInstanceQueryAndWithExceptionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ProcessInstanceQueryAndWithExceptionTest.java
@@ -21,6 +21,9 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.runtime.ProcessInstanceQuery;
 import org.flowable.job.api.Job;
 import org.flowable.job.api.TimerJobQuery;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ProcessInstanceQueryAndWithExceptionTest extends PluggableFlowableTestCase {
 
@@ -30,9 +33,8 @@ public class ProcessInstanceQueryAndWithExceptionTest extends PluggableFlowableT
 
     private org.flowable.engine.repository.Deployment deployment;
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
         deployment = repositoryService.createDeployment()
                 .addClasspathResource("org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml")
                 .addClasspathResource("org/flowable/engine/test/api/runtime/JobErrorCheck.bpmn20.xml")
@@ -40,12 +42,12 @@ public class ProcessInstanceQueryAndWithExceptionTest extends PluggableFlowableT
                 .deploy();
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
         repositoryService.deleteDeployment(deployment.getId(), true);
-        super.tearDown();
     }
 
+    @Test
     public void testQueryWithException() throws InterruptedException {
         ProcessInstance processNoException = runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY_NO_EXCEPTION);
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ProcessInstanceQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ProcessInstanceQueryTest.java
@@ -35,6 +35,9 @@ import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.runtime.ProcessInstanceQuery;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -62,9 +65,8 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
     /**
      * Setup starts 4 process instances of oneTaskProcess and 1 instance of oneTaskProcess2
      */
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
         deployment = repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml")
                 .addClasspathResource("org/flowable/engine/test/api/runtime/oneTaskProcess2.bpmn20.xml").deploy();
 
@@ -75,18 +77,19 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         processInstanceIds.add(runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY_2, "1").getId());
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
         deleteDeployments();
-        super.tearDown();
     }
 
+    @Test
     public void testQueryNoSpecificsList() {
         ProcessInstanceQuery query = runtimeService.createProcessInstanceQuery();
         assertEquals(PROCESS_DEPLOY_COUNT, query.count());
         assertEquals(PROCESS_DEPLOY_COUNT, query.list().size());
     }
 
+    @Test
     public void testQueryNoSpecificsSingleResult() {
         ProcessInstanceQuery query = runtimeService.createProcessInstanceQuery();
         try {
@@ -97,6 +100,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByProcessDefinitionKeySingleResult() {
         ProcessInstanceQuery query = runtimeService.createProcessInstanceQuery().processDefinitionKey(PROCESS_DEFINITION_KEY_2);
         assertEquals(PROCESS_DEFINITION_KEY_2_DEPLOY_COUNT, query.count());
@@ -104,11 +108,13 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         assertNotNull(query.singleResult());
     }
 
+    @Test
     public void testQueryByInvalidProcessDefinitionKey() {
         assertNull(runtimeService.createProcessInstanceQuery().processDefinitionKey("invalid").singleResult());
         assertEquals(0, runtimeService.createProcessInstanceQuery().processDefinitionKey("invalid").list().size());
     }
 
+    @Test
     public void testQueryByProcessDefinitionKeyMultipleResults() {
         ProcessInstanceQuery query = runtimeService.createProcessInstanceQuery().processDefinitionKey(PROCESS_DEFINITION_KEY);
         assertEquals(PROCESS_DEFINITION_KEY_DEPLOY_COUNT, query.count());
@@ -122,6 +128,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByProcessDefinitionKeys() {
         final Set<String> processDefinitionKeySet = new HashSet<>(2);
         processDefinitionKeySet.add(PROCESS_DEFINITION_KEY);
@@ -138,6 +145,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByInvalidProcessDefinitionKeys() {
         try {
             runtimeService.createProcessInstanceQuery().processDefinitionKeys(null);
@@ -154,6 +162,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByProcessInstanceId() {
         for (String processInstanceId : processInstanceIds) {
             assertNotNull(runtimeService.createProcessInstanceQuery().processInstanceId(processInstanceId).singleResult());
@@ -161,16 +170,19 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByProcessDefinitionCategory() {
         assertEquals(PROCESS_DEFINITION_KEY_DEPLOY_COUNT, runtimeService.createProcessInstanceQuery().processDefinitionCategory(PROCESS_DEFINITION_CATEGORY).count());
         assertEquals(PROCESS_DEFINITION_KEY_2_DEPLOY_COUNT, runtimeService.createProcessInstanceQuery().processDefinitionCategory(PROCESS_DEFINITION_CATEGORY_2).count());
     }
 
+    @Test
     public void testOrQueryByProcessDefinitionCategory() {
         assertEquals(PROCESS_DEFINITION_KEY_DEPLOY_COUNT, runtimeService.createProcessInstanceQuery().or().processDefinitionCategory(PROCESS_DEFINITION_CATEGORY).processDefinitionId("undefined").endOr().count());
         assertEquals(PROCESS_DEFINITION_KEY_2_DEPLOY_COUNT, runtimeService.createProcessInstanceQuery().or().processDefinitionCategory(PROCESS_DEFINITION_CATEGORY_2).processDefinitionId("undefined").endOr().count());
     }
 
+    @Test
     public void testQueryByProcessInstanceName() {
         runtimeService.setProcessInstanceName(processInstanceIds.get(0), "new name");
         assertNotNull(runtimeService.createProcessInstanceQuery().processInstanceName("new name").singleResult());
@@ -179,6 +191,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         assertNull(runtimeService.createProcessInstanceQuery().processInstanceName("unexisting").singleResult());
     }
 
+    @Test
     public void testOrQueryByProcessInstanceName() {
         runtimeService.setProcessInstanceName(processInstanceIds.get(0), "new name");
         assertNotNull(runtimeService.createProcessInstanceQuery().or().processInstanceName("new name").processDefinitionId("undefined").endOr().singleResult());
@@ -208,6 +221,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
                 .singleResult());
     }
 
+    @Test
     public void testQueryByProcessInstanceNameLike() {
         runtimeService.setProcessInstanceName(processInstanceIds.get(0), "new name");
         assertNotNull(runtimeService.createProcessInstanceQuery().processInstanceNameLike("% name").singleResult());
@@ -216,6 +230,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         assertNull(runtimeService.createProcessInstanceQuery().processInstanceNameLike("%nope").singleResult());
     }
 
+    @Test
     public void testOrQueryByProcessInstanceNameLike() {
         runtimeService.setProcessInstanceName(processInstanceIds.get(0), "new name");
         assertNotNull(runtimeService.createProcessInstanceQuery().or().processInstanceNameLike("% name").processDefinitionId("undefined").endOr().singleResult());
@@ -224,6 +239,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         assertNull(runtimeService.createProcessInstanceQuery().or().processInstanceNameLike("%nope").processDefinitionId("undefined").endOr().singleResult());
     }
 
+    @Test
     public void testOrQueryByProcessInstanceNameLikeIgnoreCase() {
         runtimeService.setProcessInstanceName(processInstanceIds.get(0), "new name");
         runtimeService.setProcessInstanceName(processInstanceIds.get(1), "other Name!");
@@ -249,6 +265,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByBusinessKeyAndProcessDefinitionKey() {
         assertEquals(1, runtimeService.createProcessInstanceQuery().processInstanceBusinessKey("0", PROCESS_DEFINITION_KEY).count());
         assertEquals(1, runtimeService.createProcessInstanceQuery().processInstanceBusinessKey("1", PROCESS_DEFINITION_KEY).count());
@@ -257,11 +274,13 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         assertEquals(1, runtimeService.createProcessInstanceQuery().processInstanceBusinessKey("1", PROCESS_DEFINITION_KEY_2).count());
     }
 
+    @Test
     public void testQueryByBusinessKey() {
         assertEquals(1, runtimeService.createProcessInstanceQuery().processInstanceBusinessKey("0").count());
         assertEquals(2, runtimeService.createProcessInstanceQuery().processInstanceBusinessKey("1").count());
     }
 
+    @Test
     public void testQueryByInvalidBusinessKey() {
         assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceBusinessKey("invalid").count());
 
@@ -273,6 +292,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByProcessDefinitionId() {
         final ProcessDefinition processDefinition1 = repositoryService.createProcessDefinitionQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).singleResult();
         ProcessInstanceQuery query1 = runtimeService.createProcessInstanceQuery().processDefinitionId(processDefinition1.getId());
@@ -292,6 +312,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         assertNotNull(query2.singleResult());
     }
 
+    @Test
     public void testQueryByProcessDefinitionIds() {
         final ProcessDefinition processDefinition1 = repositoryService.createProcessDefinitionQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).singleResult();
         final ProcessDefinition processDefinition2 = repositoryService.createProcessDefinitionQuery().processDefinitionKey(PROCESS_DEFINITION_KEY_2).singleResult();
@@ -311,6 +332,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByInvalidProcessDefinitionIds() {
         try {
             runtimeService.createProcessInstanceQuery().processDefinitionIds(null);
@@ -327,22 +349,26 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByProcessDefinitionName() {
         assertEquals(PROCESS_DEFINITION_KEY_DEPLOY_COUNT, runtimeService.createProcessInstanceQuery().processDefinitionName(PROCESS_DEFINITION_NAME).count());
         assertEquals(PROCESS_DEFINITION_KEY_2_DEPLOY_COUNT, runtimeService.createProcessInstanceQuery().processDefinitionName(PROCESS_DEFINITION_NAME_2).count());
     }
 
+    @Test
     public void testOrQueryByProcessDefinitionName() {
         assertEquals(PROCESS_DEFINITION_KEY_DEPLOY_COUNT, runtimeService.createProcessInstanceQuery().or().processDefinitionName(PROCESS_DEFINITION_NAME).processDefinitionId("undefined").endOr().count());
         assertEquals(PROCESS_DEFINITION_KEY_2_DEPLOY_COUNT, runtimeService.createProcessInstanceQuery().or().processDefinitionName(PROCESS_DEFINITION_NAME_2).processDefinitionId("undefined").endOr()
                 .count());
     }
 
+    @Test
     public void testQueryByInvalidProcessDefinitionName() {
         assertNull(runtimeService.createProcessInstanceQuery().processDefinitionName("invalid").singleResult());
         assertEquals(0, runtimeService.createProcessInstanceQuery().processDefinitionName("invalid").count());
     }
 
+    @Test
     public void testQueryByDeploymentId() {
         List<ProcessInstance> instances = runtimeService.createProcessInstanceQuery().deploymentId(deployment.getId()).list();
         assertEquals(PROCESS_DEPLOY_COUNT, instances.size());
@@ -354,6 +380,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         assertEquals(PROCESS_DEPLOY_COUNT, runtimeService.createProcessInstanceQuery().deploymentId(deployment.getId()).count());
     }
 
+    @Test
     public void testQueryByDeploymentIdIn() {
         List<String> deploymentIds = new ArrayList<>();
         deploymentIds.add(deployment.getId());
@@ -369,6 +396,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         assertEquals(PROCESS_DEPLOY_COUNT, runtimeService.createProcessInstanceQuery().deploymentIdIn(deploymentIds).count());
     }
 
+    @Test
     public void testOrQueryByDeploymentId() {
         List<ProcessInstance> instances = runtimeService.createProcessInstanceQuery().or().deploymentId(deployment.getId()).processDefinitionId("undefined").endOr().list();
         assertEquals(PROCESS_DEPLOY_COUNT, instances.size());
@@ -427,6 +455,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
                 .count());
     }
 
+    @Test
     public void testOrQueryByDeploymentIdIn() {
         List<String> deploymentIds = new ArrayList<>();
         deploymentIds.add(deployment.getId());
@@ -442,21 +471,25 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         assertEquals(PROCESS_DEPLOY_COUNT, runtimeService.createProcessInstanceQuery().or().deploymentIdIn(deploymentIds).processDefinitionId("undefined").endOr().count());
     }
 
+    @Test
     public void testQueryByInvalidDeploymentId() {
         assertNull(runtimeService.createProcessInstanceQuery().deploymentId("invalid").singleResult());
         assertEquals(0, runtimeService.createProcessInstanceQuery().deploymentId("invalid").count());
     }
 
+    @Test
     public void testOrQueryByInvalidDeploymentId() {
         assertNull(runtimeService.createProcessInstanceQuery().or().deploymentId("invalid").processDefinitionId("undefined").endOr().singleResult());
         assertEquals(0, runtimeService.createProcessInstanceQuery().or().deploymentId("invalid").processDefinitionId("undefined").endOr().count());
     }
 
+    @Test
     public void testQueryByInvalidProcessInstanceId() {
         assertNull(runtimeService.createProcessInstanceQuery().processInstanceId("I do not exist").singleResult());
         assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId("I do not exist").list().size());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/superProcess.bpmn20.xml", "org/flowable/engine/test/api/runtime/subProcess.bpmn20.xml" })
     public void testQueryBySuperProcessInstanceId() {
         ProcessInstance superProcessInstance = runtimeService.startProcessInstanceByKey("subProcessQueryTest");
@@ -468,6 +501,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         assertEquals(1, query.count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/superProcess.bpmn20.xml", "org/flowable/engine/test/api/runtime/subProcess.bpmn20.xml" })
     public void testOrQueryBySuperProcessInstanceId() {
         ProcessInstance superProcessInstance = runtimeService.startProcessInstanceByKey("subProcessQueryTest");
@@ -479,11 +513,13 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         assertEquals(1, query.count());
     }
 
+    @Test
     public void testQueryByInvalidSuperProcessInstanceId() {
         assertNull(runtimeService.createProcessInstanceQuery().superProcessInstanceId("invalid").singleResult());
         assertEquals(0, runtimeService.createProcessInstanceQuery().superProcessInstanceId("invalid").list().size());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/superProcess.bpmn20.xml", "org/flowable/engine/test/api/runtime/subProcess.bpmn20.xml" })
     public void testQueryBySubProcessInstanceId() {
         ProcessInstance superProcessInstance = runtimeService.startProcessInstanceByKey("subProcessQueryTest");
@@ -493,6 +529,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         assertEquals(superProcessInstance.getId(), runtimeService.createProcessInstanceQuery().subProcessInstanceId(subProcessInstance.getId()).singleResult().getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/superProcess.bpmn20.xml", "org/flowable/engine/test/api/runtime/subProcess.bpmn20.xml" })
     public void testOrQueryBySubProcessInstanceId() {
         ProcessInstance superProcessInstance = runtimeService.startProcessInstanceByKey("subProcessQueryTest");
@@ -503,12 +540,14 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
                 .getId());
     }
 
+    @Test
     public void testQueryByInvalidSubProcessInstanceId() {
         assertNull(runtimeService.createProcessInstanceQuery().subProcessInstanceId("invalid").singleResult());
         assertEquals(0, runtimeService.createProcessInstanceQuery().subProcessInstanceId("invalid").list().size());
     }
 
     // Nested subprocess make the query complexer, hence this test
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/superProcessWithNestedSubProcess.bpmn20.xml", "org/flowable/engine/test/api/runtime/nestedSubProcess.bpmn20.xml",
             "org/flowable/engine/test/api/runtime/subProcess.bpmn20.xml" })
     public void testQueryBySuperProcessInstanceIdNested() {
@@ -522,6 +561,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
     }
 
     // Nested subprocess make the query complexer, hence this test
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/superProcessWithNestedSubProcess.bpmn20.xml", "org/flowable/engine/test/api/runtime/nestedSubProcess.bpmn20.xml",
             "org/flowable/engine/test/api/runtime/subProcess.bpmn20.xml" })
     public void testQueryBySubProcessInstanceIdNested() {
@@ -534,6 +574,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         assertEquals(subProcessInstance.getId(), runtimeService.createProcessInstanceQuery().subProcessInstanceId(nestedSubProcessInstance.getId()).singleResult().getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/superProcessWithNestedSubProcess.bpmn20.xml", "org/flowable/engine/test/api/runtime/nestedSubProcess.bpmn20.xml",
             "org/flowable/engine/test/api/runtime/subProcess.bpmn20.xml" })
     public void testQueryWithExcludeSubprocesses() {
@@ -564,12 +605,14 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         assertEquals(8, instanceList.size());
     }
 
+    @Test
     public void testQueryPaging() {
         assertEquals(PROCESS_DEFINITION_KEY_DEPLOY_COUNT, runtimeService.createProcessInstanceQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).count());
         assertEquals(2, runtimeService.createProcessInstanceQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).listPage(0, 2).size());
         assertEquals(3, runtimeService.createProcessInstanceQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).listPage(1, 3).size());
     }
 
+    @Test
     public void testQuerySorting() {
         assertEquals(PROCESS_DEPLOY_COUNT, runtimeService.createProcessInstanceQuery().orderByProcessInstanceId().asc().list().size());
         assertEquals(PROCESS_DEPLOY_COUNT, runtimeService.createProcessInstanceQuery().orderByProcessDefinitionId().asc().list().size());
@@ -583,6 +626,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         assertEquals(PROCESS_DEFINITION_KEY_DEPLOY_COUNT, runtimeService.createProcessInstanceQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).orderByProcessInstanceId().desc().list().size());
     }
 
+    @Test
     public void testQueryInvalidSorting() {
         try {
             runtimeService.createProcessInstanceQuery().orderByProcessDefinitionId().list(); // asc
@@ -597,6 +641,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testQueryStringVariable() {
         Map<String, Object> vars = new HashMap<>();
@@ -699,6 +744,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         runtimeService.deleteProcessInstance(processInstance3.getId(), "test");
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testQueryLongVariable() {
         Map<String, Object> vars = new HashMap<>();
@@ -792,6 +838,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         runtimeService.deleteProcessInstance(processInstance3.getId(), "test");
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testQueryDoubleVariable() {
         Map<String, Object> vars = new HashMap<>();
@@ -885,6 +932,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         runtimeService.deleteProcessInstance(processInstance3.getId(), "test");
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testQueryIntegerVariable() {
         Map<String, Object> vars = new HashMap<>();
@@ -978,6 +1026,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         runtimeService.deleteProcessInstance(processInstance3.getId(), "test");
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testOrQueryIntegerVariable() {
         Map<String, Object> vars = new HashMap<>();
@@ -1097,6 +1146,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         runtimeService.deleteProcessInstance(processInstance3.getId(), "test");
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testQueryShortVariable() {
         Map<String, Object> vars = new HashMap<>();
@@ -1193,6 +1243,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         runtimeService.deleteProcessInstance(processInstance3.getId(), "test");
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testQueryDateVariable() throws Exception {
         Map<String, Object> vars = new HashMap<>();
@@ -1304,6 +1355,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         runtimeService.deleteProcessInstance(processInstance3.getId(), "test");
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testBooleanVariable() throws Exception {
 
@@ -1385,6 +1437,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, instances.size());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testQueryVariablesUpdatedToNullValue() {
         // Start process instance with different types of variables
@@ -1422,6 +1475,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         assertNull(notQuery.singleResult());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testQueryNullVariable() throws Exception {
         Map<String, Object> vars = new HashMap<>();
@@ -1508,6 +1562,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createProcessInstanceQuery().variableValueEquals(null).count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testQueryEqualsIgnoreCase() {
         Map<String, Object> vars = new HashMap<>();
@@ -1577,6 +1632,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testQueryLikeIgnoreCase() {
         Map<String, Object> vars = new HashMap<>();
@@ -1619,6 +1675,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = {
             "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testQueryInvalidTypes() throws Exception {
@@ -1645,6 +1702,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         runtimeService.deleteProcessInstance(processInstance.getId(), "test");
     }
 
+    @Test
     public void testQueryVariablesNullNameArgument() {
         try {
             runtimeService.createProcessInstanceQuery().variableValueEquals(null, "value");
@@ -1690,6 +1748,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testQueryAllVariableTypes() throws Exception {
         Map<String, Object> vars = new HashMap<>();
@@ -1714,6 +1773,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         runtimeService.deleteProcessInstance(processInstance.getId(), "test");
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testClashingValues() throws Exception {
         Map<String, Object> vars = new HashMap<>();
@@ -1735,6 +1795,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         runtimeService.deleteProcessInstance(processInstance2.getId(), "test");
     }
     
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testVariableExistsQuery() {
         Map<String, Object> vars = new HashMap<>();
@@ -1763,6 +1824,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, instances.size());
     }
 
+    @Test
     public void testQueryByProcessInstanceIds() {
         Set<String> processInstanceIds = new HashSet<>(this.processInstanceIds);
 
@@ -1781,6 +1843,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByProcessInstanceIdsEmpty() {
         try {
             runtimeService.createProcessInstanceQuery().processInstanceIds(new HashSet<>());
@@ -1790,6 +1853,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByProcessInstanceIdsNull() {
         try {
             runtimeService.createProcessInstanceQuery().processInstanceIds(null);
@@ -1799,6 +1863,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testNativeQuery() {
         // just test that the query will be constructed and executed, details
         // are tested in the TaskQueryTest
@@ -1814,6 +1879,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
     /**
      * Test confirming fix for ACT-1731
      */
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testIncludeBinaryVariables() throws Exception {
         // Start process with a binary variable
@@ -1826,10 +1892,12 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         assertEquals("It is I, le binary", new String(bytes));
     }
 
+    @Test
     public void testNativeQueryPaging() {
         assertEquals(5, runtimeService.createNativeProcessInstanceQuery().sql("SELECT * FROM " + managementService.getTableName(ProcessInstance.class)).listPage(0, 5).size());
     }
 
+    @Test
     public void testLocalizeProcess() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
@@ -1902,6 +1970,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         assertEquals("The One org.flowable.task.service.Task Process 'en' localized description", processInstance.getDescription());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testQueryStartedBefore() throws Exception {
         Calendar calendar = new GregorianCalendar();
@@ -1926,6 +1995,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         assertEquals(1, processInstances.size());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testQueryStartedAfter() throws Exception {
         Calendar calendar = new GregorianCalendar();
@@ -1950,6 +2020,7 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         assertEquals(1, processInstances.size());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testQueryStartedBy() throws Exception {
         final String authenticatedUser = "user1";

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ProcessInstanceSuspensionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ProcessInstanceSuspensionTest.java
@@ -26,6 +26,7 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.identitylink.api.IdentityLinkType;
 import org.flowable.job.api.Job;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -36,6 +37,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
  */
 public class ProcessInstanceSuspensionTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testProcessInstanceActiveByDefault() {
 
@@ -47,6 +49,7 @@ public class ProcessInstanceSuspensionTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testSuspendActivateProcessInstance() {
         ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
@@ -66,6 +69,7 @@ public class ProcessInstanceSuspensionTest extends PluggableFlowableTestCase {
         assertFalse(processInstance.isSuspended());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testCannotActivateActiveProcessInstance() {
         ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
@@ -84,6 +88,7 @@ public class ProcessInstanceSuspensionTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testCannotSuspendSuspendedProcessInstance() {
         ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
@@ -103,6 +108,7 @@ public class ProcessInstanceSuspensionTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/superProcessWithMultipleNestedSubProcess.bpmn20.xml", "org/flowable/engine/test/api/runtime/nestedSubProcess.bpmn20.xml",
             "org/flowable/engine/test/api/runtime/subProcess.bpmn20.xml" })
     public void testQueryForActiveAndSuspendedProcessInstances() {
@@ -122,6 +128,7 @@ public class ProcessInstanceSuspensionTest extends PluggableFlowableTestCase {
         assertEquals(piToSuspend.getId(), runtimeService.createProcessInstanceQuery().suspended().singleResult().getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testTaskSuspendedAfterProcessInstanceSuspension() {
 
@@ -147,6 +154,7 @@ public class ProcessInstanceSuspensionTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testTaskQueryAfterProcessInstanceSuspend() {
         ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
@@ -176,6 +184,7 @@ public class ProcessInstanceSuspensionTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createProcessInstanceQuery().count());
     }
 
+    @Test
     @Deployment
     public void testChildExecutionsSuspendedAfterProcessInstanceSuspend() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testChildExecutionsSuspended");
@@ -202,6 +211,7 @@ public class ProcessInstanceSuspensionTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createProcessInstanceQuery().count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testSubmitTaskFormAfterProcessInstanceSuspend() {
         ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
@@ -216,6 +226,7 @@ public class ProcessInstanceSuspensionTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testProcessInstanceOperationsFailAfterSuspend() {
 
@@ -337,6 +348,7 @@ public class ProcessInstanceSuspensionTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testSignalEventReceivedAfterProcessInstanceSuspended() {
 
@@ -363,6 +375,7 @@ public class ProcessInstanceSuspensionTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createProcessInstanceQuery().count());
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/runtime/ProcessInstanceSuspensionTest.testSignalEventReceivedAfterProcessInstanceSuspended.bpmn20.xml")
     public void testSignalEventReceivedAfterMultipleProcessInstancesSuspended() {
 
@@ -392,6 +405,7 @@ public class ProcessInstanceSuspensionTest extends PluggableFlowableTestCase {
         assertEquals(1, runtimeService.createProcessInstanceQuery().count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testTaskOperationsFailAfterProcessInstanceSuspend() {
 
@@ -567,6 +581,7 @@ public class ProcessInstanceSuspensionTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testJobNotExecutedAfterProcessInstanceSuspend() {
 
@@ -596,6 +611,7 @@ public class ProcessInstanceSuspensionTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createProcessInstanceQuery().count());
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/runtime/ProcessInstanceSuspensionTest.testJobNotExecutedAfterProcessInstanceSuspend.bpmn20.xml")
     public void testJobActivationAfterProcessInstanceSuspend() {
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ProcessInstanceUpdateBusinessKeyTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ProcessInstanceUpdateBusinessKeyTest.java
@@ -22,9 +22,11 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.impl.util.CommandContextUtil;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 public class ProcessInstanceUpdateBusinessKeyTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testProcessInstanceUpdateBusinessKey() {
         runtimeService.startProcessInstanceByKey("businessKeyProcess");
@@ -38,6 +40,7 @@ public class ProcessInstanceUpdateBusinessKeyTest extends PluggableFlowableTestC
         }
     }
 
+    @Test
     @Deployment
     public void testUpdateExistingBusinessKey() {
         runtimeService.startProcessInstanceByKey("businessKeyProcess", "testKey");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/RuntimeServiceChangeStateTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/RuntimeServiceChangeStateTest.java
@@ -52,6 +52,9 @@ import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
 import org.flowable.task.api.Task;
 import org.flowable.variable.api.event.FlowableVariableEvent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Frederik Heremans
@@ -60,18 +63,17 @@ import org.flowable.variable.api.event.FlowableVariableEvent;
 public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
 
     private ChangeStateEventListener changeStateEventListener = new ChangeStateEventListener();
-    @Override
-    protected void initializeProcessEngine() {
-        super.initializeProcessEngine();
+    @BeforeEach
+    protected void setUp() {
         processEngine.getRuntimeService().addEventListener(changeStateEventListener);
     }
 
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
-        changeStateEventListener.clear();
+    @AfterEach
+    protected void tearDown() {
+        processEngine.getRuntimeService().removeEventListener(changeStateEventListener);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/twoTasksProcess.bpmn20.xml" })
     public void testSetCurrentActivityBackwardForSimpleProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksProcess");
@@ -115,6 +117,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/twoTasksProcess.bpmn20.xml" })
     public void testSetCurrentExecutionBackwardForSimpleProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksProcess");
@@ -157,6 +160,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/twoTasksProcess.bpmn20.xml" })
     public void testSetCurrentActivityForwardForSimpleProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksProcess");
@@ -192,6 +196,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/twoTasksProcess.bpmn20.xml" })
     public void testSetCurrentExecutionForwardForSimpleProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksProcess");
@@ -226,6 +231,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/twoTasksProcessWithTimer.bpmn20.xml" })
     public void testSetCurrentActivityWithTimerForSimpleProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksProcess");
@@ -279,6 +285,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/twoTasksProcessWithTimer.bpmn20.xml" })
     public void testSetCurrentExecutionWithTimerForSimpleProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksProcess");
@@ -328,6 +335,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/twoTasksProcessWithTimer.bpmn20.xml" })
     public void testSetCurrentActivityToActivityWithTimerForSimpleProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksProcess");
@@ -388,6 +396,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/twoTasksProcessWithTimer.bpmn20.xml" })
     public void testSetCurrentExecutionToActivityWithTimerForSimpleProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksProcess");
@@ -447,6 +456,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/twoTasksProcessWithTimers.bpmn20.xml" })
     public void testSetCurrentActivityWithTimerToActivityWithTimerSimpleProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksProcessWithTimers");
@@ -510,6 +520,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskSubProcess.bpmn20.xml" })
     public void testSetCurrentActivityOutOfSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
@@ -565,6 +576,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskSubProcess.bpmn20.xml" })
     public void testSetCurrentExecutionOutOfSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
@@ -619,6 +631,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskSubProcess.bpmn20.xml" })
     public void testSetCurrentActivityIntoSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
@@ -674,6 +687,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskSubProcess.bpmn20.xml" })
     public void testSetCurrentExecutionIntoSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
@@ -728,6 +742,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskSubProcess.bpmn20.xml" })
     public void testSetCurrentActivityIntoSubProcessWithModeledDataObject() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
@@ -790,6 +805,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskSubProcess.bpmn20.xml" })
     public void testSetCurrentExecutionIntoSubProcessWithModeledDataObject() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
@@ -852,6 +868,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskSubProcessWithTimer.bpmn20.xml" })
     public void testSetCurrentActivityOutOfSubProcessWithTimer() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
@@ -923,6 +940,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskSubProcessWithTimer.bpmn20.xml" })
     public void testSetCurrentExecutionOutOfSubProcessWithTimer() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
@@ -993,6 +1011,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskSubProcessWithTimer.bpmn20.xml" })
     public void testSetCurrentActivityToTaskInSubProcessWithTimer() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
@@ -1050,6 +1069,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskSubProcessWithTimer.bpmn20.xml" })
     public void testSetCurrentExecutionToTaskInSubProcessWithTimer() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
@@ -1106,6 +1126,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskSubProcessWithTimer.bpmn20.xml" })
     public void testSetCurrentActivityToTaskInSubProcessAndExecuteTimer() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
@@ -1157,6 +1178,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskWithTimerInSubProcess.bpmn20.xml" })
     public void testSetCurrentActivityOutOfSubProcessTaskWithTimer() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
@@ -1216,6 +1238,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskWithTimerInSubProcess.bpmn20.xml" })
     public void testSetCurrentExecutionOutOfSubProcessTaskWithTimer() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
@@ -1275,6 +1298,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
     }
 
     // TODO
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskWithTimerInSubProcess.bpmn20.xml" })
     public void testSetCurrentActivityToTaskWithTimerInSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
@@ -1334,6 +1358,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskWithTimerInSubProcess.bpmn20.xml" })
     public void testSetCurrentExecutionToTaskWithTimerInSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
@@ -1394,6 +1419,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskWithTimerInSubProcess.bpmn20.xml" })
     public void testSetCurrentActivityToTaskWithTimerInSubProcessAndExecuteTimer() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
@@ -1451,6 +1477,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskNestedSubProcess.bpmn20.xml" })
     public void testSetCurrentActivityOutOfNestedSubProcessExecution() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startNestedSubProcess");
@@ -1506,6 +1533,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskNestedSubProcess.bpmn20.xml" })
     public void testSetCurrentExecutionOutOfNestedSubProcessExecution() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startNestedSubProcess");
@@ -1560,6 +1588,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskNestedSubProcess.bpmn20.xml" })
     public void testSetCurrentActivityOutOfNestedSubProcessExecutionIntoContainingSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startNestedSubProcess");
@@ -1622,6 +1651,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskNestedSubProcess.bpmn20.xml" })
     public void testSetCurrentExecutionOutOfNestedSubProcessExecutionIntoContainingSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startNestedSubProcess");
@@ -1683,6 +1713,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/taskTwoSubProcesses.bpmn20.xml" })
     public void testSetCurrentActivityFromSubProcessToAnotherSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoSubProcesses");
@@ -1739,6 +1770,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/taskTwoSubProcesses.bpmn20.xml" })
     public void testSetCurrentExecutionFromSubProcessToAnotherSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoSubProcesses");
@@ -1794,6 +1826,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskSubProcess.bpmn20.xml" })
     public void testSetCurrentActivityForSubProcessWithVariables() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
@@ -1888,6 +1921,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskSubProcess.bpmn20.xml" })
     public void testSetCurrentExecutionForSubProcessWithVariables() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
@@ -1981,6 +2015,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
     
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskSubProcess.bpmn20.xml" })
     public void testSetCurrentActivityInUnstartedSubProcessWithModeledDataObject() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
@@ -2012,6 +2047,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskSubProcess.bpmn20.xml" })
     public void testSetCurrentActivityInUnstartedSubProcessWithLocalVariableOnSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
@@ -2044,6 +2080,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/parallelTask.bpmn20.xml" })
     public void testSetCurrentActivityToMultipleActivitiesForParallelGateway() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess");
@@ -2118,6 +2155,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/parallelTask.bpmn20.xml" })
     public void testSetMultipleActivitiesToSingleActivityAfterParallelGateway() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess");
@@ -2174,6 +2212,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/parallelTask.bpmn20.xml" })
     public void testSetMultipleActivitiesIntoSynchronizingParallelGateway() {
 
@@ -2208,6 +2247,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/parallelTask.bpmn20.xml" })
     public void testSetMultipleGatewayActivitiesAndSynchronizingParallelGatewayAfterGateway() {
 
@@ -2257,6 +2297,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/parallelTask.bpmn20.xml" })
     public void testSetActivityIntoSynchronizingParallelGatewayFirst() {
 
@@ -2300,6 +2341,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/parallelTask.bpmn20.xml" })
     public void testSetActivityIntoSynchronizingParallelGatewayLast() {
 
@@ -2348,6 +2390,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/parallelTask.bpmn20.xml" })
     public void testSetCurrentExecutionToMultipleActivitiesForParallelGateway() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess");
@@ -2404,6 +2447,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/parallelTask.bpmn20.xml" })
     public void testSetMultipleExecutionsToSingleActivityAfterParallelGateway() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess");
@@ -2436,6 +2480,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/parallelTask.bpmn20.xml" })
     public void testSetMultipleExecutionsIntoSynchronizingParallelGateway() {
 
@@ -2471,6 +2516,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/parallelTask.bpmn20.xml" })
     public void testSetMultipleGatewayExecutionsAndSynchronizingParallelGatewayAfterGateway() {
 
@@ -2521,6 +2567,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/parallelTask.bpmn20.xml" })
     public void testSetExecutionIntoSynchronizingParallelGatewayFirst() {
 
@@ -2564,6 +2611,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/parallelTask.bpmn20.xml" })
     public void testSetExecutionIntoSynchronizingParallelGatewayLast() {
 
@@ -2613,6 +2661,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/inclusiveGatewayForkJoin.bpmn20.xml" })
     public void testSetCurrentActivityToMultipleActivitiesForInclusiveGateway() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startInclusiveGwProcess");
@@ -2667,6 +2716,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/inclusiveGatewayForkJoin.bpmn20.xml" })
     public void testSetMultipleActivitiesToSingleActivityAfterInclusiveGateway() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startInclusiveGwProcess");
@@ -2703,6 +2753,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/inclusiveGatewayForkJoin.bpmn20.xml" })
     public void testSetMultipleActivitiesIntoSynchronizingInclusiveGateway() {
 
@@ -2738,6 +2789,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/inclusiveGatewayForkJoin.bpmn20.xml" })
     public void testSetMultipleGatewayActivitiesAndSynchronizingInclusiveGatewayAfterGateway() {
 
@@ -2787,6 +2839,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/inclusiveGatewayForkJoin.bpmn20.xml" })
     public void testSetActivityIntoSynchronizingParallelInclusiveFirst() {
 
@@ -2831,6 +2884,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/inclusiveGatewayForkJoin.bpmn20.xml" })
     public void testSetActivityIntoSynchronizingParallelInclusiveLast() {
 
@@ -2880,6 +2934,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/inclusiveGatewayForkJoin.bpmn20.xml" })
     public void testSetCurrentExecutionToMultipleActivitiesForInclusiveGateway() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startInclusiveGwProcess");
@@ -2933,6 +2988,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/inclusiveGatewayForkJoin.bpmn20.xml" })
     public void testSetMultipleExecutionsToSingleActivityAfterInclusiveGateway() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startInclusiveGwProcess");
@@ -2965,6 +3021,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/inclusiveGatewayForkJoin.bpmn20.xml" })
     public void testSetMultipleExecutionsIntoSynchronizingInclusiveGateway() {
 
@@ -3000,6 +3057,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/inclusiveGatewayForkJoin.bpmn20.xml" })
     public void testSetMultipleGatewayExecutionsAndSynchronizingInclusiveGatewayAfterGateway() {
 
@@ -3050,6 +3108,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/inclusiveGatewayForkJoin.bpmn20.xml" })
     public void testSetExecutionIntoSynchronizingInclusiveGatewayFirst() {
 
@@ -3093,6 +3152,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/inclusiveGatewayForkJoin.bpmn20.xml" })
     public void testSetExecutionIntoSynchronizingInclusiveGatewayLast() {
 
@@ -3141,6 +3201,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/parallelSubProcesses.bpmn20.xml" })
     public void testSetCurrentActivityToMultipleActivitiesForParallelSubProcesses() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess");
@@ -3185,6 +3246,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/parallelSubProcesses.bpmn20.xml" })
     public void testSetMultipleActivitiesToSingleActivityAfterParallelSubProcesses() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess");
@@ -3218,6 +3280,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/parallelSubProcessesMultipleTasks.bpmn20.xml" })
     public void testMoveCurrentActivityInParallelSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess");
@@ -3269,6 +3332,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/multipleParallelSubProcesses.bpmn20.xml" })
     public void testSetCurrentActivityToMultipleActivitiesForInclusiveAndParallelSubProcesses() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess", Collections.singletonMap("var1", "test2"));
@@ -3331,6 +3395,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/multipleParallelSubProcesses.bpmn20.xml" })
     public void testSetCurrentActivitiesToSingleActivityForInclusiveAndParallelSubProcesses() {
         Map<String, Object> variableMap = new HashMap<>();
@@ -3378,6 +3443,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/multipleParallelSubProcesses.bpmn20.xml" })
     public void testSetCurrentActivitiesToSingleActivityInInclusiveGateway() {
         Map<String, Object> variableMap = new HashMap<>();
@@ -3446,6 +3512,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/twoTasksParentProcess.bpmn20.xml", "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testSetCurrentActivityInParentProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksParentProcess");
@@ -3479,6 +3546,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/twoTasksParentProcess.bpmn20.xml", "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testSetCurrentActivityInSubProcessInstance() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksParentProcess");
@@ -3513,6 +3581,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/multiInstanceSequential.bpmn20.xml")
     public void testSetCurrentActivityOfSequentialMultiInstanceTask() {
         ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("sequentialMultiInstance")
@@ -3550,6 +3619,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/multiInstanceSequential.bpmn20.xml")
     public void testSetCurrentParentExecutionOfSequentialMultiInstanceTask() {
         ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("sequentialMultiInstance")
@@ -3588,6 +3658,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/multiInstanceParallel.bpmn20.xml")
     public void testSetCurrentActivityOfParallelMultiInstanceTask() {
         ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("parallelMultiInstance")
@@ -3620,6 +3691,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/multiInstanceParallel.bpmn20.xml")
     public void testSetCurrentParentExecutionOfParallelMultiInstanceTask() {
         ProcessInstance parallelTasksProcInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("parallelMultiInstance")
@@ -3653,6 +3725,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(parallelTasksProcInstance.getId());
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/multiInstanceParallelSubProcess.bpmn20.xml")
     public void testSetCurrentExecutionWithinMultiInstanceParallelSubProcess() {
         ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("parallelMultiInstanceSubProcess")
@@ -3724,6 +3797,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/multiInstanceParallelSubProcess.bpmn20.xml")
     public void testSetCurrentActivityWithinMultiInstanceParallelSubProcess() {
         ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("parallelMultiInstanceSubProcess")
@@ -3769,6 +3843,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/multiInstanceNestedParallelSubProcesses.bpmn20.xml")
     public void testSetCurrentExecutionWithinNestedMultiInstanceParallelSubProcess() {
         ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("parallelNestedMultiInstanceSubProcesses").start();
@@ -3876,6 +3951,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/multiInstanceNestedParallelSubProcesses.bpmn20.xml")
     public void testSetCurrentActivityWithinNestedMultiInstanceParallelSubProcess() {
         ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("parallelNestedMultiInstanceSubProcesses").start();
@@ -3966,6 +4042,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/multiInstanceParallelSubProcess.bpmn20.xml")
     public void testSetCurrentMultiInstanceSubProcessParentExecutionWithinProcess() {
         ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("parallelMultiInstanceSubProcess")
@@ -4018,6 +4095,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/multiInstanceParallelSubProcess.bpmn20.xml")
     public void testSetCurrentMultiInstanceSubProcessParentActivityWithinProcess() {
         ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("parallelMultiInstanceSubProcess")
@@ -4062,6 +4140,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/multiInstanceNestedParallelSubProcesses.bpmn20.xml")
     public void testSetCurrentMultiInstanceNestedSubProcessParentExecutionWithinSubProcess() {
         ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("parallelNestedMultiInstanceSubProcesses").start();
@@ -4161,6 +4240,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/multiInstanceNestedParallelSubProcesses.bpmn20.xml")
     public void testSetCurrentMultiInstanceNestedSubProcessParentActivityWithinSubProcess() {
         ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("parallelNestedMultiInstanceSubProcesses").start();
@@ -4251,6 +4331,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/parallelGatewayInsideMultiInstanceSubProcess.bpmn20.xml" })
     public void testSetCurrentActivitiesUsingParallelGatewayNestedInMultiInstanceSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("parallelGatewayInsideMultiInstanceSubProcess");
@@ -4329,6 +4410,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/parallelGatewayInsideMultiInstanceSubProcess.bpmn20.xml" })
     public void testSetCurrentExecutionsUsingParallelGatewayNestedInMultiInstanceSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("parallelGatewayInsideMultiInstanceSubProcess");
@@ -4406,6 +4488,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/inclusiveGatewayNestedInsideMultiInstanceSubProcess.bpmn20.xml" })
     public void testCompleteSetCurrentActivitiesUsingInclusiveGatewayNestedInMultiInstanceSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("inclusiveGatewayInsideMultiInstanceSubProcess");
@@ -4464,6 +4547,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/inclusiveGatewayNestedInsideMultiInstanceSubProcess.bpmn20.xml" })
     public void testCompleteSetCurrentExecutionsUsingInclusiveGatewayNestedInMultiInstanceSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("inclusiveGatewayInsideMultiInstanceSubProcess");
@@ -4634,6 +4718,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleIntermediateSignalCatchEvent.bpmn20.xml" })
     public void testSetCurrentActivityToIntermediateSignalCatchEvent() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForSimpleIntermediateEvent");
@@ -4685,6 +4770,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleIntermediateSignalCatchEvent.bpmn20.xml" })
     public void testSetCurrentExecutionToIntermediateSignalCatchEvent() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForSimpleIntermediateEvent");
@@ -4735,6 +4821,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleIntermediateSignalCatchEvent.bpmn20.xml" })
     public void testSetCurrentActivityFromIntermediateSignalCatchEvent() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForSimpleIntermediateEvent");
@@ -4812,6 +4899,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleIntermediateSignalCatchEvent.bpmn20.xml" })
     public void testSetCurrentExecutionFromIntermediateSignalCatchEvent() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForSimpleIntermediateEvent");
@@ -4887,6 +4975,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleIntermediateMessageCatchEvent.bpmn20.xml" })
     public void testSetCurrentActivityToIntermediateMessageCatchEvent() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForSimpleIntermediateEvent");
@@ -4940,6 +5029,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleIntermediateMessageCatchEvent.bpmn20.xml" })
     public void testSetCurrentExecutionToIntermediateMessageCatchEvent() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForSimpleIntermediateEvent");
@@ -4991,6 +5081,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleIntermediateMessageCatchEvent.bpmn20.xml" })
     public void testSetCurrentActivityFromIntermediateMessageCatchEvent() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForSimpleIntermediateEvent");
@@ -5068,6 +5159,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleIntermediateMessageCatchEvent.bpmn20.xml" })
     public void testSetCurrentExecutionFromIntermediateMessageCatchEvent() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForSimpleIntermediateEvent");
@@ -5183,6 +5275,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         });
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleIntermediateSignalCatchEvent.bpmn20.xml" })
     public void testSetCurrentActivityToIntermediateCatchEventForMultipleProcessesTriggerSimultaneously() {
         ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("changeStateForSimpleIntermediateEvent");
@@ -5227,6 +5320,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance2.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleIntermediateSignalCatchEvent.bpmn20.xml" })
     public void testSetCurrentExecutionToIntermediateCatchEventForMultipleProcessesTriggerSimultaneously() {
         ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("changeStateForSimpleIntermediateEvent");
@@ -5268,6 +5362,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance2.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleIntermediateSignalCatchEvent.bpmn20.xml" })
     public void testSetCurrentActivityToIntermediateCatchEventForMultipleProcessesTriggerDiffered() {
         ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("changeStateForSimpleIntermediateEvent");
@@ -5363,6 +5458,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance2.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleIntermediateSignalCatchEvent.bpmn20.xml" })
     public void testSetCurrentExecutionToIntermediateCatchEventForMultipleProcessesTriggerDiffered() {
         ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("changeStateForSimpleIntermediateEvent");
@@ -5466,6 +5562,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance2.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleMessageEventSubProcess.bpmn20.xml" })
     public void testSetCurrentActivityFromMessageEventSubProcessStart() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForEventSubProcess");
@@ -5506,6 +5603,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleMessageEventSubProcess.bpmn20.xml" })
     public void testSetCurrentExecutionFromMessageEventSubProcessStart() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForEventSubProcess");
@@ -5545,6 +5643,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleSignalEventSubProcess.bpmn20.xml" })
     public void testSetCurrentActivityFromSignalEventSubProcessStart() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForEventSubProcess");
@@ -5585,6 +5684,7 @@ public class RuntimeServiceChangeStateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleSignalEventSubProcess.bpmn20.xml" })
     public void testSetCurrentExecutionFromSignalEventSubProcessStart() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForEventSubProcess");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/RuntimeServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/RuntimeServiceTest.java
@@ -45,6 +45,7 @@ import org.flowable.engine.runtime.ProcessInstanceBuilder;
 import org.flowable.engine.test.Deployment;
 import org.flowable.task.api.Task;
 import org.flowable.task.api.history.HistoricTaskInstance;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Frederik Heremans
@@ -52,6 +53,7 @@ import org.flowable.task.api.history.HistoricTaskInstance;
  */
 public class RuntimeServiceTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testStartProcessInstanceWithVariables() {
         Map<String, Object> vars = new HashMap<>();
@@ -61,6 +63,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         assertNotNull(task.getProcessVariables());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testStartProcessInstanceWithLongStringVariable() {
         Map<String, Object> vars = new HashMap<>();
@@ -75,6 +78,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         assertEquals(longString.toString(), task.getProcessVariables().get("longString"));
     }
 
+    @Test
     public void testStartProcessInstanceByKeyNullKey() {
         try {
             runtimeService.startProcessInstanceByKey(null);
@@ -84,6 +88,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testStartProcessInstanceByKeyUnexistingKey() {
         try {
             runtimeService.startProcessInstanceByKey("unexistingkey");
@@ -94,6 +99,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testStartProcessInstanceByIdNullId() {
         try {
             runtimeService.startProcessInstanceById(null);
@@ -103,6 +109,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testStartProcessInstanceByIdUnexistingId() {
         try {
             runtimeService.startProcessInstanceById("unexistingId");
@@ -113,12 +120,14 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testStartProcessInstanceByIdNullVariables() {
         runtimeService.startProcessInstanceByKey("oneTaskProcess", (Map<String, Object>) null);
         assertEquals(1, runtimeService.createProcessInstanceQuery().processDefinitionKey("oneTaskProcess").count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testStartProcessInstanceWithBusinessKey() {
         ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
@@ -147,6 +156,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         assertEquals("value2", runtimeService.getVariable(processInstance.getId(), "var"));
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testStartProcessInstanceByProcessInstanceBuilder() {
         ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
@@ -195,6 +205,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         assertEquals("101124", processInstance.getBusinessKey());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testProcessInstanceDefinitionInformation() {
         ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
@@ -210,6 +221,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         assertEquals(processDefinition.getName(), processInstance.getProcessDefinitionName());
     }
 
+    @Test
     public void testStartProcessInstanceByProcessInstanceBuilderWithTenantId() {
         org.flowable.engine.repository.Deployment deployment = repositoryService.createDeployment()
             .addClasspathResource("org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml").
@@ -231,6 +243,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testNonUniqueBusinessKey() {
         runtimeService.startProcessInstanceByKey("oneTaskProcess", "123");
@@ -240,6 +253,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         assertEquals(2, runtimeService.createProcessInstanceQuery().processInstanceBusinessKey("123").count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testStartProcessInstanceFormWithoutFormKey() {
         Map<String, Object> vars = new HashMap<>();
@@ -255,6 +269,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
     // some databases might react strange on having multiple times null for the
     // business key
     // when the unique constraint is {processDefinitionId, businessKey}
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testMultipleNullBusinessKeys() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -266,6 +281,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         assertEquals(3, runtimeService.createProcessInstanceQuery().count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testDeleteProcessInstance() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -293,6 +309,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testDeleteProcessInstanceNullReason() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -311,6 +328,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testDeleteProcessInstanceUnexistingId() {
         try {
             runtimeService.deleteProcessInstance("enexistingInstanceId", null);
@@ -321,6 +339,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testDeleteProcessInstanceNullId() {
         try {
             runtimeService.deleteProcessInstance(null, "test null id delete");
@@ -330,6 +349,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testFindActiveActivityIds() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -339,6 +359,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         assertEquals(1, activities.size());
     }
 
+    @Test
     public void testFindActiveActivityIdsUnexistingExecututionId() {
         try {
             runtimeService.getActiveActivityIds("unexistingExecutionId");
@@ -349,6 +370,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testFindActiveActivityIdsNullExecututionId() {
         try {
             runtimeService.getActiveActivityIds(null);
@@ -361,6 +383,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
     /**
      * Testcase to reproduce ACT-950 (https://jira.codehaus.org/browse/ACT-950)
      */
+    @Test
     @Deployment
     public void testFindActiveActivityIdProcessWithErrorEventAndSubProcess() {
         ProcessInstance processInstance = processEngine.getRuntimeService().startProcessInstanceByKey("errorEventSubprocess");
@@ -438,6 +461,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     public void testSignalUnexistingExecututionId() {
         try {
             runtimeService.trigger("unexistingExecutionId");
@@ -448,6 +472,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testSignalNullExecutionId() {
         try {
             runtimeService.trigger(null);
@@ -457,6 +482,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testSignalWithProcessVariables() {
 
@@ -473,6 +499,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     public void testGetVariablesUnexistingExecutionId() {
         try {
             runtimeService.getVariables("unexistingExecutionId");
@@ -483,6 +510,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testGetVariablesNullExecutionId() {
         try {
             runtimeService.getVariables(null);
@@ -492,6 +520,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testGetVariableUnexistingExecutionId() {
         try {
             runtimeService.getVariables("unexistingExecutionId");
@@ -502,6 +531,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testGetVariableNullExecutionId() {
         try {
             runtimeService.getVariables(null);
@@ -511,6 +541,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testGetVariableUnexistingVariableName() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -518,6 +549,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         assertNull(variableValue);
     }
 
+    @Test
     public void testSetVariableUnexistingExecutionId() {
         try {
             runtimeService.setVariable("unexistingExecutionId", "variableName", "value");
@@ -528,6 +560,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testSetVariableNullExecutionId() {
         try {
             runtimeService.setVariable(null, "variableName", "variableValue");
@@ -537,6 +570,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testSetVariableNullVariableName() {
         try {
@@ -548,6 +582,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testSetVariables() {
         Map<String, Object> vars = new HashMap<>();
@@ -562,6 +597,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
     }
 
     @SuppressWarnings("unchecked")
+    @Test
     public void testSetVariablesUnexistingExecutionId() {
         try {
             runtimeService.setVariables("unexistingexecution", Collections.EMPTY_MAP);
@@ -573,6 +609,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
     }
 
     @SuppressWarnings("unchecked")
+    @Test
     public void testSetVariablesNullExecutionId() {
         try {
             runtimeService.setVariables(null, Collections.EMPTY_MAP);
@@ -606,6 +643,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testRemoveVariable() {
         Map<String, Object> vars = new HashMap<>();
@@ -624,6 +662,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         checkHistoricVariableUpdateEntity("variable1", processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneSubProcess.bpmn20.xml" })
     public void testRemoveVariableInParentScope() {
         Map<String, Object> vars = new HashMap<>();
@@ -641,6 +680,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         checkHistoricVariableUpdateEntity("variable1", processInstance.getId());
     }
 
+    @Test
     public void testRemoveVariableNullExecutionId() {
         try {
             runtimeService.removeVariable(null, "variable");
@@ -650,6 +690,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testRemoveVariableLocal() {
         Map<String, Object> vars = new HashMap<>();
@@ -666,6 +707,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         checkHistoricVariableUpdateEntity("variable1", processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneSubProcess.bpmn20.xml" })
     public void testRemoveVariableLocalWithParentScope() {
         Map<String, Object> vars = new HashMap<>();
@@ -692,6 +734,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         checkHistoricVariableUpdateEntity("localVariable", processInstance.getId());
     }
 
+    @Test
     public void testRemoveLocalVariableNullExecutionId() {
         try {
             runtimeService.removeVariableLocal(null, "variable");
@@ -701,6 +744,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testRemoveVariables() {
         Map<String, Object> vars = new HashMap<>();
@@ -724,6 +768,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         checkHistoricVariableUpdateEntity("variable2", processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneSubProcess.bpmn20.xml" })
     public void testRemoveVariablesWithParentScope() {
         Map<String, Object> vars = new HashMap<>();
@@ -755,6 +800,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
     }
 
     @SuppressWarnings("unchecked")
+    @Test
     public void testRemoveVariablesNullExecutionId() {
         try {
             runtimeService.removeVariables(null, Collections.EMPTY_LIST);
@@ -764,6 +810,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneSubProcess.bpmn20.xml" })
     public void testRemoveVariablesLocalWithParentScope() {
         Map<String, Object> vars = new HashMap<>();
@@ -810,6 +857,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
     }
 
     @SuppressWarnings("unchecked")
+    @Test
     public void testRemoveVariablesLocalNullExecutionId() {
         try {
             runtimeService.removeVariablesLocal(null, Collections.EMPTY_LIST);
@@ -819,6 +867,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/RuntimeServiceTest.catchAlertSignal.bpmn20.xml",
         "org/flowable/engine/test/api/runtime/RuntimeServiceTest.catchPanicSignal.bpmn20.xml" })
     public void testSignalEventReceived() {
@@ -851,6 +900,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/RuntimeServiceTest.catchAlertMessage.bpmn20.xml",
         "org/flowable/engine/test/api/runtime/RuntimeServiceTest.catchPanicMessage.bpmn20.xml" })
     public void testMessageEventReceived() {
@@ -876,6 +926,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     public void testSignalEventReceivedNonExistingExecution() {
         try {
             runtimeService.signalEventReceived("alert", "nonexistingExecution");
@@ -886,6 +937,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testMessageEventReceivedNonExistingExecution() {
         try {
             runtimeService.messageEventReceived("alert", "nonexistingExecution");
@@ -895,6 +947,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/RuntimeServiceTest.catchAlertSignal.bpmn20.xml" })
     public void testExecutionWaitingForDifferentSignal() {
         runtimeService.startProcessInstanceByKey("catchAlertSignal");
@@ -907,6 +960,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testSetProcessInstanceName() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -965,6 +1019,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testGetVariableUnexistingVariableNameWithCast() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -972,6 +1027,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         assertNull(variableValue);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testGetVariableExistingVariableNameWithCast() {
         Map<String, Object> params = new HashMap<>();
@@ -981,6 +1037,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         assertTrue(variableValue);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testGetVariableExistingVariableNameWithInvalidCast() {
         Map<String, Object> params = new HashMap<>();
@@ -990,6 +1047,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
             .isExactlyInstanceOf(ClassCastException.class);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testGetVariableLocalUnexistingVariableNameWithCast() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -997,6 +1055,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         assertNull(variableValue);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testGetVariableLocalExistingVariableNameWithCast() {
         Map<String, Object> params = new HashMap<>();
@@ -1006,6 +1065,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         assertTrue(variableValue);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testGetVariableLocalExistingVariableNameWithInvalidCast() {
         Map<String, Object> params = new HashMap<>();
@@ -1016,6 +1076,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
     }
 
     // Test for https://activiti.atlassian.net/browse/ACT-2186
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testHistoricVariableRemovedWhenRuntimeVariableIsRemoved() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
@@ -1052,6 +1113,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testStartTimeProcessInstance() {
         Calendar calendar = new GregorianCalendar();
@@ -1070,6 +1132,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         assertEquals(noon, processInstance.getStartTime());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testAuthenticatedStartUserProcessInstance() {
         final String authenticatedUser = "user1";
@@ -1079,6 +1142,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         assertEquals(authenticatedUser, processInstance.getStartUserId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testNoAuthenticatedStartUserProcessInstance() {
         final ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -1086,6 +1150,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         assertNull(processInstance.getStartUserId());
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml")
     public void testAdhocCallbacks() {
         ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("oneTaskProcess").

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/RuntimeVariablesTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/RuntimeVariablesTest.java
@@ -23,12 +23,14 @@ import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.variable.api.persistence.entity.VariableInstance;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Daisuke Yoshimoto
  */
 public class RuntimeVariablesTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testGetVariablesByExecutionIds() {
         ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -63,6 +65,7 @@ public class RuntimeVariablesTest extends PluggableFlowableTestCase {
         checkVariable(processInstance2.getId(), "executionVar2", "helloWorld2", variables);
     }
 
+    @Test
     @Deployment(resources = {
             "org/flowable/engine/test/api/runtime/RuntimeVariablesTest.testGetVariablesByExecutionIds.bpmn20.xml"
     })
@@ -97,6 +100,7 @@ public class RuntimeVariablesTest extends PluggableFlowableTestCase {
         fail();
     }
 
+    @Test
     @Deployment(resources = {
             "org/flowable/engine/test/api/runtime/variableScope.bpmn20.xml"
     })

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/DelegateTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/DelegateTaskTest.java
@@ -22,6 +22,7 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.task.api.history.HistoricTaskInstance;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Falko Menge
@@ -31,6 +32,7 @@ public class DelegateTaskTest extends PluggableFlowableTestCase {
     /**
      * @see <a href="https://activiti.atlassian.net/browse/ACT-380">https://activiti.atlassian.net/browse/ACT-380</a>
      */
+    @Test
     @Deployment
     public void testGetCandidates() {
         runtimeService.startProcessInstanceByKey("DelegateTaskTest.testGetCandidates");
@@ -51,6 +53,7 @@ public class DelegateTaskTest extends PluggableFlowableTestCase {
         assertTrue(candidateGroups.contains("accountancy"));
     }
 
+    @Test
     @Deployment
     public void testChangeCategoryInDelegateTask() {
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/SubTaskQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/SubTaskQueryTest.java
@@ -18,6 +18,9 @@ import java.util.List;
 
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.task.api.TaskQuery;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for cub-tasks querying
@@ -29,7 +32,7 @@ public class SubTaskQueryTest extends PluggableFlowableTestCase {
 
     private List<String> taskIds;
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
 
         identityService.saveUser(identityService.newUser("kermit"));
@@ -44,7 +47,7 @@ public class SubTaskQueryTest extends PluggableFlowableTestCase {
         taskIds = generateTestSubTasks();
     }
 
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
         identityService.deleteGroup("accountancy");
         identityService.deleteGroup("management");
@@ -56,6 +59,7 @@ public class SubTaskQueryTest extends PluggableFlowableTestCase {
     /**
      * test for task inclusion/exclusion (no other filters, no sort)
      */
+    @Test
     public void testQueryExcludeSubtasks() throws Exception {
         // query all tasks, including subtasks
         TaskQuery query = taskService.createTaskQuery();
@@ -70,6 +74,7 @@ public class SubTaskQueryTest extends PluggableFlowableTestCase {
     /**
      * test for task inclusion/exclusion (no other filters, no sort)
      */
+    @Test
     public void testQueryWithPagination() throws Exception {
         // query all tasks, including subtasks
         TaskQuery query = taskService.createTaskQuery();
@@ -84,6 +89,7 @@ public class SubTaskQueryTest extends PluggableFlowableTestCase {
     /**
      * test for task inclusion/exclusion (no other filters, order by task assignee )
      */
+    @Test
     public void testQueryExcludeSubtasksSorted() throws Exception {
         // query all tasks, including subtasks
         TaskQuery query = taskService.createTaskQuery().orderByTaskAssignee().asc();
@@ -98,6 +104,7 @@ public class SubTaskQueryTest extends PluggableFlowableTestCase {
     /**
      * test for task inclusion/exclusion when additional filter is specified (like assignee), no order.
      */
+    @Test
     public void testQueryByAssigneeExcludeSubtasks() throws Exception {
         // gonzo has 2 root tasks and 3+2 subtasks assigned
         // include subtasks
@@ -125,6 +132,7 @@ public class SubTaskQueryTest extends PluggableFlowableTestCase {
     /**
      * test for task inclusion/exclusion when additional filter is specified (like assignee), no order.
      */
+    @Test
     public void testQueryByAssigneeExcludeSubtasksPaginated() throws Exception {
         // gonzo has 2 root tasks and 3+2 subtasks assigned
         // include subtasks
@@ -152,6 +160,7 @@ public class SubTaskQueryTest extends PluggableFlowableTestCase {
     /**
      * test for task inclusion/exclusion when additional filter is specified (like assignee), ordered.
      */
+    @Test
     public void testQueryByAssigneeExcludeSubtasksOrdered() throws Exception {
         SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy hh:mm:ss.SSS");
 
@@ -185,6 +194,7 @@ public class SubTaskQueryTest extends PluggableFlowableTestCase {
     /**
      * test for task inclusion/exclusion when additional filter is specified (like assignee), ordered.
      */
+    @Test
     public void testQueryByAssigneeExcludeSubtasksOrderedAndPaginated() throws Exception {
         SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy hh:mm:ss.SSS");
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/SubTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/SubTaskTest.java
@@ -25,6 +25,7 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.task.api.Task;
 import org.flowable.task.api.history.HistoricTaskInstance;
 import org.flowable.task.service.impl.persistence.CountingTaskEntity;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tom Baeyens
@@ -32,6 +33,7 @@ import org.flowable.task.service.impl.persistence.CountingTaskEntity;
  */
 public class SubTaskTest extends PluggableFlowableTestCase {
 
+    @Test
     public void testSubTask() {
         Task gonzoTask = taskService.newTask();
         gonzoTask.setName("gonzoTask");
@@ -78,6 +80,7 @@ public class SubTaskTest extends PluggableFlowableTestCase {
         taskService.deleteTask(gonzoTaskId, true);
     }
     
+    @Test
     public void testMakeSubTaskStandaloneTask() {
         Task parentTask = taskService.newTask();
         parentTask.setName("parent");
@@ -114,6 +117,7 @@ public class SubTaskTest extends PluggableFlowableTestCase {
         taskService.deleteTask(subTaskTwo.getId(), true);
     }
 
+    @Test
     public void testSubTaskDeleteOnProcessInstanceDelete() {
         Deployment deployment = repositoryService.createDeployment()
                 .addClasspathResource("org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml")

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskAndVariablesQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskAndVariablesQueryTest.java
@@ -32,6 +32,9 @@ import org.flowable.task.api.Task;
 import org.flowable.task.api.TaskQuery;
 import org.flowable.task.api.history.HistoricTaskInstance;
 import org.flowable.task.service.impl.persistence.entity.TaskEntity;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tijs Rademakers
@@ -41,7 +44,7 @@ public class TaskAndVariablesQueryTest extends PluggableFlowableTestCase {
     private List<String> taskIds;
     private List<String> multipleTaskIds;
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
 
         identityService.saveUser(identityService.newUser("kermit"));
@@ -58,7 +61,7 @@ public class TaskAndVariablesQueryTest extends PluggableFlowableTestCase {
         taskIds = generateTestTasks();
     }
 
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
         identityService.deleteGroup("accountancy");
         identityService.deleteGroup("management");
@@ -68,6 +71,7 @@ public class TaskAndVariablesQueryTest extends PluggableFlowableTestCase {
         taskService.deleteTasks(taskIds, true);
     }
 
+    @Test
     @Deployment
     public void testQuery() {
         org.flowable.task.api.Task task = taskService.createTaskQuery().includeTaskLocalVariables().taskAssignee("gonzo").singleResult();
@@ -145,6 +149,7 @@ public class TaskAndVariablesQueryTest extends PluggableFlowableTestCase {
         assertEquals("This is a binary process variable", new String((byte[]) task.getProcessVariables().get("binaryVariable")));
     }
     
+    @Test
     @Deployment
     public void testVariableExistsQuery() {
         Map<String, Object> startMap = new HashMap<>();
@@ -193,6 +198,7 @@ public class TaskAndVariablesQueryTest extends PluggableFlowableTestCase {
         assertNull(task);
     }
 
+    @Test
     public void testQueryWithPagingAndVariables() {
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().includeProcessVariables().includeTaskLocalVariables().orderByTaskPriority().desc().listPage(0, 1);
         assertEquals(1, tasks.size());
@@ -226,6 +232,7 @@ public class TaskAndVariablesQueryTest extends PluggableFlowableTestCase {
     }
 
     // Unit test for https://activiti.atlassian.net/browse/ACT-4152
+    @Test
     public void testQueryWithIncludeTaskVariableAndTaskCategory() {
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().taskAssignee("gonzo").list();
         for (org.flowable.task.api.Task task : tasks) {
@@ -246,6 +253,7 @@ public class TaskAndVariablesQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryWithLimitAndVariables() throws Exception {
 
         int taskVariablesLimit = 2000;
@@ -280,6 +288,7 @@ public class TaskAndVariablesQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testOrQuery() {
         Map<String, Object> startMap = new HashMap<>();
@@ -309,6 +318,7 @@ public class TaskAndVariablesQueryTest extends PluggableFlowableTestCase {
         assertEquals(123, task.getProcessVariables().get("anotherProcessVar"));
     }
 
+    @Test
     @Deployment
     public void testOrQueryMultipleVariableValues() {
         Map<String, Object> startMap = new HashMap<>();
@@ -333,6 +343,7 @@ public class TaskAndVariablesQueryTest extends PluggableFlowableTestCase {
         assertEquals(123, task.getProcessVariables().get("anotherProcessVar"));
     }
 
+    @Test
     public void testQueryTaskDefinitionId() {
         Task taskWithDefinitionId = createTaskWithDefinitionId("testTaskId");
         try {
@@ -355,6 +366,7 @@ public class TaskAndVariablesQueryTest extends PluggableFlowableTestCase {
         }
     }
     
+    @Test
     public void testQueryTaskDefinitionId_multipleResults() {
         Task taskWithDefinitionId1 = createTaskWithDefinitionId("testTaskId1");
         Task taskWithDefinitionId2 = createTaskWithDefinitionId("testTaskId2");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskBatchDeleteTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskBatchDeleteTest.java
@@ -15,12 +15,14 @@ package org.flowable.engine.test.api.task;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 public class TaskBatchDeleteTest extends PluggableFlowableTestCase {
 
     /**
      * Validating fix for ACT-2070
      */
+    @Test
     @Deployment
     public void testDeleteTaskWithChildren() throws Exception {
 
@@ -44,6 +46,7 @@ public class TaskBatchDeleteTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment
     public void testDeleteCancelledMultiInstanceTasks() throws Exception {
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskDueDateTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskDueDateTest.java
@@ -19,25 +19,27 @@ import org.flowable.common.engine.impl.history.HistoryLevel;
 import org.flowable.engine.impl.test.HistoryTestHelper;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.task.api.history.HistoricTaskInstance;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
  */
 public class TaskDueDateTest extends PluggableFlowableTestCase {
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
 
         for (org.flowable.task.api.Task task : taskService.createTaskQuery().list()) {
             taskService.deleteTask(task.getId(), true);
         }
 
-        super.tearDown();
     }
 
     /**
      * See https://activiti.atlassian.net/browse/ACT-2089
      */
+    @Test
     public void testDueDateSortingWithNulls() {
         Date now = processEngineConfiguration.getClock().getCurrentTime();
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskIdentityLinksTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskIdentityLinksTest.java
@@ -25,6 +25,7 @@ import org.flowable.engine.test.Deployment;
 import org.flowable.identitylink.api.IdentityLink;
 import org.flowable.identitylink.api.IdentityLinkType;
 import org.flowable.identitylink.api.history.HistoricIdentityLink;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tom Baeyens
@@ -35,6 +36,7 @@ public class TaskIdentityLinksTest extends PluggableFlowableTestCase {
     private static final String IDENTITY_LINKS_PROCESS_BPMN20_XML = "org/flowable/engine/test/api/task/IdentityLinksProcess.bpmn20.xml";
     private static final String IDENTITY_LINKS_PROCESS = "IdentityLinksProcess";
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/task/IdentityLinksProcess.bpmn20.xml")
     public void testCandidateUserLink() {
         runtimeService.startProcessInstanceByKey("IdentityLinksProcess");
@@ -58,6 +60,7 @@ public class TaskIdentityLinksTest extends PluggableFlowableTestCase {
         assertEquals(0, taskService.getIdentityLinksForTask(taskId).size());
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/task/IdentityLinksProcess.bpmn20.xml")
     public void testCandidateGroupLink() {
         runtimeService.startProcessInstanceByKey("IdentityLinksProcess");
@@ -103,6 +106,7 @@ public class TaskIdentityLinksTest extends PluggableFlowableTestCase {
         assertEquals(0, taskService.getIdentityLinksForTask(taskId).size());
     }
     
+    @Test
     @Deployment(resources = IDENTITY_LINKS_PROCESS_BPMN20_XML)
     public void testAssigneeIdentityLinkHistory() {
         if (!HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
@@ -147,6 +151,7 @@ public class TaskIdentityLinksTest extends PluggableFlowableTestCase {
         assertNull(unassigned.getUserId());
     }
 
+    @Test
     @Deployment(resources = IDENTITY_LINKS_PROCESS_BPMN20_XML)
     public void testClaimingIdentityLinkHistory() {
         if (!HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
@@ -191,6 +196,7 @@ public class TaskIdentityLinksTest extends PluggableFlowableTestCase {
         assertNull(unassigned.getUserId());
     }
 
+    @Test
     @Deployment(resources = IDENTITY_LINKS_PROCESS_BPMN20_XML)
     public void testOwnerIdentityLinkHistory() {
         if (!HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
@@ -234,6 +240,7 @@ public class TaskIdentityLinksTest extends PluggableFlowableTestCase {
         assertNull(unassigned.getUserId());
     }
     
+    @Test
     @Deployment(resources = IDENTITY_LINKS_PROCESS_BPMN20_XML)
     public void testUnchangedIdentityIdCreatesNoLinks() {
         if (!HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
@@ -260,6 +267,7 @@ public class TaskIdentityLinksTest extends PluggableFlowableTestCase {
         assertEquals("kermit", assigned.getUserId());
     }
 
+    @Test
     @Deployment(resources = IDENTITY_LINKS_PROCESS_BPMN20_XML)
     public void testNullIdentityIdCreatesNoLinks() {
         if (!HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
@@ -282,6 +290,7 @@ public class TaskIdentityLinksTest extends PluggableFlowableTestCase {
         assertEquals(0, history.size());
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/task/IdentityLinksProcess.bpmn20.xml")
     public void testCustomTypeUserLink() {
         runtimeService.startProcessInstanceByKey("IdentityLinksProcess");
@@ -305,6 +314,7 @@ public class TaskIdentityLinksTest extends PluggableFlowableTestCase {
         assertEquals(0, taskService.getIdentityLinksForTask(taskId).size());
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/task/IdentityLinksProcess.bpmn20.xml")
     public void testCustomLinkGroupLink() {
         runtimeService.startProcessInstanceByKey("IdentityLinksProcess");
@@ -328,6 +338,7 @@ public class TaskIdentityLinksTest extends PluggableFlowableTestCase {
         assertEquals(0, taskService.getIdentityLinksForTask(taskId).size());
     }
 
+    @Test
     public void testDeleteAssignee() {
         org.flowable.task.api.Task task = taskService.newTask();
         task.setAssignee("nonExistingUser");
@@ -343,6 +354,7 @@ public class TaskIdentityLinksTest extends PluggableFlowableTestCase {
         taskService.deleteTask(task.getId(), true);
     }
 
+    @Test
     public void testDeleteOwner() {
         org.flowable.task.api.Task task = taskService.newTask();
         task.setOwner("nonExistingUser");
@@ -358,6 +370,7 @@ public class TaskIdentityLinksTest extends PluggableFlowableTestCase {
         taskService.deleteTask(task.getId(), true);
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/task/TaskIdentityLinksTest.testDeleteCandidateUser.bpmn20.xml")
     public void testDeleteCandidateUser() {
         runtimeService.startProcessInstanceByKey("TaskIdentityLinks");
@@ -372,6 +385,7 @@ public class TaskIdentityLinksTest extends PluggableFlowableTestCase {
         assertEquals("user", identityLink.getUserId());
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/task/IdentityLinksProcess.bpmn20.xml")
     public void testEmptyCandidateUserLink() {
         runtimeService.startProcessInstanceByKey("IdentityLinksProcess");
@@ -397,6 +411,7 @@ public class TaskIdentityLinksTest extends PluggableFlowableTestCase {
     }
 
     // Test custom identity links
+    @Test
     @Deployment
     public void testCustomIdentityLink() {
         runtimeService.startProcessInstanceByKey("customIdentityLink");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskInfoQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskInfoQueryTest.java
@@ -20,19 +20,22 @@ import org.flowable.engine.impl.test.HistoryTestHelper;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.task.api.TaskInfo;
 import org.flowable.task.api.TaskInfoQueryWrapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
  */
 public class TaskInfoQueryTest extends PluggableFlowableTestCase {
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
         for (org.flowable.task.api.Task task : taskService.createTaskQuery().list()) {
             taskService.deleteTask(task.getId(), true);
         }
     }
 
+    @Test
     public void testTaskInfoQuery() {
         Date now = processEngineConfiguration.getClock().getCurrentTime();
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskQueryTest.java
@@ -36,6 +36,9 @@ import org.flowable.task.api.Task;
 import org.flowable.task.api.TaskQuery;
 import org.flowable.task.service.impl.persistence.entity.TaskEntity;
 import org.flowable.variable.service.impl.persistence.entity.VariableInstanceEntity;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -48,7 +51,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
 
     private List<String> taskIds;
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
 
         identityService.saveUser(identityService.newUser("kermit"));
@@ -65,7 +68,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         taskIds = generateTestTasks();
     }
 
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
         identityService.deleteGroup("accountancy");
         identityService.deleteGroup("management");
@@ -75,6 +78,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         taskService.deleteTasks(taskIds, true);
     }
 
+    @Test
     public void testBasicTaskPropertiesNotNull() {
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskId(taskIds.get(0)).singleResult();
         assertNotNull(task.getDescription());
@@ -83,6 +87,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertNotNull(task.getCreateTime());
     }
 
+    @Test
     public void testQueryNoCriteria() {
         TaskQuery query = taskService.createTaskQuery();
         assertEquals(12, query.count());
@@ -95,6 +100,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByTaskId() {
         TaskQuery query = taskService.createTaskQuery().taskId(taskIds.get(0));
         assertNotNull(query.singleResult());
@@ -102,6 +108,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(1, query.count());
     }
 
+    @Test
     public void testQueryByTaskIdOr() {
         TaskQuery query = taskService.createTaskQuery().or().taskId(taskIds.get(0)).taskName("INVALID NAME").endOr();
         assertNotNull(query.singleResult());
@@ -109,6 +116,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(1, query.count());
     }
 
+    @Test
     public void testQueryByInvalidTaskId() {
         TaskQuery query = taskService.createTaskQuery().taskId("invalid");
         assertNull(query.singleResult());
@@ -123,6 +131,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByInvalidTaskIdOr() {
         TaskQuery query = taskService.createTaskQuery().or().taskId("invalid").taskName("invalid");
         assertNull(query.singleResult());
@@ -137,6 +146,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByName() {
         TaskQuery query = taskService.createTaskQuery().taskName("testTask");
         assertEquals(6, query.list().size());
@@ -150,6 +160,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByNameOr() {
         TaskQuery query = taskService.createTaskQuery().or().taskName("testTask").taskId("invalid");
         assertEquals(6, query.list().size());
@@ -163,6 +174,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByInvalidName() {
         TaskQuery query = taskService.createTaskQuery().taskName("invalid");
         assertNull(query.singleResult());
@@ -177,6 +189,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByInvalidNameOr() {
         TaskQuery query = taskService.createTaskQuery().or().taskId("invalid").taskName("invalid");
         assertNull(query.singleResult());
@@ -191,6 +204,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByNameIn() {
         final List<String> taskNameList = new ArrayList<>(2);
         taskNameList.add("testTask");
@@ -208,6 +222,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByNameInIgnoreCase() {
         final List<String> taskNameList = new ArrayList<>(2);
         taskNameList.add("testtask");
@@ -225,6 +240,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByNameInOr() {
         final List<String> taskNameList = new ArrayList<>(2);
         taskNameList.add("testTask");
@@ -242,6 +258,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByNameInIgnoreCaseOr() {
         final List<String> taskNameList = new ArrayList<>(2);
         taskNameList.add("testtask");
@@ -259,6 +276,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByInvalidNameIn() {
         final List<String> taskNameList = new ArrayList<>(1);
         taskNameList.add("invalid");
@@ -275,6 +293,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByInvalidNameInIgnoreCase() {
         final List<String> taskNameList = new ArrayList<>(1);
         taskNameList.add("invalid");
@@ -291,6 +310,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByInvalidNameInOr() {
         final List<String> taskNameList = new ArrayList<>(2);
         taskNameList.add("invalid");
@@ -307,6 +327,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByInvalidNameInIgnoreCaseOr() {
         final List<String> taskNameList = new ArrayList<>(2);
         taskNameList.add("invalid");
@@ -323,6 +344,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByNameLike() {
         TaskQuery query = taskService.createTaskQuery().taskNameLike("gonzo%");
         assertNotNull(query.singleResult());
@@ -330,6 +352,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(1, query.count());
     }
 
+    @Test
     public void testQueryByNameLikeOr() {
         TaskQuery query = taskService.createTaskQuery().or().taskId("invalid").taskNameLike("gonzo%");
         assertNotNull(query.singleResult());
@@ -337,6 +360,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(1, query.count());
     }
 
+    @Test
     public void testQueryByInvalidNameLike() {
         TaskQuery query = taskService.createTaskQuery().taskNameLike("1");
         assertNull(query.singleResult());
@@ -350,6 +374,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByInvalidNameLikeOr() {
         TaskQuery query = taskService.createTaskQuery().or().taskId("invalid").taskNameLike("1");
         assertNull(query.singleResult());
@@ -363,6 +388,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByDescription() {
         TaskQuery query = taskService.createTaskQuery().taskDescription("testTask description");
         assertEquals(6, query.list().size());
@@ -375,6 +401,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByDescriptionOr() {
         TaskQuery query = taskService.createTaskQuery().or().taskId("invalid").taskDescription("testTask description");
         assertEquals(6, query.list().size());
@@ -387,6 +414,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByInvalidDescription() {
         TaskQuery query = taskService.createTaskQuery().taskDescription("invalid");
         assertNull(query.singleResult());
@@ -401,6 +429,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByInvalidDescriptionOr() {
         TaskQuery query = taskService.createTaskQuery().or().taskId("invalid").taskDescription("invalid");
         assertNull(query.singleResult());
@@ -415,6 +444,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByDescriptionLike() {
         TaskQuery query = taskService.createTaskQuery().taskDescriptionLike("%gonzo%");
         assertNotNull(query.singleResult());
@@ -422,6 +452,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(1, query.count());
     }
 
+    @Test
     public void testQueryByDescriptionLikeOr() {
         TaskQuery query = taskService.createTaskQuery().or().taskId("invalid").taskDescriptionLike("%gonzo%");
         assertNotNull(query.singleResult());
@@ -429,6 +460,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(1, query.count());
     }
 
+    @Test
     public void testQueryByInvalidDescriptionLike() {
         TaskQuery query = taskService.createTaskQuery().taskDescriptionLike("invalid");
         assertNull(query.singleResult());
@@ -443,6 +475,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByInvalidDescriptionLikeOr() {
         TaskQuery query = taskService.createTaskQuery().or().taskId("invalid").taskDescriptionLike("invalid");
         assertNull(query.singleResult());
@@ -457,6 +490,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByPriority() {
         TaskQuery query = taskService.createTaskQuery().taskPriority(10);
         assertEquals(2, query.list().size());
@@ -486,6 +520,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(6, query.list().size());
     }
 
+    @Test
     public void testQueryByPriorityOr() {
         TaskQuery query = taskService.createTaskQuery().or().taskId("invalid").taskPriority(10);
         assertEquals(2, query.list().size());
@@ -515,6 +550,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(6, query.list().size());
     }
 
+    @Test
     public void testQueryByInvalidPriority() {
         try {
             taskService.createTaskQuery().taskPriority(null);
@@ -524,6 +560,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByInvalidPriorityOr() {
         try {
             taskService.createTaskQuery().or().taskId("invalid").taskPriority(null);
@@ -533,6 +570,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByAssignee() {
         TaskQuery query = taskService.createTaskQuery().taskAssignee("gonzo");
         assertEquals(1, query.count());
@@ -545,6 +583,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertNull(query.singleResult());
     }
 
+    @Test
     public void testQueryByAssigneeOr() {
         TaskQuery query = taskService.createTaskQuery().or().taskId("invalid").taskAssignee("gonzo");
         assertEquals(1, query.count());
@@ -557,6 +596,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertNull(query.singleResult());
     }
 
+    @Test
     public void testQueryByAssigneeIds() {
         TaskQuery query = taskService.createTaskQuery().taskAssigneeIds(Arrays.asList("gonzo", "kermit"));
         assertEquals(1, query.count());
@@ -591,6 +631,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         taskService.deleteTask(adhocTask.getId(), true);
     }
 
+    @Test
     public void testQueryByAssigneeIdsOr() {
         TaskQuery query = taskService.createTaskQuery().or().taskId("invalid").taskAssigneeIds(Arrays.asList("gonzo", "kermit"));
         assertEquals(1, query.count());
@@ -625,6 +666,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         taskService.deleteTask(adhocTask.getId(), true);
     }
 
+    @Test
     public void testQueryByInvolvedUser() {
         try {
             org.flowable.task.api.Task adhocTask = taskService.newTask();
@@ -644,6 +686,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByInvolvedUserOr() {
         try {
             org.flowable.task.api.Task adhocTask = taskService.newTask();
@@ -667,6 +710,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByInvolvedGroups() {
         try {
             org.flowable.task.api.Task adhocTask = taskService.newTask();
@@ -682,6 +726,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByInvolvedGroupOr() {
         try {
             org.flowable.task.api.Task adhocTask = taskService.newTask();
@@ -713,6 +758,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByInvolvedGroupOrAssignee() {
         try {
             org.flowable.task.api.Task adhocTask = taskService.newTask();
@@ -739,6 +785,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByInvolvedGroupOrOwner() {
         try {
             org.flowable.task.api.Task adhocTask = taskService.newTask();
@@ -765,6 +812,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByInvolvedGroupAndAssignee() {
         try {
             org.flowable.task.api.Task adhocTask = taskService.newTask();
@@ -793,6 +841,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByInvolvedGroupAndOwner() {
         try {
             org.flowable.task.api.Task adhocTask = taskService.newTask();
@@ -823,6 +872,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByInvolvedGroupAndOwnerLike() {
         try {
             org.flowable.task.api.Task adhocTask = taskService.newTask();
@@ -852,6 +902,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByInvolvedGroupAndAssigneeLike() {
         try {
             org.flowable.task.api.Task adhocTask = taskService.newTask();
@@ -882,6 +933,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByInvolvedGroupAndAssigneeIds() {
         try {
             org.flowable.task.api.Task adhocTask = taskService.newTask();
@@ -912,6 +964,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByInvolvedGroupOrOwnerLike() {
         try {
             org.flowable.task.api.Task adhocTask = taskService.newTask();
@@ -944,6 +997,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByInvolvedGroupOrAssigneeLike() {
         try {
             org.flowable.task.api.Task adhocTask = taskService.newTask();
@@ -976,6 +1030,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByInvolvedGroupOrAssigneeIds() {
         try {
             org.flowable.task.api.Task adhocTask = taskService.newTask();
@@ -1008,6 +1063,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByInvolvedGroupOrAssigneeId() {
         try {
             org.flowable.task.api.Task adhocTask = taskService.newTask();
@@ -1040,6 +1096,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByInvolvedGroupTaskName() {
         try {
             org.flowable.task.api.Task adhocTask = taskService.newTask();
@@ -1084,6 +1141,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByCandidateGroupsTaskName() {
         try {
             org.flowable.task.api.Task adhocTask = taskService.newTask();
@@ -1129,6 +1187,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByCandidateUserTaskName() {
         try {
             org.flowable.task.api.Task adhocTask = taskService.newTask();
@@ -1174,6 +1233,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByCandidateGroupTaskName() {
         try {
             org.flowable.task.api.Task adhocTask = taskService.newTask();
@@ -1219,6 +1279,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByNullAssignee() {
         try {
             taskService.createTaskQuery().taskAssignee(null).list();
@@ -1228,6 +1289,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByNullAssigneeOr() {
         try {
             taskService.createTaskQuery().or().taskId("invalid").taskAssignee(null).list();
@@ -1237,18 +1299,21 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByUnassigned() {
         TaskQuery query = taskService.createTaskQuery().taskUnassigned();
         assertEquals(11, query.count());
         assertEquals(11, query.list().size());
     }
 
+    @Test
     public void testQueryByUnassignedOr() {
         TaskQuery query = taskService.createTaskQuery().or().taskId("invalid").taskUnassigned();
         assertEquals(11, query.count());
         assertEquals(11, query.list().size());
     }
 
+    @Test
     public void testQueryByCandidateUser() {
         TaskQuery query = taskService.createTaskQuery().taskCandidateUser("kermit");
         assertEquals(11, query.count());
@@ -1271,6 +1336,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByCandidateUserOr() {
         TaskQuery query = taskService.createTaskQuery().or().taskId("invalid").taskCandidateUser("kermit");
         assertEquals(11, query.count());
@@ -1293,6 +1359,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByNullCandidateUser() {
         try {
             taskService.createTaskQuery().taskCandidateUser(null).list();
@@ -1301,6 +1368,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByNullCandidateUserOr() {
         try {
             taskService.createTaskQuery().or().taskId("invalid").taskCandidateUser(null).list();
@@ -1309,6 +1377,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByCandidateGroup() {
         TaskQuery query = taskService.createTaskQuery().taskCandidateGroup("management");
         assertEquals(3, query.count());
@@ -1325,6 +1394,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, query.list().size());
     }
 
+    @Test
     public void testQueryByCandidateGroupOr() {
         TaskQuery query = taskService.createTaskQuery().or().taskId("invalid").taskCandidateGroup("management");
         assertEquals(3, query.count());
@@ -1341,6 +1411,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, query.list().size());
     }
 
+    @Test
     public void testQueryByCandidateOrAssigned() {
         TaskQuery query = taskService.createTaskQuery().taskCandidateOrAssigned("kermit");
         assertEquals(11, query.count());
@@ -1382,6 +1453,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByCandidateOrAssignedOr() {
         TaskQuery query = taskService.createTaskQuery().or().taskId("invalid").taskCandidateOrAssigned("kermit");
         assertEquals(11, query.count());
@@ -1423,6 +1495,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
     
+    @Test
     public void testQueryIgnoreAssigneeValue() {
         List<String> createdTasks = new ArrayList<>();
         Task kermitAssigneeTask = taskService.newTask();
@@ -1486,6 +1559,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         taskService.deleteTasks(createdTasks, true);
     }
 
+    @Test
     public void testQueryIgnoreAssigneeValueOr() {
         List<String> createdTasks = new ArrayList<>();
         Task kermitAssigneeTask = taskService.newTask();
@@ -1563,6 +1637,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         taskService.deleteTasks(createdTasks, true);
     }
 
+    @Test
     public void testQueryByNullCandidateGroup() {
         try {
             taskService.createTaskQuery().taskCandidateGroup(null).list();
@@ -1572,6 +1647,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByNullCandidateGroupOr() {
         try {
             taskService.createTaskQuery().or().taskId("invalid").taskCandidateGroup(null).list();
@@ -1581,6 +1657,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByCandidateGroupIn() {
         List<String> groups = Arrays.asList("management", "accountancy");
         TaskQuery query = taskService.createTaskQuery().taskCandidateGroupIn(groups);
@@ -1614,6 +1691,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(5, query.list().size());
     }
 
+    @Test
     public void testQueryByCandidateGroupInOr() {
         List<String> groups = Arrays.asList("management", "accountancy");
         TaskQuery query = taskService.createTaskQuery().or().taskId("invalid").taskCandidateGroupIn(groups);
@@ -1651,6 +1729,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(5, query.list().size());
     }
 
+    @Test
     public void testQueryByNullCandidateGroupIn() {
         try {
             taskService.createTaskQuery().taskCandidateGroupIn(null).list();
@@ -1666,6 +1745,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByNullCandidateGroupInOr() {
         try {
             taskService.createTaskQuery().or().taskId("invalid").taskCandidateGroupIn(null).list();
@@ -1681,6 +1761,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByDelegationState() {
         TaskQuery query = taskService.createTaskQuery().taskDelegationState(null);
         assertEquals(12, query.count());
@@ -1718,6 +1799,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(1, query.list().size());
     }
 
+    @Test
     public void testQueryByDelegationStateOr() {
         TaskQuery query = taskService.createTaskQuery().or().taskId("invalid").taskDelegationState(null);
         assertEquals(12, query.count());
@@ -1755,6 +1837,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(1, query.list().size());
     }
 
+    @Test
     public void testQueryCreatedOn() throws Exception {
         SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy hh:mm:ss.SSS");
 
@@ -1766,6 +1849,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(6, query.list().size());
     }
 
+    @Test
     public void testQueryCreatedOnOr() throws Exception {
         SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy hh:mm:ss.SSS");
 
@@ -1777,6 +1861,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(6, query.list().size());
     }
 
+    @Test
     public void testQueryCreatedBefore() throws Exception {
         SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy hh:mm:ss.SSS");
 
@@ -1793,6 +1878,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, query.list().size());
     }
 
+    @Test
     public void testQueryCreatedBeforeOr() throws Exception {
         SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy hh:mm:ss.SSS");
 
@@ -1809,6 +1895,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, query.list().size());
     }
 
+    @Test
     public void testQueryCreatedAfter() throws Exception {
         SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy hh:mm:ss.SSS");
 
@@ -1825,6 +1912,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, query.list().size());
     }
 
+    @Test
     public void testQueryCreatedAfterOr() throws Exception {
         SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy hh:mm:ss.SSS");
 
@@ -1841,6 +1929,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, query.list().size());
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/task/taskDefinitionProcess.bpmn20.xml")
     public void testTaskDefinitionKey() throws Exception {
 
@@ -1859,6 +1948,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(0L, count.longValue());
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/task/taskDefinitionProcess.bpmn20.xml")
     public void testTaskDefinitionKeyOr() throws Exception {
 
@@ -1877,6 +1967,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(0L, count.longValue());
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/task/taskDefinitionProcess.bpmn20.xml")
     public void testTaskDefinitionKeyLike() throws Exception {
 
@@ -1910,6 +2001,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(0L, count.longValue());
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/task/taskDefinitionProcess.bpmn20.xml")
     public void testTaskDefinitionKeyLikeOr() throws Exception {
 
@@ -1943,6 +2035,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(0L, count.longValue());
     }
 
+    @Test
     @Deployment
     public void testTaskVariableValueEquals() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -2028,6 +2121,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, taskService.createTaskQuery().taskVariableValueLessThanOrEqual("integerVar", 1000).count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/task/TaskQueryTest.testTaskVariableValueEquals.bpmn20.xml" })
     public void testTaskVariableValueEqualsOr() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -2113,6 +2207,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueLessThanOrEqual("integerVar", 1000).count());
     }
 
+    @Test
     @Deployment
     public void testProcessVariableValueEquals() throws Exception {
         Map<String, Object> variables = new HashMap<>();
@@ -2198,6 +2293,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(1, taskService.createTaskQuery().processVariableValueEquals(928374L).taskVariableValueEquals(928374L).count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/task/TaskQueryTest.testProcessVariableValueEquals.bpmn20.xml" })
     public void testProcessVariableValueEqualsOn() throws Exception {
         Map<String, Object> variables = new HashMap<>();
@@ -2270,6 +2366,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals(otherDate.getTime()).count());
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml")
     public void testVariableValueEqualsIgnoreCase() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -2310,6 +2407,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml")
     public void testProcessVariableValueEqualsIgnoreCase() throws Exception {
         Map<String, Object> variables = new HashMap<>();
@@ -2332,6 +2430,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, taskService.createTaskQuery().processVariableValueEqualsIgnoreCase("lower", "uiop").count());
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml")
     public void testProcessVariableValueLike() throws Exception {
         Map<String, Object> variables = new HashMap<>();
@@ -2344,6 +2443,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, taskService.createTaskQuery().processVariableValueLike("mixed", "a%").count());
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml")
     public void testProcessVariableValueLikeIgnoreCase() throws Exception {
         Map<String, Object> variables = new HashMap<>();
@@ -2356,6 +2456,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, taskService.createTaskQuery().processVariableValueLikeIgnoreCase("mixed", "Azz%").count());
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml")
     public void testProcessVariableValueGreaterThan() throws Exception {
         Map<String, Object> variables = new HashMap<>();
@@ -2367,6 +2468,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, taskService.createTaskQuery().processVariableValueGreaterThan("number", 10).count());
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml")
     public void testProcessVariableValueGreaterThanOrEquals() throws Exception {
         Map<String, Object> variables = new HashMap<>();
@@ -2379,6 +2481,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, taskService.createTaskQuery().processVariableValueGreaterThanOrEqual("number", 11).count());
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml")
     public void testProcessVariableValueLessThan() throws Exception {
         Map<String, Object> variables = new HashMap<>();
@@ -2390,6 +2493,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, taskService.createTaskQuery().processVariableValueLessThan("number", 10).count());
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml")
     public void testProcessVariableValueLessThanOrEquals() throws Exception {
         Map<String, Object> variables = new HashMap<>();
@@ -2402,6 +2506,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, taskService.createTaskQuery().processVariableValueLessThanOrEqual("number", 8).count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml" })
     public void testProcessDefinitionId() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -2413,6 +2518,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, taskService.createTaskQuery().processDefinitionId("unexisting").count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml" })
     public void testProcessDefinitionIdOr() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -2440,6 +2546,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
                 .processDefinitionId("unexisting").count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml" })
     public void testProcessDefinitionKey() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -2451,6 +2558,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, taskService.createTaskQuery().processDefinitionKey("unexisting").count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml" })
     public void testProcessDefinitionKeyOr() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -2464,6 +2572,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(1, taskService.createTaskQuery().or().taskId(taskIds.get(0)).processDefinitionKey("unexisting").endOr().count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml" })
     public void testProcessDefinitionKeyIn() throws Exception {
         runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -2476,6 +2585,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(1, taskService.createTaskQuery().processDefinitionKeyIn(includeIds).count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml" })
     public void testProcessDefinitionKeyInOr() throws Exception {
         runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -2499,6 +2609,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
                 .count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml" })
     public void testProcessDefinitionName() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -2510,6 +2621,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, taskService.createTaskQuery().processDefinitionName("unexisting").count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml" })
     public void testProcessDefinitionNameOr() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -2521,6 +2633,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").processDefinitionName("unexisting").count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml" })
     public void testProcessCategoryIn() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -2533,6 +2646,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, taskService.createTaskQuery().processCategoryIn(Collections.singletonList("unexisting")).count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml" })
     public void testProcessCategoryInOr() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -2562,6 +2676,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").processCategoryIn(Collections.singletonList("unexisting")).count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml" })
     public void testProcessCategoryNotIn() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -2574,6 +2689,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, taskService.createTaskQuery().processCategoryNotIn(Collections.singletonList("Examples")).count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml" })
     public void testProcessCategoryNotInOr() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -2586,6 +2702,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").processCategoryNotIn(Collections.singletonList("Examples")).count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml" })
     public void testProcessInstanceIdIn() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -2598,6 +2715,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, taskService.createTaskQuery().processInstanceIdIn(Collections.singletonList("unexisting")).count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml" })
     public void testProcessInstanceIdInOr() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -2611,6 +2729,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").processInstanceIdIn(Collections.singletonList("unexisting")).count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml" })
     public void testProcessInstanceIdInMultiple() throws Exception {
         ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -2622,6 +2741,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, taskService.createTaskQuery().processInstanceIdIn(Arrays.asList("unexisting1", "unexisting2")).count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml" })
     public void testProcessInstanceIdInOrMultiple() throws Exception {
         ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -2633,6 +2753,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").processInstanceIdIn(Arrays.asList("unexisting1", "unexisting2")).count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml" })
     public void testProcessInstanceBusinessKey() throws Exception {
         runtimeService.startProcessInstanceByKey("oneTaskProcess", "BUSINESS-KEY-1");
@@ -2642,6 +2763,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, taskService.createTaskQuery().processInstanceBusinessKey("NON-EXISTING").count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml" })
     public void testProcessInstanceBusinessKeyOr() throws Exception {
         runtimeService.startProcessInstanceByKey("oneTaskProcess", "BUSINESS-KEY-1");
@@ -2651,6 +2773,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").processInstanceBusinessKey("NON-EXISTING").count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml" })
     public void testTaskDueDate() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -2676,6 +2799,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(1, taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDueBefore(otherDate.getTime()).count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml" })
     public void testTaskDueDateOr() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -2701,6 +2825,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(1, taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDueBefore(otherDate.getTime()).count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml" })
     public void testTaskDueBefore() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -2732,6 +2857,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDueBefore(oneHourAgo.getTime()).count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml" })
     public void testTaskDueBeforeOr() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -2763,6 +2889,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, taskService.createTaskQuery().processInstanceId(processInstance.getId()).or().taskId("invalid").taskDueBefore(oneHourAgo.getTime()).count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml" })
     public void testTaskDueAfter() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -2794,6 +2921,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDueAfter(oneHourAgo.getTime()).count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml" })
     public void testTaskDueAfterOn() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -2825,6 +2953,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, taskService.createTaskQuery().processInstanceId(processInstance.getId()).or().taskId("invalid").taskDueAfter(oneHourAgo.getTime()).count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml" })
     public void testTaskWithoutDueDate() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -2846,6 +2975,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(1, taskService.createTaskQuery().processInstanceId(processInstance.getId()).withoutTaskDueDate().count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml" })
     public void testTaskWithoutDueDateOr() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -2867,6 +2997,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(1, taskService.createTaskQuery().processInstanceId(processInstance.getId()).or().taskId("invalid").withoutTaskDueDate().count());
     }
 
+    @Test
     public void testQueryPaging() {
         TaskQuery query = taskService.createTaskQuery().taskCandidateUser("kermit");
 
@@ -2891,6 +3022,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
                                                         // tasks
     }
 
+    @Test
     public void testQuerySorting() {
         assertEquals(12, taskService.createTaskQuery().orderByTaskId().asc().list().size());
         assertEquals(12, taskService.createTaskQuery().orderByTaskName().asc().list().size());
@@ -2916,6 +3048,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(6, taskService.createTaskQuery().orderByTaskId().taskName("testTask").desc().list().size());
     }
 
+    @Test
     public void testNativeQueryPaging() {
         assertEquals("ACT_RU_TASK", managementService.getTableName(org.flowable.task.api.Task.class));
         assertEquals("ACT_RU_TASK", managementService.getTableName(TaskEntity.class));
@@ -2923,6 +3056,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(2, taskService.createNativeTaskQuery().sql("SELECT * FROM " + managementService.getTableName(org.flowable.task.api.Task.class)).listPage(10, 12).size());
     }
 
+    @Test
     public void testNativeQuery() {
         assertEquals("ACT_RU_TASK", managementService.getTableName(org.flowable.task.api.Task.class));
         assertEquals("ACT_RU_TASK", managementService.getTableName(TaskEntity.class));
@@ -2953,6 +3087,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
                 .count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml" })
     public void testIncludeIdentityLinks() throws Exception {
         // Start process with a binary variable
@@ -2993,6 +3128,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
     /**
      * Test confirming fix for ACT-1731
      */
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml" })
     public void testIncludeBinaryVariables() throws Exception {
         // Start process with a binary variable
@@ -3019,6 +3155,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
     /**
      * Test confirming fix for ACT-1731
      */
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml" })
     public void testIncludeBinaryVariablesOr() throws Exception {
         // Start process with a binary variable
@@ -3042,6 +3179,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals("It is I, le binary", new String(bytes));
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml" })
     public void testQueryByDeploymentId() throws Exception {
         org.flowable.engine.repository.Deployment deployment = repositoryService.createDeploymentQuery().singleResult();
@@ -3052,6 +3190,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, taskService.createTaskQuery().deploymentId("invalid").count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml" })
     public void testQueryByDeploymentIdOr() throws Exception {
         org.flowable.engine.repository.Deployment deployment = repositoryService.createDeploymentQuery().singleResult();
@@ -3062,6 +3201,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").deploymentId("invalid").count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml" })
     public void testQueryByDeploymentIdIn() throws Exception {
         org.flowable.engine.repository.Deployment deployment = repositoryService.createDeploymentQuery().singleResult();
@@ -3081,6 +3221,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, taskService.createTaskQuery().deploymentIdIn(deploymentIds).count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml" })
     public void testQueryByDeploymentIdInOr() throws Exception {
         org.flowable.engine.repository.Deployment deployment = repositoryService.createDeploymentQuery().singleResult();
@@ -3102,6 +3243,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").deploymentIdIn(deploymentIds).count());
     }
 
+    @Test
     public void testQueryByTaskNameLikeIgnoreCase() {
 
         // Runtime
@@ -3125,6 +3267,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByTaskNameOrDescriptionLikeIgnoreCase() {
 
         // Runtime
@@ -3141,6 +3284,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     public void testQueryByTaskDescriptionLikeIgnoreCase() {
 
         // Runtime
@@ -3166,6 +3310,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByAssigneeLikeIgnoreCase() {
 
         // Runtime
@@ -3187,6 +3332,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testQueryByOwnerLikeIgnoreCase() {
 
         // Runtime
@@ -3208,6 +3354,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml" })
     public void testQueryByBusinessKeyLikeIgnoreCase() {
         runtimeService.startProcessInstanceByKey("oneTaskProcess", "BUSINESS-KEY-1");
@@ -3233,6 +3380,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml" })
     public void testQueryByProcessDefinitionKeyLikeIgnoreCase() {
 
@@ -3256,6 +3404,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testCombinationOfOrAndLikeIgnoreCase() {
 
         // Runtime
@@ -3270,6 +3419,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
     }
 
     // Test for https://jira.codehaus.org/browse/ACT-2103
+    @Test
     public void testTaskLocalAndProcessInstanceVariableEqualsInOr() {
 
         deployOneTaskTestProcess();
@@ -3310,6 +3460,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
                 .size());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml" })
     public void testLocalizeTasks() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskServiceTest.java
@@ -64,6 +64,8 @@ import org.flowable.task.api.history.HistoricTaskInstance;
 import org.flowable.task.service.TaskPostProcessor;
 import org.flowable.task.service.TaskServiceConfiguration;
 import org.flowable.task.service.impl.persistence.CountingTaskEntity;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Frederik Heremans
@@ -74,14 +76,14 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
     private Task task = null;
 
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
-        super.tearDown();
         if (task != null) {
             taskService.deleteTask(task.getId(), true);
         }
     }
 
+    @Test
     public void testCreateTaskWithBuilder() {
         task = taskService.createTaskBuilder().
                         name("testName").
@@ -117,6 +119,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         assertThat(updatedTask.getScopeType(), is(ScopeTypes.CMMN));
     }
 
+    @Test
     public void testBuilderCreateTaskWithParent() {
         Task parentTask = taskService.newTask();
         taskService.saveTask(parentTask);
@@ -135,6 +138,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testCreateTaskWithOwnerAssigneeAndIdentityLinks() {
         task = taskService.createTaskBuilder().
                         name("testName").
@@ -162,6 +166,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         taskService.deleteGroupIdentityLink(updatedTask.getId(), "testGroupBuilder", IdentityLinkType.CANDIDATE);
     }
 
+    @Test
     public void testCreateTaskWithBuilderAndPostprocessor() {
         TaskServiceConfiguration taskServiceConfiguration = (TaskServiceConfiguration) this.processEngineConfiguration.getServiceConfigurations().get(EngineConfigurationConstants.KEY_TASK_SERVICE_CONFIG);
         TaskPostProcessor previousTaskPostProcessor = taskServiceConfiguration.getTaskPostProcessor();
@@ -195,6 +200,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testCreateTaskWithOwnerAssigneeAndIdentityLinksAndPostProcessor() {
         TaskServiceConfiguration taskServiceConfiguration = (TaskServiceConfiguration) this.processEngineConfiguration.getServiceConfigurations().get(EngineConfigurationConstants.KEY_TASK_SERVICE_CONFIG);
         TaskPostProcessor previousTaskPostProcessor = taskServiceConfiguration.getTaskPostProcessor();
@@ -237,6 +243,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testSaveTaskUpdate() throws Exception {
 
         SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy hh:mm:ss");
@@ -292,6 +299,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         taskService.deleteTask(task.getId(), true);
     }
 
+    @Test
     public void testTaskOwner() {
         org.flowable.task.api.Task task = taskService.newTask();
         task.setOwner("johndoe");
@@ -311,6 +319,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         taskService.deleteTask(task.getId(), true);
     }
 
+    @Test
     public void testTaskComments() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             org.flowable.task.api.Task task = taskService.newTask();
@@ -341,6 +350,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testCustomTaskComments() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             org.flowable.task.api.Task task = taskService.newTask();
@@ -383,6 +393,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         }
     }
     
+    @Test
     public void testUpdateTaskComments() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             org.flowable.task.api.Task task = taskService.newTask();
@@ -413,6 +424,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testTaskAttachments() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             org.flowable.task.api.Task task = taskService.newTask();
@@ -443,6 +455,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testSaveTaskAttachment() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             org.flowable.task.api.Task task = taskService.newTask();
@@ -474,6 +487,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testTaskAttachmentWithProcessInstanceId() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
@@ -499,6 +513,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testMultipleProcessesStarted() {
 
@@ -512,6 +527,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         assertEquals(20, tasks.size());
     }
 
+    @Test
     public void testTaskDelegation() {
         org.flowable.task.api.Task task = taskService.newTask();
         task.setOwner("johndoe");
@@ -557,6 +573,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         taskService.deleteTask(taskId, true);
     }
 
+    @Test
     public void testTaskDelegationThroughServiceCall() {
         org.flowable.task.api.Task task = taskService.newTask();
         task.setOwner("johndoe");
@@ -584,6 +601,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         taskService.deleteTask(taskId, true);
     }
 
+    @Test
     public void testTaskAssignee() {
         org.flowable.task.api.Task task = taskService.newTask();
         task.setAssignee("johndoe");
@@ -603,6 +621,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         taskService.deleteTask(task.getId(), true);
     }
 
+    @Test
     public void testSaveTaskNullTask() {
         try {
             taskService.saveTask(null);
@@ -612,6 +631,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testDeleteTaskNullTaskId() {
         try {
             taskService.deleteTask(null);
@@ -621,11 +641,13 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testDeleteTaskUnexistingTaskId() {
         // Deleting unexisting task should be silently ignored
         taskService.deleteTask("unexistingtaskid");
     }
 
+    @Test
     public void testDeleteTasksNullTaskIds() {
         try {
             taskService.deleteTasks(null);
@@ -635,6 +657,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testDeleteTasksTaskIdsUnexistingTaskId() {
 
         org.flowable.task.api.Task existingTask = taskService.newTask();
@@ -649,6 +672,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         assertNull(existingTask);
     }
 
+    @Test
     public void testDeleteTaskIdentityLink() {
         org.flowable.task.api.Task task = null;
         try {
@@ -682,6 +706,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testClaimNullArguments() {
         try {
             taskService.claim(null, "userid");
@@ -691,6 +716,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testClaimUnexistingTaskId() {
         User user = identityService.newUser("user");
         identityService.saveUser(user);
@@ -706,6 +732,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         identityService.deleteUser(user.getId());
     }
 
+    @Test
     public void testClaimAlreadyClaimedTaskByOtherUser() {
         org.flowable.task.api.Task task = taskService.newTask();
         taskService.saveTask(task);
@@ -729,6 +756,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         identityService.deleteUser(secondUser.getId());
     }
 
+    @Test
     public void testClaimAlreadyClaimedTaskBySameUser() {
         org.flowable.task.api.Task task = taskService.newTask();
         taskService.saveTask(task);
@@ -747,6 +775,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         identityService.deleteUser(user.getId());
     }
 
+    @Test
     public void testUnClaimTask() {
         org.flowable.task.api.Task task = taskService.newTask();
         taskService.saveTask(task);
@@ -768,6 +797,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         identityService.deleteUser(user.getId());
     }
 
+    @Test
     public void testCompleteTaskNullTaskId() {
         try {
             taskService.complete(null);
@@ -777,6 +807,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testCompleteTaskUnexistingTaskId() {
         try {
             taskService.complete("unexistingtask");
@@ -787,6 +818,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testCompleteTaskWithParametersNullTaskId() {
         try {
             taskService.complete(null);
@@ -796,6 +828,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testCompleteTaskWithParametersUnexistingTaskId() {
         try {
             taskService.complete("unexistingtask");
@@ -806,6 +839,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testCompleteTaskWithParametersNullParameters() {
         org.flowable.task.api.Task task = taskService.newTask();
         taskService.saveTask(task);
@@ -823,6 +857,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
     }
 
     @SuppressWarnings("unchecked")
+    @Test
     public void testCompleteTaskWithParametersEmptyParameters() {
         org.flowable.task.api.Task task = taskService.newTask();
         taskService.saveTask(task);
@@ -839,6 +874,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         assertNull(task);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/twoTasksProcess.bpmn20.xml" })
     public void testCompleteWithParametersTask() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksProcess");
@@ -862,6 +898,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         assertEquals("myValue", variables.get("myParam"));
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/twoTasksProcess.bpmn20.xml" })
     public void testCompleteWithParametersTask2() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksProcess");
@@ -888,6 +925,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         assertEquals("myValue", variables.get("myParam"));
     }
 
+    @Test
     @Deployment(resources = {"org/flowable/engine/test/api/twoTasksProcess.bpmn20.xml"})
     public void testCompleteWithExecutionBaseNewPropertyExpressionTask() {
         runtimeService.startProcessInstanceByKey("twoTasksProcess");
@@ -908,6 +946,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = {"org/flowable/engine/test/api/twoTasksProcess.bpmn20.xml"})
     public void testCompleteWithExecutionIdParametersTask() {
         runtimeService.startProcessInstanceByKey("twoTasksProcess");
@@ -926,6 +965,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = {"org/flowable/engine/test/api/twoTasksProcess.bpmn20.xml"})
     public void testCompleteWithExecutionNameParametersTask() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksProcess");
@@ -944,6 +984,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         assertEquals("myUpdatedName", subExecution.getName());
     }
 
+    @Test
     @Deployment
     public void testCompleteWithTaskLocalParameters() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testTaskLocalVars");
@@ -969,6 +1010,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskWithFormKeyProcess.bpmn20.xml" })
     public void testCompleteTaskWithFormKey() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskWithFormProcess");
@@ -998,6 +1040,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testSetAssignee() {
         User user = identityService.newUser("user");
         identityService.saveUser(user);
@@ -1020,6 +1063,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         taskService.deleteTask(task.getId(), true);
     }
 
+    @Test
     public void testSetAssigneeNullTaskId() {
         try {
             taskService.setAssignee(null, "userId");
@@ -1029,6 +1073,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testSetAssigneeUnexistingTask() {
         User user = identityService.newUser("user");
         identityService.saveUser(user);
@@ -1044,6 +1089,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         identityService.deleteUser(user.getId());
     }
 
+    @Test
     public void testAddCandidateUserDuplicate() {
         // Check behavior when adding the same user twice as candidate
         User user = identityService.newUser("user");
@@ -1061,6 +1107,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         taskService.deleteTask(task.getId(), true);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testCountingTaskForAddRemoveIdentityLink() {
         processEngineConfiguration.setEnableTaskRelationshipCounts(true);
@@ -1124,6 +1171,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         taskServiceConfiguration.setEnableTaskRelationshipCounts(false);
     }
 
+    @Test
     public void testAddCandidateUserNullTaskId() {
         try {
             taskService.addCandidateUser(null, "userId");
@@ -1133,6 +1181,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testAddCandidateUserNullUserId() {
         try {
             taskService.addCandidateUser("taskId", null);
@@ -1142,6 +1191,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testAddCandidateUserUnexistingTask() {
         User user = identityService.newUser("user");
         identityService.saveUser(user);
@@ -1157,6 +1207,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         identityService.deleteUser(user.getId());
     }
 
+    @Test
     public void testAddCandidateGroupNullTaskId() {
         try {
             taskService.addCandidateGroup(null, "groupId");
@@ -1166,6 +1217,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testAddCandidateGroupNullGroupId() {
         try {
             taskService.addCandidateGroup("taskId", null);
@@ -1175,6 +1227,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testAddCandidateGroupUnexistingTask() {
         Group group = identityService.newGroup("group");
         identityService.saveGroup(group);
@@ -1188,6 +1241,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         identityService.deleteGroup(group.getId());
     }
 
+    @Test
     public void testAddGroupIdentityLinkNullTaskId() {
         try {
             taskService.addGroupIdentityLink(null, "groupId", IdentityLinkType.CANDIDATE);
@@ -1197,6 +1251,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testAddGroupIdentityLinkNullUserId() {
         try {
             taskService.addGroupIdentityLink("taskId", null, IdentityLinkType.CANDIDATE);
@@ -1206,6 +1261,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testAddGroupIdentityLinkUnexistingTask() {
         User user = identityService.newUser("user");
         identityService.saveUser(user);
@@ -1221,6 +1277,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         identityService.deleteUser(user.getId());
     }
 
+    @Test
     public void testAddUserIdentityLinkNullTaskId() {
         try {
             taskService.addUserIdentityLink(null, "userId", IdentityLinkType.CANDIDATE);
@@ -1230,6 +1287,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testAddUserIdentityLinkNullUserId() {
         try {
             taskService.addUserIdentityLink("taskId", null, IdentityLinkType.CANDIDATE);
@@ -1239,6 +1297,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testAddUserIdentityLinkUnexistingTask() {
         User user = identityService.newUser("user");
         identityService.saveUser(user);
@@ -1254,6 +1313,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         identityService.deleteUser(user.getId());
     }
 
+    @Test
     public void testGetIdentityLinksWithCandidateUser() {
         org.flowable.task.api.Task task = taskService.newTask();
         taskService.saveTask(task);
@@ -1273,6 +1333,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         identityService.deleteUser("kermit");
     }
 
+    @Test
     public void testGetIdentityLinksWithCandidateGroup() {
         org.flowable.task.api.Task task = taskService.newTask();
         taskService.saveTask(task);
@@ -1292,6 +1353,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         identityService.deleteGroup("muppets");
     }
 
+    @Test
     public void testGetIdentityLinksWithAssignee() {
         org.flowable.task.api.Task task = taskService.newTask();
         taskService.saveTask(task);
@@ -1311,6 +1373,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         identityService.deleteUser("kermit");
     }
 
+    @Test
     public void testGetIdentityLinksWithNonExistingAssignee() {
         org.flowable.task.api.Task task = taskService.newTask();
         taskService.saveTask(task);
@@ -1327,6 +1390,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         taskService.deleteTask(taskId, true);
     }
 
+    @Test
     public void testGetIdentityLinksWithOwner() {
         org.flowable.task.api.Task task = taskService.newTask();
         taskService.saveTask(task);
@@ -1357,6 +1421,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         identityService.deleteUser("fozzie");
     }
 
+    @Test
     public void testGetIdentityLinksWithNonExistingOwner() {
         org.flowable.task.api.Task task = taskService.newTask();
         taskService.saveTask(task);
@@ -1381,6 +1446,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         taskService.deleteTask(taskId, true);
     }
 
+    @Test
     public void testSetPriority() {
         org.flowable.task.api.Task task = taskService.newTask();
         taskService.saveTask(task);
@@ -1394,6 +1460,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         taskService.deleteTask(task.getId(), true);
     }
 
+    @Test
     public void testSetPriorityUnexistingTaskId() {
         try {
             taskService.setPriority("unexistingtask", 12345);
@@ -1404,6 +1471,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testSetPriorityNullTaskId() {
         try {
             taskService.setPriority(null, 12345);
@@ -1413,6 +1481,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testSetDueDate() {
         org.flowable.task.api.Task task = taskService.newTask();
         taskService.saveTask(task);
@@ -1435,6 +1504,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         taskService.deleteTask(task.getId(), true);
     }
 
+    @Test
     public void testSetDueDateUnexistingTaskId() {
         try {
             taskService.setDueDate("unexistingtask", new Date());
@@ -1444,6 +1514,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testSetDueDateNullTaskId() {
         try {
             taskService.setDueDate(null, new Date());
@@ -1456,6 +1527,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
     /**
      * @see <a href="https://activiti.atlassian.net/browse/ACT-1059">https://activiti.atlassian.net/browse/ACT-1059</a>
      */
+    @Test
     public void testSetDelegationState() {
         org.flowable.task.api.Task task = taskService.newTask();
         task.setOwner("wuzh");
@@ -1503,6 +1575,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testRemoveVariable() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -1520,6 +1593,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         checkHistoricVariableUpdateEntity("variable1", processInstance.getId());
     }
 
+    @Test
     public void testRemoveVariableNullTaskId() {
         try {
             taskService.removeVariable(null, "variable");
@@ -1529,6 +1603,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testRemoveVariables() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -1563,6 +1638,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
     }
 
     @SuppressWarnings("unchecked")
+    @Test
     public void testRemoveVariablesNullTaskId() {
         try {
             taskService.removeVariables(null, Collections.EMPTY_LIST);
@@ -1572,6 +1648,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testRemoveVariableLocal() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -1590,6 +1667,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         checkHistoricVariableUpdateEntity("variable1", processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testCountingTaskForAddRemoveVariable() {
         processEngineConfiguration.setEnableTaskRelationshipCounts(true);
@@ -1643,6 +1721,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         taskServiceConfiguration.setEnableTaskRelationshipCounts(false);
     }
 
+    @Test
     public void testRemoveVariableLocalNullTaskId() {
         try {
             taskService.removeVariableLocal(null, "variable");
@@ -1652,6 +1731,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testRemoveVariablesLocal() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -1686,6 +1766,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
     }
 
     @SuppressWarnings("unchecked")
+    @Test
     public void testRemoveVariablesLocalNullTaskId() {
         try {
             taskService.removeVariablesLocal(null, Collections.EMPTY_LIST);
@@ -1695,6 +1776,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testGetVariableByHistoricActivityInstance() throws Exception {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.FULL, processEngineConfiguration)) {
@@ -1738,6 +1820,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testUserTaskOptimisticLocking() {
         runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -1758,6 +1841,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testDeleteTaskWithDeleteReason() {
         // ACT-900: deleteReason can be manually specified - can only be
         // validated when historyLevel > ACTIVITY
@@ -1785,6 +1869,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testResolveTaskNullTaskId() {
         try {
             taskService.resolveTask(null);
@@ -1794,6 +1879,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testResolveTaskUnexistingTaskId() {
         try {
             taskService.resolveTask("blergh");
@@ -1803,6 +1889,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testResolveTaskWithParametersNullParameters() {
         org.flowable.task.api.Task task = taskService.newTask();
         task.setDelegationState(DelegationState.PENDING);
@@ -1823,6 +1910,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
     }
 
     @SuppressWarnings("unchecked")
+    @Test
     public void testResolveTaskWithParametersEmptyParameters() {
         org.flowable.task.api.Task task = taskService.newTask();
         task.setDelegationState(DelegationState.PENDING);
@@ -1842,6 +1930,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         taskService.deleteTask(taskId, true);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/twoTasksProcess.bpmn20.xml" })
     public void testResolveWithParametersTask() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksProcess");
@@ -1867,6 +1956,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         assertEquals("myValue", variables.get("myParam"));
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testDeleteTaskPartOfProcess() {
         runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -1911,6 +2001,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment
     public void testFormKeyExpression() {
         runtimeService.startProcessInstanceByKey("testFormExpression", CollectionUtil.singletonMap("var", "abc"));
@@ -1933,6 +2024,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testGetVariableLocalWithCast() {
         runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -1946,6 +2038,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         assertEquals("value1", variable);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testGetVariableLocalNotExistingWithCast() {
         runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -1957,6 +2050,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         assertNull(variable);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testGetVariableLocalWithInvalidCast() {
         runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -1969,6 +2063,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
             .isExactlyInstanceOf(ClassCastException.class);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testGetVariableWithCast() {
         runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -1982,6 +2077,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         assertEquals("value1", variable);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testGetVariableNotExistingWithCast() {
         runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -1993,6 +2089,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         assertNull(variable);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testGetVariableWithInvalidCast() {
         runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -2005,6 +2102,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
             .isExactlyInstanceOf(ClassCastException.class);
     }
 
+    @Test
     public void testClaimTime() {
         org.flowable.task.api.Task task = taskService.newTask();
         taskService.saveTask(task);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskVariablesTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskVariablesTest.java
@@ -25,12 +25,14 @@ import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.variable.api.persistence.entity.VariableInstance;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tom Baeyens
  */
 public class TaskVariablesTest extends PluggableFlowableTestCase {
 
+    @Test
     public void testStandaloneTaskVariables() {
         org.flowable.task.api.Task task = taskService.newTask();
         task.setName("gonzoTask");
@@ -43,6 +45,7 @@ public class TaskVariablesTest extends PluggableFlowableTestCase {
         taskService.deleteTask(taskId, true);
     }
 
+    @Test
     @Deployment
     public void testTaskExecutionVariables() {
         String processInstanceId = runtimeService.startProcessInstanceByKey("oneTaskProcess").getId();
@@ -93,6 +96,7 @@ public class TaskVariablesTest extends PluggableFlowableTestCase {
         assertEquals(expectedVariables, runtimeService.getVariablesLocal(processInstanceId));
     }
 
+    @Test
     public void testSerializableTaskVariable() {
         org.flowable.task.api.Task task = taskService.newTask();
         task.setName("MyTask");
@@ -112,6 +116,7 @@ public class TaskVariablesTest extends PluggableFlowableTestCase {
         taskService.deleteTask(task.getId(), true);
     }
 
+    @Test
     @Deployment
     public void testGetVariablesLocalByTaskIds() {
         ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("twoTaskProcess");
@@ -183,6 +188,7 @@ public class TaskVariablesTest extends PluggableFlowableTestCase {
         fail();
     }
 
+    @Test
     @Deployment(resources = {
             "org/flowable/engine/test/api/task/TaskVariablesTest.testTaskExecutionVariables.bpmn20.xml"
     })
@@ -205,6 +211,7 @@ public class TaskVariablesTest extends PluggableFlowableTestCase {
         assertEquals(serializableTypeVar, variables.get(0).getValue());
     }
 
+    @Test
     @Deployment(resources = {
             "org/flowable/engine/test/api/runtime/variableScope.bpmn20.xml"
     })

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/tenant/TenancyTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/tenant/TenancyTest.java
@@ -28,6 +28,9 @@ import org.flowable.engine.repository.ProcessDefinition;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.job.api.Job;
 import org.junit.Assert;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * A test case for the various implications of the tenancy support (tenant id column to entities + query support)
@@ -40,15 +43,13 @@ public class TenancyTest extends PluggableFlowableTestCase {
 
     private List<String> autoCleanedUpDeploymentIds = new ArrayList<>();
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
         this.autoCleanedUpDeploymentIds.clear();
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
 
         if (!autoCleanedUpDeploymentIds.isEmpty()) {
             for (String deploymentId : autoCleanedUpDeploymentIds) {
@@ -90,6 +91,7 @@ public class TenancyTest extends PluggableFlowableTestCase {
         return repositoryService.createProcessDefinitionQuery().deploymentId(id).singleResult().getId();
     }
 
+    @Test
     public void testDeploymentTenancy() {
 
         deployTestProcessWithTestTenant();
@@ -104,6 +106,7 @@ public class TenancyTest extends PluggableFlowableTestCase {
         assertEquals(0, repositoryService.createDeploymentQuery().deploymentWithoutTenantId().list().size());
     }
 
+    @Test
     public void testProcessDefinitionTenancy() {
 
         // Deploy a process with tenant and verify
@@ -140,6 +143,7 @@ public class TenancyTest extends PluggableFlowableTestCase {
                 .singleResult().getId());
     }
 
+    @Test
     public void testProcessInstanceTenancy() {
 
         // Start a number of process instances with tenant
@@ -165,6 +169,7 @@ public class TenancyTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     public void testExecutionTenancy() {
 
         // Start a number of process instances with tenant
@@ -198,6 +203,7 @@ public class TenancyTest extends PluggableFlowableTestCase {
         assertEquals(nrOfProcessInstancesWithTenant, runtimeService.createProcessInstanceQuery().processInstanceTenantIdLike("%en%").list().size());
     }
 
+    @Test
     public void testTaskTenancy() {
 
         // Generate 10 tasks with tenant
@@ -226,6 +232,7 @@ public class TenancyTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     public void testJobTenancy() {
 
         // Deploy process with a timer and an async step AND with a tenant
@@ -270,6 +277,7 @@ public class TenancyTest extends PluggableFlowableTestCase {
         repositoryService.deleteDeployment(deploymentId2, true);
     }
 
+    @Test
     public void testModelTenancy() {
 
         // Create a few models with tenant
@@ -303,6 +311,7 @@ public class TenancyTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     public void testChangeDeploymentTenantId() {
 
         // Generate 8 tasks with tenant
@@ -370,6 +379,7 @@ public class TenancyTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testChangeDeploymentIdWithClash() {
         String processDefinitionIdWithTenant = deployTestProcessWithTestTenant("tenantA");
         String processDefinitionIdNoTenant = deployOneTaskTestProcess();
@@ -388,6 +398,7 @@ public class TenancyTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     public void testJobTenancyAfterTenantChange() {
 
         // Deploy process with a timer and an async step AND with a tenant
@@ -420,6 +431,7 @@ public class TenancyTest extends PluggableFlowableTestCase {
         repositoryService.deleteDeployment(deploymentId, true);
     }
 
+    @Test
     public void testHistoryTenancy() {
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
@@ -476,6 +488,7 @@ public class TenancyTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     public void testProcessDefinitionKeyClashBetweenTenants() {
 
         String tentanA = "tenantA";
@@ -526,6 +539,7 @@ public class TenancyTest extends PluggableFlowableTestCase {
         assertEquals(procDefIdB, processInstance.getProcessDefinitionId());
     }
 
+    @Test
     public void testSuspendProcessDefinitionTenancy() {
 
         // Deploy one process definition for tenant A, and two process
@@ -574,6 +588,7 @@ public class TenancyTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testSignalFromProcessTenancy() {
 
         // Deploy process both with and without tenant
@@ -610,6 +625,7 @@ public class TenancyTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     public void testSignalThroughApiTenancy() {
 
         // Deploy process both with and without tenant
@@ -648,6 +664,7 @@ public class TenancyTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testSignalThroughApiTenancyReversed() { // cause reversing the
                                                         // order of calling DID
                                                         // leave to an error!
@@ -688,6 +705,7 @@ public class TenancyTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testSignalAsyncThroughApiTenancy() {
 
         // Deploy process both with and without tenant
@@ -741,6 +759,7 @@ public class TenancyTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testStartProcessInstanceBySignalTenancy() {
 
         // Deploy process both with and without tenant
@@ -780,6 +799,7 @@ public class TenancyTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testStartProcessInstanceByMessageTenancy() {
 
         // Deploy process both with and without tenant
@@ -813,6 +833,7 @@ public class TenancyTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testStartProcessInstanceByMessageTenancyReversed() { // same as
                                                                      // above,
                                                                      // but now
@@ -845,6 +866,7 @@ public class TenancyTest extends PluggableFlowableTestCase {
     }
 
     // Bug from http://forums.activiti.org/content/callactiviti-tenant-id
+    @Test
     public void testCallActivityWithTenant() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             String tenantId = "apache";
@@ -880,6 +902,7 @@ public class TenancyTest extends PluggableFlowableTestCase {
     /*
      * See https://activiti.atlassian.net/browse/ACT-4034
      */
+    @Test
     public void testGetLatestProcessDefinitionVersionForSameProcessDefinitionKey() {
         String tenant1 = "tenant1";
         String tenant2 = "tenant2";

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/v6/Flowable6ExecutionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/v6/Flowable6ExecutionTest.java
@@ -26,9 +26,11 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 public class Flowable6ExecutionTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testOneTaskProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -81,6 +83,7 @@ public class Flowable6ExecutionTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testOneNestedTaskProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneNestedTaskProcess");
@@ -187,6 +190,7 @@ public class Flowable6ExecutionTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testSubProcessWithTimer() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("subProcessWithTimer");
@@ -293,6 +297,7 @@ public class Flowable6ExecutionTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testSubProcessEvents() {
         SubProcessEventListener listener = new SubProcessEventListener();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/v6/Flowable6Test.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/v6/Flowable6Test.java
@@ -26,6 +26,7 @@ import org.flowable.engine.repository.ProcessDefinition;
 import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.job.api.Job;
+import org.junit.jupiter.api.Test;
 
 /**
  * These are the first tests ever written for Flowable 6. Keeping them here for nostalgic reasons.
@@ -34,6 +35,7 @@ import org.flowable.job.api.Job;
  */
 public class Flowable6Test extends PluggableFlowableTestCase {
 
+    @Test
     public void testSimplestProcessPossible() {
         repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/api/v6/Flowable6Test.simplestProcessPossible.bpmn20.xml").deploy();
 
@@ -47,6 +49,7 @@ public class Flowable6Test extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @org.flowable.engine.test.Deployment
     public void testOneTaskProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -60,6 +63,7 @@ public class Flowable6Test extends PluggableFlowableTestCase {
         taskService.complete(task.getId());
     }
 
+    @Test
     @org.flowable.engine.test.Deployment(resources = "org/flowable/engine/test/api/v6/Flowable6Test.testOneTaskProcess.bpmn20.xml")
     public void testOneTaskProcessCleanupInMiddleOfProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -71,6 +75,7 @@ public class Flowable6Test extends PluggableFlowableTestCase {
         assertEquals("kermit", task.getAssignee());
     }
 
+    @Test
     @org.flowable.engine.test.Deployment
     public void testSimpleParallelGateway() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("simpleParallelGateway");
@@ -89,6 +94,7 @@ public class Flowable6Test extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createProcessInstanceQuery().count());
     }
 
+    @Test
     @org.flowable.engine.test.Deployment
     public void testSimpleNestedParallelGateway() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("simpleParallelGateway");
@@ -112,6 +118,7 @@ public class Flowable6Test extends PluggableFlowableTestCase {
     /*
      * This fails on Activiti 5
      */
+    @Test
     @org.flowable.engine.test.Deployment
     public void testLongServiceTaskLoop() {
         int maxCount = 3210; // You can make this as big as you want (as long as it still fits within transaction timeouts).
@@ -132,6 +139,7 @@ public class Flowable6Test extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @org.flowable.engine.test.Deployment
     public void testScriptTask() {
         Map<String, Object> variableMap = new HashMap<>();
@@ -152,6 +160,7 @@ public class Flowable6Test extends PluggableFlowableTestCase {
         assertNull(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).singleResult());
     }
 
+    @Test
     @org.flowable.engine.test.Deployment
     public void testSimpleTimerBoundaryEvent() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("simpleBoundaryTimer");
@@ -169,6 +178,7 @@ public class Flowable6Test extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createExecutionQuery().count());
     }
 
+    @Test
     @org.flowable.engine.test.Deployment
     public void testSimpleTimerBoundaryEventTimerDoesNotFire() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("simpleBoundaryTimer");
@@ -185,6 +195,7 @@ public class Flowable6Test extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createExecutionQuery().count());
     }
 
+    @Test
     @org.flowable.engine.test.Deployment
     public void testSimpleNonInterruptingTimerBoundaryEvent() {
 
@@ -225,6 +236,7 @@ public class Flowable6Test extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createExecutionQuery().count());
     }
 
+    @Test
     @org.flowable.engine.test.Deployment
     public void testConditionsWithoutExclusiveGateway() {
 
@@ -274,6 +286,7 @@ public class Flowable6Test extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @org.flowable.engine.test.Deployment
     public void testNonInterruptingMoreComplex() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("nonInterruptingTimer");
@@ -325,6 +338,7 @@ public class Flowable6Test extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createExecutionQuery().count());
     }
 
+    @Test
     @org.flowable.engine.test.Deployment
     public void testNonInterruptingMoreComplex2() {
 
@@ -415,6 +429,7 @@ public class Flowable6Test extends PluggableFlowableTestCase {
     /**
      * Based on the process and use cases described in http://www.bp-3.com/blogs/2013/09/joins-and-ibm-bpm-diving-deeper/
      */
+    @Test
     @org.flowable.engine.test.Deployment
     public void testInclusiveTrickyMerge() {
 
@@ -482,6 +497,7 @@ public class Flowable6Test extends PluggableFlowableTestCase {
     /**
      * Simple test that checks if all databases have correctly added the process definition tag.
      */
+    @Test
     @org.flowable.engine.test.Deployment(resources = "org/flowable/engine/test/api/v6/Flowable6Test.testOneTaskProcess.bpmn20.xml")
     public void testProcessDefinitionTagCreated() {
         ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/variables/SerializableVariableTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/variables/SerializableVariableTest.java
@@ -21,12 +21,14 @@ import org.flowable.engine.delegate.JavaDelegate;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
  */
 public class SerializableVariableTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testUpdateSerializableInServiceTask() {
         Map<String, Object> vars = new HashMap<>();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/variables/TransientVariablesTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/variables/TransientVariablesTest.java
@@ -29,12 +29,14 @@ import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.task.service.delegate.DelegateTask;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
  */
 public class TransientVariablesTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testSetTransientVariableInServiceTask() {
 
@@ -50,6 +52,7 @@ public class TransientVariablesTest extends PluggableFlowableTestCase {
         assertNull(runtimeService.getVariable(processInstance.getId(), "response"));
     }
 
+    @Test
     @Deployment
     public void testUseTransientVariableInExclusiveGateway() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("transientVarsTest");
@@ -60,6 +63,7 @@ public class TransientVariablesTest extends PluggableFlowableTestCase {
         assertNull(runtimeService.getVariable(processInstance.getId(), "response"));
     }
 
+    @Test
     @Deployment
     public void testTaskCompleteWithTransientVariables() {
         Map<String, Object> persistentVars = new HashMap<>();
@@ -89,6 +93,7 @@ public class TransientVariablesTest extends PluggableFlowableTestCase {
         assertNull(runtimeService.getVariable(processInstance.getId(), "thirdTransientVar"));
     }
 
+    @Test
     @Deployment
     public void testTaskResolveWithTransientVariables() {
         Map<String, Object> persistentVars = new HashMap<>();
@@ -118,6 +123,7 @@ public class TransientVariablesTest extends PluggableFlowableTestCase {
         assertNull(runtimeService.getVariable(processInstance.getId(), "thirdTransientVar"));
     }
 
+    @Test
     @Deployment
     public void testTaskListenerWithTransientVariables() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("transientVarsTest");
@@ -129,6 +135,7 @@ public class TransientVariablesTest extends PluggableFlowableTestCase {
         assertEquals("transientVar01transientVar02transientVar03", mergedResult);
     }
 
+    @Test
     @Deployment
     public void testTransientVariableShadowsPersistentVariable() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("transientVarsTest", CollectionUtil.singletonMap("theVar", "Hello World"));
@@ -137,6 +144,7 @@ public class TransientVariablesTest extends PluggableFlowableTestCase {
         assertEquals("I am shadowed", varValue);
     }
 
+    @Test
     @Deployment
     public void testTriggerWithTransientVars() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("transientVarsTest");
@@ -154,6 +162,7 @@ public class TransientVariablesTest extends PluggableFlowableTestCase {
         assertNull(runtimeService.getVariable(processInstance.getId(), "transientVar"));
     }
 
+    @Test
     @Deployment
     public void testStartProcessInstanceByKey() {
         ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder()
@@ -181,6 +190,7 @@ public class TransientVariablesTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.getVariables(processInstance.getId()).size());
     }
 
+    @Test
     @Deployment
     public void testStartProcessInstanceById() {
 
@@ -211,6 +221,7 @@ public class TransientVariablesTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.getVariables(processInstance.getId()).size());
     }
 
+    @Test
     @Deployment
     public void testStartProcessInstanceByMessage() {
 
@@ -239,6 +250,7 @@ public class TransientVariablesTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.getVariables(processInstance.getId()).size());
     }
 
+    @Test
     @Deployment
     public void testLoopingExclusiveGateway() {
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/variables/VariablesTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/variables/VariablesTest.java
@@ -29,6 +29,9 @@ import org.flowable.engine.repository.Deployment;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Testing various constructs with variables. Created to test the changes done in https://jira.codehaus.org/browse/ACT-1900.
@@ -39,9 +42,8 @@ public class VariablesTest extends PluggableFlowableTestCase {
 
     protected String processInstanceId;
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
 
         repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/api/variables/VariablesTest.bpmn20.xml").deploy();
 
@@ -90,16 +92,16 @@ public class VariablesTest extends PluggableFlowableTestCase {
         return vars;
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
 
         for (Deployment deployment : repositoryService.createDeploymentQuery().list()) {
             repositoryService.deleteDeployment(deployment.getId(), true);
         }
 
-        super.tearDown();
     }
 
+    @Test
     public void testGetVariables() {
 
         // Regular getVariables after process instance start
@@ -184,6 +186,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals(10, nrOfSerializable);
     }
 
+    @Test
     public void testGetVariablesLocal() {
 
         // Regular getVariables after process instance start
@@ -236,6 +239,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals(0, vars.size());
     }
 
+    @Test
     public void testGetVariable() {
 
         // This actually does a specific select. Before, this was not the case
@@ -246,6 +250,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("stringVarValue-3", value);
     }
 
+    @Test
     public void testGetVariablesLocal2() {
 
         // Trying the same after moving the process
@@ -344,6 +349,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     public void testGetVariablesWithCollectionThroughRuntimeService() {
 
         Map<String, Object> vars = runtimeService.getVariables(processInstanceId, Arrays.asList("intVar1", "intVar3", "intVar5", "intVar9"));
@@ -367,6 +373,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @org.flowable.engine.test.Deployment
     public void testGetVariableAllVariableFetchingDefault() {
 
@@ -386,6 +393,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("HELLO world", varValue);
     }
 
+    @Test
     @org.flowable.engine.test.Deployment
     public void testGetVariableAllVariableFetchingDisabled() {
 
@@ -400,6 +408,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("HELLO world!", varValue);
     }
 
+    @Test
     @org.flowable.engine.test.Deployment
     public void testGetVariableInDelegateMixed() {
 
@@ -413,6 +422,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("Hiya", (String) runtimeService.getVariable(processInstanceId, "testVar2"));
     }
 
+    @Test
     @org.flowable.engine.test.Deployment
     public void testGetVariableInDelegateMixed2() {
 
@@ -426,6 +436,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("1234", (String) runtimeService.getVariable(processInstanceId, "testVar"));
     }
 
+    @Test
     @org.flowable.engine.test.Deployment
     public void testGetVariableInDelegateMixed3() {
 
@@ -446,6 +457,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertNull(runtimeService.getVariable(processInstanceId, "testVar3"));
     }
 
+    @Test
     public void testTaskGetVariables() {
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskName("Task 1").singleResult();
@@ -518,6 +530,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("Override", taskService.getVariables(task.getId(), varNames).get("stringVar1"));
     }
 
+    @Test
     public void testLocalDateVariable() {
 
         Calendar todayCal = new GregorianCalendar();
@@ -552,6 +565,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals(processInstanceId, processInstance.getId());
     }
 
+    @Test
     public void testLocalDateTimeVariable() {
 
         Calendar todayCal = new GregorianCalendar();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/StartToEndTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/StartToEndTest.java
@@ -22,12 +22,14 @@ import org.flowable.engine.impl.persistence.entity.ExecutionEntity;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
  */
 public class StartToEndTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testStartToEnd() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startToEnd");
@@ -35,6 +37,7 @@ public class StartToEndTest extends PluggableFlowableTestCase {
         assertTrue(processInstance.isEnded());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/StartToEndTest.testStartToEnd.bpmn20.xml" })
     public void testStartProcessInstanceWithVariables() {
         Map<String, Object> varMap = new HashMap<>();
@@ -45,6 +48,7 @@ public class StartToEndTest extends PluggableFlowableTestCase {
         assertEquals("hello", returnVarMap.get("test"));
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/StartToEndTest.testStartWithServiceTask.bpmn20.xml" })
     public void testStartProcessInstanceWithServiceTask() {
         Map<String, Object> varMap = new HashMap<>();
@@ -59,6 +63,7 @@ public class StartToEndTest extends PluggableFlowableTestCase {
         assertEquals(10L, returnVarMap.get("long"));
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/StartToEndTest.testStartWithSerializableVariables.bpmn20.xml" })
     public void testStartProcessInstanceWithSerializbleVariables() {
         Map<String, Object> varMap = new HashMap<>();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/async/AsyncEmailTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/async/AsyncEmailTaskTest.java
@@ -18,6 +18,7 @@ import java.util.List;
 import org.flowable.engine.test.Deployment;
 import org.flowable.engine.test.bpmn.mail.EmailServiceTaskTest;
 import org.flowable.engine.test.bpmn.mail.EmailTestCase;
+import org.junit.jupiter.api.Test;
 import org.subethamail.wiser.WiserMessage;
 
 /**
@@ -27,6 +28,7 @@ import org.subethamail.wiser.WiserMessage;
  */
 public class AsyncEmailTaskTest extends EmailTestCase {
 
+    @Test
     @Deployment
     public void testSimpleTextMail() throws Exception {
         String procId = runtimeService.startProcessInstanceByKey("simpleTextOnly").getId();
@@ -44,6 +46,7 @@ public class AsyncEmailTaskTest extends EmailTestCase {
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment
     public void testSimpleTextMailSendTask() throws Exception {
         runtimeService.startProcessInstanceByKey("simpleTextOnly");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/async/AsyncExclusiveJobsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/async/AsyncExclusiveJobsTest.java
@@ -17,12 +17,14 @@ import org.flowable.engine.history.HistoricActivityInstance;
 import org.flowable.engine.impl.test.HistoryTestHelper;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 public class AsyncExclusiveJobsTest extends PluggableFlowableTestCase {
 
     /**
      * Test for https://activiti.atlassian.net/browse/ACT-4035.
      */
+    @Test
     @Deployment
     public void testExclusiveJobs() {
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/async/AsyncTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/async/AsyncTaskTest.java
@@ -26,6 +26,7 @@ import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
 import org.flowable.variable.api.history.HistoricVariableInstance;
 import org.junit.Assert;
+import org.junit.jupiter.api.Test;
 
 /**
  * 
@@ -35,6 +36,7 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
 
     public static boolean INVOCATION;
 
+    @Test
     @Deployment
     public void testAsyncServiceNoListeners() {
         INVOCATION = false;
@@ -53,6 +55,7 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
         assertEquals(0, managementService.createJobQuery().count());
     }
 
+    @Test
     @Deployment
     public void testAsyncServiceListeners() {
         String pid = runtimeService.startProcessInstanceByKey("asyncService").getProcessInstanceId();
@@ -65,6 +68,7 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
         assertEquals(0, managementService.createJobQuery().count());
     }
 
+    @Test
     @Deployment
     public void testAsyncServiceConcurrent() {
         INVOCATION = false;
@@ -83,6 +87,7 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
         assertEquals(0, managementService.createJobQuery().count());
     }
 
+    @Test
     @Deployment
     public void testAsyncServiceMultiInstance() {
         INVOCATION = false;
@@ -101,6 +106,7 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
         assertEquals(0, managementService.createJobQuery().count());
     }
 
+    @Test
     @Deployment
     public void testFailingAsyncServiceTimer() {
         // start process
@@ -164,6 +170,7 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment
     public void testAsyncServiceSubProcessTimer() {
         INVOCATION = false;
@@ -184,6 +191,7 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
         assertEquals(0, managementService.createJobQuery().count());
     }
 
+    @Test
     @Deployment
     public void testAsyncServiceSubProcess() {
         // start process
@@ -198,6 +206,7 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment
     public void testAsyncTask() {
         // start process
@@ -211,6 +220,7 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
         assertEquals(0, managementService.createJobQuery().count());
     }
 
+    @Test
     @Deployment
     public void testAsyncEndEvent() {
         // start process
@@ -242,6 +252,7 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testAsyncScript() {
         // start process
@@ -269,6 +280,7 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
         runtimeService.trigger(eid);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/async/AsyncTaskTest.testAsyncCallActivity.bpmn20.xml",
             "org/flowable/engine/test/bpmn/async/AsyncTaskTest.testAsyncServiceNoListeners.bpmn20.xml" })
     public void testAsyncCallActivity() throws Exception {
@@ -283,6 +295,7 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createProcessInstanceQuery().count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/async/AsyncTaskTest.testBasicAsyncCallActivity.bpmn20.xml", "org/flowable/engine/test/bpmn/StartToEndTest.testStartToEnd.bpmn20.xml" })
     public void testBasicAsyncCallActivity() {
         runtimeService.startProcessInstanceByKey("myProcess");
@@ -291,6 +304,7 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
         assertEquals(0, managementService.createJobQuery().count());
     }
 
+    @Test
     @Deployment
     public void testAsyncUserTask() {
         // start process
@@ -320,6 +334,7 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment
     public void testMultiInstanceAsyncTask() {
         // start process
@@ -371,6 +386,7 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testMultiInstanceTask() {
         // start process
@@ -405,6 +421,7 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testMultiInstanceAsyncSequentialTask() {
         // start process
@@ -456,6 +473,7 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testMultiInstanceSequentialTask() {
         // start process

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/callactivity/CallActivityAdvancedTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/callactivity/CallActivityAdvancedTest.java
@@ -36,6 +36,7 @@ import org.flowable.identitylink.api.IdentityLink;
 import org.flowable.identitylink.api.IdentityLinkType;
 import org.flowable.task.api.Task;
 import org.flowable.task.api.TaskQuery; 
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
@@ -45,6 +46,7 @@ import org.flowable.task.api.TaskQuery;
  */
 public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/callactivity/CallActivity.testCallSimpleSubProcess.bpmn20.xml", "org/flowable/engine/test/bpmn/callactivity/simpleSubProcess.bpmn20.xml" })
     public void testCallSimpleSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("callSimpleSubProcess");
@@ -90,6 +92,7 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/callactivity/CallActivity.testCallSimpleSubProcessWithExpressions.bpmn20.xml",
             "org/flowable/engine/test/bpmn/callactivity/simpleSubProcess.bpmn20.xml" })
     public void testCallSimpleSubProcessWithExpressions() {
@@ -125,6 +128,7 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
     /**
      * Test case for a possible tricky case: reaching the end event of the subprocess leads to an end event in the super process instance.
      */
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/callactivity/CallActivity.testSubProcessEndsSuperProcess.bpmn20.xml",
             "org/flowable/engine/test/bpmn/callactivity/simpleSubProcess.bpmn20.xml" })
     public void testSubProcessEndsSuperProcess() {
@@ -143,6 +147,7 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createExecutionQuery().list().size());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/callactivity/CallActivity.testCallParallelSubProcess.bpmn20.xml",
             "org/flowable/engine/test/bpmn/callactivity/simpleParallelSubProcess.bpmn20.xml" })
     public void testCallParallelSubProcess() {
@@ -168,6 +173,7 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createExecutionQuery().count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/callactivity/CallActivity.testCallSequentialSubProcess.bpmn20.xml",
             "org/flowable/engine/test/bpmn/callactivity/CallActivity.testCallSimpleSubProcessWithExpressions.bpmn20.xml", "org/flowable/engine/test/bpmn/callactivity/simpleSubProcess.bpmn20.xml",
             "org/flowable/engine/test/bpmn/callactivity/simpleSubProcess2.bpmn20.xml" })
@@ -221,6 +227,7 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/callactivity/CallActivity.testTimerOnCallActivity.bpmn20.xml", "org/flowable/engine/test/bpmn/callactivity/simpleSubProcess.bpmn20.xml" })
     public void testTimerOnCallActivity() {
         Date startTime = processEngineConfiguration.getClock().getCurrentTime();
@@ -256,6 +263,7 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
     /**
      * Test case for handing over process variables to a sub process
      */
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/callactivity/CallActivity.testSubProcessDataInputOutput.bpmn20.xml",
             "org/flowable/engine/test/bpmn/callactivity/simpleSubProcess.bpmn20.xml" })
     public void testSubProcessWithDataInputOutput() {
@@ -323,6 +331,7 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
     /**
      * Test case for deleting a sub process
      */
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/callactivity/CallActivity.testTwoSubProcesses.bpmn20.xml", "org/flowable/engine/test/bpmn/callactivity/simpleSubProcess.bpmn20.xml" })
     public void testTwoSubProcesses() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("callTwoSubProcesses");
@@ -346,6 +355,7 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
         assertEquals(0, taskList.size());
     }
 
+    @Test
     @Deployment(resources = {
             "org/flowable/engine/test/bpmn/callactivity/CallActivity.testStartUserIdSetWhenLooping.bpmn20.xml",
             "org/flowable/engine/test/bpmn/callactivity/simpleSubProcess.bpmn20.xml"
@@ -376,6 +386,7 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/callactivity/CallActivity.testCallSimpleSubProcess.bpmn20.xml", "org/flowable/engine/test/bpmn/callactivity/simpleSubProcess.bpmn20.xml" })
     public void testAuthenticatedStartUserInCallActivity() {
         final String authenticatedUser = "user1";
@@ -397,6 +408,7 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
         assertEquals(authenticatedUser, subProcessIdentityLinks.get(0).getUserId());
     }
     
+    @Test
     @Deployment(resources = { 
             "org/flowable/engine/test/bpmn/callactivity/CallActivity.testCallSimpleSubProcess.bpmn20.xml", 
             "org/flowable/engine/test/bpmn/callactivity/simpleSubProcess.bpmn20.xml" 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/callactivity/CallActivityWithElementType.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/callactivity/CallActivityWithElementType.java
@@ -13,12 +13,14 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.test.Deployment;
 import org.flowable.task.api.Task;
 import org.flowable.task.api.TaskQuery;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests {@link org.flowable.engine.impl.bpmn.behavior.CallActivityBehavior} with calledElementType id
  */
 public class CallActivityWithElementType extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment(resources =
         "org/flowable/engine/test/bpmn/callactivity/simpleSubProcess.bpmn20.xml")
     public void testCallSimpleSubProcessByKey() throws IOException {
@@ -28,6 +30,7 @@ public class CallActivityWithElementType extends PluggableFlowableTestCase {
         );
     }
 
+    @Test
     @Deployment(resources =
         "org/flowable/engine/test/bpmn/callactivity/simpleSubProcess.bpmn20.xml")
     public void testCallSimpleSubProcessById() throws IOException {
@@ -39,6 +42,7 @@ public class CallActivityWithElementType extends PluggableFlowableTestCase {
         );
     }
 
+    @Test
     @Deployment(resources =
         "org/flowable/engine/test/bpmn/callactivity/simpleSubProcess.bpmn20.xml")
     public void testCallSimpleSubProcessByIdExpression() throws IOException {
@@ -50,6 +54,7 @@ public class CallActivityWithElementType extends PluggableFlowableTestCase {
         );
     }
 
+    @Test
     @Deployment(resources =
         "org/flowable/engine/test/bpmn/callactivity/simpleSubProcess.bpmn20.xml")
     public void testCallSimpleSubProcessByKeyExpression() throws IOException {
@@ -61,6 +66,7 @@ public class CallActivityWithElementType extends PluggableFlowableTestCase {
         );
     }
 
+    @Test
     @Deployment(resources =
         "org/flowable/engine/test/bpmn/callactivity/simpleSubProcess.bpmn20.xml")
     public void testCallSimpleSubProcessWithUnrecognizedElementType() throws IOException {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/deployment/BpmnDeploymentTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/deployment/BpmnDeploymentTest.java
@@ -31,7 +31,9 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.repository.DeploymentProperties;
 import org.flowable.engine.repository.ProcessDefinition;
 import org.flowable.engine.test.Deployment;
+import org.flowable.engine.test.DeploymentId;
 import org.flowable.validation.validator.Problems;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
@@ -39,6 +41,7 @@ import org.flowable.validation.validator.Problems;
  */
 public class BpmnDeploymentTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testGetBpmnXmlFileThroughService() {
         String deploymentId = repositoryService.createDeploymentQuery().singleResult().getId();
@@ -74,6 +77,7 @@ public class BpmnDeploymentTest extends PluggableFlowableTestCase {
         return new String(bytes);
     }
 
+    @Test
     public void testViolateBPMNIdMaximumLength() {
         try {
             repositoryService.createDeployment()
@@ -88,6 +92,7 @@ public class BpmnDeploymentTest extends PluggableFlowableTestCase {
         assertEquals(0, repositoryService.createDeploymentQuery().count());
     }
 
+    @Test
     public void testViolateProcessDefinitionIdMaximumLength() {
         try {
             repositoryService.createDeployment()
@@ -102,6 +107,7 @@ public class BpmnDeploymentTest extends PluggableFlowableTestCase {
         assertEquals(0, repositoryService.createDeploymentQuery().count());
     }
 
+    @Test
     public void testViolateProcessDefinitionNameAndDescriptionMaximumLength() {
         try {
             repositoryService.createDeployment()
@@ -117,6 +123,7 @@ public class BpmnDeploymentTest extends PluggableFlowableTestCase {
         assertEquals(0, repositoryService.createDeploymentQuery().count());
     }
 
+    @Test
     public void testViolateDefinitionTargetNamespaceMaximumLength() {
         try {
             repositoryService.createDeployment()
@@ -131,6 +138,7 @@ public class BpmnDeploymentTest extends PluggableFlowableTestCase {
         assertEquals(0, repositoryService.createDeploymentQuery().count());
     }
 
+    @Test
     public void testDeploySameFileTwice() {
         String bpmnResourceName = "org/flowable/engine/test/bpmn/deployment/BpmnDeploymentTest.testGetBpmnXmlFileThroughService.bpmn20.xml";
         repositoryService.createDeployment().enableDuplicateFiltering().addClasspathResource(bpmnResourceName).name("twice").deploy();
@@ -149,6 +157,7 @@ public class BpmnDeploymentTest extends PluggableFlowableTestCase {
         repositoryService.deleteDeployment(deploymentId);
     }
     
+    @Test
     public void testDeploySameFileTwiceAfterInitialDeployment() {
         String bpmnResourceName = "org/flowable/engine/test/bpmn/deployment/BpmnDeploymentTest.testProcessDiagramResource.bpmn20.xml";
         repositoryService.createDeployment().enableDuplicateFiltering().addClasspathResource(bpmnResourceName).name("twice").deploy();
@@ -173,6 +182,7 @@ public class BpmnDeploymentTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testDeployTwoProcessesWithDuplicateIdAtTheSameTime() {
         try {
             String bpmnResourceName = "org/flowable/engine/test/bpmn/deployment/BpmnDeploymentTest.testGetBpmnXmlFileThroughService.bpmn20.xml";
@@ -185,6 +195,7 @@ public class BpmnDeploymentTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testDeployDifferentFiles() {
         String bpmnResourceName = "org/flowable/engine/test/bpmn/deployment/BpmnDeploymentTest.testGetBpmnXmlFileThroughService.bpmn20.xml";
         repositoryService.createDeployment().enableDuplicateFiltering().addClasspathResource(bpmnResourceName).name("twice").deploy();
@@ -206,6 +217,7 @@ public class BpmnDeploymentTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testStartFormKey() {
         String deploymentId = repositoryService.createDeploymentQuery().singleResult().getId();
@@ -222,6 +234,7 @@ public class BpmnDeploymentTest extends PluggableFlowableTestCase {
         assertTrue(processDefinition.hasStartFormKey());
     }
 
+    @Test
     public void testDiagramCreationDisabled() {
         // disable diagram generation
         processEngineConfiguration.setCreateDiagramOnDeploy(false);
@@ -254,9 +267,10 @@ public class BpmnDeploymentTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/deployment/BpmnDeploymentTest.testProcessDiagramResource.bpmn20.xml",
             "org/flowable/engine/test/bpmn/deployment/BpmnDeploymentTest.testProcessDiagramResource.jpg" })
-    public void testProcessDiagramResource() {
+    public void testProcessDiagramResource(@DeploymentId String deploymentIdFromDeploymentAnnotation) {
         ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
 
         assertEquals("org/flowable/engine/test/bpmn/deployment/BpmnDeploymentTest.testProcessDiagramResource.bpmn20.xml", processDefinition.getResourceName());
@@ -274,6 +288,7 @@ public class BpmnDeploymentTest extends PluggableFlowableTestCase {
         assertEquals(33343, diagramBytes.length);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/deployment/BpmnDeploymentTest.testMultipleDiagramResourcesProvided.bpmn20.xml",
             "org/flowable/engine/test/bpmn/deployment/BpmnDeploymentTest.testMultipleDiagramResourcesProvided.a.jpg",
             "org/flowable/engine/test/bpmn/deployment/BpmnDeploymentTest.testMultipleDiagramResourcesProvided.b.jpg",
@@ -288,6 +303,7 @@ public class BpmnDeploymentTest extends PluggableFlowableTestCase {
         assertEquals("org/flowable/engine/test/bpmn/deployment/BpmnDeploymentTest.testMultipleDiagramResourcesProvided.c.jpg", processC.getDiagramResourceName());
     }
 
+    @Test
     @Deployment
     public void testProcessDefinitionDescription() {
         String id = repositoryService.createProcessDefinitionQuery().singleResult().getId();
@@ -295,6 +311,7 @@ public class BpmnDeploymentTest extends PluggableFlowableTestCase {
         assertEquals("This is really good process documentation!", processDefinition.getDescription());
     }
 
+    @Test
     public void testDeploySameFileTwiceForDifferentTenantId() {
         String bpmnResourceName = "org/flowable/engine/test/bpmn/deployment/BpmnDeploymentTest.testGetBpmnXmlFileThroughService.bpmn20.xml";
         repositoryService.createDeployment().enableDuplicateFiltering().addClasspathResource(bpmnResourceName).name("twice").tenantId("Tenant_A").deploy();
@@ -317,6 +334,7 @@ public class BpmnDeploymentTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testV5Deployment() {
         String bpmnResourceName = "org/flowable/engine/test/bpmn/deployment/BpmnDeploymentTest.testGetBpmnXmlFileThroughService.bpmn20.xml";
         try {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/deployment/MessageEventsAndNewVersionDeploymentsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/deployment/MessageEventsAndNewVersionDeploymentsTest.java
@@ -21,6 +21,7 @@ import org.flowable.engine.impl.test.HistoryTestHelper;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.EventSubscription;
 import org.flowable.engine.runtime.ProcessInstance;
+import org.junit.jupiter.api.Test;
 
 /**
  * A test specifically written to test how events (start/boundary) are handled when deploying a new version of a process definition.
@@ -43,6 +44,7 @@ public class MessageEventsAndNewVersionDeploymentsTest extends PluggableFlowable
      * BOUNDARY MESSAGE EVENT
      */
 
+    @Test
     public void testMessageBoundaryEvent() {
         String deploymentId1 = deployBoundaryMessageTestProcess();
         runtimeService.startProcessInstanceByKey("messageTest");
@@ -67,6 +69,7 @@ public class MessageEventsAndNewVersionDeploymentsTest extends PluggableFlowable
     /**
      * Verifying that the event subscriptions do get removed when removing a deployment.
      */
+    @Test
     public void testBoundaryEventSubscriptionDeletedOnDeploymentDelete() {
         String deploymentId = deployBoundaryMessageTestProcess();
         runtimeService.startProcessInstanceByKey("messageTest");
@@ -88,6 +91,7 @@ public class MessageEventsAndNewVersionDeploymentsTest extends PluggableFlowable
     /**
      * Verifying that the event subscriptions do get removed when removing a process instance.
      */
+    @Test
     public void testBoundaryEventSubscriptionsDeletedOnProcessInstanceDelete() {
         String deploymentId1 = deployBoundaryMessageTestProcess();
         runtimeService.startProcessInstanceByKey("messageTest");
@@ -114,6 +118,7 @@ public class MessageEventsAndNewVersionDeploymentsTest extends PluggableFlowable
      * START MESSAGE EVENT
      */
 
+    @Test
     public void testStartMessageEvent() {
         String deploymentId1 = deployStartMessageTestProcess();
         assertEquals(1, getAllEventSubscriptions().size());
@@ -132,6 +137,7 @@ public class MessageEventsAndNewVersionDeploymentsTest extends PluggableFlowable
         cleanup(deploymentId1, deploymentId2);
     }
 
+    @Test
     public void testMessageStartEventSubscriptionAfterDeploymentDelete() {
 
         // Deploy two version of process definition, delete latest and check if all is good
@@ -167,6 +173,7 @@ public class MessageEventsAndNewVersionDeploymentsTest extends PluggableFlowable
     /**
      * v1 -> has start message event v2 -> has no start message event v3 -> has start message event
      */
+    @Test
     public void testDeployIntermediateVersionWithoutMessageStartEvent() {
         String deploymentId1 = deployStartMessageTestProcess();
         assertEquals(1, getAllEventSubscriptions().size());
@@ -200,6 +207,7 @@ public class MessageEventsAndNewVersionDeploymentsTest extends PluggableFlowable
         cleanup(deploymentId1, deploymentId2, deploymentId3);
     }
 
+    @Test
     public void testDeleteDeploymentWithStartMessageEvents1() {
         String deploymentId1;
         String deploymentId2;
@@ -212,6 +220,7 @@ public class MessageEventsAndNewVersionDeploymentsTest extends PluggableFlowable
         cleanup(deploymentId1, deploymentId2);
     }
 
+    @Test
     public void testDeleteDeploymentWithStartMessageEvents2() {
         String deploymentId1 = deployStartMessageTestProcess();
         String deploymentId2 = deployProcessWithoutEvents();
@@ -224,6 +233,7 @@ public class MessageEventsAndNewVersionDeploymentsTest extends PluggableFlowable
         cleanup(deploymentId1, deploymentId3);
     }
 
+    @Test
     public void testDeleteDeploymentWithStartMessageEvents3() {
         String deploymentId1 = deployStartMessageTestProcess();
         String deploymentId2 = deployProcessWithoutEvents();
@@ -236,6 +246,7 @@ public class MessageEventsAndNewVersionDeploymentsTest extends PluggableFlowable
         cleanup(deploymentId2, deploymentId3);
     }
 
+    @Test
     public void testDeleteDeploymentWithStartMessageEvents4() {
         String deploymentId1 = deployStartMessageTestProcess();
         String deploymentId2 = deployProcessWithoutEvents();
@@ -249,6 +260,7 @@ public class MessageEventsAndNewVersionDeploymentsTest extends PluggableFlowable
         cleanup(deploymentId1);
     }
 
+    @Test
     public void testDeleteDeploymentWithStartMessageEvents5() {
         String deploymentId1 = deployStartMessageTestProcess();
         String deploymentId2 = deployProcessWithoutEvents();
@@ -267,6 +279,7 @@ public class MessageEventsAndNewVersionDeploymentsTest extends PluggableFlowable
         cleanup(deploymentId1);
     }
 
+    @Test
     public void testDeleteDeploymentWithStartMessageEvents6() {
         String deploymentId1 = deployStartMessageTestProcess();
         String deploymentId2 = deployProcessWithoutEvents();
@@ -298,6 +311,7 @@ public class MessageEventsAndNewVersionDeploymentsTest extends PluggableFlowable
         cleanup(deploymentId4);
     }
 
+    @Test
     public void testDeleteDeploymentWithStartMessageEvents7() {
         String deploymentId1 = deployStartMessageTestProcess();
         String deploymentId2 = deployProcessWithoutEvents();
@@ -329,6 +343,7 @@ public class MessageEventsAndNewVersionDeploymentsTest extends PluggableFlowable
      * BOTH BOUNDARY AND START MESSAGE
      */
 
+    @Test
     public void testBothBoundaryAndStartEvent() {
 
         // Deploy process with both boundary and start event
@@ -381,6 +396,7 @@ public class MessageEventsAndNewVersionDeploymentsTest extends PluggableFlowable
         cleanup(deploymentId1);
     }
 
+    @Test
     public void testBothBoundaryAndStartSameMessageId() {
 
         // Deploy process with both boundary and start event

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/deployment/MessageEventsAndNewVersionDeploymentsWithTenantIdTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/deployment/MessageEventsAndNewVersionDeploymentsWithTenantIdTest.java
@@ -21,6 +21,7 @@ import org.flowable.engine.impl.test.HistoryTestHelper;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.EventSubscription;
 import org.flowable.engine.runtime.ProcessInstance;
+import org.junit.jupiter.api.Test;
 
 /**
  * A test specifically written to test how events (start/boundary) are handled when deploying a new version of a process definition.
@@ -45,6 +46,7 @@ public class MessageEventsAndNewVersionDeploymentsWithTenantIdTest extends Plugg
      * BOUNDARY MESSAGE EVENT
      */
 
+    @Test
     public void testMessageBoundaryEvent() {
         String deploymentId1 = deployBoundaryMessageTestProcess();
         runtimeService.startProcessInstanceByKeyAndTenantId("messageTest", TENANT_ID);
@@ -69,6 +71,7 @@ public class MessageEventsAndNewVersionDeploymentsWithTenantIdTest extends Plugg
     /**
      * Verifying that the event subscriptions do get removed when removing a deployment.
      */
+    @Test
     public void testBoundaryEventSubscriptionDeletedOnDeploymentDelete() {
         String deploymentId = deployBoundaryMessageTestProcess();
         runtimeService.startProcessInstanceByKeyAndTenantId("messageTest", TENANT_ID);
@@ -90,6 +93,7 @@ public class MessageEventsAndNewVersionDeploymentsWithTenantIdTest extends Plugg
     /**
      * Verifying that the event subscriptions do get removed when removing a process instance.
      */
+    @Test
     public void testBoundaryEventSubscriptionsDeletedOnProcessInstanceDelete() {
         String deploymentId1 = deployBoundaryMessageTestProcess();
         runtimeService.startProcessInstanceByKeyAndTenantId("messageTest", TENANT_ID);
@@ -116,6 +120,7 @@ public class MessageEventsAndNewVersionDeploymentsWithTenantIdTest extends Plugg
      * START MESSAGE EVENT
      */
 
+    @Test
     public void testStartMessageEvent() {
         String deploymentId1 = deployStartMessageTestProcess();
         assertEquals(1, getAllEventSubscriptions().size());
@@ -134,6 +139,7 @@ public class MessageEventsAndNewVersionDeploymentsWithTenantIdTest extends Plugg
         cleanup(deploymentId1, deploymentId2);
     }
 
+    @Test
     public void testMessageStartEventSubscriptionAfterDeploymentDelete() {
 
         // Deploy two version of process definition, delete latest and check if all is good
@@ -169,6 +175,7 @@ public class MessageEventsAndNewVersionDeploymentsWithTenantIdTest extends Plugg
     /**
      * v1 -> has start message event v2 -> has no start message event v3 -> has start message event
      */
+    @Test
     public void testDeployIntermediateVersionWithoutMessageStartEvent() {
         String deploymentId1 = deployStartMessageTestProcess();
         assertEquals(1, getAllEventSubscriptions().size());
@@ -202,6 +209,7 @@ public class MessageEventsAndNewVersionDeploymentsWithTenantIdTest extends Plugg
         cleanup(deploymentId1, deploymentId2, deploymentId3);
     }
 
+    @Test
     public void testDeleteDeploymentWithStartMessageEvents1() {
         String deploymentId1;
         String deploymentId2;
@@ -214,6 +222,7 @@ public class MessageEventsAndNewVersionDeploymentsWithTenantIdTest extends Plugg
         cleanup(deploymentId1, deploymentId2);
     }
 
+    @Test
     public void testDeleteDeploymentWithStartMessageEvents2() {
         String deploymentId1 = deployStartMessageTestProcess();
         String deploymentId2 = deployProcessWithoutEvents();
@@ -226,6 +235,7 @@ public class MessageEventsAndNewVersionDeploymentsWithTenantIdTest extends Plugg
         cleanup(deploymentId1, deploymentId3);
     }
 
+    @Test
     public void testDeleteDeploymentWithStartMessageEvents3() {
         String deploymentId1 = deployStartMessageTestProcess();
         String deploymentId2 = deployProcessWithoutEvents();
@@ -238,6 +248,7 @@ public class MessageEventsAndNewVersionDeploymentsWithTenantIdTest extends Plugg
         cleanup(deploymentId2, deploymentId3);
     }
 
+    @Test
     public void testDeleteDeploymentWithStartMessageEvents4() {
         String deploymentId1 = deployStartMessageTestProcess();
         String deploymentId2 = deployProcessWithoutEvents();
@@ -251,6 +262,7 @@ public class MessageEventsAndNewVersionDeploymentsWithTenantIdTest extends Plugg
         cleanup(deploymentId1);
     }
 
+    @Test
     public void testDeleteDeploymentWithStartMessageEvents5() {
         String deploymentId1 = deployStartMessageTestProcess();
         String deploymentId2 = deployProcessWithoutEvents();
@@ -269,6 +281,7 @@ public class MessageEventsAndNewVersionDeploymentsWithTenantIdTest extends Plugg
         cleanup(deploymentId1);
     }
 
+    @Test
     public void testDeleteDeploymentWithStartMessageEvents6() {
         String deploymentId1 = deployStartMessageTestProcess();
         String deploymentId2 = deployProcessWithoutEvents();
@@ -300,6 +313,7 @@ public class MessageEventsAndNewVersionDeploymentsWithTenantIdTest extends Plugg
         cleanup(deploymentId4);
     }
 
+    @Test
     public void testDeleteDeploymentWithStartMessageEvents7() {
         String deploymentId1 = deployStartMessageTestProcess();
         String deploymentId2 = deployProcessWithoutEvents();
@@ -331,6 +345,7 @@ public class MessageEventsAndNewVersionDeploymentsWithTenantIdTest extends Plugg
      * BOTH BOUNDARY AND START MESSAGE
      */
 
+    @Test
     public void testBothBoundaryAndStartEvent() {
 
         // Deploy process with both boundary and start event
@@ -383,6 +398,7 @@ public class MessageEventsAndNewVersionDeploymentsWithTenantIdTest extends Plugg
         cleanup(deploymentId1);
     }
 
+    @Test
     public void testBothBoundaryAndStartSameMessageId() {
 
         // Deploy process with both boundary and start event

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/deployment/ParsedDeploymentTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/deployment/ParsedDeploymentTest.java
@@ -35,6 +35,9 @@ import org.flowable.engine.impl.persistence.entity.ProcessDefinitionEntity;
 import org.flowable.engine.impl.persistence.entity.ResourceEntity;
 import org.flowable.engine.impl.persistence.entity.ResourceEntityImpl;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ParsedDeploymentTest extends PluggableFlowableTestCase {
 
@@ -55,7 +58,7 @@ public class ParsedDeploymentTest extends PluggableFlowableTestCase {
             "<process id='" + EN2_ID + "' name='Expense Note 2' />");
     private static final String EN_XML_NAME = "en." + ResourceNameUtil.BPMN_RESOURCE_SUFFIXES[1];
 
-    @Override
+    @BeforeEach
     public void setUp() {
         CommandContext commandContext = processEngineConfiguration.getCommandContextFactory().createCommandContext(null);
         if (commandContext.getEngineConfigurations() == null) {
@@ -65,11 +68,12 @@ public class ParsedDeploymentTest extends PluggableFlowableTestCase {
         Context.setCommandContext(commandContext);
     }
 
-    @Override
+    @AfterEach
     public void tearDown() {
         Context.removeCommandContext();
     }
 
+    @Test
     public void testCreateAndQuery() throws UnsupportedEncodingException {
         DeploymentEntity entity = assembleUnpersistedDeploymentEntity();
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/deployment/SignalEventsAndNewVersionDeploymentsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/deployment/SignalEventsAndNewVersionDeploymentsTest.java
@@ -21,6 +21,7 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.EventSubscription;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * A test specifically written to test how events (start/boundary) are handled when deploying a new version of a process definition.
@@ -43,6 +44,7 @@ public class SignalEventsAndNewVersionDeploymentsTest extends PluggableFlowableT
      * BOUNDARY SIGNAL EVENT
      */
 
+    @Test
     @Deployment
     public void testGlobalSignalBoundaryEvent() {
         runtimeService.startProcessInstanceByKey("signalTest");
@@ -69,6 +71,7 @@ public class SignalEventsAndNewVersionDeploymentsTest extends PluggableFlowableT
     /**
      * Verifying that the event subscriptions do get removed when removing a deployment.
      */
+    @Test
     public void testBoundaryEventSubscriptionDeletedOnDeploymentDelete() {
         String deploymentId = deployBoundarySignalTestProcess();
         runtimeService.startProcessInstanceByKey("signalTest");
@@ -90,6 +93,7 @@ public class SignalEventsAndNewVersionDeploymentsTest extends PluggableFlowableT
     /**
      * Verifying that the event subscriptions do get removed when removing a process instance.
      */
+    @Test
     public void testBoundaryEventSubscrptionsDeletedOnProcessInstanceDelete() {
         String deploymentId1 = deployBoundarySignalTestProcess();
         runtimeService.startProcessInstanceByKey("signalTest");
@@ -116,6 +120,7 @@ public class SignalEventsAndNewVersionDeploymentsTest extends PluggableFlowableT
      * START SIGNAL EVENT
      */
 
+    @Test
     public void testStartSignalEvent() {
         String deploymentId1 = deployStartSignalTestProcess();
         assertEquals(1, getAllEventSubscriptions().size());
@@ -130,6 +135,7 @@ public class SignalEventsAndNewVersionDeploymentsTest extends PluggableFlowableT
         cleanup(deploymentId1, deploymentId2);
     }
 
+    @Test
     public void testSignalStartEventSubscriptionAfterDeploymentDelete() {
 
         // Deploy two version of process definition, delete latest and check if all is good
@@ -165,6 +171,7 @@ public class SignalEventsAndNewVersionDeploymentsTest extends PluggableFlowableT
     /**
      * v1 -> has start signal event v2 -> has no start signal event v3 -> has start signal event
      */
+    @Test
     public void testDeployIntermediateVersionWithoutSignalStartEvent() {
         String deploymentId1 = deployStartSignalTestProcess();
         assertEquals(1, getAllEventSubscriptions().size());
@@ -194,6 +201,7 @@ public class SignalEventsAndNewVersionDeploymentsTest extends PluggableFlowableT
         cleanup(deploymentId1, deploymentId2, deploymentId3);
     }
 
+    @Test
     public void testDeleteDeploymentWithStartSignalEvents1() {
         String deploymentId1;
         String deploymentId2;
@@ -206,6 +214,7 @@ public class SignalEventsAndNewVersionDeploymentsTest extends PluggableFlowableT
         cleanup(deploymentId1, deploymentId2);
     }
 
+    @Test
     public void testDeleteDeploymentWithStartSignalEvents2() {
         String deploymentId1 = deployStartSignalTestProcess();
         String deploymentId2 = deployProcessWithoutEvents();
@@ -218,6 +227,7 @@ public class SignalEventsAndNewVersionDeploymentsTest extends PluggableFlowableT
         cleanup(deploymentId1, deploymentId3);
     }
 
+    @Test
     public void testDeleteDeploymentWithStartSignalEvents3() {
         String deploymentId1 = deployStartSignalTestProcess();
         String deploymentId2 = deployProcessWithoutEvents();
@@ -230,6 +240,7 @@ public class SignalEventsAndNewVersionDeploymentsTest extends PluggableFlowableT
         cleanup(deploymentId2, deploymentId3);
     }
 
+    @Test
     public void testDeleteDeploymentWithStartSignalEvents4() {
         String deploymentId1 = deployStartSignalTestProcess();
         String deploymentId2 = deployProcessWithoutEvents();
@@ -243,6 +254,7 @@ public class SignalEventsAndNewVersionDeploymentsTest extends PluggableFlowableT
         cleanup(deploymentId1);
     }
 
+    @Test
     public void testDeleteDeploymentWithStartSignalEvents5() {
         String deploymentId1 = deployStartSignalTestProcess();
         String deploymentId2 = deployProcessWithoutEvents();
@@ -257,6 +269,7 @@ public class SignalEventsAndNewVersionDeploymentsTest extends PluggableFlowableT
         cleanup(deploymentId1);
     }
 
+    @Test
     public void testDeleteDeploymentWithStartSignalEvents6() {
         String deploymentId1 = deployStartSignalTestProcess();
         String deploymentId2 = deployProcessWithoutEvents();
@@ -276,6 +289,7 @@ public class SignalEventsAndNewVersionDeploymentsTest extends PluggableFlowableT
         cleanup(deploymentId4);
     }
 
+    @Test
     public void testDeleteDeploymentWithStartSignalEvents7() {
         String deploymentId1 = deployStartSignalTestProcess();
         String deploymentId2 = deployProcessWithoutEvents();
@@ -299,6 +313,7 @@ public class SignalEventsAndNewVersionDeploymentsTest extends PluggableFlowableT
      * BOTH BOUNDARY AND START SIGNAL
      */
 
+    @Test
     public void testBothBoundaryAndStartEvent() {
 
         // Deploy process with both boundary and start event
@@ -343,6 +358,7 @@ public class SignalEventsAndNewVersionDeploymentsTest extends PluggableFlowableT
         cleanup(deploymentId1);
     }
 
+    @Test
     public void testBothBoundaryAndStartSameSignalId() {
 
         // Deploy process with both boundary and start event

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/deployment/TimerEventsAndNewVersionDeploymentsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/deployment/TimerEventsAndNewVersionDeploymentsTest.java
@@ -15,6 +15,7 @@ package org.flowable.engine.test.bpmn.deployment;
 
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.job.api.Job;
+import org.junit.jupiter.api.Test;
 
 /**
  * A test specifically written to test how events (start/boundary) are handled when deploying a new version of a process definition.
@@ -27,6 +28,7 @@ public class TimerEventsAndNewVersionDeploymentsTest extends PluggableFlowableTe
 
     private static final String TEST_PROCESS_NO_TIMER = "org/flowable/engine/test/bpmn/deployment/TimerEventsAndNewVersionDeploymentsTest.processWithoutEvents.bpmn20.xml";
 
+    @Test
     public void testTimerCreationOnNewDeployments() {
         String deploymentId1 = deployTimerProcess();
         assertTimerJobs(1);
@@ -43,6 +45,7 @@ public class TimerEventsAndNewVersionDeploymentsTest extends PluggableFlowableTe
         cleanup(deploymentId1, deploymentId2, deploymentId3, deploymentId4);
     }
 
+    @Test
     public void testTimerRestoreOnDeploymentDelete1() {
         String deploymentId1 = deployTimerProcess();
         String deploymentId2 = deployProcessWithoutTimers(); // Process has same key
@@ -59,6 +62,7 @@ public class TimerEventsAndNewVersionDeploymentsTest extends PluggableFlowableTe
         cleanup(deploymentId1, deploymentId2, deploymentId3);
     }
 
+    @Test
     public void testTimerRestoreOnDeploymentDelete2() {
         String deploymentId1 = deployTimerProcess();
         String deploymentId2 = deployProcessWithoutTimers(); // Process has same key

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/dynamic/DynamicBpmnInjectionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/dynamic/DynamicBpmnInjectionTest.java
@@ -33,9 +33,11 @@ import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.task.api.Task;
 import org.flowable.task.api.history.HistoricTaskInstance;
+import org.junit.jupiter.api.Test;
 
 public class DynamicBpmnInjectionTest extends PluggableFlowableTestCase {
 
+    @Test
     public void testInjectUserTaskInProcessInstance() {
         deployOneTaskTestProcess();
 
@@ -58,6 +60,7 @@ public class DynamicBpmnInjectionTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     public void testInjectParallelTask() {
         deployOneTaskTestProcess();
 
@@ -88,6 +91,7 @@ public class DynamicBpmnInjectionTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
     
+    @Test
     @org.flowable.engine.test.Deployment
     public void testOneTaskDi() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -157,6 +161,7 @@ public class DynamicBpmnInjectionTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());  
     }
 
+    @Test
     public void testInjectParallelTaskNoJoin() {
         deployOneTaskTestProcess();
 
@@ -191,6 +196,7 @@ public class DynamicBpmnInjectionTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     public void testInjectParallelSubProcessSimple() {
         deployOneTaskTestProcess();
         Deployment deployment = repositoryService.createDeployment()
@@ -228,6 +234,7 @@ public class DynamicBpmnInjectionTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     public void testInjectParallelSubProcessComplex() {
         Deployment deployment = repositoryService.createDeployment()
                 .addClasspathResource("org/flowable/engine/test/bpmn/dynamic/dynamic_test_process01.bpmn")
@@ -287,6 +294,7 @@ public class DynamicBpmnInjectionTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
     
+    @Test
     public void testInjectParallelTask2Times() {
         deployOneTaskTestProcess();
 
@@ -337,6 +345,7 @@ public class DynamicBpmnInjectionTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     public void testInjectParallelSubProcessComplexNoJoin() {
         Deployment deployment = repositoryService.createDeployment()
                 .addClasspathResource("org/flowable/engine/test/bpmn/dynamic/dynamic_test_process01.bpmn")

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/dynamic/DynamicCandidateGroupsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/dynamic/DynamicCandidateGroupsTest.java
@@ -21,6 +21,7 @@ import org.flowable.engine.DynamicBpmnConstants;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -31,6 +32,7 @@ public class DynamicCandidateGroupsTest extends PluggableFlowableTestCase implem
 
     private static final String TASK_ONE_SID = "sid-B94D5D22-E93E-4401-ADC5-C5C073E1EEB4";
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/dynamic/dynamic-bpmn-test-process.bpmn20.xml" })
     public void testIsShouldBePossibleToChangeCandidateGroups() {
         ProcessInstance instance = runtimeService.startProcessInstanceByKey("dynamicServiceTest");
@@ -50,6 +52,7 @@ public class DynamicCandidateGroupsTest extends PluggableFlowableTestCase implem
         assertThat(salesTaskCount, is(1L));
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/dynamic/dynamic-bpmn-test-process.bpmn20.xml" })
     public void testIsShouldBePossibleToResetChangeCandidateGroups() {
         ProcessInstance instance = runtimeService.startProcessInstanceByKey("dynamicServiceTest");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/dynamic/DynamicProcessDefinitionSummaryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/dynamic/DynamicProcessDefinitionSummaryTest.java
@@ -26,6 +26,7 @@ import org.flowable.engine.dynamic.PropertiesParserConstants;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -40,10 +41,12 @@ public class DynamicProcessDefinitionSummaryTest extends PluggableFlowableTestCa
     private static final String TASK_TWO_SID = "sid-B1C37EBE-A273-4DDE-B909-89302638526A";
     private static final String SCRIPT_TASK_SID = "sid-A403BAE0-E367-449A-90B2-48834FCAA2F9";
 
+    @Test
     public void testProcessDefinitionInfoCacheIsEnabledWithPluggableActivitiTestCase() throws Exception {
         assertThat(processEngineConfiguration.isEnableProcessDefinitionInfoCache(), is(true));
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/dynamic/dynamic-bpmn-test-process.bpmn20.xml" })
     public void testIfNoProcessInfoIsAvailableTheBpmnModelIsUsed() throws Exception {
         // setup
@@ -85,6 +88,7 @@ public class DynamicProcessDefinitionSummaryTest extends PluggableFlowableTestCa
         assertThat(jsonNode.get(SCRIPT_TASK_SCRIPT).get(DYNAMIC_VALUE), is(nullValue()));
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/dynamic/dynamic-bpmn-test-process.bpmn20.xml" })
     public void testTheCandidateUserOfTheFirstTasksIsChanged() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("dynamicServiceTest");
@@ -115,6 +119,7 @@ public class DynamicProcessDefinitionSummaryTest extends PluggableFlowableTestCa
         assertThat("David must have one task", davidTask, is(not(nullValue())));
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/dynamic/dynamic-bpmn-test-process.bpmn20.xml" })
     public void testTheCandidateUserOfTheFirstTasksIsChangedMultipleTimes() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("dynamicServiceTest");
@@ -147,6 +152,7 @@ public class DynamicProcessDefinitionSummaryTest extends PluggableFlowableTestCa
         assertThat("David must have two task", davidTasks.size(), is(2));
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/dynamic/dynamic-bpmn-test-process.bpmn20.xml" })
     public void testTheCandidateGroupOfTheFirstTasksIsChanged() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("dynamicServiceTest");
@@ -164,6 +170,7 @@ public class DynamicProcessDefinitionSummaryTest extends PluggableFlowableTestCa
         assertThat((ArrayNode) taskOneNode.get(USER_TASK_CANDIDATE_GROUPS).get(DYNAMIC_VALUE), is(dynamicCandidateGroups));
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/dynamic/dynamic-bpmn-test-process.bpmn20.xml" })
     public void testTheCandidateGroupOfTheFirstTasksIsChangedMultipleTimes() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("dynamicServiceTest");
@@ -183,6 +190,7 @@ public class DynamicProcessDefinitionSummaryTest extends PluggableFlowableTestCa
         assertThat((ArrayNode) taskOneNode.get(USER_TASK_CANDIDATE_GROUPS).get(DYNAMIC_VALUE), is(candidateGroups));
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/dynamic/dynamic-bpmn-test-process.bpmn20.xml" })
     public void testTheScriptOfTheScriptTasksIsChanged() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("dynamicServiceTest");
@@ -197,6 +205,7 @@ public class DynamicProcessDefinitionSummaryTest extends PluggableFlowableTestCa
         assertThat(scriptTaskNode.get(SCRIPT_TASK_SCRIPT).get(DYNAMIC_VALUE).asText(), is("var x = \"hallo\";"));
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/dynamic/dynamic-bpmn-test-process.bpmn20.xml" })
     public void testItShouldBePossibleToResetDynamicCandidateUsers() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("dynamicServiceTest");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/IntermediateNoneEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/IntermediateNoneEventTest.java
@@ -17,6 +17,7 @@ import org.flowable.engine.delegate.ExecutionListener;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 public class IntermediateNoneEventTest extends PluggableFlowableTestCase {
 
@@ -29,6 +30,7 @@ public class IntermediateNoneEventTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testIntermediateNoneTimerEvent() throws Exception {
         assertFalse(listenerExecuted);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/MessageEventDefinitionWithExtensionElementsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/MessageEventDefinitionWithExtensionElementsTest.java
@@ -23,7 +23,7 @@ import org.flowable.bpmn.model.Message;
 import org.flowable.bpmn.model.MessageEventDefinition;
 import org.flowable.engine.impl.bpmn.parser.BpmnParse;
 import org.flowable.engine.impl.bpmn.parser.handler.MessageEventDefinitionParseHandler;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 public class MessageEventDefinitionWithExtensionElementsTest {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/compensate/CompensateEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/compensate/CompensateEventTest.java
@@ -26,6 +26,7 @@ import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.engine.test.EnableVerboseExecutionTreeLogging;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tijs Rademakers
@@ -33,6 +34,7 @@ import org.flowable.engine.test.EnableVerboseExecutionTreeLogging;
 @EnableVerboseExecutionTreeLogging
 public class CompensateEventTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testCompensateSubprocess() {
 
@@ -45,6 +47,7 @@ public class CompensateEventTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment
     public void testCompensateSubprocessWithoutActivityRef() {
 
@@ -57,6 +60,7 @@ public class CompensateEventTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment
     public void testCompensateSubprocessWithUserTask() {
 
@@ -71,6 +75,7 @@ public class CompensateEventTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment
     public void testCompensateSubprocessWithUserTask2() {
 
@@ -88,6 +93,7 @@ public class CompensateEventTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment
     public void testCompensateMiSubprocess() {
 
@@ -101,6 +107,7 @@ public class CompensateEventTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment
     public void testCompensateScope() {
 
@@ -115,6 +122,7 @@ public class CompensateEventTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/event/compensate/CompensateEventTest.SubProcess1.bpmn20.xml",
             "org/flowable/engine/test/bpmn/event/compensate/CompensateEventTest.SubProcess2.bpmn20.xml",
             "org/flowable/engine/test/bpmn/event/compensate/CompensateEventTest.testCompensateTwoSubprocesses.bpmn20.xml" })
@@ -150,6 +158,7 @@ public class CompensateEventTest extends PluggableFlowableTestCase {
         assertEquals("compensated1", testVariable1.toString());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/event/compensate/CompensateEventTest.testCallActivityCompensationHandler.bpmn20.xml",
             "org/flowable/engine/test/bpmn/event/compensate/CompensationHandler.bpmn20.xml" })
     public void testCallActivityCompensationHandler() {
@@ -172,6 +181,7 @@ public class CompensateEventTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     public void testMultipleCompensationCatchEventsFails() {
         try {
             repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/bpmn/event/compensate/CompensateEventTest.testMultipleCompensationCatchEventsFails.bpmn20.xml").deploy();
@@ -180,6 +190,7 @@ public class CompensateEventTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testInvalidActivityRefFails() {
         try {
             repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/bpmn/event/compensate/CompensateEventTest.testInvalidActivityRefFails.bpmn20.xml").deploy();
@@ -191,6 +202,7 @@ public class CompensateEventTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/event/compensate/CompensateEventTest.testCompensationStepEndRecorded.bpmn20.xml" })
     public void testCompensationStepEndTimeRecorded() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("compensationStepEndRecordedProcess");
@@ -207,6 +219,7 @@ public class CompensateEventTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testCompensateWithSubprocess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("compensateProcess");
@@ -241,6 +254,7 @@ public class CompensateEventTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/event/compensate/CompensateEventTest.testCompensateWithSubprocess.bpmn20.xml" })
     public void testCompensateWithSubprocess2() {
 
@@ -257,6 +271,7 @@ public class CompensateEventTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment
     public void testCompensateNestedSubprocess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("compensateProcess");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/end/EndEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/end/EndEventTest.java
@@ -16,6 +16,7 @@ import org.flowable.common.engine.api.FlowableOptimisticLockingException;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
@@ -23,6 +24,7 @@ import org.flowable.engine.test.Deployment;
 public class EndEventTest extends PluggableFlowableTestCase {
 
     // Test case for ACT-1259
+    @Test
     @Deployment
     public void testConcurrentEndOfSameProcess() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskWithDelay");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.java
@@ -43,6 +43,8 @@ import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.task.api.history.HistoricTaskInstance;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Nico Rehwaldt
@@ -52,9 +54,8 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
 
     public static int serviceTaskInvokedCount;
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
         serviceTaskInvokedCount = 0;
         serviceTaskInvokedCount2 = 0;
     }
@@ -80,6 +81,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testProcessTerminate() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
@@ -100,6 +102,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertHistoricActivitiesDeleteReason(pi, null, "preTerminateTask");
     }
     
+    @Test
     @Deployment
     public void testTerminateExecutionListener() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
@@ -113,6 +116,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertEquals(1, TerminateExecutionListener.endCalled);
     }
 
+    @Test
     @Deployment
     public void testProcessTerminateAll() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
@@ -130,6 +134,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertHistoricActivitiesDeleteReason(pi, null, "preTerminateTask");
     }
 
+    @Test
     @Deployment
     public void testTerminateWithSubProcess() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
@@ -151,6 +156,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertHistoricActivitiesDeleteReason(pi, null, "preTerminateEnd");
     }
 
+    @Test
     @Deployment
     public void testTerminateWithSubProcess2() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
@@ -172,6 +178,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertHistoricActivitiesDeleteReason(pi, DeleteReason.TERMINATE_END_EVENT, "SubProcess_1");
     }
 
+    @Test
     @Deployment
     public void testTerminateWithSubProcessTerminateAll() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
@@ -190,6 +197,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertHistoricActivitiesDeleteReason(pi, null, "preNormalEnd");
     }
 
+    @Test
     @Deployment(resources = {
             "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateWithCallActivity.bpmn",
             "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.subProcessNoTerminate.bpmn"
@@ -213,6 +221,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertHistoricActivitiesDeleteReason(subProcessInstance, DeleteReason.TERMINATE_END_EVENT, "task");
     }
 
+    @Test
     @Deployment(resources = {
             "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateWithCallActivityTerminateAll.bpmn20.xml",
             "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.subProcessNoTerminate.bpmn" })
@@ -236,6 +245,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertHistoricActivitiesDeleteReason(subProcessInstance, DeleteReason.TERMINATE_END_EVENT, "task");
     }
 
+    @Test
     @Deployment(resources = {
             "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateInExclusiveGatewayWithCallActivity.bpmn",
             "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.subProcessNoTerminate.bpmn"
@@ -255,6 +265,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertHistoricProcessInstanceDetails(pi);
     }
 
+    @Test
     @Deployment
     public void testTerminateInExclusiveGatewayWithMultiInstanceSubProcess() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample-terminateAfterExclusiveGateway");
@@ -274,6 +285,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertHistoricActivitiesDeleteReason(pi, DeleteReason.TERMINATE_END_EVENT, "task");
     }
 
+    @Test
     @Deployment
     public void testTerminateInExclusiveGatewayWithMultiInstanceSubProcessTerminateAll() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample-terminateAfterExclusiveGateway");
@@ -297,6 +309,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertHistoricProcessInstanceDetails(pi);
     }
     
+    @Test
     @Deployment
     public void testTerminateParallelGateway() throws Exception {
         final List<FlowableEvent> events = new ArrayList<>();
@@ -327,6 +340,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertNull(historicTask);
     }
 
+    @Test
     @Deployment
     public void testTerminateInSubProcess() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
@@ -342,6 +356,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertHistoricProcessInstanceDetails(pi);
     }
 
+    @Test
     @Deployment
     public void testTerminateInSubProcessTerminateAll() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
@@ -349,6 +364,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertHistoricProcessInstanceDetails(pi);
     }
 
+    @Test
     @Deployment
     public void testTerminateInSubProcessWithBoundary() throws Exception {
         Date startTime = new Date();
@@ -399,6 +415,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertHistoricProcessInstanceDetails(pi);
     }
 
+    @Test
     @Deployment
     public void testTerminateInSubProcessWithBoundaryTerminateAll() throws Exception {
         // Test terminating subprocess
@@ -415,6 +432,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertHistoricProcessInstanceDetails(pi);
     }
 
+    @Test
     @Deployment
     public void testTerminateInSubProcessConcurrent() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
@@ -429,6 +447,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertHistoricProcessInstanceDetails(pi);
     }
 
+    @Test
     @Deployment
     public void testTerminateInSubProcessConcurrentTerminateAll() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
@@ -436,6 +455,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertHistoricProcessInstanceDetails(pi);
     }
 
+    @Test
     @Deployment
     public void testTerminateInSubProcessConcurrentTerminateAll2() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
@@ -450,6 +470,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertHistoricProcessInstanceDetails(pi);
     }
 
+    @Test
     @Deployment
     public void testTerminateInSubProcessConcurrentMultiInstance() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
@@ -475,6 +496,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertHistoricProcessInstanceDetails(pi);
     }
 
+    @Test
     @Deployment
     public void testTerminateInSubProcessConcurrentMultiInstance2() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
@@ -493,6 +515,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertHistoricProcessInstanceDetails(pi);
     }
 
+    @Test
     @Deployment
     public void testTerminateInSubProcessConcurrentMultiInstanceTerminateAll() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
@@ -500,6 +523,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertHistoricProcessInstanceDetails(pi);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateInCallActivityConcurrentCallActivity.bpmn",
             "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateAfterUserTask.bpmn",
             "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
@@ -516,6 +540,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertEquals(1, runtimeService.createProcessInstanceQuery().processInstanceId(pi.getId()).count());
     }
 
+    @Test
     @Deployment
     public void testTerminateInSubProcessMultiInstance() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
@@ -530,6 +555,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertHistoricProcessInstanceDetails(pi);
     }
 
+    @Test
     @Deployment
     public void testTerminateInSubProcessSequentialConcurrentMultiInstance() throws Exception {
 
@@ -550,6 +576,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertHistoricProcessInstanceDetails(pi);
     }
 
+    @Test
     @Deployment
     public void testTerminateInSubProcessSequentialConcurrentMultiInstanceTerminateAll() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
@@ -557,6 +584,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertHistoricProcessInstanceDetails(pi);
     }
 
+    @Test
     @Deployment(resources = {
             "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateInCallActivity.bpmn",
             "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.subProcessTerminate.bpmn"
@@ -575,6 +603,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertHistoricProcessInstanceDetails(pi);
     }
 
+    @Test
     @Deployment(resources = {
             "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateInCallActivityMulitInstance.bpmn",
             "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.subProcessTerminate.bpmn"
@@ -593,6 +622,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertHistoricProcessInstanceDetails(pi);
     }
 
+    @Test
     @Deployment(resources = {
             "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateInCallActivityMulitInstance.bpmn",
             "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.subProcessTerminateTerminateAll.bpmn20.xml" })
@@ -602,6 +632,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertHistoricProcessInstanceDetails(pi);
     }
 
+    @Test
     @Deployment(resources = {
             "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateInCallActivityConcurrent.bpmn",
             "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.subProcessConcurrentTerminate.bpmn"
@@ -620,6 +651,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertHistoricProcessInstanceDetails(pi);
     }
 
+    @Test
     @Deployment
     public void testMiCallActivityParallel() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testMiCallActivity");
@@ -652,6 +684,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertHistoricProcessInstanceDetails(processInstance);
     }
 
+    @Test
     @Deployment
     public void testMiCallActivitySequential() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testMiCallActivity");
@@ -688,6 +721,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment(resources = {
             "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateInCallActivityConcurrent.bpmn",
             "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.subProcessConcurrentTerminateTerminateAll.bpmn20.xml"
@@ -698,6 +732,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertHistoricProcessInstanceDetails(pi);
     }
 
+    @Test
     @Deployment(resources = {
             "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateInCallActivityConcurrentMulitInstance.bpmn",
             "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.subProcessConcurrentTerminate.bpmn"
@@ -716,6 +751,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertHistoricProcessInstanceDetails(pi);
     }
 
+    @Test
     @Deployment(resources = {
             "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateInCallActivityConcurrentMulitInstance.bpmn",
             "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.subProcessConcurrentTerminateTerminateAll.bpmn20.xml" })
@@ -725,6 +761,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertHistoricProcessInstanceDetails(pi);
     }
 
+    @Test
     @Deployment
     public void testTerminateNestedSubprocesses() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("TestTerminateNestedSubprocesses");
@@ -760,6 +797,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertNotNull(task);
     }
 
+    @Test
     @Deployment
     public void testTerminateNestedSubprocessesTerminateAll1() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("TestTerminateNestedSubprocesses");
@@ -771,6 +809,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertHistoricProcessInstanceDetails(processInstance);
     }
 
+    @Test
     @Deployment
     public void testTerminateNestedSubprocessesTerminateAll2() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("TestTerminateNestedSubprocesses");
@@ -784,6 +823,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment
     public void testTerminateNestedMiSubprocesses() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("TestTerminateNestedMiSubprocesses");
@@ -814,6 +854,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertNotNull(task);
     }
 
+    @Test
     @Deployment
     public void testTerminateNestedMiSubprocessesSequential() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("TestTerminateNestedMiSubprocesses");
@@ -845,6 +886,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertNotNull(taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("H").singleResult());
     }
 
+    @Test
     @Deployment
     public void testTerminateNestedMiSubprocessesTerminateAll1() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("TestTerminateNestedMiSubprocesses");
@@ -854,6 +896,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertHistoricProcessInstanceDetails(processInstance);
     }
 
+    @Test
     @Deployment
     public void testTerminateNestedMiSubprocessesTerminateAll2() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("TestTerminateNestedMiSubprocesses");
@@ -864,6 +907,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertHistoricProcessInstanceDetails(processInstance);
     }
 
+    @Test
     @Deployment
     public void testTerminateNestedMiSubprocessesTerminateAll3() { // Same as 1, but sequential Multi-Instance
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("TestTerminateNestedMiSubprocesses");
@@ -873,6 +917,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertHistoricProcessInstanceDetails(processInstance);
     }
 
+    @Test
     @Deployment
     public void testTerminateNestedMiSubprocessesTerminateAll4() { // Same as 2, but sequential Multi-Instance
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("TestTerminateNestedMiSubprocesses");
@@ -883,6 +928,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertHistoricProcessInstanceDetails(processInstance);
     }
 
+    @Test
     @Deployment
     public void testNestedCallActivities() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("TestNestedCallActivities");
@@ -913,6 +959,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment
     public void testNestedCallActivitiesTerminateAll() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("TestNestedCallActivities");
@@ -955,6 +1002,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         return tasks;
     }
 
+    @Test
     public void testParseTerminateEndEventDefinitionWithExtensions() {
         org.flowable.engine.repository.Deployment deployment = repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.parseExtensionElements.bpmn20.xml").deploy();
         ProcessDefinition processDefinitionQuery = repositoryService.createProcessDefinitionQuery().deploymentId(deployment.getId()).singleResult();
@@ -978,6 +1026,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
     }
 
     // Unit test for ACT-4101 : NPE when there are multiple routes to terminateEndEvent, and both are reached
+    @Test
     @Deployment
     public void testThreeExecutionsArrivingInTerminateEndEvent() {
         Map<String, Object> variableMap = new HashMap<>();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/end/TerminateMultiInstanceEndEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/end/TerminateMultiInstanceEndEventTest.java
@@ -19,12 +19,14 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
  */
 public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testMultiInstanceEmbeddedSubprocess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("terminateMi");
@@ -53,6 +55,7 @@ public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCas
         assertEquals(0, runtimeService.createExecutionQuery().count());
     }
 
+    @Test
     @Deployment
     public void testMultiInstanceEmbeddedSubprocessSequential() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("terminateMi");
@@ -79,6 +82,7 @@ public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCas
         assertEquals(0, runtimeService.createExecutionQuery().count());
     }
 
+    @Test
     @Deployment
     public void testMultiInstanceEmbeddedSubprocess2() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("terminateMi");
@@ -109,6 +113,7 @@ public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCas
         assertEquals(0, runtimeService.createExecutionQuery().count());
     }
 
+    @Test
     @Deployment
     public void testMultiInstanceEmbeddedSubprocess2Sequential() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("terminateMi");
@@ -138,6 +143,7 @@ public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCas
         assertEquals(0, runtimeService.createExecutionQuery().count());
     }
 
+    @Test
     @Deployment(resources = {
             "org/flowable/engine/test/bpmn/event/end/TerminateMultiInstanceEndEventTest.testTerminateMiCallactivity-parentProcess.bpmn20.xml",
             "org/flowable/engine/test/bpmn/event/end/TerminateMultiInstanceEndEventTest.testTerminateMiCallactivity-calledProcess.bpmn20.xml"
@@ -172,6 +178,7 @@ public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCas
         assertEquals("Parallel task", afterMiTasks.get(1).getName());
     }
 
+    @Test
     @Deployment(resources = {
             "org/flowable/engine/test/bpmn/event/end/TerminateMultiInstanceEndEventTest.testTerminateMiCallactivity-parentProcessSequential.bpmn20.xml",
             "org/flowable/engine/test/bpmn/event/end/TerminateMultiInstanceEndEventTest.testTerminateMiCallactivity-calledProcess.bpmn20.xml"
@@ -201,6 +208,7 @@ public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCas
         assertEquals("Parallel task", afterMiTasks.get(1).getName());
     }
 
+    @Test
     @Deployment
     public void testTerminateNestedMiEmbeddedSubprocess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey(
@@ -248,6 +256,7 @@ public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCas
         assertEquals(0, runtimeService.createExecutionQuery().count());
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/bpmn/event/end/TerminateMultiInstanceEndEventTest.testTerminateNestedMiEmbeddedSubprocess.bpmn20.xml")
     public void testTerminateNestedMiEmbeddedSubprocess2() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey(
@@ -260,6 +269,7 @@ public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCas
 
     }
 
+    @Test
     @Deployment
     public void testTerminateNestedMiEmbeddedSubprocessWithOneLoopCardinality() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey(

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/error/BoundaryErrorEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/error/BoundaryErrorEventTest.java
@@ -24,6 +24,7 @@ import org.flowable.engine.history.HistoricProcessInstance;
 import org.flowable.engine.impl.test.HistoryTestHelper;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
@@ -31,6 +32,7 @@ import org.flowable.engine.test.Deployment;
  */
 public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testCatchErrorOnEmbeddedSubprocess() {
         runtimeService.startProcessInstanceByKey("boundaryErrorOnEmbeddedSubprocess");
@@ -45,6 +47,7 @@ public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
         assertEquals("task after catching the error", task.getName());
     }
 
+    @Test
     public void testThrowErrorWithEmptyErrorCode() {
         try {
             repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/bpmn/event/error/BoundaryErrorEventTest.testThrowErrorWithEmptyErrorCode.bpmn20.xml").deploy();
@@ -53,16 +56,19 @@ public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testCatchErrorOnEmbeddedSubprocessWithEmptyErrorCode() {
         testCatchErrorOnEmbeddedSubprocess();
     }
 
+    @Test
     @Deployment
     public void testCatchErrorOnEmbeddedSubprocessWithoutErrorCode() {
         testCatchErrorOnEmbeddedSubprocess();
     }
 
+    @Test
     @Deployment
     public void testCatchErrorOfInnerSubprocessOnOuterSubprocess() {
         runtimeService.startProcessInstanceByKey("boundaryErrorTest");
@@ -79,11 +85,13 @@ public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
         assertEquals("task outside subprocess", taskAfterError.getName());
     }
 
+    @Test
     @Deployment
     public void testCatchErrorInConcurrentEmbeddedSubprocesses() {
         assertErrorCaughtInConcurrentEmbeddedSubprocesses("boundaryEventTestConcurrentSubprocesses");
     }
 
+    @Test
     @Deployment
     public void testCatchErrorInConcurrentEmbeddedSubprocessesThrownByScriptTask() {
         assertErrorCaughtInConcurrentEmbeddedSubprocesses("catchErrorInConcurrentEmbeddedSubprocessesThrownByScriptTask");
@@ -123,6 +131,7 @@ public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
         assertEquals("task D", task.getName());
     }
 
+    @Test
     @Deployment
     public void testDeeplyNestedErrorThrown() {
 
@@ -147,6 +156,7 @@ public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment
     public void testDeeplyNestedErrorThrownOnlyAutomaticSteps() {
         // input == 1 -> error2 is thrown -> caught on subprocess2 -> end event
@@ -170,6 +180,7 @@ public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/event/error/BoundaryErrorEventTest.testCatchErrorOnCallActivity-parent.bpmn20.xml",
             "org/flowable/engine/test/bpmn/event/error/BoundaryErrorEventTest.subprocess.bpmn20.xml" })
     public void testCatchErrorOnCallActivity() {
@@ -188,6 +199,7 @@ public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
         assertProcessEnded(procId);
     }
     
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/event/error/BoundaryErrorEventTest.multipleErrorsCatch.bpmn20.xml",
         "org/flowable/engine/test/bpmn/event/error/BoundaryErrorEventTest.multipleErrorsThrow.bpmn20.xml" })
     public void testCatchMultipleErrorsOnCallActivity() {
@@ -200,6 +212,7 @@ public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
         assertProcessEnded(procId);
     }
     
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/event/error/BoundaryErrorEventTest.multipleErrorsCatch.bpmn20.xml",
         "org/flowable/engine/test/bpmn/event/error/BoundaryErrorEventTest.multipleErrorsThrow2.bpmn20.xml" })
     public void testCatchMultipleErrorsOnCallActivityNoSpecificError() {
@@ -212,6 +225,7 @@ public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
         assertProcessEnded(procId);
     }
     
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/event/error/BoundaryErrorEventTest.callActivityWithErrorEndEventCatch.bpmn20.xml",
         "org/flowable/engine/test/bpmn/event/error/BoundaryErrorEventTest.callActivityWithErrorEndEventThrow.bpmn20.xml" })
     public void testCatchErrorEndEventOnCallActivity() {
@@ -224,6 +238,7 @@ public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
         assertProcessEnded(procId);
     }
     
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/event/error/BoundaryErrorEventTest.callActivityWithErrorEndEventCatch.bpmn20.xml",
         "org/flowable/engine/test/bpmn/event/error/BoundaryErrorEventTest.callActivityWithErrorEndEventThrow2.bpmn20.xml" })
     public void testCatchErrorEndEventOnCallActivityNoSpecificError() {
@@ -236,6 +251,7 @@ public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/event/error/BoundaryErrorEventTest.subprocess.bpmn20.xml" })
     public void testUncaughtError() {
         runtimeService.startProcessInstanceByKey("simpleSubProcess");
@@ -251,6 +267,7 @@ public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/event/error/BoundaryErrorEventTest.testUncaughtErrorOnCallActivity-parent.bpmn20.xml",
             "org/flowable/engine/test/bpmn/event/error/BoundaryErrorEventTest.subprocess.bpmn20.xml" })
     public void testUncaughtErrorOnCallActivity() {
@@ -267,6 +284,7 @@ public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/event/error/BoundaryErrorEventTest.testCatchErrorThrownByCallActivityOnSubprocess.bpmn20.xml",
             "org/flowable/engine/test/bpmn/event/error/BoundaryErrorEventTest.subprocess.bpmn20.xml" })
     public void testCatchErrorThrownByCallActivityOnSubprocess() {
@@ -285,6 +303,7 @@ public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/event/error/BoundaryErrorEventTest.testCatchErrorThrownByCallActivityOnCallActivity.bpmn20.xml",
             "org/flowable/engine/test/bpmn/event/error/BoundaryErrorEventTest.subprocess2ndLevel.bpmn20.xml", "org/flowable/engine/test/bpmn/event/error/BoundaryErrorEventTest.subprocess.bpmn20.xml" })
     public void testCatchErrorThrownByCallActivityOnCallActivity() throws InterruptedException {
@@ -303,6 +322,7 @@ public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment
     public void testCatchErrorOnParallelMultiInstance() {
         String procId = runtimeService.startProcessInstanceByKey("catchErrorOnParallelMi").getId();
@@ -323,6 +343,7 @@ public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment
     public void testCatchErrorOnSequentialMultiInstance() {
         String procId = runtimeService.startProcessInstanceByKey("catchErrorOnSequentialMi").getId();
@@ -341,36 +362,42 @@ public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment
     public void testCatchErrorThrownByJavaDelegateOnServiceTask() {
         String procId = runtimeService.startProcessInstanceByKey("catchErrorThrownByJavaDelegateOnServiceTask").getId();
         assertThatErrorHasBeenCaught(procId);
     }
 
+    @Test
     @Deployment
     public void testCatchErrorThrownByJavaDelegateOnServiceTaskNotCancelActivity() {
         String procId = runtimeService.startProcessInstanceByKey("catchErrorThrownByJavaDelegateOnServiceTaskNotCancelActiviti").getId();
         assertThatErrorHasBeenCaught(procId);
     }
 
+    @Test
     @Deployment
     public void testCatchErrorThrownByJavaDelegateOnServiceTaskWithErrorCode() {
         String procId = runtimeService.startProcessInstanceByKey("catchErrorThrownByJavaDelegateOnServiceTaskWithErrorCode").getId();
         assertThatErrorHasBeenCaught(procId);
     }
 
+    @Test
     @Deployment
     public void testCatchErrorThrownByJavaDelegateOnEmbeddedSubProcess() {
         String procId = runtimeService.startProcessInstanceByKey("catchErrorThrownByJavaDelegateOnEmbeddedSubProcess").getId();
         assertThatErrorHasBeenCaught(procId);
     }
 
+    @Test
     @Deployment
     public void testCatchErrorThrownByJavaDelegateOnEmbeddedSubProcessInduction() {
         String procId = runtimeService.startProcessInstanceByKey("catchErrorThrownByJavaDelegateOnEmbeddedSubProcessInduction").getId();
         assertThatErrorHasBeenCaught(procId);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/event/error/BoundaryErrorEventTest.testCatchErrorThrownByJavaDelegateOnCallActivity-parent.bpmn20.xml",
             "org/flowable/engine/test/bpmn/event/error/BoundaryErrorEventTest.testCatchErrorThrownByJavaDelegateOnCallActivity-child.bpmn20.xml" })
     public void testCatchErrorThrownByJavaDelegateOnCallActivity() {
@@ -378,6 +405,7 @@ public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
         assertThatErrorHasBeenCaught(procId);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/event/error/BoundaryErrorEventTest.testCatchErrorThrownByJavaDelegateOnCallActivity-child.bpmn20.xml" })
     public void testUncaughtErrorThrownByJavaDelegateOnServiceTask() {
         try {
@@ -387,6 +415,7 @@ public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/event/error/BoundaryErrorEventTest.testUncaughtErrorThrownByJavaDelegateOnCallActivity-parent.bpmn20.xml",
             "org/flowable/engine/test/bpmn/event/error/BoundaryErrorEventTest.testCatchErrorThrownByJavaDelegateOnCallActivity-child.bpmn20.xml" })
     public void testUncaughtErrorThrownByJavaDelegateOnCallActivity() {
@@ -397,24 +426,28 @@ public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/event/error/BoundaryErrorEventTest.testCatchErrorOnGroovyScriptTask.bpmn20.xml" })
     public void testCatchErrorOnGroovyScriptTask() {
         String procId = runtimeService.startProcessInstanceByKey("catchErrorOnScriptTask").getId();
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/event/error/BoundaryErrorEventTest.testCatchErrorOnJavaScriptScriptTask.bpmn20.xml" })
     public void testCatchErrorOnJavaScriptScriptTask() {
         String procId = runtimeService.startProcessInstanceByKey("catchErrorOnScriptTask").getId();
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/event/error/BoundaryErrorEventTest.testUncaughtErrorOnScriptTaskWithEmptyErrorEventDefinition.bpmn20.xml" })
     public void testUncaughtErrorOnScriptTaskWithEmptyErrorEventDefinition() {
         String procId = runtimeService.startProcessInstanceByKey("uncaughtErrorOnScriptTaskWithEmptyErrorEventDefinition").getId();
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/event/error/BoundaryErrorEventTest.testUncaughtErrorOnScriptTask.bpmn20.xml" })
     public void testUncaughtErrorOnScriptTask() {
         try {
@@ -426,6 +459,7 @@ public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testCatchErrorThrownByJavaDelegateOnMultiInstanceServiceTaskSequential() {
         Map<String, Object> variables = new HashMap<>();
@@ -434,6 +468,7 @@ public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
         assertThatErrorHasBeenCaught(procId);
     }
 
+    @Test
     @Deployment
     public void testCatchErrorThrownByJavaDelegateOnMultiInstanceServiceTaskParallel() {
         Map<String, Object> variables = new HashMap<>();
@@ -442,6 +477,7 @@ public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
         assertThatErrorHasBeenCaught(procId);
     }
 
+    @Test
     @Deployment
     public void testErrorThrownByJavaDelegateNotCaughtByOtherEventType() {
         String procId = runtimeService.startProcessInstanceByKey("testErrorThrownByJavaDelegateNotCaughtByOtherEventType").getId();
@@ -460,6 +496,7 @@ public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment
     public void testConcurrentExecutionsInterruptedOnDestroyScope() {
 
@@ -472,6 +509,7 @@ public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("process");
     }
 
+    @Test
     @Deployment
     public void testCatchErrorThrownByExpressionOnServiceTask() {
         HashMap<String, Object> variables = new HashMap<>();
@@ -480,6 +518,7 @@ public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
         assertThatErrorHasBeenCaught(procId);
     }
 
+    @Test
     @Deployment
     public void testCatchErrorThrownByDelegateExpressionOnServiceTask() {
         HashMap<String, Object> variables = new HashMap<>();
@@ -488,6 +527,7 @@ public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
         assertThatErrorHasBeenCaught(procId);
     }
 
+    @Test
     @Deployment
     public void testCatchErrorThrownByJavaDelegateProvidedByDelegateExpressionOnServiceTask() {
         HashMap<String, Object> variables = new HashMap<>();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/error/ErrorEventSubProcessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/error/ErrorEventSubProcessTest.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tijs Rademakers
@@ -28,6 +29,7 @@ public class ErrorEventSubProcessTest extends PluggableFlowableTestCase {
     private static final String LOCAL_ERROR_FLAG_VARIABLE_NAME = "localError";
     private static final String PROCESS_KEY_UNDER_TEST = "helloWorldWithBothSubProcessTypes";
 
+    @Test
     @Deployment
     // an event subprocesses takes precedence over a boundary event
     public void testEventSubprocessTakesPrecedence() {
@@ -35,6 +37,7 @@ public class ErrorEventSubProcessTest extends PluggableFlowableTestCase {
         assertThatErrorHasBeenCaught(procId);
     }
 
+    @Test
     @Deployment
     // an event subprocess with errorCode takes precedence over a catch-all handler
     public void testErrorCodeTakesPrecedence() {
@@ -51,36 +54,42 @@ public class ErrorEventSubProcessTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment
     public void testCatchErrorInEmbeddedSubProcess() {
         String procId = runtimeService.startProcessInstanceByKey("CatchErrorInEmbeddedSubProcess").getId();
         assertThatErrorHasBeenCaught(procId);
     }
 
+    @Test
     @Deployment
     public void testCatchErrorThrownByScriptTaskInEmbeddedSubProcess() {
         String procId = runtimeService.startProcessInstanceByKey("CatchErrorThrownByScriptTaskInEmbeddedSubProcess").getId();
         assertThatErrorHasBeenCaught(procId);
     }
 
+    @Test
     @Deployment
     public void testCatchErrorThrownByScriptTaskInEmbeddedSubProcessWithErrorCode() {
         String procId = runtimeService.startProcessInstanceByKey("CatchErrorThrownByScriptTaskInEmbeddedSubProcessWithErrorCode").getId();
         assertThatErrorHasBeenCaught(procId);
     }
 
+    @Test
     @Deployment
     public void testCatchErrorThrownByScriptTaskInTopLevelProcess() {
         String procId = runtimeService.startProcessInstanceByKey("CatchErrorThrownByScriptTaskInTopLevelProcess").getId();
         assertThatErrorHasBeenCaught(procId);
     }
 
+    @Test
     @Deployment
     public void testCatchErrorThrownByScriptTaskInsideSubProcessInTopLevelProcess() {
         String procId = runtimeService.startProcessInstanceByKey("CatchErrorThrownByScriptTaskInsideSubProcessInTopLevelProcess").getId();
         assertThatErrorHasBeenCaught(procId);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/event/error/ErrorEventSubProcessTest.testThrowErrorInScriptTaskInsideCallActivitiCatchInTopLevelProcess.bpmn20.xml",
             "org/flowable/engine/test/bpmn/event/error/BoundaryErrorEventTest.testCatchErrorThrownByJavaDelegateOnCallActivity-child.bpmn20.xml" })
     public void testThrowErrorInScriptTaskInsideCallActivitiCatchInTopLevelProcess() {
@@ -88,6 +97,7 @@ public class ErrorEventSubProcessTest extends PluggableFlowableTestCase {
         assertThatErrorHasBeenCaught(procId);
     }
     
+    @Test
     @Deployment(resources = {"org/flowable/engine/test/bpmn/event/error/ErrorEventSubProcessTest.testCatchMultipleRethrowParent.bpmn",
                     "org/flowable/engine/test/bpmn/event/error/ErrorEventSubProcessTest.testCatchMultipleRethrowSubProcess.bpmn"})
     public void testMultipleRethrowEvents() {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/error/mapError/BoundaryErrorMapTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/error/mapError/BoundaryErrorMapTest.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.test.Deployment;
 import org.flowable.standalone.testing.helpers.ServiceTaskTestMock;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Saeid Mirzaei
@@ -25,6 +26,7 @@ import org.flowable.standalone.testing.helpers.ServiceTaskTestMock;
 public class BoundaryErrorMapTest extends PluggableFlowableTestCase {
 
     // exception matches the only mapping, directly
+    @Test
     @Deployment
     public void testClassDelegateSingleDirectMap() {
         FlagDelegate.reset();
@@ -35,6 +37,7 @@ public class BoundaryErrorMapTest extends PluggableFlowableTestCase {
         assertTrue(FlagDelegate.isVisited());
     }
 
+    @Test
     @Deployment
     public void testExpressionSingleDirectMap() {
         FlagDelegate.reset();
@@ -45,6 +48,7 @@ public class BoundaryErrorMapTest extends PluggableFlowableTestCase {
         assertTrue(FlagDelegate.isVisited());
     }
 
+    @Test
     @Deployment
     public void testDelegateExpressionSingleDirectMap() {
         FlagDelegate.reset();
@@ -55,6 +59,7 @@ public class BoundaryErrorMapTest extends PluggableFlowableTestCase {
         assertTrue(FlagDelegate.isVisited());
     }
 
+    @Test
     @Deployment
     public void testRootCauseSingleDirectMap() {
         FlagDelegate.reset();
@@ -67,6 +72,7 @@ public class BoundaryErrorMapTest extends PluggableFlowableTestCase {
     }
 
     // exception does not match the single mapping
+    @Test
     @Deployment(resources = "org/flowable/engine/test/bpmn/event/error/mapError/BoundaryErrorMapTest.testClassDelegateSingleDirectMap.bpmn20.xml")
     public void testClassDelegateSingleDirectMapNotMatchingException() {
         FlagDelegate.reset();
@@ -83,6 +89,7 @@ public class BoundaryErrorMapTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/bpmn/event/error/mapError/BoundaryErrorMapTest.testExpressionSingleDirectMap.bpmn20.xml")
     public void testExpressionSingleDirectMapNotMatchingException() {
         FlagDelegate.reset();
@@ -99,6 +106,7 @@ public class BoundaryErrorMapTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/bpmn/event/error/mapError/BoundaryErrorMapTest.testDelegateExpressionSingleDirectMap.bpmn20.xml")
     public void testDelegateExpressionSingleDirectMapNotMatchingException() {
         FlagDelegate.reset();
@@ -115,6 +123,7 @@ public class BoundaryErrorMapTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/bpmn/event/error/mapError/BoundaryErrorMapTest.testRootCauseSingleDirectMap.bpmn20.xml")
     public void testRootCauseSingleDirectMapNotMatchingException() {
         FlagDelegate.reset();
@@ -133,6 +142,7 @@ public class BoundaryErrorMapTest extends PluggableFlowableTestCase {
     }
 
     // exception matches by inheritance
+    @Test
     @Deployment(resources = "org/flowable/engine/test/bpmn/event/error/mapError/BoundaryErrorMapTest.testClassDelegateSingleInheritedMapWithRootCause.bpmn20.xml")
     public void testClassDelegateSingleInheritedMapWithRootCauseNotMatchingException() {
         FlagDelegate.reset();
@@ -151,6 +161,7 @@ public class BoundaryErrorMapTest extends PluggableFlowableTestCase {
     }
 
     // exception matches by inheritance
+    @Test
     @Deployment
     public void testClassDelegateSingleInheritedMap() {
         Map<String, Object> vars = new HashMap<>();
@@ -162,6 +173,7 @@ public class BoundaryErrorMapTest extends PluggableFlowableTestCase {
     }
 
     // exception matches by inheritance
+    @Test
     @Deployment
     public void testClassDelegateSingleInheritedMapWithRootCause() {
         Map<String, Object> vars = new HashMap<>();
@@ -174,6 +186,7 @@ public class BoundaryErrorMapTest extends PluggableFlowableTestCase {
     }
 
     // check the default map
+    @Test
     @Deployment
     public void testClassDelegateDefaultMap() {
         Map<String, Object> vars = new HashMap<>();
@@ -184,6 +197,7 @@ public class BoundaryErrorMapTest extends PluggableFlowableTestCase {
         assertTrue(FlagDelegate.isVisited());
     }
 
+    @Test
     @Deployment
     public void testExpressionDefaultMap() {
         Map<String, Object> vars = new HashMap<>();
@@ -194,6 +208,7 @@ public class BoundaryErrorMapTest extends PluggableFlowableTestCase {
         assertTrue(FlagDelegate.isVisited());
     }
 
+    @Test
     @Deployment
     public void testDelegateExpressionDefaultMap() {
         Map<String, Object> vars = new HashMap<>();
@@ -204,6 +219,7 @@ public class BoundaryErrorMapTest extends PluggableFlowableTestCase {
         assertTrue(FlagDelegate.isVisited());
     }
 
+    @Test
     @Deployment
     public void testSeqMultInstanceSingleDirectMap() {
         FlagDelegate.reset();
@@ -214,6 +230,7 @@ public class BoundaryErrorMapTest extends PluggableFlowableTestCase {
         assertTrue(FlagDelegate.isVisited());
     }
 
+    @Test
     @Deployment
     public void testSubProcessSingleDirectMap() {
         FlagDelegate.reset();
@@ -224,6 +241,7 @@ public class BoundaryErrorMapTest extends PluggableFlowableTestCase {
         assertTrue(FlagDelegate.isVisited());
     }
 
+    @Test
     @Deployment(resources = {
             "org/flowable/engine/test/bpmn/event/error/mapError/BoundaryErrorMapTest.testCallProcessSingleDirectMap.bpmn20.xml",
             "org/flowable/engine/test/bpmn/event/error/mapError/BoundaryErrorMapTest.testCallProcessCalee.bpmn20.xml" })
@@ -236,6 +254,7 @@ public class BoundaryErrorMapTest extends PluggableFlowableTestCase {
         assertTrue(FlagDelegate.isVisited());
     }
 
+    @Test
     @Deployment(resources = {
             "org/flowable/engine/test/bpmn/event/error/mapError/BoundaryErrorMapTest.testExpressionCallProcessSingleDirectMap.bpmn20.xml",
             "org/flowable/engine/test/bpmn/event/error/mapError/BoundaryErrorMapTest.testCallProcessExpressionSubProcess.bpmn20.xml" })
@@ -248,6 +267,7 @@ public class BoundaryErrorMapTest extends PluggableFlowableTestCase {
         assertTrue(FlagDelegate.isVisited());
     }
 
+    @Test
     @Deployment(resources = {
             "org/flowable/engine/test/bpmn/event/error/mapError/BoundaryErrorMapTest.testDelegateExpressionCallProcessSingleDirectMap.bpmn20.xml",
             "org/flowable/engine/test/bpmn/event/error/mapError/BoundaryErrorMapTest.testCallProcessDelegateExpressionSubProcess.bpmn20.xml" })

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageBoundaryEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageBoundaryEventTest.java
@@ -22,12 +22,14 @@ import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.TimerJobQuery;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tijs Rademakers
  */
 public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testSingleBoundaryMessageEvent() {
         runtimeService.startProcessInstanceByKey("process");
@@ -69,6 +71,7 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     public void testDoubleBoundaryMessageEventSameMessageId() {
         // deployment fails when two boundary message events have the same
         // messageId
@@ -80,6 +83,7 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testDoubleBoundaryMessageEvent() {
         runtimeService.startProcessInstanceByKey("process");
@@ -137,6 +141,7 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createProcessInstanceQuery().count());
     }
 
+    @Test
     @Deployment
     public void testDoubleBoundaryMessageEventMultiInstance() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process");
@@ -225,6 +230,7 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment
     public void testBoundaryMessageEventInsideSubprocess() {
 
@@ -271,6 +277,7 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createProcessInstanceQuery().count());
     }
 
+    @Test
     @Deployment
     public void testBoundaryMessageEventOnSubprocessAndInsideSubprocess() {
 
@@ -385,6 +392,7 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment
     public void testBoundaryMessageEventOnSubprocess() {
         runtimeService.startProcessInstanceByKey("process");
@@ -444,6 +452,7 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment
     public void testBoundaryMessageEventOnSubprocessAndInsideSubprocessMultiInstance() {
 
@@ -488,6 +497,7 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment
     public void testSingleBoundaryMessageEventWithBoundaryTimerEvent() {
         final Date startTime = new Date();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageEventSubprocessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageEventSubprocessTest.java
@@ -20,12 +20,14 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tijs Rademakers
  */
 public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testInterruptingUnderProcessDefinition() {
         testInterruptingUnderProcessDefinition(1, 3);
@@ -34,6 +36,7 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
     /**
      * Checks if unused event subscriptions are properly deleted.
      */
+    @Test
     @Deployment
     public void testTwoInterruptingUnderProcessDefinition() {
         testInterruptingUnderProcessDefinition(2, 4);
@@ -70,6 +73,7 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
     }
 
+    @Test
     @Deployment
     public void testNonInterruptingUnderProcessDefinition() {
 
@@ -144,6 +148,7 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
     }
 
+    @Test
     @Deployment
     public void testNonInterruptingMultipleInstances() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process");
@@ -189,6 +194,7 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
     }
 
+    @Test
     @Deployment
     public void testNonInterruptingSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process");
@@ -234,6 +240,7 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
     }
 
+    @Test
     @Deployment
     public void testInterruptingSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process");
@@ -258,6 +265,7 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
     }
     
+    @Test
     @Deployment
     public void testStartingAdditionalTasks() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startingAdditionalTasks");
@@ -319,6 +327,7 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
     }
     
+    @Test
     @Deployment(resources="org/flowable/engine/test/bpmn/event/message/MessageEventSubprocessTest.testStartingAdditionalTasks.bpmn20.xml")
     public void testStartingAdditionalTasksNoNestedEventSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startingAdditionalTasks");
@@ -354,6 +363,7 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
     }
     
+    @Test
     @Deployment(resources="org/flowable/engine/test/bpmn/event/message/MessageEventSubprocessTest.testStartingAdditionalTasks.bpmn20.xml")
     public void testStartingAdditionalTasksWithNestedEventSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startingAdditionalTasks");
@@ -429,6 +439,7 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
     }
     
+    @Test
     @Deployment
     public void testStartingAdditionalTasksInterrupting() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startingAdditionalTasks");
@@ -471,6 +482,7 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
     }
     
+    @Test
     @Deployment(resources="org/flowable/engine/test/bpmn/event/message/MessageEventSubprocessTest.testStartingAdditionalTasksInterrupting.bpmn20.xml")
     public void testStartingAdditionalTasksInterruptingWithMainEventSubProcessInterrupt() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startingAdditionalTasks");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageIntermediateEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageIntermediateEventTest.java
@@ -23,12 +23,14 @@ import org.flowable.engine.runtime.EventSubscription;
 import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tijs Rademakers
  */
 public class MessageIntermediateEventTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testSingleIntermediateMessageEvent() {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("process");
@@ -59,6 +61,7 @@ public class MessageIntermediateEventTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment
     public void testSingleIntermediateMessageExpressionEvent() {
         Map<String, Object> variableMap = new HashMap<>();
@@ -81,6 +84,7 @@ public class MessageIntermediateEventTest extends PluggableFlowableTestCase {
         taskService.complete(task.getId());
     }
 
+    @Test
     @Deployment
     public void testConcurrentIntermediateMessageEvent() {
 
@@ -111,6 +115,7 @@ public class MessageIntermediateEventTest extends PluggableFlowableTestCase {
         taskService.complete(task.getId());
     }
 
+    @Test
     @Deployment
     public void testAsyncTriggeredMessageEvent() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageNonInterruptingBoundaryEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageNonInterruptingBoundaryEventTest.java
@@ -16,6 +16,7 @@ package org.flowable.engine.test.bpmn.event.message;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * 
@@ -23,6 +24,7 @@ import org.flowable.engine.test.Deployment;
  */
 public class MessageNonInterruptingBoundaryEventTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testSingleNonInterruptingBoundaryMessageEvent() {
         runtimeService.startProcessInstanceByKey("process");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageStartEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageStartEventTest.java
@@ -23,12 +23,14 @@ import org.flowable.engine.runtime.EventSubscription;
 import org.flowable.engine.runtime.EventSubscriptionQuery;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tijs Rademakers
  */
 public class MessageStartEventTest extends PluggableFlowableTestCase {
 
+    @Test
     public void testDeploymentCreatesSubscriptions() {
         String deploymentId = repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/bpmn/event/message/MessageStartEventTest.testSingleMessageStartEvent.bpmn20.xml")
                 .deploy().getId();
@@ -40,6 +42,7 @@ public class MessageStartEventTest extends PluggableFlowableTestCase {
         repositoryService.deleteDeployment(deploymentId);
     }
 
+    @Test
     public void testSameMessageNameFails() {
         String deploymentId = repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/bpmn/event/message/MessageStartEventTest.testSingleMessageStartEvent.bpmn20.xml")
                 .deploy().getId();
@@ -55,6 +58,7 @@ public class MessageStartEventTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     public void testSameMessageNameInSameProcessFails() {
         try {
             repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/bpmn/event/message/testSameMessageNameInSameProcessFails.bpmn20.xml").deploy();
@@ -64,6 +68,7 @@ public class MessageStartEventTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testUpdateProcessVersionCancelsSubscriptions() {
         String deploymentId = repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/bpmn/event/message/MessageStartEventTest.testSingleMessageStartEvent.bpmn20.xml")
                 .deploy().getId();
@@ -99,6 +104,7 @@ public class MessageStartEventTest extends PluggableFlowableTestCase {
         repositoryService.deleteDeployment(newDeploymentId);
     }
 
+    @Test
     @Deployment
     public void testSingleMessageStartEvent() {
 
@@ -144,6 +150,7 @@ public class MessageStartEventTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
     
+    @Test
     @Deployment
     public void testBusinessKeySet() {
         ProcessInstance pi1 = runtimeService.startProcessInstanceByKey("start-by-message-1", "business-key-123");
@@ -160,6 +167,7 @@ public class MessageStartEventTest extends PluggableFlowableTestCase {
                 .getBusinessKey());
     }
 
+    @Test
     @Deployment
     public void testMessageStartEventAndNoneStartEvent() {
 
@@ -191,6 +199,7 @@ public class MessageStartEventTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment
     public void testMultipleMessageStartEvents() {
 
@@ -230,6 +239,7 @@ public class MessageStartEventTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment
     public void testQueryMessageStartEvents() {
         assertEventSubscriptionQuery(runtimeService.createEventSubscriptionQuery(), 2);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/signal/SignalEventSubprocessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/signal/SignalEventSubprocessTest.java
@@ -20,12 +20,14 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tijs Rademakers
  */
 public class SignalEventSubprocessTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testInterruptingUnderProcessDefinition() {
         testInterruptingUnderProcessDefinition(1, 3);
@@ -34,6 +36,7 @@ public class SignalEventSubprocessTest extends PluggableFlowableTestCase {
     /**
      * Checks if unused event subscriptions are properly deleted.
      */
+    @Test
     @Deployment
     public void testTwoInterruptingUnderProcessDefinition() {
         testInterruptingUnderProcessDefinition(2, 4);
@@ -70,6 +73,7 @@ public class SignalEventSubprocessTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
     }
 
+    @Test
     @Deployment
     public void testNonInterruptingUnderProcessDefinition() {
 
@@ -145,6 +149,7 @@ public class SignalEventSubprocessTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
     }
 
+    @Test
     @Deployment
     public void testNonInterruptingMultipleInstances() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process");
@@ -190,6 +195,7 @@ public class SignalEventSubprocessTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
     }
 
+    @Test
     @Deployment
     public void testNonInterruptingSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process");
@@ -235,6 +241,7 @@ public class SignalEventSubprocessTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
     }
 
+    @Test
     @Deployment
     public void testInterruptingSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process");
@@ -259,6 +266,7 @@ public class SignalEventSubprocessTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
     }
     
+    @Test
     @Deployment
     public void testStartingAdditionalTasks() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startingAdditionalTasks");
@@ -320,6 +328,7 @@ public class SignalEventSubprocessTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
     }
     
+    @Test
     @Deployment(resources="org/flowable/engine/test/bpmn/event/signal/SignalEventSubprocessTest.testStartingAdditionalTasks.bpmn20.xml")
     public void testStartingAdditionalTasksNoNestedEventSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startingAdditionalTasks");
@@ -355,6 +364,7 @@ public class SignalEventSubprocessTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
     }
     
+    @Test
     @Deployment(resources="org/flowable/engine/test/bpmn/event/signal/SignalEventSubprocessTest.testStartingAdditionalTasks.bpmn20.xml")
     public void testStartingAdditionalTasksWithNestedEventSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startingAdditionalTasks");
@@ -430,6 +440,7 @@ public class SignalEventSubprocessTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
     }
     
+    @Test
     @Deployment
     public void testStartingAdditionalTasksInterrupting() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startingAdditionalTasks");
@@ -472,6 +483,7 @@ public class SignalEventSubprocessTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
     }
     
+    @Test
     @Deployment(resources="org/flowable/engine/test/bpmn/event/signal/SignalEventSubprocessTest.testStartingAdditionalTasksInterrupting.bpmn20.xml")
     public void testStartingAdditionalTasksInterruptingWithMainEventSubProcessInterrupt() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startingAdditionalTasks");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/signal/SignalEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/signal/SignalEventTest.java
@@ -30,12 +30,14 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
 import org.flowable.validation.validator.Problems;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tijs Rademakers
  */
 public class SignalEventTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/event/signal/SignalEventTests.catchAlertSignal.bpmn20.xml",
             "org/flowable/engine/test/bpmn/event/signal/SignalEventTests.throwAlertSignal.bpmn20.xml" })
     public void testSignalCatchIntermediate() {
@@ -50,6 +52,7 @@ public class SignalEventTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createProcessInstanceQuery().count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/event/signal/SignalEventTests.catchAlertSignalExpression.bpmn20.xml",
             "org/flowable/engine/test/bpmn/event/signal/SignalEventTests.throwAlertSignalExpression.bpmn20.xml" })
     public void testSignalCatchIntermediateExpression() {
@@ -66,6 +69,7 @@ public class SignalEventTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createProcessInstanceQuery().count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/event/signal/SignalEventTests.catchAlertSignalBoundary.bpmn20.xml",
             "org/flowable/engine/test/bpmn/event/signal/SignalEventTests.throwAlertSignal.bpmn20.xml" })
     public void testSignalCatchBoundary() {
@@ -80,6 +84,7 @@ public class SignalEventTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createProcessInstanceQuery().count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/event/signal/SignalEventTests.catchAlertSignalBoundaryWithReceiveTask.bpmn20.xml",
             "org/flowable/engine/test/bpmn/event/signal/SignalEventTests.throwAlertSignal.bpmn20.xml" })
     public void testSignalCatchBoundaryWithVariables() {
@@ -94,6 +99,7 @@ public class SignalEventTest extends PluggableFlowableTestCase {
         assertEquals("catchSignal", runtimeService.getVariable(pi.getId(), "processName"));
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/event/signal/SignalEventTests.catchAlertSignal.bpmn20.xml",
             "org/flowable/engine/test/bpmn/event/signal/SignalEventTests.throwAlertSignalAsynch.bpmn20.xml" })
     public void testSignalCatchIntermediateAsynch() {
@@ -124,6 +130,7 @@ public class SignalEventTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/event/signal/SignalEventTests.catchMultipleSignals.bpmn20.xml",
             "org/flowable/engine/test/bpmn/event/signal/SignalEventTests.throwAlertSignal.bpmn20.xml", "org/flowable/engine/test/bpmn/event/signal/SignalEventTests.throwAbortSignal.bpmn20.xml" })
     public void testSignalCatchDifferentSignals() {
@@ -151,6 +158,7 @@ public class SignalEventTest extends PluggableFlowableTestCase {
     /**
      * Verifies the solution of https://jira.codehaus.org/browse/ACT-1309
      */
+    @Test
     @Deployment
     public void testSignalBoundaryOnSubProcess() {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("signalEventOnSubprocess");
@@ -158,6 +166,7 @@ public class SignalEventTest extends PluggableFlowableTestCase {
         assertProcessEnded(pi.getProcessInstanceId());
     }
 
+    @Test
     public void testDuplicateSignalNames() {
         try {
             repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/bpmn/event/signal/SignalEventTests.duplicateSignalNames.bpmn20.xml").deploy();
@@ -169,6 +178,7 @@ public class SignalEventTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testNoSignalName() {
         try {
             repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/bpmn/event/signal/SignalEventTests.noSignalName.bpmn20.xml").deploy();
@@ -180,6 +190,7 @@ public class SignalEventTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testSignalNoId() {
         try {
             repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/bpmn/event/signal/SignalEventTests.signalNoId.bpmn20.xml").deploy();
@@ -191,6 +202,7 @@ public class SignalEventTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testSignalNoRef() {
         try {
             repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/bpmn/event/signal/SignalEventTests.signalNoRef.bpmn20.xml").deploy();
@@ -209,6 +221,7 @@ public class SignalEventTest extends PluggableFlowableTestCase {
     /**
      * TestCase to reproduce Issue ACT-1344
      */
+    @Test
     @Deployment
     public void testNonInterruptingSignal() {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("nonInterruptingSignalEvent");
@@ -240,6 +253,7 @@ public class SignalEventTest extends PluggableFlowableTestCase {
     /**
      * TestCase to reproduce Issue ACT-1344
      */
+    @Test
     @Deployment
     public void testNonInterruptingSignalWithSubProcess() {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("nonInterruptingSignalWithSubProcess");
@@ -274,6 +288,7 @@ public class SignalEventTest extends PluggableFlowableTestCase {
         assertEquals(1, tasks.size());
     }
 
+    @Test
     @Deployment
     public void testUseSignalForExceptionsBetweenParallelPaths() {
         runtimeService.startProcessInstanceByKey("processWithSignal");
@@ -301,6 +316,7 @@ public class SignalEventTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createExecutionQuery().count());
     }
 
+    @Test
     @Deployment
     public void testSignalWithProcessInstanceScope() {
         // Start the process that catches the signal
@@ -319,6 +335,7 @@ public class SignalEventTest extends PluggableFlowableTestCase {
         assertEquals("userTaskWithSignalCatch", taskService.createTaskQuery().processInstanceId(processInstanceCatch.getId()).singleResult().getName());
     }
 
+    @Test
     @Deployment
     public void testSignalWithGlobalScope() {
         // Start the process that catches the signal
@@ -333,6 +350,7 @@ public class SignalEventTest extends PluggableFlowableTestCase {
         assertEquals("userTaskAfterSignalCatch", taskService.createTaskQuery().processInstanceId(processInstanceCatch.getId()).singleResult().getName());
     }
 
+    @Test
     @Deployment
     public void testAsyncTriggeredSignalEvent() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("processWithSignalCatch");
@@ -353,6 +371,7 @@ public class SignalEventTest extends PluggableFlowableTestCase {
         assertEquals(0, managementService.createJobQuery().count());
     }
 
+    @Test
     @Deployment
     public void testSignalUserTask() {
         runtimeService.startProcessInstanceByKey("catchSignal");
@@ -369,6 +388,7 @@ public class SignalEventTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     public void testSignalStartEventFromProcess() {
 
         // Deploy test processes
@@ -408,6 +428,7 @@ public class SignalEventTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     public void testSignalStartEventFromProcesAsync() {
 
         // Deploy test processes
@@ -458,6 +479,7 @@ public class SignalEventTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     public void testSignalStartEventFromAPI() {
 
         // Deploy test processes
@@ -495,6 +517,7 @@ public class SignalEventTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     public void testSignalStartEventFromAPIAsync() {
 
         // Deploy test processes
@@ -539,12 +562,14 @@ public class SignalEventTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment
     public void testEarlyFinishedProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("callerProcess");
         assertNotNull(processInstance.getId());
     }
 
+    @Test
     @Deployment
     public void testNoneEndEventAfterSignalInConcurrentProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("my-process");
@@ -563,6 +588,7 @@ public class SignalEventTest extends PluggableFlowableTestCase {
         assertEquals("usertask2", task.getTaskDefinitionKey());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/event/signal/SignalEventTests.catchAlertSignal.bpmn20.xml",
             "org/flowable/engine/test/bpmn/event/signal/SignalEventTests.throwAlertSignal.bpmn20.xml" })
     public void testSignalCatchSuspendedDefinition() {
@@ -579,6 +605,7 @@ public class SignalEventTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createProcessInstanceQuery().count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/event/signal/SignalEventTests.catchAlertSignal.bpmn20.xml",
             "org/flowable/engine/test/bpmn/event/signal/SignalEventTests.throwAlertSignal.bpmn20.xml" })
     public void testSignalCatchSuspendedDefinitionAndInstances() {
@@ -604,6 +631,7 @@ public class SignalEventTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createProcessInstanceQuery().count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/event/signal/SignalEventTests.catchAlertSignal.bpmn20.xml",
             "org/flowable/engine/test/bpmn/event/signal/SignalEventTests.throwAlertSignal.bpmn20.xml" })
     public void testSignalCatchSuspendedInstance() {
@@ -629,6 +657,7 @@ public class SignalEventTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createProcessInstanceQuery().count());
     }
 
+    @Test
     public void testSignalStartEventWithSuspendedDefinition() {
 
         repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/bpmn/event/signal/SignalEventTest.testSignalStartEvent.bpmn20.xml").deploy();
@@ -665,6 +694,7 @@ public class SignalEventTest extends PluggableFlowableTestCase {
     /**
      * Test case for https://activiti.atlassian.net/browse/ACT-1978
      */
+    @Test
     public void testSignalDeleteOnRedeploy() {
 
         // Deploy test processes
@@ -685,6 +715,7 @@ public class SignalEventTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testSignalWaitOnUserTaskBoundaryEvent() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("signal-wait");
@@ -701,6 +732,7 @@ public class SignalEventTest extends PluggableFlowableTestCase {
     /**
      * From https://forums.activiti.org/content/boundary-signal-causes-already-taking-transition
      */
+    @Test
     @Deployment
     public void testSignalThrowAndCatchInSameTransaction() {
 
@@ -753,6 +785,7 @@ public class SignalEventTest extends PluggableFlowableTestCase {
         assertEquals(1, usingTask.size());
     }
 
+    @Test
     @Deployment
     public void testMultipleSignalStartEvents() {
         runtimeService.signalEventReceived("signal1");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventFullHistoryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventFullHistoryTest.java
@@ -16,6 +16,7 @@ package org.flowable.engine.test.bpmn.event.timer;
 import org.flowable.engine.impl.test.ResourceFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Frederik Heremans
@@ -26,6 +27,7 @@ public class BoundaryTimerEventFullHistoryTest extends ResourceFlowableTestCase 
         super("org/flowable/standalone/history/fullhistory.flowable.cfg.xml");
     }
 
+    @Test
     @Deployment
     public void testSetProcessVariablesFromTaskWhenTimerOnTask() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("timerVariablesProcess");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventRepeatWithDurationAndEndTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventRepeatWithDurationAndEndTest.java
@@ -27,9 +27,11 @@ import org.flowable.job.api.Job;
 import org.flowable.job.service.impl.persistence.entity.TimerJobEntity;
 import org.joda.time.DateTime;
 import org.joda.time.format.ISODateTimeFormat;
+import org.junit.jupiter.api.Test;
 
 public class BoundaryTimerEventRepeatWithDurationAndEndTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testRepeatWithDurationAndEnd() throws Throwable {
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventRepeatWithDurationTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventRepeatWithDurationTest.java
@@ -27,9 +27,11 @@ import org.flowable.job.api.Job;
 import org.flowable.job.service.impl.persistence.entity.TimerJobEntity;
 import org.joda.time.DateTime;
 import org.joda.time.format.ISODateTimeFormat;
+import org.junit.jupiter.api.Test;
 
 public class BoundaryTimerEventRepeatWithDurationTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testRepeatWithDuration() throws Throwable {
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventRepeatWithEndTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventRepeatWithEndTest.java
@@ -26,12 +26,14 @@ import org.flowable.job.api.Job;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Vasile Dirla
  */
 public class BoundaryTimerEventRepeatWithEndTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testRepeatWithEnd() throws Throwable {
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventRepeatWithStartAndDurationTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventRepeatWithStartAndDurationTest.java
@@ -28,9 +28,11 @@ import org.flowable.job.api.Job;
 import org.flowable.job.service.impl.persistence.entity.TimerJobEntity;
 import org.joda.time.DateTime;
 import org.joda.time.format.ISODateTimeFormat;
+import org.junit.jupiter.api.Test;
 
 public class BoundaryTimerEventRepeatWithStartAndDurationTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testRepeatWithStartAndDuration() throws Throwable {
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventTest.java
@@ -32,6 +32,7 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
 import org.flowable.job.api.TimerJobQuery;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
@@ -62,6 +63,7 @@ public class BoundaryTimerEventTest extends PluggableFlowableTestCase {
      *
      * See process image next to the process xml resource
      */
+    @Test
     @Deployment
     public void testMultipleTimersOnUserTask() {
 
@@ -85,6 +87,7 @@ public class BoundaryTimerEventTest extends PluggableFlowableTestCase {
         assertEquals("Third Task", task.getName());
     }
 
+    @Test
     @Deployment
     public void testTimerOnNestingOfSubprocesses() {
 
@@ -106,6 +109,7 @@ public class BoundaryTimerEventTest extends PluggableFlowableTestCase {
         assertEquals("task outside subprocess", task.getName());
     }
 
+    @Test
     @Deployment
     public void testExpressionOnTimer() {
         // Set the clock fixed
@@ -138,7 +142,8 @@ public class BoundaryTimerEventTest extends PluggableFlowableTestCase {
             assertNotNull(historyService.createHistoricActivityInstanceQuery().processInstanceId(pi.getId()).activityId("boundaryTimer").singleResult());
         }
     }
-    
+
+    @Test
     @Deployment
     public void testExpressionWithJavaDurationOnTimer() {
         // Set the clock fixed
@@ -172,6 +177,7 @@ public class BoundaryTimerEventTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testNullExpressionOnTimer() {
 
@@ -188,6 +194,7 @@ public class BoundaryTimerEventTest extends PluggableFlowableTestCase {
         }
     }
     
+    @Test
     @Deployment
     public void testNullDueDateWithRepetition() {
 
@@ -205,6 +212,7 @@ public class BoundaryTimerEventTest extends PluggableFlowableTestCase {
         assertEquals(1, jobs.size());
     }
     
+    @Test
     @Deployment
     public void testNullDueDateWithWrongRepetition() {
 
@@ -223,6 +231,7 @@ public class BoundaryTimerEventTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testTimerInSingleTransactionProcess() {
         // make sure that if a PI completes in single transaction, JobEntities
@@ -232,6 +241,7 @@ public class BoundaryTimerEventTest extends PluggableFlowableTestCase {
         assertEquals(0, managementService.createJobQuery().count());
     }
 
+    @Test
     @Deployment
     public void testRepeatingTimerWithCancelActivity() {
         runtimeService.startProcessInstanceByKey("repeatingTimerAndCallActivity");
@@ -250,6 +260,7 @@ public class BoundaryTimerEventTest extends PluggableFlowableTestCase {
         assertEquals(1, taskService.createTaskQuery().count());
     }
 
+    @Test
     @Deployment
     public void testInfiniteRepeatingTimer() throws Exception {
 
@@ -284,6 +295,7 @@ public class BoundaryTimerEventTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment
     public void testRepeatTimerDuration() throws Exception {
 
@@ -315,6 +327,7 @@ public class BoundaryTimerEventTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment
     public void testBoundaryTimerEvent() throws Exception {
 
@@ -382,6 +395,7 @@ public class BoundaryTimerEventTest extends PluggableFlowableTestCase {
         assertEquals(0, jobList.size());
     }
 
+    @Test
     @Deployment
     public void testBoundaryTimerEvent2() throws Exception {
 
@@ -426,6 +440,7 @@ public class BoundaryTimerEventTest extends PluggableFlowableTestCase {
         assertEquals(0, jobList.size());
     }
 
+    @Test
     @Deployment
     public void testRescheduleBoundaryTimerOnUserTask() {
         // startDate variable set to one hour from now
@@ -486,6 +501,7 @@ public class BoundaryTimerEventTest extends PluggableFlowableTestCase {
         assertNull(timerJob);
     }
 
+    @Test
     @Deployment
     public void testRescheduleRepeatBoundaryTimer() {
         // startDate variable set to one hour from now
@@ -547,6 +563,7 @@ public class BoundaryTimerEventTest extends PluggableFlowableTestCase {
         assertNull(timerJob);
     }
 
+    @Test
     @Deployment
     public void testRescheduleBoundaryTimerOnSubProcess() {
         // startDate variable set to one hour from now
@@ -604,6 +621,7 @@ public class BoundaryTimerEventTest extends PluggableFlowableTestCase {
         assertNull(timerJob);
     }
 
+    @Test
     @Deployment
     public void test3BoundaryTimerEvents() throws Exception {
 
@@ -681,6 +699,7 @@ public class BoundaryTimerEventTest extends PluggableFlowableTestCase {
         processEngineConfiguration.getClock().reset();
     }
 
+    @Test
     @Deployment
     public void test2Boundary1IntermediateTimerEvents() throws Exception {
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerNonInterruptingEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerNonInterruptingEventTest.java
@@ -25,12 +25,14 @@ import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
 import org.flowable.job.api.TimerJobQuery;
 import org.flowable.task.api.TaskQuery;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
  */
 public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testMultipleTimersOnUserTask() {
         // Set the clock fixed
@@ -95,6 +97,7 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
         assertProcessEnded(pi.getId());
     }
 
+    @Test
     @Deployment
     public void testJoin() {
         // Set the clock fixed
@@ -134,6 +137,7 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
         assertProcessEnded(pi.getId());
     }
 
+    @Test
     @Deployment
     public void testTimerOnConcurrentTasks() {
         String procId = runtimeService.startProcessInstanceByKey("nonInterruptingOnConcurrentTasks").getId();
@@ -157,6 +161,7 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
     }
 
     // Difference with previous test: now the join will be reached first
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/event/timer/BoundaryTimerNonInterruptingEventTest.testTimerOnConcurrentTasks.bpmn20.xml" })
     public void testTimerOnConcurrentTasks2() {
         String procId = runtimeService.startProcessInstanceByKey("nonInterruptingOnConcurrentTasks").getId();
@@ -181,6 +186,7 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment
     public void testTimerWithCycle() throws Exception {
         String processInstanceId = runtimeService.startProcessInstanceByKey("nonInterruptingCycle").getId();
@@ -214,6 +220,7 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
     /*
      * see https://activiti.atlassian.net/browse/ACT-1173
      */
+    @Test
     @Deployment
     public void testTimerOnEmbeddedSubprocess() {
         String id = runtimeService.startProcessInstanceByKey("nonInterruptingTimerOnEmbeddedSubprocess").getId();
@@ -242,6 +249,7 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
     /*
      * see https://activiti.atlassian.net/browse/ACT-1106
      */
+    @Test
     @Deployment
     public void testReceiveTaskWithBoundaryTimer() {
         // Set the clock fixed
@@ -277,6 +285,7 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
         assertProcessEnded(pi.getId());
     }
 
+    @Test
     @Deployment
     public void testTimerOnConcurrentSubprocess() {
         String procId = runtimeService.startProcessInstanceByKey("testTimerOnConcurrentSubprocess").getId();
@@ -305,6 +314,7 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/bpmn/event/timer/BoundaryTimerNonInterruptingEventTest.testTimerOnConcurrentSubprocess.bpmn20.xml")
     public void testTimerOnConcurrentSubprocess2() {
         String procId = runtimeService.startProcessInstanceByKey("testTimerOnConcurrentSubprocess").getId();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/DurationTimeTimerEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/DurationTimeTimerEventTest.java
@@ -27,6 +27,9 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
 import org.flowable.job.api.TimerJobQuery;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Filip Hrisafov
@@ -35,9 +38,8 @@ public class DurationTimeTimerEventTest extends PluggableFlowableTestCase {
 
     private Map<Object, Object> initialBeans;
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         initialBeans = processEngineConfiguration.getExpressionManager().getBeans();
 
         Map<Object, Object> newBeans = new HashMap<>();
@@ -46,12 +48,12 @@ public class DurationTimeTimerEventTest extends PluggableFlowableTestCase {
         processEngineConfiguration.getExpressionManager().setBeans(newBeans);
     }
 
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
-        super.tearDown();
         processEngineConfiguration.getExpressionManager().setBeans(initialBeans);
     }
 
+    @Test
     public void testExpressionStartTimerEvent() {
         Instant yesterday = Instant.now().minus(1, ChronoUnit.DAYS);
         processEngineConfiguration.getClock().setCurrentTime(Date.from(yesterday));
@@ -73,6 +75,7 @@ public class DurationTimeTimerEventTest extends PluggableFlowableTestCase {
         assertThat(jobQuery.count()).isEqualTo(0);
     }
 
+    @Test
     @Deployment
     public void testVariableExpressionBoundaryTimerEvent() {
         HashMap<String, Object> variables = new HashMap<>();
@@ -96,6 +99,7 @@ public class DurationTimeTimerEventTest extends PluggableFlowableTestCase {
         processEngineConfiguration.getClock().reset();
     }
 
+    @Test
     @Deployment
     public void testBeanExpressionBoundaryTimerEvent() {
         Instant yesterday = Instant.now().minus(1, ChronoUnit.DAYS);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/InstantTimeTimerEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/InstantTimeTimerEventTest.java
@@ -22,6 +22,7 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
 import org.flowable.job.api.TimerJobQuery;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author martin.grofcik
@@ -32,6 +33,7 @@ public class InstantTimeTimerEventTest extends ResourceFlowableTestCase {
         super("org/flowable/engine/test/bpmn/event/timer/InstantTimeTimerEventTest.cfg.xml");
     }
 
+    @Test
     @Deployment
     public void testExpressionStartTimerEvent() throws Exception {
         TimerJobQuery jobQuery = managementService.createTimerJobQuery();
@@ -42,7 +44,8 @@ public class InstantTimeTimerEventTest extends ResourceFlowableTestCase {
         jobQuery = managementService.createTimerJobQuery();
         assertEquals(0, jobQuery.count());
     }
-    
+
+    @Test
     @Deployment
     public void testVariableExpressionBoundaryTimerEvent() {
         HashMap<String, Object> variables = new HashMap<>();
@@ -63,6 +66,7 @@ public class InstantTimeTimerEventTest extends ResourceFlowableTestCase {
         processEngineConfiguration.getClock().reset();
     }
 
+    @Test
     @Deployment
     public void testBeanExpressionBoundaryTimerEvent() {
         processEngineConfiguration.getClock().setCurrentTime(new Date(0));

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/IntermediateTimerEventRepeatWithEndTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/IntermediateTimerEventRepeatWithEndTest.java
@@ -26,12 +26,14 @@ import org.flowable.job.api.Job;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Vasile Dirla
  */
 public class IntermediateTimerEventRepeatWithEndTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testRepeatWithEnd() throws Throwable {
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/IntermediateTimerEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/IntermediateTimerEventTest.java
@@ -27,10 +27,12 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
 import org.flowable.job.api.TimerJobQuery;
+import org.junit.jupiter.api.Test;
 
 public class IntermediateTimerEventTest extends PluggableFlowableTestCase {
     private SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
 
+    @Test
     @Deployment
     public void testCatchingTimerEvent() throws Exception {
 
@@ -51,6 +53,7 @@ public class IntermediateTimerEventTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment
     public void testTimerEventWithStartAndDuration() throws Exception {
 
@@ -98,6 +101,7 @@ public class IntermediateTimerEventTest extends PluggableFlowableTestCase {
         processEngineConfiguration.getClock().reset();
     }
 
+    @Test
     @Deployment
     public void testExpression() {
         // Set the clock fixed
@@ -136,6 +140,7 @@ public class IntermediateTimerEventTest extends PluggableFlowableTestCase {
         assertProcessEnded(pi3.getProcessInstanceId());
     }
 
+    @Test
     @Deployment
     public void testLoop() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testLoop");
@@ -150,6 +155,7 @@ public class IntermediateTimerEventTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment
     public void testLoopWithCycle() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testLoop");
@@ -164,6 +170,7 @@ public class IntermediateTimerEventTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment
     public void testRescheduleTimer() {
         // startDate variable set to one hour from now
@@ -223,6 +230,7 @@ public class IntermediateTimerEventTest extends PluggableFlowableTestCase {
         assertNull(timerJob);
     }
 
+    @Test
     @Deployment
     public void testParallelTimerEvents() throws Exception {
         // Set the clock fixed

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/StartTimerEventRepeatWithEndExpressionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/StartTimerEventRepeatWithEndExpressionTest.java
@@ -24,6 +24,9 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.api.event.TestFlowableEntityEventListener;
 import org.flowable.job.api.Job;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Vasile Dirla
@@ -32,17 +35,14 @@ public class StartTimerEventRepeatWithEndExpressionTest extends PluggableFlowabl
 
     private TestFlowableEntityEventListener listener;
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
         listener = new TestFlowableEntityEventListener(Job.class);
         processEngineConfiguration.getEventDispatcher().addEventListener(listener);
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
-
         if (listener != null) {
             processEngineConfiguration.getEventDispatcher().removeEventListener(listener);
         }
@@ -51,6 +51,7 @@ public class StartTimerEventRepeatWithEndExpressionTest extends PluggableFlowabl
     /**
      * Timer repetition
      */
+    @Test
     public void testCycleDateStartTimerEvent() throws Exception {
         Clock previousClock = processEngineConfiguration.getClock();
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/StartTimerEventRepeatWithEndTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/StartTimerEventRepeatWithEndTest.java
@@ -25,6 +25,10 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.api.event.TestFlowableEntityEventListener;
 import org.flowable.job.api.Job;
+import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Vasile Dirla
@@ -33,16 +37,14 @@ public class StartTimerEventRepeatWithEndTest extends PluggableFlowableTestCase 
 
     private TestFlowableEntityEventListener listener;
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
         listener = new TestFlowableEntityEventListener(Job.class);
         processEngineConfiguration.getEventDispatcher().addEventListener(listener);
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
 
         if (listener != null) {
             processEngineConfiguration.getEventDispatcher().removeEventListener(listener);
@@ -52,6 +54,7 @@ public class StartTimerEventRepeatWithEndTest extends PluggableFlowableTestCase 
     /**
      * Timer repetition
      */
+    @Test
     public void testCycleDateStartTimerEvent() throws Exception {
         Clock previousClock = processEngineConfiguration.getClock();
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/StartTimerEventRepeatWithoutEndDateTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/StartTimerEventRepeatWithoutEndDateTest.java
@@ -24,6 +24,9 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.api.event.TestFlowableEntityEventListener;
 import org.flowable.job.api.Job;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Vasile Dirla
@@ -32,16 +35,14 @@ public class StartTimerEventRepeatWithoutEndDateTest extends PluggableFlowableTe
 
     private TestFlowableEntityEventListener listener;
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
         listener = new TestFlowableEntityEventListener(Job.class);
         processEngineConfiguration.getEventDispatcher().addEventListener(listener);
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
 
         if (listener != null) {
             processEngineConfiguration.getEventDispatcher().removeEventListener(listener);
@@ -51,6 +52,7 @@ public class StartTimerEventRepeatWithoutEndDateTest extends PluggableFlowableTe
     /**
      * Timer repetition
      */
+    @Test
     public void testCycleDateStartTimerEvent() throws Exception {
         Clock previousClock = processEngineConfiguration.getClock();
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/StartTimerEventRepeatWithoutEndTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/StartTimerEventRepeatWithoutEndTest.java
@@ -28,6 +28,9 @@ import org.flowable.engine.delegate.event.AbstractFlowableEngineEventListener;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Saeid Mirzaei Test case for ACT-4066
@@ -56,20 +59,19 @@ public class StartTimerEventRepeatWithoutEndTest extends PluggableFlowableTestCa
 
     }
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
 
         startEventListener = new StartEventListener();
         processEngineConfiguration.getEventDispatcher().addEventListener(startEventListener);
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
         processEngineConfiguration.getEventDispatcher().removeEventListener(startEventListener);
-        super.tearDown();
     }
 
+    @Test
     @Deployment
     public void testStartTimerEventRepeatWithoutN() {
         counter = 0;

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/StartTimerEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/StartTimerEventTest.java
@@ -29,12 +29,14 @@ import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
 import org.flowable.job.api.TimerJobQuery;
 import org.flowable.job.service.impl.cmd.CancelJobsCmd;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
  */
 public class StartTimerEventTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testDurationStartTimerEvent() throws Exception {
 
@@ -56,6 +58,7 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment
     public void testFixedDateStartTimerEvent() throws Exception {
         // After process start, there should be timer created
@@ -73,6 +76,7 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
 
     // FIXME: This test likes to run in an endless loop when invoking the
     // waitForJobExecutorOnCondition method
+    @Test
     @Deployment
     public void testCycleDateStartTimerEvent() throws Exception {
         processEngineConfiguration.getClock().setCurrentTime(new Date());
@@ -110,6 +114,7 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
         processEngineConfiguration.getClock().setCurrentTime(new Date(processEngineConfiguration.getClock().getCurrentTime().getTime() + ((minutes * 60 * 1000) + 5000)));
     }
 
+    @Test
     @Deployment
     public void testCycleWithLimitStartTimerEvent() throws Exception {
         processEngineConfiguration.getClock().setCurrentTime(new Date());
@@ -131,6 +136,7 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
         assertEquals(0, jobQuery.count());
     }
 
+    @Test
     @Deployment
     public void testExpressionStartTimerEvent() throws Exception {
         // ACT-1415: fixed start-date is an expression
@@ -146,6 +152,7 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
         assertEquals(0, jobQuery.count());
     }
 
+    @Test
     @Deployment
     public void testVersionUpgradeShouldCancelJobs() throws Exception {
         processEngineConfiguration.getClock().setCurrentTime(new Date());
@@ -188,6 +195,7 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
         repositoryService.deleteDeployment(id, true);
     }
 
+    @Test
     @Deployment
     public void testTimerShouldNotBeRecreatedOnDeploymentCacheReboot() {
 
@@ -210,6 +218,7 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
     }
 
     // Test for ACT-1533
+    @Test
     public void testTimerShouldNotBeRemovedWhenUndeployingOldVersion() throws Exception {
         // Deploy test process
         String processXml = new String(IoUtil.readInputStream(getClass().getResourceAsStream("StartTimerEventTest.testTimerShouldNotBeRemovedWhenUndeployingOldVersion.bpmn20.xml"), ""));
@@ -238,6 +247,7 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
         repositoryService.deleteDeployment(secondDeploymentId, true);
     }
 
+    @Test
     public void testOldJobsDeletedOnRedeploy() {
 
         for (int i = 0; i < 3; i++) {
@@ -262,6 +272,7 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     public void testTimersRecreatedOnDeploymentDelete() {
 
         // v1 has timer
@@ -333,6 +344,7 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
     }
 
     // Same test as above, but now with tenants
+    @Test
     public void testTimersRecreatedOnDeploymentDeleteWithTenantId() {
 
         // Deploy 4 versions without tenantId
@@ -412,6 +424,7 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
     }
 
     // Can't use @Deployment, we need to control the clock very strict to have a good test
+    @Test
     public void testMultipleStartEvents() {
 
         // Human time (GMT): Tue, 10 May 2016 18:50:01 GMT

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/TimeExpressionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/TimeExpressionTest.java
@@ -21,6 +21,7 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test timer expression according to act-865
@@ -44,6 +45,7 @@ public class TimeExpressionTest extends PluggableFlowableTestCase {
         return jobs.get(0).getDuedate();
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/event/timer/IntermediateTimerEventTest.testExpression.bpmn20.xml" })
     public void testTimeExpressionComplete() throws Exception {
         Date dt = new Date();
@@ -52,6 +54,7 @@ public class TimeExpressionTest extends PluggableFlowableTestCase {
         assertEquals(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").format(dt), new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").format(dueDate));
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/event/timer/IntermediateTimerEventTest.testExpression.bpmn20.xml" })
     public void testTimeExpressionWithoutSeconds() throws Exception {
         Date dt = new Date();
@@ -60,6 +63,7 @@ public class TimeExpressionTest extends PluggableFlowableTestCase {
         assertEquals(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm").format(dt), new SimpleDateFormat("yyyy-MM-dd'T'HH:mm").format(dueDate));
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/event/timer/IntermediateTimerEventTest.testExpression.bpmn20.xml" })
     public void testTimeExpressionWithoutMinutes() throws Exception {
         Date dt = new Date();
@@ -68,6 +72,7 @@ public class TimeExpressionTest extends PluggableFlowableTestCase {
         assertEquals(new SimpleDateFormat("yyyy-MM-dd'T'HH").format(dt), new SimpleDateFormat("yyyy-MM-dd'T'HH").format(dueDate));
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/event/timer/IntermediateTimerEventTest.testExpression.bpmn20.xml" })
     public void testTimeExpressionWithoutTime() throws Exception {
         Date dt = new Date();
@@ -76,6 +81,7 @@ public class TimeExpressionTest extends PluggableFlowableTestCase {
         assertEquals(new SimpleDateFormat("yyyy-MM-dd").format(dt), new SimpleDateFormat("yyyy-MM-dd").format(dueDate));
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/event/timer/IntermediateTimerEventTest.testExpression.bpmn20.xml" })
     public void testTimeExpressionWithoutDay() throws Exception {
         Date dt = new Date();
@@ -84,6 +90,7 @@ public class TimeExpressionTest extends PluggableFlowableTestCase {
         assertEquals(new SimpleDateFormat("yyyy-MM").format(dt), new SimpleDateFormat("yyyy-MM").format(dueDate));
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/event/timer/IntermediateTimerEventTest.testExpression.bpmn20.xml" })
     public void testTimeExpressionWithoutMonth() throws Exception {
         Date dt = new Date();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/TimerCustomCalendarTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/TimerCustomCalendarTest.java
@@ -27,6 +27,7 @@ import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
+import org.junit.jupiter.api.Test;
 
 /**
  * testing custom calendar for timer definitions Created by martin.grofcik
@@ -37,6 +38,7 @@ public class TimerCustomCalendarTest extends ResourceFlowableTestCase {
         super("org/flowable/engine/test/bpmn/event/timer/TimerCustomCalendarTest.flowable.cfg.xml");
     }
 
+    @Test
     @Deployment
     public void testCycleTimer() {
         List<Job> jobs = this.managementService.createTimerJobQuery().list();
@@ -59,6 +61,7 @@ public class TimerCustomCalendarTest extends ResourceFlowableTestCase {
         assertThat("There must be no job.", jobs.isEmpty());
     }
 
+    @Test
     @Deployment
     public void testCustomDurationTimerCalendar() {
         ProcessInstance processInstance = this.runtimeService.startProcessInstanceByKey("testCustomDurationCalendar");
@@ -76,6 +79,7 @@ public class TimerCustomCalendarTest extends ResourceFlowableTestCase {
         runtimeService.trigger(execution.getId());
     }
 
+    @Test
     @Deployment
     public void testInvalidDurationTimerCalendar() {
         try {
@@ -86,6 +90,7 @@ public class TimerCustomCalendarTest extends ResourceFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testBoundaryTimer() {
         this.runtimeService.startProcessInstanceByKey("testBoundaryTimer");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/TimerEventSubprocessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/TimerEventSubprocessTest.java
@@ -19,12 +19,14 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tijs Rademakers
  */
 public class TimerEventSubprocessTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testInterruptingUnderProcessDefinition() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process");
@@ -57,6 +59,7 @@ public class TimerEventSubprocessTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
     }
 
+    @Test
     @Deployment
     public void testNonInterruptingUnderProcessDefinition() {
 
@@ -122,6 +125,7 @@ public class TimerEventSubprocessTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
     }
 
+    @Test
     @Deployment
     public void testNonInterruptingSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process");
@@ -169,6 +173,7 @@ public class TimerEventSubprocessTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
     }
 
+    @Test
     @Deployment
     public void testInterruptingSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process");
@@ -193,6 +198,7 @@ public class TimerEventSubprocessTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
     }
     
+    @Test
     @Deployment
     public void testStartingAdditionalTasks() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startingAdditionalTasks");
@@ -250,6 +256,7 @@ public class TimerEventSubprocessTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
     }
     
+    @Test
     @Deployment(resources="org/flowable/engine/test/bpmn/event/timer/TimerEventSubprocessTest.testStartingAdditionalTasks.bpmn20.xml")
     public void testStartingAdditionalTasksNoNestedEventSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startingAdditionalTasks");
@@ -283,6 +290,7 @@ public class TimerEventSubprocessTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
     }
     
+    @Test
     @Deployment(resources="org/flowable/engine/test/bpmn/event/timer/TimerEventSubprocessTest.testStartingAdditionalTasks.bpmn20.xml")
     public void testStartingAdditionalTasksWithNestedEventSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startingAdditionalTasks");
@@ -343,6 +351,7 @@ public class TimerEventSubprocessTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
     }
     
+    @Test
     @Deployment
     public void testStartingAdditionalTasksInterrupting() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startingAdditionalTasks");
@@ -385,6 +394,7 @@ public class TimerEventSubprocessTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
     }
     
+    @Test
     @Deployment(resources="org/flowable/engine/test/bpmn/event/timer/TimerEventSubprocessTest.testStartingAdditionalTasksInterrupting.bpmn20.xml")
     public void testStartingAdditionalTasksInterruptingWithMainEventSubProcessInterrupt() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startingAdditionalTasks");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/compatibility/BoundaryTimerEventRepeatCompatibilityTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/compatibility/BoundaryTimerEventRepeatCompatibilityTest.java
@@ -23,9 +23,11 @@ import org.flowable.job.service.impl.persistence.entity.TimerJobEntity;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
+import org.junit.jupiter.api.Test;
 
 public class BoundaryTimerEventRepeatCompatibilityTest extends TimerEventCompatibilityTest {
 
+    @Test
     @Deployment
     public void testRepeatWithoutEnd() throws Throwable {
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/compatibility/IntermediateTimerEventRepeatCompatibilityTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/compatibility/IntermediateTimerEventRepeatCompatibilityTest.java
@@ -25,9 +25,11 @@ import org.flowable.job.api.Job;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
+import org.junit.jupiter.api.Test;
 
 public class IntermediateTimerEventRepeatCompatibilityTest extends TimerEventCompatibilityTest {
 
+    @Test
     @Deployment
     public void testRepeatWithEnd() throws Throwable {
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/compatibility/StartTimerEventRepeatCompatibilityTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/compatibility/StartTimerEventRepeatCompatibilityTest.java
@@ -22,21 +22,22 @@ import org.flowable.common.engine.impl.util.DefaultClockImpl;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.api.event.TestFlowableEntityEventListener;
 import org.flowable.job.api.Job;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class StartTimerEventRepeatCompatibilityTest extends TimerEventCompatibilityTest {
 
     private TestFlowableEntityEventListener listener;
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
         listener = new TestFlowableEntityEventListener(Job.class);
         processEngineConfiguration.getEventDispatcher().addEventListener(listener);
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
 
         if (listener != null) {
             processEngineConfiguration.getEventDispatcher().removeEventListener(listener);
@@ -46,6 +47,7 @@ public class StartTimerEventRepeatCompatibilityTest extends TimerEventCompatibil
     /**
      * Timer repetition
      */
+    @Test
     public void testCycleDateStartTimerEvent() throws Exception {
         Clock previousClock = processEngineConfiguration.getClock();
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/exclusive/ExclusiveTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/exclusive/ExclusiveTaskTest.java
@@ -16,6 +16,7 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
 import org.flowable.job.service.impl.persistence.entity.JobEntity;
+import org.junit.jupiter.api.Test;
 
 /**
  * 
@@ -23,6 +24,7 @@ import org.flowable.job.service.impl.persistence.entity.JobEntity;
  */
 public class ExclusiveTaskTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testNonExclusiveService() {
         // start process
@@ -38,6 +40,7 @@ public class ExclusiveTaskTest extends PluggableFlowableTestCase {
         assertEquals(0, managementService.createJobQuery().count());
     }
 
+    @Test
     @Deployment
     public void testExclusiveService() {
         // start process
@@ -53,6 +56,7 @@ public class ExclusiveTaskTest extends PluggableFlowableTestCase {
         assertEquals(0, managementService.createJobQuery().count());
     }
 
+    @Test
     @Deployment
     public void testExclusiveServiceConcurrent() {
         // start process

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/exclusive/ExclusiveTimerEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/exclusive/ExclusiveTimerEventTest.java
@@ -18,9 +18,11 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.TimerJobQuery;
+import org.junit.jupiter.api.Test;
 
 public class ExclusiveTimerEventTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testCatchingTimerEvent() throws Exception {
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/gateway/EventBasedGatewayTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/gateway/EventBasedGatewayTest.java
@@ -23,6 +23,7 @@ import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Daniel Meyer
@@ -30,6 +31,7 @@ import org.flowable.job.api.Job;
  */
 public class EventBasedGatewayTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/gateway/EventBasedGatewayTest.testCatchAlertAndTimer.bpmn20.xml",
             "org/flowable/engine/test/bpmn/gateway/EventBasedGatewayTest.throwAlertSignal.bpmn20.xml" })
     public void testCatchSignalCancelsTimer() {
@@ -56,6 +58,7 @@ public class EventBasedGatewayTest extends PluggableFlowableTestCase {
         assertHistoricActivitiesDeleteReason(pi1, DeleteReason.EVENT_BASED_GATEWAY_CANCEL, "timerEvent");
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/gateway/EventBasedGatewayTest.testCatchAlertAndTimer.bpmn20.xml" })
     public void testCatchTimerCancelsSignal() {
 
@@ -86,6 +89,7 @@ public class EventBasedGatewayTest extends PluggableFlowableTestCase {
         assertHistoricActivitiesDeleteReason(processInstance, DeleteReason.EVENT_BASED_GATEWAY_CANCEL, "signalEvent");
     }
 
+    @Test
     @Deployment
     public void testCatchSignalAndMessageAndTimer() {
 
@@ -124,6 +128,7 @@ public class EventBasedGatewayTest extends PluggableFlowableTestCase {
         assertHistoricActivitiesDeleteReason(processInstance, DeleteReason.EVENT_BASED_GATEWAY_CANCEL, "timerEvent");
     }
 
+    @Test
     public void testConnectedToActivity() {
 
         try {
@@ -137,6 +142,7 @@ public class EventBasedGatewayTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment
     public void testAsyncEventBasedGateway() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("asyncEventBasedGateway");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/gateway/ExclusiveGatewayTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/gateway/ExclusiveGatewayTest.java
@@ -24,12 +24,14 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
  */
 public class ExclusiveGatewayTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testDivergingExclusiveGateway() {
         for (int i = 1; i <= 3; i++) {
@@ -39,6 +41,7 @@ public class ExclusiveGatewayTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testSkipExpression() {
         for (int i = 1; i <= 3; i++) {
@@ -52,6 +55,7 @@ public class ExclusiveGatewayTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testMergingExclusiveGateway() {
         runtimeService.startProcessInstanceByKey("exclusiveGwMerging");
@@ -60,12 +64,14 @@ public class ExclusiveGatewayTest extends PluggableFlowableTestCase {
 
     // If there are multiple outgoing seqFlow with valid conditions, the first
     // defined one should be chosen.
+    @Test
     @Deployment
     public void testMultipleValidConditions() {
         runtimeService.startProcessInstanceByKey("exclusiveGwMultipleValidConditions", CollectionUtil.singletonMap("input", 5));
         assertEquals("Task 2", taskService.createTaskQuery().singleResult().getName());
     }
 
+    @Test
     @Deployment
     public void testNoSequenceFlowSelected() {
         try {
@@ -79,6 +85,7 @@ public class ExclusiveGatewayTest extends PluggableFlowableTestCase {
     /**
      * Test for bug ACT-10: whitespaces/newlines in expressions lead to exceptions
      */
+    @Test
     @Deployment
     public void testWhitespaceInExpression() {
         // Starting a process instance will lead to an exception if whitespace
@@ -86,6 +93,7 @@ public class ExclusiveGatewayTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("whiteSpaceInExpression", CollectionUtil.singletonMap("input", 1));
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/gateway/ExclusiveGatewayTest.testDivergingExclusiveGateway.bpmn20.xml" })
     public void testUnknownVariableInExpression() {
         // Instead of 'input' we're starting a process instance with the name
@@ -98,6 +106,7 @@ public class ExclusiveGatewayTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testDecideBasedOnBeanProperty() {
         runtimeService.startProcessInstanceByKey("decisionBasedOnBeanProperty", CollectionUtil.singletonMap("order", new ExclusiveGatewayTestOrder(150)));
@@ -107,6 +116,7 @@ public class ExclusiveGatewayTest extends PluggableFlowableTestCase {
         assertEquals("Standard service", task.getName());
     }
 
+    @Test
     @Deployment
     public void testDecideBasedOnListOrArrayOfBeans() {
         List<ExclusiveGatewayTestOrder> orders = new ArrayList<>();
@@ -130,6 +140,7 @@ public class ExclusiveGatewayTest extends PluggableFlowableTestCase {
         assertEquals("Basic service", task.getName());
     }
 
+    @Test
     @Deployment
     public void testDecideBasedOnBeanMethod() {
         runtimeService.startProcessInstanceByKey("decisionBasedOnBeanMethod", CollectionUtil.singletonMap("order", new ExclusiveGatewayTestOrder(300)));
@@ -139,6 +150,7 @@ public class ExclusiveGatewayTest extends PluggableFlowableTestCase {
         assertEquals("Gold Member service", task.getName());
     }
 
+    @Test
     @Deployment
     public void testInvalidMethodExpression() {
         try {
@@ -149,6 +161,7 @@ public class ExclusiveGatewayTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testDefaultSequenceFlow() {
 
@@ -163,6 +176,7 @@ public class ExclusiveGatewayTest extends PluggableFlowableTestCase {
         assertEquals("Default input", task.getName());
     }
 
+    @Test
     public void testInvalidProcessDefinition() {
         String defaultFlowWithCondition = "<?xml version='1.0' encoding='UTF-8'?>"
                 + "<definitions id='definitions' xmlns='http://www.omg.org/spec/BPMN/20100524/MODEL' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xmlns:activiti='http://activiti.org/bpmn' targetNamespace='Examples'>"
@@ -193,6 +207,7 @@ public class ExclusiveGatewayTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment
     public void testAsyncExclusiveGateway() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("asyncExclusive", CollectionUtil.singletonMap("input", 1));
@@ -206,6 +221,7 @@ public class ExclusiveGatewayTest extends PluggableFlowableTestCase {
     }
 
     // From https://github.com/Activiti/Activiti/issues/796
+    @Test
     @Deployment
     public void testExclusiveDirectlyToEnd() {
         if (processEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.ACTIVITY)) {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/gateway/InclusiveGatewayDefaultFlowTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/gateway/InclusiveGatewayDefaultFlowTest.java
@@ -18,6 +18,9 @@ import java.util.Map;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class InclusiveGatewayDefaultFlowTest extends PluggableFlowableTestCase {
 
@@ -25,20 +28,19 @@ public class InclusiveGatewayDefaultFlowTest extends PluggableFlowableTestCase {
 
     private String deploymentId;
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
         deploymentId = repositoryService.createDeployment()
                 .addClasspathResource("org/flowable/engine/test/bpmn/gateway/InclusiveGatewayTest.defaultFlowTest.bpmn20.xml")
                 .deploy().getId();
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
         repositoryService.deleteDeployment(deploymentId, true);
-        super.tearDown();
     }
 
+    @Test
     public void testDefaultFlowOnly() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY);
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("usertask1").singleResult();
@@ -46,6 +48,7 @@ public class InclusiveGatewayDefaultFlowTest extends PluggableFlowableTestCase {
         assertEquals("usertask1", execution.getActivityId());
     }
 
+    @Test
     public void testCompatibleConditionFlow() {
         Map<String, Object> variables = new HashMap<>();
         variables.put("var1", "true");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/gateway/InclusiveGatewayTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/gateway/InclusiveGatewayTest.java
@@ -37,6 +37,7 @@ import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.task.api.Task;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
@@ -54,6 +55,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
     private static final String BEAN_TASK2_NAME = "Standard service";
     private static final String BEAN_TASK3_NAME = "Gold Member service";
 
+    @Test
     @Deployment
     public void testDivergingInclusiveGateway() {
         for (int i = 1; i <= 3; i++) {
@@ -76,6 +78,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testMergingInclusiveGateway() {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("inclusiveGwMerging", CollectionUtil.singletonMap("input", 2));
@@ -84,6 +87,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         runtimeService.deleteProcessInstance(pi.getId(), "testing deletion");
     }
 
+    @Test
     @Deployment
     public void testPartialMergingInclusiveGateway() {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("partialInclusiveGwMerging", CollectionUtil.singletonMap("input", 2));
@@ -98,6 +102,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         runtimeService.deleteProcessInstance(pi.getId(), "testing deletion");
     }
 
+    @Test
     @Deployment
     public void testNoSequenceFlowSelected() {
         try {
@@ -111,6 +116,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
     /**
      * Test for ACT-1216: When merging a concurrent execution the parent is not activated correctly
      */
+    @Test
     @Deployment
     public void testParentActivationOnNonJoiningEnd() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("parentActivationOnNonJoiningEnd");
@@ -159,6 +165,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
     /**
      * Test for bug ACT-10: whitespaces/newlines in expressions lead to exceptions
      */
+    @Test
     @Deployment
     public void testWhitespaceInExpression() {
         // Starting a process instance will lead to an exception if whitespace
@@ -167,6 +174,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("inclusiveWhiteSpaceInExpression", CollectionUtil.singletonMap("input", 1));
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/gateway/InclusiveGatewayTest.testDivergingInclusiveGateway.bpmn20.xml" })
     public void testUnknownVariableInExpression() {
         // Instead of 'input' we're starting a process instance with the name
@@ -179,6 +187,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testDecideBasedOnBeanProperty() {
         runtimeService.startProcessInstanceByKey("inclusiveDecisionBasedOnBeanProperty", CollectionUtil.singletonMap("order", new InclusiveGatewayTestOrder(150)));
@@ -193,6 +202,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         assertEquals(0, expectedNames.size());
     }
 
+    @Test
     @Deployment
     public void testDecideBasedOnListOrArrayOfBeans() {
         List<InclusiveGatewayTestOrder> orders = new ArrayList<>();
@@ -243,6 +253,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         assertEquals(0, expectedNames.size());
     }
 
+    @Test
     @Deployment
     public void testDecideBasedOnBeanMethod() {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("inclusiveDecisionBasedOnBeanMethod", CollectionUtil.singletonMap("order", new InclusiveGatewayTestOrder(200)));
@@ -270,6 +281,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment
     public void testInvalidMethodExpression() {
         try {
@@ -280,6 +292,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testDefaultSequenceFlow() {
         // Input == 1 -> default is not selected, other 2 tasks are selected
@@ -306,6 +319,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         assertEquals("Default input", task.getName());
     }
 
+    @Test
     @Deployment
     public void testNoIdOnSequenceFlow() {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("inclusiveNoIdOnSequenceFlow", CollectionUtil.singletonMap("input", 3));
@@ -330,6 +344,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
      *
      * In case of loops, special care needs to be taken in the algorithm, or else stackoverflows will happen very quickly.
      */
+    @Test
     @Deployment
     public void testLoop() {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("inclusiveTestLoop", CollectionUtil.singletonMap("counter", 1));
@@ -344,6 +359,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         assertProcessEnded(pi.getId());
     }
 
+    @Test
     @Deployment
     public void testJoinAfterSubprocesses() {
         // Test case to test act-1204
@@ -399,6 +415,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testJoinAfterParallelGateway() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("InclusiveGateway");
@@ -424,6 +441,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         assertNotNull(execution);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/gateway/InclusiveGatewayTest.testJoinAfterCall.bpmn20.xml",
             "org/flowable/engine/test/bpmn/gateway/InclusiveGatewayTest.testJoinAfterCallSubProcess.bpmn20.xml" })
     public void testJoinAfterCall() {
@@ -462,6 +480,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         assertNull(processInstance);
     }
 
+    @Test
     @Deployment
     public void testAsyncBehavior() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("async");
@@ -469,6 +488,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
     }
 
+    @Test
     @Deployment
     public void testDirectSequenceFlow() {
         Map<String, Object> varMap = new HashMap<>();
@@ -495,6 +515,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         assertTrue(processInstance.isEnded());
     }
 
+    @Test
     @Deployment
     public void testSkipExpression() {
         Map<String, Object> varMap = new HashMap<>();
@@ -524,6 +545,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         assertTrue(processInstance.isEnded());
     }
 
+    @Test
     @Deployment
     public void testMultipleProcessInstancesMergedBug() {
 
@@ -566,6 +588,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
     }
 
     // See https://github.com/flowable/flowable-engine/issues/582
+    @Test
     @Deployment
     public void testInclusiveGatewayInEventSubProcess() {
 
@@ -632,6 +655,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         return result;
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/gateway/InclusiveGatewayTest.insideMultiInstanceParallelSubProcess.bpmn20.xml" })
     public void testInclusiveGatewayInclusiveGatewayInsideParallelMultiInstanceSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("inclusiveGatewayInsideParallelMultiInstanceSubProcess");
@@ -720,6 +744,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/gateway/InclusiveGatewayTest.insideMultiInstanceSequentialSubProcess.bpmn20.xml" })
     public void testInclusiveGatewayInclusiveGatewayInsideSequentialMultiInstanceSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("inclusiveGatewayInsideSequentialMultiInstanceSubProcess");
@@ -846,6 +871,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
     }
 
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/gateway/InclusiveGatewayTest.inSubProcessNestedInMultiInstanceParallelSubProcess.bpmn20.xml" })
     public void testInSubProcessNestedInMultiInstanceParallelSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("inclusiveGatewayInsideSubProcessNestedInMultiInstanceParallelSubProcess");
@@ -997,6 +1023,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = {"org/flowable/engine/test/bpmn/gateway/InclusiveGatewayTest.inCalledActivityNestedInMultiInstanceParallelSubProcess.bpmn20.xml",
     "org/flowable/engine/test/bpmn/gateway/InclusiveGatewayTest.simpleParallelFlow.bpmn20.xml"})
     public void testInCalledActivityNestedInMultiInstanceSubProcess() {
@@ -1141,6 +1168,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
     }
 
     /*
+     * @Test
      * @Deployment public void testAsyncBehavior() { for (int i = 0; i < 100; i++) { ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("async"); } assertEquals(200,
      * managementService.createJobQuery().count()); waitForJobExecutorToProcessAllJobs(120000, 5000); assertEquals(0, managementService.createJobQuery().count()); assertEquals(0,
      * runtimeService.createProcessInstanceQuery().count()); }
@@ -1148,6 +1176,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
 
     // /* This test case is related to ACT-1877 */
     //
+    // @Test
     // @Deployment(resources={"org/flowable/engine/test/bpmn/gateway/InclusiveGatewayTest.testWithSignalBoundaryEvent.bpmn20.xml"})
     // public void testJoinAfterBoudarySignalEvent() {
     //

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/gateway/ParallelGatewayTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/gateway/ParallelGatewayTest.java
@@ -30,6 +30,7 @@ import org.flowable.engine.test.Deployment;
 import org.flowable.task.api.Task;
 import org.flowable.task.api.TaskQuery;
 import org.junit.Assert;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
@@ -40,30 +41,35 @@ public class ParallelGatewayTest extends PluggableFlowableTestCase {
      * Case where there is a parallel gateway that splits into 3 paths of execution, that are immediately joined, without any wait states in between. In the end, no executions should be in the
      * database.
      */
+    @Test
     @Deployment
     public void testSplitMergeNoWaitstates() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("forkJoinNoWaitStates");
         assertTrue(processInstance.isEnded());
     }
 
+    @Test
     @Deployment
     public void testUnstructuredConcurrencyTwoForks() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("unstructuredConcurrencyTwoForks");
         assertTrue(processInstance.isEnded());
     }
 
+    @Test
     @Deployment
     public void testUnstructuredConcurrencyTwoJoins() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("unstructuredConcurrencyTwoJoins");
         assertTrue(processInstance.isEnded());
     }
 
+    @Test
     @Deployment
     public void testForkFollowedByOnlyEndEvents() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("forkFollowedByEndEvents");
         assertTrue(processInstance.isEnded());
     }
 
+    @Test
     @Deployment
     public void testNestedForksFollowedByEndEvents() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("nestedForksFollowedByEndEvents");
@@ -71,6 +77,7 @@ public class ParallelGatewayTest extends PluggableFlowableTestCase {
     }
 
     // ACT-482
+    @Test
     @Deployment
     public void testNestedForkJoin() {
         runtimeService.startProcessInstanceByKey("nestedForkJoin");
@@ -113,6 +120,7 @@ public class ParallelGatewayTest extends PluggableFlowableTestCase {
     /**
      * https://activiti.atlassian.net/browse/ACT-1222
      */
+    @Test
     @Deployment
     public void testRecyclingExecutionWithCallActivity() {
         runtimeService.startProcessInstanceByKey("parent-process");
@@ -143,6 +151,7 @@ public class ParallelGatewayTest extends PluggableFlowableTestCase {
     }
 
     // Test to verify ACT-1755
+    @Test
     @Deployment
     public void testHistoryTables() {
         if (processEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.ACTIVITY)) {
@@ -156,6 +165,7 @@ public class ParallelGatewayTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testAsyncBehavior() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("async");
@@ -164,11 +174,13 @@ public class ParallelGatewayTest extends PluggableFlowableTestCase {
     }
 
     /*
+     * @Test
      * @Deployment public void testAsyncBehavior() { for (int i = 0; i < 100; i++) { ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("async"); } assertEquals(200,
      * managementService.createJobQuery().count()); waitForJobExecutorToProcessAllJobs(120000, 5000); assertEquals(0, managementService.createJobQuery().count()); assertEquals(0,
      * runtimeService.createProcessInstanceQuery().count()); }
      */
 
+    @Test
     @Deployment
     public void testHistoricActivityInstanceEndTimes() {
         runtimeService.startProcessInstanceByKey("nestedForkJoin");
@@ -183,6 +195,7 @@ public class ParallelGatewayTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testNonTerminatingEndEventShouldNotRemoveSubscriptions() {
         ProcessDefinition processDefinition = repositoryService

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/java/EventJavaTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/java/EventJavaTest.java
@@ -28,12 +28,14 @@ import org.flowable.bpmn.model.UserTask;
 import org.flowable.common.engine.impl.util.io.InputStreamSource;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.repository.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tijs Rademakers
  */
 public class EventJavaTest extends PluggableFlowableTestCase {
 
+    @Test
     public void testStartEventWithExecutionListener() throws Exception {
         BpmnModel bpmnModel = new BpmnModel();
         Process process = new Process();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/mail/EmailSendTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/mail/EmailSendTaskTest.java
@@ -36,6 +36,7 @@ import org.flowable.common.engine.impl.history.HistoryLevel;
 import org.flowable.common.engine.impl.util.CollectionUtil;
 import org.flowable.engine.impl.test.HistoryTestHelper;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 import org.subethamail.wiser.WiserMessage;
 
 /**
@@ -44,6 +45,7 @@ import org.subethamail.wiser.WiserMessage;
  */
 public class EmailSendTaskTest extends EmailTestCase {
 
+    @Test
     @Deployment
     public void testSimpleTextMail() throws Exception {
         runtimeService.startProcessInstanceByKey("simpleTextOnly");
@@ -55,6 +57,7 @@ public class EmailSendTaskTest extends EmailTestCase {
         assertEmailSend(message, false, "Hello Kermit!", "This a text only e-mail.", "flowable@localhost", Collections.singletonList("kermit@activiti.org"), null);
     }
 
+    @Test
     @Deployment
     public void testSimpleTextMailMultipleRecipients() {
         runtimeService.startProcessInstanceByKey("simpleTextOnlyMultipleRecipients");
@@ -75,6 +78,7 @@ public class EmailSendTaskTest extends EmailTestCase {
         assertEquals("mispiggy@activiti.org", recipients.get(2));
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/bpmn/mail/EmailSendTaskTest.testSimpleTextMailMultipleRecipients.bpmn20.xml")
     public void testSimpleTextMailMultipleRecipientsAndForceTo() {
         processEngineConfiguration.setMailServerForceTo("no-reply@flowable.org, no-reply2@flowable.org");
@@ -89,6 +93,7 @@ public class EmailSendTaskTest extends EmailTestCase {
             );
     }
 
+    @Test
     @Deployment
     public void testTextMailExpressions() throws Exception {
 
@@ -113,6 +118,7 @@ public class EmailSendTaskTest extends EmailTestCase {
                 Collections.singletonList(recipient), null);
     }
 
+    @Test
     @Deployment
     public void testCcAndBcc() throws Exception {
         runtimeService.startProcessInstanceByKey("ccAndBcc");
@@ -130,6 +136,7 @@ public class EmailSendTaskTest extends EmailTestCase {
             );
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/bpmn/mail/EmailSendTaskTest.testCcAndBcc.bpmn20.xml")
     public void testCcAndBccWithForceTo() throws Exception {
         processEngineConfiguration.setMailServerForceTo("no-reply@flowable");
@@ -148,6 +155,7 @@ public class EmailSendTaskTest extends EmailTestCase {
             );
     }
 
+    @Test
     @Deployment
     public void testHtmlMail() throws Exception {
         runtimeService.startProcessInstanceByKey("htmlMail", CollectionUtil.singletonMap("gender", "male"));
@@ -157,6 +165,7 @@ public class EmailSendTaskTest extends EmailTestCase {
         assertEmailSend(messages.get(0), true, "Test", "Mr. <b>Kermit</b>", "flowable@localhost", Collections.singletonList("kermit@activiti.org"), null);
     }
 
+    @Test
     @Deployment
     public void testTextMailWithFileAttachment() throws Exception {
         HashMap<String, Object> vars = new HashMap<>();
@@ -172,6 +181,7 @@ public class EmailSendTaskTest extends EmailTestCase {
         assertEquals(new AttachmentsBean().getFile().getName(), attachmentFileName);
     }
 
+    @Test
     @Deployment
     public void testTextMailWithFileAttachments() throws Exception {
         HashMap<String, Object> vars = new HashMap<>();
@@ -190,6 +200,7 @@ public class EmailSendTaskTest extends EmailTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testTextMailWithFileAttachmentsByPath() throws Exception {
         HashMap<String, Object> vars = new HashMap<>();
@@ -208,6 +219,7 @@ public class EmailSendTaskTest extends EmailTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testTextMailWithDataSourceAttachment() throws Exception {
         String fileName = "file-name-to-be-displayed";
@@ -227,6 +239,7 @@ public class EmailSendTaskTest extends EmailTestCase {
         assertEquals(fileName, attachmentFileName);
     }
 
+    @Test
     @Deployment
     public void testTextMailWithNotExistingFileAttachment() throws Exception {
         HashMap<String, Object> vars = new HashMap<>();
@@ -239,6 +252,7 @@ public class EmailSendTaskTest extends EmailTestCase {
         assertFalse(message.getMimeMessage().getContent() instanceof MimeMultipart);
     }
 
+    @Test
     @Deployment
     public void testHtmlMailWithFileAttachment() throws Exception {
         HashMap<String, Object> vars = new HashMap<>();
@@ -255,6 +269,7 @@ public class EmailSendTaskTest extends EmailTestCase {
         assertEquals(new AttachmentsBean().getFile().getName(), attachmentFileName);
     }
 
+    @Test
     @Deployment
     public void testInvalidAddress() throws Exception {
         try {
@@ -267,6 +282,7 @@ public class EmailSendTaskTest extends EmailTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testMissingToAddress() {
         assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("missingToAddress"))
@@ -274,6 +290,7 @@ public class EmailSendTaskTest extends EmailTestCase {
             .hasMessage("No recipient could be found for sending email");
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/bpmn/mail/EmailSendTaskTest.testMissingToAddress.bpmn20.xml")
     public void testMissingToAddressWithForceTo() {
         processEngineConfiguration.setMailServerForceTo("no-reply@flowable.org");
@@ -282,6 +299,7 @@ public class EmailSendTaskTest extends EmailTestCase {
             .hasMessage("No recipient could be found for sending email");
     }
 
+    @Test
     @Deployment
     public void testInvalidAddressWithoutException() throws Exception {
         String piId = runtimeService.startProcessInstanceByKey("invalidAddressWithoutException").getId();
@@ -290,6 +308,7 @@ public class EmailSendTaskTest extends EmailTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testInvalidAddressWithoutExceptionVariableName() throws Exception {
         String piId = runtimeService.startProcessInstanceByKey("invalidAddressWithoutException").getId();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/mail/EmailServiceTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/mail/EmailServiceTaskTest.java
@@ -36,6 +36,7 @@ import org.flowable.common.engine.impl.history.HistoryLevel;
 import org.flowable.common.engine.impl.util.CollectionUtil;
 import org.flowable.engine.impl.test.HistoryTestHelper;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 import org.subethamail.wiser.WiserMessage;
 
 /**
@@ -44,6 +45,7 @@ import org.subethamail.wiser.WiserMessage;
  */
 public class EmailServiceTaskTest extends EmailTestCase {
 
+    @Test
     @Deployment
     public void testSimpleTextMail() throws Exception {
         String procId = runtimeService.startProcessInstanceByKey("simpleTextOnly").getId();
@@ -56,6 +58,7 @@ public class EmailServiceTaskTest extends EmailTestCase {
         assertProcessEnded(procId);
     }
 
+    @Test
     public void testSimpleTextMailWhenMultiTenant() throws Exception {
         String tenantId = "myEmailTenant";
 
@@ -75,6 +78,7 @@ public class EmailServiceTaskTest extends EmailTestCase {
         deleteDeployments();
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/bpmn/mail/EmailSendTaskTest.testSimpleTextMail.bpmn20.xml", tenantId = "forceToEmailTenant")
     public void testSimpleTextMailWhenMultiTenantWithForceTo() throws Exception {
         String tenantId = "forceToEmailTenant";
@@ -98,6 +102,7 @@ public class EmailServiceTaskTest extends EmailTestCase {
         assertProcessEnded(procId);
     }
 
+    @Test
     public void testSimpleTextMailForNonExistentTenant() throws Exception {
         String tenantId = "nonExistentTenant";
 
@@ -117,6 +122,7 @@ public class EmailServiceTaskTest extends EmailTestCase {
         deleteDeployments();
     }
 
+    @Test
     public void testSimpleTextMailForNonExistentTenantWithForceTo() throws Exception {
         processEngineConfiguration.setMailServerForceTo("no-reply@flowable.org");
         String tenantId = "nonExistentTenant";
@@ -137,6 +143,7 @@ public class EmailServiceTaskTest extends EmailTestCase {
         deleteDeployments();
     }
 
+    @Test
     @Deployment
     public void testSimpleTextMailMultipleRecipients() {
         runtimeService.startProcessInstanceByKey("simpleTextOnlyMultipleRecipients");
@@ -157,6 +164,7 @@ public class EmailServiceTaskTest extends EmailTestCase {
         assertEquals("mispiggy@activiti.org", recipients.get(2));
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/bpmn/mail/EmailServiceTaskTest.testSimpleTextMailMultipleRecipients.bpmn20.xml")
     public void testSimpleTextMailMultipleRecipientsAndForceTo() {
         processEngineConfiguration.setMailServerForceTo("no-reply@flowable.org, no-reply2@flowable.org");
@@ -171,6 +179,7 @@ public class EmailServiceTaskTest extends EmailTestCase {
             );
     }
 
+    @Test
     @Deployment
     public void testTextMailExpressions() throws Exception {
 
@@ -195,6 +204,7 @@ public class EmailServiceTaskTest extends EmailTestCase {
                 recipient), null);
     }
 
+    @Test
     @Deployment
     public void testCcAndBcc() throws Exception {
         runtimeService.startProcessInstanceByKey("ccAndBcc");
@@ -212,6 +222,7 @@ public class EmailServiceTaskTest extends EmailTestCase {
             );
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/bpmn/mail/EmailServiceTaskTest.testCcAndBcc.bpmn20.xml")
     public void testCcAndBccWithForceTo() throws Exception {
         processEngineConfiguration.setMailServerForceTo("no-reply@flowable");
@@ -230,6 +241,7 @@ public class EmailServiceTaskTest extends EmailTestCase {
             );
     }
 
+    @Test
     @Deployment
     public void testHtmlMail() throws Exception {
         runtimeService.startProcessInstanceByKey("htmlMail", CollectionUtil.singletonMap("gender", "male"));
@@ -240,6 +252,7 @@ public class EmailServiceTaskTest extends EmailTestCase {
                 "kermit@activiti.org"), null);
     }
 
+    @Test
     @Deployment
     public void testVariableTemplatedMail() throws Exception {
         Map<String, Object> vars = new HashMap<>();
@@ -253,6 +266,7 @@ public class EmailServiceTaskTest extends EmailTestCase {
                 "kermit@activiti.org"), null);
     }
 
+    @Test
     @Deployment
     public void testTextMailWithFileAttachment() throws Exception {
         HashMap<String, Object> vars = new HashMap<>();
@@ -268,6 +282,7 @@ public class EmailServiceTaskTest extends EmailTestCase {
         assertEquals(new AttachmentsBean().getFile().getName(), attachmentFileName);
     }
 
+    @Test
     @Deployment
     public void testTextMailWithFileAttachments() throws Exception {
         HashMap<String, Object> vars = new HashMap<>();
@@ -286,6 +301,7 @@ public class EmailServiceTaskTest extends EmailTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testTextMailWithFileAttachmentsByPath() throws Exception {
         HashMap<String, Object> vars = new HashMap<>();
@@ -304,6 +320,7 @@ public class EmailServiceTaskTest extends EmailTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testTextMailWithDataSourceAttachment() throws Exception {
         String fileName = "file-name-to-be-displayed";
@@ -323,6 +340,7 @@ public class EmailServiceTaskTest extends EmailTestCase {
         assertEquals(fileName, attachmentFileName);
     }
 
+    @Test
     @Deployment
     public void testTextMailWithNotExistingFileAttachment() throws Exception {
         HashMap<String, Object> vars = new HashMap<>();
@@ -335,6 +353,7 @@ public class EmailServiceTaskTest extends EmailTestCase {
         assertFalse(message.getMimeMessage().getContent() instanceof MimeMultipart);
     }
 
+    @Test
     @Deployment
     public void testHtmlMailWithFileAttachment() throws Exception {
         HashMap<String, Object> vars = new HashMap<>();
@@ -351,6 +370,7 @@ public class EmailServiceTaskTest extends EmailTestCase {
         assertEquals(new AttachmentsBean().getFile().getName(), attachmentFileName);
     }
 
+    @Test
     @Deployment
     public void testInvalidAddress() throws Exception {
         try {
@@ -363,6 +383,7 @@ public class EmailServiceTaskTest extends EmailTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testInvalidAddressWithoutException() throws Exception {
         String piId = runtimeService.startProcessInstanceByKey("invalidAddressWithoutException").getId();
@@ -371,6 +392,7 @@ public class EmailServiceTaskTest extends EmailTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testInvalidAddressWithoutExceptionVariableName() throws Exception {
         String piId = runtimeService.startProcessInstanceByKey("invalidAddressWithoutException").getId();
@@ -379,6 +401,7 @@ public class EmailServiceTaskTest extends EmailTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testMissingToAddress() {
         assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("missingToAddress"))
@@ -386,6 +409,7 @@ public class EmailServiceTaskTest extends EmailTestCase {
             .hasMessage("No recipient could be found for sending email");
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/bpmn/mail/EmailServiceTaskTest.testMissingToAddress.bpmn20.xml")
     public void testMissingToAddressWithForceTo() {
         processEngineConfiguration.setMailServerForceTo("no-reply@flowable.org");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/mail/EmailTestCase.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/mail/EmailTestCase.java
@@ -18,20 +18,23 @@ import java.util.Map;
 
 import org.flowable.engine.cfg.MailServerInfo;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.subethamail.wiser.Wiser;
 
 /**
  * @author Joram Barrez
  */
+@Tag("email")
 public abstract class EmailTestCase extends PluggableFlowableTestCase {
 
     protected Wiser wiser;
     private String initialForceTo;
     private Map<String, MailServerInfo> initialMailServers;
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
 
         initialForceTo = processEngineConfiguration.getMailServerForceTo();
         Map<String, MailServerInfo> mailServers = processEngineConfiguration.getMailServers();
@@ -52,14 +55,13 @@ public abstract class EmailTestCase extends PluggableFlowableTestCase {
         }
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
         wiser.stop();
 
         // Fix for slow Jenkins
         Thread.sleep(250L);
 
-        super.tearDown();
         processEngineConfiguration.setMailServerForceTo(initialForceTo);
         processEngineConfiguration.setMailServers(initialMailServers);
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/multiinstance/DynamicMultiInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/multiinstance/DynamicMultiInstanceTest.java
@@ -25,6 +25,7 @@ import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.task.api.TaskQuery;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -33,6 +34,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
  */
 public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.sequentialUserTasks.bpmn20.xml" })
     public void testAddSequentialUserTask() {
         if (!processEngineConfiguration.isAsyncHistoryEnabled()) {
@@ -67,6 +69,7 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
         }
     }
     
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.sequentialUserTasks.bpmn20.xml" })
     public void testDeleteSequentialUserTask() {
         if (!processEngineConfiguration.isAsyncHistoryEnabled()) {
@@ -93,6 +96,7 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
         }
     }
     
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.sequentialUserTasks.bpmn20.xml" })
     public void testDeleteSequentialUserTaskWithCompletion() {
         if (!processEngineConfiguration.isAsyncHistoryEnabled()) {
@@ -119,6 +123,7 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testParallelUserTasks() {
         if (!processEngineConfiguration.isAsyncHistoryEnabled()) {
@@ -147,6 +152,7 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
         }
     }
     
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/DynamicMultiInstanceTest.testParallelUserTasks.bpmn20.xml" })
     public void testDeleteParallelUserTasks() {
         if (!processEngineConfiguration.isAsyncHistoryEnabled()) {
@@ -171,6 +177,7 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
         }
     }
     
+    @Test
     @Deployment
     public void testParallelUserTasksBasedOnCollection() {
         if (!processEngineConfiguration.isAsyncHistoryEnabled()) {
@@ -207,6 +214,7 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testNestedParallelCallActivity.bpmn20.xml",
         "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml" })
     public void testAddNestedParallelCallActivity() {
@@ -229,6 +237,7 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
         }
     }
         
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testNestedParallelCallActivity.bpmn20.xml",
         "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml" })
     public void testDeleteNestedParallelCallActivity() {
@@ -262,6 +271,7 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
         }
     }
     
+    @Test
     @Deployment
     public void testSequentialSubProcessCompletionCondition() {
         if (!processEngineConfiguration.isAsyncHistoryEnabled()) {
@@ -285,6 +295,7 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
         }
     }
     
+    @Test
     @Deployment(resources = {"org/flowable/engine/test/bpmn/multiinstance/DynamicMultiInstanceTest.testSequentialSubProcessCompletionCondition.bpmn20.xml"})
     public void testDeleteSequentialSubProcessCompletionCondition() {
         if (!processEngineConfiguration.isAsyncHistoryEnabled()) {
@@ -321,6 +332,7 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
         }
     }
     
+    @Test
     @Deployment(resources = {"org/flowable/engine/test/bpmn/multiinstance/DynamicMultiInstanceTest.testSequentialSubProcessCompletionCondition.bpmn20.xml"})
     public void testDeleteSequentialSubProcessAsCompleted() {
         if (!processEngineConfiguration.isAsyncHistoryEnabled()) {
@@ -357,6 +369,7 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
         }
     }
     
+    @Test
     @Deployment(resources = {"org/flowable/engine/test/bpmn/multiinstance/DynamicMultiInstanceTest.testSequentialSubProcessCompletionCondition.bpmn20.xml"})
     public void testChangeCompletionConditionSequentialSubProcess() {
         if (!processEngineConfiguration.isAsyncHistoryEnabled()) {
@@ -384,6 +397,7 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
         }
     }
     
+    @Test
     @Deployment
     public void testMultipleParallelSubProcess() {
         if (!processEngineConfiguration.isAsyncHistoryEnabled()) {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.java
@@ -43,6 +43,7 @@ import org.flowable.task.api.Task;
 import org.flowable.task.api.TaskQuery;
 import org.flowable.task.api.history.HistoricTaskInstance;
 import org.flowable.task.service.delegate.DelegateTask;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
@@ -50,11 +51,13 @@ import org.flowable.task.service.delegate.DelegateTask;
  */
 public class MultiInstanceTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.sequentialUserTasks.bpmn20.xml" })
     public void testSequentialUserTasks() {
         checkSequentialUserTasks("miSequentialUserTasks");
     }
 
+    @Test
     @Deployment
     public void testSequentialUserTasksCustomExtensions() {
         checkSequentialUserTasks("miSequentialUserTasksCustomExtensions");
@@ -82,6 +85,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.sequentialUserTasks.bpmn20.xml" })
     public void testSequentialUserTasksHistory() {
         String procId = runtimeService.startProcessInstanceByKey("miSequentialUserTasks", CollectionUtil.singletonMap("nrOfLoops", 4)).getId();
@@ -113,6 +117,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.sequentialUserTasks.bpmn20.xml" })
     public void testSequentialUserTasksWithTimer() {
         String procId = runtimeService.startProcessInstanceByKey("miSequentialUserTasks", CollectionUtil.singletonMap("nrOfLoops", 3)).getId();
@@ -131,6 +136,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.sequentialUserTasks.bpmn20.xml" })
     public void testSequentialUserTasksCompletionCondition() {
         String procId = runtimeService.startProcessInstanceByKey("miSequentialUserTasks", CollectionUtil.singletonMap("nrOfLoops", 10)).getId();
@@ -144,6 +150,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment
     public void testNestedSequentialUserTasks() {
         String procId = runtimeService.startProcessInstanceByKey("miNestedSequentialUserTasks").getId();
@@ -157,6 +164,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment
     public void testParallelUserTasks() {
         String procId = runtimeService.startProcessInstanceByKey("miParallelUserTasks").getId();
@@ -173,6 +181,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testParallelUserTasks.bpmn20.xml" })
     public void testParallelUserTasksHistory() {
         runtimeService.startProcessInstanceByKey("miParallelUserTasks");
@@ -205,6 +214,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testParallelUserTasksWithTimer() {
         String procId = runtimeService.startProcessInstanceByKey("miParallelUserTasksWithTimer").getId();
@@ -223,6 +233,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment
     public void testParallelUserTasksCompletionCondition() {
         String procId = runtimeService.startProcessInstanceByKey("miParallelUserTasksCompletionCondition").getId();
@@ -238,6 +249,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment
     public void testParallelUserTasksBasedOnCollection() {
         List<String> assigneeList = Arrays.asList("kermit", "gonzo", "mispiggy", "fozzie", "bubba");
@@ -259,6 +271,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment
     public void testParallelUserTasksCustomCollectionStringExtension() {
     	checkParallelUserTasksCustomCollection("miParallelUserTasksCollection");
@@ -288,6 +301,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getProcessInstanceId());
     }
 
+    @Test
     @Deployment
     public void testParallelUserTasksCustomCollectionStringExtensionDelegateExpression() {
     	checkParallelUserTasksCustomCollectionDelegateExpression("miParallelUserTasksCollection");
@@ -314,31 +328,37 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment
     public void testParallelUserTasksCustomCollectionExpressionExtension() {
     	checkParallelUserTasksCustomCollection("miParallelUserTasksCollection");
     }
 
+    @Test
     @Deployment
     public void testParallelUserTasksCustomCollectionExpressionExtensionDelegateExpression() {
     	checkParallelUserTasksCustomCollectionDelegateExpression("miParallelUserTasksCollection");
     }
 
+    @Test
     @Deployment
     public void testParallelUserTasksCustomExtensionsCollection() {
     	checkParallelUserTasksCustomCollection("miParallelUserTasksCollection");
     }
 
+    @Test
     @Deployment
     public void testParallelUserTasksCustomExtensionsCollectionDelegateExpression() {
     	checkParallelUserTasksCustomCollectionDelegateExpression("miParallelUserTasksCollection");
     }
 
+    @Test
     @Deployment
     public void testParallelUserTasksCustomExtensions() {
         checkParallelUserTasksCustomExtensions("miParallelUserTasks");
     }
 
+    @Test
     @Deployment
     public void testParallelUserTasksCustomExtensionsLoopIndexVariable() {
         checkParallelUserTasksCustomExtensions("miParallelUserTasksLoopVariable");
@@ -369,6 +389,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getProcessInstanceId());
     }
 
+    @Test
     @Deployment
     public void testParallelUserTasksExecutionAndTaskListeners() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("miParallelUserTasks");
@@ -387,6 +408,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
     
+    @Test
     @Deployment
     public void testExecutionListener() {
         Map<String, Object> vars = new HashMap<>();
@@ -415,6 +437,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
     
+    @Test
     @Deployment
     public void testSequentialExecutionListener() {
         Map<String, Object> vars = new HashMap<>();
@@ -457,6 +480,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment
     public void testNestedParallelUserTasks() {
         String procId = runtimeService.startProcessInstanceByKey("miNestedParallelUserTasks").getId();
@@ -470,6 +494,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment
     public void testSequentialScriptTasks() {
         Map<String, Object> vars = new HashMap<>();
@@ -480,6 +505,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertEquals(10, sum);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testSequentialScriptTasks.bpmn20.xml" })
     public void testSequentialScriptTasksHistory() {
         Map<String, Object> vars = new HashMap<>();
@@ -500,6 +526,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testSequentialScriptTasksCompletionCondition() {
         runtimeService.startProcessInstanceByKey("miSequentialScriptTaskCompletionCondition").getId();
@@ -520,6 +547,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertEquals(5, sum);
     }
 
+    @Test
     @Deployment
     public void testParallelScriptTasks() {
         Map<String, Object> vars = new HashMap<>();
@@ -543,6 +571,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertEquals(45, sum);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testParallelScriptTasks.bpmn20.xml" })
     public void testParallelScriptTasksHistory() {
         Map<String, Object> vars = new HashMap<>();
@@ -560,6 +589,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testParallelScriptTasksCompletionCondition() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("miParallelScriptTaskCompletionCondition");
@@ -571,6 +601,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testParallelScriptTasksCompletionCondition.bpmn20.xml" })
     public void testParallelScriptTasksCompletionConditionHistory() {
         runtimeService.startProcessInstanceByKey("miParallelScriptTaskCompletionCondition");
@@ -580,6 +611,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testSequentialSubProcess() {
         String procId = runtimeService.startProcessInstanceByKey("miSequentialSubprocess").getId();
@@ -605,6 +637,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment
     public void testSequentialSubProcessEndEvent() {
         // ACT-1185: end-event in subprocess causes inactivated execution
@@ -630,6 +663,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testSequentialSubProcess.bpmn20.xml" })
     public void testSequentialSubProcessHistory() {
         runtimeService.startProcessInstanceByKey("miSequentialSubprocess");
@@ -660,6 +694,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testSequentialSubProcessWithTimer() {
         String procId = runtimeService.startProcessInstanceByKey("miSequentialSubprocessWithTimer").getId();
@@ -684,6 +719,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment
     public void testSequentialSubProcessCompletionCondition() {
         String procId = runtimeService.startProcessInstanceByKey("miSequentialSubprocessCompletionCondition").getId();
@@ -703,6 +739,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment
     public void testNestedSequentialSubProcess() {
         String procId = runtimeService.startProcessInstanceByKey("miNestedSequentialSubProcess").getId();
@@ -716,6 +753,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment
     public void testNestedSequentialSubProcessWithTimer() {
         String procId = runtimeService.startProcessInstanceByKey("miNestedSequentialSubProcessWithTimer").getId();
@@ -742,6 +780,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment
     public void testParallelSubProcess() {
         String procId = runtimeService.startProcessInstanceByKey("miParallelSubprocess").getId();
@@ -755,6 +794,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testParallelSubProcess.bpmn20.xml" })
     public void testParallelSubProcessHistory() {
         runtimeService.startProcessInstanceByKey("miParallelSubprocess");
@@ -773,6 +813,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testParallelSubProcessWithTimer() {
         String procId = runtimeService.startProcessInstanceByKey("miParallelSubprocessWithTimer").getId();
@@ -795,6 +836,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment
     public void testParallelSubProcessCompletionCondition() {
         String procId = runtimeService.startProcessInstanceByKey("miParallelSubprocessCompletionCondition").getId();
@@ -826,6 +868,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment
     public void testParallelSubProcessAllAutomatic() {
         String procId = runtimeService.startProcessInstanceByKey("miParallelSubprocessAllAutomatics", CollectionUtil.singletonMap("nrOfLoops", 5)).getId();
@@ -846,6 +889,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testParallelSubProcessAllAutomatic.bpmn20.xml" })
     public void testParallelSubProcessAllAutomaticCompletionCondition() {
         String procId = runtimeService.startProcessInstanceByKey("miParallelSubprocessAllAutomatics", CollectionUtil.singletonMap("nrOfLoops", 10)).getId();
@@ -866,6 +910,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment
     public void testNestedParallelSubProcess() {
         String procId = runtimeService.startProcessInstanceByKey("miNestedParallelSubProcess").getId();
@@ -878,6 +923,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment
     public void testNestedParallelSubProcessWithTimer() {
         String procId = runtimeService.startProcessInstanceByKey("miNestedParallelSubProcess").getId();
@@ -900,6 +946,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testCallActivityLocalVariables.bpmn20.xml",
             "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml" })
     public void testCallActivityLocalVariables() {
@@ -930,6 +977,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertProcessEnded(procId);
     }
     
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testCallActivityNormalVariables.bpmn20.xml",
             "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml" })
         public void testCallActivityNormalVariables() {
@@ -960,6 +1008,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertProcessEnded(procId);
     }
     
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testSequentialCallActivity.bpmn20.xml",
     "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml" })
 public void testSequentialCallActivity() {
@@ -977,6 +1026,7 @@ for (int i = 0; i < 3; i++) {
 assertProcessEnded(procId);
 }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testSequentialCallActivityWithList.bpmn20.xml")
     public void testSequentialCallActivityWithList() {
         ArrayList<String> list = new ArrayList<>();
@@ -1011,6 +1061,7 @@ assertProcessEnded(procId);
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testSequentialCallActivityWithTimer.bpmn20.xml",
             "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml" })
     public void testSequentialCallActivityWithTimer() {
@@ -1036,6 +1087,7 @@ assertProcessEnded(procId);
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testParallelCallActivity.bpmn20.xml",
             "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml" })
     public void testParallelCallActivity() {
@@ -1049,6 +1101,7 @@ assertProcessEnded(procId);
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testParallelCallActivity.bpmn20.xml",
             "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml" })
     public void testParallelCallActivityHistory() {
@@ -1089,6 +1142,7 @@ assertProcessEnded(procId);
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testParallelCallActivityWithTimer.bpmn20.xml",
             "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml" })
     public void testParallelCallActivityWithTimer() {
@@ -1111,6 +1165,7 @@ assertProcessEnded(procId);
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testNestedSequentialCallActivity.bpmn20.xml",
             "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml" })
     public void testNestedSequentialCallActivity() {
@@ -1128,6 +1183,7 @@ assertProcessEnded(procId);
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testNestedSequentialCallActivityWithTimer.bpmn20.xml",
             "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml" })
     public void testNestedSequentialCallActivityWithTimer() {
@@ -1158,6 +1214,7 @@ assertProcessEnded(procId);
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testNestedParallelCallActivity.bpmn20.xml",
             "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml" })
     public void testNestedParallelCallActivity() {
@@ -1172,6 +1229,7 @@ assertProcessEnded(procId);
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testNestedParallelCallActivityWithTimer.bpmn20.xml",
             "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml" })
     public void testNestedParallelCallActivityWithTimer() {
@@ -1195,6 +1253,7 @@ assertProcessEnded(procId);
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testNestedParallelCallActivityCompletionCondition.bpmn20.xml",
             "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml" })
     public void testNestedParallelCallActivityCompletionCondition() {
@@ -1215,6 +1274,7 @@ assertProcessEnded(procId);
     }
 
     // ACT-764
+    @Test
     @Deployment
     public void testSequentialServiceTaskWithClass() {
         ProcessInstance procInst = runtimeService.startProcessInstanceByKey("multiInstanceServiceTask", CollectionUtil.singletonMap("result", 5));
@@ -1226,6 +1286,7 @@ assertProcessEnded(procId);
         assertProcessEnded(procInst.getId());
     }
 
+    @Test
     @Deployment
     public void testSequentialServiceTaskWithClassAndCollection() {
         Collection<Integer> items = Arrays.asList(1, 2, 3, 4, 5, 6);
@@ -1243,6 +1304,7 @@ assertProcessEnded(procId);
     }
 
     // ACT-901
+    @Test
     @Deployment
     public void testAct901() {
 
@@ -1267,6 +1329,7 @@ assertProcessEnded(procId);
         assertEquals(0, tasks.size());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.callActivityWithBoundaryErrorEvent.bpmn20.xml",
             "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.throwingErrorEventSubProcess.bpmn20.xml" })
     public void testMultiInstanceCallActivityWithErrorBoundaryEvent() {
@@ -1293,6 +1356,7 @@ assertProcessEnded(procId);
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.callActivityWithBoundaryErrorEventSequential.bpmn20.xml",
             "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.throwingErrorEventSubProcess.bpmn20.xml" })
     public void testSequentialMultiInstanceCallActivityWithErrorBoundaryEvent() {
@@ -1319,6 +1383,7 @@ assertProcessEnded(procId);
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment
     public void testMultiInstanceParallelReceiveTask() {
         runtimeService.startProcessInstanceByKey("multi-instance-receive");
@@ -1338,6 +1403,7 @@ assertProcessEnded(procId);
         assertEquals(0, runtimeService.createExecutionQuery().count());
     }
 
+    @Test
     @Deployment
     public void testMultiInstanceParalelReceiveTaskWithTimer() {
         Date startTime = new Date();
@@ -1361,6 +1427,7 @@ assertProcessEnded(procId);
         assertEquals(0, runtimeService.createExecutionQuery().count());
     }
 
+    @Test
     @Deployment
     public void testMultiInstanceSequentialReceiveTask() {
         runtimeService.startProcessInstanceByKey("multi-instance-receive");
@@ -1381,6 +1448,7 @@ assertProcessEnded(procId);
         assertEquals(0, runtimeService.createExecutionQuery().count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testNestedMultiInstanceTasks.bpmn20.xml" })
     public void testNestedMultiInstanceTasks() {
         List<String> processes = Arrays.asList("process A", "process B");
@@ -1403,6 +1471,7 @@ assertProcessEnded(procId);
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testSequentialSubprocessEmptyCollection.bpmn20.xml" })
     public void testSequentialSubprocessEmptyCollection() {
         Collection<String> collection = Collections.emptyList();
@@ -1415,6 +1484,7 @@ assertProcessEnded(procId);
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testSequentialEmptyCollection.bpmn20.xml" })
     public void testSequentialEmptyCollection() {
         Collection<String> collection = Collections.emptyList();
@@ -1427,6 +1497,7 @@ assertProcessEnded(procId);
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testSequentialEmptyCollection.bpmn20.xml" })
     public void testSequentialEmptyCollectionWithNonEmptyCollection() {
         Collection<String> collection = Collections.singleton("Test");
@@ -1440,6 +1511,7 @@ assertProcessEnded(procId);
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testParallelEmptyCollection.bpmn20.xml" })
     public void testParalellEmptyCollection() throws Exception {
         Collection<String> collection = Collections.emptyList();
@@ -1452,6 +1524,7 @@ assertProcessEnded(procId);
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testParallelEmptyCollection.bpmn20.xml" })
     public void testParalellEmptyCollectionWithNonEmptyCollection() {
         Collection<String> collection = Collections.singleton("Test");
@@ -1465,6 +1538,7 @@ assertProcessEnded(procId);
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment
     public void testInfiniteLoopWithDelegateExpressionFix() {
 
@@ -1491,6 +1565,7 @@ assertProcessEnded(procId);
         }
     }
 
+    @Test
     @Deployment
     public void testEmptyCollectionOnParallelUserTask() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
@@ -1503,6 +1578,7 @@ assertProcessEnded(procId);
         }
     }
 
+    @Test
     @Deployment
     public void testZeroLoopCardinalityOnParallelUserTask() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
@@ -1513,6 +1589,7 @@ assertProcessEnded(procId);
         }
     }
 
+    @Test
     @Deployment
     public void testEmptyCollectionOnSequentialEmbeddedSubprocess() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
@@ -1525,6 +1602,7 @@ assertProcessEnded(procId);
         }
     }
 
+    @Test
     @Deployment
     public void testEmptyCollectionOnParallelEmbeddedSubprocess() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
@@ -1538,6 +1616,7 @@ assertProcessEnded(procId);
         }
     }
 
+    @Test
     @Deployment
     public void testExecutionListenersOnMultiInstanceSubprocess() {
         resetTestCounts();
@@ -1556,6 +1635,7 @@ assertProcessEnded(procId);
         assertEquals(1, TestEndExecutionListener.countWithoutLoopCounter.get());
     }
 
+    @Test
     @Deployment
     public void testExecutionListenersOnMultiInstanceUserTask() {
         resetTestCounts();
@@ -1575,6 +1655,7 @@ assertProcessEnded(procId);
         assertEquals(1, TestEndExecutionListener.countWithoutLoopCounter.get());
     }
 
+    @Test
     @Deployment
     public void testParallelAfterSequentialMultiInstance() {
 
@@ -1584,6 +1665,7 @@ assertProcessEnded(procId);
         assertEquals(0, runtimeService.createExecutionQuery().count());
     }
 
+    @Test
     @Deployment
     public void testEndTimeOnMiSubprocess() {
 
@@ -1659,6 +1741,7 @@ assertProcessEnded(procId);
         }
     }
 
+    @Test
     @Deployment
     public void testChangingCollection() {
         Map<String, Object> vars = new HashMap<>();
@@ -1673,6 +1756,7 @@ assertProcessEnded(procId);
         assertEquals(0, instances.size());
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.simpleMultiInstanceWithCollectionVariable.bpmn20.xml")
     public void testCollectionVariableMissing() {
         try {
@@ -1683,6 +1767,7 @@ assertProcessEnded(procId);
         }
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.simpleMultiInstanceWithCollectionVariable.bpmn20.xml")
     public void testCollectionVariableIsNotACollection() {
         Map<String, Object> vars = new HashMap<>();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/parallel/ParallelTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/parallel/ParallelTest.java
@@ -15,12 +15,14 @@ package org.flowable.engine.test.bpmn.parallel;
 
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tom Baeyens
  */
 public class ParallelTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testParallel() {
         runtimeService.startProcessInstanceByKey("myProc");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/parse/BpmnParseTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/parse/BpmnParseTest.java
@@ -24,6 +24,7 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.impl.test.TestHelper;
 import org.flowable.engine.repository.ProcessDefinition;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * 
@@ -31,6 +32,7 @@ import org.flowable.engine.test.Deployment;
  */
 public class BpmnParseTest extends PluggableFlowableTestCase {
 
+    @Test
     public void testInvalidProcessDefinition() {
         try {
             String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testInvalidProcessDefinition");
@@ -41,6 +43,7 @@ public class BpmnParseTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testParseWithBpmnNamespacePrefix() {
         repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/bpmn/parse/BpmnParseTest.testParseWithBpmnNamespacePrefix.bpmn20.xml").deploy();
         assertEquals(1, repositoryService.createProcessDefinitionQuery().count());
@@ -48,6 +51,7 @@ public class BpmnParseTest extends PluggableFlowableTestCase {
         repositoryService.deleteDeployment(repositoryService.createDeploymentQuery().singleResult().getId(), true);
     }
 
+    @Test
     public void testParseWithMultipleDocumentation() {
         repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/bpmn/parse/BpmnParseTest.testParseWithMultipleDocumentation.bpmn20.xml").deploy();
         assertEquals(1, repositoryService.createProcessDefinitionQuery().count());
@@ -55,6 +59,7 @@ public class BpmnParseTest extends PluggableFlowableTestCase {
         repositoryService.deleteDeployment(repositoryService.createDeploymentQuery().singleResult().getId(), true);
     }
 
+    @Test
     @Deployment
     public void testParseDiagramInterchangeElements() {
 
@@ -84,6 +89,7 @@ public class BpmnParseTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment
     public void testParseNamespaceInConditionExpressionType() {
 
@@ -99,6 +105,7 @@ public class BpmnParseTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment
     public void testParseDiagramInterchangeElementsForUnknownModelElements() {
         ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().processDefinitionKey("TestAnnotation").singleResult();
@@ -107,6 +114,7 @@ public class BpmnParseTest extends PluggableFlowableTestCase {
         assertEquals(0, mainProcess.getExtensionElements().size());
     }
 
+    @Test
     public void testParseSwitchedSourceAndTargetRefsForAssociations() {
         repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/bpmn/parse/BpmnParseTest.testParseSwitchedSourceAndTargetRefsForAssociations.bpmn20.xml").deploy();
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/sequenceflow/ConditionalSequenceFlowTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/sequenceflow/ConditionalSequenceFlowTest.java
@@ -20,6 +20,7 @@ import org.flowable.common.engine.impl.util.CollectionUtil;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -29,6 +30,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
  */
 public class ConditionalSequenceFlowTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testUelExpression() {
         Map<String, Object> variables = CollectionUtil.singletonMap("input", "right");
@@ -39,6 +41,7 @@ public class ConditionalSequenceFlowTest extends PluggableFlowableTestCase {
         assertEquals("task right", task.getName());
     }
 
+    @Test
     @Deployment
     public void testSkipExpression() {
         Map<String, Object> variables = new HashMap<>();
@@ -53,6 +56,7 @@ public class ConditionalSequenceFlowTest extends PluggableFlowableTestCase {
         assertEquals("task left", task.getName());
     }
 
+    @Test
     @Deployment
     public void testDynamicExpression() {
         Map<String, Object> variables = CollectionUtil.singletonMap("input", "right");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/sequenceflow/DefaultSequenceFlowTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/sequenceflow/DefaultSequenceFlowTest.java
@@ -17,6 +17,7 @@ import org.flowable.common.engine.impl.util.CollectionUtil;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.test.Deployment;
 import org.flowable.engine.test.bpmn.gateway.ExclusiveGatewayTest;
+import org.junit.jupiter.api.Test;
 
 /**
  * See {@link ExclusiveGatewayTest} for a default sequence flow test on an exclusive gateway.
@@ -25,6 +26,7 @@ import org.flowable.engine.test.bpmn.gateway.ExclusiveGatewayTest;
  */
 public class DefaultSequenceFlowTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testDefaultSequenceFlowOnTask() {
         String procId = runtimeService.startProcessInstanceByKey("defaultSeqFlow", CollectionUtil.singletonMap("input", 2)).getId();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/servicetask/CallServiceInServiceTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/servicetask/CallServiceInServiceTaskTest.java
@@ -20,12 +20,14 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.idm.api.Group;
 import org.flowable.idm.api.User;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
  */
 public class CallServiceInServiceTaskTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testStartProcessFromDelegate() {
         runtimeService.startProcessInstanceByKey("startProcessFromDelegate");
@@ -50,6 +52,7 @@ public class CallServiceInServiceTaskTest extends PluggableFlowableTestCase {
         assertTrue(oneTaskProcessFound);
     }
 
+    @Test
     @Deployment
     public void testRollBackOnException() {
         Exception expectedException = null;
@@ -65,6 +68,7 @@ public class CallServiceInServiceTaskTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createProcessInstanceQuery().count());
     }
 
+    @Test
     @Deployment
     public void testMultipleServiceInvocationsFromDelegate() {
         runtimeService.startProcessInstanceByKey("multipleServiceInvocations");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/servicetask/DynamicServiceTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/servicetask/DynamicServiceTaskTest.java
@@ -22,6 +22,7 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.variable.api.history.HistoricVariableInstance;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -30,6 +31,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
  */
 public class DynamicServiceTaskTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testChangeClassName() {
         // first test without changing the class name
@@ -71,6 +73,7 @@ public class DynamicServiceTaskTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment
     public void testChangeExpression() {
         // first test without changing the class name
@@ -118,6 +121,7 @@ public class DynamicServiceTaskTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment
     public void testChangeDelegateExpression() {
         // first test without changing the class name

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/servicetask/RepeatingServiceTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/servicetask/RepeatingServiceTaskTest.java
@@ -14,6 +14,7 @@
 package org.flowable.engine.test.bpmn.servicetask;
 
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
@@ -21,6 +22,7 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 public class RepeatingServiceTaskTest extends PluggableFlowableTestCase {
 
     // @Deployment
+    @Test
     public void testMultipleInvocationsInSameTransation() {
         // ProcessInstance processInstance =
         // runtimeService.startProcessInstanceByKey("repeating",

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/servicetask/ServiceTaskVariablesTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/servicetask/ServiceTaskVariablesTest.java
@@ -20,6 +20,7 @@ import org.flowable.engine.delegate.JavaDelegate;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
+import org.junit.jupiter.api.Test;
 
 /**
  * 
@@ -74,6 +75,7 @@ public class ServiceTaskVariablesTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment
     public void testSerializedVariablesBothAsync() {
 
@@ -94,6 +96,7 @@ public class ServiceTaskVariablesTest extends PluggableFlowableTestCase {
         assertTrue(isOkInDelegate3);
     }
 
+    @Test
     @Deployment
     public void testSerializedVariablesThirdAsync() {
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/servicetask/TriggerableServiceTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/servicetask/TriggerableServiceTaskTest.java
@@ -23,9 +23,11 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
+import org.junit.jupiter.api.Test;
 
 public class TriggerableServiceTaskTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testClassDelegate() {
         String processId = runtimeService.startProcessInstanceByKey("process").getProcessInstanceId();
@@ -44,6 +46,7 @@ public class TriggerableServiceTaskTest extends PluggableFlowableTestCase {
         assertEquals(3, runtimeService.getVariable(processId, "count"));
     }
 
+    @Test
     @Deployment
     public void testDelegateExpression() {
         Map<String, Object> varMap = new HashMap<>();
@@ -65,6 +68,7 @@ public class TriggerableServiceTaskTest extends PluggableFlowableTestCase {
         assertEquals(3, runtimeService.getVariable(processId, "count"));
     }
 
+    @Test
     @Deployment
     public void testAsyncJobs() {
         String processId = runtimeService.startProcessInstanceByKey("process").getProcessInstanceId();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/subprocess/CallActivityTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/subprocess/CallActivityTest.java
@@ -32,6 +32,8 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.task.api.Task;
 import org.flowable.variable.api.history.HistoricVariableInstance;
 import org.flowable.variable.api.history.HistoricVariableInstanceQuery;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class CallActivityTest extends ResourceFlowableTestCase {
 
@@ -50,6 +52,7 @@ public class CallActivityTest extends ResourceFlowableTestCase {
         super("org/flowable/standalone/parsing/encoding.flowable.cfg.xml");
     }
 
+    @Test
     public void testInstantiateProcessByMessage() throws Exception {
         BpmnModel messageTriggeredBpmnModel = loadBPMNModel(MESSAGE_TRIGGERED_PROCESS_RESOURCE);
 
@@ -60,6 +63,7 @@ public class CallActivityTest extends ResourceFlowableTestCase {
         assertNotNull(childProcessInstance);
     }
 
+    @Test
     public void testInstantiateSuspendedProcessByMessage() throws Exception {
         BpmnModel messageTriggeredBpmnModel = loadBPMNModel(MESSAGE_TRIGGERED_PROCESS_RESOURCE);
 
@@ -77,6 +81,7 @@ public class CallActivityTest extends ResourceFlowableTestCase {
 
     }
 
+    @Test
     public void testInstantiateChildProcess() throws Exception {
         BpmnModel childBpmnModel = loadBPMNModel(CHILD_PROCESS_RESOURCE);
 
@@ -86,6 +91,7 @@ public class CallActivityTest extends ResourceFlowableTestCase {
         assertNotNull(childProcessInstance);
     }
 
+    @Test
     public void testInstantiateSuspendedChildProcess() throws Exception {
         BpmnModel childBpmnModel = loadBPMNModel(CHILD_PROCESS_RESOURCE);
 
@@ -102,6 +108,7 @@ public class CallActivityTest extends ResourceFlowableTestCase {
 
     }
 
+    @Test
     public void testInstantiateSubprocess() throws Exception {
         BpmnModel mainBpmnModel = loadBPMNModel(MAIN_PROCESS_RESOURCE);
         BpmnModel childBpmnModel = loadBPMNModel(CHILD_PROCESS_RESOURCE);
@@ -121,6 +128,7 @@ public class CallActivityTest extends ResourceFlowableTestCase {
 
     }
 
+    @Test
     public void testInheritVariablesSubprocess() throws Exception {
         BpmnModel mainBpmnModel = loadBPMNModel(INHERIT_VARIABLES_MAIN_PROCESS_RESOURCE);
         BpmnModel childBpmnModel = loadBPMNModel(INHERIT_VARIABLES_CHILD_PROCESS_RESOURCE);
@@ -158,6 +166,7 @@ public class CallActivityTest extends ResourceFlowableTestCase {
         }
     }
 
+    @Test
     public void testNotInheritVariablesSubprocess() throws Exception {
         BpmnModel mainBpmnModel = loadBPMNModel(NOT_INHERIT_VARIABLES_MAIN_PROCESS_RESOURCE);
         BpmnModel childBpmnModel = loadBPMNModel(INHERIT_VARIABLES_CHILD_PROCESS_RESOURCE);
@@ -193,6 +202,7 @@ public class CallActivityTest extends ResourceFlowableTestCase {
         assertEquals(0, variableInstances.size());
     }
 
+    @Test
     public void testSameDeploymentSubprocess() throws Exception {
         BpmnModel mainBpmnModel = loadBPMNModel(SAME_DEPLOYMENT_MAIN_PROCESS_RESOURCE);
         BpmnModel childBpmnModel = loadBPMNModel(SAME_DEPLOYMENT_CHILD_PROCESS_RESOURCE);
@@ -220,6 +230,7 @@ public class CallActivityTest extends ResourceFlowableTestCase {
         assertEquals("The child process must have the name of the child process within the same deployment", "User Task", task.getName());
     }
     
+    @Test
     public void testSameDeploymentSubprocessWithTenant() throws Exception {
         BpmnModel mainBpmnModel = loadBPMNModel(SAME_DEPLOYMENT_MAIN_PROCESS_RESOURCE);
         BpmnModel childBpmnModel = loadBPMNModel(SAME_DEPLOYMENT_CHILD_PROCESS_RESOURCE);
@@ -249,6 +260,7 @@ public class CallActivityTest extends ResourceFlowableTestCase {
         assertEquals("The child process must have the name of the child process within the same deployment", "User Task", task.getName());
     }
 
+    @Test
     public void testNotSameDeploymentSubprocess() throws Exception {
         BpmnModel mainBpmnModel = loadBPMNModel(NOT_SAME_DEPLOYMENT_MAIN_PROCESS_RESOURCE);
         BpmnModel childBpmnModel = loadBPMNModel(SAME_DEPLOYMENT_CHILD_PROCESS_RESOURCE);
@@ -276,6 +288,7 @@ public class CallActivityTest extends ResourceFlowableTestCase {
         assertEquals("The child process must have the name of the newest child process deployment", "User Task V2", task.getName());
     }
     
+    @Test
     public void testNotSameDeploymentSubprocessWithTenant() throws Exception {
         BpmnModel mainBpmnModel = loadBPMNModel(NOT_SAME_DEPLOYMENT_MAIN_PROCESS_RESOURCE);
         BpmnModel childBpmnModel = loadBPMNModel(SAME_DEPLOYMENT_CHILD_PROCESS_RESOURCE);
@@ -305,6 +318,7 @@ public class CallActivityTest extends ResourceFlowableTestCase {
         assertEquals("The child process must have the name of the newest child process deployment", "User Task V2", task.getName());
     }
 
+    @Test
     public void testSameDeploymentSubprocessNotInSameDeployment() throws Exception {
         BpmnModel mainBpmnModel = loadBPMNModel(SAME_DEPLOYMENT_MAIN_PROCESS_RESOURCE);
         BpmnModel childBpmnModel = loadBPMNModel(SAME_DEPLOYMENT_CHILD_PROCESS_RESOURCE);
@@ -337,6 +351,7 @@ public class CallActivityTest extends ResourceFlowableTestCase {
                 "is no deployed child process in the same deployment", "User Task V2", task.getName());
     }
     
+    @Test
     public void testSameDeploymentSubprocessNotInSameDeploymentWithTenant() throws Exception {
         BpmnModel mainBpmnModel = loadBPMNModel(SAME_DEPLOYMENT_MAIN_PROCESS_RESOURCE);
         BpmnModel childBpmnModel = loadBPMNModel(SAME_DEPLOYMENT_CHILD_PROCESS_RESOURCE);
@@ -380,12 +395,11 @@ public class CallActivityTest extends ResourceFlowableTestCase {
         }
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
         for (Deployment deployment : repositoryService.createDeploymentQuery().list()) {
             repositoryService.deleteDeployment(deployment.getId(), true);
         }
-        super.tearDown();
     }
 
     protected BpmnModel loadBPMNModel(String bpmnModelFilePath) throws Exception {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/subprocess/SubProcessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/subprocess/SubProcessTest.java
@@ -28,6 +28,7 @@ import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
 import org.flowable.task.api.TaskQuery;
 import org.flowable.task.api.history.HistoricTaskInstance;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
@@ -35,6 +36,7 @@ import org.flowable.task.api.history.HistoricTaskInstance;
  */
 public class SubProcessTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testSimpleSubProcess() {
 
@@ -52,6 +54,7 @@ public class SubProcessTest extends PluggableFlowableTestCase {
     /**
      * Same test case as before, but now with all automatic steps
      */
+    @Test
     @Deployment
     public void testSimpleAutomaticSubProcess() {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("simpleSubProcessAutomatic");
@@ -59,6 +62,7 @@ public class SubProcessTest extends PluggableFlowableTestCase {
         assertProcessEnded(pi.getId());
     }
 
+    @Test
     @Deployment
     public void testSimpleSubProcessWithTimer() {
 
@@ -121,6 +125,7 @@ public class SubProcessTest extends PluggableFlowableTestCase {
     /**
      * Test case where the simple sub process of previous test cases is nested within another subprocess.
      */
+    @Test
     @Deployment
     public void testNestedSimpleSubProcess() {
 
@@ -144,6 +149,7 @@ public class SubProcessTest extends PluggableFlowableTestCase {
         assertProcessEnded(pi.getId());
     }
 
+    @Test
     @Deployment
     public void testNestedSimpleSubprocessWithTimerOnInnerSubProcess() {
         Date startTime = new Date();
@@ -172,6 +178,7 @@ public class SubProcessTest extends PluggableFlowableTestCase {
     /**
      * Test case where the simple sub process of previous test cases is nested within two other sub processes
      */
+    @Test
     @Deployment
     public void testDoubleNestedSimpleSubProcess() {
         // After staring the process, the task in the inner subprocess must be active
@@ -187,6 +194,7 @@ public class SubProcessTest extends PluggableFlowableTestCase {
         assertEquals("Task after subprocesses", taskAfterSubProcesses.getName());
     }
 
+    @Test
     @Deployment
     public void testSimpleParallelSubProcess() {
 
@@ -208,6 +216,7 @@ public class SubProcessTest extends PluggableFlowableTestCase {
         assertEquals("Task after sub process", taskAfterSubProcess.getName());
     }
 
+    @Test
     @Deployment
     public void testSimpleParallelSubProcessWithTimer() {
 
@@ -236,6 +245,7 @@ public class SubProcessTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment
     public void testTwoSubProcessInParallel() {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("twoSubProcessInParallel");
@@ -268,6 +278,7 @@ public class SubProcessTest extends PluggableFlowableTestCase {
         assertProcessEnded(pi.getId());
     }
 
+    @Test
     @Deployment
     public void testTwoSubProcessInParallelWithinSubProcess() {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("twoSubProcessInParallelWithinSubProcess");
@@ -292,6 +303,7 @@ public class SubProcessTest extends PluggableFlowableTestCase {
         assertProcessEnded(pi.getId());
     }
 
+    @Test
     @Deployment
     public void testTwoNestedSubProcessesInParallelWithTimer() {
 
@@ -326,6 +338,7 @@ public class SubProcessTest extends PluggableFlowableTestCase {
     /**
      * @see <a href="https://activiti.atlassian.net/browse/ACT-1072">https://activiti.atlassian.net/browse/ACT-1072</a>
      */
+    @Test
     @Deployment
     public void testNestedSimpleSubProcessWithoutEndEvent() {
         testNestedSimpleSubProcess();
@@ -334,6 +347,7 @@ public class SubProcessTest extends PluggableFlowableTestCase {
     /**
      * @see <a href="https://activiti.atlassian.net/browse/ACT-1072">https://activiti.atlassian.net/browse/ACT-1072</a>
      */
+    @Test
     @Deployment
     public void testSimpleSubProcessWithoutEndEvent() {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("testSimpleSubProcessWithoutEndEvent");
@@ -343,6 +357,7 @@ public class SubProcessTest extends PluggableFlowableTestCase {
     /**
      * @see <a href="https://activiti.atlassian.net/browse/ACT-1072">https://activiti.atlassian.net/browse/ACT-1072</a>
      */
+    @Test
     @Deployment
     public void testNestedSubProcessesWithoutEndEvents() {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("testNestedSubProcessesWithoutEndEvents");
@@ -352,6 +367,7 @@ public class SubProcessTest extends PluggableFlowableTestCase {
     /**
      * @see <a href="https://activiti.atlassian.net/browse/ACT-1847">https://activiti.atlassian.net/browse/ACT-1847</a>
      */
+    @Test
     @Deployment
     public void testDataObjectScope() {
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/subprocess/adhoc/AdhocSubProcessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/subprocess/adhoc/AdhocSubProcessTest.java
@@ -27,12 +27,14 @@ import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.task.api.history.HistoricTaskInstance;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tijs Rademakers
  */
 public class AdhocSubProcessTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testSimpleAdhocSubProcess() {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("simpleSubProcess");
@@ -64,6 +66,7 @@ public class AdhocSubProcessTest extends PluggableFlowableTestCase {
         assertNull(runtimeService.createProcessInstanceQuery().processInstanceId(pi.getId()).singleResult());
     }
 
+    @Test
     @Deployment
     public void testSimpleAdhocSubProcessViaExecution() {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("simpleSubProcess");
@@ -101,6 +104,7 @@ public class AdhocSubProcessTest extends PluggableFlowableTestCase {
         assertNull(runtimeService.createProcessInstanceQuery().processInstanceId(pi.getId()).singleResult());
     }
 
+    @Test
     @Deployment
     public void testSimpleCompletionCondition() {
         Map<String, Object> variableMap = new HashMap<>();
@@ -161,6 +165,7 @@ public class AdhocSubProcessTest extends PluggableFlowableTestCase {
         assertNull(runtimeService.createProcessInstanceQuery().processInstanceId(pi.getId()).singleResult());
     }
 
+    @Test
     @Deployment
     public void testParallelAdhocSubProcess() {
         Map<String, Object> variableMap = new HashMap<>();
@@ -192,6 +197,7 @@ public class AdhocSubProcessTest extends PluggableFlowableTestCase {
         assertNull(runtimeService.createProcessInstanceQuery().processInstanceId(pi.getId()).singleResult());
     }
 
+    @Test
     @Deployment
     public void testSequentialAdhocSubProcess() {
         Map<String, Object> variableMap = new HashMap<>();
@@ -234,6 +240,7 @@ public class AdhocSubProcessTest extends PluggableFlowableTestCase {
         assertNull(runtimeService.createProcessInstanceQuery().processInstanceId(pi.getId()).singleResult());
     }
 
+    @Test
     @Deployment
     public void testFlowsInAdhocSubProcess() {
         Map<String, Object> variableMap = new HashMap<>();
@@ -273,6 +280,7 @@ public class AdhocSubProcessTest extends PluggableFlowableTestCase {
         assertNull(runtimeService.createProcessInstanceQuery().processInstanceId(pi.getId()).singleResult());
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/bpmn/subprocess/adhoc/AdhocSubProcessTest.testFlowsInAdhocSubProcess.bpmn20.xml")
     public void testCompleteFlowBeforeEndInAdhocSubProcess() {
         Map<String, Object> variableMap = new HashMap<>();
@@ -300,6 +308,7 @@ public class AdhocSubProcessTest extends PluggableFlowableTestCase {
         assertNull(runtimeService.createProcessInstanceQuery().processInstanceId(pi.getId()).singleResult());
     }
 
+    @Test
     @Deployment
     public void testParallelFlowsInAdhocSubProcess() {
         Map<String, Object> variableMap = new HashMap<>();
@@ -340,6 +349,7 @@ public class AdhocSubProcessTest extends PluggableFlowableTestCase {
         assertNull(runtimeService.createProcessInstanceQuery().processInstanceId(pi.getId()).singleResult());
     }
 
+    @Test
     @Deployment
     public void testKeepRemainingInstancesAdhocSubProcess() {
         Map<String, Object> variableMap = new HashMap<>();
@@ -378,6 +388,7 @@ public class AdhocSubProcessTest extends PluggableFlowableTestCase {
         assertNull(runtimeService.createProcessInstanceQuery().processInstanceId(pi.getId()).singleResult());
     }
 
+    @Test
     @Deployment
     public void testParallelFlowsWithKeepRemainingInstancesAdhocSubProcess() {
         Map<String, Object> variableMap = new HashMap<>();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/subprocess/transaction/TransactionSubProcessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/subprocess/transaction/TransactionSubProcessTest.java
@@ -23,12 +23,14 @@ import org.flowable.engine.runtime.EventSubscriptionQuery;
 import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tijs Rademakers
  */
 public class TransactionSubProcessTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/subprocess/transaction/TransactionSubProcessTest.testSimpleCase.bpmn20.xml" })
     public void testSimpleCaseTxSuccessful() {
 
@@ -76,6 +78,7 @@ public class TransactionSubProcessTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createExecutionQuery().count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/subprocess/transaction/TransactionSubProcessTest.testSimpleCase.bpmn20.xml" })
     public void testSimpleCaseTxCancelled() {
 
@@ -122,6 +125,7 @@ public class TransactionSubProcessTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createExecutionQuery().count());
     }
 
+    @Test
     @Deployment
     public void testCancelEndConcurrent() {
 
@@ -165,6 +169,7 @@ public class TransactionSubProcessTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createExecutionQuery().count());
     }
 
+    @Test
     @Deployment
     public void testNestedCancelInner() {
 
@@ -218,6 +223,7 @@ public class TransactionSubProcessTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createExecutionQuery().count());
     }
 
+    @Test
     @Deployment
     public void testNestedCancelOuter() {
 
@@ -266,6 +272,7 @@ public class TransactionSubProcessTest extends PluggableFlowableTestCase {
      * 
      * see spec page 470: "If the cancelActivity attribute is set, the Activity the Event is attached to is then cancelled (in case of a multi-instance, all its instances are cancelled);"
      */
+    @Test
     @Deployment
     public void testMultiInstanceTx() {
 
@@ -294,6 +301,7 @@ public class TransactionSubProcessTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/subprocess/transaction/TransactionSubProcessTest.testMultiInstanceTx.bpmn20.xml" })
     public void testMultiInstanceTxSuccessful() {
 
@@ -326,6 +334,7 @@ public class TransactionSubProcessTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     public void testMultipleCancelBoundaryFails() {
         try {
             repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/bpmn/subprocess/transaction/TransactionSubProcessTest.testMultipleCancelBoundaryFails.bpmn20.xml").deploy();
@@ -337,6 +346,7 @@ public class TransactionSubProcessTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testCancelBoundaryNoTransactionFails() {
         try {
             repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/bpmn/subprocess/transaction/TransactionSubProcessTest.testCancelBoundaryNoTransactionFails.bpmn20.xml")
@@ -349,6 +359,7 @@ public class TransactionSubProcessTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testCancelEndNoTransactionFails() {
         try {
             repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/bpmn/subprocess/transaction/TransactionSubProcessTest.testCancelEndNoTransactionFails.bpmn20.xml").deploy();
@@ -364,6 +375,7 @@ public class TransactionSubProcessTest extends PluggableFlowableTestCase {
         return runtimeService.createEventSubscriptionQuery();
     }
 
+    @Test
     @Deployment
     public void testParseWithDI() {
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/DisabledDefinitionInfoCacheTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/DisabledDefinitionInfoCacheTest.java
@@ -16,33 +16,23 @@ package org.flowable.engine.test.bpmn.usertask;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.flowable.engine.ProcessEngine;
-import org.flowable.engine.ProcessEngineConfiguration;
-import org.flowable.engine.impl.cfg.ProcessEngineConfigurationImpl;
-import org.flowable.engine.impl.test.AbstractFlowableTestCase;
+import org.flowable.engine.impl.test.ResourceFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * @author Tijs Rademakers
  */
-public class DisabledDefinitionInfoCacheTest extends AbstractFlowableTestCase {
+public class DisabledDefinitionInfoCacheTest extends ResourceFlowableTestCase {
 
-    protected static ProcessEngine cachedProcessEngine;
-
-    @Override
-    protected void initializeProcessEngine() {
-        if (cachedProcessEngine == null) {
-            ProcessEngineConfigurationImpl processEngineConfiguration = (ProcessEngineConfigurationImpl) ProcessEngineConfiguration
-                    .createProcessEngineConfigurationFromResource("org/flowable/engine/test/bpmn/usertask/flowable.cfg.xml");
-
-            cachedProcessEngine = processEngineConfiguration.buildProcessEngine();
-        }
-        processEngine = cachedProcessEngine;
+    public DisabledDefinitionInfoCacheTest() {
+        super("org/flowable/engine/test/bpmn/usertask/flowable.cfg.xml");
     }
 
+    @Test
     @Deployment
     public void testChangeFormKey() {
         // first test without changing the form key
@@ -68,6 +58,7 @@ public class DisabledDefinitionInfoCacheTest extends AbstractFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment
     public void testChangeClassName() {
         // first test without changing the class name

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/DynamicUserTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/DynamicUserTaskTest.java
@@ -22,6 +22,7 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.identitylink.api.IdentityLink;
 import org.flowable.identitylink.api.IdentityLinkType;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -30,6 +31,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
  */
 public class DynamicUserTaskTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/usertask/DynamicUserTaskTest.assignment.bpmn20.xml" })
     public void testChangeAssignee() {
         // first test without changing the form key
@@ -55,6 +57,7 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/usertask/DynamicUserTaskTest.assignment.bpmn20.xml" })
     public void testChangeOwner() {
         // first test without changing the form key
@@ -80,6 +83,7 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/usertask/DynamicUserTaskTest.basictask.bpmn20.xml" })
     public void testChangeCandidateUsers() {
         // first test without changing the form key
@@ -146,6 +150,7 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/usertask/DynamicUserTaskTest.basictask.bpmn20.xml" })
     public void testChangeCandidateGroups() {
         // first test without changing the form key
@@ -212,6 +217,7 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/usertask/DynamicUserTaskTest.basictask.bpmn20.xml" })
     public void testChangeCandidateUsersAndGroups() {
         // first test without changing the form key
@@ -302,6 +308,7 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/usertask/DynamicUserTaskTest.basictask.bpmn20.xml" })
     public void testChangeNameAndDescription() {
         // first test without changing the form key
@@ -330,6 +337,7 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/usertask/DynamicUserTaskTest.assignment.bpmn20.xml" })
     public void testChangePriorityAndCategory() {
         // first test without changing the form key
@@ -358,6 +366,7 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment
     public void testChangeFormKey() {
         // first test without changing the form key
@@ -383,6 +392,7 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment
     public void testChangeFormKeyWithExpression() {
         // first test without changing the form key

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/ImportExportTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/ImportExportTest.java
@@ -21,6 +21,8 @@ import org.flowable.common.engine.impl.util.io.InputStreamSource;
 import org.flowable.common.engine.impl.util.io.StreamSource;
 import org.flowable.engine.impl.test.ResourceFlowableTestCase;
 import org.flowable.engine.runtime.Execution;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Created by p3700487 on 23/02/15.
@@ -31,6 +33,7 @@ public class ImportExportTest extends ResourceFlowableTestCase {
         super("org/flowable/standalone/parsing/encoding.flowable.cfg.xml");
     }
 
+    @Test
     public void testConvertXMLToModel() throws Exception {
         BpmnModel bpmnModel = readXMLFile();
         bpmnModel = exportAndReadXMLFile(bpmnModel);
@@ -45,12 +48,11 @@ public class ImportExportTest extends ResourceFlowableTestCase {
         assertNotNull(execution);
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
         for (org.flowable.engine.repository.Deployment deployment : repositoryService.createDeploymentQuery().list()) {
             repositoryService.deleteDeployment(deployment.getId(), true);
         }
-        super.tearDown();
     }
 
     protected String getResource() {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/InitiatorTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/InitiatorTest.java
@@ -15,12 +15,14 @@ package org.flowable.engine.test.bpmn.usertask;
 
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tom Baeyens
  */
 public class InitiatorTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testInitiator() {
         try {
@@ -34,6 +36,7 @@ public class InitiatorTest extends PluggableFlowableTestCase {
     }
 
     // See ACT-1372
+    @Test
     @Deployment
     public void testInitiatorWithWhiteSpaceInExpression() {
         try {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/TaskAssignmentCandidateTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/TaskAssignmentCandidateTest.java
@@ -16,6 +16,9 @@ import java.util.List;
 
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test case for task candidate use case.
@@ -24,18 +27,19 @@ import org.flowable.engine.test.Deployment;
  */
 public class TaskAssignmentCandidateTest extends PluggableFlowableTestCase {
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         identityService.saveGroup(identityService.newGroup("accounting"));
         identityService.saveGroup(identityService.newGroup("management"));
     }
 
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
         identityService.deleteGroup("accounting");
         identityService.deleteGroup("management");
     }
 
+    @Test
     @Deployment
     public void testCandidateGroups() {
         runtimeService.startProcessInstanceByKey("taskCandidateExample");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/TaskAssignmentExtensionsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/TaskAssignmentExtensionsTest.java
@@ -19,6 +19,9 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.impl.test.TestHelper;
 import org.flowable.engine.test.Deployment;
 import org.flowable.task.api.TaskQuery;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Testcase for the non-spec extensions to the task candidate use case.
@@ -27,7 +30,7 @@ import org.flowable.task.api.TaskQuery;
  */
 public class TaskAssignmentExtensionsTest extends PluggableFlowableTestCase {
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         identityService.saveUser(identityService.newUser("kermit"));
         identityService.saveUser(identityService.newUser("gonzo"));
@@ -41,7 +44,7 @@ public class TaskAssignmentExtensionsTest extends PluggableFlowableTestCase {
         identityService.createMembership("fozzie", "management");
     }
 
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
         identityService.deleteGroup("accountancy");
         identityService.deleteGroup("management");
@@ -50,6 +53,7 @@ public class TaskAssignmentExtensionsTest extends PluggableFlowableTestCase {
         identityService.deleteUser("kermit");
     }
 
+    @Test
     @Deployment
     public void testAssigneeExtension() {
         runtimeService.startProcessInstanceByKey("assigneeExtension");
@@ -58,6 +62,7 @@ public class TaskAssignmentExtensionsTest extends PluggableFlowableTestCase {
         assertEquals("my task", tasks.get(0).getName());
     }
 
+    @Test
     public void testDuplicateAssigneeDeclaration() {
         try {
             String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testDuplicateAssigneeDeclaration");
@@ -68,6 +73,7 @@ public class TaskAssignmentExtensionsTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testOwnerExtension() {
         runtimeService.startProcessInstanceByKey("ownerExtension");
@@ -76,6 +82,7 @@ public class TaskAssignmentExtensionsTest extends PluggableFlowableTestCase {
         assertEquals("my task", tasks.get(0).getName());
     }
 
+    @Test
     @Deployment
     public void testCandidateUsersExtension() {
         runtimeService.startProcessInstanceByKey("candidateUsersExtension");
@@ -85,6 +92,7 @@ public class TaskAssignmentExtensionsTest extends PluggableFlowableTestCase {
         assertEquals(1, tasks.size());
     }
 
+    @Test
     @Deployment
     public void testCandidateGroupsExtension() {
         runtimeService.startProcessInstanceByKey("candidateGroupsExtension");
@@ -107,6 +115,7 @@ public class TaskAssignmentExtensionsTest extends PluggableFlowableTestCase {
 
     // Test where the candidate user extension is used together
     // with the spec way of defining candidate users
+    @Test
     @Deployment
     public void testMixedCandidateUserDefinition() {
         runtimeService.startProcessInstanceByKey("mixedCandidateUser");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/TaskDueDateExtensionsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/TaskDueDateExtensionsTest.java
@@ -25,6 +25,7 @@ import org.flowable.engine.impl.test.ResourceFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.joda.time.Period;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Frederik Heremans
@@ -35,6 +36,7 @@ public class TaskDueDateExtensionsTest extends ResourceFlowableTestCase {
         super("org/flowable/engine/test/bpmn/usertask/TaskDueDateExtensionsTest.flowable.cfg.xml");
     }
 
+    @Test
     @Deployment
     public void testDueDateExtension() throws Exception {
 
@@ -51,6 +53,7 @@ public class TaskDueDateExtensionsTest extends ResourceFlowableTestCase {
         assertEquals(date, task.getDueDate());
     }
 
+    @Test
     @Deployment
     public void testDueDateStringExtension() throws Exception {
 
@@ -67,6 +70,7 @@ public class TaskDueDateExtensionsTest extends ResourceFlowableTestCase {
         assertEquals(date, task.getDueDate());
     }
 
+    @Test
     @Deployment
     public void testRelativeDueDateStringExtension() throws Exception {
         Clock clock = processEngineConfiguration.getClock();
@@ -88,6 +92,7 @@ public class TaskDueDateExtensionsTest extends ResourceFlowableTestCase {
         clock.reset();
     }
 
+    @Test
     @Deployment
     public void testRelativeDueDateStringWithCalendarNameExtension() throws Exception {
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/TaskPriorityExtensionsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/TaskPriorityExtensionsTest.java
@@ -19,12 +19,14 @@ import java.util.Map;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Thilo-Alexander Ginkel
  */
 public class TaskPriorityExtensionsTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testPriorityExtension() throws Exception {
         testPriorityExtension(25);
@@ -44,6 +46,7 @@ public class TaskPriorityExtensionsTest extends PluggableFlowableTestCase {
         assertEquals(priority, task.getPriority());
     }
 
+    @Test
     @Deployment
     public void testPriorityExtensionString() throws Exception {
         final ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("taskPriorityExtensionString");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/UserTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/UserTaskTest.java
@@ -26,12 +26,14 @@ import org.flowable.identitylink.api.IdentityLink;
 import org.flowable.identitylink.api.IdentityLinkType;
 import org.flowable.task.api.Task;
 import org.flowable.task.api.history.HistoricTaskInstance;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
  */
 public class UserTaskTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testTaskPropertiesNotNull() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -53,12 +55,14 @@ public class UserTaskTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testQuerySortingWithParameter() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
         assertEquals(1, taskService.createTaskQuery().processInstanceId(processInstance.getId()).list().size());
     }
 
+    @Test
     @Deployment
     public void testCompleteAfterParallelGateway() throws InterruptedException {
         // related to https://activiti.atlassian.net/browse/ACT-1054
@@ -78,6 +82,7 @@ public class UserTaskTest extends PluggableFlowableTestCase {
         taskService.complete(task.getId());
     }
 
+    @Test
     @Deployment
     public void testTaskCategory() {
         runtimeService.startProcessInstanceByKey("testTaskCategory");
@@ -121,6 +126,7 @@ public class UserTaskTest extends PluggableFlowableTestCase {
     }
 
     // See https://activiti.atlassian.net/browse/ACT-4041
+    @Test
     public void testTaskFormKeyWhenUsingIncludeVariables() {
         deployOneTaskTestProcess();
         runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -146,6 +152,7 @@ public class UserTaskTest extends PluggableFlowableTestCase {
         assertEquals("test123", task.getFormKey());
     }
     
+    @Test
     @Deployment
     public void testEmptyAssignmentExpression() {
         Map<String, Object> variableMap = new HashMap<>();
@@ -175,6 +182,7 @@ public class UserTaskTest extends PluggableFlowableTestCase {
         assertEquals(0, identityLinks.size());
     }
     
+    @Test
     @Deployment
     public void testNonStringProperties() {
         Map<String, Object> vars = new HashMap<>();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/cache/ProcessDefinitionCacheTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/cache/ProcessDefinitionCacheTest.java
@@ -27,6 +27,7 @@ import org.flowable.engine.impl.cfg.StandaloneProcessEngineConfiguration;
 import org.flowable.engine.impl.test.AbstractTestCase;
 import org.flowable.engine.repository.ProcessDefinition;
 import org.flowable.engine.runtime.ProcessInstance;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test cases for testing functionality when the process engine is rebooted.
@@ -37,6 +38,7 @@ public class ProcessDefinitionCacheTest extends AbstractTestCase {
 
     // Test for a bug: when the process engine is rebooted the cache is cleaned and the deployed process definition is
     // removed from the process cache. This led to problems because the id wasn't fetched from the DB after a redeploy.
+    @Test
     public void testStartProcessInstanceByIdAfterReboot() {
 
         // In case this test is run in a test suite, previous engines might have been initialized and cached. First we close the
@@ -100,6 +102,7 @@ public class ProcessDefinitionCacheTest extends AbstractTestCase {
         schemaProcessEngine.close();
     }
 
+    @Test
     public void testDeployRevisedProcessAfterDeleteOnOtherProcessEngine() {
 
         // Setup both process engines

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/cfg/RetryInterceptorTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/cfg/RetryInterceptorTest.java
@@ -25,10 +25,10 @@ import org.flowable.common.engine.impl.interceptor.RetryInterceptor;
 import org.flowable.engine.ProcessEngine;
 import org.flowable.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.flowable.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration;
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Daniel Meyer
@@ -40,7 +40,7 @@ public class RetryInterceptorTest {
 
     protected RetryInterceptor retryInterceptor;
 
-    @Before
+    @BeforeEach
     public void setupProcessEngine() {
         ProcessEngineConfigurationImpl processEngineConfiguration = (ProcessEngineConfigurationImpl) new StandaloneInMemProcessEngineConfiguration();
         processEngineConfiguration.setJdbcUrl("jdbc:h2:mem:retryInterceptorTest");
@@ -51,7 +51,7 @@ public class RetryInterceptorTest {
         processEngine = processEngineConfiguration.buildProcessEngine();
     }
 
-    @After
+    @AfterEach
     public void shutdownProcessEngine() {
         processEngine.close();
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/cfg/executioncount/ChangeConfigAndRebootEngineTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/cfg/executioncount/ChangeConfigAndRebootEngineTest.java
@@ -26,6 +26,7 @@ import org.flowable.engine.impl.util.CommandContextUtil;
 import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,11 +57,10 @@ public class ChangeConfigAndRebootEngineTest extends ResourceFlowableTestCase {
     protected void rebootEngine(boolean newExecutionRelationshipCountValue) {
         LOGGER.info("Rebooting engine");
         this.newExecutionRelationshipCountValue = newExecutionRelationshipCountValue;
-        closeDownProcessEngine();
-        initializeProcessEngine();
-        initializeServices();
+        rebootEngine();
     }
 
+    @Test
     @Deployment
     public void testChangeExecutionCountSettingAndRebootengine() {
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/cfg/executioncount/VerifyDatabaseOperationsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/cfg/executioncount/VerifyDatabaseOperationsTest.java
@@ -36,6 +36,9 @@ import org.flowable.engine.test.profiler.TotalExecutionTimeCommandInterceptor;
 import org.flowable.job.api.Job;
 import org.flowable.task.service.TaskServiceConfiguration;
 import org.junit.Assert;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
@@ -51,9 +54,8 @@ public class VerifyDatabaseOperationsTest extends PluggableFlowableTestCase {
     protected DbSqlSessionFactory oldDbSqlSessionFactory;
     protected HistoryLevel oldHistoryLevel;
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
 
         // Enable flags
         this.oldIsBulkInsertableValue = processEngineConfiguration.isBulkInsertEnabled();
@@ -101,7 +103,7 @@ public class VerifyDatabaseOperationsTest extends PluggableFlowableTestCase {
         processEngineConfiguration.addSessionFactory(newDbSqlSessionFactory);
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
 
         processEngineConfiguration.setBulkInsertEnabled(oldIsBulkInsertableValue);
@@ -131,9 +133,9 @@ public class VerifyDatabaseOperationsTest extends PluggableFlowableTestCase {
         for (Deployment deployment : repositoryService.createDeploymentQuery().list()) {
             repositoryService.deleteDeployment(deployment.getId(), true);
         }
-        super.tearDown();
     }
 
+    @Test
     public void testStartToEnd() {
         if (!processEngineConfiguration.isAsyncHistoryEnabled()) {
             deployStartProcessInstanceAndProfile("process01.bpmn20.xml", "process01");
@@ -152,6 +154,7 @@ public class VerifyDatabaseOperationsTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testVariablesAndPassthrough() {
         if (!processEngineConfiguration.isAsyncHistoryEnabled()) {
             deployStartProcessInstanceAndProfile("process-variables-servicetask01.bpmn20.xml", "process-variables-servicetask01");
@@ -169,6 +172,7 @@ public class VerifyDatabaseOperationsTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testManyVariablesViaServiceTaskAndPassthroughs() {
         if (!processEngineConfiguration.isAsyncHistoryEnabled()) {
             deployStartProcessInstanceAndProfile("process-variables-servicetask02.bpmn20.xml", "process-variables-servicetask02");
@@ -186,6 +190,7 @@ public class VerifyDatabaseOperationsTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testOnlyPassThroughs() {
         if (!processEngineConfiguration.isAsyncHistoryEnabled()) {
             deployStartProcessInstanceAndProfile("process02.bpmn20.xml", "process02");
@@ -202,6 +207,7 @@ public class VerifyDatabaseOperationsTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testParallelForkAndJoin() {
         if (!processEngineConfiguration.isAsyncHistoryEnabled()) {
             deployStartProcessInstanceAndProfile("process03.bpmn20.xml", "process03");
@@ -218,6 +224,7 @@ public class VerifyDatabaseOperationsTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testNestedParallelForkAndJoin() {
         if (!processEngineConfiguration.isAsyncHistoryEnabled()) {
             deployStartProcessInstanceAndProfile("process04.bpmn20.xml", "process04");
@@ -235,6 +242,7 @@ public class VerifyDatabaseOperationsTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testExclusiveGateway() {
         if (!processEngineConfiguration.isAsyncHistoryEnabled()) {
             deployStartProcessInstanceAndProfile("process05.bpmn20.xml", "process05");
@@ -252,6 +260,7 @@ public class VerifyDatabaseOperationsTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testAsyncJob() {
         if (!processEngineConfiguration.isAsyncHistoryEnabled()) {
             deployStartProcessInstanceAndProfile("process06.bpmn20.xml", "process06", false);
@@ -284,6 +293,7 @@ public class VerifyDatabaseOperationsTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testOneTaskProcess() {
         if (!processEngineConfiguration.isAsyncHistoryEnabled()) {
             deployStartProcessInstanceAndProfile("process-usertask-01.bpmn20.xml", "process-usertask-01", false);
@@ -341,6 +351,7 @@ public class VerifyDatabaseOperationsTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testOneTaskWithBoundaryTimerProcess() {
         if (!processEngineConfiguration.isAsyncHistoryEnabled()) {
             deployStartProcessInstanceAndProfile("process-usertask-02.bpmn20.xml", "process-usertask-02", false);
@@ -371,6 +382,7 @@ public class VerifyDatabaseOperationsTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testRemoveTaskVariables() {
         if (!processEngineConfiguration.isAsyncHistoryEnabled()) {
             // TODO: move to separate class
@@ -404,6 +416,7 @@ public class VerifyDatabaseOperationsTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testClaimTask() {
         if (!processEngineConfiguration.isAsyncHistoryEnabled()) {
             // TODO: move to separate class
@@ -423,6 +436,7 @@ public class VerifyDatabaseOperationsTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testTaskCandidateUsers() {
         if (!processEngineConfiguration.isAsyncHistoryEnabled()) {
             // TODO: move to separate class
@@ -474,6 +488,7 @@ public class VerifyDatabaseOperationsTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testTaskCandidateGroups() {
         if (!processEngineConfiguration.isAsyncHistoryEnabled()) {
             // TODO: move to separate class

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/cfg/multitenant/MultiTenantProcessEngineTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/cfg/multitenant/MultiTenantProcessEngineTest.java
@@ -27,10 +27,10 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.job.service.impl.asyncexecutor.multitenant.ExecutorPerTenantAsyncExecutor;
 import org.flowable.job.service.impl.asyncexecutor.multitenant.SharedExecutorServiceAsyncExecutor;
 import org.h2.jdbcx.JdbcDataSource;
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
@@ -41,12 +41,12 @@ public class MultiTenantProcessEngineTest {
     private MultiSchemaMultiTenantProcessEngineConfiguration config;
     private ProcessEngine processEngine;
 
-    @Before
+    @BeforeEach
     public void setup() {
         setupTenantInfoHolder();
     }
 
-    @After
+    @AfterEach
     public void close() {
         processEngine.close();
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/cfg/taskcount/ChangeTaskCountConfigAndRebootEngineTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/cfg/taskcount/ChangeTaskCountConfigAndRebootEngineTest.java
@@ -23,6 +23,7 @@ import org.flowable.engine.impl.util.CommandContextUtil;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.task.service.impl.persistence.CountingTaskEntity;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,11 +52,10 @@ public class ChangeTaskCountConfigAndRebootEngineTest extends ResourceFlowableTe
     protected void rebootEngine(boolean newTaskRelationshipCountValue) {
         LOGGER.info("Rebooting engine");
         this.newTaskRelationshipCountValue = newTaskRelationshipCountValue;
-        closeDownProcessEngine();
-        initializeProcessEngine();
-        initializeServices();
+        rebootEngine();
     }
 
+    @Test
     @Deployment
     public void testChangeTaskCountSettingAndRebootengine() {
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/cmd/FailedJobRetryCmdTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/cmd/FailedJobRetryCmdTest.java
@@ -18,12 +18,14 @@ import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Saeid Mirzaei
  */
 public class FailedJobRetryCmdTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/cmd/FailedJobRetryCmdTest.testFailedServiceTask.bpmn20.xml" })
     public void testFailedServiceTask() {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("failedServiceTask");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/concurrency/ConcurrentEngineUsageTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/concurrency/ConcurrentEngineUsageTest.java
@@ -25,6 +25,7 @@ import org.flowable.common.engine.impl.identity.Authentication;
 import org.flowable.engine.impl.test.HistoryTestHelper;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,6 +39,7 @@ public class ConcurrentEngineUsageTest extends PluggableFlowableTestCase {
     private static final Logger LOGGER = LoggerFactory.getLogger(ConcurrentEngineUsageTest.class);
     private static final int MAX_RETRIES = 5;
 
+    @Test
     @Deployment
     public void testConcurrentUsage() throws Exception {
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/concurrency/OptimisticLockingExceptionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/concurrency/OptimisticLockingExceptionTest.java
@@ -27,12 +27,14 @@ import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.junit.Assert;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
  */
 public class OptimisticLockingExceptionTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/concurrency/CompetingJoinTest.testCompetingJoins.bpmn20.xml" })
     public void testOptimisticLockExceptionForConcurrentJoin() throws Exception {
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/db/ConnectionPoolTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/db/ConnectionPoolTest.java
@@ -19,12 +19,14 @@ import org.apache.ibatis.datasource.pooled.PooledDataSource;
 import org.flowable.engine.ProcessEngineConfiguration;
 import org.flowable.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.flowable.engine.impl.test.AbstractTestCase;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
  */
 public class ConnectionPoolTest extends AbstractTestCase {
 
+    @Test
     public void testMyBatisConnectionPoolProperlyConfigured() {
         ProcessEngineConfigurationImpl config = (ProcessEngineConfigurationImpl) ProcessEngineConfiguration
                 .createProcessEngineConfigurationFromResource("org/flowable/engine/test/db/connection-pool.flowable.cfg.xml");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/db/DatabaseTablePrefixTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/db/DatabaseTablePrefixTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.engine.test.db;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.sql.Connection;
 import java.sql.SQLException;
 
@@ -23,15 +25,15 @@ import org.flowable.common.engine.impl.util.ReflectUtil;
 import org.flowable.engine.ProcessEngine;
 import org.flowable.engine.ProcessEngineConfiguration;
 import org.flowable.engine.impl.cfg.ProcessEngineConfigurationImpl;
-
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Daniel Meyer
  * @author Joram Barrez
  */
-public class DatabaseTablePrefixTest extends TestCase {
+public class DatabaseTablePrefixTest {
 
+    @Test
     public void testPerformDatabaseSchemaOperationCreate() throws Exception {
 
         DataSource dataSource = createDataSourceAndSchema();
@@ -98,6 +100,7 @@ public class DatabaseTablePrefixTest extends TestCase {
     }
     
     
+    @Test
     public void testProcessEngineReboot() throws Exception {
         
         ProcessEngine processEngine1 = null;

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/db/DeploymentPersistenceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/db/DeploymentPersistenceTest.java
@@ -22,12 +22,14 @@ import java.util.Set;
 import org.flowable.common.engine.impl.util.IoUtil;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.repository.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tom Baeyens
  */
 public class DeploymentPersistenceTest extends PluggableFlowableTestCase {
 
+    @Test
     public void testDeploymentPersistence() {
         Deployment deployment = repositoryService.createDeployment().name("strings").addString("org/flowable/test/HelloWorld.string", "hello world").addString("org/flowable/test/TheAnswer.string", "42")
                 .deploy();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/db/DuplicateVariableInsertTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/db/DuplicateVariableInsertTest.java
@@ -26,6 +26,7 @@ import org.flowable.engine.impl.cmd.SetExecutionVariablesCmd;
 import org.flowable.engine.impl.cmd.SetTaskVariablesCmd;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
+import org.junit.jupiter.api.Test;
 
 public class DuplicateVariableInsertTest extends PluggableFlowableTestCase {
 
@@ -33,6 +34,7 @@ public class DuplicateVariableInsertTest extends PluggableFlowableTestCase {
      * Test for ACT-1887: Inserting the same new variable at the same time, from 2 different threads, using 2 modified commands that use a barrier for starting and a barrier for completing the
      * command, so they each insert a new variable guaranteed.
      */
+    @Test
     public void testDuplicateVariableInsertOnExecution() throws Exception {
         String processDefinitionId = deployOneTaskTestProcess();
         final ProcessInstance processInstance = runtimeService.startProcessInstanceById(processDefinitionId);
@@ -85,6 +87,7 @@ public class DuplicateVariableInsertTest extends PluggableFlowableTestCase {
      * Test for ACT-1887: Inserting the same new variable at the same time, from 2 different threads, using 2 modified commands that use a barrier for starting and a barrier for completing the
      * command, so they each insert a new variable guaranteed.
      */
+    @Test
     public void testDuplicateVariableInsertOnTask() throws Exception {
         String processDefinitionId = deployOneTaskTestProcess();
         final ProcessInstance processInstance = runtimeService.startProcessInstanceById(processDefinitionId);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/db/MetaDataTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/db/MetaDataTest.java
@@ -22,6 +22,7 @@ import org.flowable.common.engine.impl.interceptor.CommandContext;
 import org.flowable.engine.impl.ProcessEngineImpl;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.impl.util.CommandContextUtil;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,6 +33,7 @@ public class MetaDataTest extends PluggableFlowableTestCase {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MetaDataTest.class);
 
+    @Test
     public void testMetaData() {
         ((ProcessEngineImpl) processEngine).getProcessEngineConfiguration().getCommandExecutor().execute(new Command<Object>() {
             @Override

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/db/ProcessDefinitionPersistenceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/db/ProcessDefinitionPersistenceTest.java
@@ -22,6 +22,7 @@ import org.flowable.bpmn.model.StartEvent;
 import org.flowable.engine.impl.RepositoryServiceImpl;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.repository.ProcessDefinition;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tom Baeyens
@@ -29,6 +30,7 @@ import org.flowable.engine.repository.ProcessDefinition;
  */
 public class ProcessDefinitionPersistenceTest extends PluggableFlowableTestCase {
 
+    @Test
     public void testProcessDefinitionPersistence() {
         String deploymentId = repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/db/processOne.bpmn20.xml")
                 .addClasspathResource("org/flowable/engine/test/db/processTwo.bpmn20.xml").deploy().getId();
@@ -40,6 +42,7 @@ public class ProcessDefinitionPersistenceTest extends PluggableFlowableTestCase 
         repositoryService.deleteDeployment(deploymentId);
     }
 
+    @Test
     public void testProcessDefinitionIntrospection() {
         String deploymentId = repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/db/processOne.bpmn20.xml").deploy().getId();
 
@@ -72,6 +75,7 @@ public class ProcessDefinitionPersistenceTest extends PluggableFlowableTestCase 
         repositoryService.deleteDeployment(deploymentId);
     }
 
+    @Test
     public void testProcessDefinitionQuery() {
         String deployment1Id = repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/db/processOne.bpmn20.xml")
                 .addClasspathResource("org/flowable/engine/test/db/processTwo.bpmn20.xml").deploy().getId();
@@ -90,6 +94,7 @@ public class ProcessDefinitionPersistenceTest extends PluggableFlowableTestCase 
         repositoryService.deleteDeployment(deployment2Id);
     }
 
+    @Test
     public void testProcessDefinitionGraphicalNotationFlag() {
         String deploymentId = repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/db/process-with-di.bpmn20.xml")
                 .addClasspathResource("org/flowable/engine/test/db/process-without-di.bpmn20.xml").deploy().getId();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/db/ProcessInstanceMigrationTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/db/ProcessInstanceMigrationTest.java
@@ -31,6 +31,7 @@ import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.task.api.history.HistoricTaskInstance;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Falko Menge
@@ -46,6 +47,7 @@ public class ProcessInstanceMigrationTest extends PluggableFlowableTestCase {
     private static final String TEST_PROCESS_USER_TASK_V2 = "org/flowable/engine/test/db/ProcessInstanceMigrationTest.testSetProcessDefinitionVersionWithTaskV2.bpmn20.xml";
     private static final String TEST_PROCESS_NESTED_SUB_EXECUTIONS = "org/flowable/engine/test/db/ProcessInstanceMigrationTest.testSetProcessDefinitionVersionSubExecutionsNested.bpmn20.xml";
 
+    @Test
     public void testSetProcessDefinitionVersionEmptyArguments() {
         try {
             new SetProcessDefinitionVersionCmd(null, 23);
@@ -76,6 +78,7 @@ public class ProcessInstanceMigrationTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testSetProcessDefinitionVersionNonExistingPI() {
         CommandExecutor commandExecutor = processEngineConfiguration.getCommandExecutor();
         try {
@@ -87,6 +90,7 @@ public class ProcessInstanceMigrationTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { TEST_PROCESS_WITH_PARALLEL_GATEWAY })
     public void testSetProcessDefinitionVersionPIIsSubExecution() {
         // start process instance
@@ -104,6 +108,7 @@ public class ProcessInstanceMigrationTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { TEST_PROCESS })
     public void testSetProcessDefinitionVersionNonExistingPD() {
         // start process instance
@@ -119,6 +124,7 @@ public class ProcessInstanceMigrationTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { TEST_PROCESS })
     public void testSetProcessDefinitionVersionActivityMissing() {
         // start process instance
@@ -146,6 +152,7 @@ public class ProcessInstanceMigrationTest extends PluggableFlowableTestCase {
         repositoryService.deleteDeployment(deployment.getId(), true);
     }
 
+    @Test
     @Deployment
     public void testSetProcessDefinitionVersion() {
         // start process instance
@@ -188,6 +195,7 @@ public class ProcessInstanceMigrationTest extends PluggableFlowableTestCase {
         deleteDeployments();
     }
 
+    @Test
     @Deployment(resources = { TEST_PROCESS_WITH_PARALLEL_GATEWAY })
     public void testSetProcessDefinitionVersionSubExecutions() {
         // start process instance
@@ -216,6 +224,7 @@ public class ProcessInstanceMigrationTest extends PluggableFlowableTestCase {
         repositoryService.deleteDeployment(deployment.getId(), true);
     }
 
+    @Test
     @Deployment(resources = { TEST_PROCESS_CALL_ACTIVITY })
     public void testSetProcessDefinitionVersionWithCallActivity() {
         // start process instance
@@ -243,6 +252,7 @@ public class ProcessInstanceMigrationTest extends PluggableFlowableTestCase {
         repositoryService.deleteDeployment(deployment.getId(), true);
     }
 
+    @Test
     @Deployment(resources = { TEST_PROCESS_USER_TASK_V1 })
     public void testSetProcessDefinitionVersionWithWithTask() {
         try {
@@ -284,6 +294,7 @@ public class ProcessInstanceMigrationTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { TEST_PROCESS_NESTED_SUB_EXECUTIONS })
     public void testSetProcessDefinitionVersionSubExecutionsNested() {
         // start process instance

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/db/ProcessInstanceSuspensionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/db/ProcessInstanceSuspensionTest.java
@@ -29,6 +29,7 @@ import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
 import org.flowable.job.service.JobServiceConfiguration;
 import org.flowable.job.service.impl.persistence.entity.TimerJobEntity;
+import org.junit.jupiter.api.Test;
 
 /**
  * 
@@ -36,6 +37,7 @@ import org.flowable.job.service.impl.persistence.entity.TimerJobEntity;
  */
 public class ProcessInstanceSuspensionTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/db/oneJobProcess.bpmn20.xml" })
     public void testJobsNotVisibleToAcquisitionIfInstanceSuspended() {
 
@@ -60,6 +62,7 @@ public class ProcessInstanceSuspensionTest extends PluggableFlowableTestCase {
         assertEquals(0, acquiredJobs.size());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/db/oneJobProcess.bpmn20.xml" })
     public void testJobsNotVisibleToAcquisitionIfDefinitionSuspended() {
 
@@ -84,6 +87,7 @@ public class ProcessInstanceSuspensionTest extends PluggableFlowableTestCase {
         assertEquals(0, acquiredJobs.size());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/db/oneJobProcess.bpmn20.xml" })
     public void testJobsVisibleToAcquisitionIfDefinitionSuspendedWithoutProcessInstances() {
 
@@ -108,6 +112,7 @@ public class ProcessInstanceSuspensionTest extends PluggableFlowableTestCase {
         assertEquals(1, acquiredJobs.size());
     }
 
+    @Test
     @Deployment
     public void testSuspendedProcessTimerExecution() throws Exception {
         // Process with boundary timer-event that fires in 1 hour

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/db/VariableScopeTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/db/VariableScopeTest.java
@@ -28,6 +28,7 @@ import org.flowable.engine.impl.util.CommandContextUtil;
 import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tijs Rademakers
@@ -36,6 +37,7 @@ import org.flowable.engine.test.Deployment;
  */
 public class VariableScopeTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testVariableScope() {
 
@@ -89,6 +91,7 @@ public class VariableScopeTest extends PluggableFlowableTestCase {
     /**
      * A testcase to produce and fix issue ACT-862.
      */
+    @Test
     @Deployment
     public void testVariableNamesScope() {
 
@@ -150,6 +153,7 @@ public class VariableScopeTest extends PluggableFlowableTestCase {
         taskService.complete(subProcessTask.getId());
     }
 
+    @Test
     @Deployment
     public void testModeledVariableScope() {
 
@@ -241,6 +245,7 @@ public class VariableScopeTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testGetVariableLocal() {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("getVariableLocal");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/debugger/DebugProcessOperationTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/debugger/DebugProcessOperationTest.java
@@ -20,6 +20,7 @@ import org.flowable.engine.runtime.ProcessDebugger;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -36,6 +37,7 @@ public class DebugProcessOperationTest extends ResourceFlowableTestCase {
         super("/org/flowable/engine/impl/agenda/DebugProcessOperationTest.flowable.cfg.xml");
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml")
     public void testDebugOneTaskProcess() {
         ProcessInstance oneTaskProcess = this.runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -57,6 +59,7 @@ public class DebugProcessOperationTest extends ResourceFlowableTestCase {
         assertThat("No process instance is running.", this.runtimeService.createExecutionQuery().count(), is(0L));
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/impl/agenda/oneFailureScriptTask.bpmn20.xml")
     public void testDebuggerExecutionFailure() {
         ProcessInstance oneTaskProcess = this.runtimeService.startProcessInstanceByKey("oneTaskFailingProcess");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/el/ExpressionManagerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/el/ExpressionManagerTest.java
@@ -25,23 +25,21 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.variable.service.impl.el.NoExecutionVariableScope;
 import org.hamcrest.core.Is;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Frederik Heremans
  */
 public class ExpressionManagerTest extends PluggableFlowableTestCase {
 
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
-    }
-
+    @Test
     public void testExpressionEvaluationWithoutProcessContext() {
         Expression expression = this.processEngineConfiguration.getExpressionManager().createExpression("#{1 == 1}");
         Object value = expression.getValue(new NoExecutionVariableScope());
         assertThat(value, Is.<Object>is(true));
     }
 
+    @Test
     @Deployment
     public void testMethodExpressions() {
         // Process contains 2 service tasks. one containing a method with no
@@ -56,6 +54,7 @@ public class ExpressionManagerTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createProcessInstanceQuery().processDefinitionKey("methodExpressionProcess").count());
     }
 
+    @Test
     @Deployment
     public void testExecutionAvailable() {
         Map<String, Object> vars = new HashMap<>();
@@ -69,6 +68,7 @@ public class ExpressionManagerTest extends PluggableFlowableTestCase {
         assertEquals("myValue", value);
     }
 
+    @Test
     @Deployment
     public void testAuthenticatedUserIdAvailable() {
         try {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricActivityInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricActivityInstanceTest.java
@@ -26,6 +26,7 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tom Baeyens
@@ -33,6 +34,7 @@ import org.flowable.engine.test.Deployment;
  */
 public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testHistoricActivityInstanceNoop() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("noopProcess");
@@ -50,6 +52,7 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
         assertTrue(historicActivityInstance.getDurationInMillis() >= 0);
     }
 
+    @Test
     @Deployment
     public void testHistoricActivityInstanceReceive() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("receiveProcess");
@@ -82,6 +85,7 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
         assertNotNull(historicActivityInstance.getStartTime());
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/history/oneTaskProcess.bpmn20.xml")
     public void testHistoricActivityInstanceUnfinished() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -98,6 +102,7 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
         assertEquals("One active (unfinished) User org.flowable.task.service.Task", 1, unfinishedActivityInstanceCount);
     }
 
+    @Test
     @Deployment
     public void testHistoricActivityInstanceQuery() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("noopProcess");
@@ -153,6 +158,7 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testHistoricActivityInstanceForEventsQuery() {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("eventProcess");
@@ -185,6 +191,7 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
         assertNotNull(endEvent.getEndTime());
     }
 
+    @Test
     @Deployment
     public void testHistoricActivityInstanceProperties() {
         // Start process instance
@@ -200,6 +207,7 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
         assertEquals("kermit", historicActivityInstance.getAssignee());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/history/calledProcess.bpmn20.xml", "org/flowable/engine/test/history/HistoricActivityInstanceTest.testCallSimpleSubProcess.bpmn20.xml" })
     public void testHistoricActivityInstanceCalledProcessId() {
         runtimeService.startProcessInstanceByKey("callSimpleSubProcess");
@@ -213,6 +221,7 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
         assertEquals(oldInstance.getId(), historicActivityInstance.getCalledProcessInstanceId());
     }
 
+    @Test
     @Deployment
     public void testSorting() {
         runtimeService.startProcessInstanceByKey("process");
@@ -257,6 +266,7 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
         assertEquals(expectedActivityInstances, historyService.createHistoricActivityInstanceQuery().orderByProcessInstanceId().desc().count());
     }
 
+    @Test
     public void testInvalidSorting() {
         try {
             historyService.createHistoricActivityInstanceQuery().asc().list();
@@ -283,6 +293,7 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
     /**
      * Test to validate fix for ACT-1399: Boundary-event and event-based auditing
      */
+    @Test
     @Deployment
     public void testBoundaryEvent() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("boundaryEventProcess");
@@ -321,6 +332,7 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
     /**
      * Test to validate fix for ACT-1399: Boundary-event and event-based auditing
      */
+    @Test
     @Deployment
     public void testEventBasedGateway() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("catchSignal");
@@ -340,6 +352,7 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
     /**
      * Test to validate fix for ACT-1549: endTime of joining parallel gateway is not set
      */
+    @Test
     @Deployment
     public void testParallelJoinEndTime() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("forkJoin");
@@ -364,6 +377,7 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
         assertNotNull(historicActivityInstance.get(1).getEndTime());
     }
 
+    @Test
     @Deployment
     public void testLoop() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("historic-activity-loops", CollectionUtil.singletonMap("input", 0));

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricProcessInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricProcessInstanceTest.java
@@ -32,6 +32,7 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.runtime.ProcessInstanceBuilder;
 import org.flowable.engine.test.Deployment;
 import org.flowable.identitylink.api.history.HistoricIdentityLink;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tom Baeyens
@@ -39,6 +40,7 @@ import org.flowable.identitylink.api.history.HistoricIdentityLink;
  */
 public class HistoricProcessInstanceTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/history/oneTaskProcess.bpmn20.xml" })
     public void testHistoricDataCreatedForProcessExecution() {
 
@@ -94,6 +96,7 @@ public class HistoricProcessInstanceTest extends PluggableFlowableTestCase {
         assertEquals(1, historyService.createHistoricProcessInstanceQuery().finished().count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/history/oneTaskProcess.bpmn20.xml" })
     public void testDeleteProcessInstanceHistoryCreated() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -109,6 +112,7 @@ public class HistoricProcessInstanceTest extends PluggableFlowableTestCase {
     }
 
     /*
+     * @Test
      * @Deployment(resources = {"org/flowable/engine/test/history/oneTaskProcess.bpmn20.xml"}) public void testHistoricProcessInstanceVariables() { Map<String,Object> vars = new
      * HashMap<String,Object>(); vars.put("foo", "bar"); vars.put("baz", "boo");
      * 
@@ -119,6 +123,7 @@ public class HistoricProcessInstanceTest extends PluggableFlowableTestCase {
      * "boo").count()); }
      */
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/history/oneTaskProcess.bpmn20.xml" })
     public void testHistoricProcessInstanceQuery() {
         Calendar startTime = Calendar.getInstance();
@@ -198,6 +203,7 @@ public class HistoricProcessInstanceTest extends PluggableFlowableTestCase {
         assertEquals(0, historyService.createHistoricProcessInstanceQuery().involvedUser("gonzo").count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/history/oneTaskProcess.bpmn20.xml" })
     public void testHistoricProcessInstanceOrQuery() {
         Calendar startTime = Calendar.getInstance();
@@ -298,6 +304,7 @@ public class HistoricProcessInstanceTest extends PluggableFlowableTestCase {
         assertEquals(0, historyService.createHistoricProcessInstanceQuery().or().involvedUser("gonzo").processDefinitionId("undefined").endOr().count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/history/oneTaskProcess.bpmn20.xml" })
     public void testHistoricProcessInstanceSorting() {
         ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -393,6 +400,7 @@ public class HistoricProcessInstanceTest extends PluggableFlowableTestCase {
         assertTrue(processInstance.contains(processInstance2.getId()));
     }
 
+    @Test
     public void testInvalidSorting() {
         try {
             historyService.createHistoricProcessInstanceQuery().asc();
@@ -416,6 +424,7 @@ public class HistoricProcessInstanceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/history/oneTaskProcess.bpmn20.xml" })
     // ACT-1098
     public void testDeleteReason() {
@@ -431,6 +440,7 @@ public class HistoricProcessInstanceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/history/oneTaskProcess.bpmn20.xml" })
     public void testHistoricIdentityLinksOnProcessInstance() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
@@ -468,6 +478,7 @@ public class HistoricProcessInstanceTest extends PluggableFlowableTestCase {
     /**
      * Validation for ACT-821
      */
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/history/HistoricProcessInstanceTest.testDeleteHistoricProcessInstanceWithCallActivity.bpmn20.xml",
             "org/flowable/engine/test/history/HistoricProcessInstanceTest.testDeleteHistoricProcessInstanceWithCallActivity-subprocess.bpmn20.xml" })
     public void testDeleteHistoricProcessInstanceWithCallActivity() {
@@ -490,6 +501,7 @@ public class HistoricProcessInstanceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/history/oneTaskProcess.bpmn20.xml" })
     public void testHistoricProcessInstanceName() {
         String piName = "Customized Process Instance Name";
@@ -508,6 +520,7 @@ public class HistoricProcessInstanceTest extends PluggableFlowableTestCase {
     /**
      * Validation for https://jira.codehaus.org/browse/ACT-2182
      */
+    @Test
     public void testNameAndTenantIdSetWhenFetchingVariables() {
 
         String tenantId = "testTenantId";

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricTaskInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricTaskInstanceTest.java
@@ -30,6 +30,7 @@ import org.flowable.engine.test.Deployment;
 import org.flowable.identitylink.api.history.HistoricIdentityLink;
 import org.flowable.identitylink.api.IdentityLinkType;
 import org.flowable.task.api.history.HistoricTaskInstance;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tom Baeyens
@@ -37,6 +38,7 @@ import org.flowable.task.api.history.HistoricTaskInstance;
  */
 public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testHistoricTaskInstance() throws Exception {
         Map<String, Object> varMap = new HashMap<>();
@@ -113,12 +115,14 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         assertEquals(0, historyService.createHistoricTaskInstanceQuery().count());
     }
 
+    @Test
     public void testDeleteHistoricTaskInstance() throws Exception {
         // deleting unexisting historic task instance should be silently ignored
         historyService.deleteHistoricTaskInstance("unexistingId");
         waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
     }
 
+    @Test
     @Deployment
     public void testHistoricTaskInstanceQuery() throws Exception {
         Calendar start = Calendar.getInstance();
@@ -291,6 +295,7 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         assertEquals(1, historyService.createHistoricTaskInstanceQuery().unfinished().count());
     }
 
+    @Test
     @Deployment
     public void testHistoricIdentityLinksForTaskOwner() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTaskProcess");
@@ -341,6 +346,7 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         assertNotNull(historicIdentityLinksForTask.get(0).getCreateTime());
     }
 
+    @Test
     @Deployment
     public void testHistoricIdentityLinksOnTaskClaim() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTaskProcess");
@@ -452,6 +458,7 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         assertEquals("newKid", historicIdentityLinksForTask.get(0).getUserId());
     }
 
+    @Test
     @Deployment
     public void testHistoricTaskInstanceOrQuery() throws Exception {
         Calendar start = Calendar.getInstance();
@@ -662,6 +669,7 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().unfinished().endOr().count());
     }
 
+    @Test
     @Deployment
     public void testHistoricTaskInstanceQueryProcessFinished() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("TwoTaskHistoricTaskQueryTest");
@@ -691,6 +699,7 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         assertEquals(2, historyService.createHistoricTaskInstanceQuery().processFinished().count());
     }
 
+    @Test
     @Deployment
     public void testHistoricTaskInstanceQuerySorting() {
         ProcessInstance instance = runtimeService.startProcessInstanceByKey("HistoricTaskQueryTest");
@@ -727,6 +736,7 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         assertEquals(1, historyService.createHistoricTaskInstanceQuery().orderByTaskId().desc().count());
     }
 
+    @Test
     @Deployment
     public void testHistoricIdentityLinksOnTask() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("historicIdentityLinks");
@@ -792,6 +802,7 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testInvalidSorting() {
         try {
             historyService.createHistoricTaskInstanceQuery().asc();
@@ -818,6 +829,7 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
     /**
      * Test to validate fix for ACT-1939: HistoryService loads invalid task local variables for completed task
      */
+    @Test
     @Deployment
     public void testVariableUpdateOrderHistoricTaskInstance() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("historicTask");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricTaskInstanceUpdateTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricTaskInstanceUpdateTest.java
@@ -17,12 +17,14 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.task.api.history.HistoricTaskInstance;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Frederik Heremans
  */
 public class HistoricTaskInstanceUpdateTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testHistoricTaskInstanceUpdate() {
         runtimeService.startProcessInstanceByKey("HistoricTaskInstanceTest").getId();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricVariableInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricVariableInstanceTest.java
@@ -33,12 +33,14 @@ import org.flowable.engine.test.Deployment;
 import org.flowable.task.api.TaskQuery;
 import org.flowable.variable.api.history.HistoricVariableInstance;
 import org.flowable.variable.service.impl.persistence.entity.HistoricVariableInstanceEntity;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
  */
 public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment(resources = { "org/flowable/examples/bpmn/callactivity/orderProcess.bpmn20.xml", "org/flowable/examples/bpmn/callactivity/checkCreditProcess.bpmn20.xml" })
     public void testOrderProcessWithCallActivity() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.FULL, processEngineConfiguration)) {
@@ -60,6 +62,7 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testSimple() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.FULL, processEngineConfiguration)) {
@@ -85,6 +88,7 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testSimpleNoWaitState() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.FULL, processEngineConfiguration)) {
@@ -104,6 +108,7 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testParallel() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.FULL, processEngineConfiguration)) {
@@ -137,6 +142,7 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testParallelNoWaitState() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.FULL, processEngineConfiguration)) {
@@ -158,6 +164,7 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testTwoSubProcessInParallelWithinSubProcess() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.FULL, processEngineConfiguration)) {
@@ -184,6 +191,7 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/history/HistoricVariableInstanceTest.testCallSimpleSubProcess.bpmn20.xml", "org/flowable/engine/test/history/simpleSubProcess.bpmn20.xml" })
     public void testHistoricVariableInstanceQuery() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.FULL, processEngineConfiguration)) {
@@ -223,6 +231,7 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testHistoricVariableQuery2() {
         deployTwoTasksTestProcess();
         
@@ -294,6 +303,7 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     public void testHistoricVariableQueryByExecutionIds() {
         deployTwoTasksTestProcess();
 
@@ -332,6 +342,7 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
         assertEquals("hello", historicVariableInstances.get(2).getValue());
     }
 
+    @Test
     @Deployment(resources = {
             "org/flowable/engine/test/api/runtime/variableScope.bpmn20.xml"
     })
@@ -371,6 +382,7 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
         assertEquals("executionVar", historicVariableInstances.get(1).getValue());
     }
 
+    @Test
     public void testHistoricVariableQueryByTaskIds() {
         deployTwoTasksTestProcess();
         // Generate data
@@ -401,6 +413,7 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
         assertEquals("hello1", historicVariableInstances.get(0).getValue());
     }
 
+    @Test
     @Deployment(resources = {
             "org/flowable/engine/test/api/runtime/variableScope.bpmn20.xml"
     })
@@ -433,6 +446,7 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
         assertEquals("taskVar", historicVariableInstances.get(1).getValue());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testHistoricProcessVariableOnDeletion() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.FULL, processEngineConfiguration)) {
@@ -447,6 +461,7 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/standalone/history/FullHistoryTest.testVariableUpdatesAreLinkedToActivity.bpmn20.xml" })
     public void testVariableUpdatesLinkedToActivity() throws Exception {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.FULL, processEngineConfiguration)) {
@@ -504,6 +519,7 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
     // Test for ACT-1528, which (correctly) reported that deleting any
     // historic process instance would remove ALL historic variables.
     // Yes. Real serious bug.
+    @Test
     @Deployment
     public void testHistoricProcessInstanceDeleteCascadesCorrectly() {
 
@@ -551,6 +567,7 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/history/HistoricVariableInstanceTest.testSimple.bpmn20.xml")
     public void testNativeHistoricVariableInstanceQuery() {
 
@@ -586,6 +603,7 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/history/HistoricVariableInstanceTest.testSimple.bpmn20.xml")
     public void testNativeHistoricDetailQuery() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.FULL, processEngineConfiguration)) {
@@ -630,6 +648,7 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/history/oneTaskProcess.bpmn20.xml" })
     public void testChangeType() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.FULL, processEngineConfiguration)) {
@@ -676,6 +695,7 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
         return historyService.createHistoricVariableInstanceQuery().variableName(variableName).singleResult();
     }
 
+    @Test
     @Deployment
     public void testRestrictByExecutionId() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.FULL, processEngineConfiguration)) {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/ProcessInstanceLogQueryAndByteArrayTypeVariableTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/ProcessInstanceLogQueryAndByteArrayTypeVariableTest.java
@@ -24,6 +24,8 @@ import org.flowable.engine.impl.test.HistoryTestHelper;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.variable.api.history.HistoricVariableInstance;
 import org.flowable.variable.service.impl.persistence.entity.HistoricVariableInstanceEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Daisuke Yoshimoto
@@ -42,10 +44,8 @@ public class ProcessInstanceLogQueryAndByteArrayTypeVariableTest extends Pluggab
         LARGE_STRING_VALUE = sb.toString();
     }
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
-
         // Deploy test process
         deployTwoTasksTestProcess();
 
@@ -61,11 +61,7 @@ public class ProcessInstanceLogQueryAndByteArrayTypeVariableTest extends Pluggab
         }
     }
 
-    @Override
-    protected void tearDown() throws Exception {
-        super.tearDown();
-    }
-
+    @Test
     public void testIncludeVariables() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.FULL, processEngineConfiguration)) {
             ProcessInstanceHistoryLog log = historyService.createProcessInstanceHistoryLogQuery(processInstanceId)
@@ -81,6 +77,7 @@ public class ProcessInstanceLogQueryAndByteArrayTypeVariableTest extends Pluggab
         }
     }
 
+    @Test
     public void testIncludeVariableUpdates() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.FULL, processEngineConfiguration)) {
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/impl/CustomConfigurationFlowableTestCase.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/impl/CustomConfigurationFlowableTestCase.java
@@ -15,7 +15,7 @@ package org.flowable.engine.test.impl;
 import org.flowable.engine.ProcessEngine;
 import org.flowable.engine.ProcessEngineConfiguration;
 import org.flowable.engine.impl.cfg.ProcessEngineConfigurationImpl;
-import org.flowable.engine.impl.test.AbstractFlowableTestCase;
+import org.flowable.engine.impl.test.ResourceFlowableTestCase;
 
 /**
  * Reads the default flowable.cfg.xml from the test classpath, but allows to change the settings before the engine is built.
@@ -26,26 +26,20 @@ import org.flowable.engine.impl.test.AbstractFlowableTestCase;
  * 
  * @author Joram Barrez
  */
-public abstract class CustomConfigurationFlowableTestCase extends AbstractFlowableTestCase {
-    
+public abstract class CustomConfigurationFlowableTestCase extends ResourceFlowableTestCase {
+
     protected String cfgResource = "flowable.cfg.xml";
-    
+
+    public CustomConfigurationFlowableTestCase(String engineName) {
+        super("flowable.cfg.xml", engineName);
+    }
+
     @Override
-    protected void initializeProcessEngine() {
-        ProcessEngineConfiguration processEngineConfiguration = ProcessEngineConfiguration.createProcessEngineConfigurationFromResource("flowable.cfg.xml");
-        processEngineConfiguration.setEngineName(getEngineName()); // to distinguish between different engines in different tests
+    protected final void additionalConfiguration(ProcessEngineConfiguration processEngineConfiguration) {
         processEngineConfiguration.setDatabaseSchemaUpdate(ProcessEngineConfiguration.DB_SCHEMA_UPDATE_TRUE);
         configureConfiguration((ProcessEngineConfigurationImpl) processEngineConfiguration);
-        this.processEngine = processEngineConfiguration.buildProcessEngine();
     }
-    
-    @Override
-    protected void closeDownProcessEngine() {
-        this.processEngine.close();
-    }
-    
-    protected abstract String getEngineName();
-    
+
     protected abstract void configureConfiguration(ProcessEngineConfigurationImpl processEngineConfiguration);
 
     public String getCfgResource() {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/impl/calendar/MapBusinessCalendarManagerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/impl/calendar/MapBusinessCalendarManagerTest.java
@@ -15,6 +15,8 @@ package org.flowable.engine.test.impl.calendar;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -24,14 +26,14 @@ import org.flowable.common.engine.api.FlowableException;
 import org.flowable.common.engine.impl.calendar.BusinessCalendar;
 import org.flowable.common.engine.impl.calendar.CycleBusinessCalendar;
 import org.flowable.common.engine.impl.calendar.MapBusinessCalendarManager;
-
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
 /**
  * Created by martin.grofcik
  */
-public class MapBusinessCalendarManagerTest extends TestCase {
+public class MapBusinessCalendarManagerTest {
 
+    @Test
     public void testMapConstructor() {
         Map<String, BusinessCalendar> calendars = new HashMap<>(1);
         CycleBusinessCalendar calendar = new CycleBusinessCalendar(null);
@@ -41,6 +43,7 @@ public class MapBusinessCalendarManagerTest extends TestCase {
         assertEquals(calendar, businessCalendarManager.getBusinessCalendar("someKey"));
     }
 
+    @Test
     public void testInvalidCalendarNameRequest() {
         @SuppressWarnings("unchecked")
         MapBusinessCalendarManager businessCalendarManager = new MapBusinessCalendarManager(Collections.EMPTY_MAP);
@@ -53,6 +56,7 @@ public class MapBusinessCalendarManagerTest extends TestCase {
         }
     }
 
+    @Test
     public void testNullCalendars() {
         try {
             new MapBusinessCalendarManager(null);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/AsyncExecutorTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/AsyncExecutorTest.java
@@ -26,7 +26,7 @@ import org.flowable.job.api.JobInfo;
 import org.flowable.job.service.impl.asyncexecutor.AsyncExecutor;
 import org.flowable.job.service.impl.asyncexecutor.DefaultAsyncJobExecutor;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/AsyncExecutorTwoEnginesTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/AsyncExecutorTwoEnginesTest.java
@@ -23,7 +23,7 @@ import org.flowable.job.api.JobInfo;
 import org.flowable.job.service.impl.asyncexecutor.AsyncExecutor;
 import org.flowable.job.service.impl.asyncexecutor.DefaultAsyncJobExecutor;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/JobExecutorCmdExceptionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/JobExecutorCmdExceptionTest.java
@@ -20,6 +20,9 @@ import org.flowable.engine.impl.util.CommandContextUtil;
 import org.flowable.job.api.Job;
 import org.flowable.job.service.impl.persistence.entity.JobEntity;
 import org.flowable.job.service.impl.persistence.entity.JobEntityImpl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tom Baeyens
@@ -30,17 +33,18 @@ public class JobExecutorCmdExceptionTest extends PluggableFlowableTestCase {
 
     private CommandExecutor commandExecutor;
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         processEngineConfiguration.addJobHandler(tweetExceptionHandler);
         this.commandExecutor = processEngineConfiguration.getCommandExecutor();
     }
 
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
         processEngineConfiguration.removeJobHandler(tweetExceptionHandler.getType());
     }
 
+    @Test
     public void testJobCommandsWith2Exceptions() {
         commandExecutor.execute(new Command<String>() {
 
@@ -80,6 +84,7 @@ public class JobExecutorCmdExceptionTest extends PluggableFlowableTestCase {
         managementService.executeJob(job.getId());
     }
 
+    @Test
     public void testJobCommandsWith3Exceptions() {
         tweetExceptionHandler.setExceptionsRemaining(3);
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/JobExecutorCmdHappyTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/JobExecutorCmdHappyTest.java
@@ -25,12 +25,14 @@ import org.flowable.job.service.impl.cmd.AcquireTimerJobsCmd;
 import org.flowable.job.service.impl.cmd.ExecuteAsyncJobCmd;
 import org.flowable.job.service.impl.persistence.entity.JobEntity;
 import org.flowable.job.service.impl.persistence.entity.TimerJobEntity;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tom Baeyens
  */
 public class JobExecutorCmdHappyTest extends JobExecutorTestCase {
 
+    @Test
     public void testJobCommandsWithMessage() {
         CommandExecutor commandExecutor = processEngineConfiguration.getCommandExecutor();
 
@@ -59,6 +61,7 @@ public class JobExecutorCmdHappyTest extends JobExecutorTestCase {
     static final long SOME_TIME = 928374923546L;
     static final long SECOND = 1000;
 
+    @Test
     public void testJobCommandsWithTimer() {
         // clock gets automatically reset in LogTestCase.runTest
         processEngineConfiguration.getClock().setCurrentTime(new Date(SOME_TIME));

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/JobExecutorExceptionsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/JobExecutorExceptionsTest.java
@@ -21,12 +21,14 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.TimerJobQuery;
 import org.junit.Assert;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
  */
 public class JobExecutorExceptionsTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/mgmt/ManagementServiceTest.testGetJobExceptionStacktrace.bpmn20.xml" })
     public void testQueryByExceptionWithRealJobExecutor() {
         TimerJobQuery query = managementService.createTimerJobQuery().withException();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/JobExecutorFailRetryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/JobExecutorFailRetryTest.java
@@ -14,6 +14,7 @@ package org.flowable.engine.test.jobexecutor;
 
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Saeid Mirzaei
@@ -21,6 +22,7 @@ import org.flowable.engine.test.Deployment;
 
 public class JobExecutorFailRetryTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testFailedServiceTask() {
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/JobExecutorTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/JobExecutorTest.java
@@ -26,12 +26,14 @@ import org.flowable.common.engine.impl.interceptor.EngineConfigurationConstants;
 import org.flowable.job.service.JobServiceConfiguration;
 import org.flowable.job.service.impl.asyncexecutor.JobManager;
 import org.flowable.job.service.impl.persistence.entity.TimerJobEntityManager;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tom Baeyens
  */
 public class JobExecutorTest extends JobExecutorTestCase {
 
+    @Test
     public void testBasicJobExecutorOperation() throws Exception {
         CommandExecutor commandExecutor = processEngineConfiguration.getCommandExecutor();
         commandExecutor.execute(new Command<Void>() {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/JobExecutorTestCase.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/JobExecutorTestCase.java
@@ -19,6 +19,8 @@ import org.flowable.job.service.impl.persistence.entity.JobEntity;
 import org.flowable.job.service.impl.persistence.entity.JobEntityImpl;
 import org.flowable.job.service.impl.persistence.entity.TimerJobEntity;
 import org.flowable.job.service.impl.persistence.entity.TimerJobEntityImpl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * @author Tom Baeyens
@@ -27,12 +29,12 @@ public abstract class JobExecutorTestCase extends PluggableFlowableTestCase {
 
     protected TweetHandler tweetHandler = new TweetHandler();
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         processEngineConfiguration.addJobHandler(tweetHandler);
     }
 
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
         processEngineConfiguration.removeJobHandler(tweetHandler.getType());
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/JobProcessorTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/JobProcessorTest.java
@@ -17,6 +17,8 @@ import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.JobInfo;
 import org.flowable.job.service.JobProcessor;
 import org.flowable.job.service.JobProcessorContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -39,12 +41,12 @@ public class JobProcessorTest extends ResourceFlowableTestCase {
         super("org/flowable/engine/test/jobexecutor/JobProcessorTest.flowable.cfg.xml");
     }
 
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
-        super.tearDown();
         CHECK_SUM.set(0);
     }
 
+    @Test
     @Deployment
     public void testIntermediateTimer() {
         // Arrange
@@ -62,6 +64,7 @@ public class JobProcessorTest extends ResourceFlowableTestCase {
         assertCheckSum(2);
     }
 
+    @Test
     @Deployment
     public void testAsyncTask() {
         // Arrange

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/ResetExpiredJobsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/ResetExpiredJobsTest.java
@@ -27,12 +27,14 @@ import org.flowable.job.service.impl.asyncexecutor.ResetExpiredJobsCmd;
 import org.flowable.job.service.impl.cmd.AcquireJobsCmd;
 import org.flowable.job.service.impl.persistence.entity.JobEntity;
 import org.flowable.job.service.impl.persistence.entity.JobInfoEntity;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
  */
 public class ResetExpiredJobsTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testResetExpiredJobs() {
 
@@ -98,6 +100,7 @@ public class ResetExpiredJobsTest extends PluggableFlowableTestCase {
         }
     }
     
+    @Test
     @Deployment
     public void testResetExpiredJobTimeout() {
         Date startOfTestTime = new Date();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/json/JsonTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/json/JsonTest.java
@@ -23,6 +23,7 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.variable.api.history.HistoricVariableInstance;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -39,11 +40,7 @@ public class JsonTest extends PluggableFlowableTestCase {
 
     protected ObjectMapper objectMapper = new ObjectMapper();
 
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
-    }
-
+    @Test
     @Deployment
     public void testJsonObjectAvailable() {
         Map<String, Object> vars = new HashMap<>();
@@ -121,6 +118,7 @@ public class JsonTest extends PluggableFlowableTestCase {
         assertNull(runtimeService.getVariable(processInstance.getId(), BIG_JSON_OBJ));
     }
 
+    @Test
     @Deployment
     public void testDirectJsonPropertyAccess() {
         Map<String, Object> vars = new HashMap<>();
@@ -156,6 +154,7 @@ public class JsonTest extends PluggableFlowableTestCase {
         assertEquals("userTaskSuccess", task.getTaskDefinitionKey());
     }
 
+    @Test
     @Deployment
     public void testJsonArrayAvailable() {
         Map<String, Object> vars = new HashMap<>();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/logging/mdc/MDCLoggingTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/logging/mdc/MDCLoggingTest.java
@@ -23,6 +23,7 @@ import org.apache.log4j.PatternLayout;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.logging.LogMDC;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 public class MDCLoggingTest extends PluggableFlowableTestCase {
 
@@ -67,6 +68,7 @@ public class MDCLoggingTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testLogger() {
         setCustomLogger();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/regression/DeleteProcessInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/regression/DeleteProcessInstanceTest.java
@@ -23,6 +23,7 @@ import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
+import org.junit.jupiter.api.Test;
 //SLF4J
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,6 +35,7 @@ public class DeleteProcessInstanceTest extends PluggableFlowableTestCase {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DeleteProcessInstanceTest.class);
 
+    @Test
     @Deployment
     public void testNoEndTimeSet() {
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/regression/ProcessValidationExecutedAfterDeployTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/regression/ProcessValidationExecutedAfterDeployTest.java
@@ -18,6 +18,7 @@ import org.flowable.common.engine.api.FlowableException;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.repository.ProcessDefinition;
 import org.flowable.validation.ProcessValidator;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -30,6 +31,7 @@ import org.junit.jupiter.api.Test;
 public class ProcessValidationExecutedAfterDeployTest extends PluggableFlowableTestCase {
 
     protected ProcessValidator processValidator;
+    protected ProcessValidator initialProcessValidator;
 
     private void disableValidation() {
         processValidator = processEngineConfiguration.getProcessValidator();
@@ -45,8 +47,15 @@ public class ProcessValidationExecutedAfterDeployTest extends PluggableFlowableT
     }
 
     @BeforeEach
+    public void setUp() {
+        // We need to make sure that we have the initial validator before we run the tests
+        initialProcessValidator = processEngineConfiguration.getProcessValidator();
+    }
+
+    @AfterEach
     protected void tearDown() throws Exception {
-        enableValidation();
+        // Set the initial validator at the end of the tests
+        processEngineConfiguration.setProcessValidator(initialProcessValidator);
     }
 
     private ProcessDefinition getLatestProcessDefinitionVersionByKey(String processDefinitionKey) {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/regression/ProcessValidationExecutedAfterDeployTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/regression/ProcessValidationExecutedAfterDeployTest.java
@@ -18,6 +18,8 @@ import org.flowable.common.engine.api.FlowableException;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.repository.ProcessDefinition;
 import org.flowable.validation.ProcessValidator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * From http://forums.activiti.org/content/skip-parse-validation-while-fetching- startformdata
@@ -42,10 +44,9 @@ public class ProcessValidationExecutedAfterDeployTest extends PluggableFlowableT
         processEngineConfiguration.getProcessDefinitionCache().clear();
     }
 
-    @Override
+    @BeforeEach
     protected void tearDown() throws Exception {
         enableValidation();
-        super.tearDown();
     }
 
     private ProcessDefinition getLatestProcessDefinitionVersionByKey(String processDefinitionKey) {
@@ -61,6 +62,7 @@ public class ProcessValidationExecutedAfterDeployTest extends PluggableFlowableT
         return definitions.get(0);
     }
 
+    @Test
     public void testGetLatestProcessDefinitionTextByKey() {
 
         disableValidation();
@@ -84,6 +86,7 @@ public class ProcessValidationExecutedAfterDeployTest extends PluggableFlowableT
         }
     }
 
+    @Test
     public void testGetStartFormData() {
 
         disableValidation();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/regression/RegressionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/regression/RegressionTest.java
@@ -13,6 +13,7 @@
 package org.flowable.engine.test.regression;
 
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
+import org.junit.jupiter.api.Test;
 
 /**
  * All tests that do not belong to any other test case, but test a supposedly working feature go here.
@@ -23,6 +24,7 @@ public class RegressionTest extends PluggableFlowableTestCase {
 
     // https://jira.codehaus.org/browse/ACT-1623
     // NPE when eventbased gateway is after referenced event
+    @Test
     public void testAct1623() throws Exception {
 
         // Deploy processes

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/transactions/TransactionRollbackTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/transactions/TransactionRollbackTest.java
@@ -18,6 +18,7 @@ import org.flowable.engine.delegate.DelegateExecution;
 import org.flowable.engine.impl.delegate.ActivityBehavior;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tom Baeyens
@@ -34,6 +35,7 @@ public class TransactionRollbackTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testRollback() {
         try {
@@ -48,6 +50,7 @@ public class TransactionRollbackTest extends PluggableFlowableTestCase {
         assertEquals(0, runtimeService.createExecutionQuery().count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/transactions/trivial.bpmn20.xml", "org/flowable/engine/test/transactions/rollbackAfterSubProcess.bpmn20.xml" })
     public void testRollbackAfterSubProcess() {
         try {

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/authorization/StartAuthorizationTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/authorization/StartAuthorizationTest.java
@@ -25,6 +25,7 @@ import org.flowable.engine.test.Deployment;
 import org.flowable.identitylink.api.IdentityLink;
 import org.flowable.idm.api.Group;
 import org.flowable.idm.api.User;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Saeid Mirzaei
@@ -95,6 +96,7 @@ public class StartAuthorizationTest extends PluggableFlowableTestCase {
         identityService.deleteUser("user3");
     }
 
+    @Test
     @Deployment
     public void testIdentityLinks() throws Exception {
 
@@ -133,6 +135,7 @@ public class StartAuthorizationTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testAddAndRemoveIdentityLinks() throws Exception {
 
@@ -187,6 +190,7 @@ public class StartAuthorizationTest extends PluggableFlowableTestCase {
         return found;
     }
 
+    @Test
     @Deployment
     public void testPotentialStarter() throws Exception {
         // first check an unauthorized user. An exception is expected
@@ -234,6 +238,7 @@ public class StartAuthorizationTest extends PluggableFlowableTestCase {
     /*
      * if there is no security definition, then user authorization check is not done. This ensures backward compatibility
      */
+    @Test
     @Deployment
     public void testPotentialStarterNoDefinition() throws Exception {
         identityService = processEngine.getIdentityService();
@@ -246,6 +251,7 @@ public class StartAuthorizationTest extends PluggableFlowableTestCase {
     }
 
     // this test checks the list without user constraint
+    @Test
     @Deployment
     public void testProcessDefinitionList() throws Exception {
 

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/callactivity/CallActivityTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/callactivity/CallActivityTest.java
@@ -21,12 +21,14 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.task.api.TaskQuery;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
  */
 public class CallActivityTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment(resources = { "org/flowable/examples/bpmn/callactivity/orderProcess.bpmn20.xml", "org/flowable/examples/bpmn/callactivity/checkCreditProcess.bpmn20.xml" })
     public void testOrderProcessWithCallActivity() {
         // After the process has started, the 'verify credit history' task
@@ -48,6 +50,7 @@ public class CallActivityTest extends PluggableFlowableTestCase {
         assertEquals("Prepare and Ship", prepareAndShipTask.getName());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/examples/bpmn/callactivity/mainProcess.bpmn20.xml", "org/flowable/examples/bpmn/callactivity/childProcess.bpmn20.xml" })
     public void testCallActivityWithModeledDataObjectsInSubProcess() {
         // After the process has started, the 'verify credit history' task should be active
@@ -64,6 +67,7 @@ public class CallActivityTest extends PluggableFlowableTestCase {
         assertEquals("Batman", runtimeService.getVariable(subProcessInstance.getId(), "Name"));
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/examples/bpmn/callactivity/mainProcess.bpmn20.xml",
             "org/flowable/examples/bpmn/callactivity/childProcess.bpmn20.xml",
             "org/flowable/examples/bpmn/callactivity/mainProcessBusinessKey.bpmn20.xml",

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/event/error/BoundaryErrorEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/event/error/BoundaryErrorEventTest.java
@@ -19,26 +19,28 @@ import java.util.Map;
 import org.flowable.common.engine.impl.identity.Authentication;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
  */
 public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
 
         // Normally the UI will do this automatically for us
         Authentication.setAuthenticatedUserId("kermit");
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
         Authentication.setAuthenticatedUserId(null);
-        super.tearDown();
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/examples/bpmn/event/error/reviewSalesLead.bpmn20.xml" })
     public void testReviewSalesLeadProcess() {
 

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/event/timer/BoundaryTimerEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/event/timer/BoundaryTimerEventTest.java
@@ -16,12 +16,14 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
  */
 public class BoundaryTimerEventTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testInterruptingTimerDuration() {
 

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/executionlistener/CustomFlowExecutionListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/executionlistener/CustomFlowExecutionListenerTest.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import org.flowable.engine.impl.test.ResourceFlowableTestCase;
 import org.flowable.engine.test.Deployment;
 import org.flowable.variable.api.history.HistoricVariableInstance;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tijs Rademakers
@@ -29,6 +30,7 @@ public class CustomFlowExecutionListenerTest extends ResourceFlowableTestCase {
         super("org/flowable/examples/bpmn/executionlistener/custom.flow.parse.handler.flowable.cfg.xml");
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/examples/bpmn/executionlistener/CustomFlowExecutionListenerTest.bpmn20.xml" })
     public void testScriptExecutionListener() {
         Map<String, Object> variableMap = new HashMap<>();

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/executionlistener/ExecutionListenerOnTransactionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/executionlistener/ExecutionListenerOnTransactionTest.java
@@ -22,12 +22,14 @@ import org.flowable.engine.impl.test.HistoryTestHelper;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Yvo Swillens
  */
 public class ExecutionListenerOnTransactionTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testOnClosedExecutionListenersWithRollback() {
 
@@ -61,6 +63,7 @@ public class ExecutionListenerOnTransactionTest extends PluggableFlowableTestCas
         assertEquals(1, managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).count());
     }
 
+    @Test
     @Deployment
     public void testOnCloseFailureExecutionListenersWithRollback() {
 
@@ -94,6 +97,7 @@ public class ExecutionListenerOnTransactionTest extends PluggableFlowableTestCas
         assertEquals("Service Task 3", currentActivities.get(1).getActivityName());
     }
 
+    @Test
     @Deployment
     public void testOnClosedExecutionListenersWithExecutionVariables() {
 
@@ -119,6 +123,7 @@ public class ExecutionListenerOnTransactionTest extends PluggableFlowableTestCas
         assertEquals("test2", currentActivities.get(2).getExecutionVariables().get("injectedExecutionVariable"));
     }
 
+    @Test
     @Deployment
     public void testOnCloseFailureExecutionListenersWithTransactionalOperation() {
 
@@ -150,6 +155,7 @@ public class ExecutionListenerOnTransactionTest extends PluggableFlowableTestCas
         assertEquals("Service Task 1", currentActivities.get(0).getActivityName());
     }
 
+    @Test
     @Deployment
     public void testOnClosedExecutionListenersWithCustomPropertiesResolver() {
 

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/executionlistener/ExecutionListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/executionlistener/ExecutionListenerTest.java
@@ -22,12 +22,14 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.examples.bpmn.executionlistener.CurrentActivityExecutionListener.CurrentActivity;
 import org.flowable.examples.bpmn.executionlistener.RecorderExecutionListener.RecordedEvent;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Frederik Heremans
  */
 public class ExecutionListenerTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment(resources = { "org/flowable/examples/bpmn/executionlistener/ExecutionListenersProcess.bpmn20.xml" })
     public void testExecutionListenersOnAllPossibleElements() {
         RecorderExecutionListener.clear();
@@ -80,6 +82,7 @@ public class ExecutionListenerTest extends PluggableFlowableTestCase {
         assertEquals("End Process Listener", event.getParameter());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/examples/bpmn/executionlistener/ExecutionListenersStartEndEvent.bpmn20.xml" })
     public void testExecutionListenersOnStartEndEvents() {
         RecorderExecutionListener.clear();
@@ -112,6 +115,7 @@ public class ExecutionListenerTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/examples/bpmn/executionlistener/ExecutionListenersFieldInjectionProcess.bpmn20.xml" })
     public void testExecutionListenerFieldInjection() {
         Map<String, Object> variables = new HashMap<>();
@@ -128,6 +132,7 @@ public class ExecutionListenerTest extends PluggableFlowableTestCase {
         assertEquals("Yes, I am listening!", varSetByListener);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/examples/bpmn/executionlistener/ExecutionListenersCurrentActivity.bpmn20.xml" })
     public void testExecutionListenerCurrentActivity() {
 
@@ -149,6 +154,7 @@ public class ExecutionListenerTest extends PluggableFlowableTestCase {
         assertEquals("End Event", currentActivities.get(2).getActivityName());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/examples/bpmn/executionlistener/ExecutionListenersForSubprocessStartEndEvent.bpmn20.xml" })
     public void testExecutionListenersForSubprocessStartEndEvents() {
         RecorderExecutionListener.clear();

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/executionlistener/ScriptExecutionListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/executionlistener/ScriptExecutionListenerTest.java
@@ -22,12 +22,14 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.variable.api.history.HistoricVariableInstance;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tijs Rademakers
  */
 public class ScriptExecutionListenerTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment(resources = { "org/flowable/examples/bpmn/executionlistener/ScriptExecutionListenerTest.bpmn20.xml" })
     public void testScriptExecutionListener() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("scriptExecutionListenerProcess");

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/expression/UelExpressionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/expression/UelExpressionTest.java
@@ -17,12 +17,14 @@ import org.flowable.common.engine.impl.util.CollectionUtil;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
  */
 public class UelExpressionTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testValueAndMethodExpression() {
         // An order of price 150 is a standard order (goes through an UEL value

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/gateway/ExclusiveGatewayTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/gateway/ExclusiveGatewayTest.java
@@ -19,6 +19,7 @@ import org.flowable.common.engine.api.FlowableException;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * Example of using the exclusive gateway.
@@ -31,6 +32,7 @@ public class ExclusiveGatewayTest extends PluggableFlowableTestCase {
      * The test process has an XOR gateway where, the 'input' variable is used to select one of the outgoing sequence flow. Every one of those sequence flow goes to another task, allowing us to test
      * the decision very easily.
      */
+    @Test
     @Deployment
     public void testDecisionFunctionality() {
 

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/gateway/InclusiveGatewayTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/gateway/InclusiveGatewayTest.java
@@ -20,6 +20,7 @@ import org.flowable.common.engine.api.FlowableException;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * Example of using the exclusive gateway.
@@ -36,6 +37,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
     /**
      * The test process has an OR gateway where, the 'input' variable is used to select the expected outgoing sequence flow.
      */
+    @Test
     @Deployment
     public void testDecisionFunctionality() {
 

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/gateway/ParallelGatewayTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/gateway/ParallelGatewayTest.java
@@ -19,12 +19,14 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.task.api.TaskQuery;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
  */
 public class ParallelGatewayTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testForkJoin() {
 
@@ -48,6 +50,7 @@ public class ParallelGatewayTest extends PluggableFlowableTestCase {
         assertEquals("Archive Order", tasks.get(0).getName());
     }
 
+    @Test
     @Deployment
     public void testUnbalancedForkJoin() {
 

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/mail/EmailSendTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/mail/EmailSendTaskTest.java
@@ -22,6 +22,10 @@ import javax.mail.internet.MimeMessage;
 
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.subethamail.wiser.Wiser;
 import org.subethamail.wiser.WiserMessage;
 
@@ -29,15 +33,14 @@ import org.subethamail.wiser.WiserMessage;
  * @author Joram Barrez
  * @author Falko Menge
  */
+@Tag("email")
 public class EmailSendTaskTest extends PluggableFlowableTestCase {
 
     /* Wiser is a fake email server for unit testing */
     private Wiser wiser;
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
-
         boolean serverUpAndRunning = false;
         while (!serverUpAndRunning) {
             wiser = new Wiser();
@@ -54,12 +57,12 @@ public class EmailSendTaskTest extends PluggableFlowableTestCase {
         }
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
         wiser.stop();
-        super.tearDown();
     }
 
+    @Test
     @Deployment
     public void testSendEmail() throws Exception {
 

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/mail/EmailServiceTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/mail/EmailServiceTaskTest.java
@@ -22,6 +22,9 @@ import javax.mail.internet.MimeMessage;
 
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.subethamail.wiser.Wiser;
 import org.subethamail.wiser.WiserMessage;
 
@@ -33,20 +36,19 @@ public class EmailServiceTaskTest extends PluggableFlowableTestCase {
     /* Wiser is a fake email server for unit testing */
     private Wiser wiser;
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
         wiser = new Wiser();
         wiser.setPort(5025);
         wiser.start();
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
         wiser.stop();
-        super.tearDown();
     }
 
+    @Test
     @Deployment
     public void testSendEmail() throws Exception {
 

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/receivetask/ReceiveTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/receivetask/ReceiveTaskTest.java
@@ -17,12 +17,14 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
  */
 public class ReceiveTaskTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testWaitStateBehavior() {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("receiveTask");

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/scripttask/ScriptTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/scripttask/ScriptTaskTest.java
@@ -19,6 +19,7 @@ import org.flowable.common.engine.impl.util.CollectionUtil;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -29,6 +30,7 @@ import java.util.Map;
  */
 public class ScriptTaskTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testSetScriptResultToProcessVariable() {
         Map<String, Object> variables = new HashMap<>();
@@ -41,6 +43,7 @@ public class ScriptTaskTest extends PluggableFlowableTestCase {
         assertEquals(pi.getId(), runtimeService.getVariable(pi.getId(), "newProcessVariableName"));
     }
 
+    @Test
     @Deployment
     public void testFailingScript() {
         Exception expectedException = null;
@@ -54,6 +57,7 @@ public class ScriptTaskTest extends PluggableFlowableTestCase {
         verifyExceptionInStacktrace(expectedException, MissingPropertyException.class);
     }
 
+    @Test
     @Deployment
     public void testExceptionThrownInScript() {
         Exception expectedException = null;
@@ -66,6 +70,7 @@ public class ScriptTaskTest extends PluggableFlowableTestCase {
         verifyExceptionInStacktrace(expectedException, IllegalStateException.class);
     }
 
+    @Test
     @Deployment
     public void testAutoStoreVariables() {
         // The first script should NOT store anything as 'autoStoreVariables' is set to false
@@ -77,23 +82,30 @@ public class ScriptTaskTest extends PluggableFlowableTestCase {
         assertEquals(42, ((Number) runtimeService.getVariable(id, "sum")).intValue());
     }
 
+    @Test
     public void testNoScriptProvided() {
         try {
-            repositoryService.createDeployment().addClasspathResource("org/flowable/examples/bpmn/scripttask/ScriptTaskTest.testNoScriptProvided.bpmn20.xml").deploy();
+            deploymentIdsForAutoCleanup.add(
+                repositoryService.createDeployment().addClasspathResource("org/flowable/examples/bpmn/scripttask/ScriptTaskTest.testNoScriptProvided.bpmn20.xml").deploy().getId()
+            );
+            fail("Deployment should not have worked");
         } catch (FlowableException e) {
             assertTextPresent("No script provided", e.getMessage());
         }
     }
 
+    @Test
     @Deployment
     public void testErrorInScript() {
         try {
             runtimeService.startProcessInstanceByKey("testErrorInScript");
+            fail("Starting process should result in error in script");
         } catch (FlowableException e) {
             assertTextPresent("Error in Script", e.getMessage());
         }
     }
 
+    @Test
     @Deployment
     public void testNoErrorInScript() {
         boolean noError = true;
@@ -107,6 +119,7 @@ public class ScriptTaskTest extends PluggableFlowableTestCase {
         assertTrue(noError);
     }
 
+    @Test
     @Deployment
     public void testSetScriptResultToProcessVariableWithoutFormat() {
         Map<String, Object> variables = new HashMap<>();
@@ -119,6 +132,7 @@ public class ScriptTaskTest extends PluggableFlowableTestCase {
         assertEquals(pi.getId(), runtimeService.getVariable(pi.getId(), "newProcessVariableName"));
     }
 
+    @Test
     @Deployment
     public void testDynamicScript() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testDynamicScript", CollectionUtil.map("a", 20, "b", 22));

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/servicetask/ExpressionServiceTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/servicetask/ExpressionServiceTaskTest.java
@@ -24,6 +24,7 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.task.api.Task;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -33,6 +34,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
  */
 public class ExpressionServiceTaskTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testSetServiceResultToProcessVariables() {
         Map<String, Object> variables = new HashMap<>();
@@ -41,6 +43,7 @@ public class ExpressionServiceTaskTest extends PluggableFlowableTestCase {
         assertEquals("ok", runtimeService.getVariable(pi.getId(), "result"));
     }
 
+    @Test
     @Deployment
     public void testSetServiceResultToProcessVariablesWithSkipExpression() {
         Map<String, Object> variables = new HashMap<>();
@@ -72,6 +75,7 @@ public class ExpressionServiceTaskTest extends PluggableFlowableTestCase {
         assertEquals("okBean", runtimeService.getVariable(pi3.getId(), "result"));
     }
 
+    @Test
     @Deployment
     public void testBackwardsCompatibleExpression() {
         Map<String, Object> variables = new HashMap<>();
@@ -80,6 +84,7 @@ public class ExpressionServiceTaskTest extends PluggableFlowableTestCase {
         assertEquals("...---...", runtimeService.getVariable(pi.getId(), "result"));
     }
 
+    @Test
     @Deployment
     public void testSetServiceResultWithParallelMultiInstance() {
         Map<String, Object> variables = new HashMap<>();
@@ -98,6 +103,7 @@ public class ExpressionServiceTaskTest extends PluggableFlowableTestCase {
         assertThat(tasks.get(0).getTaskDefinitionKey(), is("processWaitState"));
     }
 
+    @Test
     @Deployment
     public void testSetServiceLocalScopedResultWithParallelMultiInstance() {
         Map<String, Object> variables = new HashMap<>();

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/servicetask/JavaServiceTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/servicetask/JavaServiceTaskTest.java
@@ -23,6 +23,7 @@ import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
@@ -30,6 +31,7 @@ import org.flowable.job.api.Job;
  */
 public class JavaServiceTaskTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testJavaServiceDelegation() {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("javaServiceDelegation", CollectionUtil.singletonMap("input", "Activiti BPM Engine"));
@@ -37,6 +39,7 @@ public class JavaServiceTaskTest extends PluggableFlowableTestCase {
         assertEquals("ACTIVITI BPM ENGINE", runtimeService.getVariable(execution.getId(), "input"));
     }
 
+    @Test
     @Deployment
     public void testFieldInjection() {
         // Process contains 2 service-tasks using field-injection. One should
@@ -49,6 +52,7 @@ public class JavaServiceTaskTest extends PluggableFlowableTestCase {
         assertEquals("HELLO SETTER", runtimeService.getVariable(execution.getId(), "setterVar"));
     }
 
+    @Test
     @Deployment
     public void testExpressionFieldInjection() {
         Map<String, Object> vars = new HashMap<>();
@@ -63,6 +67,7 @@ public class JavaServiceTaskTest extends PluggableFlowableTestCase {
         assertEquals("elam :si redneg ruoY", runtimeService.getVariable(execution.getId(), "var1"));
     }
     
+    @Test
     @Deployment
     public void testServiceTaskWithSkipExpression() {
       Map<String, Object> vars = new HashMap<>();
@@ -77,6 +82,7 @@ public class JavaServiceTaskTest extends PluggableFlowableTestCase {
       assertEquals("waitState", waitExecution.getActivityId());
     }
     
+    @Test
     @Deployment
     public void testAsyncServiceTaskWithSkipExpression() {
       Map<String, Object> vars = new HashMap<>();
@@ -98,6 +104,7 @@ public class JavaServiceTaskTest extends PluggableFlowableTestCase {
       assertEquals("waitState", waitExecution.getActivityId());
     }
 
+    @Test
     @Deployment
     public void testExpressionFieldInjectionWithSkipExpression() {
         Map<String, Object> vars = new HashMap<>();
@@ -132,6 +139,7 @@ public class JavaServiceTaskTest extends PluggableFlowableTestCase {
         assertFalse(pi2VarMap.containsKey("var2"));
     }
 
+    @Test
     @Deployment
     public void testUnexistingClassDelegation() {
         try {
@@ -144,15 +152,19 @@ public class JavaServiceTaskTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     public void testIllegalUseOfResultVariableName() {
         try {
-            repositoryService.createDeployment().addClasspathResource("org/flowable/examples/bpmn/servicetask/JavaServiceTaskTest.testIllegalUseOfResultVariableName.bpmn20.xml").deploy();
+            deploymentIdsForAutoCleanup.add(
+                repositoryService.createDeployment().addClasspathResource("org/flowable/examples/bpmn/servicetask/JavaServiceTaskTest.testIllegalUseOfResultVariableName.bpmn20.xml").deploy().getId()
+            );
             fail();
         } catch (FlowableException e) {
             assertTrue(e.getMessage().contains("resultVariable"));
         }
     }
 
+    @Test
     @Deployment
     public void testExceptionHandling() {
 
@@ -172,6 +184,7 @@ public class JavaServiceTaskTest extends PluggableFlowableTestCase {
         assertEquals("Fix Exception", task.getName());
     }
 
+    @Test
     @Deployment
     public void testGetBusinessKeyFromDelegateExecution() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("businessKeyProcess", "1234567890");

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/servicetask/MethodExpressionServiceTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/servicetask/MethodExpressionServiceTaskTest.java
@@ -18,12 +18,14 @@ import java.util.Map;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Christian Stettler
  */
 public class MethodExpressionServiceTaskTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testSetServiceResultToProcessVariables() {
         Map<String, Object> variables = new HashMap<>();
@@ -34,6 +36,7 @@ public class MethodExpressionServiceTaskTest extends PluggableFlowableTestCase {
         assertEquals("ok", runtimeService.getVariable(pi.getId(), "result"));
     }
 
+    @Test
     @Deployment
     public void testSetServiceResultToProcessVariablesWithSkipExpression() {
         Map<String, Object> variables = new HashMap<>();

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/shell/ShellTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/shell/ShellTaskTest.java
@@ -15,6 +15,10 @@ package org.flowable.examples.bpmn.shell;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 public class ShellTaskTest extends PluggableFlowableTestCase {
 
@@ -38,16 +42,19 @@ public class ShellTaskTest extends PluggableFlowableTestCase {
             return OsType.UNKOWN;
     }
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
         osType = getSystemOsType();
     }
 
+    @Test
     public void testOsDetection() throws Exception {
         assertNotSame(OsType.UNKOWN, osType);
     }
 
+    @Test
     @Deployment
+    @EnabledOnOs(OS.WINDOWS)
     public void testEchoShellWindows() {
         if (osType == OsType.WINDOWS) {
 
@@ -59,7 +66,9 @@ public class ShellTaskTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
+    @EnabledOnOs(OS.LINUX)
     public void testEchoShellLinux() {
         if (osType == OsType.LINUX) {
 
@@ -71,7 +80,9 @@ public class ShellTaskTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
+    @EnabledOnOs(OS.MAC)
     public void testEchoShellMac() {
         if (osType == OsType.MAC) {
 

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/subprocess/SubProcessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/subprocess/SubProcessTest.java
@@ -19,12 +19,14 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.repository.Deployment;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.junit.Assert;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
  */
 public class SubProcessTest extends PluggableFlowableTestCase {
 
+    @Test
     public void testSimpleSubProcess() {
 
         Deployment deployment = repositoryService.createDeployment().addClasspathResource("org/flowable/examples/bpmn/subprocess/SubProcessTest.fixSystemFailureProcess.bpmn20.xml").deploy();

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/tasklistener/CustomTaskAssignmentTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/tasklistener/CustomTaskAssignmentTest.java
@@ -17,6 +17,9 @@ import java.util.Map;
 
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
@@ -25,9 +28,8 @@ import org.flowable.engine.test.Deployment;
  */
 public class CustomTaskAssignmentTest extends PluggableFlowableTestCase {
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
 
         identityService.saveUser(identityService.newUser("kermit"));
         identityService.saveUser(identityService.newUser("fozzie"));
@@ -38,15 +40,15 @@ public class CustomTaskAssignmentTest extends PluggableFlowableTestCase {
         identityService.createMembership("kermit", "management");
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
         identityService.deleteUser("kermit");
         identityService.deleteUser("fozzie");
         identityService.deleteUser("gonzo");
         identityService.deleteGroup("management");
-        super.tearDown();
     }
 
+    @Test
     @Deployment
     public void testCandidateGroupAssignment() {
         runtimeService.startProcessInstanceByKey("customTaskAssignment");
@@ -55,6 +57,7 @@ public class CustomTaskAssignmentTest extends PluggableFlowableTestCase {
         assertEquals(0, taskService.createTaskQuery().taskCandidateUser("fozzie").count());
     }
 
+    @Test
     @Deployment
     public void testCandidateUserAssignment() {
         runtimeService.startProcessInstanceByKey("customTaskAssignment");
@@ -63,6 +66,7 @@ public class CustomTaskAssignmentTest extends PluggableFlowableTestCase {
         assertEquals(0, taskService.createTaskQuery().taskCandidateUser("gonzo").count());
     }
 
+    @Test
     @Deployment
     public void testAssigneeAssignment() {
         runtimeService.startProcessInstanceByKey("setAssigneeInListener");
@@ -71,6 +75,7 @@ public class CustomTaskAssignmentTest extends PluggableFlowableTestCase {
         assertEquals(0, taskService.createTaskQuery().taskAssignee("gonzo").count());
     }
 
+    @Test
     @Deployment
     public void testOverwriteExistingAssignments() {
         runtimeService.startProcessInstanceByKey("overrideAssigneeInListener");
@@ -79,6 +84,7 @@ public class CustomTaskAssignmentTest extends PluggableFlowableTestCase {
         assertEquals(0, taskService.createTaskQuery().taskAssignee("gonzo").count());
     }
 
+    @Test
     @Deployment
     public void testOverwriteExistingAssignmentsFromVariable() {
         // prepare variables
@@ -97,6 +103,7 @@ public class CustomTaskAssignmentTest extends PluggableFlowableTestCase {
         assertEquals(0, taskService.createTaskQuery().taskAssignee("kermit").count());
     }
 
+    @Test
     @Deployment
     public void testReleaseTask() throws Exception {
         runtimeService.startProcessInstanceByKey("releaseTaskProcess");

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/tasklistener/ScriptTaskListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/tasklistener/ScriptTaskListenerTest.java
@@ -18,12 +18,14 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.task.api.history.HistoricTaskInstance;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Rich Kroll, Tijs Rademakers
  */
 public class ScriptTaskListenerTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment(resources = { "org/flowable/examples/bpmn/tasklistener/ScriptTaskListenerTest.bpmn20.xml" })
     public void testScriptTaskListener() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("scriptTaskListenerProcess");

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/tasklistener/TaskListenerOnTransactionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/tasklistener/TaskListenerOnTransactionTest.java
@@ -22,12 +22,14 @@ import org.flowable.engine.impl.test.HistoryTestHelper;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Yvo Swillens
  */
 public class TaskListenerOnTransactionTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testOnCompleteCommitted() {
         CurrentTaskTransactionDependentTaskListener.clear();
@@ -55,6 +57,7 @@ public class TaskListenerOnTransactionTest extends PluggableFlowableTestCase {
         assertNotNull(currentTasks.get(0).getProcessInstanceId());
     }
 
+    @Test
     @Deployment
     public void testOnCompleteRolledBack() {
         CurrentTaskTransactionDependentTaskListener.clear();
@@ -97,6 +100,7 @@ public class TaskListenerOnTransactionTest extends PluggableFlowableTestCase {
         assertNotNull(currentTasks.get(1).getProcessInstanceId());
     }
 
+    @Test
     @Deployment
     public void testOnCompleteExecutionVariables() {
 
@@ -126,6 +130,7 @@ public class TaskListenerOnTransactionTest extends PluggableFlowableTestCase {
         assertEquals("test2", currentTasks.get(1).getExecutionVariables().get("injectedExecutionVariable"));
     }
 
+    @Test
     @Deployment
     public void testOnCompleteTransactionalOperation() {
         CurrentTaskTransactionDependentTaskListener.clear();
@@ -160,6 +165,7 @@ public class TaskListenerOnTransactionTest extends PluggableFlowableTestCase {
         assertEquals("User Task 1", currentTasks.get(0).getTaskName());
     }
 
+    @Test
     @Deployment
     public void testOnCompleteCustomPropertiesResolver() {
         CurrentTaskTransactionDependentTaskListener.clear();

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/tasklistener/TaskListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/tasklistener/TaskListenerTest.java
@@ -17,12 +17,14 @@ import java.util.List;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
  */
 public class TaskListenerTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment(resources = { "org/flowable/examples/bpmn/tasklistener/TaskListenerTest.bpmn20.xml" })
     public void testTaskCreateListener() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("taskListenerProcess");
@@ -42,6 +44,7 @@ public class TaskListenerTest extends PluggableFlowableTestCase {
         runtimeService.deleteProcessInstance(processInstance.getProcessInstanceId(), "");
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/examples/bpmn/tasklistener/TaskListenerInSubProcessTest.bpmn20.xml" })
     public void testTaskCreateListenerInSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("taskListenerInSubProcess");
@@ -52,6 +55,7 @@ public class TaskListenerTest extends PluggableFlowableTestCase {
         runtimeService.deleteProcessInstance(processInstance.getProcessInstanceId(), "");
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/examples/bpmn/tasklistener/TaskListenerTest.bpmn20.xml" })
     public void testTaskAssignmentListener() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("taskListenerProcess");
@@ -71,6 +75,7 @@ public class TaskListenerTest extends PluggableFlowableTestCase {
     /**
      * Validate fix for ACT-1627: Not throwing assignment event on every update
      */
+    @Test
     @Deployment(resources = { "org/flowable/examples/bpmn/tasklistener/TaskListenerTest.bpmn20.xml" })
     public void testTaskAssignmentListenerNotCalledWhenAssigneeNotUpdated() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("taskListenerProcess");
@@ -117,6 +122,7 @@ public class TaskListenerTest extends PluggableFlowableTestCase {
         waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
     }
     
+    @Test
     @Deployment(resources = { "org/flowable/examples/bpmn/tasklistener/TaskListenerTest.bpmn20.xml" })
     public void testTaskUnassignListener() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("taskListenerProcess");
@@ -144,6 +150,7 @@ public class TaskListenerTest extends PluggableFlowableTestCase {
         waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/examples/bpmn/tasklistener/TaskListenerTest.bpmn20.xml" })
     public void testTaskCompleteListener() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("taskListenerProcess");
@@ -158,6 +165,7 @@ public class TaskListenerTest extends PluggableFlowableTestCase {
         assertEquals("Act", runtimeService.getVariable(processInstance.getId(), "shortName"));
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/examples/bpmn/tasklistener/TaskListenerTest.bpmn20.xml" })
     public void testTaskListenerWithExpression() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("taskListenerProcess");
@@ -170,6 +178,7 @@ public class TaskListenerTest extends PluggableFlowableTestCase {
         assertEquals("Write meeting notes", runtimeService.getVariable(processInstance.getId(), "greeting2"));
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/examples/bpmn/tasklistener/TaskListenerTest.bpmn20.xml" })
     public void testAllEventsTaskListener() {
         runtimeService.startProcessInstanceByKey("taskListenerProcess");
@@ -186,6 +195,7 @@ public class TaskListenerTest extends PluggableFlowableTestCase {
         waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/examples/bpmn/tasklistener/TaskListenerTest.testTaskListenersOnDelete.bpmn20.xml" })
     public void testTaskListenersOnDeleteByComplete() {
         TaskDeleteListener.clear();
@@ -215,6 +225,7 @@ public class TaskListenerTest extends PluggableFlowableTestCase {
         assertEquals("Complete Task Listener executed.", TaskSimpleCompleteListener.getCurrentMessages().get(0));
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/examples/bpmn/tasklistener/TaskListenerTest.testTaskListenersOnDelete.bpmn20.xml" })
     public void testTaskListenersOnDeleteByDeleteProcessInstance() {
         TaskDeleteListener.clear();

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/usertask/FinancialReportProcessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/usertask/FinancialReportProcessTest.java
@@ -17,10 +17,13 @@ import java.util.List;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class FinancialReportProcessTest extends PluggableFlowableTestCase {
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         identityService.saveUser(identityService.newUser("fozzie"));
         identityService.saveUser(identityService.newUser("kermit"));
@@ -32,7 +35,7 @@ public class FinancialReportProcessTest extends PluggableFlowableTestCase {
         identityService.createMembership("kermit", "management");
     }
 
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
         identityService.deleteUser("fozzie");
         identityService.deleteUser("kermit");
@@ -40,6 +43,7 @@ public class FinancialReportProcessTest extends PluggableFlowableTestCase {
         identityService.deleteGroup("management");
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/examples/bpmn/usertask/FinancialReportProcess.bpmn20.xml" })
     public void testProcess() {
 

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/usertask/SkipExpressionUserTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/usertask/SkipExpressionUserTaskTest.java
@@ -30,9 +30,11 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.task.api.history.HistoricTaskInstance;
+import org.junit.jupiter.api.Test;
 
 public class SkipExpressionUserTaskTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void test() {
         runtimeService.startProcessInstanceByKey("skipExpressionUserTask");
@@ -58,6 +60,7 @@ public class SkipExpressionUserTaskTest extends PluggableFlowableTestCase {
         assertEquals(0, tasks3.size());
     }
 
+    @Test
     @Deployment
     public void testWithCandidateGroups() {
         Map<String, Object> vars = new HashMap<>();
@@ -67,6 +70,7 @@ public class SkipExpressionUserTaskTest extends PluggableFlowableTestCase {
         assertEquals(0, taskService.createTaskQuery().list().size());
     }
 
+    @Test
     @Deployment
     public void testSkipMultipleTasks() {
         Map<String, Object> variables = new HashMap<>();
@@ -81,6 +85,7 @@ public class SkipExpressionUserTaskTest extends PluggableFlowableTestCase {
         assertEquals("Task3", tasks.get(0).getName());
     }
     
+    @Test
     @Deployment
     public void testEvents() {
         SkipFlowableEventListener eventListener = new SkipFlowableEventListener();

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/usertask/taskassignee/TaskAssigneeTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/usertask/taskassignee/TaskAssigneeTest.java
@@ -17,6 +17,7 @@ import java.util.List;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * Simple process test to validate the current implementation prototype.
@@ -25,6 +26,7 @@ import org.flowable.engine.test.Deployment;
  */
 public class TaskAssigneeTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testTaskAssignee() {
 

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/usertask/taskcandidate/TaskCandidateTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/usertask/taskcandidate/TaskCandidateTest.java
@@ -22,6 +22,9 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.idm.api.Group;
 import org.flowable.idm.api.User;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez, Saeid Mirzaei
@@ -32,9 +35,8 @@ public class TaskCandidateTest extends PluggableFlowableTestCase {
 
     private static final String GONZO = "gonzo";
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
 
         Group accountants = identityService.newGroup("accountancy");
         identityService.saveGroup(accountants);
@@ -54,7 +56,7 @@ public class TaskCandidateTest extends PluggableFlowableTestCase {
         identityService.createMembership(GONZO, "sales");
     }
 
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
         identityService.deleteUser(KERMIT);
         identityService.deleteUser(GONZO);
@@ -62,9 +64,9 @@ public class TaskCandidateTest extends PluggableFlowableTestCase {
         identityService.deleteGroup("accountancy");
         identityService.deleteGroup("management");
 
-        super.tearDown();
     }
 
+    @Test
     @Deployment
     public void testSingleCandidateGroup() {
 
@@ -100,6 +102,7 @@ public class TaskCandidateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment
     public void testMultipleCandidateGroups() {
 
@@ -146,6 +149,7 @@ public class TaskCandidateTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
+    @Test
     @Deployment
     public void testMultipleCandidateUsers() {
         runtimeService.startProcessInstanceByKey("multipleCandidateUsersExample", Collections.singletonMap("Variable", (Object) "var"));
@@ -171,6 +175,7 @@ public class TaskCandidateTest extends PluggableFlowableTestCase {
         assertEquals(1, task.getTaskLocalVariables().size());
     }
 
+    @Test
     @Deployment
     public void testMixedCandidateUserAndGroup() {
         runtimeService.startProcessInstanceByKey("mixedCandidateUserAndGroupExample");
@@ -181,6 +186,7 @@ public class TaskCandidateTest extends PluggableFlowableTestCase {
 
     // test if candidate group works with expression, when there is a function
     // with one parameter
+    @Test
     @Deployment
     public void testCandidateExpressionOneParam() {
         Map<String, Object> params = new HashMap<>();
@@ -193,6 +199,7 @@ public class TaskCandidateTest extends PluggableFlowableTestCase {
 
     // test if candidate group works with expression, when there is a function
     // with two parameters
+    @Test
     @Deployment
     public void testCandidateExpressionTwoParams() {
         Map<String, Object> params = new HashMap<>();

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/groovy/GroovyScriptTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/groovy/GroovyScriptTest.java
@@ -21,12 +21,14 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
 import org.flowable.job.api.JobQuery;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tom Baeyens
  */
 public class GroovyScriptTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testScriptExecution() {
         int[] inputArray = new int[] { 1, 2, 3, 4, 5 };
@@ -36,6 +38,7 @@ public class GroovyScriptTest extends PluggableFlowableTestCase {
         assertEquals(15, result.intValue());
     }
 
+    @Test
     @Deployment
     public void testSetVariableThroughExecutionInScript() {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("setScriptVariableThroughExecution");
@@ -46,6 +49,7 @@ public class GroovyScriptTest extends PluggableFlowableTestCase {
         assertEquals("test123", runtimeService.getVariable(pi.getId(), "myVar"));
     }
 
+    @Test
     @Deployment
     public void testAsyncScript() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testAsyncScript");

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/identity/IdentityTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/identity/IdentityTest.java
@@ -20,12 +20,14 @@ import java.util.Set;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.idm.api.Group;
 import org.flowable.idm.api.User;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tom Baeyens
  */
 public class IdentityTest extends PluggableFlowableTestCase {
 
+    @Test
     public void testAuthentication() {
         User user = identityService.newUser("johndoe");
         user.setPassword("xxx");
@@ -37,6 +39,7 @@ public class IdentityTest extends PluggableFlowableTestCase {
         identityService.deleteUser("johndoe");
     }
 
+    @Test
     public void testFindGroupsByUserAndType() {
         Group sales = identityService.newGroup("sales");
         sales.setType("hierarchy");
@@ -94,6 +97,7 @@ public class IdentityTest extends PluggableFlowableTestCase {
         identityService.deleteUser("jackblack");
     }
 
+    @Test
     public void testUser() {
         User user = identityService.newUser("johndoe");
         user.setFirstName("John");
@@ -110,6 +114,7 @@ public class IdentityTest extends PluggableFlowableTestCase {
         identityService.deleteUser("johndoe");
     }
 
+    @Test
     public void testGroup() {
         Group group = identityService.newGroup("sales");
         group.setName("Sales division");
@@ -122,6 +127,7 @@ public class IdentityTest extends PluggableFlowableTestCase {
         identityService.deleteGroup("sales");
     }
 
+    @Test
     public void testMembership() {
         Group sales = identityService.newGroup("sales");
         identityService.saveGroup(sales);

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/mgmt/ManagementServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/mgmt/ManagementServiceTest.java
@@ -23,6 +23,9 @@ import org.flowable.engine.ManagementService;
 import org.flowable.engine.impl.context.Context;
 import org.flowable.engine.impl.persistence.entity.PropertyEntity;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Test case for the various operations of the {@link ManagementService}
@@ -32,6 +35,9 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
  */
 public class ManagementServiceTest extends PluggableFlowableTestCase {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(ManagementServiceTest.class);
+
+    @Test
     public void testTableCount() {
         Map<String, Long> tableCount = managementService.getTableCount();
 
@@ -62,6 +68,7 @@ public class ManagementServiceTest extends PluggableFlowableTestCase {
         assertEquals(new Long(0), tableCount.get(tablePrefix + "ACT_RU_IDENTITYLINK"));
     }
 
+    @Test
     public void testGetTableMetaData() {
 
         String tablePrefix = processEngineConfiguration.getDatabaseTablePrefix();

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/mgmt/TablePageQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/mgmt/TablePageQueryTest.java
@@ -18,12 +18,14 @@ import java.util.Map;
 
 import org.flowable.common.engine.api.management.TablePage;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
  */
 public class TablePageQueryTest extends PluggableFlowableTestCase {
 
+    @Test
     public void testGetTablePage() {
         String tablePrefix = processEngineConfiguration.getDatabaseTablePrefix();
         List<String> taskIds = generateDummyTasks(20);
@@ -45,6 +47,7 @@ public class TablePageQueryTest extends PluggableFlowableTestCase {
         taskService.deleteTasks(taskIds, true);
     }
 
+    @Test
     public void testGetSortedTablePage() {
         String tablePrefix = processEngineConfiguration.getDatabaseTablePrefix();
         List<String> taskIds = generateDummyTasks(15);

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/processdefinitions/ProcessDefinitionsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/processdefinitions/ProcessDefinitionsTest.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import org.flowable.engine.impl.bpmn.deployer.ResourceNameUtil;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.repository.ProcessDefinition;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tom Baeyens
@@ -33,6 +34,7 @@ public class ProcessDefinitionsTest extends PluggableFlowableTestCase {
 
     private static final String TARGET_NAMESPACE = "targetNamespace='http://activiti.org/BPMN20'";
 
+    @Test
     public void testGetProcessDefinitions() {
         List<String> deploymentIds = new ArrayList<>();
         deploymentIds.add(deployProcessString(("<definitions " + NAMESPACE + " " + TARGET_NAMESPACE + ">" + "  <process id='IDR' name='Insurance Damage Report 1' />" + "</definitions>")));
@@ -114,6 +116,7 @@ public class ProcessDefinitionsTest extends PluggableFlowableTestCase {
         deleteDeployments(deploymentIds);
     }
 
+    @Test
     public void testDeployIdenticalProcessDefinitions() {
         List<String> deploymentIds = new ArrayList<>();
         deploymentIds.add(deployProcessString(("<definitions " + NAMESPACE + " " + TARGET_NAMESPACE + ">" + "  <process id='IDR' name='Insurance Damage Report' />" + "</definitions>")));
@@ -139,6 +142,7 @@ public class ProcessDefinitionsTest extends PluggableFlowableTestCase {
         deleteDeployments(deploymentIds);
     }
 
+    @Test
     public void testProcessDefinitionDescription() {
         String deploymentId = deployProcessString(("<definitions " + NAMESPACE + " " + TARGET_NAMESPACE + ">" + "  <process id='test' name='test'><documentation>This is a test</documentation></process></definitions>"));
         ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().deploymentId(deploymentId).singleResult();

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/runtime/StandardAgendaFailingTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/runtime/StandardAgendaFailingTest.java
@@ -14,20 +14,18 @@ package org.flowable.examples.runtime;
 
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.test.Deployment;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * This test shows that bpmn endless loop with activiti6 is not only fiction
  */
 public class StandardAgendaFailingTest extends PluggableFlowableTestCase {
 
-    @Ignore("Endless loop with the standard agenda implementation can run 'forever'.")
+    @Test
+    @Disabled("Endless loop with the standard agenda implementation can run 'forever'.")
     @Deployment(resources = "org/flowable/examples/runtime/WatchDogAgendaTest-endlessloop.bpmn20.xml")
     public void ignoreStandardAgendaWithEndLessLoop() {
         this.runtimeService.startProcessInstanceByKey("endlessloop");
-    }
-
-    public void testEmpty() {
-        // empty test to let maven build pass through
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/runtime/WatchDogAgendaTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/runtime/WatchDogAgendaTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertThat;
 import org.flowable.common.engine.api.FlowableException;
 import org.flowable.engine.impl.test.ResourceFlowableTestCase;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * This class shows an example of configurable agenda usage.
@@ -28,6 +29,7 @@ public class WatchDogAgendaTest extends ResourceFlowableTestCase {
         super("org/flowable/examples/runtime/WatchDogAgendaTest.flowable.cfg.xml");
     }
 
+    @Test
     @Deployment(resources = "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml")
     public void testWatchDogWithOneTaskProcess() {
         this.runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -36,6 +38,7 @@ public class WatchDogAgendaTest extends ResourceFlowableTestCase {
         assertThat(this.runtimeService.createProcessInstanceQuery().count(), is(0L));
     }
 
+    @Test
     @Deployment(resources = "org/flowable/examples/runtime/WatchDogAgendaTest-endlessloop.bpmn20.xml")
     public void testWatchDogWithEndLessLoop() {
         try {

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/task/StandaloneTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/task/StandaloneTaskTest.java
@@ -22,26 +22,28 @@ import org.flowable.engine.impl.test.HistoryTestHelper;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.task.service.impl.persistence.entity.TaskEntity;
 import org.flowable.variable.api.history.HistoricVariableInstance;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
  */
 public class StandaloneTaskTest extends PluggableFlowableTestCase {
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         identityService.saveUser(identityService.newUser("kermit"));
         identityService.saveUser(identityService.newUser("gonzo"));
     }
 
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
         identityService.deleteUser("kermit");
         identityService.deleteUser("gonzo");
-        super.tearDown();
     }
 
+    @Test
     public void testCreateToComplete() {
 
         // Create and save task
@@ -87,6 +89,7 @@ public class StandaloneTaskTest extends PluggableFlowableTestCase {
         assertNull(taskService.createTaskQuery().taskId(taskId).singleResult());
     }
 
+    @Test
     public void testOptimisticLockingThrownOnMultipleUpdates() {
         org.flowable.task.api.Task task = taskService.newTask();
         taskService.saveTask(task);
@@ -112,6 +115,7 @@ public class StandaloneTaskTest extends PluggableFlowableTestCase {
     }
 
     // See https://activiti.atlassian.net/browse/ACT-1290
+    @Test
     public void testRevisionUpdatedOnSave() {
         org.flowable.task.api.Task task = taskService.newTask();
         taskService.saveTask(task);
@@ -129,6 +133,7 @@ public class StandaloneTaskTest extends PluggableFlowableTestCase {
     }
 
     // See https://activiti.atlassian.net/browse/ACT-1290
+    @Test
     public void testRevisionUpdatedOnSaveWhenFetchedUsingQuery() {
         org.flowable.task.api.Task task = taskService.newTask();
         taskService.saveTask(task);
@@ -149,6 +154,7 @@ public class StandaloneTaskTest extends PluggableFlowableTestCase {
         taskService.deleteTask(task.getId(), true);
     }
 
+    @Test
     public void testHistoricVariableOkOnUpdate() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             // 1. create a task

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/taskforms/TaskFormsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/taskforms/TaskFormsTest.java
@@ -19,6 +19,9 @@ import org.flowable.common.engine.impl.util.CollectionUtil;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.repository.ProcessDefinition;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tom Baeyens
@@ -26,19 +29,20 @@ import org.flowable.engine.test.Deployment;
  */
 public class TaskFormsTest extends PluggableFlowableTestCase {
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         identityService.saveUser(identityService.newUser("fozzie"));
         identityService.saveGroup(identityService.newGroup("management"));
         identityService.createMembership("fozzie", "management");
     }
 
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
         identityService.deleteGroup("management");
         identityService.deleteUser("fozzie");
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/examples/taskforms/VacationRequest_deprecated_forms.bpmn20.xml", "org/flowable/examples/taskforms/approve.form",
             "org/flowable/examples/taskforms/request.form", "org/flowable/examples/taskforms/adjustRequest.form" })
     public void testTaskFormsWithVacationRequestProcess() {
@@ -71,6 +75,7 @@ public class TaskFormsTest extends PluggableFlowableTestCase {
         assertEquals("Adjust vacation request", task.getName());
     }
 
+    @Test
     @Deployment
     public void testTaskFormUnavailable() {
         String procDefId = repositoryService.createProcessDefinitionQuery().singleResult().getId();

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/test/OneTaskProcessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/test/OneTaskProcessTest.java
@@ -30,6 +30,9 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.repository.ProcessDefinition;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * This class provides examples how to test one task process
@@ -38,16 +41,15 @@ public class OneTaskProcessTest extends PluggableFlowableTestCase {
 
     protected EventLogger databaseEventLogger;
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
 
         // Database event logger setup
         databaseEventLogger = new EventLogger(processEngineConfiguration.getClock(), processEngineConfiguration.getObjectMapper());
         runtimeService.addEventListener(databaseEventLogger);
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
         // Cleanup
         for (EventLogEntry eventLogEntry : managementService.getEventLogEntries(null, null)) {
@@ -57,9 +59,9 @@ public class OneTaskProcessTest extends PluggableFlowableTestCase {
         // Database event logger teardown
         runtimeService.removeEventListener(databaseEventLogger);
 
-        super.tearDown();
     }
 
+    @Test
     @Deployment(resources = {"org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
     public void testStandardJUnitOneTaskProcess() {
         // Arrange -> start process
@@ -72,6 +74,7 @@ public class OneTaskProcessTest extends PluggableFlowableTestCase {
         assertThat(this.runtimeService.createProcessInstanceQuery().processInstanceId(oneTaskProcess.getId()).count(), is(0L));
     }
 
+    @Test
     @Deployment(resources = {"org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
     public void testProcessModelByAnotherProcess() {
         testProcessModelByAnotherProcess(
@@ -89,6 +92,7 @@ public class OneTaskProcessTest extends PluggableFlowableTestCase {
         assertThat(this.runtimeService.createProcessInstanceQuery().processInstanceId(pUnitTestProcessInstance.getId()).count(), is(0L));
     }
 
+    @Test
     @Deployment(resources = {"org/flowable/engine/test/api/twoTasksProcess.bpmn20.xml"})
     public void testProcessModelFailure() {
         // deploy different process - test should fail
@@ -100,6 +104,7 @@ public class OneTaskProcessTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = {"org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml"})
     public void testGenerateProcessTestSemiAutomatically() {
         // Generate "user" events

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/variables/DataObjectsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/variables/DataObjectsTest.java
@@ -8,8 +8,10 @@ import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.task.api.Task;
+import org.junit.jupiter.api.Test;
 
 public class DataObjectsTest extends PluggableFlowableTestCase {
+    @Test
     @Deployment
     public void testRetrieveDataObjectsFromNestedSubprocess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("DataObjectsTest");

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/variables/VariablesTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/variables/VariablesTest.java
@@ -32,6 +32,7 @@ import org.flowable.variable.api.history.HistoricVariableInstance;
 import org.flowable.variable.api.persistence.entity.VariableInstance;
 import org.flowable.variable.api.types.ValueFields;
 import org.flowable.variable.api.types.VariableType;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -40,6 +41,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
  */
 public class VariablesTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testBasicVariableOperations() {
         processEngineConfiguration.getVariableTypes().addType(CustomVariableType.instance);
@@ -182,6 +184,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
 
     }
 
+    @Test
     @Deployment
     public void testLocalizeVariables() {
         // Start process instance with different types of variables
@@ -261,6 +264,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertEquals("pepsi-cola", variableInstance.getValue());
     }
 
+    @Test
     @Deployment
     public void testLocalizeDataObjects() {
         // Start process instance with different types of variables
@@ -1676,6 +1680,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
     }
 
     // Test case for ACT-1839
+    @Test
     @Deployment(resources = { "org/flowable/examples/variables/VariablesTest.testChangeTypeSerializable.bpmn20.xml" })
     public void testChangeTypeSerializable() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("variable-type-change-test");
@@ -1692,6 +1697,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
     }
 
     // test case for ACT-1082
+    @Test
     @Deployment(resources = { "org/flowable/examples/variables/VariablesTest.testBasicVariableOperations.bpmn20.xml" })
     public void testChangeVariableType() {
 
@@ -1755,6 +1761,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
     }
 
     // test case for ACT-1428
+    @Test
     @Deployment
     public void testNullVariable() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("taskAssigneeProcess");
@@ -1805,6 +1812,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
     /**
      * Test added to validate UUID variable type + querying (ACT-1665)
      */
+    @Test
     @Deployment
     public void testUUIDVariableAndQuery() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/calendar/AdvancedCycleBusinessCalendarTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/calendar/AdvancedCycleBusinessCalendarTest.java
@@ -21,11 +21,13 @@ import org.flowable.common.engine.impl.calendar.AdvancedCycleBusinessCalendar;
 import org.flowable.common.engine.impl.runtime.Clock;
 import org.flowable.common.engine.impl.util.DefaultClockImpl;
 import org.flowable.engine.impl.test.AbstractTestCase;
+import org.junit.jupiter.api.Test;
 
 public class AdvancedCycleBusinessCalendarTest extends AbstractTestCase {
 
     private static final Clock testingClock = new DefaultClockImpl();
 
+    @Test
     public void testDaylightSavingFallIso() throws Exception {
         AdvancedCycleBusinessCalendar businessCalendar = new AdvancedCycleBusinessCalendar(testingClock);
 
@@ -34,6 +36,7 @@ public class AdvancedCycleBusinessCalendarTest extends AbstractTestCase {
         assertEquals(parseCalendar("20131104-05:00:00", TimeZone.getTimeZone("UTC")).getTime(), businessCalendar.resolveDuedate("R2/2013-11-03T00:00:00-04:00/P1D DSTZONE:US/Eastern"));
     }
 
+    @Test
     public void testDaylightSavingSpringIso() throws Exception {
         AdvancedCycleBusinessCalendar businessCalendar = new AdvancedCycleBusinessCalendar(testingClock);
 
@@ -42,6 +45,7 @@ public class AdvancedCycleBusinessCalendarTest extends AbstractTestCase {
         assertEquals(parseCalendar("20140310-04:00:00", TimeZone.getTimeZone("UTC")).getTime(), businessCalendar.resolveDuedate("R2/2014-03-09T00:00:00-05:00/P1D DSTZONE:US/Eastern"));
     }
 
+    @Test
     public void testIsoString() throws Exception {
         AdvancedCycleBusinessCalendar businessCalendar = new AdvancedCycleBusinessCalendar(testingClock);
 
@@ -50,6 +54,7 @@ public class AdvancedCycleBusinessCalendarTest extends AbstractTestCase {
         assertEquals(parseCalendar("20140311-04:00:00", TimeZone.getTimeZone("UTC")).getTime(), businessCalendar.resolveDuedate("R2/2014-03-10T04:00:00/P1D DSTZONE:US/Eastern"));
     }
 
+    @Test
     public void testLegacyIsoString() throws Exception {
         AdvancedCycleBusinessCalendar businessCalendar = new AdvancedCycleBusinessCalendar(testingClock);
 
@@ -58,6 +63,7 @@ public class AdvancedCycleBusinessCalendarTest extends AbstractTestCase {
         assertEquals(parseCalendar("20140311-00:00:00", TimeZone.getDefault()).getTime(), businessCalendar.resolveDuedate("R2/2014-03-10T00:00:00/P1D"));
     }
 
+    @Test
     public void testDaylightSavingFallCron() throws Exception {
         AdvancedCycleBusinessCalendar businessCalendar = new AdvancedCycleBusinessCalendar(testingClock);
 
@@ -66,6 +72,7 @@ public class AdvancedCycleBusinessCalendarTest extends AbstractTestCase {
         assertEquals(parseCalendar("20131103-17:00:00", TimeZone.getTimeZone("UTC")).getTime(), businessCalendar.resolveDuedate("0 0 12 1/1 * ? * DSTZONE:US/Eastern"));
     }
 
+    @Test
     public void testDaylightSavingSpringCron() throws Exception {
         AdvancedCycleBusinessCalendar businessCalendar = new AdvancedCycleBusinessCalendar(testingClock);
 
@@ -74,6 +81,7 @@ public class AdvancedCycleBusinessCalendarTest extends AbstractTestCase {
         assertEquals(parseCalendar("20140309-16:00:00", TimeZone.getTimeZone("UTC")).getTime(), businessCalendar.resolveDuedate("0 0 12 1/1 * ? * DSTZONE:US/Eastern"));
     }
 
+    @Test
     public void testCronString() throws Exception {
         AdvancedCycleBusinessCalendar businessCalendar = new AdvancedCycleBusinessCalendar(testingClock);
 
@@ -82,6 +90,7 @@ public class AdvancedCycleBusinessCalendarTest extends AbstractTestCase {
         assertEquals(parseCalendar("20140310-16:00:00", TimeZone.getTimeZone("UTC")).getTime(), businessCalendar.resolveDuedate("0 0 12 1/1 * ? * DSTZONE:US/Eastern"));
     }
 
+    @Test
     public void testLegacyCronString() throws Exception {
         AdvancedCycleBusinessCalendar businessCalendar = new AdvancedCycleBusinessCalendar(testingClock);
 

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/calendar/CycleBusinessCalendarTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/calendar/CycleBusinessCalendarTest.java
@@ -20,9 +20,11 @@ import org.flowable.common.engine.impl.calendar.CycleBusinessCalendar;
 import org.flowable.common.engine.impl.runtime.Clock;
 import org.flowable.common.engine.impl.util.DefaultClockImpl;
 import org.flowable.engine.impl.test.AbstractTestCase;
+import org.junit.jupiter.api.Test;
 
 public class CycleBusinessCalendarTest extends AbstractTestCase {
 
+    @Test
     public void testSimpleCron() throws Exception {
         Clock testingClock = new DefaultClockImpl();
         CycleBusinessCalendar businessCalendar = new CycleBusinessCalendar(testingClock);
@@ -38,6 +40,7 @@ public class CycleBusinessCalendarTest extends AbstractTestCase {
         assertEquals(expectedDuedate, duedate);
     }
 
+    @Test
     public void testSimpleDuration() throws Exception {
         Clock testingClock = new DefaultClockImpl();
         CycleBusinessCalendar businessCalendar = new CycleBusinessCalendar(testingClock);

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/calendar/DurationBusinessCalendarTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/calendar/DurationBusinessCalendarTest.java
@@ -20,12 +20,14 @@ import org.flowable.common.engine.impl.calendar.DurationBusinessCalendar;
 import org.flowable.common.engine.impl.runtime.Clock;
 import org.flowable.common.engine.impl.util.DefaultClockImpl;
 import org.flowable.engine.impl.test.AbstractTestCase;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tom Baeyens
  */
 public class DurationBusinessCalendarTest extends AbstractTestCase {
 
+    @Test
     public void testSimpleDuration() throws Exception {
         Clock testingClock = new DefaultClockImpl();
         DurationBusinessCalendar businessCalendar = new DurationBusinessCalendar(testingClock);

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/calendar/DurationHelperTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/calendar/DurationHelperTest.java
@@ -26,7 +26,7 @@ import org.apache.commons.lang3.time.DateUtils;
 import org.flowable.common.engine.impl.calendar.DurationHelper;
 import org.flowable.common.engine.impl.runtime.Clock;
 import org.flowable.common.engine.impl.util.DefaultClockImpl;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DurationHelperTest {
 

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/cfg/CustomMybatisMapperTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/cfg/CustomMybatisMapperTest.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import org.flowable.common.engine.impl.cmd.CustomSqlExecution;
 import org.flowable.engine.impl.cmd.AbstractCustomSqlExecution;
 import org.flowable.engine.impl.test.ResourceFlowableTestCase;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author jbarrez
@@ -28,6 +29,7 @@ public class CustomMybatisMapperTest extends ResourceFlowableTestCase {
         super("org/flowable/standalone/cfg/custom-mybatis-mappers-flowable.cfg.xml");
     }
 
+    @Test
     public void testSelectTaskColumns() {
 
         // Create test data
@@ -64,6 +66,7 @@ public class CustomMybatisMapperTest extends ResourceFlowableTestCase {
 
     }
 
+    @Test
     public void testFetchTaskWithSpecificVariable() {
 
         // Create test data

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/cfg/CustomMybatisXMLMapperTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/cfg/CustomMybatisXMLMapperTest.java
@@ -19,6 +19,7 @@ import org.flowable.common.engine.impl.interceptor.CommandContext;
 import org.flowable.engine.impl.test.ResourceFlowableTestCase;
 import org.flowable.engine.impl.util.CommandContextUtil;
 import org.flowable.engine.task.Attachment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Bassam Al-Sarori
@@ -29,6 +30,7 @@ public class CustomMybatisXMLMapperTest extends ResourceFlowableTestCase {
         super("org/flowable/standalone/cfg/custom-mybatis-xml-mappers-flowable.cfg.xml");
     }
 
+    @Test
     public void testSelectOneTask() {
         // Create test data
         for (int i = 0; i < 4; i++) {
@@ -57,6 +59,7 @@ public class CustomMybatisXMLMapperTest extends ResourceFlowableTestCase {
         deleteTasks(taskService.createTaskQuery().list());
     }
 
+    @Test
     public void testSelectTaskList() {
         // Create test data
         for (int i = 0; i < 5; i++) {
@@ -78,6 +81,7 @@ public class CustomMybatisXMLMapperTest extends ResourceFlowableTestCase {
         deleteCustomTasks(tasks);
     }
 
+    @Test
     public void testSelectTasksByCustomQuery() {
         // Create test data
         for (int i = 0; i < 5; i++) {
@@ -96,6 +100,7 @@ public class CustomMybatisXMLMapperTest extends ResourceFlowableTestCase {
         deleteCustomTasks(tasks);
     }
 
+    @Test
     public void testSelectTaskByCustomQuery() {
         // Create test data
         for (int i = 0; i < 5; i++) {
@@ -112,6 +117,7 @@ public class CustomMybatisXMLMapperTest extends ResourceFlowableTestCase {
         deleteCustomTasks(tasks);
     }
 
+    @Test
     public void testCustomQueryListPage() {
         // Create test data
         for (int i = 0; i < 15; i++) {
@@ -128,6 +134,7 @@ public class CustomMybatisXMLMapperTest extends ResourceFlowableTestCase {
         deleteCustomTasks(tasks);
     }
 
+    @Test
     public void testCustomQueryOrderBy() {
         // Create test data
         for (int i = 0; i < 5; i++) {
@@ -155,6 +162,7 @@ public class CustomMybatisXMLMapperTest extends ResourceFlowableTestCase {
         deleteCustomTasks(tasks);
     }
 
+    @Test
     public void testAttachmentQuery() {
         String taskId = createTask("task1", null, null, 0);
 

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/deploy/CustomDeploymentCacheTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/deploy/CustomDeploymentCacheTest.java
@@ -17,6 +17,7 @@ import java.text.MessageFormat;
 
 import org.flowable.engine.impl.test.ResourceFlowableTestCase;
 import org.flowable.engine.repository.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
@@ -27,6 +28,7 @@ public class CustomDeploymentCacheTest extends ResourceFlowableTestCase {
         super("org/flowable/standalone/deploy/custom.deployment.cache.test.flowable.cfg.xml");
     }
 
+    @Test
     public void testCustomDeploymentCacheUsed() throws IOException {
         CustomDeploymentCache customCache = (CustomDeploymentCache) processEngineConfiguration.getProcessDefinitionCache();
         assertNull(customCache.getCachedProcessDefinition());

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/deploy/DeploymentCacheLimitTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/deploy/DeploymentCacheLimitTest.java
@@ -19,6 +19,7 @@ import org.flowable.common.engine.impl.persistence.deploy.DefaultDeploymentCache
 import org.flowable.engine.impl.persistence.deploy.ProcessDefinitionCacheEntry;
 import org.flowable.engine.impl.test.ResourceFlowableTestCase;
 import org.flowable.engine.repository.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
@@ -29,6 +30,7 @@ public class DeploymentCacheLimitTest extends ResourceFlowableTestCase {
         super("org/flowable/standalone/deploy/deployment.cache.limit.test.flowable.cfg.xml");
     }
 
+    @Test
     public void testDeploymentCacheLimit() throws IOException {
         int processDefinitionCacheLimit = 3; // This is set in the configuration
                                              // above

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/el/ExpressionBeanAccessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/el/ExpressionBeanAccessTest.java
@@ -20,6 +20,7 @@ import org.flowable.common.engine.api.FlowableException;
 import org.flowable.engine.impl.test.ResourceFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Frederik Heremans
@@ -30,6 +31,7 @@ public class ExpressionBeanAccessTest extends ResourceFlowableTestCase {
         super("org/flowable/standalone/el/flowable.cfg.xml");
     }
 
+    @Test
     @Deployment
     public void testConfigurationBeanAccess() {
         // Exposed bean returns 'I'm exposed' when to-string is called in first

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/escapeclause/DeploymentQueryEscapeClauseTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/escapeclause/DeploymentQueryEscapeClauseTest.java
@@ -13,6 +13,9 @@
 package org.flowable.standalone.escapeclause;
 
 import org.flowable.engine.repository.DeploymentQuery;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class DeploymentQueryEscapeClauseTest extends AbstractEscapeClauseTestCase {
 
@@ -20,7 +23,7 @@ public class DeploymentQueryEscapeClauseTest extends AbstractEscapeClauseTestCas
 
     private String deploymentTwoId;
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
         deploymentOneId = repositoryService
                 .createDeployment()
@@ -39,16 +42,15 @@ public class DeploymentQueryEscapeClauseTest extends AbstractEscapeClauseTestCas
                 .deploy()
                 .getId();
 
-        super.setUp();
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
         repositoryService.deleteDeployment(deploymentOneId, true);
         repositoryService.deleteDeployment(deploymentTwoId, true);
     }
 
+    @Test
     public void testQueryByNameLike() {
         DeploymentQuery query = repositoryService.createDeploymentQuery().deploymentNameLike("%\\%%");
         assertEquals("one%", query.singleResult().getName());
@@ -61,12 +63,14 @@ public class DeploymentQueryEscapeClauseTest extends AbstractEscapeClauseTestCas
         assertEquals(1, query.count());
     }
 
+    @Test
     public void testQueryByProcessDefinitionKeyLike() {
         DeploymentQuery query = repositoryService.createDeploymentQuery().processDefinitionKeyLike("%\\_%");
         assertEquals(1, query.list().size());
         assertEquals(1, query.count());
     }
 
+    @Test
     public void testQueryByTenantIdLike() {
         DeploymentQuery query = repositoryService.createDeploymentQuery().deploymentTenantIdLike("%\\%%");
         assertEquals("One%", query.singleResult().getTenantId());

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/escapeclause/ExecutionQueryEscapeClauseTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/escapeclause/ExecutionQueryEscapeClauseTest.java
@@ -17,6 +17,9 @@ import java.util.Map;
 
 import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ExecutionQueryEscapeClauseTest extends AbstractEscapeClauseTestCase {
 
@@ -28,7 +31,7 @@ public class ExecutionQueryEscapeClauseTest extends AbstractEscapeClauseTestCase
 
     private ProcessInstance processInstance2;
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
         deploymentOneId = repositoryService
                 .createDeployment()
@@ -52,16 +55,15 @@ public class ExecutionQueryEscapeClauseTest extends AbstractEscapeClauseTestCase
         vars.put("var1", "Two_");
         processInstance2 = runtimeService.startProcessInstanceByKeyAndTenantId("oneTaskProcess", vars, "Two_");
 
-        super.setUp();
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
         repositoryService.deleteDeployment(deploymentOneId, true);
         repositoryService.deleteDeployment(deploymentTwoId, true);
     }
 
+    @Test
     public void testQueryByTenantIdLike() {
         Execution execution = runtimeService.createExecutionQuery().onlyChildExecutions().executionTenantIdLike("%\\%%").singleResult();
         assertNotNull(execution);
@@ -70,6 +72,7 @@ public class ExecutionQueryEscapeClauseTest extends AbstractEscapeClauseTestCase
         assertNotNull(execution);
     }
 
+    @Test
     public void testQueryLikeByQueryVariableValue() {
         Execution execution = runtimeService.createExecutionQuery().variableValueLike("var1", "%\\%%").singleResult();
         assertNotNull(execution);
@@ -80,6 +83,7 @@ public class ExecutionQueryEscapeClauseTest extends AbstractEscapeClauseTestCase
         assertEquals(processInstance2.getId(), execution.getId());
     }
 
+    @Test
     public void testQueryLikeIgnoreCaseByQueryVariableValue() {
         Execution execution = runtimeService.createExecutionQuery().variableValueLikeIgnoreCase("var1", "%\\%%").singleResult();
         assertNotNull(execution);
@@ -90,6 +94,7 @@ public class ExecutionQueryEscapeClauseTest extends AbstractEscapeClauseTestCase
         assertEquals(processInstance2.getId(), execution.getId());
     }
 
+    @Test
     public void testQueryLikeByQueryProcessVariableValue() {
         Execution execution = runtimeService.createExecutionQuery().onlyChildExecutions().processVariableValueLike("var1", "%\\%%").singleResult();
         assertNotNull(execution);
@@ -98,6 +103,7 @@ public class ExecutionQueryEscapeClauseTest extends AbstractEscapeClauseTestCase
         assertNotNull(execution);
     }
 
+    @Test
     public void testQueryLikeIgnoreCaseByQueryProcessVariableValue() {
         Execution execution = runtimeService.createExecutionQuery().onlyChildExecutions().processVariableValueLikeIgnoreCase("var1", "%\\%%").singleResult();
         assertNotNull(execution);

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/escapeclause/HistoricActivityInstanceEscapeClauseTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/escapeclause/HistoricActivityInstanceEscapeClauseTest.java
@@ -13,6 +13,9 @@
 package org.flowable.standalone.escapeclause;
 
 import org.flowable.engine.history.HistoricActivityInstanceQuery;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class HistoricActivityInstanceEscapeClauseTest extends AbstractEscapeClauseTestCase {
 
@@ -20,7 +23,7 @@ public class HistoricActivityInstanceEscapeClauseTest extends AbstractEscapeClau
 
     private String deploymentTwoId;
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
         deploymentOneId = repositoryService
                 .createDeployment()
@@ -36,16 +39,15 @@ public class HistoricActivityInstanceEscapeClauseTest extends AbstractEscapeClau
                 .deploy()
                 .getId();
 
-        super.setUp();
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
         repositoryService.deleteDeployment(deploymentOneId, true);
         repositoryService.deleteDeployment(deploymentTwoId, true);
     }
 
+    @Test
     public void testQueryByTenantIdLike() {
         runtimeService.startProcessInstanceByKeyAndTenantId("noopProcess", "One%");
         runtimeService.startProcessInstanceByKeyAndTenantId("noopProcess", "Two_");

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/escapeclause/HistoricProcessInstanceQueryEscapeClauseTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/escapeclause/HistoricProcessInstanceQueryEscapeClauseTest.java
@@ -22,6 +22,9 @@ import org.flowable.engine.history.HistoricProcessInstance;
 import org.flowable.engine.history.HistoricProcessInstanceQuery;
 import org.flowable.engine.impl.test.HistoryTestHelper;
 import org.flowable.engine.runtime.ProcessInstance;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class HistoricProcessInstanceQueryEscapeClauseTest extends AbstractEscapeClauseTestCase {
 
@@ -33,7 +36,7 @@ public class HistoricProcessInstanceQueryEscapeClauseTest extends AbstractEscape
 
     private ProcessInstance processInstance2;
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
         deploymentOneId = repositoryService
                 .createDeployment()
@@ -65,16 +68,15 @@ public class HistoricProcessInstanceQueryEscapeClauseTest extends AbstractEscape
         task = taskService.createTaskQuery().processInstanceId(processInstance2.getId()).singleResult();
         taskService.complete(task.getId());
 
-        super.setUp();
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
         repositoryService.deleteDeployment(deploymentOneId, true);
         repositoryService.deleteDeployment(deploymentTwoId, true);
     }
 
+    @Test
     public void testQueryByProcessKeyNotIn() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // processKeyNotIn
@@ -125,6 +127,7 @@ public class HistoricProcessInstanceQueryEscapeClauseTest extends AbstractEscape
         }
     }
 
+    @Test
     public void testQueryByTenantIdLike() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // tenantIdLike
@@ -147,6 +150,7 @@ public class HistoricProcessInstanceQueryEscapeClauseTest extends AbstractEscape
         }
     }
 
+    @Test
     public void testQueryByProcessInstanceNameLike() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // processInstanceNameLike
@@ -169,6 +173,7 @@ public class HistoricProcessInstanceQueryEscapeClauseTest extends AbstractEscape
         }
     }
 
+    @Test
     public void testQueryByProcessInstanceNameLikeIgnoreCase() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // processInstanceNameLike
@@ -191,6 +196,7 @@ public class HistoricProcessInstanceQueryEscapeClauseTest extends AbstractEscape
         }
     }
 
+    @Test
     public void testQueryLikeByQueryVariableValue() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // queryVariableValue
@@ -213,6 +219,7 @@ public class HistoricProcessInstanceQueryEscapeClauseTest extends AbstractEscape
         }
     }
 
+    @Test
     public void testQueryLikeIgnoreCaseByQueryVariableValue() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // queryVariableValueIgnoreCase

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/escapeclause/HistoricTaskQueryEscapeClauseTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/escapeclause/HistoricTaskQueryEscapeClauseTest.java
@@ -21,6 +21,9 @@ import org.flowable.common.engine.impl.history.HistoryLevel;
 import org.flowable.engine.impl.test.HistoryTestHelper;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.task.api.history.HistoricTaskInstance;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class HistoricTaskQueryEscapeClauseTest extends AbstractEscapeClauseTestCase {
 
@@ -40,7 +43,7 @@ public class HistoricTaskQueryEscapeClauseTest extends AbstractEscapeClauseTestC
 
     private org.flowable.task.api.Task task4;
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
         deploymentOneId = repositoryService
                 .createDeployment()
@@ -87,16 +90,15 @@ public class HistoricTaskQueryEscapeClauseTest extends AbstractEscapeClauseTestC
         taskService.setOwner(task4.getId(), "owner_");
         taskService.complete(task4.getId(), vars2, true);
 
-        super.setUp();
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
         repositoryService.deleteDeployment(deploymentOneId, true);
         repositoryService.deleteDeployment(deploymentTwoId, true);
     }
 
+    @Test
     public void testQueryByProcessDefinitionKeyLike() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // processDefinitionKeyLike
@@ -115,6 +117,7 @@ public class HistoricTaskQueryEscapeClauseTest extends AbstractEscapeClauseTestC
         }
     }
 
+    @Test
     public void testQueryByProcessDefinitionKeyLikeIgnoreCase() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // processDefinitionKeyLikeIgnoreCase
@@ -133,6 +136,7 @@ public class HistoricTaskQueryEscapeClauseTest extends AbstractEscapeClauseTestC
         }
     }
 
+    @Test
     public void testQueryByProcessDefinitionNameLike() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // processDefinitionNameLike
@@ -165,6 +169,7 @@ public class HistoricTaskQueryEscapeClauseTest extends AbstractEscapeClauseTestC
         }
     }
 
+    @Test
     public void testQueryByProcessInstanceBusinessKeyLike() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // processInstanceBusinessKeyLike
@@ -205,6 +210,7 @@ public class HistoricTaskQueryEscapeClauseTest extends AbstractEscapeClauseTestC
         }
     }
 
+    @Test
     public void testQueryByProcessInstanceBusinessKeyLikeIgnoreCase() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // processInstanceBusinessKeyLikeIgnoreCase
@@ -245,6 +251,7 @@ public class HistoricTaskQueryEscapeClauseTest extends AbstractEscapeClauseTestC
         }
     }
 
+    @Test
     public void testQueryByTaskDefinitionKeyLike() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // taskDefinitionKeyLike
@@ -263,6 +270,7 @@ public class HistoricTaskQueryEscapeClauseTest extends AbstractEscapeClauseTestC
         }
     }
 
+    @Test
     public void testQueryByTaskNameLike() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // taskNameLike
@@ -303,6 +311,7 @@ public class HistoricTaskQueryEscapeClauseTest extends AbstractEscapeClauseTestC
         }
     }
 
+    @Test
     public void testQueryByTaskNameLikeIgnoreCase() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // taskNameLikeIgnoreCase
@@ -343,6 +352,7 @@ public class HistoricTaskQueryEscapeClauseTest extends AbstractEscapeClauseTestC
         }
     }
 
+    @Test
     public void testQueryByTaskDescriptionLike() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // taskDescriptionLike
@@ -383,6 +393,7 @@ public class HistoricTaskQueryEscapeClauseTest extends AbstractEscapeClauseTestC
         }
     }
 
+    @Test
     public void testQueryByTaskDescriptionLikeIgnoreCase() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // taskDescriptionLikeIgnoreCase
@@ -423,6 +434,7 @@ public class HistoricTaskQueryEscapeClauseTest extends AbstractEscapeClauseTestC
         }
     }
 
+    @Test
     public void testQueryByTaskDeleteReasonLike() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // make test data
@@ -457,6 +469,7 @@ public class HistoricTaskQueryEscapeClauseTest extends AbstractEscapeClauseTestC
         }
     }
 
+    @Test
     public void testQueryByTaskOwnerLike() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // taskOwnerLike
@@ -497,6 +510,7 @@ public class HistoricTaskQueryEscapeClauseTest extends AbstractEscapeClauseTestC
         }
     }
 
+    @Test
     public void testQueryByTaskOwnerLikeIgnoreCase() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // taskOwnerLikeIgnoreCase
@@ -537,6 +551,7 @@ public class HistoricTaskQueryEscapeClauseTest extends AbstractEscapeClauseTestC
         }
     }
 
+    @Test
     public void testQueryByTaskAssigneeLike() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // taskAssigneeLike
@@ -577,6 +592,7 @@ public class HistoricTaskQueryEscapeClauseTest extends AbstractEscapeClauseTestC
         }
     }
 
+    @Test
     public void testQueryByTaskAssigneeLikeIgnoreCase() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // taskAssigneeLikeIgnoreCase
@@ -617,6 +633,7 @@ public class HistoricTaskQueryEscapeClauseTest extends AbstractEscapeClauseTestC
         }
     }
 
+    @Test
     public void testQueryByTenantIdLike() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // tenantIdLike
@@ -657,6 +674,7 @@ public class HistoricTaskQueryEscapeClauseTest extends AbstractEscapeClauseTestC
         }
     }
 
+    @Test
     public void testQueryLikeByQueryVariableValue() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // variableValueLike
@@ -697,6 +715,7 @@ public class HistoricTaskQueryEscapeClauseTest extends AbstractEscapeClauseTestC
         }
     }
 
+    @Test
     public void testQueryLikeIgnoreCaseByQueryVariableValue() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // variableValueLikeIgnoreCase

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/escapeclause/HistoricVariableInstanceEscapeClauseTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/escapeclause/HistoricVariableInstanceEscapeClauseTest.java
@@ -19,6 +19,9 @@ import org.flowable.common.engine.impl.history.HistoryLevel;
 import org.flowable.engine.impl.test.HistoryTestHelper;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.variable.api.history.HistoricVariableInstance;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class HistoricVariableInstanceEscapeClauseTest extends AbstractEscapeClauseTestCase {
 
@@ -30,7 +33,7 @@ public class HistoricVariableInstanceEscapeClauseTest extends AbstractEscapeClau
 
     private ProcessInstance processInstance2;
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
         deploymentOneId = repositoryService
                 .createDeployment()
@@ -62,16 +65,15 @@ public class HistoricVariableInstanceEscapeClauseTest extends AbstractEscapeClau
         task = taskService.createTaskQuery().processInstanceId(processInstance2.getId()).singleResult();
         taskService.complete(task.getId());
 
-        super.setUp();
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
         repositoryService.deleteDeployment(deploymentOneId, true);
         repositoryService.deleteDeployment(deploymentTwoId, true);
     }
 
+    @Test
     public void testQueryByVariableNameLike() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             HistoricVariableInstance historicVariable = historyService.createHistoricVariableInstanceQuery().variableNameLike("%\\%%").singleResult();
@@ -86,6 +88,7 @@ public class HistoricVariableInstanceEscapeClauseTest extends AbstractEscapeClau
         }
     }
 
+    @Test
     public void testQueryLikeByQueryVariableValue() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             HistoricVariableInstance historicVariable = historyService.createHistoricVariableInstanceQuery().variableValueLike("var%", "%\\%%").singleResult();
@@ -98,6 +101,7 @@ public class HistoricVariableInstanceEscapeClauseTest extends AbstractEscapeClau
         }
     }
 
+    @Test
     public void testQueryLikeByQueryVariableValueIgnoreCase() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             HistoricVariableInstance historicVariable = historyService.createHistoricVariableInstanceQuery().variableValueLikeIgnoreCase("var%", "%\\%%").singleResult();

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/escapeclause/JobQueryEscapeClauseTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/escapeclause/JobQueryEscapeClauseTest.java
@@ -13,6 +13,9 @@
 package org.flowable.standalone.escapeclause;
 
 import org.flowable.job.api.TimerJobQuery;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class JobQueryEscapeClauseTest extends AbstractEscapeClauseTestCase {
 
@@ -20,9 +23,8 @@ public class JobQueryEscapeClauseTest extends AbstractEscapeClauseTestCase {
     private String deploymentTwoId;
     private String deploymentThreeId;
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
 
         deploymentId = repositoryService.createDeployment()
                 .addClasspathResource("org/flowable/engine/test/api/mgmt/timerOnTask.bpmn20.xml")
@@ -49,14 +51,14 @@ public class JobQueryEscapeClauseTest extends AbstractEscapeClauseTestCase {
         runtimeService.startProcessInstanceByKeyAndTenantId("timerOnTask", "test").getId();
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
         repositoryService.deleteDeployment(deploymentId, true);
         repositoryService.deleteDeployment(deploymentTwoId, true);
         repositoryService.deleteDeployment(deploymentThreeId, true);
-        super.tearDown();
     }
 
+    @Test
     public void testQueryByTenantIdLike() {
         TimerJobQuery query = managementService.createTimerJobQuery().jobTenantIdLike("%\\%%");
         assertEquals("tenant%", query.singleResult().getTenantId());

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/escapeclause/ModelQueryEscapeClauseTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/escapeclause/ModelQueryEscapeClauseTest.java
@@ -14,6 +14,9 @@ package org.flowable.standalone.escapeclause;
 
 import org.flowable.engine.repository.Model;
 import org.flowable.engine.repository.ModelQuery;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ModelQueryEscapeClauseTest extends AbstractEscapeClauseTestCase {
 
@@ -21,7 +24,7 @@ public class ModelQueryEscapeClauseTest extends AbstractEscapeClauseTestCase {
 
     private String modelTwoId;
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
         Model model = repositoryService.newModel();
         model.setTenantId("mytenant%");
@@ -42,16 +45,15 @@ public class ModelQueryEscapeClauseTest extends AbstractEscapeClauseTestCase {
         repositoryService.addModelEditorSource(modelOneId, "bytes".getBytes("utf-8"));
         repositoryService.addModelEditorSource(modelTwoId, "bytes".getBytes("utf-8"));
 
-        super.setUp();
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
         repositoryService.deleteModel(modelOneId);
         repositoryService.deleteModel(modelTwoId);
     }
 
+    @Test
     public void testQueryByNameLike() throws Exception {
         ModelQuery query = repositoryService.createModelQuery().modelNameLike("%\\%%");
         Model model = query.singleResult();
@@ -70,6 +72,7 @@ public class ModelQueryEscapeClauseTest extends AbstractEscapeClauseTestCase {
         assertEquals(1, query.count());
     }
 
+    @Test
     public void testQueryByCategoryLike() throws Exception {
         ModelQuery query = repositoryService.createModelQuery().modelCategoryLike("%\\%%");
         Model model = query.singleResult();
@@ -88,6 +91,7 @@ public class ModelQueryEscapeClauseTest extends AbstractEscapeClauseTestCase {
         assertEquals(1, query.count());
     }
 
+    @Test
     public void testQueryByTenantIdLike() throws Exception {
         ModelQuery query = repositoryService.createModelQuery().modelTenantIdLike("%\\%%");
         Model model = query.singleResult();

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/escapeclause/ProcessDefinitionQueryEscapeClauseTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/escapeclause/ProcessDefinitionQueryEscapeClauseTest.java
@@ -13,13 +13,16 @@
 package org.flowable.standalone.escapeclause;
 
 import org.flowable.engine.repository.ProcessDefinitionQuery;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ProcessDefinitionQueryEscapeClauseTest extends AbstractEscapeClauseTestCase {
 
     private String deploymentOneId;
     private String deploymentTwoId;
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
         deploymentOneId = repositoryService
                 .createDeployment()
@@ -38,16 +41,15 @@ public class ProcessDefinitionQueryEscapeClauseTest extends AbstractEscapeClause
                 .deploy()
                 .getId();
 
-        super.setUp();
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
         repositoryService.deleteDeployment(deploymentOneId, true);
         repositoryService.deleteDeployment(deploymentTwoId, true);
     }
 
+    @Test
     public void testQueryByNameLike() {
         ProcessDefinitionQuery query = repositoryService.createProcessDefinitionQuery().processDefinitionNameLike("%\\%%");
         assertEquals("One%", query.singleResult().getName());
@@ -60,6 +62,7 @@ public class ProcessDefinitionQueryEscapeClauseTest extends AbstractEscapeClause
         assertEquals(1, query.count());
     }
 
+    @Test
     public void testQueryByCategoryLike() {
         ProcessDefinitionQuery query = repositoryService.createProcessDefinitionQuery().processDefinitionCategoryLike("%\\_%");
         assertEquals("Examples_", query.singleResult().getCategory());
@@ -67,6 +70,7 @@ public class ProcessDefinitionQueryEscapeClauseTest extends AbstractEscapeClause
         assertEquals(1, query.count());
     }
 
+    @Test
     public void testQueryByKeyLike() {
         ProcessDefinitionQuery query = repositoryService.createProcessDefinitionQuery().processDefinitionKeyLike("%\\_%");
         assertEquals("two_", query.singleResult().getKey());
@@ -74,6 +78,7 @@ public class ProcessDefinitionQueryEscapeClauseTest extends AbstractEscapeClause
         assertEquals(1, query.count());
     }
 
+    @Test
     public void testQueryByResourceNameLike() {
         ProcessDefinitionQuery query = repositoryService.createProcessDefinitionQuery().processDefinitionResourceNameLike("%\\%%");
         assertEquals("org/flowable/engine/test/repository/one%.bpmn20.xml", query.singleResult().getResourceName());
@@ -86,6 +91,7 @@ public class ProcessDefinitionQueryEscapeClauseTest extends AbstractEscapeClause
         assertEquals(1, query.count());
     }
 
+    @Test
     public void testQueryByTenantIdLike() {
         ProcessDefinitionQuery query = repositoryService.createProcessDefinitionQuery().processDefinitionTenantIdLike("%\\%%");
         assertEquals("One%", query.singleResult().getTenantId());

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/escapeclause/ProcessInstanceQueryEscapeClauseTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/escapeclause/ProcessInstanceQueryEscapeClauseTest.java
@@ -16,6 +16,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.flowable.engine.runtime.ProcessInstance;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ProcessInstanceQueryEscapeClauseTest extends AbstractEscapeClauseTestCase {
 
@@ -27,7 +30,7 @@ public class ProcessInstanceQueryEscapeClauseTest extends AbstractEscapeClauseTe
 
     private ProcessInstance processInstance2;
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
         deploymentOneId = repositoryService
                 .createDeployment()
@@ -53,16 +56,15 @@ public class ProcessInstanceQueryEscapeClauseTest extends AbstractEscapeClauseTe
         processInstance2 = runtimeService.startProcessInstanceByKeyAndTenantId("oneTaskProcess", vars, "Two_");
         runtimeService.setProcessInstanceName(processInstance2.getId(), "Two_");
 
-        super.setUp();
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
         repositoryService.deleteDeployment(deploymentOneId, true);
         repositoryService.deleteDeployment(deploymentTwoId, true);
     }
 
+    @Test
     public void testQueryByTenantIdLike() {
         // tenantIdLike
         ProcessInstance processInstance = runtimeService.createProcessInstanceQuery().processInstanceTenantIdLike("%\\%%").singleResult();
@@ -83,6 +85,7 @@ public class ProcessInstanceQueryEscapeClauseTest extends AbstractEscapeClauseTe
         assertEquals(processInstance2.getId(), processInstance.getId());
     }
 
+    @Test
     public void testQueryByProcessInstanceNameLike() {
         // processInstanceNameLike
         assertNotNull(runtimeService.createProcessInstanceQuery().processInstanceNameLike("%\\%%").singleResult());
@@ -99,6 +102,7 @@ public class ProcessInstanceQueryEscapeClauseTest extends AbstractEscapeClauseTe
         assertEquals(processInstance2.getId(), runtimeService.createProcessInstanceQuery().or().processInstanceNameLike("%\\_%").processDefinitionId("undefined").singleResult().getId());
     }
 
+    @Test
     public void testQueryProcessInstanceNameLikeIgnoreCase() {
         // processInstanceNameLike
         assertNotNull(runtimeService.createProcessInstanceQuery().processInstanceNameLikeIgnoreCase("%\\%%").singleResult());
@@ -115,6 +119,7 @@ public class ProcessInstanceQueryEscapeClauseTest extends AbstractEscapeClauseTe
         assertEquals(processInstance2.getId(), runtimeService.createProcessInstanceQuery().or().processInstanceNameLikeIgnoreCase("%\\_%").processDefinitionId("undefined").singleResult().getId());
     }
 
+    @Test
     public void testQueryLikeByQueryVariableValue() {
         // queryVariableValue
         ProcessInstance processInstance = runtimeService.createProcessInstanceQuery().variableValueLike("var1", "%\\%%").singleResult();
@@ -135,6 +140,7 @@ public class ProcessInstanceQueryEscapeClauseTest extends AbstractEscapeClauseTe
         assertEquals(processInstance2.getId(), processInstance.getId());
     }
 
+    @Test
     public void testQueryLikeByQueryVariableValueIgnoreCase() {
         // queryVariableValueIgnoreCase
         ProcessInstance processInstance = runtimeService.createProcessInstanceQuery().variableValueLikeIgnoreCase("var1", "%\\%%").singleResult();

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/escapeclause/TaskQueryEscapeClauseTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/escapeclause/TaskQueryEscapeClauseTest.java
@@ -18,6 +18,9 @@ import java.util.List;
 import org.flowable.common.engine.impl.history.HistoryLevel;
 import org.flowable.engine.impl.test.HistoryTestHelper;
 import org.flowable.engine.runtime.ProcessInstance;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TaskQueryEscapeClauseTest extends AbstractEscapeClauseTestCase {
 
@@ -33,7 +36,7 @@ public class TaskQueryEscapeClauseTest extends AbstractEscapeClauseTestCase {
 
     private org.flowable.task.api.Task task2;
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
         deploymentOneId = repositoryService
                 .createDeployment()
@@ -68,16 +71,15 @@ public class TaskQueryEscapeClauseTest extends AbstractEscapeClauseTestCase {
         taskService.setOwner(task2.getId(), "owner_");
         taskService.setVariableLocal(task2.getId(), "var1", "Two_");
 
-        super.setUp();
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
         repositoryService.deleteDeployment(deploymentOneId, true);
         repositoryService.deleteDeployment(deploymentTwoId, true);
     }
 
+    @Test
     public void testQueryByNameLike() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // nameLike
@@ -100,6 +102,7 @@ public class TaskQueryEscapeClauseTest extends AbstractEscapeClauseTestCase {
         }
     }
 
+    @Test
     public void testQueryByNameLikeIgnoreCase() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // nameLikeIgnoreCase
@@ -122,6 +125,7 @@ public class TaskQueryEscapeClauseTest extends AbstractEscapeClauseTestCase {
         }
     }
 
+    @Test
     public void testQueryByDescriptionLike() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // descriptionLike
@@ -144,6 +148,7 @@ public class TaskQueryEscapeClauseTest extends AbstractEscapeClauseTestCase {
         }
     }
 
+    @Test
     public void testQueryByDescriptionLikeIgnoreCase() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // descriptionLikeIgnoreCase
@@ -166,6 +171,7 @@ public class TaskQueryEscapeClauseTest extends AbstractEscapeClauseTestCase {
         }
     }
 
+    @Test
     public void testQueryByAssigneeLike() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // assigneeLike
@@ -186,6 +192,7 @@ public class TaskQueryEscapeClauseTest extends AbstractEscapeClauseTestCase {
         }
     }
 
+    @Test
     public void testQueryByAssigneeLikeIgnoreCase() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // assigneeLikeIgnoreCase
@@ -206,6 +213,7 @@ public class TaskQueryEscapeClauseTest extends AbstractEscapeClauseTestCase {
         }
     }
 
+    @Test
     public void testQueryByOwnerLike() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // taskOwnerLike
@@ -228,6 +236,7 @@ public class TaskQueryEscapeClauseTest extends AbstractEscapeClauseTestCase {
         }
     }
 
+    @Test
     public void testQueryByOwnerLikeIgnoreCase() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // taskOwnerLikeIgnoreCase
@@ -250,6 +259,7 @@ public class TaskQueryEscapeClauseTest extends AbstractEscapeClauseTestCase {
         }
     }
 
+    @Test
     public void testQueryByProcessInstanceBusinessKeyLike() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // processInstanceBusinessKeyLike
@@ -272,6 +282,7 @@ public class TaskQueryEscapeClauseTest extends AbstractEscapeClauseTestCase {
         }
     }
 
+    @Test
     public void testQueryByProcessInstanceBusinessKeyLikeIgnoreCase() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // processInstanceBusinessKeyLike
@@ -294,6 +305,7 @@ public class TaskQueryEscapeClauseTest extends AbstractEscapeClauseTestCase {
         }
     }
 
+    @Test
     public void testQueryByKeyLike() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // taskDefinitionKeyLike
@@ -312,6 +324,7 @@ public class TaskQueryEscapeClauseTest extends AbstractEscapeClauseTestCase {
         }
     }
 
+    @Test
     public void testQueryByProcessDefinitionKeyLike() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // processDefinitionKeyLike
@@ -330,6 +343,7 @@ public class TaskQueryEscapeClauseTest extends AbstractEscapeClauseTestCase {
         }
     }
 
+    @Test
     public void testQueryByProcessDefinitionKeyLikeIgnoreCase() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // processDefinitionKeyLikeIgnoreCase
@@ -348,6 +362,7 @@ public class TaskQueryEscapeClauseTest extends AbstractEscapeClauseTestCase {
         }
     }
 
+    @Test
     public void testQueryByProcessDefinitionNameLike() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // processDefinitionNameLike
@@ -373,6 +388,7 @@ public class TaskQueryEscapeClauseTest extends AbstractEscapeClauseTestCase {
         }
     }
 
+    @Test
     public void testQueryLikeByQueryVariableValue() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // taskVariableValueLike
@@ -395,6 +411,7 @@ public class TaskQueryEscapeClauseTest extends AbstractEscapeClauseTestCase {
         }
     }
 
+    @Test
     public void testQueryLikeIgnoreCaseByQueryVariableValue() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // taskVariableValueLikeIgnoreCase

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/event/EngineEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/event/EngineEventsTest.java
@@ -15,6 +15,7 @@ package org.flowable.standalone.event;
 import org.flowable.common.engine.api.delegate.event.FlowableEngineEventType;
 import org.flowable.engine.impl.test.ResourceFlowableTestCase;
 import org.flowable.engine.test.api.event.TestFlowableEventListener;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test to verify event-listeners, which are configured in the cfg.xml, are notified.
@@ -27,6 +28,7 @@ public class EngineEventsTest extends ResourceFlowableTestCase {
         super("org/flowable/standalone/event/flowable-eventlistener.cfg.xml");
     }
 
+    @Test
     public void testEngineEventsTest() {
         // Fetch the listener to check received events
         TestFlowableEventListener listener = (TestFlowableEventListener) processEngineConfiguration.getBeans().get("eventListener");

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/event/EventListenersConfigurationTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/event/EventListenersConfigurationTest.java
@@ -17,6 +17,7 @@ import org.flowable.common.engine.api.delegate.event.FlowableEvent;
 import org.flowable.engine.delegate.event.impl.FlowableProcessEventImpl;
 import org.flowable.engine.impl.test.ResourceFlowableTestCase;
 import org.flowable.engine.test.api.event.TestFlowableEventListener;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test to verify event-listeners, which are configured in the cfg.xml, are notified.
@@ -29,6 +30,7 @@ public class EventListenersConfigurationTest extends ResourceFlowableTestCase {
         super("org/flowable/standalone/event/flowable-eventlistener.cfg.xml");
     }
 
+    @Test
     public void testEventListenerConfiguration() {
         // Fetch the listener to check received events
         TestFlowableEventListener listener = (TestFlowableEventListener) processEngineConfiguration.getBeans().get("eventListener");

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/event/GetProcessOnProcessDefinitionInitializesEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/event/GetProcessOnProcessDefinitionInitializesEventTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertThat;
 
 import org.flowable.common.engine.api.delegate.event.FlowableEngineEventType;
 import org.flowable.engine.impl.test.ResourceFlowableTestCase;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test getProcess on ProcessDefinition {@link FlowableEngineEventType#ENTITY_INITIALIZED} event
@@ -32,6 +33,7 @@ public class GetProcessOnProcessDefinitionInitializesEventTest extends ResourceF
     /**
      * Test to verify process is accessible on processDefinitionEntityInitialized event.
      */
+    @Test
     public void testProcessAccessibleProcessDefinitionEntityInitializedEvent() throws Exception {
         // deploy any process
         this.deployOneTaskTestProcess();

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/event/ProcessDefinitionScopedEventListenerDefinitionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/event/ProcessDefinitionScopedEventListenerDefinitionTest.java
@@ -24,6 +24,8 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.engine.test.api.event.StaticTestFlowableEventListener;
 import org.flowable.engine.test.api.event.TestFlowableEventListener;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for event-listeners that are registered on a process-definition scope, rather than on the global engine-wide scope, declared in the BPMN XML.
@@ -41,6 +43,7 @@ public class ProcessDefinitionScopedEventListenerDefinitionTest extends Resource
     /**
      * Test to verify listeners defined in the BPMN xml are added to the process definition and are active.
      */
+    @Test
     @Deployment
     public void testProcessDefinitionListenerDefinition() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testEventListeners");
@@ -82,6 +85,7 @@ public class ProcessDefinitionScopedEventListenerDefinitionTest extends Resource
     /**
      * Test to verify listeners defined in the BPMN xml with invalid class/delegateExpression values cause an exception when process is started.
      */
+    @Test
     public void testProcessDefinitionListenerDefinitionError() throws Exception {
 
         // Deploy process with expression which references an unexisting bean
@@ -99,6 +103,7 @@ public class ProcessDefinitionScopedEventListenerDefinitionTest extends Resource
     /**
      * Test to verify if event listeners defined in the BPMN XML which have illegal event-types cause an exception on deploy.
      */
+    @Test
     public void testProcessDefinitionListenerDefinitionIllegalType() throws Exception {
         // In case deployment doesn't fail, we delete the deployment in the
         // finally block to
@@ -123,6 +128,7 @@ public class ProcessDefinitionScopedEventListenerDefinitionTest extends Resource
     /**
      * Test to verify listeners defined in the BPMN xml are added to the process definition and are active, for all entity types
      */
+    @Test
     @Deployment
     public void testProcessDefinitionListenerDefinitionEntities() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testEventListeners");
@@ -142,9 +148,8 @@ public class ProcessDefinitionScopedEventListenerDefinitionTest extends Resource
 
     }
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
         testListenerBean = (TestFlowableEventListener) processEngineConfiguration.getBeans().get("testEventListener");
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/event/TypedEventListenersConfigurationTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/event/TypedEventListenersConfigurationTest.java
@@ -17,6 +17,7 @@ import org.flowable.common.engine.api.delegate.event.FlowableEvent;
 import org.flowable.engine.delegate.event.impl.FlowableProcessEventImpl;
 import org.flowable.engine.impl.test.ResourceFlowableTestCase;
 import org.flowable.engine.test.api.event.TestFlowableEventListener;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test to verify event-listeners, which are configured in the cfg.xml, are notified.
@@ -29,6 +30,7 @@ public class TypedEventListenersConfigurationTest extends ResourceFlowableTestCa
         super("org/flowable/standalone/event/flowable-typed-eventlistener.cfg.xml");
     }
 
+    @Test
     public void testEventListenerConfiguration() {
         // Fetch the listener to check received events
         TestFlowableEventListener listener = (TestFlowableEventListener) processEngineConfiguration.getBeans().get("eventListener");

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/history/BulkDeleteNoHistoryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/history/BulkDeleteNoHistoryTest.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import org.flowable.engine.impl.test.ResourceFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 public class BulkDeleteNoHistoryTest extends ResourceFlowableTestCase {
 
@@ -28,6 +29,7 @@ public class BulkDeleteNoHistoryTest extends ResourceFlowableTestCase {
         super("org/flowable/standalone/history/nohistory.flowable.cfg.xml");
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testLargeAmountOfVariableBulkDelete() throws Exception {
         Map<String, Object> variables = new HashMap<>();

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/history/FullHistoryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/history/FullHistoryTest.java
@@ -44,6 +44,7 @@ import org.flowable.variable.api.history.HistoricVariableInstance;
 import org.flowable.variable.api.history.HistoricVariableInstanceQuery;
 import org.flowable.variable.service.impl.types.EntityManagerSession;
 import org.flowable.variable.service.impl.types.EntityManagerSessionFactory;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tom Baeyens
@@ -57,6 +58,7 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
         super("org/flowable/standalone/history/fullhistory.flowable.cfg.xml");
     }
 
+    @Test
     @Deployment
     public void testVariableUpdates() {
         Map<String, Object> variables = new HashMap<>();
@@ -234,6 +236,7 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
         assertNull(historicVariable);
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/history/oneTaskProcess.bpmn20.xml" })
     public void testHistoricVariableInstanceQueryTaskVariables() {
         Map<String, Object> variables = new HashMap<>();
@@ -277,6 +280,7 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = "org/flowable/standalone/history/FullHistoryTest.testVariableUpdates.bpmn20.xml")
     public void testHistoricVariableInstanceQuery() {
         Map<String, Object> variables = new HashMap<>();
@@ -313,6 +317,7 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
 
     }
 
+    @Test
     @Deployment
     public void testHistoricVariableUpdatesAllTypes() throws Exception {
 
@@ -450,6 +455,7 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
         assertEquals(processInstance.getId(), historicVariable.getProcessInstanceId());
     }
 
+    @Test
     @Deployment
     public void testHistoricFormProperties() throws Exception {
         Date startedDate = new SimpleDateFormat("dd/MM/yyyy hh:mm:ss SSS").parse("01/01/2001 01:23:46 000");
@@ -534,6 +540,7 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
         assertEquals(4, props.size());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/history/oneTaskProcess.bpmn20.xml" })
     public void testHistoricVariableQuery() throws Exception {
         Map<String, Object> variables = new HashMap<>();
@@ -567,6 +574,7 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
         assertEquals(0, historyService.createHistoricVariableInstanceQuery().processInstanceId("unexisting").count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/history/oneTaskProcess.bpmn20.xml" })
     public void testHistoricVariableQueryExcludeTaskRelatedDetails() throws Exception {
         Map<String, Object> variables = new HashMap<>();
@@ -590,6 +598,7 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
         assertEquals(1, historyService.createHistoricDetailQuery().variableUpdates().processInstanceId(processInstance.getId()).excludeTaskDetails().taskId(task.getId()).count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/history/oneTaskProcess.bpmn20.xml" })
     public void testHistoricFormPropertiesQuery() throws Exception {
         Map<String, String> formProperties = new HashMap<>();
@@ -618,6 +627,7 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
         assertEquals(0, historyService.createHistoricDetailQuery().formProperties().processInstanceId("unexisting").count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/history/oneTaskProcess.bpmn20.xml" })
     public void testHistoricVariableQuerySorting() throws Exception {
         Map<String, Object> variables = new HashMap<>();
@@ -651,6 +661,7 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
         assertEquals(2, historyService.createHistoricDetailQuery().variableUpdates().orderByVariableType().desc().list().size());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/history/oneTaskProcess.bpmn20.xml" })
     public void testHistoricFormPropertySorting() throws Exception {
 
@@ -678,6 +689,7 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
         assertEquals(2, historyService.createHistoricDetailQuery().formProperties().orderByFormPropertyId().desc().list().size());
     }
 
+    @Test
     @Deployment
     public void testHistoricDetailQueryMixed() throws Exception {
 
@@ -715,6 +727,7 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
         assertEquals(12345L, varUpdate2.getValue());
     }
 
+    @Test
     public void testHistoricDetailQueryInvalidSorting() throws Exception {
         try {
             historyService.createHistoricDetailQuery().asc().list();
@@ -766,6 +779,7 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testHistoricTaskInstanceVariableUpdates() {
         String processInstanceId = runtimeService.startProcessInstanceByKey("HistoricTaskInstanceTest").getId();
@@ -794,6 +808,7 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
     }
 
     // ACT-592
+    @Test
     @Deployment
     public void testSetVariableOnProcessInstanceWithTimer() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("timerVariablesProcess");
@@ -801,6 +816,7 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
         assertEquals(123456L, runtimeService.getVariable(processInstance.getId(), "myVar"));
     }
 
+    @Test
     @Deployment
     public void testDeleteHistoricProcessInstance() {
         // Start process-instance with some variables set
@@ -845,6 +861,7 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testDeleteRunningHistoricProcessInstance() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("HistoricTaskInstanceTest");
@@ -863,6 +880,7 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
     /**
      * Test created to validate ACT-621 fix.
      */
+    @Test
     @Deployment
     public void testHistoricFormPropertiesOnReEnteringActivity() {
         Map<String, Object> variables = new HashMap<>();
@@ -902,6 +920,7 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
         assertEquals(historicActInst1.getActivityId(), historicActInst2.getActivityId());
     }
 
+    @Test
     @Deployment
     public void testHistoricTaskInstanceQueryTaskVariableValueEquals() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("HistoricTaskInstanceTest");
@@ -967,6 +986,7 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
         assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskVariableValueEquals("nullVar", null).count());
     }
 
+    @Test
     @Deployment
     public void testHistoricTaskInstanceQueryProcessVariableValueEquals() throws Exception {
         // Set some variables on the process instance
@@ -1035,6 +1055,7 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
         assertEquals(1, historyService.createHistoricTaskInstanceQuery().processVariableValueEquals("longVar", 67890L).count());
     }
 
+    @Test
     @Deployment
     public void testHistoricProcessInstanceVariableValueEquals() throws Exception {
         // Set some variables on the process instance
@@ -1097,6 +1118,7 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
         assertEquals(1, historyService.createHistoricProcessInstanceQuery().variableValueEquals("nullVar", null).count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/standalone/history/FullHistoryTest.testHistoricProcessInstanceVariableValueEquals.bpmn20.xml" })
     public void testHistoricProcessInstanceVariableValueNotEquals() throws Exception {
         // Set some variables on the process instance
@@ -1166,6 +1188,7 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
         assertEquals(0, historyService.createHistoricProcessInstanceQuery().variableValueNotEquals("nullVar", null).count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/standalone/history/FullHistoryTest.testHistoricProcessInstanceVariableValueEquals.bpmn20.xml" })
     public void testHistoricProcessInstanceVariableValueLessThanAndGreaterThan() throws Exception {
         // Set some variables on the process instance
@@ -1208,6 +1231,7 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
         // 12344L).count());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/standalone/history/FullHistoryTest.testVariableUpdatesAreLinkedToActivity.bpmn20.xml" })
     public void testVariableUpdatesLinkedToActivity() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("ProcessWithSubProcess");
@@ -1257,6 +1281,7 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
         assertFalse(historicActivityInstance2.getExecutionId().equals(update2.getExecutionId()));
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/standalone/jpa/JPAVariableTest.testQueryJPAVariable.bpmn20.xml" })
     public void testReadJpaVariableValueFromHistoricVariableUpdate() {
 
@@ -1296,6 +1321,7 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
     /**
      * Test confirming fix for ACT-1731
      */
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/history/oneTaskProcess.bpmn20.xml" })
     public void testQueryHistoricTaskIncludeBinaryVariable() throws Exception {
         // Start process with a binary variable
@@ -1325,6 +1351,7 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
     /**
      * Test confirming fix for ACT-1731
      */
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/history/oneTaskProcess.bpmn20.xml" })
     public void testQueryHistoricProcessInstanceIncludeBinaryVariable() throws Exception {
         // Start process with a binary variable
@@ -1345,6 +1372,7 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
     }
 
     // Test for https://activiti.atlassian.net/browse/ACT-2186
+    @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testHistoricVariableRemovedWhenRuntimeVariableIsRemoved()
             throws Exception {

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/history/async/AsyncHistoryDateUtilTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/history/async/AsyncHistoryDateUtilTest.java
@@ -17,7 +17,7 @@ import java.util.Date;
 
 import org.flowable.job.service.impl.history.async.AsyncHistoryDateUtil;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AsyncHistoryDateUtilTest {
   

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/idgenerator/TaskIdGeneratorTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/idgenerator/TaskIdGeneratorTest.java
@@ -14,6 +14,7 @@ package org.flowable.standalone.idgenerator;
 
 import org.flowable.engine.impl.test.ResourceFlowableTestCase;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -29,6 +30,7 @@ public class TaskIdGeneratorTest extends ResourceFlowableTestCase {
         super("org/flowable/standalone/idgenerator/taskidgenerator.test.flowable.cfg.xml");
     }
 
+    @Test
     @Deployment(resources = "org/flowable/standalone/idgenerator/UuidGeneratorTest.testUuidGeneratorUsage.bpmn20.xml")
     public void testUuidGeneratorUsage() {
 

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/idgenerator/UuidGeneratorTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/idgenerator/UuidGeneratorTest.java
@@ -19,6 +19,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.flowable.engine.impl.test.ResourceFlowableTestCase;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
@@ -29,6 +30,7 @@ public class UuidGeneratorTest extends ResourceFlowableTestCase {
         super("org/flowable/standalone/idgenerator/uuidgenerator.test.flowable.cfg.xml");
     }
 
+    @Test
     @Deployment
     public void testUuidGeneratorUsage() {
 

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/initialization/NoDbConnectionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/initialization/NoDbConnectionTest.java
@@ -16,12 +16,14 @@ import java.sql.SQLException;
 
 import org.flowable.engine.ProcessEngineConfiguration;
 import org.flowable.engine.impl.test.AbstractTestCase;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tom Baeyens
  */
 public class NoDbConnectionTest extends AbstractTestCase {
 
+    @Test
     public void testNoDbConnection() {
         try {
             ProcessEngineConfiguration.createProcessEngineConfigurationFromResource("org/flowable/standalone/initialization/nodbconnection.flowable.cfg.xml").buildProcessEngine();

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/initialization/ProcessEngineInitializationTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/initialization/ProcessEngineInitializationTest.java
@@ -25,12 +25,14 @@ import org.flowable.engine.ProcessEngine;
 import org.flowable.engine.ProcessEngineConfiguration;
 import org.flowable.engine.impl.ProcessEngineImpl;
 import org.flowable.engine.impl.test.AbstractTestCase;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tom Baeyens
  */
 public class ProcessEngineInitializationTest extends AbstractTestCase {
 
+    @Test
     public void testNoTables() {
         try {
             ProcessEngineConfiguration.createProcessEngineConfigurationFromResource("org/flowable/standalone/initialization/notables.flowable.cfg.xml").buildProcessEngine();
@@ -41,6 +43,7 @@ public class ProcessEngineInitializationTest extends AbstractTestCase {
         }
     }
 
+    @Test
     public void testVersionMismatch() {
         // first create the schema
         ProcessEngineImpl processEngine = (ProcessEngineImpl) ProcessEngineConfiguration.createProcessEngineConfigurationFromResource("org/flowable/standalone/initialization/notables.flowable.cfg.xml")

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/interceptor/CommandContextTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/interceptor/CommandContextTest.java
@@ -17,12 +17,14 @@ import org.flowable.common.engine.impl.context.Context;
 import org.flowable.common.engine.impl.interceptor.Command;
 import org.flowable.common.engine.impl.interceptor.CommandContext;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tom Baeyens
  */
 public class CommandContextTest extends PluggableFlowableTestCase {
 
+    @Test
     public void testCommandContextGetCurrentAfterException() {
         try {
             processEngineConfiguration.getCommandExecutor().execute(new Command<Object>() {

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/jpa/HistoricJPAVariableTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/jpa/HistoricJPAVariableTest.java
@@ -20,51 +20,41 @@ import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 
 import org.flowable.common.engine.api.history.HistoricData;
-import org.flowable.engine.ProcessEngine;
-import org.flowable.engine.ProcessEngineConfiguration;
 import org.flowable.engine.history.ProcessInstanceHistoryLog;
-import org.flowable.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.flowable.engine.impl.persistence.entity.HistoricDetailVariableInstanceUpdateEntity;
-import org.flowable.engine.impl.test.AbstractFlowableTestCase;
+import org.flowable.engine.impl.test.ResourceFlowableTestCase;
 import org.flowable.engine.test.Deployment;
 import org.flowable.variable.api.history.HistoricVariableInstance;
 import org.flowable.variable.service.impl.persistence.entity.HistoricVariableInstanceEntity;
 import org.flowable.variable.service.impl.types.EntityManagerSession;
 import org.flowable.variable.service.impl.types.EntityManagerSessionFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Daisuke Yoshimoto
  */
-public class HistoricJPAVariableTest extends AbstractFlowableTestCase {
+@Tag("jpa")
+public class HistoricJPAVariableTest extends ResourceFlowableTestCase {
 
-    protected static ProcessEngine cachedProcessEngine;
+    private EntityManagerFactory entityManagerFactory;
 
-    private static EntityManagerFactory entityManagerFactory;
-
-    private static FieldAccessJPAEntity simpleEntityFieldAccess;
-    private static boolean entitiesInitialized;
+    private FieldAccessJPAEntity simpleEntityFieldAccess;
 
     protected String processInstanceId;
 
-    @Override
-    protected void initializeProcessEngine() {
-        if (cachedProcessEngine == null) {
-            ProcessEngineConfigurationImpl processEngineConfiguration = (ProcessEngineConfigurationImpl) ProcessEngineConfiguration
-                    .createProcessEngineConfigurationFromResource("org/flowable/standalone/jpa/flowable.cfg.xml");
+    public HistoricJPAVariableTest() {
+        super("org/flowable/standalone/jpa/flowable.cfg.xml");
+    }
 
-            cachedProcessEngine = processEngineConfiguration.buildProcessEngine();
-
-            EntityManagerSessionFactory entityManagerSessionFactory = (EntityManagerSessionFactory) processEngineConfiguration
-                    .getSessionFactories()
-                    .get(EntityManagerSession.class);
-
-            entityManagerFactory = entityManagerSessionFactory.getEntityManagerFactory();
-        }
-        processEngine = cachedProcessEngine;
+    @BeforeEach
+    protected void setUp() {
+        entityManagerFactory = ((EntityManagerSessionFactory) processEngineConfiguration.getSessionFactories().get(EntityManagerSession.class))
+            .getEntityManagerFactory();
     }
 
     public void setupJPAEntities() {
-        if (!entitiesInitialized) {
             EntityManager manager = entityManagerFactory.createEntityManager();
             manager.getTransaction().begin();
 
@@ -77,10 +67,9 @@ public class HistoricJPAVariableTest extends AbstractFlowableTestCase {
             manager.flush();
             manager.getTransaction().commit();
             manager.close();
-            entitiesInitialized = true;
-        }
     }
 
+    @Test
     @Deployment
     public void testGetJPAEntityAsHistoricVariable() {
         setupJPAEntities();
@@ -106,6 +95,7 @@ public class HistoricJPAVariableTest extends AbstractFlowableTestCase {
         assertEquals(((FieldAccessJPAEntity) value).getValue(), simpleEntityFieldAccess.getValue());
     }
 
+    @Test
     @Deployment
     public void testGetJPAEntityAsHistoricLog() {
         setupJPAEntities();
@@ -136,6 +126,7 @@ public class HistoricJPAVariableTest extends AbstractFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/standalone/jpa/HistoricJPAVariableTest.testGetJPAEntityAsHistoricLog.bpmn20.xml" })
     public void testGetJPAUpdateEntityAsHistoricLog() {
         setupJPAEntities();

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/jpa/JPAEnhancedVariableTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/jpa/JPAEnhancedVariableTest.java
@@ -21,14 +21,14 @@ import java.util.Map;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 
-import org.flowable.engine.ProcessEngine;
-import org.flowable.engine.ProcessEngineConfiguration;
-import org.flowable.engine.impl.cfg.ProcessEngineConfigurationImpl;
-import org.flowable.engine.impl.test.AbstractFlowableTestCase;
+import org.flowable.engine.impl.test.ResourceFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.variable.service.impl.types.EntityManagerSession;
 import org.flowable.variable.service.impl.types.EntityManagerSessionFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,34 +37,28 @@ import org.slf4j.LoggerFactory;
  * 
  * @author <a href="mailto:eugene.khrustalev@gmail.com">Eugene Khrustalev</a>
  */
-public class JPAEnhancedVariableTest extends AbstractFlowableTestCase {
+@Tag("jpa")
+public class JPAEnhancedVariableTest extends ResourceFlowableTestCase {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(JPAEnhancedVariableTest.class);
-    private static EntityManagerFactory entityManagerFactory;
-    protected static ProcessEngine cachedProcessEngine;
+    private EntityManagerFactory entityManagerFactory;
 
-    private static FieldAccessJPAEntity fieldEntity;
-    private static FieldAccessJPAEntity fieldEntity2;
-    private static PropertyAccessJPAEntity propertyEntity;
+    private FieldAccessJPAEntity fieldEntity;
+    private FieldAccessJPAEntity fieldEntity2;
+    private PropertyAccessJPAEntity propertyEntity;
 
-    @Override
-    protected void initializeProcessEngine() {
-        if (cachedProcessEngine == null) {
-            ProcessEngineConfigurationImpl processEngineConfiguration = (ProcessEngineConfigurationImpl) ProcessEngineConfiguration
-                    .createProcessEngineConfigurationFromResource("org/flowable/standalone/jpa/flowable.cfg.xml");
-
-            cachedProcessEngine = processEngineConfiguration.buildProcessEngine();
-
-            EntityManagerSessionFactory entityManagerSessionFactory = (EntityManagerSessionFactory) processEngineConfiguration.getSessionFactories().get(EntityManagerSession.class);
-
-            entityManagerFactory = entityManagerSessionFactory.getEntityManagerFactory();
-
-            setupJPAVariables();
-        }
-        processEngine = cachedProcessEngine;
+    public JPAEnhancedVariableTest() {
+        super("org/flowable/standalone/jpa/flowable.cfg.xml");
     }
 
-    private static void setupJPAVariables() {
+    @BeforeEach
+    protected void setUp() {
+        entityManagerFactory = ((EntityManagerSessionFactory) processEngineConfiguration.getSessionFactories().get(EntityManagerSession.class))
+            .getEntityManagerFactory();
+        setupJPAVariables();
+    }
+
+    private void setupJPAVariables() {
         EntityManager em = entityManagerFactory.createEntityManager();
         em.getTransaction().begin();
 
@@ -104,6 +98,7 @@ public class JPAEnhancedVariableTest extends AbstractFlowableTestCase {
         return processEngine.getTaskService().createTaskQuery().processInstanceId(instance.getProcessInstanceId()).includeProcessVariables().singleResult();
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/standalone/jpa/JPAVariableTest.testStoreJPAEntityAsVariable.bpmn20.xml" })
     public void testEnhancedEntityVariables() throws Exception {
         // test if enhancement is used
@@ -132,6 +127,7 @@ public class JPAEnhancedVariableTest extends AbstractFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/standalone/jpa/JPAVariableTest.testStoreJPAEntityAsVariable.bpmn20.xml" })
     public void testEnhancedEntityListVariables() throws Exception {
         // test if enhancement is used

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/jpa/JPAVariableTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/jpa/JPAVariableTest.java
@@ -27,66 +27,57 @@ import javax.persistence.EntityManagerFactory;
 
 import org.flowable.common.engine.api.FlowableException;
 import org.flowable.common.engine.api.FlowableIllegalArgumentException;
-import org.flowable.engine.ProcessEngine;
-import org.flowable.engine.ProcessEngineConfiguration;
-import org.flowable.engine.impl.cfg.ProcessEngineConfigurationImpl;
-import org.flowable.engine.impl.test.AbstractFlowableTestCase;
+import org.flowable.engine.impl.test.ResourceFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.variable.service.impl.types.EntityManagerSession;
 import org.flowable.variable.service.impl.types.EntityManagerSessionFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Frederik Heremans
  */
-public class JPAVariableTest extends AbstractFlowableTestCase {
+@Tag("jpa")
+public class JPAVariableTest extends ResourceFlowableTestCase {
 
-    protected static ProcessEngine cachedProcessEngine;
+    private FieldAccessJPAEntity simpleEntityFieldAccess;
+    private PropertyAccessJPAEntity simpleEntityPropertyAccess;
+    private SubclassFieldAccessJPAEntity subclassFieldAccess;
+    private SubclassPropertyAccessJPAEntity subclassPropertyAccess;
 
-    private static FieldAccessJPAEntity simpleEntityFieldAccess;
-    private static PropertyAccessJPAEntity simpleEntityPropertyAccess;
-    private static SubclassFieldAccessJPAEntity subclassFieldAccess;
-    private static SubclassPropertyAccessJPAEntity subclassPropertyAccess;
+    private ByteIdJPAEntity byteIdJPAEntity;
+    private ShortIdJPAEntity shortIdJPAEntity;
+    private IntegerIdJPAEntity integerIdJPAEntity;
+    private LongIdJPAEntity longIdJPAEntity;
+    private FloatIdJPAEntity floatIdJPAEntity;
+    private DoubleIdJPAEntity doubleIdJPAEntity;
+    private CharIdJPAEntity charIdJPAEntity;
+    private StringIdJPAEntity stringIdJPAEntity;
+    private DateIdJPAEntity dateIdJPAEntity;
+    private SQLDateIdJPAEntity sqlDateIdJPAEntity;
+    private BigDecimalIdJPAEntity bigDecimalIdJPAEntity;
+    private BigIntegerIdJPAEntity bigIntegerIdJPAEntity;
+    private CompoundIdJPAEntity compoundIdJPAEntity;
 
-    private static ByteIdJPAEntity byteIdJPAEntity;
-    private static ShortIdJPAEntity shortIdJPAEntity;
-    private static IntegerIdJPAEntity integerIdJPAEntity;
-    private static LongIdJPAEntity longIdJPAEntity;
-    private static FloatIdJPAEntity floatIdJPAEntity;
-    private static DoubleIdJPAEntity doubleIdJPAEntity;
-    private static CharIdJPAEntity charIdJPAEntity;
-    private static StringIdJPAEntity stringIdJPAEntity;
-    private static DateIdJPAEntity dateIdJPAEntity;
-    private static SQLDateIdJPAEntity sqlDateIdJPAEntity;
-    private static BigDecimalIdJPAEntity bigDecimalIdJPAEntity;
-    private static BigIntegerIdJPAEntity bigIntegerIdJPAEntity;
-    private static CompoundIdJPAEntity compoundIdJPAEntity;
+    private FieldAccessJPAEntity entityToQuery;
+    private FieldAccessJPAEntity entityToUpdate;
 
-    private static FieldAccessJPAEntity entityToQuery;
-    private static FieldAccessJPAEntity entityToUpdate;
+    private EntityManagerFactory entityManagerFactory;
 
-    private static boolean entitiesInitialized;
+    public JPAVariableTest() {
+        super("org/flowable/standalone/jpa/flowable.cfg.xml");
+    }
 
-    private static EntityManagerFactory entityManagerFactory;
-
-    @Override
-    protected void initializeProcessEngine() {
-        if (cachedProcessEngine == null) {
-            ProcessEngineConfigurationImpl processEngineConfiguration = (ProcessEngineConfigurationImpl) ProcessEngineConfiguration
-                    .createProcessEngineConfigurationFromResource("org/flowable/standalone/jpa/flowable.cfg.xml");
-
-            cachedProcessEngine = processEngineConfiguration.buildProcessEngine();
-
-            EntityManagerSessionFactory entityManagerSessionFactory = (EntityManagerSessionFactory) processEngineConfiguration.getSessionFactories().get(EntityManagerSession.class);
-
-            entityManagerFactory = entityManagerSessionFactory.getEntityManagerFactory();
-        }
-        processEngine = cachedProcessEngine;
+    @BeforeEach
+    protected void setUp() {
+        entityManagerFactory = ((EntityManagerSessionFactory) processEngineConfiguration.getSessionFactories().get(EntityManagerSession.class))
+            .getEntityManagerFactory();
+        setupJPAEntities();
     }
 
     public void setupJPAEntities() {
-
-        if (!entitiesInitialized) {
 
             EntityManager manager = entityManagerFactory.createEntityManager();
             manager.getTransaction().begin();
@@ -165,8 +156,6 @@ public class JPAVariableTest extends AbstractFlowableTestCase {
             manager.getTransaction().commit();
             manager.close();
 
-            entitiesInitialized = true;
-        }
     }
 
     public void setupIllegalJPAEntities() {
@@ -210,9 +199,9 @@ public class JPAVariableTest extends AbstractFlowableTestCase {
         manager.close();
     }
 
+    @Test
     @Deployment
     public void testStoreJPAEntityAsVariable() {
-        setupJPAEntities();
         // -----------------------------------------------------------------------------
         // Simple test, Start process with JPA entities as variables
         // -----------------------------------------------------------------------------
@@ -336,9 +325,9 @@ public class JPAVariableTest extends AbstractFlowableTestCase {
         assertEquals(bigIntegerIdJPAEntity.getBigIntegerId(), ((BigIntegerIdJPAEntity) bigIntegerIdResult).getBigIntegerId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/standalone/jpa/JPAVariableTest.testStoreJPAEntityAsVariable.bpmn20.xml" })
     public void testStoreJPAEntityListAsVariable() {
-        setupJPAEntities();
         // -----------------------------------------------------------------------------
         // Simple test, Start process with lists of JPA entities as variables
         // -----------------------------------------------------------------------------
@@ -385,9 +374,9 @@ public class JPAVariableTest extends AbstractFlowableTestCase {
         assertEquals(((SubclassPropertyAccessJPAEntity) list.get(0)).getId(), simpleEntityPropertyAccess.getId());
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/standalone/jpa/JPAVariableTest.testStoreJPAEntityAsVariable.bpmn20.xml" })
     public void testStoreJPAEntityListAsVariableEdgeCases() {
-        setupJPAEntities();
 
         // Test using mixed JPA-entities which are not serializable, should not
         // be picked up by JPA list type en therefor fail
@@ -434,6 +423,7 @@ public class JPAVariableTest extends AbstractFlowableTestCase {
     }
 
     // https://activiti.atlassian.net/browse/ACT-995
+    @Test
     @Deployment(resources = "org/flowable/standalone/jpa/JPAVariableTest.testQueryJPAVariable.bpmn20.xml")
     public void testReplaceExistingJPAEntityWithAnotherOfSameType() {
         EntityManager manager = entityManagerFactory.createEntityManager();
@@ -467,6 +457,7 @@ public class JPAVariableTest extends AbstractFlowableTestCase {
         assertEquals(newVariable.getId(), ((FieldAccessJPAEntity) variable).getId());
     }
 
+    @Test
     @Deployment
     public void testIllegalEntities() {
         setupIllegalJPAEntities();
@@ -529,6 +520,7 @@ public class JPAVariableTest extends AbstractFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testQueryJPAVariable() {
         setupQueryJPAEntity();
@@ -584,6 +576,7 @@ public class JPAVariableTest extends AbstractFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testUpdateJPAEntityValues() {
         setupJPAEntityToUpdate();

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/parsing/BPMNParseHandlerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/parsing/BPMNParseHandlerTest.java
@@ -14,6 +14,7 @@ package org.flowable.standalone.parsing;
 
 import org.flowable.engine.impl.test.ResourceFlowableTestCase;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Frederik Heremans
@@ -25,6 +26,7 @@ public class BPMNParseHandlerTest extends ResourceFlowableTestCase {
         super("org/flowable/standalone/parsing/bpmn.parse.listener.flowable.cfg.xml");
     }
 
+    @Test
     @Deployment
     public void testAlterProcessDefinitionKeyWhenDeploying() throws Exception {
         // Check if process-definition has different key

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/parsing/ChineseConverterTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/parsing/ChineseConverterTest.java
@@ -21,6 +21,7 @@ import org.flowable.common.engine.impl.util.io.InputStreamSource;
 import org.flowable.common.engine.impl.util.io.StreamSource;
 import org.flowable.engine.impl.test.ResourceFlowableTestCase;
 import org.flowable.engine.repository.Deployment;
+import org.junit.jupiter.api.Test;
 
 public class ChineseConverterTest extends ResourceFlowableTestCase {
 
@@ -28,6 +29,7 @@ public class ChineseConverterTest extends ResourceFlowableTestCase {
         super("org/flowable/standalone/parsing/encoding.flowable.cfg.xml");
     }
 
+    @Test
     public void testConvertXMLToModel() throws Exception {
         BpmnModel bpmnModel = readXMLFile();
         bpmnModel = exportAndReadXMLFile(bpmnModel);

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/parsing/CustomActivityBehaviorFactoryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/parsing/CustomActivityBehaviorFactoryTest.java
@@ -16,6 +16,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.flowable.engine.impl.test.ResourceFlowableTestCase;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
@@ -29,12 +31,12 @@ public class CustomActivityBehaviorFactoryTest extends ResourceFlowableTestCase 
     // The custom activity factory will change this value
     public static AtomicInteger COUNTER = new AtomicInteger(0);
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
         COUNTER.set(0);
     }
 
+    @Test
     @Deployment
     public void testCustomActivityBehaviorFactory() {
         int nrOfProcessInstances = 6;

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/parsing/CustomDefaultBpmnParseHandlerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/parsing/CustomDefaultBpmnParseHandlerTest.java
@@ -14,6 +14,7 @@ package org.flowable.standalone.parsing;
 
 import org.flowable.engine.impl.test.ResourceFlowableTestCase;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Frederik Heremans
@@ -25,6 +26,7 @@ public class CustomDefaultBpmnParseHandlerTest extends ResourceFlowableTestCase 
         super("org/flowable/standalone/parsing/custom.default.parse.handler.flowable.cfg.xml");
     }
 
+    @Test
     @Deployment
     public void testCustomDefaultUserTaskParsing() throws Exception {
         // The task which is created after process instance start should be

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/parsing/CustomListenerFactoryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/parsing/CustomListenerFactoryTest.java
@@ -16,6 +16,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.flowable.engine.impl.test.ResourceFlowableTestCase;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
@@ -29,12 +31,12 @@ public class CustomListenerFactoryTest extends ResourceFlowableTestCase {
     // The custom activity factory will change this value
     public static AtomicInteger COUNTER = new AtomicInteger(0);
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
         COUNTER.set(0);
     }
 
+    @Test
     @Deployment
     public void testCustomListenerFactory() {
         int nrOfProcessInstances = 4;

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/rules/BusinessRuleTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/rules/BusinessRuleTaskTest.java
@@ -15,12 +15,14 @@ package org.flowable.standalone.rules;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tijs Rademakers
  */
 public class BusinessRuleTaskTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testBusinessRuleTask() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("customRule");

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/rules/RulesDeployerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/rules/RulesDeployerTest.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import org.flowable.engine.impl.test.ResourceFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tijs Rademakers
@@ -31,6 +32,7 @@ public class RulesDeployerTest extends ResourceFlowableTestCase {
     }
 
     @SuppressWarnings("unchecked")
+    @Test
     @Deployment(resources = { "org/flowable/standalone/rules/rulesDeploymentTestProcess.bpmn20.xml", "org/flowable/standalone/rules/simpleRule1.drl" })
     public void testRulesDeployment() {
         Map<String, Object> variableMap = new HashMap<>();

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/scripting/ScriptBeanAccessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/scripting/ScriptBeanAccessTest.java
@@ -16,6 +16,7 @@ package org.flowable.standalone.scripting;
 import org.flowable.engine.impl.test.ResourceFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tom Baeyens
@@ -26,6 +27,7 @@ public class ScriptBeanAccessTest extends ResourceFlowableTestCase {
         super("org/flowable/standalone/scripting/flowable.cfg.xml");
     }
 
+    @Test
     @Deployment
     public void testConfigurationBeanAccess() {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("ScriptBeanAccess");

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/testing/FlowableJupiterSubclassTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/testing/FlowableJupiterSubclassTest.java
@@ -1,0 +1,29 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.standalone.testing;
+
+/**
+ * This test is explicitly empty.
+ * <p>
+ * The purpose of this test is to make sure that FlowableExtensions works with tests methods that are defined in a parent class.
+ * <p>
+ * When running the test suite over this class, JUnit will execute the test from {@link FlowableJupiterTest}.
+ * This means that the code in {@link org.flowable.engine.impl.test.TestHelper} needs to be able to find the test method even when it's not declared on the test class itself.
+ * <p>
+ * Specifically, {@link org.flowable.engine.impl.test.TestHelper} needs to call getMethod() rather than getDeclaredMethod() since the method is declared in a parent of the actual test class.
+ *
+ * @author Filip Hrisafov
+ */
+class FlowableJupiterSubclassTest extends FlowableJupiterTest {
+
+}

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/testing/FlowableJupiterTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/testing/FlowableJupiterTest.java
@@ -1,0 +1,78 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.flowable.standalone.testing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.flowable.engine.ManagementService;
+import org.flowable.engine.ProcessEngine;
+import org.flowable.engine.RepositoryService;
+import org.flowable.engine.RuntimeService;
+import org.flowable.engine.TaskService;
+import org.flowable.engine.test.Deployment;
+import org.flowable.engine.test.DeploymentId;
+import org.flowable.engine.test.FlowableTest;
+import org.flowable.engine.test.FlowableTestHelper;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test runners follow the this rule: - if the class extends Testcase, run as Junit 3 - otherwise use Junit 4, or JUnit 5
+ * <p>
+ * So this test can be included in the regular test suite without problems.
+ *
+ * @author Filip Hrisafov
+ */
+@FlowableTest
+class FlowableJupiterTest {
+
+    @Test
+    @Deployment
+    void extensionUsageExample(ProcessEngine processEngine) {
+        RuntimeService runtimeService = processEngine.getRuntimeService();
+        runtimeService.startProcessInstanceByKey("extensionUsage");
+
+        TaskService taskService = processEngine.getTaskService();
+        org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
+        assertThat(task.getName()).isEqualTo("My Task");
+
+        taskService.complete(task.getId());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+    }
+
+    @Test
+    @Deployment(resources = "org/flowable/standalone/testing/FlowableJupiterTest.extensionUsageExample.bpmn20.xml")
+    void extensionUsageDeploymentIdExample(@DeploymentId String deploymentId, FlowableTestHelper testHelper, RepositoryService repositoryService) {
+        assertThat(deploymentId).as("deploymentId parameter").isEqualTo(testHelper.getDeploymentIdFromDeploymentAnnotation());
+
+        org.flowable.engine.repository.Deployment deployment = repositoryService.createDeploymentQuery().singleResult();
+
+        assertThat(deployment.getId()).as("queried deployment").isEqualTo(deploymentId);
+    }
+
+    // this is to show how JobTestHelper could be used to wait for jobs to be all processed
+    @Test
+    @Deployment(resources = { "org/flowable/engine/test/bpmn/async/AsyncTaskTest.testAsyncTask.bpmn20.xml" })
+    void testWaitForJobs(FlowableTestHelper testHelper, RuntimeService runtimeService, ManagementService managementService) {
+        // start process
+        runtimeService.startProcessInstanceByKey("asyncTask");
+
+        // now there should be one job in the database:
+        assertThat(managementService.createJobQuery().count()).isEqualTo(1);
+
+        testHelper.waitForJobExecutorToProcessAllJobs(5000L, 500L);
+
+        // the job is done
+        assertThat(managementService.createJobQuery().count()).isEqualTo(0);
+    }
+}

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/testing/MockSupportWithFlowableJupiterTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/testing/MockSupportWithFlowableJupiterTest.java
@@ -1,0 +1,123 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.standalone.testing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.flowable.engine.ProcessEngine;
+import org.flowable.engine.test.Deployment;
+import org.flowable.engine.test.FlowableTest;
+import org.flowable.engine.test.mock.FlowableMockSupport;
+import org.flowable.engine.test.mock.MockServiceTask;
+import org.flowable.engine.test.mock.NoOpServiceTasks;
+import org.flowable.standalone.testing.helpers.ServiceTaskTestMock;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Filip Hrisafov
+ */
+@FlowableTest
+@MockServiceTask(originalClassName = "com.yourcompany.delegate", mockedClass = ServiceTaskTestMock.class)
+@MockServiceTask(originalClassName = "com.yourcompany.anotherDelegate", mockedClassName = "org.flowable.standalone.testing.helpers.ServiceTaskTestMock")
+class MockSupportWithFlowableJupiterTest {
+
+    private ProcessEngine processEngine;
+
+    @BeforeEach
+    void setUp(FlowableMockSupport mockSupport, ProcessEngine processEngine) {
+        this.processEngine = processEngine;
+        ServiceTaskTestMock.CALL_COUNT.set(0);
+    }
+
+    @Test
+    @Deployment
+    void testClassDelegateMockSupport() {
+        assertThat(ServiceTaskTestMock.CALL_COUNT).hasValue(0);
+        processEngine.getRuntimeService().startProcessInstanceByKey("mockSupportTest");
+        assertThat(ServiceTaskTestMock.CALL_COUNT).hasValue(1);
+    }
+
+    @Test
+    @Deployment
+    void testClassDelegateStringMockSupport() {
+        assertThat(ServiceTaskTestMock.CALL_COUNT).hasValue(0);
+        processEngine.getRuntimeService().startProcessInstanceByKey("mockSupportTest");
+        assertThat(ServiceTaskTestMock.CALL_COUNT).hasValue(1);
+    }
+
+    @Test
+    @Deployment
+    @MockServiceTask(originalClassName = "com.yourcompany.custom.delegate", mockedClassName = "org.flowable.standalone.testing.helpers.ServiceTaskTestMock")
+    void testMockedServiceTaskAnnotation() {
+        assertThat(ServiceTaskTestMock.CALL_COUNT).hasValue(0);
+        processEngine.getRuntimeService().startProcessInstanceByKey("mockSupportTest");
+        assertThat(ServiceTaskTestMock.CALL_COUNT).hasValue(1);
+    }
+
+    @Test
+    @Deployment(resources = { "org/flowable/standalone/testing/MockSupportWithFlowableJupiterTest.testMockedServiceTaskAnnotation.bpmn20.xml" })
+    @MockServiceTask(id = "serviceTask", mockedClassName = "org.flowable.standalone.testing.helpers.ServiceTaskTestMock")
+    void testMockedServiceTaskByIdAnnotation() {
+        assertThat(ServiceTaskTestMock.CALL_COUNT).hasValue(0);
+        processEngine.getRuntimeService().startProcessInstanceByKey("mockSupportTest");
+        assertThat(ServiceTaskTestMock.CALL_COUNT).hasValue(1);
+    }
+
+    @Test
+    @Deployment
+    @MockServiceTask(originalClassName = "com.yourcompany.delegate1", mockedClassName = "org.flowable.standalone.testing.helpers.ServiceTaskTestMock")
+    @MockServiceTask(originalClassName = "com.yourcompany.delegate2", mockedClassName = "org.flowable.standalone.testing.helpers.ServiceTaskTestMock")
+    void testMockedServiceTasksAnnotation() {
+        assertThat(ServiceTaskTestMock.CALL_COUNT).hasValue(0);
+        processEngine.getRuntimeService().startProcessInstanceByKey("mockSupportTest");
+        assertThat(ServiceTaskTestMock.CALL_COUNT).hasValue(2);
+    }
+
+    @Test
+    @Deployment
+    @NoOpServiceTasks
+    void testNoOpServiceTasksAnnotation(FlowableMockSupport mockSupport) {
+        assertThat(mockSupport.getNrOfNoOpServiceTaskExecutions()).isEqualTo(0);
+        processEngine.getRuntimeService().startProcessInstanceByKey("mockSupportTest");
+        assertThat(mockSupport.getNrOfNoOpServiceTaskExecutions()).isEqualTo(5);
+
+        assertThat(mockSupport.getExecutedNoOpServiceTaskDelegateClassNames())
+            .containsExactly(
+                "com.yourcompany.delegate1",
+                "com.yourcompany.delegate2",
+                "com.yourcompany.delegate3",
+                "com.yourcompany.delegate4",
+                "com.yourcompany.delegate5"
+            );
+    }
+
+    @Test
+    @Deployment(resources = { "org/flowable/standalone/testing/MockSupportWithFlowableJupiterTest.testNoOpServiceTasksAnnotation.bpmn20.xml" })
+    @NoOpServiceTasks(ids = { "serviceTask1", "serviceTask3", "serviceTask5" }, classNames = { "com.yourcompany.delegate2", "com.yourcompany.delegate4" })
+    void testNoOpServiceTasksWithIdsAnnotation(FlowableMockSupport mockSupport) {
+        assertThat(mockSupport.getNrOfNoOpServiceTaskExecutions()).isEqualTo(0);
+        processEngine.getRuntimeService().startProcessInstanceByKey("mockSupportTest");
+        assertThat(mockSupport.getNrOfNoOpServiceTaskExecutions()).isEqualTo(5);
+
+        assertThat(mockSupport.getExecutedNoOpServiceTaskDelegateClassNames())
+            .containsExactly(
+                "com.yourcompany.delegate1",
+                "com.yourcompany.delegate2",
+                "com.yourcompany.delegate3",
+                "com.yourcompany.delegate4",
+                "com.yourcompany.delegate5"
+            );
+    }
+
+}

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/validation/DefaultProcessValidatorTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/validation/DefaultProcessValidatorTest.java
@@ -32,8 +32,8 @@ import org.flowable.validation.ValidationError;
 import org.flowable.validation.validator.Problems;
 import org.flowable.validation.validator.ValidatorSetNames;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author jbarrez
@@ -42,7 +42,7 @@ public class DefaultProcessValidatorTest {
 
     protected ProcessValidator processValidator;
 
-    @Before
+    @BeforeEach
     public void setupProcessValidator() {
         ProcessValidatorFactory processValidatorFactory = new ProcessValidatorFactory();
         this.processValidator = processValidatorFactory.createDefaultProcessValidator();

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/validation/DisabledSchemaValidationTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/validation/DisabledSchemaValidationTest.java
@@ -19,10 +19,10 @@ import org.flowable.engine.ProcessEngines;
 import org.flowable.engine.RepositoryService;
 import org.flowable.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration;
 import org.flowable.engine.repository.Deployment;
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joram Barrez
@@ -33,7 +33,7 @@ public class DisabledSchemaValidationTest {
 
     protected RepositoryService repositoryService;
 
-    @Before
+    @BeforeEach
     public void setup() {
         this.processEngine = new StandaloneInMemProcessEngineConfiguration()
                 .setEngineName(this.getClass().getName())
@@ -42,7 +42,7 @@ public class DisabledSchemaValidationTest {
         this.repositoryService = processEngine.getRepositoryService();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         for (Deployment deployment : repositoryService.createDeploymentQuery().list()) {
             repositoryService.deleteDeployment(deployment.getId());

--- a/modules/flowable-engine/src/test/resources/org/flowable/standalone/testing/FlowableJupiterSubclassTest.extensionUsageExample.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/standalone/testing/FlowableJupiterSubclassTest.extensionUsageExample.bpmn20.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:flowable="http://flowable.org/bpmn"
+             targetNamespace="Examples">
+
+    <process id="extensionUsage">
+
+        <startEvent id="start"/>
+        <sequenceFlow id="flow1" sourceRef="start" targetRef="theTask"/>
+
+        <userTask id="theTask" name="My Task"/>
+        <sequenceFlow id="flow2" sourceRef="theTask" targetRef="theEnd"/>
+
+        <endEvent id="theEnd"/>
+
+    </process>
+
+</definitions>

--- a/modules/flowable-engine/src/test/resources/org/flowable/standalone/testing/FlowableJupiterTest.extensionUsageExample.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/standalone/testing/FlowableJupiterTest.extensionUsageExample.bpmn20.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:flowable="http://flowable.org/bpmn"
+             targetNamespace="Examples">
+
+    <process id="extensionUsage">
+
+        <startEvent id="start"/>
+        <sequenceFlow id="flow1" sourceRef="start" targetRef="theTask"/>
+
+        <userTask id="theTask" name="My Task"/>
+        <sequenceFlow id="flow2" sourceRef="theTask" targetRef="theEnd"/>
+
+        <endEvent id="theEnd"/>
+
+    </process>
+
+</definitions>

--- a/modules/flowable-engine/src/test/resources/org/flowable/standalone/testing/MockSupportWithFlowableJupiterTest.testClassDelegateMockSupport.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/standalone/testing/MockSupportWithFlowableJupiterTest.testClassDelegateMockSupport.bpmn20.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:flowable="http://flowable.org/bpmn"
+             targetNamespace="Examples">
+
+    <process id="mockSupportTest">
+
+        <startEvent id="start"/>
+        <sequenceFlow id="flow1" sourceRef="start" targetRef="serviceTask"/>
+
+        <serviceTask id="serviceTask" flowable:class="com.yourcompany.delegate"/>
+        <sequenceFlow id="flow2" sourceRef="serviceTask" targetRef="theEnd"/>
+
+        <endEvent id="theEnd"/>
+
+    </process>
+
+</definitions>

--- a/modules/flowable-engine/src/test/resources/org/flowable/standalone/testing/MockSupportWithFlowableJupiterTest.testClassDelegateStringMockSupport.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/standalone/testing/MockSupportWithFlowableJupiterTest.testClassDelegateStringMockSupport.bpmn20.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:flowable="http://flowable.org/bpmn"
+             targetNamespace="Examples">
+
+    <process id="mockSupportTest">
+
+        <startEvent id="start"/>
+        <sequenceFlow id="flow1" sourceRef="start" targetRef="serviceTask"/>
+
+        <serviceTask id="serviceTask" flowable:class="com.yourcompany.anotherDelegate"/>
+        <sequenceFlow id="flow2" sourceRef="serviceTask" targetRef="theEnd"/>
+
+        <endEvent id="theEnd"/>
+
+    </process>
+
+</definitions>

--- a/modules/flowable-engine/src/test/resources/org/flowable/standalone/testing/MockSupportWithFlowableJupiterTest.testMockedServiceTaskAnnotation.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/standalone/testing/MockSupportWithFlowableJupiterTest.testMockedServiceTaskAnnotation.bpmn20.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:flowable="http://flowable.org/bpmn"
+             targetNamespace="Examples">
+
+    <process id="mockSupportTest">
+
+        <startEvent id="start"/>
+        <sequenceFlow id="flow1" sourceRef="start" targetRef="serviceTask"/>
+
+        <serviceTask id="serviceTask" flowable:class="com.yourcompany.custom.delegate"/>
+        <sequenceFlow id="flow2" sourceRef="serviceTask" targetRef="theEnd"/>
+
+        <endEvent id="theEnd"/>
+
+    </process>
+
+</definitions>

--- a/modules/flowable-engine/src/test/resources/org/flowable/standalone/testing/MockSupportWithFlowableJupiterTest.testMockedServiceTasksAnnotation.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/standalone/testing/MockSupportWithFlowableJupiterTest.testMockedServiceTasksAnnotation.bpmn20.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:flowable="http://flowable.org/bpmn"
+             targetNamespace="Examples">
+
+    <process id="mockSupportTest">
+
+        <startEvent id="start"/>
+        <sequenceFlow id="flow1" sourceRef="start" targetRef="serviceTask1"/>
+
+        <serviceTask id="serviceTask1" flowable:class="com.yourcompany.delegate1"/>
+        <sequenceFlow id="flow2" sourceRef="serviceTask1" targetRef="serviceTask2"/>
+
+        <serviceTask id="serviceTask2" flowable:class="com.yourcompany.delegate2"/>
+        <sequenceFlow id="flow3" sourceRef="serviceTask2" targetRef="theEnd"/>
+
+        <endEvent id="theEnd"/>
+
+    </process>
+
+</definitions>

--- a/modules/flowable-engine/src/test/resources/org/flowable/standalone/testing/MockSupportWithFlowableJupiterTest.testNoOpServiceTasksAnnotation.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/standalone/testing/MockSupportWithFlowableJupiterTest.testNoOpServiceTasksAnnotation.bpmn20.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:flowable="http://flowable.org/bpmn"
+             targetNamespace="Examples">
+
+    <process id="mockSupportTest">
+
+        <startEvent id="start"/>
+        <sequenceFlow id="flow1" sourceRef="start" targetRef="serviceTask1"/>
+
+        <serviceTask id="serviceTask1" flowable:class="com.yourcompany.delegate1"/>
+        <sequenceFlow id="flow2" sourceRef="serviceTask1" targetRef="serviceTask2"/>
+
+        <serviceTask id="serviceTask2" flowable:class="com.yourcompany.delegate2"/>
+        <sequenceFlow id="flow3" sourceRef="serviceTask2" targetRef="serviceTask3"/>
+
+        <serviceTask id="serviceTask3" flowable:class="com.yourcompany.delegate3"/>
+        <sequenceFlow id="flow4" sourceRef="serviceTask3" targetRef="serviceTask4"/>
+
+        <serviceTask id="serviceTask4" flowable:class="com.yourcompany.delegate4"/>
+        <sequenceFlow id="flow5" sourceRef="serviceTask4" targetRef="serviceTask5"/>
+
+        <serviceTask id="serviceTask5" flowable:class="com.yourcompany.delegate5"/>
+        <sequenceFlow id="flow6" sourceRef="serviceTask5" targetRef="theEnd"/>
+
+        <endEvent id="theEnd"/>
+
+    </process>
+
+</definitions>

--- a/modules/flowable-form-engine-configurator/pom.xml
+++ b/modules/flowable-form-engine-configurator/pom.xml
@@ -40,6 +40,21 @@
 			<artifactId>junit</artifactId>
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/modules/flowable-form-engine/pom.xml
+++ b/modules/flowable-form-engine/pom.xml
@@ -104,6 +104,21 @@
             <artifactId>junit</artifactId>
             <scope>provided</scope>
         </dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
 
     </dependencies>
 

--- a/modules/flowable-form-spring-configurator/pom.xml
+++ b/modules/flowable-form-spring-configurator/pom.xml
@@ -52,6 +52,21 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>

--- a/modules/flowable-form-spring-configurator/src/test/java/org/flowable/form/spring/configurator/test/FormWithSpringBeanTest.java
+++ b/modules/flowable-form-spring-configurator/src/test/java/org/flowable/form/spring/configurator/test/FormWithSpringBeanTest.java
@@ -24,6 +24,7 @@ import org.flowable.form.engine.FormEngineConfiguration;
 import org.flowable.form.model.ExpressionFormField;
 import org.flowable.form.model.SimpleFormModel;
 import org.flowable.task.api.Task;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
@@ -32,6 +33,7 @@ import org.springframework.test.context.ContextConfiguration;
 @ContextConfiguration("classpath:flowable-context.xml")
 public class FormWithSpringBeanTest extends SpringFormFlowableTestCase {
 
+    @Test
     @Deployment(resources = { "org/flowable/form/spring/configurator/test/oneTaskWithFormKeyProcess.bpmn20.xml",
         "org/flowable/form/spring/configurator/test/simple.form" })
     public void testFormOnUserTask() {

--- a/modules/flowable-form-spring-configurator/src/test/java/org/flowable/form/spring/configurator/test/SpringFormFlowableTestCase.java
+++ b/modules/flowable-form-spring-configurator/src/test/java/org/flowable/form/spring/configurator/test/SpringFormFlowableTestCase.java
@@ -12,57 +12,31 @@
  */
 package org.flowable.form.spring.configurator.test;
 
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
-import org.flowable.engine.ProcessEngine;
 import org.flowable.engine.impl.test.AbstractFlowableTestCase;
+import org.flowable.engine.impl.test.EnsureCleanDb;
+import org.flowable.spring.impl.test.InternalFlowableSpringExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestContextManager;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /**
  * @author Joram Barrez
  * @author Josh Long
  */
+@EnsureCleanDb(excludeTables = {
+    "ACT_GE_PROPERTY",
+    "ACT_ID_PROPERTY",
+    "ACT_FO_DATABASECHANGELOGLOCK",
+    "ACT_FO_DATABASECHANGELOG"
+})
+@ExtendWith(InternalFlowableSpringExtension.class)
+@ExtendWith(SpringExtension.class)
 public abstract class SpringFormFlowableTestCase extends AbstractFlowableTestCase implements ApplicationContextAware {
-
-    // we need a data structure to store all the resolved ProcessEngines and map them to something
-    protected Map<Object, ProcessEngine> cachedProcessEngines = new ConcurrentHashMap<>();
-    
-    static {
-        TABLENAMES_EXCLUDED_FROM_DB_CLEAN_CHECK.add("ACT_FO_DATABASECHANGELOGLOCK");
-        TABLENAMES_EXCLUDED_FROM_DB_CLEAN_CHECK.add("ACT_FO_DATABASECHANGELOG");
-    }
-
-    protected TestContextManager testContextManager;
 
     @Autowired
     protected ApplicationContext applicationContext;
-
-    public SpringFormFlowableTestCase() {
-        this.testContextManager = new TestContextManager(getClass());
-    }
-
-    @Override
-    public void runBare() throws Throwable {
-        testContextManager.prepareTestInstance(this); // this will initialize all dependencies
-        super.runBare();
-    }
-
-    @Override
-    protected void initializeProcessEngine() {
-        ContextConfiguration contextConfiguration = getClass().getAnnotation(ContextConfiguration.class);
-        String[] value = contextConfiguration.value();
-        boolean hasOneArg = value != null && value.length == 1;
-        String key = hasOneArg ? value[0] : ProcessEngine.class.getName();
-        ProcessEngine engine = this.cachedProcessEngines.containsKey(key) ? this.cachedProcessEngines.get(key) : this.applicationContext.getBean(ProcessEngine.class);
-
-        this.cachedProcessEngines.put(key, engine);
-        this.processEngine = engine;
-    }
 
     @Override
     public void setApplicationContext(ApplicationContext applicationContext) {

--- a/modules/flowable-form-spring/pom.xml
+++ b/modules/flowable-form-spring/pom.xml
@@ -124,6 +124,21 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>

--- a/modules/flowable-groovy-script-static-engine/pom.xml
+++ b/modules/flowable-groovy-script-static-engine/pom.xml
@@ -126,6 +126,21 @@
       <artifactId>junit</artifactId>
       <scope>provided</scope>
     </dependency>
+      <dependency>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter-api</artifactId>
+          <scope>test</scope>
+      </dependency>
+      <dependency>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter-engine</artifactId>
+          <scope>test</scope>
+      </dependency>
+      <dependency>
+          <groupId>org.junit.vintage</groupId>
+          <artifactId>junit-vintage-engine</artifactId>
+          <scope>test</scope>
+      </dependency>
   </dependencies>
 
   <profiles>

--- a/modules/flowable-groovy-script-static-engine/src/test/java/org/flowable/examples/groovy/GroovyStaticScriptTest.java
+++ b/modules/flowable-groovy-script-static-engine/src/test/java/org/flowable/examples/groovy/GroovyStaticScriptTest.java
@@ -17,12 +17,14 @@ import org.flowable.common.engine.impl.util.CollectionUtil;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Filip Grochowski
  */
 public class GroovyStaticScriptTest extends PluggableFlowableTestCase {
 
+    @Test
     @Deployment
     public void testGroovyStaticScriptEngine() {
         int[] inputArray = new int[] { 1, 2, 3, 4, 5 };
@@ -34,6 +36,7 @@ public class GroovyStaticScriptTest extends PluggableFlowableTestCase {
         assertEquals(15, sum.intValue());
     }
     
+    @Test
     @Deployment
     public void testGroovyScriptEngine() {
         int[] inputArray = new int[] { 1, 2, 3, 4, 5 };

--- a/modules/flowable-http/pom.xml
+++ b/modules/flowable-http/pom.xml
@@ -168,6 +168,21 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/modules/flowable-http/src/test/java/org/flowable/http/bpmn/HttpServiceTaskTest.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/bpmn/HttpServiceTaskTest.java
@@ -27,6 +27,7 @@ import org.flowable.engine.test.Deployment;
 import org.flowable.http.bpmn.HttpServiceTaskTestServer.HttpServiceTaskTestServlet;
 import org.flowable.task.api.Task;
 import org.flowable.variable.api.history.HistoricVariableInstance;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -38,12 +39,14 @@ public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
 
     private ObjectMapper mapper = new ObjectMapper();
 
+    @Test
     @Deployment
     public void testSimpleGetOnly() {
         String procId = runtimeService.startProcessInstanceByKey("simpleGetOnly").getId();
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment
     public void testGetWithVariableName() {
         String procId = runtimeService.startProcessInstanceByKey("simpleGetOnly").getId();
@@ -55,6 +58,7 @@ public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment
     public void testGetWithoutVariableName() {
         String procId = runtimeService.startProcessInstanceByKey("simpleGetOnly").getId();
@@ -66,6 +70,7 @@ public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment
     public void testGetWithResponseHandler() {
         String procId = runtimeService.startProcessInstanceByKey("simpleGetOnly").getId();
@@ -87,6 +92,7 @@ public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment
     public void testGetWithParametrizedResponseHandler() {
         String procId = runtimeService.startProcessInstanceByKey("simpleGetOnly").getId();
@@ -108,6 +114,7 @@ public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment
     public void testGetWithRequestHandler() {
         String procId = runtimeService.startProcessInstanceByKey("simpleGetOnly").getId();
@@ -119,6 +126,7 @@ public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment
     public void testGetWithBpmnThrowingResponseHandler() {
         String procId = runtimeService.startProcessInstanceByKey("simpleGetOnly").getId();
@@ -130,6 +138,7 @@ public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment
     public void testGetWithBpmnThrowingRequestHandler() {
         String procId = runtimeService.startProcessInstanceByKey("simpleGetOnly").getId();
@@ -141,12 +150,14 @@ public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment
     public void testHttpsSelfSigned() {
         String procId = runtimeService.startProcessInstanceByKey("httpsSelfSigned").getId();
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment
     public void testConnectTimeout() {
         try {
@@ -158,6 +169,7 @@ public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testRequestTimeout() {
         try {
@@ -170,6 +182,7 @@ public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = "org/flowable/http/bpmn/HttpServiceTaskTest.testRequestTimeout2.bpmn20.xml" )
     public void testRequestTimeoutFromProcessModelHasPrecedence() {
         // set up timeout for test
@@ -194,7 +207,8 @@ public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
         this.processEngineConfiguration.getHttpClientConfig().setConnectTimeout(defaultConnectTimeOut);
         this.processEngineConfiguration.getHttpClientConfig().setConnectionRequestTimeout(defaultRequestTimeOut);
     }
-    
+
+    @Test
     @Deployment(resources = "org/flowable/http/bpmn/HttpServiceTaskTest.testRequestTimeout3.bpmn20.xml" )
     public void testRequestTimeoutFromProcessModelHasPrecedenceSuccess() {
         // set up timeout for test
@@ -216,6 +230,7 @@ public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
         this.processEngineConfiguration.getHttpClientConfig().setConnectionRequestTimeout(defaultRequestTimeOut);
     }
 
+    @Test
     @Deployment
     public void testDisallowRedirects() {
         try {
@@ -227,6 +242,7 @@ public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testFailStatusCodes() {
         ProcessInstance process = null;
@@ -240,24 +256,28 @@ public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
         assertNull("Process instance was not started.", process);
     }
 
+    @Test
     @Deployment
     public void testHandleStatusCodes() {
         String procId = runtimeService.startProcessInstanceByKey("handleStatusCodes").getId();
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment
     public void testIgnoreException() {
         String procId = runtimeService.startProcessInstanceByKey("ignoreException").getId();
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment
     public void testMapException() {
         String procId = runtimeService.startProcessInstanceByKey("mapException").getId();
         assertProcessEnded(procId);
     }
 
+    @Test
     @Deployment
     public void testHttpGet2XX() throws Exception {
         ProcessInstance process = runtimeService.startProcessInstanceByKey("testHttpGet2XX");
@@ -283,6 +303,7 @@ public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
         continueProcess(process);
     }
 
+    @Test
     @Deployment
     public void testHttpGet3XX() {
         ProcessInstance process = runtimeService.startProcessInstanceByKey("testHttpGet3XX");
@@ -294,6 +315,7 @@ public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
         continueProcess(process);
     }
 
+    @Test
     @Deployment
     public void testHttpGet4XX() {
         try {
@@ -305,6 +327,7 @@ public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testHttpGet5XX() {
         ProcessInstance process = runtimeService.startProcessInstanceByKey("testHttpGet5XX");
@@ -326,6 +349,7 @@ public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
         continueProcess(process);
     }
 
+    @Test
     @Deployment
     public void testHttpPost2XX() throws Exception {
         ProcessInstance process = runtimeService.startProcessInstanceByKey("testHttpPost2XX");
@@ -352,6 +376,7 @@ public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
         continueProcess(process);
     }
 
+    @Test
     @Deployment
     public void testHttpPost3XX() {
         ProcessInstance process = runtimeService.startProcessInstanceByKey("testHttpPost3XX");
@@ -363,6 +388,7 @@ public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
         continueProcess(process);
     }
 
+    @Test
     @Deployment
     public void testHttpPostBodyEncoding() throws Exception {
         ProcessInstance process = runtimeService.startProcessInstanceByKey("testHttpPostBodyEncoding");
@@ -386,6 +412,7 @@ public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
         continueProcess(process);
     }
 
+    @Test
     @Deployment
     public void testHttpDelete4XX() {
         ProcessInstance process = runtimeService.startProcessInstanceByKey("testHttpDelete4XX");
@@ -398,6 +425,7 @@ public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
         continueProcess(process);
     }
 
+    @Test
     @Deployment
     public void testHttpPut5XX() throws Exception {
 
@@ -438,6 +466,7 @@ public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
         continueProcess(process);
     }
     
+    @Test
     @Deployment
     public void testTransientJsonResponseVariable() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testTransientJsonResponseVariable");
@@ -449,6 +478,7 @@ public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
         assertEquals("Hello John", ((JsonNode) variables.get("postResponse")).get("result").asText());
     }
     
+    @Test
     @Deployment
     public void testArrayNodeResponse() {
         runtimeService.startProcessInstanceByKey("testArrayNodeResponse");

--- a/modules/flowable-http/src/test/java/org/flowable/http/bpmn/HttpServiceTaskTestCase.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/bpmn/HttpServiceTaskTestCase.java
@@ -13,22 +13,26 @@
 package org.flowable.http.bpmn;
 
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
+import org.flowable.engine.impl.test.EnsureCleanDb;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 
 /**
  * Http Server and API to test HTTP Activity
  *
  * @author Harsha Teja Kanna
  */
+@EnsureCleanDb(excludeTables = {
+    "ACT_GE_PROPERTY",
+    "ACT_ID_PROPERTY",
+    "ACT_CMMN_DATABASECHANGELOG",
+    "ACT_CMMN_DATABASECHANGELOGLOCK"
+})
+@Tag("http")
 public abstract class HttpServiceTaskTestCase extends PluggableFlowableTestCase {
     
-    static {
-        TABLENAMES_EXCLUDED_FROM_DB_CLEAN_CHECK.add("ACT_CMMN_DATABASECHANGELOG");
-        TABLENAMES_EXCLUDED_FROM_DB_CLEAN_CHECK.add("ACT_CMMN_DATABASECHANGELOGLOCK");
-    }
-
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
         HttpServiceTaskTestServer.setUp();
     }
 }

--- a/modules/flowable-http/src/test/java/org/flowable/http/bpmn/async/HttpServiceTaskAsyncTest.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/bpmn/async/HttpServiceTaskAsyncTest.java
@@ -18,12 +18,14 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.http.bpmn.HttpServiceTaskTestCase;
 import org.flowable.job.api.Job;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Harsha Teja Kanna
  */
 public class HttpServiceTaskAsyncTest extends HttpServiceTaskTestCase {
 
+    @Test
     @Deployment
     public void testAsyncSimpleGetOnly() {
         String procId = runtimeService.startProcessInstanceByKey("asyncSimpleGetOnly").getId();
@@ -34,6 +36,7 @@ public class HttpServiceTaskAsyncTest extends HttpServiceTaskTestCase {
         assertEquals(0, managementService.createJobQuery().count());
     }
 
+    @Test
     @Deployment
     public void testFailedJobRetryTimeCycle() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("asyncFailedJobRetryTimeCycle");

--- a/modules/flowable-http/src/test/java/org/flowable/http/bpmn/cfg/HttpServiceTaskCfgTest.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/bpmn/cfg/HttpServiceTaskCfgTest.java
@@ -17,6 +17,7 @@ import javax.net.ssl.SSLHandshakeException;
 import org.flowable.common.engine.api.FlowableException;
 import org.flowable.engine.ProcessEngineConfiguration;
 import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,6 +39,7 @@ public class HttpServiceTaskCfgTest extends HttpServiceTaskCfgTestCase {
                 .setDisableCertVerify(false);
     }
 
+    @Test
     @Deployment
     public void testHttpsSelfSignedFail() {
         try {

--- a/modules/flowable-http/src/test/java/org/flowable/http/bpmn/cfg/HttpServiceTaskCfgTestCase.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/bpmn/cfg/HttpServiceTaskCfgTestCase.java
@@ -14,6 +14,7 @@ package org.flowable.http.bpmn.cfg;
 
 import org.flowable.engine.impl.test.ResourceFlowableTestCase;
 import org.flowable.http.bpmn.HttpServiceTaskTestServer;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * Http Server and API to test HTTP Service Task config
@@ -26,9 +27,8 @@ public abstract class HttpServiceTaskCfgTestCase extends ResourceFlowableTestCas
         super(configPath);
     }
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
         HttpServiceTaskTestServer.setUp();
     }
 }

--- a/modules/flowable-http/src/test/java/org/flowable/http/bpmn/custom/HttpServiceTaskCustomTest.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/bpmn/custom/HttpServiceTaskCustomTest.java
@@ -14,12 +14,14 @@ package org.flowable.http.bpmn.custom;
 
 import org.flowable.engine.test.Deployment;
 import org.flowable.http.bpmn.HttpServiceTaskTestCase;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Harsha Teja Kanna
  */
 public class HttpServiceTaskCustomTest extends HttpServiceTaskTestCase {
 
+    @Test
     @Deployment
     public void testCustomBehaviorImpl() {
         String procId = runtimeService.startProcessInstanceByKey("simpleGetOnly").getId();

--- a/modules/flowable-http/src/test/java/org/flowable/http/bpmn/examples/HttpServiceTaskExampleTest.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/bpmn/examples/HttpServiceTaskExampleTest.java
@@ -17,11 +17,14 @@ import java.util.Map;
 
 import org.flowable.engine.test.Deployment;
 import org.flowable.http.bpmn.HttpServiceTaskTestCase;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Harsha Teja Kanna
  */
 public class HttpServiceTaskExampleTest extends HttpServiceTaskTestCase {
+
+    @Test
     @Deployment
     public void testExampleUsage() {
         Map<String, Object> variables = new HashMap<>();

--- a/modules/flowable-http/src/test/java/org/flowable/http/bpmn/validation/HttpServiceTaskValidationTest.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/bpmn/validation/HttpServiceTaskValidationTest.java
@@ -15,6 +15,7 @@ package org.flowable.http.bpmn.validation;
 import org.flowable.common.engine.api.FlowableException;
 import org.flowable.engine.test.Deployment;
 import org.flowable.http.bpmn.HttpServiceTaskTestCase;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -29,6 +30,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
  * @author Harsha Teja Kanna
  */
 public class HttpServiceTaskValidationTest extends HttpServiceTaskTestCase {
+    @Test
     @Deployment
     public void testInvalidProcess() {
         try {
@@ -40,6 +42,7 @@ public class HttpServiceTaskValidationTest extends HttpServiceTaskTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testInvalidHeaders() {
         try {
@@ -51,6 +54,7 @@ public class HttpServiceTaskValidationTest extends HttpServiceTaskTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testInvalidFlags() {
         try {
@@ -62,6 +66,7 @@ public class HttpServiceTaskValidationTest extends HttpServiceTaskTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testInvalidTimeout() {
         Map<String, Object> variables = new HashMap<>();

--- a/modules/flowable-identitylink-service/pom.xml
+++ b/modules/flowable-identitylink-service/pom.xml
@@ -53,6 +53,21 @@
 			<artifactId>junit</artifactId>
 			<scope>provided</scope>
 		</dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>

--- a/modules/flowable-idm-engine/pom.xml
+++ b/modules/flowable-idm-engine/pom.xml
@@ -75,6 +75,21 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
 			<scope>test</scope>

--- a/modules/flowable-idm-spring/pom.xml
+++ b/modules/flowable-idm-spring/pom.xml
@@ -126,6 +126,21 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>

--- a/modules/flowable-job-service/pom.xml
+++ b/modules/flowable-job-service/pom.xml
@@ -58,6 +58,21 @@
 			<artifactId>junit</artifactId>
 			<scope>provided</scope>
 		</dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>

--- a/modules/flowable-json-converter/pom.xml
+++ b/modules/flowable-json-converter/pom.xml
@@ -120,6 +120,21 @@
       <artifactId>junit</artifactId>
       <scope>provided</scope>
     </dependency>
+      <dependency>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter-api</artifactId>
+          <scope>test</scope>
+      </dependency>
+      <dependency>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter-engine</artifactId>
+          <scope>test</scope>
+      </dependency>
+      <dependency>
+          <groupId>org.junit.vintage</groupId>
+          <artifactId>junit-vintage-engine</artifactId>
+          <scope>test</scope>
+      </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>

--- a/modules/flowable-ldap-configurator/pom.xml
+++ b/modules/flowable-ldap-configurator/pom.xml
@@ -107,6 +107,21 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
 			<scope>test</scope>

--- a/modules/flowable-ldap-configurator/src/test/java/org/flowable/test/ldap/LDAPTestCase.java
+++ b/modules/flowable-ldap-configurator/src/test/java/org/flowable/test/ldap/LDAPTestCase.java
@@ -12,14 +12,12 @@
  */
 package org.flowable.test.ldap;
 
-import java.lang.reflect.Method;
-import java.util.Vector;
-
 import javax.annotation.Resource;
 
-import junit.framework.Test;
-
 import org.flowable.spring.impl.test.SpringFlowableTestCase;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Tag;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.ldap.server.ApacheDSContainer;
 
 /**
@@ -27,11 +25,8 @@ import org.springframework.security.ldap.server.ApacheDSContainer;
  * 
  * @author Joram Barrez
  */
+@Tag("ldap")
 public class LDAPTestCase extends SpringFlowableTestCase {
-
-    private static int testCount;
-    private static int totalTestCount = -1;
-    private static boolean disableAfterTestCase;
 
     @Resource(name = "org.springframework.security.apacheDirectoryServerContainer")
     private ApacheDSContainer apacheDSContainer;
@@ -40,81 +35,14 @@ public class LDAPTestCase extends SpringFlowableTestCase {
         super();
     }
 
-    @Override
-    public void runBare() throws Throwable {
-        Throwable exception = null;
-        if (totalTestCount == -1) {
-            totalTestCount = countTotalTests();
-        }
-        if (testCount == 0) {
-            beforeTestCase();
-        }
-        testCount++;
-        try {
-            super.runBare();
-        } catch (Throwable running) {
-            exception = running;
-        }
-        if (testCount == totalTestCount) {
-            totalTestCount = -1;
-            testCount = 0;
-            if (!disableAfterTestCase) {
-                try {
-                    afterTestCase();
-                } catch (Exception afterTestCase) {
-                    if (exception == null)
-                        exception = afterTestCase;
-                }
-            } else {
-                disableAfterTestCase = false;
-            }
-        }
-        if (exception != null)
-            throw exception;
-    }
-
-    protected static void disableAfterTestCase() {
-        disableAfterTestCase = true;
-    }
-
-    protected void beforeTestCase() throws Exception {
-
-    }
-
-    protected void afterTestCase() throws Exception {
+    @AfterAll
+    static void closeDsContainer(@Autowired ApacheDSContainer apacheDSContainer) {
         // Need to do this 'manually', or otherwise the ldap server won't be
         // shut down properly
         // on the QA machine, failing the next tests
         if (apacheDSContainer != null) {
             apacheDSContainer.stop();
         }
-    }
-
-    private int countTotalTests() {
-        int count = 0;
-        Class superClass = getClass();
-        Vector names = new Vector();
-        while (Test.class.isAssignableFrom(superClass)) {
-            Method[] methods = superClass.getDeclaredMethods();
-            for (Method method : methods) {
-                String name = method.getName();
-                if (names.contains(name))
-                    continue;
-                names.addElement(name);
-                if (isTestMethod(method)) {
-                    count++;
-                }
-            }
-            superClass = superClass.getSuperclass();
-        }
-        return count;
-    }
-
-    private boolean isTestMethod(Method m) {
-        String name = m.getName();
-        Class[] parameters = m.getParameterTypes();
-        Class returnType = m.getReturnType();
-        return parameters.length == 0 && name.startsWith("test") && returnType.equals(Void.TYPE);
     }
 
 }

--- a/modules/flowable-ldap-configurator/src/test/java/org/flowable/test/ldap/LdapGroupCacheTest.java
+++ b/modules/flowable-ldap-configurator/src/test/java/org/flowable/test/ldap/LdapGroupCacheTest.java
@@ -19,6 +19,8 @@ import org.flowable.engine.test.Deployment;
 import org.flowable.ldap.LDAPGroupCache;
 import org.flowable.ldap.LDAPGroupCache.LDAPGroupCacheListener;
 import org.flowable.ldap.LDAPIdentityServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
 
 @ContextConfiguration("classpath:flowable-context-ldap-group-cache.xml")
@@ -26,9 +28,8 @@ public class LdapGroupCacheTest extends LDAPTestCase {
 
     protected TestLDAPGroupCacheListener cacheListener;
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
 
         // Set test cache listener
         LDAPGroupCache ldapGroupCache = ((LDAPIdentityServiceImpl) 
@@ -40,6 +41,7 @@ public class LdapGroupCacheTest extends LDAPTestCase {
 
     }
 
+    @Test
     @Deployment
     public void testLdapGroupCacheUsage() {
         runtimeService.startProcessInstanceByKey("testLdapGroupCache");
@@ -66,6 +68,7 @@ public class LdapGroupCacheTest extends LDAPTestCase {
         assertEquals("pepe", cacheListener.getLastCacheEviction());
     }
 
+    @Test
     public void testLdapGroupCacheExpiration() {
         assertEquals(0, taskService.createTaskQuery().taskCandidateUser("kermit").count());
         assertEquals("kermit", cacheListener.getLastCacheMiss());

--- a/modules/flowable-ldap-configurator/src/test/java/org/flowable/test/ldap/LdapIntegrationTest.java
+++ b/modules/flowable-ldap-configurator/src/test/java/org/flowable/test/ldap/LdapIntegrationTest.java
@@ -17,17 +17,20 @@ import java.util.List;
 import org.flowable.common.engine.api.FlowableException;
 import org.flowable.engine.test.Deployment;
 import org.flowable.idm.api.User;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
 
 @ContextConfiguration("classpath:flowable-context.xml")
 public class LdapIntegrationTest extends LDAPTestCase {
 
+    @Test
     public void testAuthenticationThroughLdap() {
         assertTrue(identityService.checkPassword("kermit", "pass"));
         assertTrue(identityService.checkPassword("bunsen", "pass"));
         assertFalse(identityService.checkPassword("kermit", "blah"));
     }
 
+    @Test
     public void testAuthenticationThroughLdapEmptyPassword() {
         try {
             identityService.checkPassword("kermit", null);
@@ -41,6 +44,7 @@ public class LdapIntegrationTest extends LDAPTestCase {
         }
     }
 
+    @Test
     @Deployment
     public void testCandidateGroupFetchedThroughLdap() {
         runtimeService.startProcessInstanceByKey("testCandidateGroup");
@@ -57,6 +61,7 @@ public class LdapIntegrationTest extends LDAPTestCase {
         assertEquals(1, taskService.createTaskQuery().taskCandidateUser("kermit").count());
     }
 
+    @Test
     public void testUserQueryById() {
         List<User> users = identityService.createUserQuery().userId("kermit").list();
         assertEquals(1, users.size());
@@ -72,6 +77,7 @@ public class LdapIntegrationTest extends LDAPTestCase {
         assertEquals("Bear", user.getLastName());
     }
 
+    @Test
     public void testUserQueryByFullNameLike() {
         List<User> users = identityService.createUserQuery().userFullNameLike("ermi").list();
         assertEquals(1, users.size());

--- a/modules/flowable-spring/pom.xml
+++ b/modules/flowable-spring/pom.xml
@@ -131,7 +131,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <scope>test</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/modules/flowable-spring/pom.xml
+++ b/modules/flowable-spring/pom.xml
@@ -129,6 +129,21 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <!-- no official JPA 2.1 Jar was ever published, so we have to use a vendor implementation :( -->
             <groupId>org.hibernate.javax.persistence</groupId>
             <artifactId>hibernate-jpa-2.1-api</artifactId>

--- a/modules/flowable-spring/pom.xml
+++ b/modules/flowable-spring/pom.xml
@@ -159,6 +159,11 @@
             <artifactId>spring-orm</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.flowable</groupId>
             <artifactId>flowable-idm-spring</artifactId>
             <scope>test</scope>

--- a/modules/flowable-spring/src/main/java/org/flowable/spring/impl/test/FlowableSpringExtension.java
+++ b/modules/flowable-spring/src/main/java/org/flowable/spring/impl/test/FlowableSpringExtension.java
@@ -1,0 +1,40 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.spring.impl.test;
+
+import org.flowable.engine.ProcessEngine;
+import org.flowable.engine.impl.test.ResourceFlowableExtension;
+import org.flowable.engine.test.FlowableExtension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * An extension that uses {@link SpringExtension} to get the {@link ProcessEngine} from the {@link org.springframework.context.ApplicationContext}
+ * and make it available for the {@link FlowableExtension}.
+ *
+ * @author Filip Hrisafov
+ */
+public class FlowableSpringExtension extends FlowableExtension {
+
+    private static final ExtensionContext.Namespace NAMESPACE = ExtensionContext.Namespace.create(FlowableSpringExtension.class);
+
+    @Override
+    protected ProcessEngine createProcessEngine(ExtensionContext context) {
+        return SpringExtension.getApplicationContext(context).getBean(ProcessEngine.class);
+    }
+
+    @Override
+    protected ExtensionContext.Store getStore(ExtensionContext context) {
+        return context.getRoot().getStore(NAMESPACE);
+    }
+}

--- a/modules/flowable-spring/src/main/java/org/flowable/spring/impl/test/InternalFlowableSpringExtension.java
+++ b/modules/flowable-spring/src/main/java/org/flowable/spring/impl/test/InternalFlowableSpringExtension.java
@@ -1,0 +1,42 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.spring.impl.test;
+
+import org.flowable.engine.ProcessEngine;
+import org.flowable.engine.impl.test.InternalFlowableExtension;
+import org.flowable.engine.impl.test.ResourceFlowableExtension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * An extension that uses {@link SpringExtension} to get the {@link ProcessEngine} from the {@link org.springframework.context.ApplicationContext}
+ * and make it available for the {@link InternalFlowableExtension}.
+ *
+ * @author Filip Hrisafov
+ */
+public class InternalFlowableSpringExtension extends InternalFlowableExtension {
+
+    private static final ExtensionContext.Namespace NAMESPACE = ExtensionContext.Namespace.create(ResourceFlowableExtension.class);
+
+    @Override
+    protected ProcessEngine getProcessEngine(ExtensionContext context) {
+        return getStore(context)
+            .getOrComputeIfAbsent(context.getRequiredTestClass(), key -> SpringExtension.getApplicationContext(context).getBean(ProcessEngine.class),
+                ProcessEngine.class);
+    }
+
+    @Override
+    protected ExtensionContext.Store getStore(ExtensionContext context) {
+        return context.getRoot().getStore(NAMESPACE);
+    }
+}

--- a/modules/flowable-spring/src/main/java/org/flowable/spring/impl/test/SpringFlowableTestCase.java
+++ b/modules/flowable-spring/src/main/java/org/flowable/spring/impl/test/SpringFlowableTestCase.java
@@ -12,58 +12,23 @@
  */
 package org.flowable.spring.impl.test;
 
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
-import org.flowable.engine.ProcessEngine;
 import org.flowable.engine.impl.test.AbstractFlowableTestCase;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestContextManager;
-import org.springframework.test.context.TestExecutionListeners;
-import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /**
  * @author Joram Barrez
  * @author Josh Long
  */
-@TestExecutionListeners(DependencyInjectionTestExecutionListener.class)
+@ExtendWith(InternalFlowableSpringExtension.class)
+@ExtendWith(SpringExtension.class)
 public abstract class SpringFlowableTestCase extends AbstractFlowableTestCase implements ApplicationContextAware {
-
-    // we need a data structure to store all the resolved ProcessEngines and map them to something
-    protected Map<Object, ProcessEngine> cachedProcessEngines = new ConcurrentHashMap<>();
-
-    // protected static Map<String, ProcessEngine> cachedProcessEngines = new
-    // HashMap<String, ProcessEngine>();
-
-    protected TestContextManager testContextManager;
 
     @Autowired
     protected ApplicationContext applicationContext;
-
-    public SpringFlowableTestCase() {
-        this.testContextManager = new TestContextManager(getClass());
-    }
-
-    @Override
-    public void runBare() throws Throwable {
-        testContextManager.prepareTestInstance(this); // this will initialize all dependencies
-        super.runBare();
-    }
-
-    @Override
-    protected void initializeProcessEngine() {
-        ContextConfiguration contextConfiguration = getClass().getAnnotation(ContextConfiguration.class);
-        String[] value = contextConfiguration.value();
-        boolean hasOneArg = value != null && value.length == 1;
-        String key = hasOneArg ? value[0] : ProcessEngine.class.getName();
-        ProcessEngine engine = this.cachedProcessEngines.containsKey(key) ? this.cachedProcessEngines.get(key) : this.applicationContext.getBean(ProcessEngine.class);
-
-        this.cachedProcessEngines.put(key, engine);
-        this.processEngine = engine;
-    }
 
     @Override
     public void setApplicationContext(ApplicationContext applicationContext) {

--- a/modules/flowable-spring/src/test/java/org/flowable/spring/test/autodeployment/SpringAutoDeployTest.java
+++ b/modules/flowable-spring/src/test/java/org/flowable/spring/test/autodeployment/SpringAutoDeployTest.java
@@ -25,6 +25,8 @@ import org.flowable.engine.repository.Deployment;
 import org.flowable.engine.repository.DeploymentQuery;
 import org.flowable.engine.repository.ProcessDefinition;
 import org.flowable.engine.repository.ProcessDefinitionQuery;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.AbstractXmlApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
@@ -50,14 +52,14 @@ public class SpringAutoDeployTest extends AbstractTestCase {
         this.repositoryService = applicationContext.getBean(RepositoryService.class);
     }
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
         removeAllDeployments();
         this.applicationContext = null;
         this.repositoryService = null;
-        super.tearDown();
     }
 
+    @Test
     public void testBasicActivitiSpringIntegration() {
         createAppContext("org/flowable/spring/test/autodeployment/SpringAutoDeployTest-context.xml");
         List<ProcessDefinition> processDefinitions = repositoryService.createProcessDefinitionQuery().list();
@@ -75,6 +77,7 @@ public class SpringAutoDeployTest extends AbstractTestCase {
         assertEquals(expectedProcessDefinitionKeys, processDefinitionKeys);
     }
 
+    @Test
     public void testNoRedeploymentForSpringContainerRestart() throws Exception {
         createAppContext(CTX_PATH);
         DeploymentQuery deploymentQuery = repositoryService.createDeploymentQuery();
@@ -91,6 +94,7 @@ public class SpringAutoDeployTest extends AbstractTestCase {
 
     // Updating the bpmn20 file should lead to a new deployment when restarting
     // the Spring container
+    @Test
     public void testResourceRedeploymentAfterProcessDefinitionChange() throws Exception {
         createAppContext(CTX_PATH);
         assertEquals(1, repositoryService.createDeploymentQuery().count());
@@ -126,24 +130,28 @@ public class SpringAutoDeployTest extends AbstractTestCase {
         assertEquals(6, repositoryService.createProcessDefinitionQuery().count());
     }
 
+    @Test
     public void testAutoDeployWithCreateDropOnCleanDb() {
         createAppContext(CTX_CREATE_DROP_CLEAN_DB);
         assertEquals(1, repositoryService.createDeploymentQuery().count());
         assertEquals(3, repositoryService.createProcessDefinitionQuery().count());
     }
 
+    @Test
     public void testAutoDeployWithDeploymentModeDefault() {
         createAppContext(CTX_DEPLOYMENT_MODE_DEFAULT);
         assertEquals(1, repositoryService.createDeploymentQuery().count());
         assertEquals(3, repositoryService.createProcessDefinitionQuery().count());
     }
 
+    @Test
     public void testAutoDeployWithDeploymentModeSingleResource() {
         createAppContext(CTX_DEPLOYMENT_MODE_SINGLE_RESOURCE);
         assertEquals(3, repositoryService.createDeploymentQuery().count());
         assertEquals(3, repositoryService.createProcessDefinitionQuery().count());
     }
 
+    @Test
     public void testAutoDeployWithDeploymentModeResourceParentFolder() {
         createAppContext(CTX_DEPLOYMENT_MODE_RESOURCE_PARENT_FOLDER);
         assertEquals(2, repositoryService.createDeploymentQuery().count());

--- a/modules/flowable-spring/src/test/java/org/flowable/spring/test/email/JndiEmailTest.java
+++ b/modules/flowable-spring/src/test/java/org/flowable/spring/test/email/JndiEmailTest.java
@@ -26,6 +26,8 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.spring.impl.test.SpringFlowableTestCase;
 import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.mock.jndi.SimpleNamingContextBuilder;
@@ -36,8 +38,7 @@ public class JndiEmailTest extends SpringFlowableTestCase {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(JndiEmailTest.class);
 
-    @BeforeClass
-    @Override
+    @BeforeEach
     public void setUp() {
         Properties props = new Properties();
         props.put("mail.transport.protocol", "smtp");
@@ -60,6 +61,7 @@ public class JndiEmailTest extends SpringFlowableTestCase {
         }
     }
 
+    @Test
     @Deployment(resources = { "org/flowable/spring/test/email/EmailTaskUsingJndi.bpmn20.xml" })
     public void testEmailUsingJndi() {
         Map<String, Object> variables = new HashMap<>();

--- a/modules/flowable-spring/src/test/java/org/flowable/spring/test/executionListener/ExecutionListenerOnTransactionTest.java
+++ b/modules/flowable-spring/src/test/java/org/flowable/spring/test/executionListener/ExecutionListenerOnTransactionTest.java
@@ -21,6 +21,7 @@ import org.flowable.engine.history.HistoricProcessInstance;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.spring.impl.test.SpringFlowableTestCase;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
@@ -29,6 +30,7 @@ import org.springframework.test.context.ContextConfiguration;
 @ContextConfiguration("classpath:org/flowable/spring/test/executionListener/TransactionDependentListenerTest-context.xml")
 public class ExecutionListenerOnTransactionTest extends SpringFlowableTestCase {
 
+    @Test
     @Deployment
     public void testOnClosedExecutionListenersWithRollback() {
 
@@ -62,6 +64,7 @@ public class ExecutionListenerOnTransactionTest extends SpringFlowableTestCase {
         assertEquals(1, managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).count());
     }
 
+    @Test
     @Deployment
     public void testOnCloseFailureExecutionListenersWithRollback() {
 
@@ -95,6 +98,7 @@ public class ExecutionListenerOnTransactionTest extends SpringFlowableTestCase {
         assertEquals("Service Task 3", currentActivities.get(1).getActivityName());
     }
 
+    @Test
     @Deployment
     public void testOnClosedExecutionListenersWithExecutionVariables() {
 
@@ -120,6 +124,7 @@ public class ExecutionListenerOnTransactionTest extends SpringFlowableTestCase {
         assertEquals("test2", currentActivities.get(2).getExecutionVariables().get("injectedExecutionVariable"));
     }
 
+    @Test
     @Deployment
     public void testOnCloseFailureExecutionListenersWithTransactionalOperation() {
 
@@ -151,6 +156,7 @@ public class ExecutionListenerOnTransactionTest extends SpringFlowableTestCase {
         assertEquals("Service Task 1", currentActivities.get(0).getActivityName());
     }
 
+    @Test
     @Deployment
     public void testOnClosedExecutionListenersWithCustomPropertiesResolver() {
 

--- a/modules/flowable-spring/src/test/java/org/flowable/spring/test/executionListener/TransactionDependentExecutionListenerSpringTest.java
+++ b/modules/flowable-spring/src/test/java/org/flowable/spring/test/executionListener/TransactionDependentExecutionListenerSpringTest.java
@@ -16,6 +16,7 @@ package org.flowable.spring.test.executionListener;
 import org.flowable.engine.test.Deployment;
 import org.flowable.spring.impl.test.SpringFlowableTestCase;
 import org.flowable.task.api.Task;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 
@@ -28,6 +29,7 @@ public class TransactionDependentExecutionListenerSpringTest extends SpringFlowa
     @Autowired
     MyTransactionDependentExecutionListener listener;
 
+    @Test
     @Deployment
     public void testCustomPropertiesMapDelegateExpression() {
         runtimeService.startProcessInstanceByKey("transactionDependentExecutionListenerProcess");

--- a/modules/flowable-spring/src/test/java/org/flowable/spring/test/expression/SpringLimitedExpressionsTest.java
+++ b/modules/flowable-spring/src/test/java/org/flowable/spring/test/expression/SpringLimitedExpressionsTest.java
@@ -18,6 +18,7 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.spring.impl.test.SpringFlowableTestCase;
 import org.flowable.task.api.Task;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
@@ -28,6 +29,7 @@ import org.springframework.test.context.ContextConfiguration;
 @ContextConfiguration("classpath:org/flowable/spring/test/expression/expressionLimitedBeans-context.xml")
 public class SpringLimitedExpressionsTest extends SpringFlowableTestCase {
 
+    @Test
     @Deployment
     public void testLimitedBeansExposed() throws Exception {
         // Start process, which has a service-task which calls 'bean1', which is

--- a/modules/flowable-spring/src/test/java/org/flowable/spring/test/expression/callactivity/CallActivityBasedOnSpringBeansExpressionTest.java
+++ b/modules/flowable-spring/src/test/java/org/flowable/spring/test/expression/callactivity/CallActivityBasedOnSpringBeansExpressionTest.java
@@ -17,6 +17,7 @@ import org.flowable.engine.test.Deployment;
 import org.flowable.spring.impl.test.SpringFlowableTestCase;
 import org.flowable.task.api.Task;
 import org.flowable.task.api.TaskQuery;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
@@ -28,6 +29,7 @@ import org.springframework.test.context.ContextConfiguration;
 @ContextConfiguration("classpath:org/flowable/spring/test/expression/callactivity/testCallActivityByExpression-context.xml")
 public class CallActivityBasedOnSpringBeansExpressionTest extends SpringFlowableTestCase {
 
+    @Test
     @Deployment(resources = { "org/flowable/spring/test/expression/callactivity/CallActivityBasedOnSpringBeansExpressionTest.testCallActivityByExpression.bpmn20.xml",
             "org/flowable/spring/test/expression/callactivity/simpleSubProcess.bpmn20.xml" })
     public void testCallActivityByExpression() throws Exception {

--- a/modules/flowable-spring/src/test/java/org/flowable/spring/test/fieldinjection/ListenerFieldInjectionTest.java
+++ b/modules/flowable-spring/src/test/java/org/flowable/spring/test/fieldinjection/ListenerFieldInjectionTest.java
@@ -19,6 +19,7 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.spring.impl.test.SpringFlowableTestCase;
 import org.flowable.task.api.Task;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
@@ -27,6 +28,7 @@ import org.springframework.test.context.ContextConfiguration;
 @ContextConfiguration("classpath:org/flowable/spring/test/fieldinjection/fieldInjectionSpringTest-context.xml")
 public class ListenerFieldInjectionTest extends SpringFlowableTestCase {
 
+    @Test
     @Deployment
     public void testDelegateExpressionListenerFieldInjection() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("listenerFieldInjection", CollectionUtil.singletonMap("startValue", 42));

--- a/modules/flowable-spring/src/test/java/org/flowable/spring/test/fieldinjection/ServiceTaskFieldInjectionTest.java
+++ b/modules/flowable-spring/src/test/java/org/flowable/spring/test/fieldinjection/ServiceTaskFieldInjectionTest.java
@@ -18,6 +18,7 @@ import org.flowable.common.engine.impl.util.CollectionUtil;
 import org.flowable.engine.test.Deployment;
 import org.flowable.spring.impl.test.SpringFlowableTestCase;
 import org.flowable.task.api.Task;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
@@ -26,6 +27,7 @@ import org.springframework.test.context.ContextConfiguration;
 @ContextConfiguration("classpath:org/flowable/spring/test/fieldinjection/fieldInjectionSpringTest-context.xml")
 public class ServiceTaskFieldInjectionTest extends SpringFlowableTestCase {
 
+    @Test
     @Deployment
     public void testDelegateExpressionWithSingletonBean() {
         runtimeService.startProcessInstanceByKey("delegateExpressionSingleton", CollectionUtil.singletonMap("input", 100));
@@ -42,6 +44,7 @@ public class ServiceTaskFieldInjectionTest extends SpringFlowableTestCase {
         assertEquals(1, SingletonDelegateExpressionBean.INSTANCE_COUNT.get());
     }
 
+    @Test
     @Deployment
     public void testDelegateExpressionWithPrototypeBean() {
         runtimeService.startProcessInstanceByKey("delegateExpressionPrototype", CollectionUtil.singletonMap("input", 100));

--- a/modules/flowable-spring/src/test/java/org/flowable/spring/test/jobexecutor/SpringAsyncExecutorTest.java
+++ b/modules/flowable-spring/src/test/java/org/flowable/spring/test/jobexecutor/SpringAsyncExecutorTest.java
@@ -18,23 +18,22 @@ import org.flowable.engine.ManagementService;
 import org.flowable.engine.ProcessEngineConfiguration;
 import org.flowable.engine.RuntimeService;
 import org.flowable.engine.TaskService;
+import org.flowable.engine.impl.test.CleanTest;
 import org.flowable.engine.runtime.ProcessInstance;
-import org.flowable.spring.impl.test.CleanTestExecutionListener;
 import org.flowable.spring.impl.test.SpringFlowableTestCase;
 import org.flowable.task.api.Task;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestExecutionListeners;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Pablo Ganga
  * @author Joram Barrez
  */
-@RunWith(SpringJUnit4ClassRunner.class)
-@TestExecutionListeners(CleanTestExecutionListener.class)
+@CleanTest
+// We need to use per class as the test uses auto deployments. If they are deleted then the other tests will fail
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ContextConfiguration("classpath:org/flowable/spring/test/components/SpringjobExecutorTest-context.xml")
 public class SpringAsyncExecutorTest extends SpringFlowableTestCase {
 

--- a/modules/flowable-spring/src/test/java/org/flowable/spring/test/jobexecutor/SpringAsyncHistoryExecutorTest.java
+++ b/modules/flowable-spring/src/test/java/org/flowable/spring/test/jobexecutor/SpringAsyncHistoryExecutorTest.java
@@ -21,19 +21,18 @@ import org.flowable.engine.RuntimeService;
 import org.flowable.engine.TaskService;
 import org.flowable.engine.impl.test.HistoryTestHelper;
 import org.flowable.engine.runtime.ProcessInstance;
-import org.flowable.spring.impl.test.CleanTestExecutionListener;
+import org.flowable.engine.impl.test.CleanTest;
 import org.flowable.spring.impl.test.SpringFlowableTestCase;
 import org.flowable.task.api.Task;
 import org.flowable.task.api.history.HistoricTaskInstance;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestExecutionListeners;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-@RunWith(SpringJUnit4ClassRunner.class)
-@TestExecutionListeners(CleanTestExecutionListener.class)
+@CleanTest
+// We need to use per class as the test uses auto deployments. If they are deleted then the other tests will fail
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ContextConfiguration("classpath:org/flowable/spring/test/components/SpringAsyncHistoryJobExecutorTest-context.xml")
 public class SpringAsyncHistoryExecutorTest extends SpringFlowableTestCase {
 

--- a/modules/flowable-spring/src/test/java/org/flowable/spring/test/jpa/JpaTest.java
+++ b/modules/flowable-spring/src/test/java/org/flowable/spring/test/jpa/JpaTest.java
@@ -7,6 +7,7 @@ import org.flowable.engine.repository.Deployment;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.spring.impl.test.SpringFlowableTestCase;
 import org.flowable.task.api.Task;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
@@ -16,6 +17,7 @@ import org.springframework.test.context.ContextConfiguration;
 @ContextConfiguration(locations = "JPASpringTest-context.xml")
 public class JpaTest extends SpringFlowableTestCase {
 
+    @Test
     public void testJpaVariableHappyPath() {
         before();
         Map<String, Object> variables = new HashMap<>();
@@ -50,6 +52,7 @@ public class JpaTest extends SpringFlowableTestCase {
         deleteDeployments();
     }
 
+    @Test
     public void testJpaVariableDisapprovalPath() {
 
         before();

--- a/modules/flowable-spring/src/test/java/org/flowable/spring/test/jupiter/SpringJunitJupiterTest.java
+++ b/modules/flowable-spring/src/test/java/org/flowable/spring/test/jupiter/SpringJunitJupiterTest.java
@@ -1,0 +1,164 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.flowable.spring.test.jupiter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.sql.DataSource;
+
+import org.flowable.engine.HistoryService;
+import org.flowable.engine.ManagementService;
+import org.flowable.engine.ProcessEngine;
+import org.flowable.engine.RepositoryService;
+import org.flowable.engine.RuntimeService;
+import org.flowable.engine.TaskService;
+import org.flowable.engine.repository.ProcessDefinition;
+import org.flowable.engine.test.Deployment;
+import org.flowable.engine.test.DeploymentId;
+import org.flowable.engine.test.FlowableTestHelper;
+import org.flowable.spring.ProcessEngineFactoryBean;
+import org.flowable.spring.SpringProcessEngineConfiguration;
+import org.flowable.spring.impl.test.FlowableSpringExtension;
+import org.flowable.task.api.Task;
+import org.h2.Driver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.datasource.SimpleDriverDataSource;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+/**
+ * @author Filip Hrisafov
+ */
+@ExtendWith(FlowableSpringExtension.class)
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = SpringJunitJupiterTest.TestConfiguration.class)
+public class SpringJunitJupiterTest {
+
+    @Autowired
+    private ProcessEngine processEngine;
+
+    @Autowired
+    private RuntimeService runtimeService;
+
+    @Autowired
+    private TaskService taskService;
+
+    @Autowired
+    private RepositoryService repositoryService;
+
+    @AfterEach
+    public void closeProcessEngine() {
+        // Required, since all the other tests seem to do a specific drop on the
+        // end
+        processEngine.close();
+    }
+
+    @Test
+    @Deployment
+    public void simpleProcessTest(FlowableTestHelper flowableTestHelper, @DeploymentId String deploymentId, ProcessEngine extensionProcessEngine) {
+        runtimeService.startProcessInstanceByKey("simpleProcess");
+        Task task = taskService.createTaskQuery().singleResult();
+        assertThat(task.getName()).isEqualTo("My Task");
+
+        taskService.complete(task.getId());
+        assertThat(runtimeService.createProcessInstanceQuery().list()).isEmpty();
+
+        assertThat(flowableTestHelper.getDeploymentIdFromDeploymentAnnotation())
+            .isEqualTo(deploymentId)
+            .isNotNull();
+        assertThat(flowableTestHelper.getProcessEngine())
+            .as("Spring injected process engine")
+            .isSameAs(processEngine)
+            .as("Extension injected process engine")
+            .isSameAs(extensionProcessEngine);
+
+        assertThat(flowableTestHelper.getMockSupport()).as("mockSupport").isNotNull();
+
+        ProcessDefinition deployedProcessDefinition = repositoryService.createProcessDefinitionQuery().deploymentId(deploymentId).singleResult();
+        assertThat(deployedProcessDefinition).isNotNull();
+        assertThat(deployedProcessDefinition.getId())
+            .as("Deployed ProcessDefinition")
+            .isEqualTo(task.getProcessDefinitionId());
+    }
+
+    @Configuration
+    @EnableTransactionManagement
+    static class TestConfiguration {
+
+        @Bean
+        public DataSource dataSource() {
+            SimpleDriverDataSource dataSource = new SimpleDriverDataSource();
+            dataSource.setDriverClass(Driver.class);
+            dataSource.setUrl("jdbc:h2:mem:flowable-jupiter;DB_CLOSE_DELAY=1000");
+            dataSource.setUsername("sa");
+            dataSource.setPassword("");
+
+            return dataSource;
+        }
+
+        @Bean
+        public PlatformTransactionManager transactionManager(DataSource dataSource) {
+            return new DataSourceTransactionManager(dataSource);
+        }
+
+        @Bean
+        public SpringProcessEngineConfiguration processEngineConfiguration(DataSource dataSource, PlatformTransactionManager transactionManager) {
+            SpringProcessEngineConfiguration configuration = new SpringProcessEngineConfiguration();
+            configuration.setDataSource(dataSource);
+            configuration.setTransactionManager(transactionManager);
+            configuration.setDatabaseSchemaUpdate("true");
+            return configuration;
+        }
+
+        @Bean
+        public ProcessEngineFactoryBean processEngine(SpringProcessEngineConfiguration processEngineConfiguration) {
+            ProcessEngineFactoryBean factoryBean = new ProcessEngineFactoryBean();
+            factoryBean.setProcessEngineConfiguration(processEngineConfiguration);
+            return factoryBean;
+        }
+
+        @Bean
+        public RepositoryService repositoryService(ProcessEngine processEngine) {
+            return processEngine.getRepositoryService();
+        }
+
+        @Bean
+        public RuntimeService runtimeService(ProcessEngine processEngine) {
+            return processEngine.getRuntimeService();
+        }
+
+        @Bean
+        public TaskService taskService(ProcessEngine processEngine) {
+            return processEngine.getTaskService();
+        }
+
+        @Bean
+        public HistoryService historyService(ProcessEngine processEngine) {
+            return processEngine.getHistoryService();
+        }
+
+        @Bean
+        public ManagementService managementService(ProcessEngine processEngine) {
+            return processEngine.getManagementService();
+        }
+    }
+}

--- a/modules/flowable-spring/src/test/java/org/flowable/spring/test/servicetask/BoundaryErrorEventSpringTest.java
+++ b/modules/flowable-spring/src/test/java/org/flowable/spring/test/servicetask/BoundaryErrorEventSpringTest.java
@@ -16,6 +16,7 @@ package org.flowable.spring.test.servicetask;
 import org.flowable.engine.test.Deployment;
 import org.flowable.spring.impl.test.SpringFlowableTestCase;
 import org.flowable.task.api.Task;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
@@ -26,6 +27,7 @@ import org.springframework.test.context.ContextConfiguration;
 @ContextConfiguration("classpath:org/flowable/spring/test/servicetask/serviceraskSpringTestCatchError-context.xml")
 public class BoundaryErrorEventSpringTest extends SpringFlowableTestCase {
 
+    @Test
     @Deployment
     public void testCatchErrorThrownByJavaDelegateOnServiceTask() {
         String procId = runtimeService.startProcessInstanceByKey("catchErrorThrownByExpressionDelegateOnServiceTask").getId();

--- a/modules/flowable-spring/src/test/java/org/flowable/spring/test/servicetask/ServiceTaskSpringDelegationTest.java
+++ b/modules/flowable-spring/src/test/java/org/flowable/spring/test/servicetask/ServiceTaskSpringDelegationTest.java
@@ -16,6 +16,7 @@ import org.flowable.engine.impl.test.JobTestHelper;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.spring.impl.test.SpringFlowableTestCase;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
@@ -24,6 +25,7 @@ import org.springframework.test.context.ContextConfiguration;
 @ContextConfiguration("classpath:org/flowable/spring/test/servicetask/servicetaskSpringTest-context.xml")
 public class ServiceTaskSpringDelegationTest extends SpringFlowableTestCase {
 
+    @Test
     @Deployment
     public void testDelegateExpression() {
         ProcessInstance procInst = runtimeService.startProcessInstanceByKey("delegateExpressionToSpringBean");
@@ -31,6 +33,7 @@ public class ServiceTaskSpringDelegationTest extends SpringFlowableTestCase {
         assertEquals("fieldInjectionWorking", runtimeService.getVariable(procInst.getId(), "fieldInjection"));
     }
 
+    @Test
     @Deployment
     public void testAsyncDelegateExpression() throws Exception {
         ProcessInstance procInst = runtimeService.startProcessInstanceByKey("delegateExpressionToSpringBean");
@@ -41,12 +44,14 @@ public class ServiceTaskSpringDelegationTest extends SpringFlowableTestCase {
         assertEquals("fieldInjectionWorking", runtimeService.getVariable(procInst.getId(), "fieldInjection"));
     }
 
+    @Test
     @Deployment
     public void testMethodExpressionOnSpringBean() {
         ProcessInstance procInst = runtimeService.startProcessInstanceByKey("methodExpressionOnSpringBean");
         assertEquals("ACTIVITI BPMN 2.0 PROCESS ENGINE", runtimeService.getVariable(procInst.getId(), "myVar"));
     }
 
+    @Test
     @Deployment
     public void testAsyncMethodExpressionOnSpringBean() {
         ProcessInstance procInst = runtimeService.startProcessInstanceByKey("methodExpressionOnSpringBean");
@@ -55,6 +60,7 @@ public class ServiceTaskSpringDelegationTest extends SpringFlowableTestCase {
         assertEquals("ACTIVITI BPMN 2.0 PROCESS ENGINE", runtimeService.getVariable(procInst.getId(), "myVar"));
     }
 
+    @Test
     @Deployment
     public void testExecutionAndTaskListenerDelegationExpression() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("executionAndTaskListenerDelegation");

--- a/modules/flowable-spring/src/test/java/org/flowable/spring/test/servicetask/UseFlowableServiceInServiceTaskTest.java
+++ b/modules/flowable-spring/src/test/java/org/flowable/spring/test/servicetask/UseFlowableServiceInServiceTaskTest.java
@@ -19,6 +19,7 @@ import org.flowable.engine.repository.ProcessDefinition;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.spring.impl.test.SpringFlowableTestCase;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
@@ -30,6 +31,7 @@ public class UseFlowableServiceInServiceTaskTest extends SpringFlowableTestCase 
     /**
      * This test will use the regular mechanism (delegateExecution.getProcessEngine().getRuntimeService()) to obtain the {@link RuntimeService} to start a new process.
      */
+    @Test
     @Deployment
     public void testUseRuntimeServiceNotInjectedInServiceTask() {
         runtimeService.startProcessInstanceByKey("startProcessFromDelegate");
@@ -57,6 +59,7 @@ public class UseFlowableServiceInServiceTaskTest extends SpringFlowableTestCase 
     /**
      * This test will use the dependency injection of Spring to inject the runtime service in the Java delegate.
      */
+    @Test
     @Deployment
     public void testUseInjectedRuntimeServiceInServiceTask() {
         runtimeService.startProcessInstanceByKey("startProcessFromDelegate");
@@ -81,6 +84,7 @@ public class UseFlowableServiceInServiceTaskTest extends SpringFlowableTestCase 
         assertTrue(oneTaskProcessFound);
     }
 
+    @Test
     @Deployment
     public void testRollBackOnException() {
         Exception expectedException = null;

--- a/modules/flowable-spring/src/test/java/org/flowable/spring/test/taskListener/TaskListenerOnTransactionTest.java
+++ b/modules/flowable-spring/src/test/java/org/flowable/spring/test/taskListener/TaskListenerOnTransactionTest.java
@@ -22,6 +22,7 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.spring.impl.test.SpringFlowableTestCase;
 import org.flowable.task.api.Task;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
@@ -30,6 +31,7 @@ import org.springframework.test.context.ContextConfiguration;
 @ContextConfiguration("classpath:org/flowable/spring/test/executionListener/TransactionDependentListenerTest-context.xml")
 public class TaskListenerOnTransactionTest extends SpringFlowableTestCase {
 
+    @Test
     @Deployment
     public void testOnCompleteCommitted() {
         CurrentTaskTransactionDependentTaskListener.clear();
@@ -57,6 +59,7 @@ public class TaskListenerOnTransactionTest extends SpringFlowableTestCase {
         assertNotNull(currentTasks.get(0).getProcessInstanceId());
     }
 
+    @Test
     @Deployment
     public void testOnCompleteRolledBack() {
         CurrentTaskTransactionDependentTaskListener.clear();
@@ -99,6 +102,7 @@ public class TaskListenerOnTransactionTest extends SpringFlowableTestCase {
         assertNotNull(currentTasks.get(1).getProcessInstanceId());
     }
 
+    @Test
     @Deployment
     public void testOnCompleteExecutionVariables() {
 
@@ -128,6 +132,7 @@ public class TaskListenerOnTransactionTest extends SpringFlowableTestCase {
         assertEquals("test2", currentTasks.get(1).getExecutionVariables().get("injectedExecutionVariable"));
     }
 
+    @Test
     @Deployment
     public void testOnCompleteTransactionalOperation() {
         CurrentTaskTransactionDependentTaskListener.clear();
@@ -162,6 +167,7 @@ public class TaskListenerOnTransactionTest extends SpringFlowableTestCase {
         assertEquals("User Task 1", currentTasks.get(0).getTaskName());
     }
 
+    @Test
     @Deployment
     public void testOnCompleteCustomPropertiesResolver() {
         CurrentTaskTransactionDependentTaskListener.clear();

--- a/modules/flowable-spring/src/test/java/org/flowable/spring/test/taskListener/TaskListenerSpringTest.java
+++ b/modules/flowable-spring/src/test/java/org/flowable/spring/test/taskListener/TaskListenerSpringTest.java
@@ -17,6 +17,7 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.spring.impl.test.SpringFlowableTestCase;
 import org.flowable.task.api.Task;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
@@ -25,6 +26,7 @@ import org.springframework.test.context.ContextConfiguration;
 @ContextConfiguration("classpath:org/flowable/spring/test/taskListener/TaskListenerDelegateExpressionTest-context.xml")
 public class TaskListenerSpringTest extends SpringFlowableTestCase {
 
+    @Test
     @Deployment
     public void testTaskListenerDelegateExpression() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("taskListenerDelegateExpression");

--- a/modules/flowable-spring/src/test/java/org/flowable/spring/test/taskListener/TransactionDependentTaskListenerSpringTest.java
+++ b/modules/flowable-spring/src/test/java/org/flowable/spring/test/taskListener/TransactionDependentTaskListenerSpringTest.java
@@ -16,6 +16,7 @@ package org.flowable.spring.test.taskListener;
 import org.flowable.engine.test.Deployment;
 import org.flowable.spring.impl.test.SpringFlowableTestCase;
 import org.flowable.task.api.Task;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 
@@ -28,6 +29,7 @@ public class TransactionDependentTaskListenerSpringTest extends SpringFlowableTe
     @Autowired
     MyTransactionDependentTaskListener listener;
 
+    @Test
     @Deployment
     public void testCustomPropertiesMapDelegateExpression() {
         runtimeService.startProcessInstanceByKey("transactionDependentTaskListenerProcess");

--- a/modules/flowable-spring/src/test/java/org/flowable/spring/test/taskassignment/CustomTaskAssignmentTest.java
+++ b/modules/flowable-spring/src/test/java/org/flowable/spring/test/taskassignment/CustomTaskAssignmentTest.java
@@ -15,6 +15,7 @@ package org.flowable.spring.test.taskassignment;
 import org.flowable.common.engine.impl.util.CollectionUtil;
 import org.flowable.engine.test.Deployment;
 import org.flowable.spring.impl.test.SpringFlowableTestCase;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
@@ -23,12 +24,14 @@ import org.springframework.test.context.ContextConfiguration;
 @ContextConfiguration("classpath:org/flowable/spring/test/taskassignment/taskassignment-context.xml")
 public class CustomTaskAssignmentTest extends SpringFlowableTestCase {
 
+    @Test
     @Deployment
     public void testSetAssigneeThroughSpringService() {
         runtimeService.startProcessInstanceByKey("assigneeThroughSpringService", CollectionUtil.singletonMap("emp", "fozzie"));
         assertEquals(1, taskService.createTaskQuery().taskAssignee("Kermit The Frog").count());
     }
 
+    @Test
     @Deployment
     public void testSetCandidateUsersThroughSpringService() {
         runtimeService.startProcessInstanceByKey("candidateUsersThroughSpringService", CollectionUtil.singletonMap("emp", "fozzie"));
@@ -38,6 +41,7 @@ public class CustomTaskAssignmentTest extends SpringFlowableTestCase {
         assertEquals(0, taskService.createTaskQuery().taskCandidateUser("mispiggy").count());
     }
 
+    @Test
     @Deployment
     public void testSetCandidateGroupsThroughSpringService() {
         runtimeService.startProcessInstanceByKey("candidateUsersThroughSpringService", CollectionUtil.singletonMap("emp", "fozzie"));

--- a/modules/flowable-spring/src/test/java/org/flowable/spring/test/transaction/SpringIdmTransactionsTest.java
+++ b/modules/flowable-spring/src/test/java/org/flowable/spring/test/transaction/SpringIdmTransactionsTest.java
@@ -34,6 +34,8 @@ import org.flowable.idm.api.User;
 import org.flowable.spring.impl.test.SpringFlowableTestCase;
 import org.flowable.task.api.Task;
 import org.flowable.task.service.delegate.DelegateTask;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -50,7 +52,7 @@ public class SpringIdmTransactionsTest extends SpringFlowableTestCase {
     @Autowired
     protected PlatformTransactionManager transactionManager;
 
-    @Override
+    @AfterEach
     protected void tearDown() throws Exception {
 
         List<Group> allGroups = identityService.createGroupQuery().list();
@@ -69,9 +71,9 @@ public class SpringIdmTransactionsTest extends SpringFlowableTestCase {
             identityService.deleteUser(user.getId());
         }
 
-        super.tearDown();
     }
 
+    @Test
     @Deployment
     public void testCommitOnNoException() {
 
@@ -86,6 +88,7 @@ public class SpringIdmTransactionsTest extends SpringFlowableTestCase {
 
     }
 
+    @Test
     @Deployment
     public void testTransactionRolledBackOnException() {
 
@@ -113,6 +116,7 @@ public class SpringIdmTransactionsTest extends SpringFlowableTestCase {
 
     }
 
+    @Test
     @Deployment
     public void testMultipleIdmCallsInDelegate() {
         runtimeService.startProcessInstanceByKey("multipleServiceInvocations");
@@ -128,6 +132,7 @@ public class SpringIdmTransactionsTest extends SpringFlowableTestCase {
     }
 
     // From https://github.com/flowable/flowable-engine/issues/26
+    @Test
     public void testCreateMemberships() {
         Group group = identityService.newGroup("group");
         User tom = identityService.newUser("tom");
@@ -152,6 +157,7 @@ public class SpringIdmTransactionsTest extends SpringFlowableTestCase {
         assertThat(identityService.createGroupQuery().groupMember(mat.getId()).singleResult(), is(notNullValue()));
     }
 
+    @Test
     public void testCreateMembershipsWithinTransaction() {
         final Group group = identityService.newGroup("group");
         final User tom = identityService.newUser("tom");
@@ -182,6 +188,7 @@ public class SpringIdmTransactionsTest extends SpringFlowableTestCase {
         assertThat(identityService.createGroupQuery().groupMember(mat.getId()).singleResult(), is(notNullValue()));
     }
 
+    @Test
     @Deployment
     public void testCreateMembershipsInTaskListener() {
 

--- a/modules/flowable-spring/src/test/java/org/flowable/spring/test/transaction/SpringTransactionIntegrationTest.java
+++ b/modules/flowable-spring/src/test/java/org/flowable/spring/test/transaction/SpringTransactionIntegrationTest.java
@@ -19,6 +19,7 @@ import org.flowable.bpmn.exceptions.XMLException;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.spring.impl.test.SpringFlowableTestCase;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ContextConfiguration;
@@ -38,6 +39,7 @@ public class SpringTransactionIntegrationTest extends SpringFlowableTestCase {
     @Autowired
     protected DataSource dataSource;
 
+    @Test
     @Deployment
     public void testBasicFlowableSpringIntegration() {
         userBean.hello();
@@ -46,6 +48,7 @@ public class SpringTransactionIntegrationTest extends SpringFlowableTestCase {
         assertEquals("Hello from Printer!", runtimeService.getVariable(processInstance.getId(), "myVar"));
     }
 
+    @Test
     @Deployment
     public void testRollbackTransactionOnFlowableException() {
 
@@ -75,6 +78,7 @@ public class SpringTransactionIntegrationTest extends SpringFlowableTestCase {
         jdbcTemplate.execute("drop table MY_TABLE if exists;");
     }
 
+    @Test
     public void testRollBackOnDeployment() {
         // The second process should fail. None of the processes should be
         // deployed, the first one should be rolled back

--- a/modules/flowable-spring/src/test/java/org/flowable/spring/test/usertask/UserTaskSpringTest.java
+++ b/modules/flowable-spring/src/test/java/org/flowable/spring/test/usertask/UserTaskSpringTest.java
@@ -24,6 +24,7 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.spring.impl.test.SpringFlowableTestCase;
 import org.flowable.task.api.Task;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
@@ -32,6 +33,7 @@ import org.springframework.test.context.ContextConfiguration;
 @ContextConfiguration("classpath:flowable-context.xml")
 public class UserTaskSpringTest extends SpringFlowableTestCase {
 
+    @Test
     @Deployment(resources = "org/flowable/spring/test/usertask/VacationRequest.bpmn20.xml")
     public void testFormProperties() {
         ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().processDefinitionKey("vacationRequest").singleResult();

--- a/modules/flowable-spring/src/test/resources/org/flowable/spring/test/jupiter/SpringJunitJupiterTest.simpleProcessTest.bpmn20.xml
+++ b/modules/flowable-spring/src/test/resources/org/flowable/spring/test/jupiter/SpringJunitJupiterTest.simpleProcessTest.bpmn20.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             targetNamespace="Examples">
+
+    <process id="simpleProcess">
+
+        <startEvent id="start"/>
+        <sequenceFlow id="flow1" sourceRef="start" targetRef="theTask"/>
+
+        <userTask id="theTask" name="My Task"/>
+        <sequenceFlow id="flow2" sourceRef="theTask" targetRef="theEnd"/>
+
+        <endEvent id="theEnd"/>
+
+    </process>
+
+</definitions>

--- a/modules/flowable-task-service/pom.xml
+++ b/modules/flowable-task-service/pom.xml
@@ -56,6 +56,21 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>

--- a/modules/flowable-variable-service/pom.xml
+++ b/modules/flowable-variable-service/pom.xml
@@ -54,6 +54,21 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>

--- a/modules/flowable5-test/src/main/java/org/activiti/engine/impl/test/AbstractFlowableTestCase.java
+++ b/modules/flowable5-test/src/main/java/org/activiti/engine/impl/test/AbstractFlowableTestCase.java
@@ -42,7 +42,6 @@ import org.flowable.engine.history.HistoricActivityInstance;
 import org.flowable.engine.history.HistoricProcessInstance;
 import org.flowable.engine.impl.ProcessEngineImpl;
 import org.flowable.engine.impl.cfg.ProcessEngineConfigurationImpl;
-import org.flowable.engine.impl.test.AbstractTestCase;
 import org.flowable.engine.impl.util.CommandContextUtil;
 import org.flowable.engine.repository.Deployment;
 import org.flowable.engine.repository.ProcessDefinition;

--- a/modules/flowable5-test/src/main/java/org/activiti/engine/impl/test/AbstractTestCase.java
+++ b/modules/flowable5-test/src/main/java/org/activiti/engine/impl/test/AbstractTestCase.java
@@ -1,0 +1,76 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.engine.impl.test;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import junit.framework.TestCase;
+
+/**
+ * @author Tom Baeyens
+ */
+public abstract class AbstractTestCase extends TestCase {
+
+    protected static final String EMPTY_LINE = "\n";
+
+    protected static final Logger LOGGER = LoggerFactory.getLogger(AbstractTestCase.class);
+
+    protected boolean isEmptyLinesEnabled = true;
+
+    /**
+     * Asserts if the provided text is part of some text.
+     */
+    public void assertTextPresent(String expected, String actual) {
+        if ((actual == null) || (!actual.contains(expected))) {
+            throw new AssertionError("expected presence of [" + expected + "], but was [" + actual + "]");
+        }
+    }
+
+    /**
+     * Asserts if the provided text is part of some text, ignoring any uppercase characters
+     */
+    public void assertTextPresentIgnoreCase(String expected, String actual) {
+        assertTextPresent(expected.toLowerCase(), actual.toLowerCase());
+    }
+
+    @Override
+    protected void runTest() throws Throwable {
+        if (LOGGER.isDebugEnabled()) {
+            if (isEmptyLinesEnabled) {
+                LOGGER.debug(EMPTY_LINE);
+            }
+            LOGGER.debug("#### START {}.{} ###########################################################", this.getClass().getSimpleName(), getName());
+        }
+
+        try {
+
+            super.runTest();
+
+        } catch (AssertionError e) {
+            LOGGER.error(EMPTY_LINE);
+            LOGGER.error("ASSERTION FAILED: {}", e, e);
+            throw e;
+
+        } catch (Throwable e) {
+            LOGGER.error(EMPTY_LINE);
+            LOGGER.error("EXCEPTION: {}", e, e);
+            throw e;
+
+        } finally {
+            LOGGER.debug("#### END {}.{} #############################################################", this.getClass().getSimpleName(), getName());
+        }
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,11 @@
 		<slf4j.version>1.7.25</slf4j.version>
 		<spring.boot.version>2.0.4.RELEASE</spring.boot.version>
 
+		<junit.version>4.12</junit.version>
+		<junit.jupiter.version>5.2.0</junit.jupiter.version>
+		<junit.vintage.version>5.2.0</junit.vintage.version>
+		<junit.platform.version>1.2.0</junit.platform.version>
+
         <checkstyle.config.location>checkstyle/flowable-checkstyle.xml</checkstyle.config.location>
         <checkstyle.suppressions.location>/checkstyle/flowable-suppressions.xml</checkstyle.suppressions.location>
 
@@ -184,9 +189,16 @@
 				<version>1.5.19</version>
 			</dependency>
 			<dependency>
+				<groupId>org.junit</groupId>
+				<artifactId>junit-bom</artifactId>
+				<version>${junit.jupiter.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
 				<groupId>junit</groupId>
 				<artifactId>junit</artifactId>
-				<version>4.12</version>
+				<version>${junit.version}</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
Migrate flowable-engine and other dependent modules tests from JUnit 3 / 4 to Junit Jupiter

* Move used assertions from `TestCase` into `AbstractTestCase` (which is no longer extending `TestCase`) in order not to migrate all tests
* Add `@CleanTest` annotation which instructs the internal extensions to clean all deployments of a test
* Add `@EnsureCleanDb` annotation which instructs the internal extensions to perform an assertion for a clean DB and drop and create if it wasn't clean
* Add `InternalFlowableExtension` - a basis for other internal extensions that offers the following possibilities:
  * Perform a deployment when `@Deployment` is present before each test method
  * Validate history data after each test
  * Delete history jobs and deployment after each test
  * Assert and ensure clean db after each test (or after all test if `TestInstance.Lifecycle#PER_CLASS` is used)
  * Support for injecting the ProcessEngine, ProcessEngine services, ProcessEngineConfiguration
  and the id of the deployment done via `@Deployment` int tests and test lifecycle methods
* Add `LoggingExtension` - an extension which performs the test logging for the Flowable tests
* Add `PluggableFlowableExtension` - an extension which creates a default ProcessEngine and caches it for all tests
* Add `ResourceFlowableExtension` - an extension that starts a new ProcessEngine from a configured resource
before each test (needs to be used with `@RegisterExtensions`)
* Add `InternalFlowableSpringExtension` - an extension that uses `SpringExtension` to get the ProcessEngine from the Spring ApplicationContext
* Adapt `TestHelper` to user test class, method and the `Deployment` annotation
* Add `@DeploymentId` annotation for injecting the id of a deployment in a test method or test lifecycle methods
* Do not use `@Deployment` in ProcessDefinitionEventsService (reason: the listener is required during the deployment)
* Use `@EnabledOnOs` for the ShellTaskTest (Should result in 2 ignored tests on each machine)
* Remove empty test from StandardAgendaFailingTest and disable endless loop test
* Adapt `LDAPTestCase` to close the `ApacheDSContainer` after all tests
* Modules migrated to use JUnit Jupiter
  * flowable-camel
  * flowable-crystalball (partially)
  * flowable-cxf
  * flowable-dmn-spring-configurator
  * flowable-engine
  * flowable-form-spring-configurator
  * flowable-groovy-script-static-engine
  * flowable-http
  * flowable-ldap-configurator
  * flowable-spring

Modules that have not been migrated will be done in subsequent commits.

I have weird tests failing locally, let's see what Travis says