### PR TITLE
Fix parallel execution of CallActivity

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/FlowableEngineAgenda.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/FlowableEngineAgenda.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine;
 
+import java.util.List;
+
 import org.flowable.engine.impl.persistence.entity.ExecutionEntity;
 
 /**
@@ -40,4 +42,7 @@ public interface FlowableEngineAgenda extends Agenda {
     void planDestroyScopeOperation(ExecutionEntity execution);
 
     void planExecuteInactiveBehaviorsOperation();
+
+    void planMonitorParallelMultiInstanceOperation(ExecutionEntity executionEntity, List<? extends ExecutionEntity> executions);
+
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/agenda/DefaultFlowableEngineAgenda.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/agenda/DefaultFlowableEngineAgenda.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.impl.agenda;
 
+import java.util.List;
+
 import org.flowable.common.engine.impl.agenda.AbstractAgenda;
 import org.flowable.common.engine.impl.context.Context;
 import org.flowable.common.engine.impl.interceptor.Command;
@@ -25,17 +27,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * For each API call (and thus {@link Command}) being executed, a new agenda instance is created. On this agenda, operations are put, which the {@link CommandExecutor} will keep executing until all
- * are executed.
+ * For each API call (and thus {@link Command}) being executed, a new agenda
+ * instance is created. On this agenda, operations are put, which the
+ * {@link CommandExecutor} will keep executing until all are executed.
  *
- * The agenda also gives easy access to methods to plan new operations when writing {@link ActivityBehavior} implementations.
+ * The agenda also gives easy access to methods to plan new operations when
+ * writing {@link ActivityBehavior} implementations.
  *
- * During a {@link Command} execution, the agenda can always be fetched using {@link Context#getAgenda()}.
+ * During a {@link Command} execution, the agenda can always be fetched using
+ * {@link Context#getAgenda()}.
  *
  * @author Joram Barrez
  */
 public class DefaultFlowableEngineAgenda extends AbstractAgenda implements FlowableEngineAgenda {
-    
+
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultFlowableEngineAgenda.class);
 
     public DefaultFlowableEngineAgenda(CommandContext commandContext) {
@@ -105,6 +110,11 @@ public class DefaultFlowableEngineAgenda extends AbstractAgenda implements Flowa
     @Override
     public void planExecuteInactiveBehaviorsOperation() {
         planOperation(new ExecuteInactiveBehaviorsOperation(commandContext));
+    }
+
+    @Override
+    public void planMonitorParallelMultiInstanceOperation(ExecutionEntity executionEntity, List< ? extends ExecutionEntity> executions) {
+        planOperation(new MonitorParallelMultiInstanceOperation(commandContext, executionEntity, executions), executionEntity);
     }
 
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/agenda/MonitorParallelMultiInstanceOperation.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/agenda/MonitorParallelMultiInstanceOperation.java
@@ -1,0 +1,366 @@
+package org.flowable.engine.impl.agenda;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.flowable.bpmn.model.Activity;
+import org.flowable.bpmn.model.BoundaryEvent;
+import org.flowable.bpmn.model.CallActivity;
+import org.flowable.bpmn.model.CompensateEventDefinition;
+import org.flowable.bpmn.model.FlowElement;
+import org.flowable.bpmn.model.MultiInstanceLoopCharacteristics;
+import org.flowable.bpmn.model.SubProcess;
+import org.flowable.bpmn.model.Transaction;
+import org.flowable.common.engine.api.FlowableIllegalArgumentException;
+import org.flowable.common.engine.api.delegate.event.FlowableEngineEventType;
+import org.flowable.common.engine.impl.el.ExpressionManager;
+import org.flowable.common.engine.impl.interceptor.CommandContext;
+import org.flowable.common.engine.impl.util.CollectionUtil;
+import org.flowable.engine.DynamicBpmnConstants;
+import org.flowable.engine.delegate.DelegateExecution;
+import org.flowable.engine.delegate.event.FlowableMultiInstanceActivityCompletedEvent;
+import org.flowable.engine.delegate.event.impl.FlowableEventBuilder;
+import org.flowable.engine.impl.bpmn.helper.ScopeUtil;
+import org.flowable.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.flowable.engine.impl.context.BpmnOverrideContext;
+import org.flowable.engine.impl.jobexecutor.AsyncParallelMultiInstanceMonitorJobHandler;
+import org.flowable.engine.impl.persistence.entity.ExecutionEntity;
+import org.flowable.engine.impl.persistence.entity.ExecutionEntityManager;
+import org.flowable.engine.impl.util.CommandContextUtil;
+import org.flowable.job.service.JobService;
+import org.flowable.job.service.impl.persistence.entity.DeadLetterJobEntity;
+import org.flowable.job.service.impl.persistence.entity.JobEntity;
+import org.flowable.variable.service.impl.persistence.entity.VariableInstanceEntity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+public class MonitorParallelMultiInstanceOperation extends AbstractOperation {
+
+    private static final String NUMBER_OF_ACTIVE_INSTANCES = "nrOfActiveInstances";
+
+    private static final String NUMBER_OF_INSTANCES = "nrOfInstances";
+
+    private static final String NUMBER_OF_COMPLETED_INSTANCES = "nrOfCompletedInstances";
+
+    public static final String FAILING_THE_MONITOR = "Failing the monitor";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MonitorParallelMultiInstanceOperation.class);
+
+    private List< ? extends ExecutionEntity> childExecutions;
+
+    public MonitorParallelMultiInstanceOperation(CommandContext commandContext, ExecutionEntity rootExecution, List< ? extends ExecutionEntity> executions) {
+        super(commandContext, rootExecution);
+        this.childExecutions = executions;
+    }
+
+    @Override
+    public void run() {
+        List<ExecutionEntity> completedInstances = determineCompletedInstances(execution);
+        int nrOfCompletedInstances = completedInstances.size();
+        int nrOfInstances = getVariableOrDefault(execution, NUMBER_OF_INSTANCES, 0);
+
+        LOGGER.debug("nrOfInstances {}", nrOfInstances);
+        LOGGER.debug("nrOfCompletedInstances {}", nrOfCompletedInstances);
+
+        Collection<ExecutionEntity> inactiveExecutions = getInactiveExecutions(execution);
+
+        int numberOfFailedInstances = findNumberOfFailedInstances(execution);
+
+        boolean isCompletionConditionSatisfied = completionConditionSatisfied(execution);
+        if (nrOfCompletedInstances + numberOfFailedInstances >= nrOfInstances || inactiveExecutions.size() - 1 >= nrOfInstances
+                        || isCompletionConditionSatisfied) {
+            if (numberOfFailedInstances > 0) {
+                throw new RuntimeException(FAILING_THE_MONITOR);
+            }
+            CommandContextUtil.getHistoryManager().recordActivityEnd((ExecutionEntity) execution, null);
+
+            Activity activity = (Activity) execution.getCurrentFlowElement();
+            verifyCompensation(execution, execution, activity);
+            verifyCallActivity(execution, execution.getActivityId());
+            if (isCompletionConditionSatisfied) {
+                LinkedList<DelegateExecution> toVerify = new LinkedList<>(execution.getExecutions());
+                while (!toVerify.isEmpty()) {
+                    DelegateExecution childExecution = toVerify.pop();
+                    if (((ExecutionEntity) childExecution).isInserted()) {
+                        childExecution.inactivate();
+                    }
+
+                    List<DelegateExecution> childExecutions = (List<DelegateExecution>) childExecution.getExecutions();
+                    if (childExecutions != null && !childExecutions.isEmpty()) {
+                        toVerify.addAll(childExecutions);
+                    }
+                }
+                sendCompletedWithConditionEvent(execution);
+            } else {
+                sendCompletedEvent(execution);
+            }
+            cleanupMiRoot(execution);
+        } else {
+            executeAsynchronousJob();
+        }
+
+    }
+
+    private boolean completionConditionSatisfied(ExecutionEntity execution) {
+        MultiInstanceLoopCharacteristics multiInstanceLoopCharacteristics = getMultiInstanceLoopCharacteristics(execution);
+        if (multiInstanceLoopCharacteristics.getCompletionCondition() != null) {
+
+            ProcessEngineConfigurationImpl processEngineConfiguration = CommandContextUtil.getProcessEngineConfiguration();
+            ExpressionManager expressionManager = processEngineConfiguration.getExpressionManager();
+
+            String activeCompletionCondition = null;
+
+            if (CommandContextUtil.getProcessEngineConfiguration().isEnableProcessDefinitionInfoCache()) {
+                ObjectNode taskElementProperties = BpmnOverrideContext.getBpmnOverrideElementProperties(execution.getActivityId(),
+                                execution.getProcessDefinitionId());
+                activeCompletionCondition = getActiveValue(multiInstanceLoopCharacteristics.getCompletionCondition(),
+                                DynamicBpmnConstants.MULTI_INSTANCE_COMPLETION_CONDITION, taskElementProperties);
+
+            } else {
+                activeCompletionCondition = multiInstanceLoopCharacteristics.getCompletionCondition();
+            }
+
+            Object value = expressionManager.createExpression(activeCompletionCondition).getValue(execution);
+
+            if (!(value instanceof Boolean)) {
+                throw new FlowableIllegalArgumentException("completionCondition '" + activeCompletionCondition + "' does not evaluate to a boolean value");
+            }
+
+            Boolean booleanValue = (Boolean) value;
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Completion condition of multi-instance satisfied: {}", booleanValue);
+            }
+            return booleanValue;
+        }
+        return false;
+    }
+
+    protected String getActiveValue(String originalValue, String propertyName, ObjectNode taskElementProperties) {
+        String activeValue = originalValue;
+        if (taskElementProperties != null) {
+            JsonNode overrideValueNode = taskElementProperties.get(propertyName);
+            if (overrideValueNode != null) {
+                if (overrideValueNode.isNull()) {
+                    activeValue = null;
+                } else {
+                    activeValue = overrideValueNode.asText();
+                }
+            }
+        }
+        return activeValue;
+    }
+
+    private MultiInstanceLoopCharacteristics getMultiInstanceLoopCharacteristics(ExecutionEntity execution) {
+        FlowElement currentFlowElement = execution.getCurrentFlowElement();
+        if (currentFlowElement instanceof CallActivity) {
+            return ((CallActivity) currentFlowElement).getLoopCharacteristics();
+        }
+
+        return ((SubProcess) currentFlowElement).getLoopCharacteristics();
+    }
+
+    protected void sendCompletedWithConditionEvent(DelegateExecution execution) {
+        CommandContextUtil.getEventDispatcher(CommandContextUtil.getCommandContext())
+                        .dispatchEvent(buildCompletedEvent(execution, FlowableEngineEventType.MULTI_INSTANCE_ACTIVITY_COMPLETED_WITH_CONDITION));
+    }
+
+    private int findNumberOfFailedInstances(ExecutionEntity execution) {
+        List<ExecutionEntity> allChildExecutions = CommandContextUtil.getExecutionEntityManager().collectChildren(execution);
+        int result = 0;
+        for (ExecutionEntity executionEntity : allChildExecutions) {
+            if (hasFailedJobs(executionEntity)) {
+                result++;
+            }
+        }
+        return result;
+    }
+
+    private boolean hasFailedJobs(ExecutionEntity executionEntity) {
+        return findFailedJobsForExecution(executionEntity).size() > 0;
+    }
+
+    private List<DeadLetterJobEntity> findFailedJobsForExecution(ExecutionEntity executionEntity) {
+        return CommandContextUtil.getJobService().findDeadLetterJobsByExecutionId(executionEntity.getId());
+    }
+
+    private Collection<ExecutionEntity> getInactiveExecutions(ExecutionEntity execution) {
+        ExecutionEntityManager executionEntityManager = CommandContextUtil.getExecutionEntityManager();
+        return executionEntityManager.findInactiveExecutionsByActivityIdAndProcessInstanceId(execution.getActivityId(), execution.getProcessInstanceId());
+    }
+
+    protected void cleanupMiRoot(DelegateExecution execution) {
+        // Delete multi instance root and all child executions.
+        // Create a fresh execution to continue
+        ExecutionEntity multiInstanceRootExecution = (ExecutionEntity) getMultiInstanceRootExecution(execution);
+        FlowElement flowElement = multiInstanceRootExecution.getCurrentFlowElement();
+        ExecutionEntity parentExecution = multiInstanceRootExecution.getParent();
+
+        ExecutionEntityManager executionEntityManager = CommandContextUtil.getExecutionEntityManager();
+        Collection<String> executionIdsNotToSendCancelledEventsFor = execution.isMultiInstanceRoot() ? null : Collections.singletonList(execution.getId());
+        executionEntityManager.deleteChildExecutions(multiInstanceRootExecution, null, executionIdsNotToSendCancelledEventsFor, "MI_END", true, flowElement);
+        executionEntityManager.deleteRelatedDataForExecution(multiInstanceRootExecution, "MI_END");
+        executionEntityManager.delete(multiInstanceRootExecution);
+
+        ExecutionEntity newExecution = executionEntityManager.createChildExecution(parentExecution);
+        newExecution.setCurrentFlowElement(flowElement);
+        takeNextTransition(newExecution);
+    }
+
+    protected DelegateExecution getMultiInstanceRootExecution(DelegateExecution executionEntity) {
+        DelegateExecution multiInstanceRootExecution = null;
+        DelegateExecution currentExecution = executionEntity;
+        while (currentExecution != null && multiInstanceRootExecution == null && currentExecution.getParent() != null) {
+            if (currentExecution.isMultiInstanceRoot()) {
+                multiInstanceRootExecution = currentExecution;
+            } else {
+                currentExecution = currentExecution.getParent();
+            }
+        }
+        return multiInstanceRootExecution;
+    }
+
+    private void takeNextTransition(ExecutionEntity newExecution) {
+        CommandContextUtil.getAgenda().planTakeOutgoingSequenceFlowsOperation(newExecution, true);
+    }
+
+    private Activity verifyCompensation(DelegateExecution execution, ExecutionEntity executionToUse, Activity activity) {
+        boolean hasCompensation = false;
+        if (activity instanceof Transaction) {
+            hasCompensation = true;
+        } else if (activity instanceof SubProcess) {
+            SubProcess subProcess = (SubProcess) activity;
+            for (FlowElement subElement : subProcess.getFlowElements()) {
+                if (subElement instanceof Activity) {
+                    Activity subActivity = (Activity) subElement;
+                    if (CollectionUtil.isNotEmpty(subActivity.getBoundaryEvents())) {
+                        for (BoundaryEvent boundaryEvent : subActivity.getBoundaryEvents()) {
+                            if (CollectionUtil.isNotEmpty(boundaryEvent.getEventDefinitions())
+                                            && boundaryEvent.getEventDefinitions().get(0) instanceof CompensateEventDefinition) {
+
+                                hasCompensation = true;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if (hasCompensation) {
+            ScopeUtil.createCopyOfSubProcessExecutionForCompensation(executionToUse);
+        }
+        return activity;
+    }
+
+    private void verifyCallActivity(ExecutionEntity execution, String activityId) {
+        ExecutionEntityManager executionEntityManager = CommandContextUtil.getExecutionEntityManager();
+        if (execution != null) {
+            List<String> callActivityExecutionIds = new ArrayList<>();
+
+            // Find all execution entities that are at the call activity
+            List<ExecutionEntity> childExecutions = executionEntityManager.collectChildren(execution);
+            if (childExecutions != null) {
+                for (ExecutionEntity childExecution : childExecutions) {
+                    // LOGGER.info("Checking child execution {}",
+                    // childExecution.getPersistentState());
+                    if (activityId.equals(childExecution.getCurrentActivityId())) {
+                        callActivityExecutionIds.add(childExecution.getId());
+                    }
+                }
+
+                // Now all call activity executions have been collected, loop
+                // again and check which should be removed
+                for (int i = childExecutions.size() - 1; i >= 0; i--) {
+                    ExecutionEntity childExecution = childExecutions.get(i);
+                    if (StringUtils.isNotEmpty(childExecution.getSuperExecutionId())
+                                    && callActivityExecutionIds.contains(childExecution.getSuperExecutionId())) {
+                        if (!childExecution.isDeleted()) {
+                            // LOGGER.info("deleted {}", childExecution);
+                            executionEntityManager.deleteProcessInstanceExecutionEntity(childExecution.getId(), activityId,
+                                            "call activity completion condition met", true, false, true);
+                        } else {
+                            LOGGER.info("The child execution {} is already deleted", childExecution.getId());
+                        }
+                    }
+                }
+
+            }
+        }
+    }
+
+    private void sendCompletedEvent(ExecutionEntity execution) {
+        CommandContextUtil.getEventDispatcher(CommandContextUtil.getCommandContext())
+                        .dispatchEvent(buildCompletedEvent(execution, FlowableEngineEventType.MULTI_INSTANCE_ACTIVITY_COMPLETED));
+    }
+
+    protected FlowableMultiInstanceActivityCompletedEvent buildCompletedEvent(DelegateExecution execution, FlowableEngineEventType eventType) {
+        FlowElement flowNode = getCurrentFlowElement((ExecutionEntity) execution);
+
+        // verify the variables
+        return FlowableEventBuilder.createMultiInstanceActivityCompletedEvent(eventType, (int) execution.getVariable(NUMBER_OF_INSTANCES),
+                        (int) execution.getVariable(NUMBER_OF_ACTIVE_INSTANCES), (int) execution.getVariable(NUMBER_OF_COMPLETED_INSTANCES), flowNode.getId(),
+                        flowNode.getName(), execution.getId(), execution.getProcessInstanceId(), execution.getProcessDefinitionId(), flowNode);
+    }
+
+    private List<ExecutionEntity> determineCompletedInstances(ExecutionEntity miRootExecution) {
+        List<ExecutionEntity> completedChildEntities = new ArrayList<>();
+        for (ExecutionEntity childExecution : childExecutions) {
+            int nrOfCompletedInstancesFromChild = getVariableOrDefault(childExecution, NUMBER_OF_COMPLETED_INSTANCES, 0);
+            if (nrOfCompletedInstancesFromChild == 1) {
+                completedChildEntities.add(childExecution);
+            }
+        }
+        return completedChildEntities;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T getVariableOrDefault(ExecutionEntity childExecution, String variableName, T defaultValue) {
+        T valueFromDb = tryToFindInDb(childExecution, variableName);
+        if (valueFromDb != null) {
+            return valueFromDb;
+        }
+        Object value = childExecution.getVariableLocal(variableName);
+        DelegateExecution parent = childExecution.getParent();
+        while (value == null && parent != null) {
+            value = parent.getVariableLocal(variableName);
+            parent = parent.getParent();
+        }
+        return value == null ? defaultValue : (T) value;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T tryToFindInDb(ExecutionEntity childExecution, String variableName) {
+        VariableInstanceEntity variableInstace = CommandContextUtil.getVariableService().findVariableInstanceByExecutionAndName(childExecution.getId(),
+                        variableName);
+        return variableInstace == null ? null : (T) variableInstace.getValue();
+    }
+
+    protected void executeAsynchronousJob() {
+        JobService jobService = CommandContextUtil.getJobService(commandContext);
+        JobEntity jobForExecution = getJobEntity(jobService);
+        jobService.createAsyncJob(jobForExecution, false);
+        jobService.scheduleAsyncJob(jobForExecution);
+    }
+
+    private JobEntity getJobEntity(JobService jobService) {
+        JobEntity job = jobService.createJob();
+        job.setExecutionId(execution.getId());
+        job.setProcessInstanceId(execution.getProcessInstanceId());
+        job.setProcessDefinitionId(execution.getProcessDefinitionId());
+        job.setJobHandlerType(AsyncParallelMultiInstanceMonitorJobHandler.TYPE);
+        // Inherit tenant id (if applicable)
+        if (execution.getTenantId() != null) {
+            job.setTenantId(execution.getTenantId());
+        }
+
+        execution.getJobs().add(job);
+        return job;
+    }
+}

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/agenda/MonitorParallelMultiInstanceOperation.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/agenda/MonitorParallelMultiInstanceOperation.java
@@ -2,31 +2,12 @@ package org.flowable.engine.impl.agenda;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 
-import org.apache.commons.lang3.StringUtils;
-import org.flowable.bpmn.model.Activity;
-import org.flowable.bpmn.model.BoundaryEvent;
-import org.flowable.bpmn.model.CallActivity;
-import org.flowable.bpmn.model.CompensateEventDefinition;
-import org.flowable.bpmn.model.FlowElement;
-import org.flowable.bpmn.model.MultiInstanceLoopCharacteristics;
-import org.flowable.bpmn.model.SubProcess;
-import org.flowable.bpmn.model.Transaction;
-import org.flowable.common.engine.api.FlowableIllegalArgumentException;
-import org.flowable.common.engine.api.delegate.event.FlowableEngineEventType;
-import org.flowable.common.engine.impl.el.ExpressionManager;
 import org.flowable.common.engine.impl.interceptor.CommandContext;
-import org.flowable.common.engine.impl.util.CollectionUtil;
-import org.flowable.engine.DynamicBpmnConstants;
 import org.flowable.engine.delegate.DelegateExecution;
-import org.flowable.engine.delegate.event.FlowableMultiInstanceActivityCompletedEvent;
-import org.flowable.engine.delegate.event.impl.FlowableEventBuilder;
-import org.flowable.engine.impl.bpmn.helper.ScopeUtil;
-import org.flowable.engine.impl.cfg.ProcessEngineConfigurationImpl;
-import org.flowable.engine.impl.context.BpmnOverrideContext;
+import org.flowable.engine.impl.bpmn.helper.MultiInstanceCompletionConditionEvaluator;
+import org.flowable.engine.impl.bpmn.helper.MultiInstanceRootCleaner;
 import org.flowable.engine.impl.jobexecutor.AsyncParallelMultiInstanceMonitorJobHandler;
 import org.flowable.engine.impl.persistence.entity.ExecutionEntity;
 import org.flowable.engine.impl.persistence.entity.ExecutionEntityManager;
@@ -37,9 +18,6 @@ import org.flowable.job.service.impl.persistence.entity.JobEntity;
 import org.flowable.variable.service.impl.persistence.entity.VariableInstanceEntity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 public class MonitorParallelMultiInstanceOperation extends AbstractOperation {
 
@@ -69,106 +47,23 @@ public class MonitorParallelMultiInstanceOperation extends AbstractOperation {
         LOGGER.debug("nrOfInstances {}", nrOfInstances);
         LOGGER.debug("nrOfCompletedInstances {}", nrOfCompletedInstances);
 
+        execution.setVariable(NUMBER_OF_COMPLETED_INSTANCES, nrOfCompletedInstances);
         Collection<ExecutionEntity> inactiveExecutions = getInactiveExecutions(execution);
 
         int numberOfFailedInstances = findNumberOfFailedInstances(execution);
 
-        boolean isCompletionConditionSatisfied = completionConditionSatisfied(execution);
+        boolean isCompletionConditionSatisfied = new MultiInstanceCompletionConditionEvaluator().evaluateCompletionCondition(execution);
+
         if (nrOfCompletedInstances + numberOfFailedInstances >= nrOfInstances || inactiveExecutions.size() - 1 >= nrOfInstances
                         || isCompletionConditionSatisfied) {
             if (numberOfFailedInstances > 0) {
                 throw new RuntimeException(FAILING_THE_MONITOR);
             }
-            CommandContextUtil.getHistoryManager().recordActivityEnd((ExecutionEntity) execution, null);
-
-            Activity activity = (Activity) execution.getCurrentFlowElement();
-            verifyCompensation(execution, execution, activity);
-            verifyCallActivity(execution, execution.getActivityId());
-            if (isCompletionConditionSatisfied) {
-                LinkedList<DelegateExecution> toVerify = new LinkedList<>(execution.getExecutions());
-                while (!toVerify.isEmpty()) {
-                    DelegateExecution childExecution = toVerify.pop();
-                    if (((ExecutionEntity) childExecution).isInserted()) {
-                        childExecution.inactivate();
-                    }
-
-                    List<DelegateExecution> childExecutions = (List<DelegateExecution>) childExecution.getExecutions();
-                    if (childExecutions != null && !childExecutions.isEmpty()) {
-                        toVerify.addAll(childExecutions);
-                    }
-                }
-                sendCompletedWithConditionEvent(execution);
-            } else {
-                sendCompletedEvent(execution);
-            }
-            cleanupMiRoot(execution);
+            new MultiInstanceRootCleaner(isCompletionConditionSatisfied).finishMultiInstanceRootExecution(execution);
         } else {
             executeAsynchronousJob();
         }
 
-    }
-
-    private boolean completionConditionSatisfied(ExecutionEntity execution) {
-        MultiInstanceLoopCharacteristics multiInstanceLoopCharacteristics = getMultiInstanceLoopCharacteristics(execution);
-        if (multiInstanceLoopCharacteristics.getCompletionCondition() != null) {
-
-            ProcessEngineConfigurationImpl processEngineConfiguration = CommandContextUtil.getProcessEngineConfiguration();
-            ExpressionManager expressionManager = processEngineConfiguration.getExpressionManager();
-
-            String activeCompletionCondition = null;
-
-            if (CommandContextUtil.getProcessEngineConfiguration().isEnableProcessDefinitionInfoCache()) {
-                ObjectNode taskElementProperties = BpmnOverrideContext.getBpmnOverrideElementProperties(execution.getActivityId(),
-                                execution.getProcessDefinitionId());
-                activeCompletionCondition = getActiveValue(multiInstanceLoopCharacteristics.getCompletionCondition(),
-                                DynamicBpmnConstants.MULTI_INSTANCE_COMPLETION_CONDITION, taskElementProperties);
-
-            } else {
-                activeCompletionCondition = multiInstanceLoopCharacteristics.getCompletionCondition();
-            }
-
-            Object value = expressionManager.createExpression(activeCompletionCondition).getValue(execution);
-
-            if (!(value instanceof Boolean)) {
-                throw new FlowableIllegalArgumentException("completionCondition '" + activeCompletionCondition + "' does not evaluate to a boolean value");
-            }
-
-            Boolean booleanValue = (Boolean) value;
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Completion condition of multi-instance satisfied: {}", booleanValue);
-            }
-            return booleanValue;
-        }
-        return false;
-    }
-
-    protected String getActiveValue(String originalValue, String propertyName, ObjectNode taskElementProperties) {
-        String activeValue = originalValue;
-        if (taskElementProperties != null) {
-            JsonNode overrideValueNode = taskElementProperties.get(propertyName);
-            if (overrideValueNode != null) {
-                if (overrideValueNode.isNull()) {
-                    activeValue = null;
-                } else {
-                    activeValue = overrideValueNode.asText();
-                }
-            }
-        }
-        return activeValue;
-    }
-
-    private MultiInstanceLoopCharacteristics getMultiInstanceLoopCharacteristics(ExecutionEntity execution) {
-        FlowElement currentFlowElement = execution.getCurrentFlowElement();
-        if (currentFlowElement instanceof CallActivity) {
-            return ((CallActivity) currentFlowElement).getLoopCharacteristics();
-        }
-
-        return ((SubProcess) currentFlowElement).getLoopCharacteristics();
-    }
-
-    protected void sendCompletedWithConditionEvent(DelegateExecution execution) {
-        CommandContextUtil.getEventDispatcher(CommandContextUtil.getCommandContext())
-                        .dispatchEvent(buildCompletedEvent(execution, FlowableEngineEventType.MULTI_INSTANCE_ACTIVITY_COMPLETED_WITH_CONDITION));
     }
 
     private int findNumberOfFailedInstances(ExecutionEntity execution) {
@@ -193,120 +88,6 @@ public class MonitorParallelMultiInstanceOperation extends AbstractOperation {
     private Collection<ExecutionEntity> getInactiveExecutions(ExecutionEntity execution) {
         ExecutionEntityManager executionEntityManager = CommandContextUtil.getExecutionEntityManager();
         return executionEntityManager.findInactiveExecutionsByActivityIdAndProcessInstanceId(execution.getActivityId(), execution.getProcessInstanceId());
-    }
-
-    protected void cleanupMiRoot(DelegateExecution execution) {
-        // Delete multi instance root and all child executions.
-        // Create a fresh execution to continue
-        ExecutionEntity multiInstanceRootExecution = (ExecutionEntity) getMultiInstanceRootExecution(execution);
-        FlowElement flowElement = multiInstanceRootExecution.getCurrentFlowElement();
-        ExecutionEntity parentExecution = multiInstanceRootExecution.getParent();
-
-        ExecutionEntityManager executionEntityManager = CommandContextUtil.getExecutionEntityManager();
-        Collection<String> executionIdsNotToSendCancelledEventsFor = execution.isMultiInstanceRoot() ? null : Collections.singletonList(execution.getId());
-        executionEntityManager.deleteChildExecutions(multiInstanceRootExecution, null, executionIdsNotToSendCancelledEventsFor, "MI_END", true, flowElement);
-        executionEntityManager.deleteRelatedDataForExecution(multiInstanceRootExecution, "MI_END");
-        executionEntityManager.delete(multiInstanceRootExecution);
-
-        ExecutionEntity newExecution = executionEntityManager.createChildExecution(parentExecution);
-        newExecution.setCurrentFlowElement(flowElement);
-        takeNextTransition(newExecution);
-    }
-
-    protected DelegateExecution getMultiInstanceRootExecution(DelegateExecution executionEntity) {
-        DelegateExecution multiInstanceRootExecution = null;
-        DelegateExecution currentExecution = executionEntity;
-        while (currentExecution != null && multiInstanceRootExecution == null && currentExecution.getParent() != null) {
-            if (currentExecution.isMultiInstanceRoot()) {
-                multiInstanceRootExecution = currentExecution;
-            } else {
-                currentExecution = currentExecution.getParent();
-            }
-        }
-        return multiInstanceRootExecution;
-    }
-
-    private void takeNextTransition(ExecutionEntity newExecution) {
-        CommandContextUtil.getAgenda().planTakeOutgoingSequenceFlowsOperation(newExecution, true);
-    }
-
-    private Activity verifyCompensation(DelegateExecution execution, ExecutionEntity executionToUse, Activity activity) {
-        boolean hasCompensation = false;
-        if (activity instanceof Transaction) {
-            hasCompensation = true;
-        } else if (activity instanceof SubProcess) {
-            SubProcess subProcess = (SubProcess) activity;
-            for (FlowElement subElement : subProcess.getFlowElements()) {
-                if (subElement instanceof Activity) {
-                    Activity subActivity = (Activity) subElement;
-                    if (CollectionUtil.isNotEmpty(subActivity.getBoundaryEvents())) {
-                        for (BoundaryEvent boundaryEvent : subActivity.getBoundaryEvents()) {
-                            if (CollectionUtil.isNotEmpty(boundaryEvent.getEventDefinitions())
-                                            && boundaryEvent.getEventDefinitions().get(0) instanceof CompensateEventDefinition) {
-
-                                hasCompensation = true;
-                                break;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        if (hasCompensation) {
-            ScopeUtil.createCopyOfSubProcessExecutionForCompensation(executionToUse);
-        }
-        return activity;
-    }
-
-    private void verifyCallActivity(ExecutionEntity execution, String activityId) {
-        ExecutionEntityManager executionEntityManager = CommandContextUtil.getExecutionEntityManager();
-        if (execution != null) {
-            List<String> callActivityExecutionIds = new ArrayList<>();
-
-            // Find all execution entities that are at the call activity
-            List<ExecutionEntity> childExecutions = executionEntityManager.collectChildren(execution);
-            if (childExecutions != null) {
-                for (ExecutionEntity childExecution : childExecutions) {
-                    // LOGGER.info("Checking child execution {}",
-                    // childExecution.getPersistentState());
-                    if (activityId.equals(childExecution.getCurrentActivityId())) {
-                        callActivityExecutionIds.add(childExecution.getId());
-                    }
-                }
-
-                // Now all call activity executions have been collected, loop
-                // again and check which should be removed
-                for (int i = childExecutions.size() - 1; i >= 0; i--) {
-                    ExecutionEntity childExecution = childExecutions.get(i);
-                    if (StringUtils.isNotEmpty(childExecution.getSuperExecutionId())
-                                    && callActivityExecutionIds.contains(childExecution.getSuperExecutionId())) {
-                        if (!childExecution.isDeleted()) {
-                            // LOGGER.info("deleted {}", childExecution);
-                            executionEntityManager.deleteProcessInstanceExecutionEntity(childExecution.getId(), activityId,
-                                            "call activity completion condition met", true, false, true);
-                        } else {
-                            LOGGER.info("The child execution {} is already deleted", childExecution.getId());
-                        }
-                    }
-                }
-
-            }
-        }
-    }
-
-    private void sendCompletedEvent(ExecutionEntity execution) {
-        CommandContextUtil.getEventDispatcher(CommandContextUtil.getCommandContext())
-                        .dispatchEvent(buildCompletedEvent(execution, FlowableEngineEventType.MULTI_INSTANCE_ACTIVITY_COMPLETED));
-    }
-
-    protected FlowableMultiInstanceActivityCompletedEvent buildCompletedEvent(DelegateExecution execution, FlowableEngineEventType eventType) {
-        FlowElement flowNode = getCurrentFlowElement((ExecutionEntity) execution);
-
-        // verify the variables
-        return FlowableEventBuilder.createMultiInstanceActivityCompletedEvent(eventType, (int) execution.getVariable(NUMBER_OF_INSTANCES),
-                        (int) execution.getVariable(NUMBER_OF_ACTIVE_INSTANCES), (int) execution.getVariable(NUMBER_OF_COMPLETED_INSTANCES), flowNode.getId(),
-                        flowNode.getName(), execution.getId(), execution.getProcessInstanceId(), execution.getProcessDefinitionId(), flowNode);
     }
 
     private List<ExecutionEntity> determineCompletedInstances(ExecutionEntity miRootExecution) {

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/ParallelMultiInstanceBehavior.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/ParallelMultiInstanceBehavior.java
@@ -13,24 +13,13 @@
 package org.flowable.engine.impl.bpmn.behavior;
 
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
 
-import org.apache.commons.lang3.StringUtils;
 import org.flowable.bpmn.model.Activity;
-import org.flowable.bpmn.model.BoundaryEvent;
-import org.flowable.bpmn.model.CallActivity;
-import org.flowable.bpmn.model.CompensateEventDefinition;
-import org.flowable.bpmn.model.FlowElement;
-import org.flowable.bpmn.model.SubProcess;
-import org.flowable.bpmn.model.Transaction;
 import org.flowable.common.engine.api.FlowableIllegalArgumentException;
-import org.flowable.common.engine.impl.util.CollectionUtil;
 import org.flowable.engine.delegate.DelegateExecution;
-import org.flowable.engine.impl.bpmn.helper.ScopeUtil;
 import org.flowable.engine.impl.delegate.ActivityBehavior;
 import org.flowable.engine.impl.persistence.entity.ExecutionEntity;
-import org.flowable.engine.impl.persistence.entity.ExecutionEntityManager;
 import org.flowable.engine.impl.util.CommandContextUtil;
 
 /**
@@ -46,7 +35,8 @@ public class ParallelMultiInstanceBehavior extends MultiInstanceActivityBehavior
     }
 
     /**
-     * Handles the parallel case of spawning the instances. Will create child executions accordingly for every instance needed.
+     * Handles the parallel case of spawning the instances. Will create child
+     * executions accordingly for every instance needed.
      */
     @Override
     protected int createInstances(DelegateExecution multiInstanceRootExecution) {
@@ -62,48 +52,56 @@ public class ParallelMultiInstanceBehavior extends MultiInstanceActivityBehavior
         List<ExecutionEntity> concurrentExecutions = new ArrayList<>();
         for (int loopCounter = 0; loopCounter < nrOfInstances; loopCounter++) {
             ExecutionEntity concurrentExecution = CommandContextUtil.getExecutionEntityManager()
-                    .createChildExecution((ExecutionEntity) multiInstanceRootExecution);
+                            .createChildExecution((ExecutionEntity) multiInstanceRootExecution);
             concurrentExecution.setCurrentFlowElement(activity);
             concurrentExecution.setActive(true);
             concurrentExecution.setScope(false);
 
             concurrentExecutions.add(concurrentExecution);
             logLoopDetails(concurrentExecution, "initialized", loopCounter, 0, nrOfInstances, nrOfInstances);
-            
-            //CommandContextUtil.getHistoryManager().recordActivityStart(concurrentExecution);
         }
 
-        // Before the activities are executed, all executions MUST be created up front
+        // Before the activities are executed, all executions MUST be created up
+        // front
         // Do not try to merge this loop with the previous one, as it will lead
         // to bugs, due to possible child execution pruning.
         for (int loopCounter = 0; loopCounter < nrOfInstances; loopCounter++) {
             ExecutionEntity concurrentExecution = concurrentExecutions.get(loopCounter);
             // executions can be inactive, if instances are all automatics
-            // (no-waitstate) and completionCondition has been met in the meantime
-            if (concurrentExecution.isActive() 
-                    && !concurrentExecution.isEnded() 
-                    && !concurrentExecution.getParent().isEnded()) {
+            // (no-waitstate) and completionCondition has been met in the
+            // meantime
+            if (concurrentExecution.isActive() && !concurrentExecution.isEnded() && !concurrentExecution.getParent().isEnded()) {
                 executeOriginalBehavior(concurrentExecution, (ExecutionEntity) multiInstanceRootExecution, loopCounter);
-            } 
+            }
         }
 
         // See ACT-1586: ExecutionQuery returns wrong results when using multi
-        // instance on a receive task The parent execution must be set to false, so it wouldn't show up in
-        // the execution query when using .activityId(something). Do not we cannot nullify the
-        // activityId (that would have been a better solution), as it would break boundary event behavior.
+        // instance on a receive task The parent execution must be set to false,
+        // so it wouldn't show up in
+        // the execution query when using .activityId(something). Do not we
+        // cannot nullify the
+        // activityId (that would have been a better solution), as it would
+        // break boundary event behavior.
         if (!concurrentExecutions.isEmpty()) {
             multiInstanceRootExecution.setActive(false);
         }
 
+        scheduleMonitor(multiInstanceRootExecution, concurrentExecutions);
+
         return nrOfInstances;
     }
 
+    private void scheduleMonitor(DelegateExecution multiInstanceRootExecution, List<ExecutionEntity> childConcurrentExecutions) {
+        CommandContextUtil.getAgenda().planMonitorParallelMultiInstanceOperation((ExecutionEntity) multiInstanceRootExecution, childConcurrentExecutions);
+    }
+
     /**
-     * Called when the wrapped {@link ActivityBehavior} calls the {@link AbstractBpmnActivityBehavior#leave(DelegateExecution)} method. Handles the completion of one of the parallel instances
+     * Called when the wrapped {@link ActivityBehavior} calls the
+     * {@link AbstractBpmnActivityBehavior#leave(DelegateExecution)} method.
+     * Handles the completion of one of the parallel instances
      */
     @Override
     public void leave(DelegateExecution execution) {
-
         boolean zeroNrOfInstances = false;
         if (resolveNrOfInstances(execution) == 0) {
             // Empty collection, just leave.
@@ -111,21 +109,13 @@ public class ParallelMultiInstanceBehavior extends MultiInstanceActivityBehavior
             super.leave(execution); // Plan the default leave
         }
 
-        int loopCounter = getLoopVariable(execution, getCollectionElementIndexVariable());
-        int nrOfInstances = getLoopVariable(execution, NUMBER_OF_INSTANCES);
-        int nrOfCompletedInstances = getLoopVariable(execution, NUMBER_OF_COMPLETED_INSTANCES) + 1;
-        int nrOfActiveInstances = getLoopVariable(execution, NUMBER_OF_ACTIVE_INSTANCES) - 1;
-        
         DelegateExecution miRootExecution = getMultiInstanceRootExecution(execution);
-        if (miRootExecution != null) { // will be null in case of empty collection
-            setLoopVariable(miRootExecution, NUMBER_OF_COMPLETED_INSTANCES, nrOfCompletedInstances);
-            setLoopVariable(miRootExecution, NUMBER_OF_ACTIVE_INSTANCES, nrOfActiveInstances);
+        if (miRootExecution != null) { // will be null in case of empty
+                                       // collection
+            setLoopVariable(execution, NUMBER_OF_COMPLETED_INSTANCES, 1);
         }
-
         CommandContextUtil.getHistoryManager().recordActivityEnd((ExecutionEntity) execution, null);
         callActivityEndListeners(execution);
-        
-        logLoopDetails(execution, "instance completed", loopCounter, nrOfCompletedInstances, nrOfActiveInstances, nrOfInstances);
 
         if (zeroNrOfInstances) {
             return;
@@ -133,129 +123,14 @@ public class ParallelMultiInstanceBehavior extends MultiInstanceActivityBehavior
 
         ExecutionEntity executionEntity = (ExecutionEntity) execution;
         if (executionEntity.getParent() != null) {
-
+            if (!execution.isActive()) {
+                return;
+            }
             executionEntity.inactivate();
-            lockFirstParentScope(executionEntity);
-
-            boolean isCompletionConditionSatisfied = completionConditionSatisfied(execution.getParent());
-            if (nrOfCompletedInstances >= nrOfInstances || isCompletionConditionSatisfied) {
-
-                ExecutionEntity leavingExecution = null;
-                if (nrOfInstances > 0) {
-                    leavingExecution = executionEntity.getParent();
-                } else {
-                    CommandContextUtil.getHistoryManager().recordActivityEnd((ExecutionEntity) execution, null);
-                    leavingExecution = executionEntity;
-                }
-
-                Activity activity = (Activity) execution.getCurrentFlowElement();
-                verifyCompensation(execution, leavingExecution, activity);
-                verifyCallActivity(leavingExecution, activity);
-                
-                if (isCompletionConditionSatisfied) {
-                    LinkedList<DelegateExecution> toVerify = new LinkedList<>(miRootExecution.getExecutions());
-                    while (!toVerify.isEmpty()) {
-                        DelegateExecution childExecution = toVerify.pop();
-                        if (((ExecutionEntity) childExecution).isInserted()) {
-                            childExecution.inactivate();
-                        }
-                        
-                        List<DelegateExecution> childExecutions = (List<DelegateExecution>) childExecution.getExecutions();
-                        if (childExecutions != null && !childExecutions.isEmpty()) {
-                            toVerify.addAll(childExecutions);
-                        }
-                    }
-                    sendCompletedWithConditionEvent(leavingExecution);
-                }
-                else {
-                    sendCompletedEvent(leavingExecution);
-                }
-
-                super.leave(leavingExecution);
-              }
-
         } else {
             sendCompletedEvent(execution);
             super.leave(execution);
         }
     }
 
-    protected Activity verifyCompensation(DelegateExecution execution, ExecutionEntity executionToUse, Activity activity) {
-        boolean hasCompensation = false;
-        if (activity instanceof Transaction) {
-            hasCompensation = true;
-        } else if (activity instanceof SubProcess) {
-            SubProcess subProcess = (SubProcess) activity;
-            for (FlowElement subElement : subProcess.getFlowElements()) {
-                if (subElement instanceof Activity) {
-                    Activity subActivity = (Activity) subElement;
-                    if (CollectionUtil.isNotEmpty(subActivity.getBoundaryEvents())) {
-                        for (BoundaryEvent boundaryEvent : subActivity.getBoundaryEvents()) {
-                            if (CollectionUtil.isNotEmpty(boundaryEvent.getEventDefinitions()) &&
-                                    boundaryEvent.getEventDefinitions().get(0) instanceof CompensateEventDefinition) {
-
-                                hasCompensation = true;
-                                break;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        if (hasCompensation) {
-            ScopeUtil.createCopyOfSubProcessExecutionForCompensation(executionToUse);
-        }
-        return activity;
-    }
-
-    protected void verifyCallActivity(ExecutionEntity executionToUse, Activity activity) {
-        if (activity instanceof CallActivity) {
-            ExecutionEntityManager executionEntityManager = CommandContextUtil.getExecutionEntityManager();
-            if (executionToUse != null) {
-                List<String> callActivityExecutionIds = new ArrayList<>();
-
-                // Find all execution entities that are at the call activity
-                List<ExecutionEntity> childExecutions = executionEntityManager.collectChildren(executionToUse);
-                if (childExecutions != null) {
-                    for (ExecutionEntity childExecution : childExecutions) {
-                        if (activity.getId().equals(childExecution.getCurrentActivityId())) {
-                            callActivityExecutionIds.add(childExecution.getId());
-                        }
-                    }
-
-                    // Now all call activity executions have been collected, loop again and check which should be removed
-                    for (int i = childExecutions.size() - 1; i >= 0; i--) {
-                        ExecutionEntity childExecution = childExecutions.get(i);
-                        if (StringUtils.isNotEmpty(childExecution.getSuperExecutionId())
-                                && callActivityExecutionIds.contains(childExecution.getSuperExecutionId())) {
-
-                            executionEntityManager.deleteProcessInstanceExecutionEntity(childExecution.getId(), activity.getId(),
-                                    "call activity completion condition met", true, false, true);
-                        }
-                    }
-
-                }
-            }
-        }
-    }
-
-
-    protected void lockFirstParentScope(DelegateExecution execution) {
-
-        ExecutionEntityManager executionEntityManager = CommandContextUtil.getExecutionEntityManager();
-
-        boolean found = false;
-        ExecutionEntity parentScopeExecution = null;
-        ExecutionEntity currentExecution = (ExecutionEntity) execution;
-        while (!found && currentExecution != null && currentExecution.getParentId() != null) {
-            parentScopeExecution = executionEntityManager.findById(currentExecution.getParentId());
-            if (parentScopeExecution != null && parentScopeExecution.isScope()) {
-                found = true;
-            }
-            currentExecution = parentScopeExecution;
-        }
-
-        parentScopeExecution.forceUpdate();
-    }
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/helper/MultiInstanceCompletionConditionEvaluator.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/helper/MultiInstanceCompletionConditionEvaluator.java
@@ -1,0 +1,86 @@
+package org.flowable.engine.impl.bpmn.helper;
+
+import org.flowable.bpmn.model.Activity;
+import org.flowable.bpmn.model.FlowElement;
+import org.flowable.bpmn.model.MultiInstanceLoopCharacteristics;
+import org.flowable.common.engine.api.FlowableIllegalArgumentException;
+import org.flowable.common.engine.impl.el.ExpressionManager;
+import org.flowable.engine.DynamicBpmnConstants;
+import org.flowable.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.flowable.engine.impl.context.BpmnOverrideContext;
+import org.flowable.engine.impl.persistence.entity.ExecutionEntity;
+import org.flowable.engine.impl.util.CommandContextUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+public class MultiInstanceCompletionConditionEvaluator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MultiInstanceCompletionConditionEvaluator.class);
+
+    public boolean evaluateCompletionCondition(ExecutionEntity execution) {
+        MultiInstanceLoopCharacteristics multiInstanceLoopCharacteristics = getMultiInstanceLoopCharacteristics(execution);
+        if (multiInstanceLoopCharacteristics == null) {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("No multi instance loop characteristics detected for execution {}", execution);
+            }
+            return false;
+        }
+
+        if (multiInstanceLoopCharacteristics.getCompletionCondition() == null) {
+            return false;
+        }
+
+        ProcessEngineConfigurationImpl processEngineConfiguration = CommandContextUtil.getProcessEngineConfiguration();
+        ExpressionManager expressionManager = processEngineConfiguration.getExpressionManager();
+
+        String activeCompletionCondition = null;
+
+        if (CommandContextUtil.getProcessEngineConfiguration()
+            .isEnableProcessDefinitionInfoCache()) {
+            ObjectNode taskElementProperties = BpmnOverrideContext.getBpmnOverrideElementProperties(execution.getActivityId(),
+                execution.getProcessDefinitionId());
+            activeCompletionCondition = getActiveValue(multiInstanceLoopCharacteristics.getCompletionCondition(),
+                DynamicBpmnConstants.MULTI_INSTANCE_COMPLETION_CONDITION, taskElementProperties);
+
+        } else {
+            activeCompletionCondition = multiInstanceLoopCharacteristics.getCompletionCondition();
+        }
+
+        Object value = expressionManager.createExpression(activeCompletionCondition)
+            .getValue(execution);
+
+        if (!(value instanceof Boolean)) {
+            throw new FlowableIllegalArgumentException(
+                "completionCondition '" + activeCompletionCondition + "' does not evaluate to a boolean value");
+        }
+
+        Boolean booleanValue = (Boolean) value;
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Completion condition of multi-instance satisfied: {}", booleanValue);
+        }
+        return booleanValue;
+    }
+
+    private MultiInstanceLoopCharacteristics getMultiInstanceLoopCharacteristics(ExecutionEntity execution) {
+        FlowElement currentFlowElement = execution.getCurrentFlowElement();
+        return ((Activity) currentFlowElement).getLoopCharacteristics();
+    }
+
+    protected String getActiveValue(String originalValue, String propertyName, ObjectNode taskElementProperties) {
+        String activeValue = originalValue;
+        if (taskElementProperties != null) {
+            JsonNode overrideValueNode = taskElementProperties.get(propertyName);
+            if (overrideValueNode != null) {
+                if (overrideValueNode.isNull()) {
+                    activeValue = null;
+                } else {
+                    activeValue = overrideValueNode.asText();
+                }
+            }
+        }
+        return activeValue;
+    }
+}

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/helper/MultiInstanceRootCleaner.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/helper/MultiInstanceRootCleaner.java
@@ -1,0 +1,186 @@
+package org.flowable.engine.impl.bpmn.helper;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.flowable.bpmn.model.Activity;
+import org.flowable.bpmn.model.BoundaryEvent;
+import org.flowable.bpmn.model.CompensateEventDefinition;
+import org.flowable.bpmn.model.FlowElement;
+import org.flowable.bpmn.model.SubProcess;
+import org.flowable.bpmn.model.Transaction;
+import org.flowable.common.engine.api.delegate.event.FlowableEngineEventType;
+import org.flowable.common.engine.impl.util.CollectionUtil;
+import org.flowable.engine.delegate.DelegateExecution;
+import org.flowable.engine.delegate.event.FlowableMultiInstanceActivityCompletedEvent;
+import org.flowable.engine.delegate.event.impl.FlowableEventBuilder;
+import org.flowable.engine.impl.persistence.entity.ExecutionEntity;
+import org.flowable.engine.impl.persistence.entity.ExecutionEntityManager;
+import org.flowable.engine.impl.util.CommandContextUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MultiInstanceRootCleaner {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MultiInstanceRootCleaner.class);
+
+    private boolean isCompletionConditionSatisfied;
+
+    public MultiInstanceRootCleaner(boolean isCompletionConditionSatisfied) {
+        this.isCompletionConditionSatisfied = isCompletionConditionSatisfied;
+    }
+
+    public void finishMultiInstanceRootExecution(ExecutionEntity execution) {
+
+        CommandContextUtil.getHistoryManager()
+            .recordActivityEnd((ExecutionEntity) execution, null);
+
+        Activity activity = (Activity) execution.getCurrentFlowElement();
+        verifyCompensation(execution, execution, activity);
+        verifyCallActivity(execution, execution.getActivityId());
+        if (isCompletionConditionSatisfied) {
+            LinkedList<DelegateExecution> toVerify = new LinkedList<>(execution.getExecutions());
+            while (!toVerify.isEmpty()) {
+                DelegateExecution childExecution = toVerify.pop();
+                if (((ExecutionEntity) childExecution).isInserted()) {
+                    childExecution.inactivate();
+                }
+
+                @SuppressWarnings("unchecked")
+                List<DelegateExecution> childExecutions = (List<DelegateExecution>) childExecution.getExecutions();
+                if (childExecutions != null && !childExecutions.isEmpty()) {
+                    toVerify.addAll(childExecutions);
+                }
+            }
+            sendCompletedWithConditionEvent(execution);
+        } else {
+            sendCompletedEvent(execution);
+        }
+        cleanupMiRoot(execution);
+    }
+
+    private Activity verifyCompensation(DelegateExecution execution, ExecutionEntity executionToUse, Activity activity) {
+        boolean hasCompensation = false;
+        if (activity instanceof Transaction) {
+            hasCompensation = true;
+        } else if (activity instanceof SubProcess) {
+            SubProcess subProcess = (SubProcess) activity;
+            for (FlowElement subElement : subProcess.getFlowElements()) {
+                if (subElement instanceof Activity) {
+                    Activity subActivity = (Activity) subElement;
+                    if (CollectionUtil.isNotEmpty(subActivity.getBoundaryEvents())) {
+                        for (BoundaryEvent boundaryEvent : subActivity.getBoundaryEvents()) {
+                            if (CollectionUtil.isNotEmpty(boundaryEvent.getEventDefinitions()) && boundaryEvent.getEventDefinitions()
+                                .get(0) instanceof CompensateEventDefinition) {
+
+                                hasCompensation = true;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if (hasCompensation) {
+            ScopeUtil.createCopyOfSubProcessExecutionForCompensation(executionToUse);
+        }
+        return activity;
+    }
+
+    private void verifyCallActivity(ExecutionEntity execution, String activityId) {
+        ExecutionEntityManager executionEntityManager = CommandContextUtil.getExecutionEntityManager();
+        if (execution != null) {
+            List<String> callActivityExecutionIds = new ArrayList<>();
+
+            // Find all execution entities that are at the call activity
+            List<ExecutionEntity> childExecutions = executionEntityManager.collectChildren(execution);
+            if (childExecutions != null) {
+                for (ExecutionEntity childExecution : childExecutions) {
+                    // LOGGER.info("Checking child execution {}", childExecution.getPersistentState());
+                    if (activityId.equals(childExecution.getCurrentActivityId())) {
+                        callActivityExecutionIds.add(childExecution.getId());
+                    }
+                }
+
+                // Now all call activity executions have been collected, loop again and check which should be removed
+                for (int i = childExecutions.size() - 1; i >= 0; i--) {
+                    ExecutionEntity childExecution = childExecutions.get(i);
+                    if (StringUtils.isNotEmpty(childExecution.getSuperExecutionId())
+                        && callActivityExecutionIds.contains(childExecution.getSuperExecutionId())) {
+                        if (!childExecution.isDeleted()) {
+                            // LOGGER.info("deleted {}", childExecution);
+                            executionEntityManager.deleteProcessInstanceExecutionEntity(childExecution.getId(), activityId,
+                                "call activity completion condition met", true, false, true);
+                        } else {
+                            LOGGER.debug("The child execution {} is already deleted", childExecution.getId());
+                        }
+                    }
+                }
+
+            }
+        }
+    }
+
+    protected void sendCompletedWithConditionEvent(DelegateExecution execution) {
+        CommandContextUtil.getEventDispatcher(CommandContextUtil.getCommandContext())
+            .dispatchEvent(buildCompletedEvent(execution, FlowableEngineEventType.MULTI_INSTANCE_ACTIVITY_COMPLETED_WITH_CONDITION));
+    }
+
+    protected FlowableMultiInstanceActivityCompletedEvent buildCompletedEvent(DelegateExecution execution,
+        FlowableEngineEventType eventType) {
+        FlowElement flowNode = execution.getCurrentFlowElement();
+
+        // verify the variables
+        return FlowableEventBuilder.createMultiInstanceActivityCompletedEvent(eventType, (int) execution.getVariable("nrOfInstances"),
+            (int) execution.getVariable("nrOfActiveInstances"), (int) execution.getVariable("nrOfCompletedInstances"), flowNode.getId(),
+            flowNode.getName(), execution.getId(), execution.getProcessInstanceId(), execution.getProcessDefinitionId(), flowNode);
+    }
+
+    private void sendCompletedEvent(ExecutionEntity execution) {
+        CommandContextUtil.getEventDispatcher(CommandContextUtil.getCommandContext())
+            .dispatchEvent(buildCompletedEvent(execution, FlowableEngineEventType.MULTI_INSTANCE_ACTIVITY_COMPLETED));
+    }
+
+    protected void cleanupMiRoot(DelegateExecution execution) {
+        // Delete multi instance root and all child executions.
+        // Create a fresh execution to continue
+        ExecutionEntity multiInstanceRootExecution = (ExecutionEntity) getMultiInstanceRootExecution(execution);
+        FlowElement flowElement = multiInstanceRootExecution.getCurrentFlowElement();
+        ExecutionEntity parentExecution = multiInstanceRootExecution.getParent();
+
+        ExecutionEntityManager executionEntityManager = CommandContextUtil.getExecutionEntityManager();
+        Collection<String> executionIdsNotToSendCancelledEventsFor = execution.isMultiInstanceRoot() ? null
+            : Collections.singletonList(execution.getId());
+        executionEntityManager.deleteChildExecutions(multiInstanceRootExecution, null, executionIdsNotToSendCancelledEventsFor, "MI_END",
+            true, flowElement);
+        executionEntityManager.deleteRelatedDataForExecution(multiInstanceRootExecution, "MI_END");
+        executionEntityManager.delete(multiInstanceRootExecution);
+
+        ExecutionEntity newExecution = executionEntityManager.createChildExecution(parentExecution);
+        newExecution.setCurrentFlowElement(flowElement);
+        takeNextTransition(newExecution);
+    }
+
+    protected DelegateExecution getMultiInstanceRootExecution(DelegateExecution executionEntity) {
+        DelegateExecution multiInstanceRootExecution = null;
+        DelegateExecution currentExecution = executionEntity;
+        while (currentExecution != null && multiInstanceRootExecution == null && currentExecution.getParent() != null) {
+            if (currentExecution.isMultiInstanceRoot()) {
+                multiInstanceRootExecution = currentExecution;
+            } else {
+                currentExecution = currentExecution.getParent();
+            }
+        }
+        return multiInstanceRootExecution;
+    }
+
+    private void takeNextTransition(ExecutionEntity newExecution) {
+        CommandContextUtil.getAgenda()
+            .planTakeOutgoingSequenceFlowsOperation(newExecution, true);
+    }
+}

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -222,6 +222,7 @@ import org.flowable.engine.impl.interceptor.CommandInvoker;
 import org.flowable.engine.impl.interceptor.DelegateInterceptor;
 import org.flowable.engine.impl.interceptor.LoggingExecutionTreeCommandInvoker;
 import org.flowable.engine.impl.jobexecutor.AsyncContinuationJobHandler;
+import org.flowable.engine.impl.jobexecutor.AsyncParallelMultiInstanceMonitorJobHandler;
 import org.flowable.engine.impl.jobexecutor.AsyncTriggerJobHandler;
 import org.flowable.engine.impl.jobexecutor.DefaultFailedJobCommandFactory;
 import org.flowable.engine.impl.jobexecutor.ProcessEventJobHandler;
@@ -377,8 +378,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * @author Tom Baeyens
  * @author Joram Barrez
  */
-public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfiguration implements
-        ScriptingEngineAwareEngineConfiguration, HasExpressionManagerEngineConfiguration {
+public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfiguration
+                implements ScriptingEngineAwareEngineConfiguration, HasExpressionManagerEngineConfiguration {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ProcessEngineConfigurationImpl.class);
 
@@ -388,7 +389,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     public static final String DEFAULT_MYBATIS_MAPPING_FILE = "org/flowable/db/mapping/mappings.xml";
 
-    // SERVICES /////////////////////////////////////////////////////////////////
+    // SERVICES
+    // /////////////////////////////////////////////////////////////////
 
     protected RepositoryService repositoryService = new RepositoryServiceImpl();
     protected RuntimeService runtimeService = new RuntimeServiceImpl();
@@ -402,7 +404,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     // IDM ENGINE /////////////////////////////////////////////////////
     protected boolean disableIdmEngine;
 
-    // DATA MANAGERS /////////////////////////////////////////////////////////////
+    // DATA MANAGERS
+    // /////////////////////////////////////////////////////////////
 
     protected AttachmentDataManager attachmentDataManager;
     protected ByteArrayDataManager byteArrayDataManager;
@@ -420,7 +423,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     protected PropertyDataManager propertyDataManager;
     protected ResourceDataManager resourceDataManager;
 
-    // ENTITY MANAGERS ///////////////////////////////////////////////////////////
+    // ENTITY MANAGERS
+    // ///////////////////////////////////////////////////////////
 
     protected AttachmentEntityManager attachmentEntityManager;
     protected ByteArrayEntityManager byteArrayEntityManager;
@@ -456,17 +460,18 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     // Job Manager
 
     protected JobManager jobManager;
-    
+
     // Dynamic state manager
-    
+
     protected DynamicStateManager dynamicStateManager;
-    
+
     protected VariableServiceConfiguration variableServiceConfiguration;
     protected IdentityLinkServiceConfiguration identityLinkServiceConfiguration;
     protected TaskServiceConfiguration taskServiceConfiguration;
     protected JobServiceConfiguration jobServiceConfiguration;
 
-    // DEPLOYERS //////////////////////////////////////////////////////////////////
+    // DEPLOYERS
+    // //////////////////////////////////////////////////////////////////
 
     protected BpmnDeployer bpmnDeployer;
     protected AppDeployer appDeployer;
@@ -493,7 +498,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     protected AppResourceConverter appResourceConverter;
 
-    // JOB EXECUTOR /////////////////////////////////////////////////////////////
+    // JOB EXECUTOR
+    // /////////////////////////////////////////////////////////////
 
     protected List<JobHandler> customJobHandlers;
     protected Map<String, JobHandler> jobHandlers;
@@ -504,12 +510,14 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     protected List<HistoryJobHandler> customHistoryJobHandlers;
     protected List<HistoryJsonTransformer> customHistoryJsonTransformers;
 
-    // HELPERS //////////////////////////////////////////////////////////////////
+    // HELPERS
+    // //////////////////////////////////////////////////////////////////
     protected ProcessInstanceHelper processInstanceHelper;
     protected ListenerNotificationHelper listenerNotificationHelper;
     protected FormHandlerHelper formHandlerHelper;
 
-    // ASYNC EXECUTOR ///////////////////////////////////////////////////////////
+    // ASYNC EXECUTOR
+    // ///////////////////////////////////////////////////////////
 
     /**
      * The number of retries for a job.
@@ -517,121 +525,169 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     protected int asyncExecutorNumberOfRetries = 3;
 
     /**
-     * The minimal number of threads that are kept alive in the threadpool for job execution. Default value = 2. (This property is only applicable when using the {@link DefaultAsyncJobExecutor}).
+     * The minimal number of threads that are kept alive in the threadpool for
+     * job execution. Default value = 2. (This property is only applicable when
+     * using the {@link DefaultAsyncJobExecutor}).
      */
     protected int asyncExecutorCorePoolSize = 2;
 
     /**
-     * The maximum number of threads that are created in the threadpool for job execution. Default value = 10. (This property is only applicable when using the {@link DefaultAsyncJobExecutor}).
+     * The maximum number of threads that are created in the threadpool for job
+     * execution. Default value = 10. (This property is only applicable when
+     * using the {@link DefaultAsyncJobExecutor}).
      */
     protected int asyncExecutorMaxPoolSize = 10;
 
     /**
-     * The time (in milliseconds) a thread used for job execution must be kept alive before it is destroyed. Default setting is 5 seconds. Having a setting > 0 takes resources, but in the case of many
-     * job executions it avoids creating new threads all the time. If 0, threads will be destroyed after they've been used for job execution.
+     * The time (in milliseconds) a thread used for job execution must be kept
+     * alive before it is destroyed. Default setting is 5 seconds. Having a
+     * setting > 0 takes resources, but in the case of many job executions it
+     * avoids creating new threads all the time. If 0, threads will be destroyed
+     * after they've been used for job execution.
      * <p>
-     * (This property is only applicable when using the {@link DefaultAsyncJobExecutor}).
+     * (This property is only applicable when using the
+     * {@link DefaultAsyncJobExecutor}).
      */
     protected long asyncExecutorThreadKeepAliveTime = 5000L;
 
     /**
-     * The size of the queue on which jobs to be executed are placed, before they are actually executed. Default value = 100. (This property is only applicable when using the
-     * {@link DefaultAsyncJobExecutor}).
+     * The size of the queue on which jobs to be executed are placed, before
+     * they are actually executed. Default value = 100. (This property is only
+     * applicable when using the {@link DefaultAsyncJobExecutor}).
      */
     protected int asyncExecutorThreadPoolQueueSize = 100;
 
     /**
-     * The queue onto which jobs will be placed before they are actually executed. Threads form the async executor threadpool will take work from this queue.
+     * The queue onto which jobs will be placed before they are actually
+     * executed. Threads form the async executor threadpool will take work from
+     * this queue.
      * <p>
-     * By default null. If null, an {@link ArrayBlockingQueue} will be created of size {@link #asyncExecutorThreadPoolQueueSize}.
+     * By default null. If null, an {@link ArrayBlockingQueue} will be created
+     * of size {@link #asyncExecutorThreadPoolQueueSize}.
      * <p>
-     * When the queue is full, the job will be executed by the calling thread (ThreadPoolExecutor.CallerRunsPolicy())
+     * When the queue is full, the job will be executed by the calling thread
+     * (ThreadPoolExecutor.CallerRunsPolicy())
      * <p>
-     * (This property is only applicable when using the {@link DefaultAsyncJobExecutor}).
+     * (This property is only applicable when using the
+     * {@link DefaultAsyncJobExecutor}).
      */
     protected BlockingQueue<Runnable> asyncExecutorThreadPoolQueue;
 
     /**
-     * The time (in seconds) that is waited to gracefully shut down the threadpool used for job execution when the a shutdown on the executor (or process engine) is requested. Default value = 60.
+     * The time (in seconds) that is waited to gracefully shut down the
+     * threadpool used for job execution when the a shutdown on the executor (or
+     * process engine) is requested. Default value = 60.
      * <p>
-     * (This property is only applicable when using the {@link DefaultAsyncJobExecutor}).
+     * (This property is only applicable when using the
+     * {@link DefaultAsyncJobExecutor}).
      */
     protected long asyncExecutorSecondsToWaitOnShutdown = 60L;
 
     /**
-     * The number of timer jobs that are acquired during one query (before a job is executed, an acquirement thread fetches jobs from the database and puts them on the queue).
+     * The number of timer jobs that are acquired during one query (before a job
+     * is executed, an acquirement thread fetches jobs from the database and
+     * puts them on the queue).
      * <p>
-     * Default value = 1, as this lowers the potential on optimistic locking exceptions. Change this value if you know what you are doing.
+     * Default value = 1, as this lowers the potential on optimistic locking
+     * exceptions. Change this value if you know what you are doing.
      * <p>
-     * (This property is only applicable when using the {@link DefaultAsyncJobExecutor}).
+     * (This property is only applicable when using the
+     * {@link DefaultAsyncJobExecutor}).
      */
     protected int asyncExecutorMaxTimerJobsPerAcquisition = 1;
 
     /**
-     * The number of async jobs that are acquired during one query (before a job is executed, an acquirement thread fetches jobs from the database and puts them on the queue).
+     * The number of async jobs that are acquired during one query (before a job
+     * is executed, an acquirement thread fetches jobs from the database and
+     * puts them on the queue).
      * <p>
-     * Default value = 1, as this lowers the potential on optimistic locking exceptions. Change this value if you know what you are doing.
+     * Default value = 1, as this lowers the potential on optimistic locking
+     * exceptions. Change this value if you know what you are doing.
      * <p>
-     * (This property is only applicable when using the {@link DefaultAsyncJobExecutor}).
+     * (This property is only applicable when using the
+     * {@link DefaultAsyncJobExecutor}).
      */
     protected int asyncExecutorMaxAsyncJobsDuePerAcquisition = 1;
 
     /**
-     * The time (in milliseconds) the timer acquisition thread will wait to execute the next acquirement query. This happens when no new timer jobs were found or when less timer jobs have been fetched
-     * than set in {@link #asyncExecutorMaxTimerJobsPerAcquisition}. Default value = 10 seconds.
+     * The time (in milliseconds) the timer acquisition thread will wait to
+     * execute the next acquirement query. This happens when no new timer jobs
+     * were found or when less timer jobs have been fetched than set in
+     * {@link #asyncExecutorMaxTimerJobsPerAcquisition}. Default value = 10
+     * seconds.
      * <p>
-     * (This property is only applicable when using the {@link DefaultAsyncJobExecutor}).
+     * (This property is only applicable when using the
+     * {@link DefaultAsyncJobExecutor}).
      */
     protected int asyncExecutorDefaultTimerJobAcquireWaitTime = 10 * 1000;
 
     /**
-     * The time (in milliseconds) the async job acquisition thread will wait to execute the next acquirement query. This happens when no new async jobs were found or when less async jobs have been
-     * fetched than set in {@link #asyncExecutorMaxAsyncJobsDuePerAcquisition}. Default value = 10 seconds.
+     * The time (in milliseconds) the async job acquisition thread will wait to
+     * execute the next acquirement query. This happens when no new async jobs
+     * were found or when less async jobs have been fetched than set in
+     * {@link #asyncExecutorMaxAsyncJobsDuePerAcquisition}. Default value = 10
+     * seconds.
      * <p>
-     * (This property is only applicable when using the {@link DefaultAsyncJobExecutor}).
+     * (This property is only applicable when using the
+     * {@link DefaultAsyncJobExecutor}).
      */
     protected int asyncExecutorDefaultAsyncJobAcquireWaitTime = 10 * 1000;
 
     /**
-     * The time (in milliseconds) the async job (both timer and async continuations) acquisition thread will wait when the queue is full to execute the next query. By default set to 0 (for backwards
-     * compatibility)
+     * The time (in milliseconds) the async job (both timer and async
+     * continuations) acquisition thread will wait when the queue is full to
+     * execute the next query. By default set to 0 (for backwards compatibility)
      */
     protected int asyncExecutorDefaultQueueSizeFullWaitTime;
 
     /**
-     * When a job is acquired, it is locked so other async executors can't lock and execute it. While doing this, the 'name' of the lock owner is written into a column of the job.
+     * When a job is acquired, it is locked so other async executors can't lock
+     * and execute it. While doing this, the 'name' of the lock owner is written
+     * into a column of the job.
      * <p>
      * By default, a random UUID will be generated when the executor is created.
      * <p>
-     * It is important that each async executor instance in a cluster of Flowable engines has a different name!
+     * It is important that each async executor instance in a cluster of
+     * Flowable engines has a different name!
      * <p>
-     * (This property is only applicable when using the {@link DefaultAsyncJobExecutor}).
+     * (This property is only applicable when using the
+     * {@link DefaultAsyncJobExecutor}).
      */
     protected String asyncExecutorLockOwner;
 
     /**
-     * The amount of time (in milliseconds) a timer job is locked when acquired by the async executor. During this period of time, no other async executor will try to acquire and lock this job.
+     * The amount of time (in milliseconds) a timer job is locked when acquired
+     * by the async executor. During this period of time, no other async
+     * executor will try to acquire and lock this job.
      * <p>
      * Default value = 5 minutes;
      * <p>
-     * (This property is only applicable when using the {@link DefaultAsyncJobExecutor}).
+     * (This property is only applicable when using the
+     * {@link DefaultAsyncJobExecutor}).
      */
     protected int asyncExecutorTimerLockTimeInMillis = 5 * 60 * 1000;
 
     /**
-     * The amount of time (in milliseconds) an async job is locked when acquired by the async executor. During this period of time, no other async executor will try to acquire and lock this job.
+     * The amount of time (in milliseconds) an async job is locked when acquired
+     * by the async executor. During this period of time, no other async
+     * executor will try to acquire and lock this job.
      * <p>
      * Default value = 5 minutes;
      * <p>
-     * (This property is only applicable when using the {@link DefaultAsyncJobExecutor}).
+     * (This property is only applicable when using the
+     * {@link DefaultAsyncJobExecutor}).
      */
     protected int asyncExecutorAsyncJobLockTimeInMillis = 5 * 60 * 1000;
 
     /**
-     * The amount of time (in milliseconds) that is between two consecutive checks of 'expired jobs'. Expired jobs are jobs that were locked (a lock owner + time was written by some executor, but the
-     * job was never completed).
+     * The amount of time (in milliseconds) that is between two consecutive
+     * checks of 'expired jobs'. Expired jobs are jobs that were locked (a lock
+     * owner + time was written by some executor, but the job was never
+     * completed).
      * <p>
-     * During such a check, jobs that are expired are again made available, meaning the lock owner and lock time will be removed. Other executors will now be able to pick it up.
+     * During such a check, jobs that are expired are again made available,
+     * meaning the lock owner and lock time will be removed. Other executors
+     * will now be able to pick it up.
      * <p>
      * A job is deemed expired if the current time has passed the lock time.
      * <p>
@@ -640,29 +696,33 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     protected int asyncExecutorResetExpiredJobsInterval = 60 * 1000;
 
     /**
-     * The amount of time (in milliseconds) a job can maximum be in the 'executable' state before being deemed expired.
-     * Note that this won't happen when using the threadpool based executor, as the acquire thread will fetch these kind of jobs earlier.
-     * However, in the message queue based execution, it could be some job is posted to a queue but then never is locked nor executed.
+     * The amount of time (in milliseconds) a job can maximum be in the
+     * 'executable' state before being deemed expired. Note that this won't
+     * happen when using the threadpool based executor, as the acquire thread
+     * will fetch these kind of jobs earlier. However, in the message queue
+     * based execution, it could be some job is posted to a queue but then never
+     * is locked nor executed.
      * <p>
      * By default 24 hours, as this should be a very exceptional case.
      */
     protected int asyncExecutorResetExpiredJobsMaxTimeout = 24 * 60 * 60 * 1000;
 
     /**
-     * The {@link AsyncExecutor} has a 'cleanup' thread that resets expired jobs so they can be re-acquired by other executors. This setting defines the size of the page being used when fetching these
-     * expired jobs.
+     * The {@link AsyncExecutor} has a 'cleanup' thread that resets expired jobs
+     * so they can be re-acquired by other executors. This setting defines the
+     * size of the page being used when fetching these expired jobs.
      */
     protected int asyncExecutorResetExpiredJobsPageSize = 3;
-    
+
     /**
-     * Flags to control which threads (when using the default threadpool-based async executor) are started.
-     * This can be used to boot up engine instances that still execute jobs originating from this instance itself,
-     * but don't fetch new jobs themselves.
+     * Flags to control which threads (when using the default threadpool-based
+     * async executor) are started. This can be used to boot up engine instances
+     * that still execute jobs originating from this instance itself, but don't
+     * fetch new jobs themselves.
      */
     protected boolean isAsyncExecutorAsyncJobAcquisitionEnabled = true;
     protected boolean isAsyncExecutorTimerJobAcquisitionEnabled = true;
     protected boolean isAsyncExecutorResetExpiredJobsEnabled = true;
-    
 
     /**
      * Experimental!
@@ -670,7 +730,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
      * Set this to true when using the message queue based job executor.
      */
     protected boolean asyncExecutorMessageQueueMode;
-    
+
     // More info: see similar async executor properties.
     protected boolean asyncHistoryExecutorMessageQueueMode;
     protected int asyncHistoryExecutorNumberOfRetries = 10;
@@ -689,23 +749,27 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     protected boolean isAsyncHistoryExecutorAsyncJobAcquisitionEnabled = true;
     protected boolean isAsyncHistoryExecutorTimerJobAcquisitionEnabled = true;
     protected boolean isAsyncHistoryExecutorResetExpiredJobsEnabled = true;
-    
+
     protected String jobExecutionScope;
     protected String historyJobExecutionScope;
 
     /**
-     * Allows to define a custom factory for creating the {@link Runnable} that is executed by the async executor.
+     * Allows to define a custom factory for creating the {@link Runnable} that
+     * is executed by the async executor.
      * <p>
-     * (This property is only applicable when using the {@link DefaultAsyncJobExecutor}).
+     * (This property is only applicable when using the
+     * {@link DefaultAsyncJobExecutor}).
      */
     protected ExecuteAsyncRunnableFactory asyncExecutorExecuteAsyncRunnableFactory;
     protected InternalJobParentStateResolver internalJobParentStateResolver;
 
-    // JUEL functions ///////////////////////////////////////////////////////////
+    // JUEL functions
+    // ///////////////////////////////////////////////////////////
     protected List<FlowableFunctionDelegate> flowableFunctionDelegates;
     protected List<FlowableFunctionDelegate> customFlowableFunctionDelegates;
 
-    // BPMN PARSER //////////////////////////////////////////////////////////////
+    // BPMN PARSER
+    // //////////////////////////////////////////////////////////////
 
     protected List<BpmnParseHandler> preBpmnParseHandlers;
     protected List<BpmnParseHandler> postBpmnParseHandlers;
@@ -714,11 +778,13 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     protected ListenerFactory listenerFactory;
     protected BpmnParseFactory bpmnParseFactory;
 
-    // PROCESS VALIDATION ///////////////////////////////////////////////////////
+    // PROCESS VALIDATION
+    // ///////////////////////////////////////////////////////
 
     protected ProcessValidator processValidator;
 
-    // OTHER ////////////////////////////////////////////////////////////////////
+    // OTHER
+    // ////////////////////////////////////////////////////////////////////
 
     protected List<FormEngine> customFormEngines;
     protected Map<String, FormEngine> formEngines;
@@ -742,11 +808,14 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     protected Map<String, List<RuntimeInstanceStateChangeCallback>> processInstanceStateChangedCallbacks;
 
     /**
-     * This flag determines whether variables of the type 'serializable' will be tracked. This means that, when true, in a JavaDelegate you can write
+     * This flag determines whether variables of the type 'serializable' will be
+     * tracked. This means that, when true, in a JavaDelegate you can write
      * <p>
-     * MySerializableVariable myVariable = (MySerializableVariable) execution.getVariable("myVariable"); myVariable.setNumber(123);
+     * MySerializableVariable myVariable = (MySerializableVariable)
+     * execution.getVariable("myVariable"); myVariable.setNumber(123);
      * <p>
-     * And the changes to the java object will be reflected in the database. Otherwise, a manual call to setVariable will be needed.
+     * And the changes to the java object will be reflected in the database.
+     * Otherwise, a manual call to setVariable will be needed.
      * <p>
      * By default true for backwards compatibility.
      */
@@ -779,22 +848,29 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     protected List<EventHandler> customEventHandlers;
 
     protected FailedJobCommandFactory failedJobCommandFactory;
-    
+
     protected FormFieldHandler formFieldHandler;
 
     /**
-     * Set this to true if you want to have extra checks on the BPMN xml that is parsed. See http://www.jorambarrez.be/blog/2013/02/19/uploading-a-funny-xml -can-bring-down-your-server/
+     * Set this to true if you want to have extra checks on the BPMN xml that is
+     * parsed. See
+     * http://www.jorambarrez.be/blog/2013/02/19/uploading-a-funny-xml
+     * -can-bring-down-your-server/
      * <p>
-     * Unfortunately, this feature is not available on some platforms (JDK 6, JBoss), hence the reason why it is disabled by default. If your platform allows the use of StaxSource during XML parsing,
-     * do enable it.
+     * Unfortunately, this feature is not available on some platforms (JDK 6,
+     * JBoss), hence the reason why it is disabled by default. If your platform
+     * allows the use of StaxSource during XML parsing, do enable it.
      */
     protected boolean enableSafeBpmnXml;
 
     /**
-     * The following settings will determine the amount of entities loaded at once when the engine needs to load multiple entities (eg. when suspending a process definition with all its process
-     * instances).
+     * The following settings will determine the amount of entities loaded at
+     * once when the engine needs to load multiple entities (eg. when suspending
+     * a process definition with all its process instances).
      * <p>
-     * The default setting is quite low, as not to surprise anyone with sudden memory spikes. Change it to something higher if the environment Flowable runs in allows it.
+     * The default setting is quite low, as not to surprise anyone with sudden
+     * memory spikes. Change it to something higher if the environment Flowable
+     * runs in allows it.
      */
     protected int batchSizeProcessInstances = 25;
     protected int batchSizeTasks = 25;
@@ -803,10 +879,12 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     protected boolean enableDatabaseEventLogging;
 
     /**
-     * Using field injection together with a delegate expression for a service task / execution listener / task listener is not thread-sade , see user guide section 'Field Injection' for more
-     * information.
+     * Using field injection together with a delegate expression for a service
+     * task / execution listener / task listener is not thread-sade , see user
+     * guide section 'Field Injection' for more information.
      * <p>
-     * Set this flag to false to throw an exception at runtime when a field is injected and a delegateExpression is used.
+     * Set this flag to false to throw an exception at runtime when a field is
+     * injected and a delegateExpression is used.
      *
      * @since 5.21
      */
@@ -819,7 +897,9 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     protected List<HistoryJobProcessor> historyJobProcessors = Collections.emptyList();
 
     /**
-     * Enabled a very verbose debug output of the execution tree whilst executing operations. Most useful for core engine developers or people fiddling around with the execution tree.
+     * Enabled a very verbose debug output of the execution tree whilst
+     * executing operations. Most useful for core engine developers or people
+     * fiddling around with the execution tree.
      */
     protected boolean enableVerboseExecutionTreeLogging;
 
@@ -833,10 +913,19 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     protected DbSchemaManager taskDbSchemaManager;
     protected DbSchemaManager jobDbSchemaManager;
 
-    // Backwards compatibility //////////////////////////////////////////////////////////////
+    // Backwards compatibility
+    // //////////////////////////////////////////////////////////////
 
-    protected boolean flowable5CompatibilityEnabled; // Default flowable 5 backwards compatibility is disabled!
-    protected boolean validateFlowable5EntitiesEnabled = true; // When disabled no checks are performed for existing flowable 5 entities in the db
+    protected boolean flowable5CompatibilityEnabled; // Default flowable 5
+                                                     // backwards compatibility
+                                                     // is disabled!
+    protected boolean validateFlowable5EntitiesEnabled = true; // When disabled
+                                                               // no checks are
+                                                               // performed for
+                                                               // existing
+                                                               // flowable 5
+                                                               // entities in
+                                                               // the db
     protected boolean redeployFlowable5ProcessDefinitions;
     protected Flowable5CompatibilityHandlerFactory flowable5CompatibilityHandlerFactory;
     protected Flowable5CompatibilityHandler flowable5CompatibilityHandler;
@@ -847,7 +936,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     protected List<Object> flowable5PreBpmnParseHandlers;
     protected List<Object> flowable5PostBpmnParseHandlers;
     protected List<Object> flowable5CustomDefaultBpmnParseHandlers;
-    protected Set<Class<?>> flowable5CustomMybatisMappers;
+    protected Set<Class< ? >> flowable5CustomMybatisMappers;
     protected Set<String> flowable5CustomMybatisXMLMappers;
     protected Object flowable5ExpressionManager;
 
@@ -862,6 +951,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         // trigger build of Flowable 5 Engine
         if (flowable5CompatibilityEnabled && flowable5CompatibilityHandler != null) {
             commandExecutor.execute(new Command<Void>() {
+
                 @Override
                 public Void execute(CommandContext commandContext) {
                     flowable5CompatibilityHandler.getRawProcessEngine();
@@ -990,7 +1080,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     @Override
     public List<CommandInterceptor> getAdditionalDefaultCommandInterceptors() {
-        return Collections.<CommandInterceptor>singletonList(new BpmnOverrideContextInterceptor());
+        return Collections.<CommandInterceptor> singletonList(new BpmnOverrideContextInterceptor());
     }
     // services
     // /////////////////////////////////////////////////////////////////
@@ -1014,7 +1104,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         initTaskDbSchemaManager();
         initJobDbSchemaManager();
     }
-    
+
     public void initNonRelationalDataSource() {
         // for subclassing
     }
@@ -1060,7 +1150,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     }
 
     @Override
-    public ProcessEngineConfigurationImpl setCustomMybatisMappers(Set<Class<?>> customMybatisMappers) {
+    public ProcessEngineConfigurationImpl setCustomMybatisMappers(Set<Class< ? >> customMybatisMappers) {
         this.customMybatisMappers = customMybatisMappers;
         return this;
     }
@@ -1125,7 +1215,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         }
     }
 
-    // Entity managers //////////////////////////////////////////////////////////
+    // Entity managers
+    // //////////////////////////////////////////////////////////
 
     public void initEntityManagers() {
         if (attachmentEntityManager == null) {
@@ -1186,7 +1277,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         }
     }
 
-    // History manager ///////////////////////////////////////////////////////////
+    // History manager
+    // ///////////////////////////////////////////////////////////
 
     public void initHistoryManager() {
         if (historyManager == null) {
@@ -1197,16 +1289,18 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
             }
         }
     }
-    
-    // Dynamic state manager ////////////////////////////////////////////////////
-    
+
+    // Dynamic state manager
+    // ////////////////////////////////////////////////////
+
     public void initDynamicStateManager() {
         if (dynamicStateManager == null) {
             dynamicStateManager = new DefaultDynamicStateManager();
         }
     }
 
-    // session factories ////////////////////////////////////////////////////////
+    // session factories
+    // ////////////////////////////////////////////////////////
 
     @Override
     public void initSessionFactories() {
@@ -1228,14 +1322,14 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
             addSessionFactory(new GenericManagerFactory(EntityCache.class, EntityCacheImpl.class));
 
             commandContextFactory.setSessionFactories(sessionFactories);
-            
+
         } else {
             if (isAsyncHistoryEnabled) {
                 if (!sessionFactories.containsKey(AsyncHistorySession.class)) {
                     initAsyncHistorySessionFactory();
                 }
             }
-            
+
             if (!sessionFactories.containsKey(FlowableEngineAgenda.class)) {
                 if (agendaFactory != null) {
                     addSessionFactory(new AgendaSessionFactory(agendaFactory));
@@ -1270,7 +1364,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
             asyncHistorySessionFactory.setAsyncHistoryListener(asyncHistoryListener);
             sessionFactories.put(AsyncHistorySession.class, asyncHistorySessionFactory);
         }
-        
+
         ((AsyncHistorySessionFactory) sessionFactories.get(AsyncHistorySession.class)).registerJobDataTypes(HistoryJsonConstants.ORDERED_TYPES);
     }
 
@@ -1347,7 +1441,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         } else {
             this.taskServiceConfiguration.setInternalTaskVariableScopeResolver(new DefaultTaskVariableScopeResolver(this));
         }
-        
+
         if (this.internalTaskAssignmentManager != null) {
             this.taskServiceConfiguration.setInternalTaskAssignmentManager(this.internalTaskAssignmentManager);
         } else {
@@ -1368,9 +1462,10 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         this.taskServiceConfiguration.setHistoricTaskQueryLimit(this.historicTaskQueryLimit);
 
         this.taskServiceConfiguration.init();
-        
+
         if (dbSqlSessionFactory != null && taskServiceConfiguration.getTaskDataManager() instanceof AbstractDataManager) {
-            dbSqlSessionFactory.addLogicalEntityClassMapping("task", ((AbstractDataManager) taskServiceConfiguration.getTaskDataManager()).getManagedEntityClass());
+            dbSqlSessionFactory.addLogicalEntityClassMapping("task",
+                            ((AbstractDataManager) taskServiceConfiguration.getTaskDataManager()).getManagedEntityClass());
         }
 
         addServiceConfiguration(EngineConfigurationConstants.KEY_TASK_SERVICE_CONFIG, this.taskServiceConfiguration);
@@ -1390,44 +1485,44 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
             this.jobServiceConfiguration.setCommandExecutor(this.commandExecutor);
             this.jobServiceConfiguration.setExpressionManager(this.expressionManager);
             this.jobServiceConfiguration.setBusinessCalendarManager(this.businessCalendarManager);
-    
+
             this.jobServiceConfiguration.setFailedJobCommandFactory(this.failedJobCommandFactory);
-    
+
             List<AsyncRunnableExecutionExceptionHandler> exceptionHandlers = new ArrayList<>();
             if (customAsyncRunnableExecutionExceptionHandlers != null) {
                 exceptionHandlers.addAll(customAsyncRunnableExecutionExceptionHandlers);
             }
-    
+
             if (addDefaultExceptionHandler) {
                 exceptionHandlers.add(new DefaultAsyncRunnableExecutionExceptionHandler());
             }
-    
+
             if (internalJobParentStateResolver != null) {
-                this.jobServiceConfiguration.setJobParentStateResolver(internalJobParentStateResolver); 
+                this.jobServiceConfiguration.setJobParentStateResolver(internalJobParentStateResolver);
             } else {
                 this.jobServiceConfiguration.setJobParentStateResolver(new DefaultProcessJobParentStateResolver(this));
             }
-    
+
             this.jobServiceConfiguration.setAsyncRunnableExecutionExceptionHandlers(exceptionHandlers);
             this.jobServiceConfiguration.setAsyncExecutorNumberOfRetries(this.asyncExecutorNumberOfRetries);
             this.jobServiceConfiguration.setAsyncExecutorResetExpiredJobsMaxTimeout(this.asyncExecutorResetExpiredJobsMaxTimeout);
-    
+
             if (this.jobManager != null) {
                 this.jobServiceConfiguration.setJobManager(this.jobManager);
             }
-    
+
             if (this.internalJobManager != null) {
                 this.jobServiceConfiguration.setInternalJobManager(this.internalJobManager);
             } else {
                 this.jobServiceConfiguration.setInternalJobManager(new DefaultInternalJobManager(this));
             }
-            
+
             if (this.internalJobCompatibilityManager != null) {
                 this.jobServiceConfiguration.setInternalJobCompatibilityManager(internalJobCompatibilityManager);
             } else {
                 this.jobServiceConfiguration.setInternalJobCompatibilityManager(new DefaultInternalJobCompatibilityManager(this));
             }
-            
+
             // Async history job config
             jobServiceConfiguration.setJobTypeAsyncHistory(HistoryJsonConstants.JOB_HANDLER_TYPE_DEFAULT_ASYNC_HISTORY);
             jobServiceConfiguration.setJobTypeAsyncHistoryZipped(HistoryJsonConstants.JOB_HANDLER_TYPE_DEFAULT_ASYNC_HISTORY_ZIPPED);
@@ -1438,46 +1533,46 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
             // set the job processors
             this.jobServiceConfiguration.setJobProcessors(this.jobProcessors);
             this.jobServiceConfiguration.setHistoryJobProcessors(this.historyJobProcessors);
-            
+
             this.jobServiceConfiguration.setJobExecutionScope(this.jobExecutionScope);
             this.jobServiceConfiguration.setHistoryJobExecutionScope(this.historyJobExecutionScope);
-    
+
             this.jobServiceConfiguration.init();
         }
-        
+
         if (this.jobHandlers != null) {
             for (String type : this.jobHandlers.keySet()) {
                 this.jobServiceConfiguration.addJobHandler(type, this.jobHandlers.get(type));
             }
         }
-        
+
         if (this.historyJobHandlers != null) {
             for (String type : this.historyJobHandlers.keySet()) {
                 this.jobServiceConfiguration.addHistoryJobHandler(type, this.historyJobHandlers.get(type));
             }
         }
-        
+
         addServiceConfiguration(EngineConfigurationConstants.KEY_JOB_SERVICE_CONFIG, this.jobServiceConfiguration);
     }
 
     protected JobServiceConfiguration instantiateJobServiceConfiguration() {
-       return new JobServiceConfiguration();
+        return new JobServiceConfiguration();
     }
-    
+
     public void addJobHandler(JobHandler jobHandler) {
         this.jobHandlers.put(jobHandler.getType(), jobHandler);
         if (this.jobServiceConfiguration != null) {
             this.jobServiceConfiguration.addJobHandler(jobHandler.getType(), jobHandler);
         }
     }
-    
+
     public void removeJobHandler(String jobHandlerType) {
         this.jobHandlers.remove(jobHandlerType);
         if (this.jobServiceConfiguration != null) {
             this.jobServiceConfiguration.getJobHandlers().remove(jobHandlerType);
         }
     }
-    
+
     public void addHistoryJobHandler(HistoryJobHandler historyJobHandler) {
         this.historyJobHandlers.put(historyJobHandler.getType(), historyJobHandler);
         if (this.jobServiceConfiguration != null) {
@@ -1485,14 +1580,14 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         }
     }
 
-
     public void afterInitTaskServiceConfiguration() {
         if (engineConfigurations.containsKey(EngineConfigurationConstants.KEY_IDM_ENGINE_CONFIG)) {
-            IdmEngineConfigurationApi idmEngineConfiguration = (IdmEngineConfigurationApi) engineConfigurations.get(EngineConfigurationConstants.KEY_IDM_ENGINE_CONFIG);
+            IdmEngineConfigurationApi idmEngineConfiguration = (IdmEngineConfigurationApi) engineConfigurations
+                            .get(EngineConfigurationConstants.KEY_IDM_ENGINE_CONFIG);
             this.taskServiceConfiguration.setIdmIdentityService(idmEngineConfiguration.getIdmIdentityService());
         }
     }
-    
+
     public void removeHistoryJobHandler(String historyJobHandlerType) {
         this.historyJobHandlers.remove(historyJobHandlerType);
         if (this.jobServiceConfiguration != null) {
@@ -1609,7 +1704,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         }
     }
 
-    public Collection<? extends EngineDeployer> getDefaultDeployers() {
+    public Collection< ? extends EngineDeployer> getDefaultDeployers() {
         List<EngineDeployer> defaultDeployers = new ArrayList<>();
 
         if (bpmnDeployer == null) {
@@ -1657,7 +1752,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
             DefaultActivityBehaviorFactory defaultActivityBehaviorFactory = new DefaultActivityBehaviorFactory();
             defaultActivityBehaviorFactory.setExpressionManager(expressionManager);
             activityBehaviorFactory = defaultActivityBehaviorFactory;
-        } else if ((activityBehaviorFactory instanceof AbstractBehaviorFactory) && ((AbstractBehaviorFactory) activityBehaviorFactory).getExpressionManager() == null) {
+        } else if ((activityBehaviorFactory instanceof AbstractBehaviorFactory)
+                        && ((AbstractBehaviorFactory) activityBehaviorFactory).getExpressionManager() == null) {
             ((AbstractBehaviorFactory) activityBehaviorFactory).setExpressionManager(expressionManager);
         }
     }
@@ -1728,9 +1824,9 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         // Replace any default handler if the user wants to replace them
         if (customDefaultBpmnParseHandlers != null) {
 
-            Map<Class<?>, BpmnParseHandler> customParseHandlerMap = new HashMap<>();
+            Map<Class< ? >, BpmnParseHandler> customParseHandlerMap = new HashMap<>();
             for (BpmnParseHandler bpmnParseHandler : customDefaultBpmnParseHandlers) {
-                for (Class<?> handledType : bpmnParseHandler.getHandledTypes()) {
+                for (Class< ? > handledType : bpmnParseHandler.getHandledTypes()) {
                     customParseHandlerMap.put(handledType, bpmnParseHandler);
                 }
             }
@@ -1740,16 +1836,17 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
                 BpmnParseHandler defaultBpmnParseHandler = bpmnParserHandlers.get(i);
                 if (defaultBpmnParseHandler.getHandledTypes().size() != 1) {
                     StringBuilder supportedTypes = new StringBuilder();
-                    for (Class<?> type : defaultBpmnParseHandler.getHandledTypes()) {
+                    for (Class< ? > type : defaultBpmnParseHandler.getHandledTypes()) {
                         supportedTypes.append(" ").append(type.getCanonicalName()).append(" ");
                     }
-                    throw new FlowableException("The default BPMN parse handlers should only support one type, but " + defaultBpmnParseHandler.getClass() + " supports " + supportedTypes
-                            + ". This is likely a programmatic error");
+                    throw new FlowableException("The default BPMN parse handlers should only support one type, but " + defaultBpmnParseHandler.getClass()
+                                    + " supports " + supportedTypes + ". This is likely a programmatic error");
                 } else {
-                    Class<?> handledType = defaultBpmnParseHandler.getHandledTypes().iterator().next();
+                    Class< ? > handledType = defaultBpmnParseHandler.getHandledTypes().iterator().next();
                     if (customParseHandlerMap.containsKey(handledType)) {
                         BpmnParseHandler newBpmnParseHandler = customParseHandlerMap.get(handledType);
-                        LOGGER.info("Replacing default BpmnParseHandler {} with {}", defaultBpmnParseHandler.getClass().getName(), newBpmnParseHandler.getClass().getName());
+                        LOGGER.info("Replacing default BpmnParseHandler {} with {}", defaultBpmnParseHandler.getClass().getName(),
+                                        newBpmnParseHandler.getClass().getName());
                         bpmnParserHandlers.set(i, newBpmnParseHandler);
                     }
                 }
@@ -1770,7 +1867,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
         AsyncContinuationJobHandler asyncContinuationJobHandler = new AsyncContinuationJobHandler();
         jobHandlers.put(asyncContinuationJobHandler.getType(), asyncContinuationJobHandler);
-        
+
         AsyncTriggerJobHandler asyncTriggerJobHandler = new AsyncTriggerJobHandler();
         jobHandlers.put(asyncTriggerJobHandler.getType(), asyncTriggerJobHandler);
 
@@ -1786,6 +1883,9 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         TimerActivateProcessDefinitionHandler activateProcessDefinitionHandler = new TimerActivateProcessDefinitionHandler();
         jobHandlers.put(activateProcessDefinitionHandler.getType(), activateProcessDefinitionHandler);
 
+        AsyncParallelMultiInstanceMonitorJobHandler monitoringJobHandler = new AsyncParallelMultiInstanceMonitorJobHandler();
+        jobHandlers.put(monitoringJobHandler.getType(), monitoringJobHandler);
+
         ProcessEventJobHandler processEventJobHandler = new ProcessEventJobHandler();
         jobHandlers.put(processEventJobHandler.getType(), processEventJobHandler);
 
@@ -1800,7 +1900,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     protected void initHistoryJobHandlers() {
         if (isAsyncHistoryEnabled) {
             historyJobHandlers = new HashMap<>();
-            
+
             List<HistoryJsonTransformer> allHistoryJsonTransformers = new ArrayList<>(initDefaultHistoryJsonTransformers());
             if (customHistoryJsonTransformers != null) {
                 allHistoryJsonTransformers.addAll(customHistoryJsonTransformers);
@@ -1811,7 +1911,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
             asyncHistoryJobHandler.setAsyncHistoryJsonGroupingEnabled(isAsyncHistoryJsonGroupingEnabled);
             historyJobHandlers.put(asyncHistoryJobHandler.getType(), asyncHistoryJobHandler);
 
-            AsyncHistoryJobZippedHandler asyncHistoryJobZippedHandler = new AsyncHistoryJobZippedHandler(HistoryJsonConstants.JOB_HANDLER_TYPE_DEFAULT_ASYNC_HISTORY_ZIPPED);
+            AsyncHistoryJobZippedHandler asyncHistoryJobZippedHandler = new AsyncHistoryJobZippedHandler(
+                            HistoryJsonConstants.JOB_HANDLER_TYPE_DEFAULT_ASYNC_HISTORY_ZIPPED);
             allHistoryJsonTransformers.forEach(asyncHistoryJobZippedHandler::addHistoryJsonTransformer);
             asyncHistoryJobZippedHandler.setAsyncHistoryJsonGroupingEnabled(isAsyncHistoryJsonGroupingEnabled);
             historyJobHandlers.put(asyncHistoryJobZippedHandler.getType(), asyncHistoryJobZippedHandler);
@@ -1823,7 +1924,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
             }
         }
     }
-    
+
     protected List<HistoryJsonTransformer> initDefaultHistoryJsonTransformers() {
         List<HistoryJsonTransformer> historyJsonTransformers = new ArrayList<>();
         historyJsonTransformers.add(new ProcessInstanceStartHistoryJsonTransformer());
@@ -1845,10 +1946,10 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         historyJsonTransformers.add(new TaskPropertyChangedHistoryJsonTransformer());
         historyJsonTransformers.add(new TaskAssigneeChangedHistoryJsonTransformer());
         historyJsonTransformers.add(new TaskOwnerChangedHistoryJsonTransformer());
-        
+
         historyJsonTransformers.add(new IdentityLinkCreatedHistoryJsonTransformer());
         historyJsonTransformers.add(new IdentityLinkDeletedHistoryJsonTransformer());
-        
+
         historyJsonTransformers.add(new VariableCreatedHistoryJsonTransformer());
         historyJsonTransformers.add(new VariableUpdatedHistoryJsonTransformer());
         historyJsonTransformers.add(new VariableRemovedHistoryJsonTransformer());
@@ -1880,7 +1981,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
                 defaultAsyncExecutor.setThreadPoolQueue(asyncExecutorThreadPoolQueue);
             }
             defaultAsyncExecutor.setQueueSize(asyncExecutorThreadPoolQueueSize);
-            
+
             // Thread flags
             defaultAsyncExecutor.setAsyncJobAcquisitionEnabled(isAsyncExecutorAsyncJobAcquisitionEnabled);
             defaultAsyncExecutor.setTimerJobAcquisitionEnabled(isAsyncExecutorTimerJobAcquisitionEnabled);
@@ -1919,66 +2020,69 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         if (isAsyncHistoryEnabled) {
             if (asyncHistoryExecutor == null) {
                 DefaultAsyncHistoryJobExecutor defaultAsyncHistoryExecutor = new DefaultAsyncHistoryJobExecutor();
-    
+
                 // Message queue mode
                 defaultAsyncHistoryExecutor.setMessageQueueMode(asyncHistoryExecutorMessageQueueMode);
-    
+
                 // Thread pool config
                 defaultAsyncHistoryExecutor.setCorePoolSize(asyncHistoryExecutorCorePoolSize);
                 defaultAsyncHistoryExecutor.setMaxPoolSize(asyncHistoryExecutorMaxPoolSize);
                 defaultAsyncHistoryExecutor.setKeepAliveTime(asyncHistoryExecutorThreadKeepAliveTime);
-    
+
                 // Threadpool queue
                 if (asyncHistoryExecutorThreadPoolQueue != null) {
                     defaultAsyncHistoryExecutor.setThreadPoolQueue(asyncHistoryExecutorThreadPoolQueue);
                 }
                 defaultAsyncHistoryExecutor.setQueueSize(asyncHistoryExecutorThreadPoolQueueSize);
-                
+
                 // Thread flags
                 defaultAsyncHistoryExecutor.setAsyncJobAcquisitionEnabled(isAsyncHistoryExecutorAsyncJobAcquisitionEnabled);
                 defaultAsyncHistoryExecutor.setTimerJobAcquisitionEnabled(isAsyncHistoryExecutorTimerJobAcquisitionEnabled);
                 defaultAsyncHistoryExecutor.setResetExpiredJobEnabled(isAsyncHistoryExecutorResetExpiredJobsEnabled);
-    
+
                 // Acquisition wait time
                 defaultAsyncHistoryExecutor.setDefaultAsyncJobAcquireWaitTimeInMillis(asyncHistoryExecutorDefaultAsyncJobAcquireWaitTime);
-    
+
                 // Queue full wait time
                 defaultAsyncHistoryExecutor.setDefaultQueueSizeFullWaitTimeInMillis(asyncHistoryExecutorDefaultQueueSizeFullWaitTime);
-    
+
                 // Job locking
                 defaultAsyncHistoryExecutor.setAsyncJobLockTimeInMillis(asyncHistoryExecutorAsyncJobLockTimeInMillis);
                 if (asyncHistoryExecutorLockOwner != null) {
                     defaultAsyncHistoryExecutor.setLockOwner(asyncHistoryExecutorLockOwner);
                 }
-    
+
                 // Reset expired
                 defaultAsyncHistoryExecutor.setResetExpiredJobsInterval(asyncHistoryExecutorResetExpiredJobsInterval);
                 defaultAsyncHistoryExecutor.setResetExpiredJobsPageSize(asyncHistoryExecutorResetExpiredJobsPageSize);
-    
+
                 // Shutdown
                 defaultAsyncHistoryExecutor.setSecondsToWaitOnShutdown(asyncHistoryExecutorSecondsToWaitOnShutdown);
-    
+
                 asyncHistoryExecutor = defaultAsyncHistoryExecutor;
-                
+
                 if (asyncHistoryExecutor.getJobServiceConfiguration() == null) {
                     asyncHistoryExecutor.setJobServiceConfiguration(jobServiceConfiguration);
                 }
                 asyncHistoryExecutor.setAutoActivate(asyncHistoryExecutorActivate);
-                
+
             } else {
-                // In case an async history executor was injected, only the job handlers are set. 
-                // In the normal case, these are set on the jobServiceConfiguration, but these are not shared between instances
+                // In case an async history executor was injected, only the job
+                // handlers are set.
+                // In the normal case, these are set on the
+                // jobServiceConfiguration, but these are not shared between
+                // instances
                 if (historyJobHandlers != null) {
                     if (asyncHistoryExecutor.getJobServiceConfiguration() == null) {
                         asyncHistoryExecutor.setJobServiceConfiguration(jobServiceConfiguration);
                     }
                     historyJobHandlers.forEach((type, handler) -> {
-                        asyncHistoryExecutor.getJobServiceConfiguration().mergeHistoryJobHandler(handler); 
+                        asyncHistoryExecutor.getJobServiceConfiguration().mergeHistoryJobHandler(handler);
                     });
                 }
-                
+
             }
-            
+
         }
 
         if (asyncHistoryExecutor != null) {
@@ -2185,7 +2289,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
             jpaEntityManagerFactory = JpaHelper.createEntityManagerFactory(jpaPersistenceUnitName);
         }
         if (jpaEntityManagerFactory != null) {
-            sessionFactories.put(EntityManagerSession.class, new EntityManagerSessionFactory(jpaEntityManagerFactory, jpaHandleTransaction, jpaCloseEntityManager));
+            sessionFactories.put(EntityManagerSession.class,
+                            new EntityManagerSessionFactory(jpaEntityManagerFactory, jpaHandleTransaction, jpaCloseEntityManager));
             VariableType jpaType = variableTypes.getVariableType(JPAEntityVariableType.TYPE_NAME);
             // Add JPA-type
             if (jpaType == null) {
@@ -2243,7 +2348,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
             this.processValidator = new ProcessValidatorFactory().createDefaultProcessValidator();
         }
     }
-    
+
     public void initFormFieldHandler() {
         if (this.formFieldHandler == null) {
             this.formFieldHandler = new DefaultFormFieldHandler();
@@ -2263,7 +2368,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     public void initDatabaseEventLogging() {
         if (enableDatabaseEventLogging) {
-            // Database event logging uses the default logging mechanism and adds
+            // Database event logging uses the default logging mechanism and
+            // adds
             // a specific event listener to the list of event listeners
             getEventDispatcher().addEventListener(new EventLogger(clock, objectMapper));
         }
@@ -2293,7 +2399,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     }
 
     /**
-     * Called when the {@link ProcessEngine} is initialized, but before it is returned
+     * Called when the {@link ProcessEngine} is initialized, but before it is
+     * returned
      */
     protected void postProcessEngineInitialisation() {
         if (validateFlowable5EntitiesEnabled) {
@@ -2312,7 +2419,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
             commandExecutor.execute(new ValidateTaskRelatedEntityCountCfgCmd());
         }
 
-        // if Flowable 5 support is needed configure the Flowable 5 job processors via the compatibility handler
+        // if Flowable 5 support is needed configure the Flowable 5 job
+        // processors via the compatibility handler
         if (flowable5CompatibilityEnabled) {
             flowable5CompatibilityHandler.setJobProcessor(this.flowable5JobProcessors);
         }
@@ -2320,13 +2428,14 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     public Runnable getProcessEngineCloseRunnable() {
         return new Runnable() {
+
             @Override
             public void run() {
                 commandExecutor.execute(getSchemaCommandConfig(), new SchemaOperationProcessEngineClose());
             }
         };
     }
-    
+
     @Override
     protected List<EngineConfigurator> getEngineSpecificEngineConfigurators() {
         if (!disableIdmEngine) {
@@ -2340,7 +2449,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         }
         return Collections.emptyList();
     }
-    
+
     public ProcessEngineConfigurationImpl addConfigurator(EngineConfigurator configurator) {
         super.addConfigurator(configurator);
         return this;
@@ -2506,7 +2615,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     }
 
     @Override
-    public ProcessEngineConfigurationImpl setSessionFactories(Map<Class<?>, SessionFactory> sessionFactories) {
+    public ProcessEngineConfigurationImpl setSessionFactories(Map<Class< ? >, SessionFactory> sessionFactories) {
         this.sessionFactories = sessionFactories;
         return this;
     }
@@ -2605,10 +2714,13 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     }
 
     /**
-     * Add or replace the address of the given web-service endpoint with the given value
+     * Add or replace the address of the given web-service endpoint with the
+     * given value
      *
-     * @param endpointName The endpoint name for which a new address must be set
-     * @param address      The new address of the endpoint
+     * @param endpointName
+     *            The endpoint name for which a new address must be set
+     * @param address
+     *            The new address of the endpoint
      */
     public ProcessEngineConfiguration addWsEndpointAddress(QName endpointName, URL address) {
         this.wsOverridenEndpointAddresses.put(endpointName, address);
@@ -2618,7 +2730,9 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     /**
      * Remove the address definition of the given web-service endpoint
      *
-     * @param endpointName The endpoint name for which the address definition must be removed
+     * @param endpointName
+     *            The endpoint name for which the address definition must be
+     *            removed
      */
     public ProcessEngineConfiguration removeWsEndpointAddress(QName endpointName) {
         this.wsOverridenEndpointAddresses.remove(endpointName);
@@ -2656,7 +2770,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     public ScriptingEngines getScriptingEngines() {
         return scriptingEngines;
     }
-    
+
     @Override
     public ProcessEngineConfigurationImpl setScriptingEngines(ScriptingEngines scriptingEngines) {
         this.scriptingEngines = scriptingEngines;
@@ -2698,7 +2812,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         this.internalHistoryTaskManager = internalHistoryTaskManager;
         return this;
     }
-    
+
     public InternalTaskAssignmentManager getInternalTaskAssignmentManager() {
         return internalTaskAssignmentManager;
     }
@@ -2734,7 +2848,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         this.internalJobManager = internalJobManager;
         return this;
     }
-    
+
     public InternalJobCompatibilityManager getInternalJobCompatibilityManager() {
         return internalJobCompatibilityManager;
     }
@@ -2794,7 +2908,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         return historicProcessInstanceQueryInterceptor;
     }
 
-    public ProcessEngineConfigurationImpl setHistoricProcessInstanceQueryInterceptor(HistoricProcessInstanceQueryInterceptor historicProcessInstanceQueryInterceptor) {
+    public ProcessEngineConfigurationImpl setHistoricProcessInstanceQueryInterceptor(
+                    HistoricProcessInstanceQueryInterceptor historicProcessInstanceQueryInterceptor) {
         this.historicProcessInstanceQueryInterceptor = historicProcessInstanceQueryInterceptor;
         return this;
     }
@@ -2807,7 +2922,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         this.taskQueryInterceptor = taskQueryInterceptor;
         return this;
     }
-    
+
     public HistoricTaskQueryInterceptor getHistoricTaskQueryInterceptor() {
         return historicTaskQueryInterceptor;
     }
@@ -2897,7 +3012,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         this.listenerNotificationHelper = listenerNotificationHelper;
         return this;
     }
-    
+
     public FormHandlerHelper getFormHandlerHelper() {
         return formHandlerHelper;
     }
@@ -2950,7 +3065,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         this.customHistoryJobHandlers = customHistoryJobHandlers;
         return this;
     }
-    
+
     public List<HistoryJsonTransformer> getCustomHistoryJsonTransformers() {
         return customHistoryJsonTransformers;
     }
@@ -3521,7 +3636,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         return historicActivityInstanceEntityManager;
     }
 
-    public ProcessEngineConfigurationImpl setHistoricActivityInstanceEntityManager(HistoricActivityInstanceEntityManager historicActivityInstanceEntityManager) {
+    public ProcessEngineConfigurationImpl setHistoricActivityInstanceEntityManager(
+                    HistoricActivityInstanceEntityManager historicActivityInstanceEntityManager) {
         this.historicActivityInstanceEntityManager = historicActivityInstanceEntityManager;
         return this;
     }
@@ -3611,7 +3727,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     }
 
     public ProcessEngineConfigurationImpl setCustomAsyncRunnableExecutionExceptionHandlers(
-            List<AsyncRunnableExecutionExceptionHandler> customAsyncRunnableExecutionExceptionHandlers) {
+                    List<AsyncRunnableExecutionExceptionHandler> customAsyncRunnableExecutionExceptionHandlers) {
 
         this.customAsyncRunnableExecutionExceptionHandlers = customAsyncRunnableExecutionExceptionHandlers;
         return this;
@@ -3769,7 +3885,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         return processInstanceStateChangedCallbacks;
     }
 
-    public ProcessEngineConfigurationImpl setProcessInstanceStateChangedCallbacks(Map<String, List<RuntimeInstanceStateChangeCallback>> processInstanceStateChangedCallbacks) {
+    public ProcessEngineConfigurationImpl setProcessInstanceStateChangedCallbacks(
+                    Map<String, List<RuntimeInstanceStateChangeCallback>> processInstanceStateChangedCallbacks) {
         this.processInstanceStateChangedCallbacks = processInstanceStateChangedCallbacks;
         return this;
     }
@@ -3911,11 +4028,11 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         return this;
     }
 
-    public Set<Class<?>> getFlowable5CustomMybatisMappers() {
+    public Set<Class< ? >> getFlowable5CustomMybatisMappers() {
         return flowable5CustomMybatisMappers;
     }
 
-    public ProcessEngineConfigurationImpl setFlowable5CustomMybatisMappers(Set<Class<?>> flowable5CustomMybatisMappers) {
+    public ProcessEngineConfigurationImpl setFlowable5CustomMybatisMappers(Set<Class< ? >> flowable5CustomMybatisMappers) {
         this.flowable5CustomMybatisMappers = flowable5CustomMybatisMappers;
         return this;
     }
@@ -4141,7 +4258,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         this.jobExecutionScope = jobExecutionScope;
         return this;
     }
-    
+
     public String getHistoryJobExecutionScope() {
         return historyJobExecutionScope;
     }
@@ -4329,5 +4446,5 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         this.jobServiceConfiguration = jobServiceConfiguration;
         return this;
     }
-    
+
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/JobRetryCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/JobRetryCmd.java
@@ -56,14 +56,10 @@ public class JobRetryCmd implements Command<Object> {
 
     @Override
     public Object execute(CommandContext commandContext) {
-        JobService jobService = CommandContextUtil.getJobService(commandContext);
         TimerJobService timerJobService = CommandContextUtil.getTimerJobService(commandContext);
-        
-        JobEntity job = jobService.findJobById(jobId);
-        if (job == null) {
-            return null;
-        }
 
+        JobService jobService = CommandContextUtil.getJobService(commandContext);
+        JobEntity job = findJob(commandContext);
         ProcessEngineConfiguration processEngineConfig = CommandContextUtil.getProcessEngineConfiguration(commandContext);
 
         ExecutionEntity executionEntity = fetchExecutionEntity(commandContext, job.getExecutionId());
@@ -114,8 +110,10 @@ public class JobRetryCmd implements Command<Object> {
 
                 newJobEntity.setDuedate(durationHelper.getDateAfter());
 
-                if (job.getExceptionMessage() == null) { // is it the first exception
-                    LOGGER.debug("Applying JobRetryStrategy '{}' the first time for job {} with {} retries", failedJobRetryTimeCycleValue, job.getId(), durationHelper.getTimes());
+                if (job.getExceptionMessage() == null) { // is it the first
+                                                         // exception
+                    LOGGER.debug("Applying JobRetryStrategy '{}' the first time for job {} with {} retries", failedJobRetryTimeCycleValue, job.getId(),
+                                    durationHelper.getTimes());
 
                 } else {
                     LOGGER.debug("Decrementing retries of JobRetryStrategy '{}' for job {}", failedJobRetryTimeCycleValue, job.getId());
@@ -141,6 +139,12 @@ public class JobRetryCmd implements Command<Object> {
         }
 
         return null;
+    }
+
+    protected JobEntity findJob(CommandContext commandContext) {
+        JobService jobService = CommandContextUtil.getJobService(commandContext);
+        JobEntity job = jobService.findJobById(jobId);
+        return job == null ? null : job;
     }
 
     protected Date calculateDueDate(CommandContext commandContext, int waitTimeInSeconds, Date oldDate) {

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/jobexecutor/AsyncParallelMultiInstanceMonitorJobHandler.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/jobexecutor/AsyncParallelMultiInstanceMonitorJobHandler.java
@@ -1,0 +1,25 @@
+package org.flowable.engine.impl.jobexecutor;
+
+import org.flowable.common.engine.impl.interceptor.CommandContext;
+import org.flowable.engine.impl.persistence.entity.ExecutionEntity;
+import org.flowable.engine.impl.util.CommandContextUtil;
+import org.flowable.job.service.JobHandler;
+import org.flowable.job.service.impl.persistence.entity.JobEntity;
+import org.flowable.variable.api.delegate.VariableScope;
+
+public class AsyncParallelMultiInstanceMonitorJobHandler implements JobHandler {
+
+    public static final String TYPE = "async-parallel-multi-instance-monitor";
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+
+    @Override
+    public void execute(JobEntity job, String configuration, VariableScope variableScope, CommandContext commandContext) {
+        ExecutionEntity executionEntity = (ExecutionEntity) variableScope;
+        CommandContextUtil.getAgenda(commandContext).planMonitorParallelMultiInstanceOperation(executionEntity, executionEntity.getExecutions());
+    }
+
+}

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/jobexecutor/DefaultFailedJobCommandFactory.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/jobexecutor/DefaultFailedJobCommandFactory.java
@@ -23,7 +23,7 @@ public class DefaultFailedJobCommandFactory implements FailedJobCommandFactory {
 
     @Override
     public Command<Object> getCommand(String jobId, Throwable exception) {
-        return new JobRetryCmd(jobId, exception);
+        return new RetryOnlyParallelInstanceMonitoringJobsCmd(jobId, exception);
     }
 
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/jobexecutor/RetryOnlyParallelInstanceMonitoringJobsCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/jobexecutor/RetryOnlyParallelInstanceMonitoringJobsCmd.java
@@ -1,0 +1,39 @@
+package org.flowable.engine.impl.jobexecutor;
+
+import org.flowable.common.engine.impl.interceptor.CommandContext;
+import org.flowable.engine.impl.agenda.MonitorParallelMultiInstanceOperation;
+import org.flowable.engine.impl.cmd.JobRetryCmd;
+import org.flowable.job.service.impl.persistence.entity.JobEntity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RetryOnlyParallelInstanceMonitoringJobsCmd extends JobRetryCmd {
+
+    protected static final Logger LOGGER = LoggerFactory.getLogger(RetryOnlyParallelInstanceMonitoringJobsCmd.class);
+
+    private static final int DEFAULT_MONITOR_JOB_RETRIES_COUNT = 10;
+
+    public RetryOnlyParallelInstanceMonitoringJobsCmd(String jobId, Throwable exception) {
+        super(jobId, exception);
+    }
+
+    @Override
+    public Object execute(CommandContext commandContext) {
+        JobEntity failedJob = findJob(commandContext);
+        if (failedJob != null && failedJob.getJobHandlerType().equals(AsyncParallelMultiInstanceMonitorJobHandler.TYPE)) {
+            failedJob.setRetries(determineFailedJobRetries(failedJob));
+        }
+        return super.execute(commandContext);
+    }
+
+    private int determineFailedJobRetries(JobEntity failedJob) {
+        if (failedJob.getExceptionMessage() != null && failedJob.getExceptionMessage().equals(MonitorParallelMultiInstanceOperation.FAILING_THE_MONITOR)) {
+            return 0;
+        }
+        if (failedJob.getRetries() > 0) {
+            return failedJob.getRetries() - 1;
+        }
+        return DEFAULT_MONITOR_JOB_RETRIES_COUNT;
+    }
+
+}

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.java
@@ -37,6 +37,7 @@ import org.flowable.engine.history.HistoricActivityInstance;
 import org.flowable.engine.history.HistoricProcessInstance;
 import org.flowable.engine.impl.context.Context;
 import org.flowable.engine.impl.test.HistoryTestHelper;
+import org.flowable.engine.impl.test.JobTestHelper;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.repository.ProcessDefinition;
 import org.flowable.engine.runtime.Execution;
@@ -84,10 +85,15 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
     public void testProcessTerminate() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
 
-        long executionEntities = runtimeService.createExecutionQuery().processInstanceId(pi.getId()).count();
+        long executionEntities = runtimeService.createExecutionQuery()
+            .processInstanceId(pi.getId())
+            .count();
         assertEquals(3, executionEntities);
 
-        org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preTerminateTask").singleResult();
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .processInstanceId(pi.getId())
+            .taskDefinitionKey("preTerminateTask")
+            .singleResult();
         taskService.complete(task.getId());
 
         assertProcessEnded(pi.getId());
@@ -99,16 +105,19 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertHistoricActivitiesDeleteReason(pi, DeleteReason.TERMINATE_END_EVENT, "preNormalTerminateTask");
         assertHistoricActivitiesDeleteReason(pi, null, "preTerminateTask");
     }
-    
+
     @Deployment
     public void testTerminateExecutionListener() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
 
-        org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preTerminateTask").singleResult();
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .processInstanceId(pi.getId())
+            .taskDefinitionKey("preTerminateTask")
+            .singleResult();
         taskService.complete(task.getId());
 
         assertProcessEnded(pi.getId());
-        
+
         assertEquals(1, TerminateExecutionListener.startCalled);
         assertEquals(1, TerminateExecutionListener.endCalled);
     }
@@ -117,7 +126,10 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
     public void testProcessTerminateAll() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
 
-        org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preTerminateTask").singleResult();
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .processInstanceId(pi.getId())
+            .taskDefinitionKey("preTerminateTask")
+            .singleResult();
         taskService.complete(task.getId());
 
         assertProcessEnded(pi.getId());
@@ -135,10 +147,15 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
 
         // should terminate the process and
-        long executionEntities = runtimeService.createExecutionQuery().processInstanceId(pi.getId()).count();
+        long executionEntities = runtimeService.createExecutionQuery()
+            .processInstanceId(pi.getId())
+            .count();
         assertEquals(4, executionEntities);
 
-        org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preTerminateEnd").singleResult();
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .processInstanceId(pi.getId())
+            .taskDefinitionKey("preTerminateEnd")
+            .singleResult();
         taskService.complete(task.getId());
 
         assertProcessEnded(pi.getId());
@@ -156,10 +173,16 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
 
         // Completing the task -> terminal end event -> subprocess ends
-        org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preNormalEnd").singleResult();
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .processInstanceId(pi.getId())
+            .taskDefinitionKey("preNormalEnd")
+            .singleResult();
         taskService.complete(task.getId());
 
-        task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preTerminateEnd").singleResult();
+        task = taskService.createTaskQuery()
+            .processInstanceId(pi.getId())
+            .taskDefinitionKey("preTerminateEnd")
+            .singleResult();
         assertNotNull(task);
         taskService.complete(task.getId());
 
@@ -177,7 +200,10 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
 
         // Completing the task -> terminal end event -> all ends (terminate all)
-        org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preNormalEnd").singleResult();
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .processInstanceId(pi.getId())
+            .taskDefinitionKey("preNormalEnd")
+            .singleResult();
         taskService.complete(task.getId());
 
         assertProcessEnded(pi.getId());
@@ -190,17 +216,20 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertHistoricActivitiesDeleteReason(pi, null, "preNormalEnd");
     }
 
-    @Deployment(resources = {
-            "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateWithCallActivity.bpmn",
-            "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.subProcessNoTerminate.bpmn"
-    })
+    @Deployment(resources = { "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateWithCallActivity.bpmn",
+        "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.subProcessNoTerminate.bpmn" })
     public void testTerminateWithCallActivity() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
 
-        ProcessInstance subProcessInstance = runtimeService.createProcessInstanceQuery().superProcessInstanceId(pi.getId()).singleResult();
+        ProcessInstance subProcessInstance = runtimeService.createProcessInstanceQuery()
+            .superProcessInstanceId(pi.getId())
+            .singleResult();
         assertNotNull(subProcessInstance);
 
-        org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preTerminateEnd").singleResult();
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .processInstanceId(pi.getId())
+            .taskDefinitionKey("preTerminateEnd")
+            .singleResult();
         taskService.complete(task.getId());
 
         assertProcessEnded(pi.getId());
@@ -214,16 +243,20 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
     }
 
     @Deployment(resources = {
-            "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateWithCallActivityTerminateAll.bpmn20.xml",
-            "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.subProcessNoTerminate.bpmn" })
+        "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateWithCallActivityTerminateAll.bpmn20.xml",
+        "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.subProcessNoTerminate.bpmn" })
     public void testTerminateWithCallActivityTerminateAll() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
 
-        ProcessInstance subProcessInstance = runtimeService.createProcessInstanceQuery().superProcessInstanceId(pi.getId()).singleResult();
+        ProcessInstance subProcessInstance = runtimeService.createProcessInstanceQuery()
+            .superProcessInstanceId(pi.getId())
+            .singleResult();
         assertNotNull(subProcessInstance);
 
-        org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId())
-                .taskDefinitionKey("preTerminateEnd").singleResult();
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .processInstanceId(pi.getId())
+            .taskDefinitionKey("preTerminateEnd")
+            .singleResult();
         taskService.complete(task.getId());
 
         assertProcessEnded(pi.getId());
@@ -237,16 +270,20 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
     }
 
     @Deployment(resources = {
-            "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateInExclusiveGatewayWithCallActivity.bpmn",
-            "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.subProcessNoTerminate.bpmn"
-    })
+        "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateInExclusiveGatewayWithCallActivity.bpmn",
+        "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.subProcessNoTerminate.bpmn" })
     public void testTerminateInExclusiveGatewayWithCallActivity() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample-terminateAfterExclusiveGateway");
 
-        ProcessInstance subProcessInstance = runtimeService.createProcessInstanceQuery().superProcessInstanceId(pi.getId()).singleResult();
+        ProcessInstance subProcessInstance = runtimeService.createProcessInstanceQuery()
+            .superProcessInstanceId(pi.getId())
+            .singleResult();
         assertNotNull(subProcessInstance);
 
-        org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preTerminateEnd").singleResult();
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .processInstanceId(pi.getId())
+            .taskDefinitionKey("preTerminateEnd")
+            .singleResult();
         Map<String, Object> variables = new HashMap<>();
         variables.put("input", 1);
         taskService.complete(task.getId(), variables);
@@ -259,7 +296,10 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
     public void testTerminateInExclusiveGatewayWithMultiInstanceSubProcess() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample-terminateAfterExclusiveGateway");
 
-        org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preTerminateEnd").singleResult();
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .processInstanceId(pi.getId())
+            .taskDefinitionKey("preTerminateEnd")
+            .singleResult();
         Map<String, Object> variables = new HashMap<>();
         variables.put("input", 1);
         taskService.complete(task.getId(), variables);
@@ -279,51 +319,70 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample-terminateAfterExclusiveGateway");
 
         // Completing the task once should only destroy ONE multi instance
-        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("task").list();
+        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery()
+            .processInstanceId(pi.getId())
+            .taskDefinitionKey("task")
+            .list();
         assertEquals(5, tasks.size());
 
         for (int i = 0; i < 5; i++) {
-            taskService.complete(tasks.get(i).getId());
-            assertTrue(runtimeService.createProcessInstanceQuery().processInstanceId(pi.getId()).count() > 0);
+            taskService.complete(tasks.get(i)
+                .getId());
+            assertTrue(runtimeService.createProcessInstanceQuery()
+                .processInstanceId(pi.getId())
+                .count() > 0);
         }
 
         // Other task will now finish the process instance
-        org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preTerminateEnd").singleResult();
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .processInstanceId(pi.getId())
+            .taskDefinitionKey("preTerminateEnd")
+            .singleResult();
         Map<String, Object> variables = new HashMap<>();
         variables.put("input", 1);
         taskService.complete(task.getId(), variables);
 
-        assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(pi.getId()).count());
+        assertEquals(0, runtimeService.createProcessInstanceQuery()
+            .processInstanceId(pi.getId())
+            .count());
         assertHistoricProcessInstanceDetails(pi);
     }
-    
+
     @Deployment
     public void testTerminateParallelGateway() throws Exception {
         final List<FlowableEvent> events = new ArrayList<>();
-        processEngine.getRuntimeService().addEventListener(new AbstractFlowableEngineEventListener() {
-            
-            @Override
-            public void onEvent(FlowableEvent event) {
-                if (FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT == event.getType() || FlowableEngineEventType.TASK_CREATED == event.getType()) {
-                    events.add(event);
-                }
-                
-                if (FlowableEngineEventType.ACTIVITY_CANCELLED == event.getType()) {
-                    List<org.flowable.task.api.Task> list = Context.getProcessEngineConfiguration().getTaskService().createTaskQuery().list();
-                    if (!list.isEmpty()) {
+        processEngine.getRuntimeService()
+            .addEventListener(new AbstractFlowableEngineEventListener() {
+
+                @Override
+                public void onEvent(FlowableEvent event) {
+                    if (FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT == event.getType()
+                        || FlowableEngineEventType.TASK_CREATED == event.getType()) {
                         events.add(event);
                     }
+
+                    if (FlowableEngineEventType.ACTIVITY_CANCELLED == event.getType()) {
+                        List<org.flowable.task.api.Task> list = Context.getProcessEngineConfiguration()
+                            .getTaskService()
+                            .createTaskQuery()
+                            .list();
+                        if (!list.isEmpty()) {
+                            events.add(event);
+                        }
+                    }
                 }
-            }
-            
-            @Override
-            public boolean isFailOnException() {
-                return false;
-            }
-        });
+
+                @Override
+                public boolean isFailOnException() {
+                    return false;
+                }
+            });
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateParallel");
-        
-        HistoricTaskInstance historicTask = historyService.createHistoricTaskInstanceQuery().processInstanceId(pi.getId()).taskDefinitionKey("task").singleResult();
+
+        HistoricTaskInstance historicTask = historyService.createHistoricTaskInstanceQuery()
+            .processInstanceId(pi.getId())
+            .taskDefinitionKey("task")
+            .singleResult();
         assertNull(historicTask);
     }
 
@@ -332,10 +391,15 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
 
         // should terminate the subprocess and continue the parent
-        long executionEntities = runtimeService.createExecutionQuery().processInstanceId(pi.getId()).count();
+        long executionEntities = runtimeService.createExecutionQuery()
+            .processInstanceId(pi.getId())
+            .count();
         assertTrue(executionEntities > 0);
 
-        org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preNormalEnd").singleResult();
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .processInstanceId(pi.getId())
+            .taskDefinitionKey("preNormalEnd")
+            .singleResult();
         taskService.complete(task.getId());
 
         assertProcessEnded(pi.getId());
@@ -357,14 +421,18 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
 
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventWithBoundary");
 
-        assertEquals(3, taskService.createTaskQuery().processInstanceId(pi.getId()).count());
+        assertEquals(3, taskService.createTaskQuery()
+            .processInstanceId(pi.getId())
+            .count());
 
         // Set clock time to '1 hour and 5 seconds' ahead to fire timer
-        processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + ((60 * 60 * 1000) + 5000)));
+        processEngineConfiguration.getClock()
+            .setCurrentTime(new Date(startTime.getTime() + ((60 * 60 * 1000) + 5000)));
         waitForJobExecutorToProcessAllJobs(5000L, 25L);
 
         // timer has fired
-        assertEquals(0L, managementService.createJobQuery().count());
+        assertEquals(0L, managementService.createJobQuery()
+            .count());
 
         assertProcessEnded(pi.getId());
 
@@ -376,25 +444,37 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
 
         pi = runtimeService.startProcessInstanceByKey("terminateEndEventWithBoundary");
 
-        assertEquals(3, taskService.createTaskQuery().processInstanceId(pi.getId()).count());
+        assertEquals(3, taskService.createTaskQuery()
+            .processInstanceId(pi.getId())
+            .count());
 
         // a job for boundary event timer should exist
-        assertEquals(1L, managementService.createTimerJobQuery().count());
+        assertEquals(1L, managementService.createTimerJobQuery()
+            .count());
 
         // Complete sub process task that leads to a terminate end event
-        org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preTermInnerTask").singleResult();
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .processInstanceId(pi.getId())
+            .taskDefinitionKey("preTermInnerTask")
+            .singleResult();
         taskService.complete(task.getId());
 
         // 'preEndInnerTask' task in subprocess should have been terminated, only outerTask should exist
-        assertEquals(1, taskService.createTaskQuery().processInstanceId(pi.getId()).count());
+        assertEquals(1, taskService.createTaskQuery()
+            .processInstanceId(pi.getId())
+            .count());
 
         // job for boundary event timer should have been removed
-        assertEquals(0L, managementService.createTimerJobQuery().count());
+        assertEquals(0L, managementService.createTimerJobQuery()
+            .count());
 
         // complete outerTask
-        task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("outerTask").singleResult();
+        task = taskService.createTaskQuery()
+            .processInstanceId(pi.getId())
+            .taskDefinitionKey("outerTask")
+            .singleResult();
         taskService.complete(task.getId());
-        
+
         assertProcessEnded(pi.getId());
         assertHistoricProcessInstanceDetails(pi);
     }
@@ -405,10 +485,15 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
 
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventWithBoundary");
 
-        assertEquals(3, taskService.createTaskQuery().processInstanceId(pi.getId()).count());
+        assertEquals(3, taskService.createTaskQuery()
+            .processInstanceId(pi.getId())
+            .count());
 
         // Complete sub process task that leads to a terminate end event
-        org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preTermInnerTask").singleResult();
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .processInstanceId(pi.getId())
+            .taskDefinitionKey("preTermInnerTask")
+            .singleResult();
         taskService.complete(task.getId());
 
         assertProcessEnded(pi.getId());
@@ -419,10 +504,14 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
     public void testTerminateInSubProcessConcurrent() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
 
-        long executionEntities = runtimeService.createExecutionQuery().count();
+        long executionEntities = runtimeService.createExecutionQuery()
+            .count();
         assertTrue(executionEntities > 0);
 
-        org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preNormalEnd").singleResult();
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .processInstanceId(pi.getId())
+            .taskDefinitionKey("preNormalEnd")
+            .singleResult();
         taskService.complete(task.getId());
 
         assertProcessEnded(pi.getId());
@@ -440,10 +529,15 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
     public void testTerminateInSubProcessConcurrentTerminateAll2() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
 
-        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(pi.getId()).list();
+        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery()
+            .processInstanceId(pi.getId())
+            .list();
         assertEquals(2, tasks.size());
 
-        org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskName("User Task").singleResult();
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .processInstanceId(pi.getId())
+            .taskName("User Task")
+            .singleResult();
         taskService.complete(task.getId());
 
         assertProcessEnded(pi.getId());
@@ -454,19 +548,28 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
     public void testTerminateInSubProcessConcurrentMultiInstance() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
 
-        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(pi.getId()).list();
-        assertEquals(4, tasks.size()); // 3 user tasks in MI +1 (preNormalEnd) = 4 (2 were killed because it went directly to the terminate end event)
+        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery()
+            .processInstanceId(pi.getId())
+            .list();
+        assertEquals(4, tasks.size()); // 3 user tasks in MI +1 (preNormalEnd) = 4 (2 were killed because it went directly to the terminate
+                                       // end event)
 
-        long executionEntitiesCount = runtimeService.createExecutionQuery().count();
+        long executionEntitiesCount = runtimeService.createExecutionQuery()
+            .count();
         assertEquals(9, executionEntitiesCount);
 
-        org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preNormalEnd").singleResult();
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .processInstanceId(pi.getId())
+            .taskDefinitionKey("preNormalEnd")
+            .singleResult();
         taskService.complete(task.getId());
 
-        executionEntitiesCount = runtimeService.createExecutionQuery().count();
+        executionEntitiesCount = runtimeService.createExecutionQuery()
+            .count();
         assertEquals(8, executionEntitiesCount);
 
-        tasks = taskService.createTaskQuery().list();
+        tasks = taskService.createTaskQuery()
+            .list();
         for (org.flowable.task.api.Task t : tasks) {
             taskService.complete(t.getId());
         }
@@ -479,10 +582,16 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
     public void testTerminateInSubProcessConcurrentMultiInstance2() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
 
-        org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preNormalEnd").singleResult();
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .processInstanceId(pi.getId())
+            .taskDefinitionKey("preNormalEnd")
+            .singleResult();
         taskService.complete(task.getId());
 
-        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(pi.getId()).taskName("User Task").list();
+        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery()
+            .processInstanceId(pi.getId())
+            .taskName("User Task")
+            .list();
         assertEquals(3, tasks.size());
 
         for (org.flowable.task.api.Task t : tasks) {
@@ -500,30 +609,42 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertHistoricProcessInstanceDetails(pi);
     }
 
-    @Deployment(resources = { "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateInCallActivityConcurrentCallActivity.bpmn",
-            "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateAfterUserTask.bpmn",
-            "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
+    @Deployment(resources = {
+        "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateInCallActivityConcurrentCallActivity.bpmn",
+        "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateAfterUserTask.bpmn",
+        "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testTerminateInCallActivityConcurrentCallActivity() throws Exception {
         // GIVEN - process instance starts and creates 2 subProcessInstances (with 2 user tasks - preTerminate and my task)
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventInCallActivityConcurrentCallActivity");
-        assertThat(runtimeService.createProcessInstanceQuery().superProcessInstanceId(pi.getId()).list().size(), is(2));
+        assertThat(runtimeService.createProcessInstanceQuery()
+            .superProcessInstanceId(pi.getId())
+            .list()
+            .size(), is(2));
 
         // WHEN - complete -> terminate end event
-        org.flowable.task.api.Task preTerminate = taskService.createTaskQuery().taskName("preTerminate").singleResult();
+        org.flowable.task.api.Task preTerminate = taskService.createTaskQuery()
+            .taskName("preTerminate")
+            .singleResult();
         taskService.complete(preTerminate.getId());
 
         // THEN - super process is not finished together
-        assertEquals(1, runtimeService.createProcessInstanceQuery().processInstanceId(pi.getId()).count());
+        assertEquals(1, runtimeService.createProcessInstanceQuery()
+            .processInstanceId(pi.getId())
+            .count());
     }
 
     @Deployment
     public void testTerminateInSubProcessMultiInstance() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
 
-        long executionEntities = runtimeService.createExecutionQuery().count();
+        long executionEntities = runtimeService.createExecutionQuery()
+            .count();
         assertTrue(executionEntities > 0);
 
-        org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preNormalEnd").singleResult();
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .processInstanceId(pi.getId())
+            .taskDefinitionKey("preNormalEnd")
+            .singleResult();
         taskService.complete(task.getId());
 
         assertProcessEnded(pi.getId());
@@ -536,13 +657,17 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         // Starting multi instance with 5 instances; terminating 2, finishing 3
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
 
-        long remainingExecutions = runtimeService.createExecutionQuery().count();
+        long remainingExecutions = runtimeService.createExecutionQuery()
+            .count();
         assertTrue(remainingExecutions > 0);
 
         // three finished
         assertEquals(3, serviceTaskInvokedCount2);
 
-        org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preNormalEnd").singleResult();
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .processInstanceId(pi.getId())
+            .taskDefinitionKey("preNormalEnd")
+            .singleResult();
         taskService.complete(task.getId());
 
         // last task remaining
@@ -557,63 +682,69 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertHistoricProcessInstanceDetails(pi);
     }
 
-    @Deployment(resources = {
-            "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateInCallActivity.bpmn",
-            "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.subProcessTerminate.bpmn"
-    })
+    @Deployment(resources = { "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateInCallActivity.bpmn",
+        "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.subProcessTerminate.bpmn" })
     public void testTerminateInCallActivity() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
 
         // should terminate the called process and continue the parent
-        long executionEntities = runtimeService.createExecutionQuery().count();
+        long executionEntities = runtimeService.createExecutionQuery()
+            .count();
         assertTrue(executionEntities > 0);
 
-        org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preNormalEnd").singleResult();
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .processInstanceId(pi.getId())
+            .taskDefinitionKey("preNormalEnd")
+            .singleResult();
         taskService.complete(task.getId());
 
         assertProcessEnded(pi.getId());
         assertHistoricProcessInstanceDetails(pi);
     }
 
-    @Deployment(resources = {
-            "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateInCallActivityMulitInstance.bpmn",
-            "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.subProcessTerminate.bpmn"
-    })
+    @Deployment(resources = { "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateInCallActivityMulitInstance.bpmn",
+        "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.subProcessTerminate.bpmn" })
     public void testTerminateInCallActivityMultiInstance() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
 
         // should terminate the called process and continue the parent
-        long executionEntities = runtimeService.createExecutionQuery().count();
+        long executionEntities = runtimeService.createExecutionQuery()
+            .count();
         assertTrue(executionEntities > 0);
 
-        org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preNormalEnd").singleResult();
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .processInstanceId(pi.getId())
+            .taskDefinitionKey("preNormalEnd")
+            .singleResult();
         taskService.complete(task.getId());
 
+        JobTestHelper.waitForJobExecutorToProcessAllJobs(processEngineConfiguration, managementService, 1000L, 500L);
         assertProcessEnded(pi.getId());
         assertHistoricProcessInstanceDetails(pi);
     }
 
-    @Deployment(resources = {
-            "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateInCallActivityMulitInstance.bpmn",
-            "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.subProcessTerminateTerminateAll.bpmn20.xml" })
+    @Deployment(resources = { "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateInCallActivityMulitInstance.bpmn",
+        "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.subProcessTerminateTerminateAll.bpmn20.xml" })
     public void testTerminateInCallActivityMultiInstanceTerminateAll() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
         assertProcessEnded(pi.getId());
         assertHistoricProcessInstanceDetails(pi);
     }
 
-    @Deployment(resources = {
-            "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateInCallActivityConcurrent.bpmn",
-            "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.subProcessConcurrentTerminate.bpmn"
-    })
+    @Deployment(resources = { "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateInCallActivityConcurrent.bpmn",
+        "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.subProcessConcurrentTerminate.bpmn" })
     public void testTerminateInCallActivityConcurrent() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
 
         // should terminate the called process and continue the parent
-        long executionEntities = runtimeService.createExecutionQuery().count();
+        long executionEntities = runtimeService.createExecutionQuery()
+            .count();
         assertTrue(executionEntities > 0);
 
-        org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preNormalEnd").singleResult();
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .processInstanceId(pi.getId())
+            .taskDefinitionKey("preNormalEnd")
+            .singleResult();
         taskService.complete(task.getId());
 
         assertProcessEnded(pi.getId());
@@ -624,10 +755,14 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
     public void testMiCallActivityParallel() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testMiCallActivity");
 
-        List<org.flowable.task.api.Task> aTasks = taskService.createTaskQuery().taskName("A").list();
+        List<org.flowable.task.api.Task> aTasks = taskService.createTaskQuery()
+            .taskName("A")
+            .list();
         assertEquals(5, aTasks.size());
 
-        List<org.flowable.task.api.Task> bTasks = taskService.createTaskQuery().taskName("B").list();
+        List<org.flowable.task.api.Task> bTasks = taskService.createTaskQuery()
+            .taskName("B")
+            .list();
         assertEquals(5, bTasks.size());
 
         // Completing B should terminate one instance (it goes to a terminate end event)
@@ -637,17 +772,22 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
             taskService.complete(bTask.getId());
             bTasksCompleted++;
 
-            aTasks = taskService.createTaskQuery().taskName("A").list();
+            aTasks = taskService.createTaskQuery()
+                .taskName("A")
+                .list();
             assertEquals(5 - bTasksCompleted, aTasks.size());
         }
 
-        org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        JobTestHelper.waitForJobExecutorToProcessAllJobs(processEngineConfiguration, managementService, 1000L, 500L);
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .singleResult();
         assertEquals("After call activity", task.getName());
 
         taskService.complete(task.getId());
-        
+
         waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
-        
+
         assertProcessEnded(processInstance.getId());
         assertHistoricProcessInstanceDetails(processInstance);
     }
@@ -656,42 +796,52 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
     public void testMiCallActivitySequential() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testMiCallActivity");
 
-        List<org.flowable.task.api.Task> aTasks = taskService.createTaskQuery().taskName("A").list();
+        List<org.flowable.task.api.Task> aTasks = taskService.createTaskQuery()
+            .taskName("A")
+            .list();
         assertEquals(1, aTasks.size());
 
-        List<org.flowable.task.api.Task> bTasks = taskService.createTaskQuery().taskName("B").list();
+        List<org.flowable.task.api.Task> bTasks = taskService.createTaskQuery()
+            .taskName("B")
+            .list();
         assertEquals(1, bTasks.size());
 
         // Completing B should terminate one instance (it goes to a terminate end event)
         for (int i = 0; i < 9; i++) {
 
-            org.flowable.task.api.Task bTask = taskService.createTaskQuery().taskName("B").singleResult();
+            org.flowable.task.api.Task bTask = taskService.createTaskQuery()
+                .taskName("B")
+                .singleResult();
 
             taskService.complete(bTask.getId());
 
             if (i != 8) {
-                aTasks = taskService.createTaskQuery().taskName("A").list();
+                aTasks = taskService.createTaskQuery()
+                    .taskName("A")
+                    .list();
                 assertEquals("Expected task for i=" + i, 1, aTasks.size());
 
-                bTasks = taskService.createTaskQuery().taskName("B").list();
+                bTasks = taskService.createTaskQuery()
+                    .taskName("B")
+                    .list();
                 assertEquals("Expected task for i=" + i, 1, bTasks.size());
             }
         }
 
-        org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .singleResult();
         assertEquals("After call activity", task.getName());
 
         taskService.complete(task.getId());
-        
+
         assertProcessEnded(processInstance.getId());
         assertHistoricProcessInstanceDetails(processInstance);
 
     }
 
-    @Deployment(resources = {
-            "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateInCallActivityConcurrent.bpmn",
-            "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.subProcessConcurrentTerminateTerminateAll.bpmn20.xml"
-    })
+    @Deployment(resources = { "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateInCallActivityConcurrent.bpmn",
+        "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.subProcessConcurrentTerminateTerminateAll.bpmn20.xml" })
     public void testTerminateInCallActivityConcurrentTerminateAll() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
         assertProcessEnded(pi.getId());
@@ -699,26 +849,30 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
     }
 
     @Deployment(resources = {
-            "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateInCallActivityConcurrentMulitInstance.bpmn",
-            "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.subProcessConcurrentTerminate.bpmn"
-    })
+        "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateInCallActivityConcurrentMulitInstance.bpmn",
+        "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.subProcessConcurrentTerminate.bpmn" })
     public void testTerminateInCallActivityConcurrentMulitInstance() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
 
         // should terminate the called process and continue the parent
-        long executionEntities = runtimeService.createExecutionQuery().count();
+        long executionEntities = runtimeService.createExecutionQuery()
+            .count();
         assertTrue(executionEntities > 0);
 
-        org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preNormalEnd").singleResult();
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .processInstanceId(pi.getId())
+            .taskDefinitionKey("preNormalEnd")
+            .singleResult();
         taskService.complete(task.getId());
 
+        JobTestHelper.waitForJobExecutorToProcessAllJobs(processEngineConfiguration, managementService, 1000L, 500L);
         assertProcessEnded(pi.getId());
         assertHistoricProcessInstanceDetails(pi);
     }
 
     @Deployment(resources = {
-            "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateInCallActivityConcurrentMulitInstance.bpmn",
-            "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.subProcessConcurrentTerminateTerminateAll.bpmn20.xml" })
+        "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateInCallActivityConcurrentMulitInstance.bpmn",
+        "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.subProcessConcurrentTerminateTerminateAll.bpmn20.xml" })
     public void testTerminateInCallActivityConcurrentMulitInstanceTerminateALl() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
         assertProcessEnded(pi.getId());
@@ -729,41 +883,71 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
     public void testTerminateNestedSubprocesses() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("TestTerminateNestedSubprocesses");
 
-        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).orderByTaskName().asc().list();
-        assertEquals("A", tasks.get(0).getName());
-        assertEquals("B", tasks.get(1).getName());
-        assertEquals("D", tasks.get(2).getName());
-        assertEquals("E", tasks.get(3).getName());
-        assertEquals("F", tasks.get(4).getName());
+        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .orderByTaskName()
+            .asc()
+            .list();
+        assertEquals("A", tasks.get(0)
+            .getName());
+        assertEquals("B", tasks.get(1)
+            .getName());
+        assertEquals("D", tasks.get(2)
+            .getName());
+        assertEquals("E", tasks.get(3)
+            .getName());
+        assertEquals("F", tasks.get(4)
+            .getName());
 
         // Completing E should finish the lower subprocess and make 'H' active
-        taskService.complete(tasks.get(3).getId());
-        org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("H").singleResult();
+        taskService.complete(tasks.get(3)
+            .getId());
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .taskName("H")
+            .singleResult();
         assertNotNull(task);
 
         // Completing A should make C active
-        taskService.complete(tasks.get(0).getId());
-        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("C").singleResult();
+        taskService.complete(tasks.get(0)
+            .getId());
+        task = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .taskName("C")
+            .singleResult();
         assertNotNull(task);
 
         // Completing C should make I active
         taskService.complete(task.getId());
-        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("I").singleResult();
+        task = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .taskName("I")
+            .singleResult();
         assertNotNull(task);
 
         // Completing I and B should make G active
         taskService.complete(task.getId());
-        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("G").singleResult();
+        task = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .taskName("G")
+            .singleResult();
         assertNull(task);
-        taskService.complete(tasks.get(1).getId());
-        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("G").singleResult();
+        taskService.complete(tasks.get(1)
+            .getId());
+        task = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .taskName("G")
+            .singleResult();
         assertNotNull(task);
     }
 
     @Deployment
     public void testTerminateNestedSubprocessesTerminateAll1() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("TestTerminateNestedSubprocesses");
-        org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("E").singleResult();
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .taskName("E")
+            .singleResult();
 
         // Completing E leads to a terminate end event with terminate all set to true
         taskService.complete(task.getId());
@@ -774,11 +958,17 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
     @Deployment
     public void testTerminateNestedSubprocessesTerminateAll2() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("TestTerminateNestedSubprocesses");
-        org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("A").singleResult();
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .taskName("A")
+            .singleResult();
 
         // Completing A and C leads to a terminate end event with terminate all set to true
         taskService.complete(task.getId());
-        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("C").singleResult();
+        task = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .taskName("C")
+            .singleResult();
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -788,10 +978,16 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
     public void testTerminateNestedMiSubprocesses() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("TestTerminateNestedMiSubprocesses");
 
-        taskService.complete(taskService.createTaskQuery().taskName("A").singleResult().getId());
+        taskService.complete(taskService.createTaskQuery()
+            .taskName("A")
+            .singleResult()
+            .getId());
 
         // Should have 7 tasks C active
-        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("C").list();
+        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .taskName("C")
+            .list();
         assertEquals(7, tasks.size());
 
         // Completing these should lead to task I being active
@@ -799,18 +995,27 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
             taskService.complete(task.getId());
         }
 
-        org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("I").singleResult();
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .taskName("I")
+            .singleResult();
         assertNotNull(task);
 
         // Should have 3 instances of E active
-        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("E").list();
+        tasks = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .taskName("E")
+            .list();
         assertEquals(3, tasks.size());
 
         // Completing these should make H active
         for (org.flowable.task.api.Task t : tasks) {
             taskService.complete(t.getId());
         }
-        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("H").singleResult();
+        task = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .taskName("H")
+            .singleResult();
         assertNotNull(task);
     }
 
@@ -818,37 +1023,66 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
     public void testTerminateNestedMiSubprocessesSequential() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("TestTerminateNestedMiSubprocesses");
 
-        taskService.complete(taskService.createTaskQuery().taskName("A").singleResult().getId());
+        taskService.complete(taskService.createTaskQuery()
+            .taskName("A")
+            .singleResult()
+            .getId());
 
         // Should have 7 tasks C active after each other
         for (int i = 0; i < 7; i++) {
-            org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("C").singleResult();
+            org.flowable.task.api.Task task = taskService.createTaskQuery()
+                .processInstanceId(processInstance.getId())
+                .taskName("C")
+                .singleResult();
             assertNotNull("Task was null for i = " + i, task);
             taskService.complete(task.getId());
         }
 
         // I should be active now
-        assertNotNull(taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("I").singleResult());
+        assertNotNull(taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .taskName("I")
+            .singleResult());
 
         // Should have 3 instances of E active after each other
         for (int i = 0; i < 3; i++) {
-            assertEquals(1, taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("D").count());
-            assertEquals(1, taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("F").count());
+            assertEquals(1, taskService.createTaskQuery()
+                .processInstanceId(processInstance.getId())
+                .taskName("D")
+                .count());
+            assertEquals(1, taskService.createTaskQuery()
+                .processInstanceId(processInstance.getId())
+                .taskName("F")
+                .count());
 
             // Completing F should not finish the subprocess
-            taskService.complete(taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("F").singleResult().getId());
+            taskService.complete(taskService.createTaskQuery()
+                .processInstanceId(processInstance.getId())
+                .taskName("F")
+                .singleResult()
+                .getId());
 
-            org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("E").singleResult();
+            org.flowable.task.api.Task task = taskService.createTaskQuery()
+                .processInstanceId(processInstance.getId())
+                .taskName("E")
+                .singleResult();
             taskService.complete(task.getId());
         }
 
-        assertNotNull(taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("H").singleResult());
+        assertNotNull(taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .taskName("H")
+            .singleResult());
     }
 
     @Deployment
     public void testTerminateNestedMiSubprocessesTerminateAll1() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("TestTerminateNestedMiSubprocesses");
-        org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("E").list().get(0);
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .taskName("E")
+            .list()
+            .get(0);
         taskService.complete(task.getId());
         assertProcessEnded(processInstance.getId());
         assertHistoricProcessInstanceDetails(processInstance);
@@ -857,8 +1091,15 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
     @Deployment
     public void testTerminateNestedMiSubprocessesTerminateAll2() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("TestTerminateNestedMiSubprocesses");
-        taskService.complete(taskService.createTaskQuery().taskName("A").singleResult().getId());
-        org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("C").list().get(0);
+        taskService.complete(taskService.createTaskQuery()
+            .taskName("A")
+            .singleResult()
+            .getId());
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .taskName("C")
+            .list()
+            .get(0);
         taskService.complete(task.getId());
         assertProcessEnded(processInstance.getId());
         assertHistoricProcessInstanceDetails(processInstance);
@@ -867,7 +1108,11 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
     @Deployment
     public void testTerminateNestedMiSubprocessesTerminateAll3() { // Same as 1, but sequential Multi-Instance
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("TestTerminateNestedMiSubprocesses");
-        org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("E").list().get(0);
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .taskName("E")
+            .list()
+            .get(0);
         taskService.complete(task.getId());
         assertProcessEnded(processInstance.getId());
         assertHistoricProcessInstanceDetails(processInstance);
@@ -876,8 +1121,15 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
     @Deployment
     public void testTerminateNestedMiSubprocessesTerminateAll4() { // Same as 2, but sequential Multi-Instance
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("TestTerminateNestedMiSubprocesses");
-        taskService.complete(taskService.createTaskQuery().taskName("A").singleResult().getId());
-        org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("C").list().get(0);
+        taskService.complete(taskService.createTaskQuery()
+            .taskName("A")
+            .singleResult()
+            .getId());
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .taskName("C")
+            .list()
+            .get(0);
         taskService.complete(task.getId());
         assertProcessEnded(processInstance.getId());
         assertHistoricProcessInstanceDetails(processInstance);
@@ -889,27 +1141,34 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
 
         // Verify the tasks
         List<org.flowable.task.api.Task> tasks = assertTaskNames(processInstance,
-                Arrays.asList("B", "B", "B", "B", "Before A", "Before A", "Before A", "Before A", "Before B", "Before C"));
+            Arrays.asList("B", "B", "B", "B", "Before A", "Before A", "Before A", "Before A", "Before B", "Before C"));
 
         // Completing 'before c'
-        taskService.complete(tasks.get(9).getId());
+        taskService.complete(tasks.get(9)
+            .getId());
+        JobTestHelper.waitForJobExecutorToProcessAllJobs(processEngineConfiguration, managementService, 1000L, 500L);
         tasks = assertTaskNames(processInstance,
-                Arrays.asList("After C", "B", "B", "B", "B", "Before A", "Before A", "Before A", "Before A", "Before B"));
+            Arrays.asList("After C", "B", "B", "B", "B", "Before A", "Before A", "Before A", "Before A", "Before B"));
 
         // Completing 'before A' of one instance
-        org.flowable.task.api.Task task = taskService.createTaskQuery().taskName("task_subprocess_1").singleResult();
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .taskName("task_subprocess_1")
+            .singleResult();
         assertNull(task);
-        taskService.complete(tasks.get(5).getId());
+        taskService.complete(tasks.get(5)
+            .getId());
 
         // Multi instance call activity is sequential, so expecting 5 more times the same task
         for (int i = 0; i < 6; i++) {
-            task = taskService.createTaskQuery().taskName("subprocess1_task").singleResult();
+            task = taskService.createTaskQuery()
+                .taskName("subprocess1_task")
+                .singleResult();
             assertNotNull("Task is null for index " + i, task);
             taskService.complete(task.getId());
         }
 
         tasks = assertTaskNames(processInstance,
-                Arrays.asList("After A", "After C", "B", "B", "B", "B", "Before A", "Before A", "Before A", "Before B"));
+            Arrays.asList("After A", "After C", "B", "B", "B", "B", "Before A", "Before A", "Before A", "Before B"));
 
     }
 
@@ -919,27 +1178,32 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
 
         // Verify the tasks
         List<org.flowable.task.api.Task> tasks = assertTaskNames(processInstance,
-                Arrays.asList("B", "B", "B", "B", "Before A", "Before A", "Before A", "Before A", "Before B", "Before C"));
+            Arrays.asList("B", "B", "B", "B", "Before A", "Before A", "Before A", "Before A", "Before B", "Before C"));
 
         // Completing 'Before B' should lead to process instance termination
-        taskService.complete(tasks.get(8).getId());
+        taskService.complete(tasks.get(8)
+            .getId());
         assertProcessEnded(processInstance.getId());
         assertHistoricProcessInstanceDetails(processInstance);
 
         // Completing 'Before C' too
         processInstance = runtimeService.startProcessInstanceByKey("TestNestedCallActivities");
         tasks = assertTaskNames(processInstance,
-                Arrays.asList("B", "B", "B", "B", "Before A", "Before A", "Before A", "Before A", "Before B", "Before C"));
-        taskService.complete(tasks.get(9).getId());
+            Arrays.asList("B", "B", "B", "B", "Before A", "Before A", "Before A", "Before A", "Before B", "Before C"));
+        taskService.complete(tasks.get(9)
+            .getId());
         assertProcessEnded(processInstance.getId());
         assertHistoricProcessInstanceDetails(processInstance);
 
         // Now the tricky one. 'Before A' leads to 'callActivity A', which calls subprocess02 which terminates
         processInstance = runtimeService.startProcessInstanceByKey("TestNestedCallActivities");
         tasks = assertTaskNames(processInstance,
-                Arrays.asList("B", "B", "B", "B", "Before A", "Before A", "Before A", "Before A", "Before B", "Before C"));
-        taskService.complete(tasks.get(5).getId());
-        org.flowable.task.api.Task task = taskService.createTaskQuery().taskName("subprocess1_task").singleResult();
+            Arrays.asList("B", "B", "B", "B", "Before A", "Before A", "Before A", "Before A", "Before B", "Before C"));
+        taskService.complete(tasks.get(5)
+            .getId());
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .taskName("subprocess1_task")
+            .singleResult();
         assertNotNull(task);
         taskService.complete(task.getId());
         assertProcessEnded(processInstance.getId());
@@ -948,29 +1212,45 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
     }
 
     private List<org.flowable.task.api.Task> assertTaskNames(ProcessInstance processInstance, List<String> taskNames) {
-        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).orderByTaskName().asc().list();
+        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .orderByTaskName()
+            .asc()
+            .list();
         for (int i = 0; i < taskNames.size(); i++) {
-            assertEquals("Task name at index " + i + " does not match", taskNames.get(i), tasks.get(i).getName());
+            assertEquals("Task name at index " + i + " does not match", taskNames.get(i), tasks.get(i)
+                .getName());
         }
         return tasks;
     }
 
     public void testParseTerminateEndEventDefinitionWithExtensions() {
-        org.flowable.engine.repository.Deployment deployment = repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.parseExtensionElements.bpmn20.xml").deploy();
-        ProcessDefinition processDefinitionQuery = repositoryService.createProcessDefinitionQuery().deploymentId(deployment.getId()).singleResult();
+        org.flowable.engine.repository.Deployment deployment = repositoryService.createDeployment()
+            .addClasspathResource("org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.parseExtensionElements.bpmn20.xml")
+            .deploy();
+        ProcessDefinition processDefinitionQuery = repositoryService.createProcessDefinitionQuery()
+            .deploymentId(deployment.getId())
+            .singleResult();
         BpmnModel bpmnModel = this.processEngineConfiguration.getProcessDefinitionCache()
-                .get(processDefinitionQuery.getId()).getBpmnModel();
+            .get(processDefinitionQuery.getId())
+            .getBpmnModel();
 
-        Map<String, List<ExtensionElement>> extensionElements = bpmnModel.getProcesses().get(0)
-                .findFlowElementsOfType(EndEvent.class).get(0).getExtensionElements();
+        Map<String, List<ExtensionElement>> extensionElements = bpmnModel.getProcesses()
+            .get(0)
+            .findFlowElementsOfType(EndEvent.class)
+            .get(0)
+            .getExtensionElements();
         assertThat(extensionElements.size(), is(1));
         List<ExtensionElement> strangeProperties = extensionElements.get("strangeProperty");
         assertThat(strangeProperties.size(), is(1));
         ExtensionElement strangeProperty = strangeProperties.get(0);
         assertThat(strangeProperty.getNamespace(), is("http://activiti.org/bpmn"));
         assertThat(strangeProperty.getElementText(), is("value"));
-        assertThat(strangeProperty.getAttributes().size(), is(1));
-        ExtensionAttribute id = strangeProperty.getAttributes().get("id").get(0);
+        assertThat(strangeProperty.getAttributes()
+            .size(), is(1));
+        ExtensionAttribute id = strangeProperty.getAttributes()
+            .get("id")
+            .get(0);
         assertThat(id.getName(), is("id"));
         assertThat(id.getValue(), is("strangeId"));
 
@@ -987,22 +1267,23 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         String processInstanceId = processInstance.getId();
         assertNotNull(processInstance);
         while (processInstance != null) {
-            List<Execution> executionList = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
+            List<Execution> executionList = runtimeService.createExecutionQuery()
+                .processInstanceId(processInstance.getId())
+                .list();
             String activityId = "";
             for (Execution execution : executionList) {
                 activityId = execution.getActivityId();
-                if (activityId == null
-                        || activityId.equalsIgnoreCase("quality_control_passed_gateway")
-                        || activityId.equalsIgnoreCase("parallelgateway1")
-                        || activityId.equalsIgnoreCase("catch_bad_pixel_signal")
-                        || activityId.equalsIgnoreCase("throw_bad_pixel_signal")
-                        || activityId.equalsIgnoreCase("has_bad_pixel_pattern")
-                        || activityId.equalsIgnoreCase("")) {
+                if (activityId == null || activityId.equalsIgnoreCase("quality_control_passed_gateway")
+                    || activityId.equalsIgnoreCase("parallelgateway1") || activityId.equalsIgnoreCase("catch_bad_pixel_signal")
+                    || activityId.equalsIgnoreCase("throw_bad_pixel_signal") || activityId.equalsIgnoreCase("has_bad_pixel_pattern")
+                    || activityId.equalsIgnoreCase("")) {
                     continue;
                 }
                 runtimeService.trigger(execution.getId());
             }
-            processInstance = runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).singleResult();
+            processInstance = runtimeService.createProcessInstanceQuery()
+                .processInstanceId(processInstance.getId())
+                .singleResult();
         }
 
         assertProcessEnded(processInstanceId);
@@ -1016,7 +1297,8 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
     protected void assertHistoricProcessInstanceDetails(String processInstanceId) {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery()
-                    .processInstanceId(processInstanceId).singleResult();
+                .processInstanceId(processInstanceId)
+                .singleResult();
 
             assertNotNull(historicProcessInstance.getEndTime());
             assertNotNull(historicProcessInstance.getDurationInMillis());
@@ -1027,11 +1309,13 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
     protected void assertHistoricProcessInstanceDeleteReason(ProcessInstance processInstance, String expectedDeleteReason) {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery()
-                    .processInstanceId(processInstance.getId()).singleResult();
+                .processInstanceId(processInstance.getId())
+                .singleResult();
             if (expectedDeleteReason == null) {
                 assertNull(historicProcessInstance.getDeleteReason());
             } else {
-                assertTrue(historicProcessInstance.getDeleteReason().startsWith(expectedDeleteReason));
+                assertTrue(historicProcessInstance.getDeleteReason()
+                    .startsWith(expectedDeleteReason));
             }
         }
     }
@@ -1041,14 +1325,17 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             for (String taskName : taskNames) {
                 List<HistoricTaskInstance> historicTaskInstances = historyService.createHistoricTaskInstanceQuery()
-                        .processInstanceId(processInstance.getId()).taskName(taskName).list();
+                    .processInstanceId(processInstance.getId())
+                    .taskName(taskName)
+                    .list();
                 assertTrue(historicTaskInstances.size() > 0);
                 for (HistoricTaskInstance historicTaskInstance : historicTaskInstances) {
                     assertNotNull(historicTaskInstance.getEndTime());
                     if (expectedDeleteReason == null) {
                         assertNull(historicTaskInstance.getDeleteReason());
                     } else {
-                        assertTrue(historicTaskInstance.getDeleteReason().startsWith(expectedDeleteReason));
+                        assertTrue(historicTaskInstance.getDeleteReason()
+                            .startsWith(expectedDeleteReason));
                     }
                 }
             }
@@ -1056,18 +1343,22 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
     }
 
     @Override
-    protected void assertHistoricActivitiesDeleteReason(ProcessInstance processInstance, String expectedDeleteReason, String... activityIds) {
+    protected void assertHistoricActivitiesDeleteReason(ProcessInstance processInstance, String expectedDeleteReason,
+        String... activityIds) {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             for (String activityId : activityIds) {
                 List<HistoricActivityInstance> historicActiviyInstances = historyService.createHistoricActivityInstanceQuery()
-                        .activityId(activityId).processInstanceId(processInstance.getId()).list();
+                    .activityId(activityId)
+                    .processInstanceId(processInstance.getId())
+                    .list();
                 assertTrue(historicActiviyInstances.size() > 0);
                 for (HistoricActivityInstance historicActiviyInstance : historicActiviyInstances) {
                     assertNotNull(historicActiviyInstance.getEndTime());
                     if (expectedDeleteReason == null) {
                         assertNull(historicActiviyInstance.getDeleteReason());
                     } else {
-                        assertTrue(historicActiviyInstance.getDeleteReason().startsWith(expectedDeleteReason));
+                        assertTrue(historicActiviyInstance.getDeleteReason()
+                            .startsWith(expectedDeleteReason));
                     }
                 }
             }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/end/TerminateMultiInstanceEndEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/end/TerminateMultiInstanceEndEventTest.java
@@ -16,6 +16,7 @@ import java.util.List;
 
 import org.flowable.common.engine.impl.util.CollectionUtil;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
+import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
@@ -29,10 +30,14 @@ public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCas
     public void testMultiInstanceEmbeddedSubprocess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("terminateMi");
 
-        org.flowable.task.api.Task aTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        org.flowable.task.api.Task aTask = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .singleResult();
         taskService.complete(aTask.getId());
 
-        List<org.flowable.task.api.Task> bTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        List<org.flowable.task.api.Task> bTasks = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .list();
         assertEquals(8, bTasks.size());
 
         // Complete 2 tasks by going to task C. The 3th tasks goes to the MI terminate end and shuts down the MI.
@@ -41,197 +46,297 @@ public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCas
             taskService.complete(bTask.getId(), CollectionUtil.singletonMap("myVar", "toC"));
         }
 
-        bTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("B").list();
+        bTasks = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .taskName("B")
+            .list();
         assertEquals(6, bTasks.size());
 
-        taskService.complete(bTasks.get(0).getId(), CollectionUtil.singletonMap("myVar", "toEnd"));
+        taskService.complete(bTasks.get(0)
+            .getId(), CollectionUtil.singletonMap("myVar", "toEnd"));
 
-        org.flowable.task.api.Task afterMiTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        org.flowable.task.api.Task afterMiTask = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .singleResult();
         assertEquals("AfterMi", afterMiTask.getName());
         taskService.complete(afterMiTask.getId());
 
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertEquals(0, runtimeService.createExecutionQuery()
+            .count());
     }
 
     @Deployment
     public void testMultiInstanceEmbeddedSubprocessSequential() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("terminateMi");
 
-        org.flowable.task.api.Task aTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        org.flowable.task.api.Task aTask = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .singleResult();
         taskService.complete(aTask.getId());
 
-        List<org.flowable.task.api.Task> bTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        List<org.flowable.task.api.Task> bTasks = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .list();
         assertEquals(1, bTasks.size());
-        taskService.complete(bTasks.get(0).getId(), CollectionUtil.singletonMap("myVar", "toC"));
+        taskService.complete(bTasks.get(0)
+            .getId(), CollectionUtil.singletonMap("myVar", "toC"));
 
-        List<org.flowable.task.api.Task> cTasks = taskService.createTaskQuery().taskName("C").list();
+        List<org.flowable.task.api.Task> cTasks = taskService.createTaskQuery()
+            .taskName("C")
+            .list();
         assertEquals(1, cTasks.size());
-        taskService.complete(cTasks.get(0).getId());
+        taskService.complete(cTasks.get(0)
+            .getId());
 
-        bTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("B").list();
+        bTasks = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .taskName("B")
+            .list();
         assertEquals(1, bTasks.size());
-        taskService.complete(bTasks.get(0).getId(), CollectionUtil.singletonMap("myVar", "toEnd"));
+        taskService.complete(bTasks.get(0)
+            .getId(), CollectionUtil.singletonMap("myVar", "toEnd"));
 
-        org.flowable.task.api.Task afterMiTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        org.flowable.task.api.Task afterMiTask = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .singleResult();
         assertEquals("AfterMi", afterMiTask.getName());
         taskService.complete(afterMiTask.getId());
 
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertEquals(0, runtimeService.createExecutionQuery()
+            .count());
     }
 
     @Deployment
     public void testMultiInstanceEmbeddedSubprocess2() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("terminateMi");
 
-        org.flowable.task.api.Task aTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        org.flowable.task.api.Task aTask = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .singleResult();
         taskService.complete(aTask.getId());
 
-        List<org.flowable.task.api.Task> bTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        List<org.flowable.task.api.Task> bTasks = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .list();
         assertEquals(5, bTasks.size());
 
         // Complete one b task to get one C and D
-        taskService.complete(bTasks.get(0).getId());
+        taskService.complete(bTasks.get(0)
+            .getId());
 
         // C and D should now be active
-        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).orderByTaskName().asc().list();
+        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .orderByTaskName()
+            .asc()
+            .list();
         assertEquals(6, tasks.size());
         // 0-3 are B tasks
-        assertEquals("C", tasks.get(4).getName());
-        assertEquals("D", tasks.get(5).getName());
+        assertEquals("C", tasks.get(4)
+            .getName());
+        assertEquals("D", tasks.get(5)
+            .getName());
 
         // Completing C should terminate the multi instance
-        taskService.complete(tasks.get(4).getId());
+        taskService.complete(tasks.get(4)
+            .getId());
 
-        org.flowable.task.api.Task afterMiTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        org.flowable.task.api.Task afterMiTask = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .singleResult();
         assertEquals("AfterMi", afterMiTask.getName());
         taskService.complete(afterMiTask.getId());
 
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertEquals(0, runtimeService.createExecutionQuery()
+            .count());
     }
 
     @Deployment
     public void testMultiInstanceEmbeddedSubprocess2Sequential() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("terminateMi");
 
-        org.flowable.task.api.Task aTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        org.flowable.task.api.Task aTask = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .singleResult();
         taskService.complete(aTask.getId());
 
-        List<org.flowable.task.api.Task> bTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        List<org.flowable.task.api.Task> bTasks = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .list();
         assertEquals(1, bTasks.size());
 
         // Complete one b task to get one C and D
-        taskService.complete(bTasks.get(0).getId());
+        taskService.complete(bTasks.get(0)
+            .getId());
 
         // C and D should now be active
-        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).orderByTaskName().asc().list();
+        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .orderByTaskName()
+            .asc()
+            .list();
         assertEquals(2, tasks.size());
-        assertEquals("C", tasks.get(0).getName());
-        assertEquals("D", tasks.get(1).getName());
+        assertEquals("C", tasks.get(0)
+            .getName());
+        assertEquals("D", tasks.get(1)
+            .getName());
 
         // Completing C should terminate the multi instance
-        taskService.complete(tasks.get(0).getId());
+        taskService.complete(tasks.get(0)
+            .getId());
 
-        org.flowable.task.api.Task afterMiTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        org.flowable.task.api.Task afterMiTask = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .singleResult();
         assertEquals("AfterMi", afterMiTask.getName());
         taskService.complete(afterMiTask.getId());
 
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertEquals(0, runtimeService.createExecutionQuery()
+            .count());
     }
 
     @Deployment(resources = {
-            "org/flowable/engine/test/bpmn/event/end/TerminateMultiInstanceEndEventTest.testTerminateMiCallactivity-parentProcess.bpmn20.xml",
-            "org/flowable/engine/test/bpmn/event/end/TerminateMultiInstanceEndEventTest.testTerminateMiCallactivity-calledProcess.bpmn20.xml"
-    })
+        "org/flowable/engine/test/bpmn/event/end/TerminateMultiInstanceEndEventTest.testTerminateMiCallactivity-parentProcess.bpmn20.xml",
+        "org/flowable/engine/test/bpmn/event/end/TerminateMultiInstanceEndEventTest.testTerminateMiCallactivity-calledProcess.bpmn20.xml" })
     public void testTerminateMiCallactivity() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("terminateMiCallActivity");
 
-        org.flowable.task.api.Task taskA = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        org.flowable.task.api.Task taskA = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .singleResult();
         assertEquals("A", taskA.getName());
         taskService.complete(taskA.getId());
 
         // After completing A, four B's should be active (due to the call activity)
-        List<org.flowable.task.api.Task> bTasks = taskService.createTaskQuery().taskName("B").list();
+        List<org.flowable.task.api.Task> bTasks = taskService.createTaskQuery()
+            .taskName("B")
+            .list();
         assertEquals(4, bTasks.size());
 
         // Completing 3 B tasks, giving 3 C's and D's
         for (int i = 0; i < 3; i++) {
-            taskService.complete(bTasks.get(i).getId());
+            taskService.complete(bTasks.get(i)
+                .getId());
         }
 
-        List<org.flowable.task.api.Task> cTasks = taskService.createTaskQuery().taskName("C").list();
+        List<org.flowable.task.api.Task> cTasks = taskService.createTaskQuery()
+            .taskName("C")
+            .list();
         assertEquals(3, cTasks.size());
-        List<org.flowable.task.api.Task> dTasks = taskService.createTaskQuery().taskName("D").list();
+        List<org.flowable.task.api.Task> dTasks = taskService.createTaskQuery()
+            .taskName("D")
+            .list();
         assertEquals(3, dTasks.size());
 
         // Completing one of the C tasks should terminate the whole multi instance
-        taskService.complete(cTasks.get(0).getId());
+        taskService.complete(cTasks.get(0)
+            .getId());
 
-        List<org.flowable.task.api.Task> afterMiTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).orderByTaskName().asc().list();
+        List<org.flowable.task.api.Task> afterMiTasks = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .orderByTaskName()
+            .asc()
+            .list();
         assertEquals(2, afterMiTasks.size());
-        assertEquals("AfterMi", afterMiTasks.get(0).getName());
-        assertEquals("Parallel task", afterMiTasks.get(1).getName());
+        assertEquals("AfterMi", afterMiTasks.get(0)
+            .getName());
+        assertEquals("Parallel task", afterMiTasks.get(1)
+            .getName());
     }
 
     @Deployment(resources = {
-            "org/flowable/engine/test/bpmn/event/end/TerminateMultiInstanceEndEventTest.testTerminateMiCallactivity-parentProcessSequential.bpmn20.xml",
-            "org/flowable/engine/test/bpmn/event/end/TerminateMultiInstanceEndEventTest.testTerminateMiCallactivity-calledProcess.bpmn20.xml"
-    })
+        "org/flowable/engine/test/bpmn/event/end/TerminateMultiInstanceEndEventTest.testTerminateMiCallactivity-parentProcessSequential.bpmn20.xml",
+        "org/flowable/engine/test/bpmn/event/end/TerminateMultiInstanceEndEventTest.testTerminateMiCallactivity-calledProcess.bpmn20.xml" })
     public void testTerminateMiCallactivitySequential() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("terminateMiCallActivity");
 
-        org.flowable.task.api.Task taskA = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        org.flowable.task.api.Task taskA = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .singleResult();
         assertEquals("A", taskA.getName());
         taskService.complete(taskA.getId());
 
-        List<org.flowable.task.api.Task> bTasks = taskService.createTaskQuery().taskName("B").list();
+        List<org.flowable.task.api.Task> bTasks = taskService.createTaskQuery()
+            .taskName("B")
+            .list();
         assertEquals(1, bTasks.size());
-        taskService.complete(bTasks.get(0).getId());
+        taskService.complete(bTasks.get(0)
+            .getId());
 
-        List<org.flowable.task.api.Task> cTasks = taskService.createTaskQuery().taskName("C").list();
+        List<org.flowable.task.api.Task> cTasks = taskService.createTaskQuery()
+            .taskName("C")
+            .list();
         assertEquals(1, cTasks.size());
-        List<org.flowable.task.api.Task> dTasks = taskService.createTaskQuery().taskName("D").list();
+        List<org.flowable.task.api.Task> dTasks = taskService.createTaskQuery()
+            .taskName("D")
+            .list();
         assertEquals(1, dTasks.size());
 
         // Completing one of the C tasks should terminate the whole multi instance
-        taskService.complete(cTasks.get(0).getId());
+        taskService.complete(cTasks.get(0)
+            .getId());
 
-        List<org.flowable.task.api.Task> afterMiTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).orderByTaskName().asc().list();
+        List<org.flowable.task.api.Task> afterMiTasks = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .orderByTaskName()
+            .asc()
+            .list();
         assertEquals(2, afterMiTasks.size());
-        assertEquals("AfterMi", afterMiTasks.get(0).getName());
-        assertEquals("Parallel task", afterMiTasks.get(1).getName());
+        assertEquals("AfterMi", afterMiTasks.get(0)
+            .getName());
+        assertEquals("Parallel task", afterMiTasks.get(1)
+            .getName());
     }
 
     @Deployment
     public void testTerminateNestedMiEmbeddedSubprocess() {
-        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey(
-                "terminateNestedMiEmbeddedSubprocess", CollectionUtil.singletonMap("var", "notEnd"));
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("terminateNestedMiEmbeddedSubprocess",
+            CollectionUtil.singletonMap("var", "notEnd"));
 
-        List<org.flowable.task.api.Task> aTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("A").list();
+        List<org.flowable.task.api.Task> aTasks = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .taskName("A")
+            .list();
         assertEquals(12, aTasks.size());
-        List<org.flowable.task.api.Task> bTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("B").list();
+        List<org.flowable.task.api.Task> bTasks = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .taskName("B")
+            .list();
         assertEquals(72, bTasks.size());
 
         // Completing a few B's will create a subprocess with some C's
         int nrOfBTasksCompleted = 3;
         for (int i = 0; i < nrOfBTasksCompleted; i++) {
-            taskService.complete(bTasks.get(i).getId());
+            taskService.complete(bTasks.get(i)
+                .getId());
         }
 
-        bTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("B").list();
+        bTasks = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .taskName("B")
+            .list();
         assertEquals(72 - nrOfBTasksCompleted, bTasks.size());
 
         // Firing the timer --> inner MI gets destroyed
-        List<Job> timers = managementService.createTimerJobQuery().list();
+        List<Job> timers = managementService.createTimerJobQuery()
+            .list();
         assertEquals(nrOfBTasksCompleted, timers.size());
-        managementService.moveTimerToExecutableJob(timers.get(0).getId());
-        managementService.executeJob(timers.get(0).getId());
+        managementService.moveTimerToExecutableJob(timers.get(0)
+            .getId());
+        managementService.executeJob(timers.get(0)
+            .getId());
 
         // We only completed 3 B's. 3 other ones should be destroyed too (as one inner multi instance are 6 instances of B)
-        bTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("B").list();
+        bTasks = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .taskName("B")
+            .list();
         assertEquals(66, bTasks.size());
 
         // One of the inner multi instances should have been killed
-        List<org.flowable.task.api.Task> afterInnerMiTasks = taskService.createTaskQuery().taskName("AfterInnerMi").list();
+        List<org.flowable.task.api.Task> afterInnerMiTasks = taskService.createTaskQuery()
+            .taskName("AfterInnerMi")
+            .list();
         assertEquals(1, afterInnerMiTasks.size());
 
         for (org.flowable.task.api.Task aTask : aTasks) {
@@ -239,52 +344,82 @@ public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCas
         }
 
         // Finish
-        List<org.flowable.task.api.Task> nextTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        List<org.flowable.task.api.Task> nextTasks = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .list();
         while (nextTasks != null && nextTasks.size() > 0) {
-            taskService.complete(nextTasks.get(0).getId());
-            nextTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+            taskService.complete(nextTasks.get(0)
+                .getId());
+            nextTasks = taskService.createTaskQuery()
+                .processInstanceId(processInstance.getId())
+                .list();
         }
 
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertEquals(0, runtimeService.createExecutionQuery()
+            .count());
     }
 
     @Deployment(resources = "org/flowable/engine/test/bpmn/event/end/TerminateMultiInstanceEndEventTest.testTerminateNestedMiEmbeddedSubprocess.bpmn20.xml")
     public void testTerminateNestedMiEmbeddedSubprocess2() {
-        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey(
-                "terminateNestedMiEmbeddedSubprocess", CollectionUtil.singletonMap("var", "toEnd"));
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("terminateNestedMiEmbeddedSubprocess",
+            CollectionUtil.singletonMap("var", "toEnd"));
 
-        List<org.flowable.task.api.Task> aTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("A").list();
+        List<org.flowable.task.api.Task> aTasks = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .taskName("A")
+            .list();
         assertEquals(12, aTasks.size());
-        List<org.flowable.task.api.Task> afterInnerMiTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("AfterInnerMi").list();
+        List<org.flowable.task.api.Task> afterInnerMiTasks = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .taskName("AfterInnerMi")
+            .list();
         assertEquals(12, afterInnerMiTasks.size());
 
     }
 
     @Deployment
     public void testTerminateNestedMiEmbeddedSubprocessWithOneLoopCardinality() {
-        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey(
-                "terminateNestedMiEmbeddedSubprocess", CollectionUtil.singletonMap("var", "notEnd"));
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("terminateNestedMiEmbeddedSubprocess",
+            CollectionUtil.singletonMap("var", "notEnd"));
 
-        List<org.flowable.task.api.Task> aTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("A").list();
+        List<org.flowable.task.api.Task> aTasks = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .taskName("A")
+            .list();
         assertEquals(1, aTasks.size());
-        List<org.flowable.task.api.Task> bTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("B").list();
+        List<org.flowable.task.api.Task> bTasks = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .taskName("B")
+            .list();
         assertEquals(1, bTasks.size());
 
-        taskService.complete(bTasks.get(0).getId());
-        bTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("B").list();
+        taskService.complete(bTasks.get(0)
+            .getId());
+        bTasks = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .taskName("B")
+            .list();
         assertEquals(0, bTasks.size());
 
         // Firing the timer --> inner MI gets destroyed
-        List<Job> timers = managementService.createTimerJobQuery().list();
+        List<Job> timers = managementService.createTimerJobQuery()
+            .list();
         assertEquals(1, timers.size());
-        managementService.moveTimerToExecutableJob(timers.get(0).getId());
-        managementService.executeJob(timers.get(0).getId());
+        managementService.moveTimerToExecutableJob(timers.get(0)
+            .getId());
+        managementService.executeJob(timers.get(0)
+            .getId());
 
-        bTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("B").list();
+        bTasks = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .taskName("B")
+            .list();
         assertEquals(0, bTasks.size());
 
         // One of the inner multi instances should have been killed
-        List<org.flowable.task.api.Task> afterInnerMiTasks = taskService.createTaskQuery().taskName("AfterInnerMi").list();
+        List<org.flowable.task.api.Task> afterInnerMiTasks = taskService.createTaskQuery()
+            .taskName("AfterInnerMi")
+            .list();
         assertEquals(1, afterInnerMiTasks.size());
 
         for (org.flowable.task.api.Task aTask : aTasks) {
@@ -292,13 +427,20 @@ public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCas
         }
 
         // Finish
-        List<org.flowable.task.api.Task> nextTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        List<org.flowable.task.api.Task> nextTasks = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .list();
         while (nextTasks != null && nextTasks.size() > 0) {
-            taskService.complete(nextTasks.get(0).getId());
-            nextTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+            taskService.complete(nextTasks.get(0)
+                .getId());
+            nextTasks = taskService.createTaskQuery()
+                .processInstanceId(processInstance.getId())
+                .list();
         }
-
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        // JobTestHelper.waitForJobExecutorToProcessAllJobs(processEngineConfiguration, managementService, 1000000L, 200L, false);
+        List<Execution> count = runtimeService.createExecutionQuery()
+            .list();
+        assertEquals(0, count.size());
     }
 
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/multiinstance/DynamicMultiInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/multiinstance/DynamicMultiInstanceTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 import org.flowable.common.engine.api.FlowableException;
 import org.flowable.common.engine.impl.util.CollectionUtil;
 import org.flowable.engine.impl.persistence.entity.ExecutionEntity;
+import org.flowable.engine.impl.test.JobTestHelper;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
@@ -224,7 +225,7 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
             for (int i = 0; i < 16; i++) {
                 taskService.complete(tasks.get(i).getId());
             }
-            
+            JobTestHelper.waitForJobExecutorToProcessAllJobs(processEngineConfiguration, managementService, 1000L, 500L);
             assertProcessEnded(procId);
         }
     }
@@ -257,7 +258,7 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
             for (int i = 0; i < 12; i++) {
                 taskService.complete(tasks.get(i).getId());
             }
-            
+            JobTestHelper.waitForJobExecutorToProcessAllJobs(processEngineConfiguration, managementService, 1000L, 500L);
             assertProcessEnded(procId);
         }
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.java
@@ -33,6 +33,7 @@ import org.flowable.engine.history.HistoricActivityInstance;
 import org.flowable.engine.history.HistoricProcessInstance;
 import org.flowable.engine.impl.persistence.entity.ExecutionEntity;
 import org.flowable.engine.impl.test.HistoryTestHelper;
+import org.flowable.engine.impl.test.JobTestHelper;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
@@ -61,38 +62,47 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
     }
 
     private void checkSequentialUserTasks(String processDefinitionKey) {
-        String procId = runtimeService.startProcessInstanceByKey(processDefinitionKey, CollectionUtil.singletonMap("nrOfLoops", 3)).getId();
+        String procId = runtimeService.startProcessInstanceByKey(processDefinitionKey, CollectionUtil.singletonMap("nrOfLoops", 3))
+            .getId();
 
-        org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .singleResult();
         assertEquals("My Task", task.getName());
         assertEquals("kermit_0", task.getAssignee());
         taskService.complete(task.getId());
 
-        task = taskService.createTaskQuery().singleResult();
+        task = taskService.createTaskQuery()
+            .singleResult();
         assertEquals("My Task", task.getName());
         assertEquals("kermit_1", task.getAssignee());
         taskService.complete(task.getId());
 
-        task = taskService.createTaskQuery().singleResult();
+        task = taskService.createTaskQuery()
+            .singleResult();
         assertEquals("My Task", task.getName());
         assertEquals("kermit_2", task.getAssignee());
         taskService.complete(task.getId());
 
-        assertNull(taskService.createTaskQuery().singleResult());
+        assertNull(taskService.createTaskQuery()
+            .singleResult());
         assertProcessEnded(procId);
     }
 
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.sequentialUserTasks.bpmn20.xml" })
     public void testSequentialUserTasksHistory() {
-        String procId = runtimeService.startProcessInstanceByKey("miSequentialUserTasks", CollectionUtil.singletonMap("nrOfLoops", 4)).getId();
+        String procId = runtimeService.startProcessInstanceByKey("miSequentialUserTasks", CollectionUtil.singletonMap("nrOfLoops", 4))
+            .getId();
         for (int i = 0; i < 4; i++) {
-            taskService.complete(taskService.createTaskQuery().singleResult().getId());
+            taskService.complete(taskService.createTaskQuery()
+                .singleResult()
+                .getId());
         }
         assertProcessEnded(procId);
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
 
-            List<HistoricTaskInstance> historicTaskInstances = historyService.createHistoricTaskInstanceQuery().list();
+            List<HistoricTaskInstance> historicTaskInstances = historyService.createHistoricTaskInstanceQuery()
+                .list();
             assertEquals(4, historicTaskInstances.size());
             for (HistoricTaskInstance ht : historicTaskInstances) {
                 assertNotNull(ht.getAssignee());
@@ -100,7 +110,9 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
                 assertNotNull(ht.getEndTime());
             }
 
-            List<HistoricActivityInstance> historicActivityInstances = historyService.createHistoricActivityInstanceQuery().activityType("userTask").list();
+            List<HistoricActivityInstance> historicActivityInstances = historyService.createHistoricActivityInstanceQuery()
+                .activityType("userTask")
+                .list();
             assertEquals(4, historicActivityInstances.size());
             for (HistoricActivityInstance hai : historicActivityInstances) {
                 assertNotNull(hai.getActivityId());
@@ -115,17 +127,22 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
 
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.sequentialUserTasks.bpmn20.xml" })
     public void testSequentialUserTasksWithTimer() {
-        String procId = runtimeService.startProcessInstanceByKey("miSequentialUserTasks", CollectionUtil.singletonMap("nrOfLoops", 3)).getId();
+        String procId = runtimeService.startProcessInstanceByKey("miSequentialUserTasks", CollectionUtil.singletonMap("nrOfLoops", 3))
+            .getId();
 
         // Complete 1 tasks
-        taskService.complete(taskService.createTaskQuery().singleResult().getId());
+        taskService.complete(taskService.createTaskQuery()
+            .singleResult()
+            .getId());
 
         // Fire timer
-        Job timer = managementService.createTimerJobQuery().singleResult();
+        Job timer = managementService.createTimerJobQuery()
+            .singleResult();
         managementService.moveTimerToExecutableJob(timer.getId());
         managementService.executeJob(timer.getId());
 
-        org.flowable.task.api.Task taskAfterTimer = taskService.createTaskQuery().singleResult();
+        org.flowable.task.api.Task taskAfterTimer = taskService.createTaskQuery()
+            .singleResult();
         assertEquals("taskAfterTimer", taskAfterTimer.getTaskDefinitionKey());
         taskService.complete(taskAfterTimer.getId());
         assertProcessEnded(procId);
@@ -133,23 +150,29 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
 
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.sequentialUserTasks.bpmn20.xml" })
     public void testSequentialUserTasksCompletionCondition() {
-        String procId = runtimeService.startProcessInstanceByKey("miSequentialUserTasks", CollectionUtil.singletonMap("nrOfLoops", 10)).getId();
+        String procId = runtimeService.startProcessInstanceByKey("miSequentialUserTasks", CollectionUtil.singletonMap("nrOfLoops", 10))
+            .getId();
 
         // 10 tasks are to be created, but completionCondition stops them at 5
         for (int i = 0; i < 5; i++) {
-            org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
+            org.flowable.task.api.Task task = taskService.createTaskQuery()
+                .singleResult();
             taskService.complete(task.getId());
         }
-        assertNull(taskService.createTaskQuery().singleResult());
+        assertNull(taskService.createTaskQuery()
+            .singleResult());
         assertProcessEnded(procId);
     }
 
     @Deployment
     public void testNestedSequentialUserTasks() {
-        String procId = runtimeService.startProcessInstanceByKey("miNestedSequentialUserTasks").getId();
+        String procId = runtimeService.startProcessInstanceByKey("miNestedSequentialUserTasks")
+            .getId();
 
         for (int i = 0; i < 3; i++) {
-            org.flowable.task.api.Task task = taskService.createTaskQuery().taskAssignee("kermit").singleResult();
+            org.flowable.task.api.Task task = taskService.createTaskQuery()
+                .taskAssignee("kermit")
+                .singleResult();
             assertEquals("My Task", task.getName());
             taskService.complete(task.getId());
         }
@@ -159,33 +182,51 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
 
     @Deployment
     public void testParallelUserTasks() {
-        String procId = runtimeService.startProcessInstanceByKey("miParallelUserTasks").getId();
+        String procId = runtimeService.startProcessInstanceByKey("miParallelUserTasks")
+            .getId();
 
-        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().orderByTaskName().asc().list();
+        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery()
+            .orderByTaskName()
+            .asc()
+            .list();
         assertEquals(3, tasks.size());
-        assertEquals("My Task 0", tasks.get(0).getName());
-        assertEquals("My Task 1", tasks.get(1).getName());
-        assertEquals("My Task 2", tasks.get(2).getName());
+        assertEquals("My Task 0", tasks.get(0)
+            .getName());
+        assertEquals("My Task 1", tasks.get(1)
+            .getName());
+        assertEquals("My Task 2", tasks.get(2)
+            .getName());
 
-        taskService.complete(tasks.get(0).getId());
-        taskService.complete(tasks.get(1).getId());
-        taskService.complete(tasks.get(2).getId());
+        taskService.complete(tasks.get(0)
+            .getId());
+        taskService.complete(tasks.get(1)
+            .getId());
+        taskService.complete(tasks.get(2)
+            .getId());
         assertProcessEnded(procId);
     }
 
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testParallelUserTasks.bpmn20.xml" })
     public void testParallelUserTasksHistory() {
         runtimeService.startProcessInstanceByKey("miParallelUserTasks");
-        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().orderByTaskName().asc().list();
+        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery()
+            .orderByTaskName()
+            .asc()
+            .list();
         assertEquals(3, tasks.size());
         for (int i = 0; i < tasks.size(); i++) {
-            assertEquals("My Task " + i, tasks.get(i).getName());
-            taskService.complete(tasks.get(i).getId());
+            assertEquals("My Task " + i, tasks.get(i)
+                .getName());
+            taskService.complete(tasks.get(i)
+                .getId());
         }
 
         // Validate history
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
-            List<HistoricTaskInstance> historicTaskInstances = historyService.createHistoricTaskInstanceQuery().orderByTaskAssignee().asc().list();
+            List<HistoricTaskInstance> historicTaskInstances = historyService.createHistoricTaskInstanceQuery()
+                .orderByTaskAssignee()
+                .asc()
+                .list();
             for (int i = 0; i < historicTaskInstances.size(); i++) {
                 HistoricTaskInstance hi = historicTaskInstances.get(i);
                 assertNotNull(hi.getStartTime());
@@ -194,7 +235,9 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
                 assertEquals("kermit_" + i, hi.getAssignee());
             }
 
-            List<HistoricActivityInstance> historicActivityInstances = historyService.createHistoricActivityInstanceQuery().activityType("userTask").list();
+            List<HistoricActivityInstance> historicActivityInstances = historyService.createHistoricActivityInstanceQuery()
+                .activityType("userTask")
+                .list();
             assertEquals(3, historicActivityInstances.size());
             for (HistoricActivityInstance hai : historicActivityInstances) {
                 assertNotNull(hai.getStartTime());
@@ -207,17 +250,22 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
 
     @Deployment
     public void testParallelUserTasksWithTimer() {
-        String procId = runtimeService.startProcessInstanceByKey("miParallelUserTasksWithTimer").getId();
+        String procId = runtimeService.startProcessInstanceByKey("miParallelUserTasksWithTimer")
+            .getId();
 
-        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
-        taskService.complete(tasks.get(0).getId());
+        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery()
+            .list();
+        taskService.complete(tasks.get(0)
+            .getId());
 
         // Fire timer
-        Job timer = managementService.createTimerJobQuery().singleResult();
+        Job timer = managementService.createTimerJobQuery()
+            .singleResult();
         managementService.moveTimerToExecutableJob(timer.getId());
         managementService.executeJob(timer.getId());
 
-        org.flowable.task.api.Task taskAfterTimer = taskService.createTaskQuery().singleResult();
+        org.flowable.task.api.Task taskAfterTimer = taskService.createTaskQuery()
+            .singleResult();
         assertEquals("taskAfterTimer", taskAfterTimer.getTaskDefinitionKey());
         taskService.complete(taskAfterTimer.getId());
         assertProcessEnded(procId);
@@ -225,15 +273,19 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
 
     @Deployment
     public void testParallelUserTasksCompletionCondition() {
-        String procId = runtimeService.startProcessInstanceByKey("miParallelUserTasksCompletionCondition").getId();
-        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
+        String procId = runtimeService.startProcessInstanceByKey("miParallelUserTasksCompletionCondition")
+            .getId();
+        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery()
+            .list();
         assertEquals(5, tasks.size());
 
         // Completing 3 tasks gives 50% of tasks completed, which triggers
         // completionCondition
         for (int i = 0; i < 3; i++) {
-            assertEquals(5 - i, taskService.createTaskQuery().count());
-            taskService.complete(tasks.get(i).getId());
+            assertEquals(5 - i, taskService.createTaskQuery()
+                .count());
+            taskService.complete(tasks.get(i)
+                .getId());
         }
         assertProcessEnded(procId);
     }
@@ -241,97 +293,128 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
     @Deployment
     public void testParallelUserTasksBasedOnCollection() {
         List<String> assigneeList = Arrays.asList("kermit", "gonzo", "mispiggy", "fozzie", "bubba");
-        String procId = runtimeService.startProcessInstanceByKey("miParallelUserTasksBasedOnCollection", CollectionUtil.singletonMap("assigneeList", assigneeList)).getId();
+        String procId = runtimeService
+            .startProcessInstanceByKey("miParallelUserTasksBasedOnCollection", CollectionUtil.singletonMap("assigneeList", assigneeList))
+            .getId();
 
-        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().orderByTaskAssignee().asc().list();
+        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery()
+            .orderByTaskAssignee()
+            .asc()
+            .list();
         assertEquals(5, tasks.size());
-        assertEquals("bubba", tasks.get(0).getAssignee());
-        assertEquals("fozzie", tasks.get(1).getAssignee());
-        assertEquals("gonzo", tasks.get(2).getAssignee());
-        assertEquals("kermit", tasks.get(3).getAssignee());
-        assertEquals("mispiggy", tasks.get(4).getAssignee());
+        assertEquals("bubba", tasks.get(0)
+            .getAssignee());
+        assertEquals("fozzie", tasks.get(1)
+            .getAssignee());
+        assertEquals("gonzo", tasks.get(2)
+            .getAssignee());
+        assertEquals("kermit", tasks.get(3)
+            .getAssignee());
+        assertEquals("mispiggy", tasks.get(4)
+            .getAssignee());
 
         // Completing 3 tasks will trigger completioncondition
-        taskService.complete(tasks.get(0).getId());
-        taskService.complete(tasks.get(1).getId());
-        taskService.complete(tasks.get(2).getId());
-        assertEquals(0, taskService.createTaskQuery().count());
+        taskService.complete(tasks.get(0)
+            .getId());
+        taskService.complete(tasks.get(1)
+            .getId());
+        taskService.complete(tasks.get(2)
+            .getId());
+        assertEquals(0, taskService.createTaskQuery()
+            .count());
         assertProcessEnded(procId);
     }
 
     @Deployment
     public void testParallelUserTasksCustomCollectionStringExtension() {
-    	checkParallelUserTasksCustomCollection("miParallelUserTasksCollection");
+        checkParallelUserTasksCustomCollection("miParallelUserTasksCollection");
     }
 
     private void checkParallelUserTasksCustomCollection(String processDefinitionKey) {
-    	ProcessInstance processInstance = runtimeService.startProcessInstanceByKey(processDefinitionKey);
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey(processDefinitionKey);
 
-        List<Task> tasks = taskService.createTaskQuery().taskCandidateUser("wfuser1").list();
+        List<Task> tasks = taskService.createTaskQuery()
+            .taskCandidateUser("wfuser1")
+            .list();
         assertEquals(1, tasks.size());
-        assertEquals("My Task 0", tasks.get(0).getName());
+        assertEquals("My Task 0", tasks.get(0)
+            .getName());
 
-        tasks = taskService.createTaskQuery().taskCandidateUser("wfuser2").list();
+        tasks = taskService.createTaskQuery()
+            .taskCandidateUser("wfuser2")
+            .list();
         assertEquals(1, tasks.size());
-        assertEquals("My Task 1", tasks.get(0).getName());
+        assertEquals("My Task 1", tasks.get(0)
+            .getName());
 
         // should be 2 tasks total
-        tasks = taskService.createTaskQuery().orderByTaskName().asc().list();
+        tasks = taskService.createTaskQuery()
+            .orderByTaskName()
+            .asc()
+            .list();
         assertEquals(2, tasks.size());
-        assertEquals("My Task 0", tasks.get(0).getName());
-        assertEquals("My Task 1", tasks.get(1).getName());
+        assertEquals("My Task 0", tasks.get(0)
+            .getName());
+        assertEquals("My Task 1", tasks.get(1)
+            .getName());
 
         // Completing 3 tasks will trigger completion condition
-        taskService.complete(tasks.get(0).getId());
-        taskService.complete(tasks.get(1).getId());
-        assertEquals(0, taskService.createTaskQuery().count());
+        taskService.complete(tasks.get(0)
+            .getId());
+        taskService.complete(tasks.get(1)
+            .getId());
+        assertEquals(0, taskService.createTaskQuery()
+            .count());
         assertProcessEnded(processInstance.getProcessInstanceId());
     }
 
     @Deployment
     public void testParallelUserTasksCustomCollectionStringExtensionDelegateExpression() {
-    	checkParallelUserTasksCustomCollectionDelegateExpression("miParallelUserTasksCollection");
+        checkParallelUserTasksCustomCollectionDelegateExpression("miParallelUserTasksCollection");
     }
 
     private void checkParallelUserTasksCustomCollectionDelegateExpression(String processDefinitionKey) {
-    	// Add bean temporary to process engine
+        // Add bean temporary to process engine
 
-    	Map<Object, Object> originalBeans = processEngineConfiguration.getExpressionManager().getBeans();
+        Map<Object, Object> originalBeans = processEngineConfiguration.getExpressionManager()
+            .getBeans();
 
-    	try {
+        try {
 
-    		Map<Object, Object> newBeans = new HashMap<>();
-    		newBeans.put("collectionHandler", new JSONCollectionHandler());
-    		processEngineConfiguration.getExpressionManager().setBeans(newBeans);
+            Map<Object, Object> newBeans = new HashMap<>();
+            newBeans.put("collectionHandler", new JSONCollectionHandler());
+            processEngineConfiguration.getExpressionManager()
+                .setBeans(newBeans);
 
-    		checkParallelUserTasksCustomCollection(processDefinitionKey);
-    	} finally {
+            checkParallelUserTasksCustomCollection(processDefinitionKey);
+        } finally {
 
-    		// Put beans back
-    		processEngineConfiguration.getExpressionManager().setBeans(originalBeans);
+            // Put beans back
+            processEngineConfiguration.getExpressionManager()
+                .setBeans(originalBeans);
 
-    	}
+        }
 
     }
 
     @Deployment
     public void testParallelUserTasksCustomCollectionExpressionExtension() {
-    	checkParallelUserTasksCustomCollection("miParallelUserTasksCollection");
+        checkParallelUserTasksCustomCollection("miParallelUserTasksCollection");
     }
 
     @Deployment
     public void testParallelUserTasksCustomCollectionExpressionExtensionDelegateExpression() {
-    	checkParallelUserTasksCustomCollectionDelegateExpression("miParallelUserTasksCollection");
+        checkParallelUserTasksCustomCollectionDelegateExpression("miParallelUserTasksCollection");
     }
 
     @Deployment
     public void testParallelUserTasksCustomExtensionsCollection() {
-    	checkParallelUserTasksCustomCollection("miParallelUserTasksCollection");
+        checkParallelUserTasksCustomCollection("miParallelUserTasksCollection");
     }
 
     @Deployment
     public void testParallelUserTasksCustomExtensionsCollectionDelegateExpression() {
-    	checkParallelUserTasksCustomCollectionDelegateExpression("miParallelUserTasksCollection");
+        checkParallelUserTasksCustomCollectionDelegateExpression("miParallelUserTasksCollection");
     }
 
     @Deployment
@@ -350,34 +433,53 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         vars.put("assigneeList", assigneeList);
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey(processDefinitionKey, vars);
 
-        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().orderByTaskName().asc().list();
+        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery()
+            .orderByTaskName()
+            .asc()
+            .list();
         assertEquals(3, tasks.size());
-        assertEquals("My Task 0", tasks.get(0).getName());
-        assertEquals("My Task 1", tasks.get(1).getName());
-        assertEquals("My Task 2", tasks.get(2).getName());
+        assertEquals("My Task 0", tasks.get(0)
+            .getName());
+        assertEquals("My Task 1", tasks.get(1)
+            .getName());
+        assertEquals("My Task 2", tasks.get(2)
+            .getName());
 
-        tasks = taskService.createTaskQuery().orderByTaskAssignee().asc().list();
-        assertEquals("fozzie", tasks.get(0).getAssignee());
-        assertEquals("gonzo", tasks.get(1).getAssignee());
-        assertEquals("kermit", tasks.get(2).getAssignee());
+        tasks = taskService.createTaskQuery()
+            .orderByTaskAssignee()
+            .asc()
+            .list();
+        assertEquals("fozzie", tasks.get(0)
+            .getAssignee());
+        assertEquals("gonzo", tasks.get(1)
+            .getAssignee());
+        assertEquals("kermit", tasks.get(2)
+            .getAssignee());
 
         // Completing 3 tasks will trigger completion condition
-        taskService.complete(tasks.get(0).getId());
-        taskService.complete(tasks.get(1).getId());
-        taskService.complete(tasks.get(2).getId());
-        assertEquals(0, taskService.createTaskQuery().count());
+        taskService.complete(tasks.get(0)
+            .getId());
+        taskService.complete(tasks.get(1)
+            .getId());
+        taskService.complete(tasks.get(2)
+            .getId());
+        assertEquals(0, taskService.createTaskQuery()
+            .count());
         assertProcessEnded(processInstance.getProcessInstanceId());
     }
 
     @Deployment
     public void testParallelUserTasksExecutionAndTaskListeners() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("miParallelUserTasks");
-        List<Task> tasks = taskService.createTaskQuery().list();
+        List<Task> tasks = taskService.createTaskQuery()
+            .list();
         for (Task task : tasks) {
             taskService.complete(task.getId());
         }
 
-        Execution waitState = runtimeService.createExecutionQuery().activityId("waitState").singleResult();
+        Execution waitState = runtimeService.createExecutionQuery()
+            .activityId("waitState")
+            .singleResult();
         assertNotNull(waitState);
 
         assertEquals(3, runtimeService.getVariable(processInstance.getId(), "taskListenerCounter"));
@@ -386,7 +488,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         runtimeService.trigger(waitState.getId());
         assertProcessEnded(processInstance.getId());
     }
-    
+
     @Deployment
     public void testExecutionListener() {
         Map<String, Object> vars = new HashMap<>();
@@ -398,23 +500,24 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         vars.put("approveResult", "notpass");
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("approve-process", vars);
         assertNotNull(processInstance);
-        
-        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, 
-                        processEngineConfiguration.getManagementService(), 5000, 200);
 
-        List<Task> tasks = taskService.createTaskQuery().list();
-        for (Task task : tasks){
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration,
+            processEngineConfiguration.getManagementService(), 5000, 200);
+
+        List<Task> tasks = taskService.createTaskQuery()
+            .list();
+        for (Task task : tasks) {
             assertEquals(task.getAssignee(), taskService.getVariable(task.getId(), "csAssignee"));
             taskService.setVariableLocal(task.getId(), "csApproveResult", "pass");
             taskService.complete(task.getId());
-            
-            HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, 
-                            processEngineConfiguration.getManagementService(), 5000, 200);
+
+            HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration,
+                processEngineConfiguration.getManagementService(), 5000, 200);
         }
-        
+
         assertProcessEnded(processInstance.getId());
     }
-    
+
     @Deployment
     public void testSequentialExecutionListener() {
         Map<String, Object> vars = new HashMap<>();
@@ -426,42 +529,48 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         vars.put("approveResult", "notpass");
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("approve-process", vars);
         assertNotNull(processInstance);
-        
-        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, 
-                        processEngineConfiguration.getManagementService(), 5000, 200);
 
-        Task task = taskService.createTaskQuery().singleResult();
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration,
+            processEngineConfiguration.getManagementService(), 5000, 200);
+
+        Task task = taskService.createTaskQuery()
+            .singleResult();
         assertEquals(task.getAssignee(), taskService.getVariable(task.getId(), "csAssignee"));
         taskService.setVariableLocal(task.getId(), "csApproveResult", "pass");
         taskService.complete(task.getId());
-        
-        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, 
-                        processEngineConfiguration.getManagementService(), 5000, 200);
-        
-        task = taskService.createTaskQuery().singleResult();
+
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration,
+            processEngineConfiguration.getManagementService(), 5000, 200);
+
+        task = taskService.createTaskQuery()
+            .singleResult();
         assertEquals(task.getAssignee(), taskService.getVariable(task.getId(), "csAssignee"));
         taskService.setVariableLocal(task.getId(), "csApproveResult", "pass");
         taskService.complete(task.getId());
-        
-        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, 
-                        processEngineConfiguration.getManagementService(), 5000, 200);
-        
-        task = taskService.createTaskQuery().singleResult();
+
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration,
+            processEngineConfiguration.getManagementService(), 5000, 200);
+
+        task = taskService.createTaskQuery()
+            .singleResult();
         assertEquals(task.getAssignee(), taskService.getVariable(task.getId(), "csAssignee"));
         taskService.setVariableLocal(task.getId(), "csApproveResult", "pass");
         taskService.complete(task.getId());
-        
-        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, 
-                        processEngineConfiguration.getManagementService(), 5000, 200);
-        
+
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration,
+            processEngineConfiguration.getManagementService(), 5000, 200);
+
         assertProcessEnded(processInstance.getId());
     }
 
     @Deployment
     public void testNestedParallelUserTasks() {
-        String procId = runtimeService.startProcessInstanceByKey("miNestedParallelUserTasks").getId();
+        String procId = runtimeService.startProcessInstanceByKey("miNestedParallelUserTasks")
+            .getId();
 
-        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().taskAssignee("kermit").list();
+        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery()
+            .taskAssignee("kermit")
+            .list();
         for (org.flowable.task.api.Task task : tasks) {
             assertEquals("My Task", task.getName());
             taskService.complete(task.getId());
@@ -489,7 +598,11 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
 
         // Validate history
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
-            List<HistoricActivityInstance> historicInstances = historyService.createHistoricActivityInstanceQuery().activityType("scriptTask").orderByActivityId().asc().list();
+            List<HistoricActivityInstance> historicInstances = historyService.createHistoricActivityInstanceQuery()
+                .activityType("scriptTask")
+                .orderByActivityId()
+                .asc()
+                .list();
             assertEquals(7, historicInstances.size());
             for (int i = 0; i < 7; i++) {
                 HistoricActivityInstance hai = historicInstances.get(i);
@@ -502,13 +615,16 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
 
     @Deployment
     public void testSequentialScriptTasksCompletionCondition() {
-        runtimeService.startProcessInstanceByKey("miSequentialScriptTaskCompletionCondition").getId();
-        List<Execution> executions = runtimeService.createExecutionQuery().list();
+        runtimeService.startProcessInstanceByKey("miSequentialScriptTaskCompletionCondition")
+            .getId();
+        List<Execution> executions = runtimeService.createExecutionQuery()
+            .list();
         assertEquals(2, executions.size());
         Execution processInstanceExecution = null;
         Execution waitStateExecution = null;
         for (Execution execution : executions) {
-            if (execution.getId().equals(execution.getProcessInstanceId())) {
+            if (execution.getId()
+                .equals(execution.getProcessInstanceId())) {
                 processInstanceExecution = execution;
             } else {
                 waitStateExecution = execution;
@@ -526,12 +642,14 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         vars.put("sum", 0);
         vars.put("nrOfLoops", 10);
         runtimeService.startProcessInstanceByKey("miParallelScriptTask", vars);
-        List<Execution> executions = runtimeService.createExecutionQuery().list();
+        List<Execution> executions = runtimeService.createExecutionQuery()
+            .list();
         assertEquals(2, executions.size());
         Execution processInstanceExecution = null;
         Execution waitStateExecution = null;
         for (Execution execution : executions) {
-            if (execution.getId().equals(execution.getProcessInstanceId())) {
+            if (execution.getId()
+                .equals(execution.getProcessInstanceId())) {
                 processInstanceExecution = execution;
             } else {
                 waitStateExecution = execution;
@@ -551,7 +669,9 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("miParallelScriptTask", vars);
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
-            List<HistoricActivityInstance> historicActivityInstances = historyService.createHistoricActivityInstanceQuery().activityType("scriptTask").list();
+            List<HistoricActivityInstance> historicActivityInstances = historyService.createHistoricActivityInstanceQuery()
+                .activityType("scriptTask")
+                .list();
             assertEquals(4, historicActivityInstances.size());
             for (HistoricActivityInstance hai : historicActivityInstances) {
                 assertNotNull(hai.getStartTime());
@@ -563,7 +683,9 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
     @Deployment
     public void testParallelScriptTasksCompletionCondition() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("miParallelScriptTaskCompletionCondition");
-        Execution waitStateExecution = runtimeService.createExecutionQuery().activityId("waitState").singleResult();
+        Execution waitStateExecution = runtimeService.createExecutionQuery()
+            .activityId("waitState")
+            .singleResult();
         assertNotNull(waitStateExecution);
         int sum = (Integer) runtimeService.getVariable(processInstance.getId(), "sum");
         assertEquals(2, sum);
@@ -571,29 +693,39 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
     }
 
-    @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testParallelScriptTasksCompletionCondition.bpmn20.xml" })
+    @Deployment(resources = {
+        "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testParallelScriptTasksCompletionCondition.bpmn20.xml" })
     public void testParallelScriptTasksCompletionConditionHistory() {
         runtimeService.startProcessInstanceByKey("miParallelScriptTaskCompletionCondition");
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
-            List<HistoricActivityInstance> historicActivityInstances = historyService.createHistoricActivityInstanceQuery().activityType("scriptTask").list();
+            List<HistoricActivityInstance> historicActivityInstances = historyService.createHistoricActivityInstanceQuery()
+                .activityType("scriptTask")
+                .list();
             assertEquals(2, historicActivityInstances.size());
         }
     }
 
     @Deployment
     public void testSequentialSubProcess() {
-        String procId = runtimeService.startProcessInstanceByKey("miSequentialSubprocess").getId();
+        String procId = runtimeService.startProcessInstanceByKey("miSequentialSubprocess")
+            .getId();
 
-        TaskQuery query = taskService.createTaskQuery().orderByTaskName().asc();
+        TaskQuery query = taskService.createTaskQuery()
+            .orderByTaskName()
+            .asc();
         for (int i = 0; i < 4; i++) {
             List<org.flowable.task.api.Task> tasks = query.list();
             assertEquals(2, tasks.size());
 
-            assertEquals("task one", tasks.get(0).getName());
-            assertEquals("task two", tasks.get(1).getName());
+            assertEquals("task one", tasks.get(0)
+                .getName());
+            assertEquals("task two", tasks.get(1)
+                .getName());
 
-            taskService.complete(tasks.get(0).getId());
-            taskService.complete(tasks.get(1).getId());
+            taskService.complete(tasks.get(0)
+                .getId());
+            taskService.complete(tasks.get(1)
+                .getId());
 
             if (i != 3) {
                 List<String> activities = runtimeService.getActiveActivityIds(procId);
@@ -608,16 +740,21 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
     @Deployment
     public void testSequentialSubProcessEndEvent() {
         // ACT-1185: end-event in subprocess causes inactivated execution
-        String procId = runtimeService.startProcessInstanceByKey("miSequentialSubprocess").getId();
+        String procId = runtimeService.startProcessInstanceByKey("miSequentialSubprocess")
+            .getId();
 
-        TaskQuery query = taskService.createTaskQuery().orderByTaskName().asc();
+        TaskQuery query = taskService.createTaskQuery()
+            .orderByTaskName()
+            .asc();
         for (int i = 0; i < 4; i++) {
             List<org.flowable.task.api.Task> tasks = query.list();
             assertEquals(1, tasks.size());
 
-            assertEquals("task one", tasks.get(0).getName());
+            assertEquals("task one", tasks.get(0)
+                .getName());
 
-            taskService.complete(tasks.get(0).getId());
+            taskService.complete(tasks.get(0)
+                .getId());
 
             // Last run, the execution no longer exists
             if (i != 3) {
@@ -634,24 +771,33 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
     public void testSequentialSubProcessHistory() {
         runtimeService.startProcessInstanceByKey("miSequentialSubprocess");
         for (int i = 0; i < 4; i++) {
-            List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
-            taskService.complete(tasks.get(0).getId());
-            taskService.complete(tasks.get(1).getId());
+            List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery()
+                .list();
+            taskService.complete(tasks.get(0)
+                .getId());
+            taskService.complete(tasks.get(1)
+                .getId());
         }
 
         // Validate history
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
-            List<HistoricActivityInstance> onlySubProcessInstances = historyService.createHistoricActivityInstanceQuery().activityType("subProcess").list();
+            List<HistoricActivityInstance> onlySubProcessInstances = historyService.createHistoricActivityInstanceQuery()
+                .activityType("subProcess")
+                .list();
             assertEquals(4, onlySubProcessInstances.size());
 
-            List<HistoricActivityInstance> historicInstances = historyService.createHistoricActivityInstanceQuery().activityType("subProcess").list();
+            List<HistoricActivityInstance> historicInstances = historyService.createHistoricActivityInstanceQuery()
+                .activityType("subProcess")
+                .list();
             assertEquals(4, historicInstances.size());
             for (HistoricActivityInstance hai : historicInstances) {
                 assertNotNull(hai.getStartTime());
                 assertNotNull(hai.getEndTime());
             }
 
-            historicInstances = historyService.createHistoricActivityInstanceQuery().activityType("userTask").list();
+            historicInstances = historyService.createHistoricActivityInstanceQuery()
+                .activityType("userTask")
+                .list();
             assertEquals(8, historicInstances.size());
             for (HistoricActivityInstance hai : historicInstances) {
                 assertNotNull(hai.getStartTime());
@@ -662,22 +808,29 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
 
     @Deployment
     public void testSequentialSubProcessWithTimer() {
-        String procId = runtimeService.startProcessInstanceByKey("miSequentialSubprocessWithTimer").getId();
+        String procId = runtimeService.startProcessInstanceByKey("miSequentialSubprocessWithTimer")
+            .getId();
 
         // Complete one subprocess
-        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
+        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery()
+            .list();
         assertEquals(2, tasks.size());
-        taskService.complete(tasks.get(0).getId());
-        taskService.complete(tasks.get(1).getId());
-        tasks = taskService.createTaskQuery().list();
+        taskService.complete(tasks.get(0)
+            .getId());
+        taskService.complete(tasks.get(1)
+            .getId());
+        tasks = taskService.createTaskQuery()
+            .list();
         assertEquals(2, tasks.size());
 
         // Fire timer
-        Job timer = managementService.createTimerJobQuery().singleResult();
+        Job timer = managementService.createTimerJobQuery()
+            .singleResult();
         managementService.moveTimerToExecutableJob(timer.getId());
         managementService.executeJob(timer.getId());
 
-        org.flowable.task.api.Task taskAfterTimer = taskService.createTaskQuery().singleResult();
+        org.flowable.task.api.Task taskAfterTimer = taskService.createTaskQuery()
+            .singleResult();
         assertEquals("taskAfterTimer", taskAfterTimer.getTaskDefinitionKey());
         taskService.complete(taskAfterTimer.getId());
 
@@ -686,18 +839,25 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
 
     @Deployment
     public void testSequentialSubProcessCompletionCondition() {
-        String procId = runtimeService.startProcessInstanceByKey("miSequentialSubprocessCompletionCondition").getId();
+        String procId = runtimeService.startProcessInstanceByKey("miSequentialSubprocessCompletionCondition")
+            .getId();
 
-        TaskQuery query = taskService.createTaskQuery().orderByTaskName().asc();
+        TaskQuery query = taskService.createTaskQuery()
+            .orderByTaskName()
+            .asc();
         for (int i = 0; i < 3; i++) {
             List<org.flowable.task.api.Task> tasks = query.list();
             assertEquals(2, tasks.size());
 
-            assertEquals("task one", tasks.get(0).getName());
-            assertEquals("task two", tasks.get(1).getName());
+            assertEquals("task one", tasks.get(0)
+                .getName());
+            assertEquals("task two", tasks.get(1)
+                .getName());
 
-            taskService.complete(tasks.get(0).getId());
-            taskService.complete(tasks.get(1).getId());
+            taskService.complete(tasks.get(0)
+                .getId());
+            taskService.complete(tasks.get(1)
+                .getId());
         }
 
         assertProcessEnded(procId);
@@ -705,12 +865,17 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
 
     @Deployment
     public void testNestedSequentialSubProcess() {
-        String procId = runtimeService.startProcessInstanceByKey("miNestedSequentialSubProcess").getId();
+        String procId = runtimeService.startProcessInstanceByKey("miNestedSequentialSubProcess")
+            .getId();
 
         for (int i = 0; i < 3; i++) {
-            List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().taskAssignee("kermit").list();
-            taskService.complete(tasks.get(0).getId());
-            taskService.complete(tasks.get(1).getId());
+            List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery()
+                .taskAssignee("kermit")
+                .list();
+            taskService.complete(tasks.get(0)
+                .getId());
+            taskService.complete(tasks.get(1)
+                .getId());
         }
 
         assertProcessEnded(procId);
@@ -718,24 +883,34 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
 
     @Deployment
     public void testNestedSequentialSubProcessWithTimer() {
-        String procId = runtimeService.startProcessInstanceByKey("miNestedSequentialSubProcessWithTimer").getId();
+        String procId = runtimeService.startProcessInstanceByKey("miNestedSequentialSubProcessWithTimer")
+            .getId();
 
         for (int i = 0; i < 2; i++) {
-            List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().taskAssignee("kermit").list();
-            taskService.complete(tasks.get(0).getId());
-            taskService.complete(tasks.get(1).getId());
+            List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery()
+                .taskAssignee("kermit")
+                .list();
+            taskService.complete(tasks.get(0)
+                .getId());
+            taskService.complete(tasks.get(1)
+                .getId());
         }
 
         // Complete one task, to make it a bit more trickier
-        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().taskAssignee("kermit").list();
-        taskService.complete(tasks.get(0).getId());
+        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery()
+            .taskAssignee("kermit")
+            .list();
+        taskService.complete(tasks.get(0)
+            .getId());
 
         // Fire timer
-        Job timer = managementService.createTimerJobQuery().singleResult();
+        Job timer = managementService.createTimerJobQuery()
+            .singleResult();
         managementService.moveTimerToExecutableJob(timer.getId());
         managementService.executeJob(timer.getId());
 
-        org.flowable.task.api.Task taskAfterTimer = taskService.createTaskQuery().singleResult();
+        org.flowable.task.api.Task taskAfterTimer = taskService.createTaskQuery()
+            .singleResult();
         assertEquals("taskAfterTimer", taskAfterTimer.getTaskDefinitionKey());
         taskService.complete(taskAfterTimer.getId());
 
@@ -744,8 +919,12 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
 
     @Deployment
     public void testParallelSubProcess() {
-        String procId = runtimeService.startProcessInstanceByKey("miParallelSubprocess").getId();
-        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().orderByTaskName().asc().list();
+        String procId = runtimeService.startProcessInstanceByKey("miParallelSubprocess")
+            .getId();
+        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery()
+            .orderByTaskName()
+            .asc()
+            .list();
         assertEquals(4, tasks.size());
 
         for (org.flowable.task.api.Task task : tasks) {
@@ -758,13 +937,16 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testParallelSubProcess.bpmn20.xml" })
     public void testParallelSubProcessHistory() {
         runtimeService.startProcessInstanceByKey("miParallelSubprocess");
-        for (org.flowable.task.api.Task task : taskService.createTaskQuery().list()) {
+        for (org.flowable.task.api.Task task : taskService.createTaskQuery()
+            .list()) {
             taskService.complete(task.getId());
         }
 
         // Validate history
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
-            List<HistoricActivityInstance> historicActivityInstances = historyService.createHistoricActivityInstanceQuery().activityId("miSubProcess").list();
+            List<HistoricActivityInstance> historicActivityInstances = historyService.createHistoricActivityInstanceQuery()
+                .activityId("miSubProcess")
+                .list();
             assertEquals(2, historicActivityInstances.size());
             for (HistoricActivityInstance hai : historicActivityInstances) {
                 assertNotNull(hai.getStartTime());
@@ -775,20 +957,26 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
 
     @Deployment
     public void testParallelSubProcessWithTimer() {
-        String procId = runtimeService.startProcessInstanceByKey("miParallelSubprocessWithTimer").getId();
-        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
+        String procId = runtimeService.startProcessInstanceByKey("miParallelSubprocessWithTimer")
+            .getId();
+        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery()
+            .list();
         assertEquals(6, tasks.size());
 
         // Complete two tasks
-        taskService.complete(tasks.get(0).getId());
-        taskService.complete(tasks.get(1).getId());
+        taskService.complete(tasks.get(0)
+            .getId());
+        taskService.complete(tasks.get(1)
+            .getId());
 
         // Fire timer
-        Job timer = managementService.createTimerJobQuery().singleResult();
+        Job timer = managementService.createTimerJobQuery()
+            .singleResult();
         managementService.moveTimerToExecutableJob(timer.getId());
         managementService.executeJob(timer.getId());
 
-        org.flowable.task.api.Task taskAfterTimer = taskService.createTaskQuery().singleResult();
+        org.flowable.task.api.Task taskAfterTimer = taskService.createTaskQuery()
+            .singleResult();
         assertEquals("taskAfterTimer", taskAfterTimer.getTaskDefinitionKey());
         taskService.complete(taskAfterTimer.getId());
 
@@ -797,30 +985,43 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
 
     @Deployment
     public void testParallelSubProcessCompletionCondition() {
-        String procId = runtimeService.startProcessInstanceByKey("miParallelSubprocessCompletionCondition").getId();
-        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
+        String procId = runtimeService.startProcessInstanceByKey("miParallelSubprocessCompletionCondition")
+            .getId();
+        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery()
+            .list();
         assertEquals(4, tasks.size());
 
-        List<org.flowable.task.api.Task> subProcessTasks1 = taskService.createTaskQuery().taskDefinitionKey("subProcessTask1").list();
+        List<org.flowable.task.api.Task> subProcessTasks1 = taskService.createTaskQuery()
+            .taskDefinitionKey("subProcessTask1")
+            .list();
         assertEquals(2, subProcessTasks1.size());
 
-        List<org.flowable.task.api.Task> subProcessTasks2 = taskService.createTaskQuery().taskDefinitionKey("subProcessTask2").list();
+        List<org.flowable.task.api.Task> subProcessTasks2 = taskService.createTaskQuery()
+            .taskDefinitionKey("subProcessTask2")
+            .list();
         assertEquals(2, subProcessTasks2.size());
 
-        Execution taskExecution = runtimeService.createExecutionQuery().executionId(subProcessTasks1.get(0).getExecutionId()).singleResult();
+        Execution taskExecution = runtimeService.createExecutionQuery()
+            .executionId(subProcessTasks1.get(0)
+                .getExecutionId())
+            .singleResult();
         String parentExecutionId = taskExecution.getParentId();
 
         org.flowable.task.api.Task subProcessTask2 = null;
         for (org.flowable.task.api.Task task : subProcessTasks2) {
-            Execution toFindExecution = runtimeService.createExecutionQuery().executionId(task.getExecutionId()).singleResult();
-            if (toFindExecution.getParentId().equals(parentExecutionId)) {
+            Execution toFindExecution = runtimeService.createExecutionQuery()
+                .executionId(task.getExecutionId())
+                .singleResult();
+            if (toFindExecution.getParentId()
+                .equals(parentExecutionId)) {
                 subProcessTask2 = task;
                 break;
             }
         }
 
         assertNotNull(subProcessTask2);
-        taskService.complete(tasks.get(0).getId());
+        taskService.complete(tasks.get(0)
+            .getId());
         taskService.complete(subProcessTask2.getId());
 
         assertProcessEnded(procId);
@@ -828,38 +1029,57 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
 
     @Deployment
     public void testParallelSubProcessAllAutomatic() {
-        String procId = runtimeService.startProcessInstanceByKey("miParallelSubprocessAllAutomatics", CollectionUtil.singletonMap("nrOfLoops", 5)).getId();
+        String procId = runtimeService
+            .startProcessInstanceByKey("miParallelSubprocessAllAutomatics", CollectionUtil.singletonMap("nrOfLoops", 5))
+            .getId();
 
         for (int i = 0; i < 5; i++) {
-            List<Execution> waitSubExecutions = runtimeService.createExecutionQuery().activityId("subProcessWait").list();
+            List<Execution> waitSubExecutions = runtimeService.createExecutionQuery()
+                .activityId("subProcessWait")
+                .list();
             assertTrue(waitSubExecutions.size() > 0);
-            runtimeService.trigger(waitSubExecutions.get(0).getId());
+            runtimeService.trigger(waitSubExecutions.get(0)
+                .getId());
         }
 
-        List<Execution> waitSubExecutions = runtimeService.createExecutionQuery().activityId("subProcessWait").list();
+        List<Execution> waitSubExecutions = runtimeService.createExecutionQuery()
+            .activityId("subProcessWait")
+            .list();
         assertEquals(0, waitSubExecutions.size());
 
-        Execution waitState = runtimeService.createExecutionQuery().activityId("waitState").singleResult();
+        Execution waitState = runtimeService.createExecutionQuery()
+            .activityId("waitState")
+            .singleResult();
         assertEquals(10, runtimeService.getVariable(waitState.getId(), "sum"));
 
         runtimeService.trigger(waitState.getId());
         assertProcessEnded(procId);
     }
 
-    @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testParallelSubProcessAllAutomatic.bpmn20.xml" })
+    @Deployment(resources = {
+        "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testParallelSubProcessAllAutomatic.bpmn20.xml" })
     public void testParallelSubProcessAllAutomaticCompletionCondition() {
-        String procId = runtimeService.startProcessInstanceByKey("miParallelSubprocessAllAutomatics", CollectionUtil.singletonMap("nrOfLoops", 10)).getId();
+        String procId = runtimeService
+            .startProcessInstanceByKey("miParallelSubprocessAllAutomatics", CollectionUtil.singletonMap("nrOfLoops", 10))
+            .getId();
 
         for (int i = 0; i < 6; i++) {
-            List<Execution> waitSubExecutions = runtimeService.createExecutionQuery().activityId("subProcessWait").list();
+            List<Execution> waitSubExecutions = runtimeService.createExecutionQuery()
+                .activityId("subProcessWait")
+                .list();
             assertTrue(waitSubExecutions.size() > 0);
-            runtimeService.trigger(waitSubExecutions.get(0).getId());
+            runtimeService.trigger(waitSubExecutions.get(0)
+                .getId());
         }
 
-        List<Execution> waitSubExecutions = runtimeService.createExecutionQuery().activityId("subProcessWait").list();
+        List<Execution> waitSubExecutions = runtimeService.createExecutionQuery()
+            .activityId("subProcessWait")
+            .list();
         assertEquals(0, waitSubExecutions.size());
 
-        Execution waitState = runtimeService.createExecutionQuery().activityId("waitState").singleResult();
+        Execution waitState = runtimeService.createExecutionQuery()
+            .activityId("waitState")
+            .singleResult();
         assertEquals(12, runtimeService.getVariable(procId, "sum"));
 
         runtimeService.trigger(waitState.getId());
@@ -868,8 +1088,10 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
 
     @Deployment
     public void testNestedParallelSubProcess() {
-        String procId = runtimeService.startProcessInstanceByKey("miNestedParallelSubProcess").getId();
-        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
+        String procId = runtimeService.startProcessInstanceByKey("miNestedParallelSubProcess")
+            .getId();
+        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery()
+            .list();
         assertEquals(8, tasks.size());
 
         for (org.flowable.task.api.Task task : tasks) {
@@ -880,20 +1102,25 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
 
     @Deployment
     public void testNestedParallelSubProcessWithTimer() {
-        String procId = runtimeService.startProcessInstanceByKey("miNestedParallelSubProcess").getId();
-        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
+        String procId = runtimeService.startProcessInstanceByKey("miNestedParallelSubProcess")
+            .getId();
+        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery()
+            .list();
         assertEquals(12, tasks.size());
 
         for (int i = 0; i < 3; i++) {
-            taskService.complete(tasks.get(i).getId());
+            taskService.complete(tasks.get(i)
+                .getId());
         }
 
         // Fire timer
-        Job timer = managementService.createTimerJobQuery().singleResult();
+        Job timer = managementService.createTimerJobQuery()
+            .singleResult();
         managementService.moveTimerToExecutableJob(timer.getId());
         managementService.executeJob(timer.getId());
 
-        org.flowable.task.api.Task taskAfterTimer = taskService.createTaskQuery().singleResult();
+        org.flowable.task.api.Task taskAfterTimer = taskService.createTaskQuery()
+            .singleResult();
         assertEquals("taskAfterTimer", taskAfterTimer.getTaskDefinitionKey());
         taskService.complete(taskAfterTimer.getId());
 
@@ -901,81 +1128,115 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
     }
 
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testCallActivityLocalVariables.bpmn20.xml",
-            "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml" })
+        "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml" })
     public void testCallActivityLocalVariables() {
         Map<String, Object> variables = Collections.singletonMap("name", (Object) "test");
-        String procId = runtimeService.startProcessInstanceByKey("miSubProcessLocalVariables", variables).getId();
+        String procId = runtimeService.startProcessInstanceByKey("miSubProcessLocalVariables", variables)
+            .getId();
 
         for (int i = 0; i < 4; i++) {
-            List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().orderByTaskName().asc().list();
+            List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery()
+                .orderByTaskName()
+                .asc()
+                .list();
             assertEquals(2, tasks.size());
-            assertEquals("task one", tasks.get(0).getName());
-            assertEquals("task two", tasks.get(1).getName());
-            
+            assertEquals("task one", tasks.get(0)
+                .getName());
+            assertEquals("task two", tasks.get(1)
+                .getName());
+
             Map<String, Object> taskVariables = Collections.singletonMap("output", (Object) ("run" + i + 1));
-            taskService.complete(tasks.get(0).getId(), taskVariables);
-            taskService.complete(tasks.get(1).getId());
-            
-            org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(procId).singleResult();
+            taskService.complete(tasks.get(0)
+                .getId(), taskVariables);
+            taskService.complete(tasks.get(1)
+                .getId());
+
+            org.flowable.task.api.Task task = taskService.createTaskQuery()
+                .processInstanceId(procId)
+                .singleResult();
             assertNotNull(task);
             assertEquals("task", task.getTaskDefinitionKey());
-            
-            ExecutionEntity execution = (ExecutionEntity) runtimeService.createExecutionQuery().processInstanceId(procId).activityId("task").singleResult();
+
+            ExecutionEntity execution = (ExecutionEntity) runtimeService.createExecutionQuery()
+                .processInstanceId(procId)
+                .activityId("task")
+                .singleResult();
             assertEquals("run" + i + 1, runtimeService.getVariableLocal(execution.getId(), "output"));
             assertNull(runtimeService.getVariable(procId, "output"));
-            
+
             taskService.complete(task.getId());
         }
 
         assertProcessEnded(procId);
     }
-    
+
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testCallActivityNormalVariables.bpmn20.xml",
-            "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml" })
-        public void testCallActivityNormalVariables() {
+        "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml" })
+    public void testCallActivityNormalVariables() {
         Map<String, Object> variables = Collections.singletonMap("name", (Object) "test");
-        String procId = runtimeService.startProcessInstanceByKey("miSubProcessNormalVariables", variables).getId();
-        
+        String procId = runtimeService.startProcessInstanceByKey("miSubProcessNormalVariables", variables)
+            .getId();
+
         for (int i = 0; i < 4; i++) {
-            List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().orderByTaskName().asc().list();
+            List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery()
+                .orderByTaskName()
+                .asc()
+                .list();
             assertEquals(2, tasks.size());
-            assertEquals("task one", tasks.get(0).getName());
-            assertEquals("task two", tasks.get(1).getName());
-            
+            assertEquals("task one", tasks.get(0)
+                .getName());
+            assertEquals("task two", tasks.get(1)
+                .getName());
+
             Map<String, Object> taskVariables = Collections.singletonMap("output", (Object) ("run" + i + 1));
-            taskService.complete(tasks.get(0).getId(), taskVariables);
-            taskService.complete(tasks.get(1).getId());
-            
-            org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(procId).singleResult();
+            taskService.complete(tasks.get(0)
+                .getId(), taskVariables);
+            taskService.complete(tasks.get(1)
+                .getId());
+
+            org.flowable.task.api.Task task = taskService.createTaskQuery()
+                .processInstanceId(procId)
+                .singleResult();
             assertNotNull(task);
             assertEquals("task", task.getTaskDefinitionKey());
-            
-            ExecutionEntity execution = (ExecutionEntity) runtimeService.createExecutionQuery().processInstanceId(procId).activityId("task").singleResult();
+
+            ExecutionEntity execution = (ExecutionEntity) runtimeService.createExecutionQuery()
+                .processInstanceId(procId)
+                .activityId("task")
+                .singleResult();
             assertNull(runtimeService.getVariableLocal(execution.getId(), "output"));
             assertEquals("run" + i + 1, runtimeService.getVariable(procId, "output"));
-            
+
             taskService.complete(task.getId());
         }
-        
+
         assertProcessEnded(procId);
     }
-    
+
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testSequentialCallActivity.bpmn20.xml",
-    "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml" })
-public void testSequentialCallActivity() {
-String procId = runtimeService.startProcessInstanceByKey("miSequentialCallActivity").getId();
+        "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml" })
+    public void testSequentialCallActivity() {
+        String procId = runtimeService.startProcessInstanceByKey("miSequentialCallActivity")
+            .getId();
 
-for (int i = 0; i < 3; i++) {
-    List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().orderByTaskName().asc().list();
-    assertEquals(2, tasks.size());
-    assertEquals("task one", tasks.get(0).getName());
-    assertEquals("task two", tasks.get(1).getName());
-    taskService.complete(tasks.get(0).getId());
-    taskService.complete(tasks.get(1).getId());
-}
+        for (int i = 0; i < 3; i++) {
+            List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery()
+                .orderByTaskName()
+                .asc()
+                .list();
+            assertEquals(2, tasks.size());
+            assertEquals("task one", tasks.get(0)
+                .getName());
+            assertEquals("task two", tasks.get(1)
+                .getName());
+            taskService.complete(tasks.get(0)
+                .getId());
+            taskService.complete(tasks.get(1)
+                .getId());
+        }
 
-assertProcessEnded(procId);
-}
+        assertProcessEnded(procId);
+    }
 
     @Deployment(resources = "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testSequentialCallActivityWithList.bpmn20.xml")
     public void testSequentialCallActivityWithList() {
@@ -986,50 +1247,73 @@ assertProcessEnded(procId);
         HashMap<String, Object> variables = new HashMap<>();
         variables.put("list", list);
 
-        String procId = runtimeService.startProcessInstanceByKey("parentProcess", variables).getId();
-
-        org.flowable.task.api.Task task1 = taskService.createTaskQuery().processVariableValueEquals("element", "one").singleResult();
-        org.flowable.task.api.Task task2 = taskService.createTaskQuery().processVariableValueEquals("element", "two").singleResult();
-
-        assertNotNull(task1);
-        assertNotNull(task2);
+        String procId = runtimeService.startProcessInstanceByKey("parentProcess", variables)
+            .getId();
 
         HashMap<String, Object> subVariables = new HashMap<>();
         subVariables.put("x", "y");
 
+        org.flowable.task.api.Task task1 = taskService.createTaskQuery()
+            .processVariableValueEquals("element", "one")
+            .singleResult();
+
+        assertNotNull(task1);
+
         taskService.complete(task1.getId(), subVariables);
+
+        org.flowable.task.api.Task task2 = taskService.createTaskQuery()
+            .processVariableValueEquals("element", "two")
+            .singleResult();
+
+        assertNotNull(task2);
+
         taskService.complete(task2.getId(), subVariables);
 
-        org.flowable.task.api.Task task3 = taskService.createTaskQuery().processDefinitionKey("midProcess").singleResult();
+        org.flowable.task.api.Task task3 = taskService.createTaskQuery()
+            .processDefinitionKey("midProcess")
+            .singleResult();
         assertNotNull(task3);
         taskService.complete(task3.getId(), null);
 
-        org.flowable.task.api.Task task4 = taskService.createTaskQuery().processDefinitionKey("parentProcess").singleResult();
+        org.flowable.task.api.Task task4 = taskService.createTaskQuery()
+            .processDefinitionKey("parentProcess")
+            .singleResult();
         assertNotNull(task4);
         taskService.complete(task4.getId(), null);
 
         assertProcessEnded(procId);
     }
 
-    @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testSequentialCallActivityWithTimer.bpmn20.xml",
-            "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml" })
+    @Deployment(resources = {
+        "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testSequentialCallActivityWithTimer.bpmn20.xml",
+        "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml" })
     public void testSequentialCallActivityWithTimer() {
-        String procId = runtimeService.startProcessInstanceByKey("miSequentialCallActivityWithTimer").getId();
+        String procId = runtimeService.startProcessInstanceByKey("miSequentialCallActivityWithTimer")
+            .getId();
 
         // Complete first subprocess
-        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().orderByTaskName().asc().list();
+        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery()
+            .orderByTaskName()
+            .asc()
+            .list();
         assertEquals(2, tasks.size());
-        assertEquals("task one", tasks.get(0).getName());
-        assertEquals("task two", tasks.get(1).getName());
-        taskService.complete(tasks.get(0).getId());
-        taskService.complete(tasks.get(1).getId());
+        assertEquals("task one", tasks.get(0)
+            .getName());
+        assertEquals("task two", tasks.get(1)
+            .getName());
+        taskService.complete(tasks.get(0)
+            .getId());
+        taskService.complete(tasks.get(1)
+            .getId());
 
         // Fire timer
-        Job timer = managementService.createTimerJobQuery().singleResult();
+        Job timer = managementService.createTimerJobQuery()
+            .singleResult();
         managementService.moveTimerToExecutableJob(timer.getId());
         managementService.executeJob(timer.getId());
 
-        org.flowable.task.api.Task taskAfterTimer = taskService.createTaskQuery().singleResult();
+        org.flowable.task.api.Task taskAfterTimer = taskService.createTaskQuery()
+            .singleResult();
         assertEquals("taskAfterTimer", taskAfterTimer.getTaskDefinitionKey());
         taskService.complete(taskAfterTimer.getId());
 
@@ -1037,31 +1321,37 @@ assertProcessEnded(procId);
     }
 
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testParallelCallActivity.bpmn20.xml",
-            "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml" })
+        "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml" })
     public void testParallelCallActivity() {
-        String procId = runtimeService.startProcessInstanceByKey("miParallelCallActivity").getId();
-        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
+        String procId = runtimeService.startProcessInstanceByKey("miParallelCallActivity")
+            .getId();
+        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery()
+            .list();
         assertEquals(12, tasks.size());
         for (int i = 0; i < tasks.size(); i++) {
-            taskService.complete(tasks.get(i).getId());
+            taskService.complete(tasks.get(i)
+                .getId());
         }
-
+        JobTestHelper.waitForJobExecutorToProcessAllJobs(processEngineConfiguration, managementService, 1000L, 500L);
         assertProcessEnded(procId);
     }
 
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testParallelCallActivity.bpmn20.xml",
-            "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml" })
+        "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml" })
     public void testParallelCallActivityHistory() {
         runtimeService.startProcessInstanceByKey("miParallelCallActivity");
-        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
+        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery()
+            .list();
         assertEquals(12, tasks.size());
         for (int i = 0; i < tasks.size(); i++) {
-            taskService.complete(tasks.get(i).getId());
+            taskService.complete(tasks.get(i)
+                .getId());
         }
-
+        JobTestHelper.waitForJobExecutorToProcessAllJobs(processEngineConfiguration, managementService, 1000L, 500L);
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // Validate historic processes
-            List<HistoricProcessInstance> historicProcessInstances = historyService.createHistoricProcessInstanceQuery().list();
+            List<HistoricProcessInstance> historicProcessInstances = historyService.createHistoricProcessInstanceQuery()
+                .list();
             assertEquals(7, historicProcessInstances.size()); // 6 subprocesses
                                                               // + main process
             for (HistoricProcessInstance hpi : historicProcessInstances) {
@@ -1070,7 +1360,8 @@ assertProcessEnded(procId);
             }
 
             // Validate historic tasks
-            List<HistoricTaskInstance> historicTaskInstances = historyService.createHistoricTaskInstanceQuery().list();
+            List<HistoricTaskInstance> historicTaskInstances = historyService.createHistoricTaskInstanceQuery()
+                .list();
             assertEquals(12, historicTaskInstances.size());
             for (HistoricTaskInstance hti : historicTaskInstances) {
                 assertNotNull(hti.getStartTime());
@@ -1080,7 +1371,9 @@ assertProcessEnded(procId);
             }
 
             // Validate historic activities
-            List<HistoricActivityInstance> historicActivityInstances = historyService.createHistoricActivityInstanceQuery().activityType("callActivity").list();
+            List<HistoricActivityInstance> historicActivityInstances = historyService.createHistoricActivityInstanceQuery()
+                .activityType("callActivity")
+                .list();
             assertEquals(6, historicActivityInstances.size());
             for (HistoricActivityInstance hai : historicActivityInstances) {
                 assertNotNull(hai.getStartTime());
@@ -1090,21 +1383,26 @@ assertProcessEnded(procId);
     }
 
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testParallelCallActivityWithTimer.bpmn20.xml",
-            "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml" })
+        "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml" })
     public void testParallelCallActivityWithTimer() {
-        String procId = runtimeService.startProcessInstanceByKey("miParallelCallActivity").getId();
-        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
+        String procId = runtimeService.startProcessInstanceByKey("miParallelCallActivity")
+            .getId();
+        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery()
+            .list();
         assertEquals(6, tasks.size());
         for (int i = 0; i < 2; i++) {
-            taskService.complete(tasks.get(i).getId());
+            taskService.complete(tasks.get(i)
+                .getId());
         }
 
         // Fire timer
-        Job timer = managementService.createTimerJobQuery().singleResult();
+        Job timer = managementService.createTimerJobQuery()
+            .singleResult();
         managementService.moveTimerToExecutableJob(timer.getId());
         managementService.executeJob(timer.getId());
 
-        org.flowable.task.api.Task taskAfterTimer = taskService.createTaskQuery().singleResult();
+        org.flowable.task.api.Task taskAfterTimer = taskService.createTaskQuery()
+            .singleResult();
         assertEquals("taskAfterTimer", taskAfterTimer.getTaskDefinitionKey());
         taskService.complete(taskAfterTimer.getId());
 
@@ -1112,46 +1410,67 @@ assertProcessEnded(procId);
     }
 
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testNestedSequentialCallActivity.bpmn20.xml",
-            "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml" })
+        "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml" })
     public void testNestedSequentialCallActivity() {
-        String procId = runtimeService.startProcessInstanceByKey("miNestedSequentialCallActivity").getId();
+        String procId = runtimeService.startProcessInstanceByKey("miNestedSequentialCallActivity")
+            .getId();
 
         for (int i = 0; i < 4; i++) {
-            List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().orderByTaskName().asc().list();
+            List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery()
+                .orderByTaskName()
+                .asc()
+                .list();
             assertEquals(2, tasks.size());
-            assertEquals("task one", tasks.get(0).getName());
-            assertEquals("task two", tasks.get(1).getName());
-            taskService.complete(tasks.get(0).getId());
-            taskService.complete(tasks.get(1).getId());
+            assertEquals("task one", tasks.get(0)
+                .getName());
+            assertEquals("task two", tasks.get(1)
+                .getName());
+            taskService.complete(tasks.get(0)
+                .getId());
+            taskService.complete(tasks.get(1)
+                .getId());
         }
 
         assertProcessEnded(procId);
     }
 
-    @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testNestedSequentialCallActivityWithTimer.bpmn20.xml",
-            "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml" })
+    @Deployment(resources = {
+        "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testNestedSequentialCallActivityWithTimer.bpmn20.xml",
+        "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml" })
     public void testNestedSequentialCallActivityWithTimer() {
-        String procId = runtimeService.startProcessInstanceByKey("miNestedSequentialCallActivityWithTimer").getId();
+        String procId = runtimeService.startProcessInstanceByKey("miNestedSequentialCallActivityWithTimer")
+            .getId();
 
         // first instance
-        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().orderByTaskName().asc().list();
+        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery()
+            .orderByTaskName()
+            .asc()
+            .list();
         assertEquals(2, tasks.size());
-        assertEquals("task one", tasks.get(0).getName());
-        assertEquals("task two", tasks.get(1).getName());
-        taskService.complete(tasks.get(0).getId());
-        taskService.complete(tasks.get(1).getId());
+        assertEquals("task one", tasks.get(0)
+            .getName());
+        assertEquals("task two", tasks.get(1)
+            .getName());
+        taskService.complete(tasks.get(0)
+            .getId());
+        taskService.complete(tasks.get(1)
+            .getId());
 
         // one task of second instance
-        tasks = taskService.createTaskQuery().list();
+        tasks = taskService.createTaskQuery()
+            .list();
         assertEquals(2, tasks.size());
-        taskService.complete(tasks.get(0).getId());
+        taskService.complete(tasks.get(0)
+            .getId());
 
         // Fire timer
-        Job timer = managementService.createTimerJobQuery().singleResult();
+        Job timer = managementService.createTimerJobQuery()
+            .singleResult();
         managementService.moveTimerToExecutableJob(timer.getId());
         managementService.executeJob(timer.getId());
 
-        org.flowable.task.api.Task taskAfterTimer = taskService.createTaskQuery().singleResult();
+        org.flowable.task.api.Task taskAfterTimer = taskService.createTaskQuery()
+            .singleResult();
         assertEquals("taskAfterTimer", taskAfterTimer.getTaskDefinitionKey());
         taskService.complete(taskAfterTimer.getId());
 
@@ -1159,69 +1478,91 @@ assertProcessEnded(procId);
     }
 
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testNestedParallelCallActivity.bpmn20.xml",
-            "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml" })
+        "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml" })
     public void testNestedParallelCallActivity() {
-        String procId = runtimeService.startProcessInstanceByKey("miNestedParallelCallActivity").getId();
+        String procId = runtimeService.startProcessInstanceByKey("miNestedParallelCallActivity")
+            .getId();
 
-        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
+        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery()
+            .list();
         assertEquals(14, tasks.size());
         for (int i = 0; i < 14; i++) {
-            taskService.complete(tasks.get(i).getId());
+            taskService.complete(tasks.get(i)
+                .getId());
         }
+        JobTestHelper.waitForJobExecutorToProcessAllJobs(processEngineConfiguration, managementService, 1000L, 500L);
 
         assertProcessEnded(procId);
     }
 
-    @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testNestedParallelCallActivityWithTimer.bpmn20.xml",
-            "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml" })
+    @Deployment(resources = {
+        "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testNestedParallelCallActivityWithTimer.bpmn20.xml",
+        "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml" })
     public void testNestedParallelCallActivityWithTimer() {
-        String procId = runtimeService.startProcessInstanceByKey("miNestedParallelCallActivityWithTimer").getId();
+        String procId = runtimeService.startProcessInstanceByKey("miNestedParallelCallActivityWithTimer")
+            .getId();
 
-        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
+        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery()
+            .list();
         assertEquals(4, tasks.size());
         for (int i = 0; i < 3; i++) {
-            taskService.complete(tasks.get(i).getId());
+            taskService.complete(tasks.get(i)
+                .getId());
         }
 
         // Fire timer
-        Job timer = managementService.createTimerJobQuery().singleResult();
+        Job timer = managementService.createTimerJobQuery()
+            .singleResult();
         managementService.moveTimerToExecutableJob(timer.getId());
         managementService.executeJob(timer.getId());
 
-        org.flowable.task.api.Task taskAfterTimer = taskService.createTaskQuery().singleResult();
+        org.flowable.task.api.Task taskAfterTimer = taskService.createTaskQuery()
+            .singleResult();
         assertEquals("taskAfterTimer", taskAfterTimer.getTaskDefinitionKey());
         taskService.complete(taskAfterTimer.getId());
 
         assertProcessEnded(procId);
     }
 
-    @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testNestedParallelCallActivityCompletionCondition.bpmn20.xml",
-            "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml" })
+    @Deployment(resources = {
+        "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testNestedParallelCallActivityCompletionCondition.bpmn20.xml",
+        "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml" })
     public void testNestedParallelCallActivityCompletionCondition() {
-        String procId = runtimeService.startProcessInstanceByKey("miNestedParallelCallActivityCompletionCondition").getId();
+        String procId = runtimeService.startProcessInstanceByKey("miNestedParallelCallActivityCompletionCondition")
+            .getId();
 
-        assertEquals(8, taskService.createTaskQuery().count());
+        assertEquals(8, taskService.createTaskQuery()
+            .count());
 
         for (int i = 0; i < 2; i++) {
-            ProcessInstance nextSubProcessInstance = runtimeService.createProcessInstanceQuery().processDefinitionKey("externalSubProcess").listPage(0, 1).get(0);
-            List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(nextSubProcessInstance.getId()).list();
+            ProcessInstance nextSubProcessInstance = runtimeService.createProcessInstanceQuery()
+                .processDefinitionKey("externalSubProcess")
+                .listPage(0, 1)
+                .get(0);
+            List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery()
+                .processInstanceId(nextSubProcessInstance.getId())
+                .list();
             assertEquals(2, tasks.size());
             for (org.flowable.task.api.Task task : tasks) {
                 taskService.complete(task.getId());
             }
         }
-
+        JobTestHelper.waitForJobExecutorToProcessAllJobs(processEngineConfiguration, managementService, 1000L, 500L);
         assertProcessEnded(procId);
     }
 
     // ACT-764
     @Deployment
     public void testSequentialServiceTaskWithClass() {
-        ProcessInstance procInst = runtimeService.startProcessInstanceByKey("multiInstanceServiceTask", CollectionUtil.singletonMap("result", 5));
+        ProcessInstance procInst = runtimeService.startProcessInstanceByKey("multiInstanceServiceTask",
+            CollectionUtil.singletonMap("result", 5));
         Integer result = (Integer) runtimeService.getVariable(procInst.getId(), "result");
         assertEquals(160, result.intValue());
 
-        Execution waitExecution = runtimeService.createExecutionQuery().processInstanceId(procInst.getId()).activityId("wait").singleResult();
+        Execution waitExecution = runtimeService.createExecutionQuery()
+            .processInstanceId(procInst.getId())
+            .activityId("wait")
+            .singleResult();
         runtimeService.trigger(waitExecution.getId());
         assertProcessEnded(procInst.getId());
     }
@@ -1237,7 +1578,10 @@ assertProcessEnded(procId);
         Integer result = (Integer) runtimeService.getVariable(procInst.getId(), "result");
         assertEquals(720, result.intValue());
 
-        Execution waitExecution = runtimeService.createExecutionQuery().processInstanceId(procInst.getId()).activityId("wait").singleResult();
+        Execution waitExecution = runtimeService.createExecutionQuery()
+            .processInstanceId(procInst.getId())
+            .activityId("wait")
+            .singleResult();
         runtimeService.trigger(waitExecution.getId());
         assertProcessEnded(procInst.getId());
     }
@@ -1246,13 +1590,20 @@ assertProcessEnded(procId);
     @Deployment
     public void testAct901() {
 
-        Date startTime = processEngineConfiguration.getClock().getCurrentTime();
+        Date startTime = processEngineConfiguration.getClock()
+            .getCurrentTime();
 
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("multiInstanceSubProcess");
-        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(pi.getId()).orderByTaskName().asc().list();
+        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery()
+            .processInstanceId(pi.getId())
+            .orderByTaskName()
+            .asc()
+            .list();
 
-        processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + 61000L)); // timer is set to one minute
-        List<Job> timers = managementService.createTimerJobQuery().list();
+        processEngineConfiguration.getClock()
+            .setCurrentTime(new Date(startTime.getTime() + 61000L)); // timer is set to one minute
+        List<Job> timers = managementService.createTimerJobQuery()
+            .list();
         assertEquals(5, timers.size());
 
         // Execute all timers one by one (single thread vs thread pool of job
@@ -1263,58 +1614,75 @@ assertProcessEnded(procId);
         }
 
         // All tasks should be canceled
-        tasks = taskService.createTaskQuery().processInstanceId(pi.getId()).orderByTaskName().asc().list();
+        tasks = taskService.createTaskQuery()
+            .processInstanceId(pi.getId())
+            .orderByTaskName()
+            .asc()
+            .list();
         assertEquals(0, tasks.size());
     }
 
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.callActivityWithBoundaryErrorEvent.bpmn20.xml",
-            "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.throwingErrorEventSubProcess.bpmn20.xml" })
+        "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.throwingErrorEventSubProcess.bpmn20.xml" })
     public void testMultiInstanceCallActivityWithErrorBoundaryEvent() {
         Map<String, Object> variableMap = new HashMap<>();
         variableMap.put("assignees", Arrays.asList("kermit", "gonzo"));
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process", variableMap);
 
-        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
+        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery()
+            .list();
         assertEquals(2, tasks.size());
 
         // finish first call activity with error
         variableMap = new HashMap<>();
         variableMap.put("done", false);
-        taskService.complete(tasks.get(0).getId(), variableMap);
+        taskService.complete(tasks.get(0)
+            .getId(), variableMap);
 
-        tasks = taskService.createTaskQuery().list();
+        tasks = taskService.createTaskQuery()
+            .list();
         assertEquals(1, tasks.size());
 
-        taskService.complete(tasks.get(0).getId());
+        taskService.complete(tasks.get(0)
+            .getId());
 
-        List<ProcessInstance> processInstances = runtimeService.createProcessInstanceQuery().processDefinitionKey("process").list();
+        List<ProcessInstance> processInstances = runtimeService.createProcessInstanceQuery()
+            .processDefinitionKey("process")
+            .list();
         assertEquals(0, processInstances.size());
         assertProcessEnded(processInstance.getId());
     }
 
-    @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.callActivityWithBoundaryErrorEventSequential.bpmn20.xml",
-            "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.throwingErrorEventSubProcess.bpmn20.xml" })
+    @Deployment(resources = {
+        "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.callActivityWithBoundaryErrorEventSequential.bpmn20.xml",
+        "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.throwingErrorEventSubProcess.bpmn20.xml" })
     public void testSequentialMultiInstanceCallActivityWithErrorBoundaryEvent() {
         Map<String, Object> variableMap = new HashMap<>();
         variableMap.put("assignees", Arrays.asList("kermit", "gonzo"));
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process", variableMap);
 
-        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
+        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery()
+            .list();
         assertEquals(1, tasks.size());
 
         // finish first call activity with error
         variableMap = new HashMap<>();
         variableMap.put("done", false);
-        taskService.complete(tasks.get(0).getId(), variableMap);
+        taskService.complete(tasks.get(0)
+            .getId(), variableMap);
 
-        tasks = taskService.createTaskQuery().list();
+        tasks = taskService.createTaskQuery()
+            .list();
         assertEquals(1, tasks.size());
 
-        taskService.complete(tasks.get(0).getId());
+        taskService.complete(tasks.get(0)
+            .getId());
 
-        List<ProcessInstance> processInstances = runtimeService.createProcessInstanceQuery().processDefinitionKey("process").list();
+        List<ProcessInstance> processInstances = runtimeService.createProcessInstanceQuery()
+            .processDefinitionKey("process")
+            .list();
         assertEquals(0, processInstances.size());
         assertProcessEnded(processInstance.getId());
     }
@@ -1322,7 +1690,9 @@ assertProcessEnded(procId);
     @Deployment
     public void testMultiInstanceParallelReceiveTask() {
         runtimeService.startProcessInstanceByKey("multi-instance-receive");
-        List<Execution> executions = runtimeService.createExecutionQuery().activityId("theReceiveTask").list();
+        List<Execution> executions = runtimeService.createExecutionQuery()
+            .activityId("theReceiveTask")
+            .list();
         assertEquals(4, executions.size());
 
         // Complete all four of the executions
@@ -1331,54 +1701,69 @@ assertProcessEnded(procId);
         }
 
         // There is one task after the task
-        org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .singleResult();
         assertNotNull(task);
         taskService.complete(task.getId());
 
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertEquals(0, runtimeService.createExecutionQuery()
+            .count());
     }
 
     @Deployment
     public void testMultiInstanceParalelReceiveTaskWithTimer() {
         Date startTime = new Date();
-        processEngineConfiguration.getClock().setCurrentTime(startTime);
+        processEngineConfiguration.getClock()
+            .setCurrentTime(startTime);
 
         runtimeService.startProcessInstanceByKey("multiInstanceReceiveWithTimer");
-        List<Execution> executions = runtimeService.createExecutionQuery().activityId("theReceiveTask").list();
+        List<Execution> executions = runtimeService.createExecutionQuery()
+            .activityId("theReceiveTask")
+            .list();
         assertEquals(3, executions.size());
 
         // Signal only one execution. Then the timer will fire
-        runtimeService.trigger(executions.get(1).getId());
-        processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + 60000L));
+        runtimeService.trigger(executions.get(1)
+            .getId());
+        processEngineConfiguration.getClock()
+            .setCurrentTime(new Date(startTime.getTime() + 60000L));
         waitForJobExecutorToProcessAllJobs(10000L, 1000L);
 
         // The process should now be in the task after the timer
-        org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .singleResult();
         assertEquals("Task after timer", task.getName());
 
         // Completing it should end the process
         taskService.complete(task.getId());
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertEquals(0, runtimeService.createExecutionQuery()
+            .count());
     }
 
     @Deployment
     public void testMultiInstanceSequentialReceiveTask() {
         runtimeService.startProcessInstanceByKey("multi-instance-receive");
-        Execution execution = runtimeService.createExecutionQuery().activityId("theReceiveTask").singleResult();
+        Execution execution = runtimeService.createExecutionQuery()
+            .activityId("theReceiveTask")
+            .singleResult();
         assertNotNull(execution);
 
         // Complete all four of the executions
         while (execution != null) {
             runtimeService.trigger(execution.getId());
-            execution = runtimeService.createExecutionQuery().activityId("theReceiveTask").singleResult();
+            execution = runtimeService.createExecutionQuery()
+                .activityId("theReceiveTask")
+                .singleResult();
         }
 
         // There is one task after the task
-        org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .singleResult();
         assertNotNull(task);
         taskService.complete(task.getId());
 
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertEquals(0, runtimeService.createExecutionQuery()
+            .count());
     }
 
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testNestedMultiInstanceTasks.bpmn20.xml" })
@@ -1391,26 +1776,31 @@ assertProcessEnded(procId);
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("miNestedMultiInstanceTasks", variableMap);
 
-        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
+        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery()
+            .list();
         assertEquals(processes.size() * assignees.size(), tasks.size());
 
         for (org.flowable.task.api.Task t : tasks) {
             taskService.complete(t.getId());
         }
 
-        List<ProcessInstance> processInstances = runtimeService.createProcessInstanceQuery().processDefinitionKey("miNestedMultiInstanceTasks").list();
+        List<ProcessInstance> processInstances = runtimeService.createProcessInstanceQuery()
+            .processDefinitionKey("miNestedMultiInstanceTasks")
+            .list();
         assertEquals(0, processInstances.size());
         assertProcessEnded(processInstance.getId());
     }
 
-    @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testSequentialSubprocessEmptyCollection.bpmn20.xml" })
+    @Deployment(resources = {
+        "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testSequentialSubprocessEmptyCollection.bpmn20.xml" })
     public void testSequentialSubprocessEmptyCollection() {
         Collection<String> collection = Collections.emptyList();
         Map<String, Object> variableMap = new HashMap<>();
         variableMap.put("collection", collection);
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testSequentialSubProcessEmptyCollection", variableMap);
         assertNotNull(processInstance);
-        org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .singleResult();
         assertNull(task);
         assertProcessEnded(processInstance.getId());
     }
@@ -1422,7 +1812,8 @@ assertProcessEnded(procId);
         variableMap.put("collection", collection);
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testSequentialEmptyCollection", variableMap);
         assertNotNull(processInstance);
-        org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .singleResult();
         assertNull(task);
         assertProcessEnded(processInstance.getId());
     }
@@ -1434,7 +1825,8 @@ assertProcessEnded(procId);
         variableMap.put("collection", collection);
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testSequentialEmptyCollection", variableMap);
         assertNotNull(processInstance);
-        org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .singleResult();
         assertNotNull(task);
         taskService.complete(task.getId());
         assertProcessEnded(processInstance.getId());
@@ -1447,7 +1839,8 @@ assertProcessEnded(procId);
         variableMap.put("collection", collection);
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testParalellEmptyCollection", variableMap);
         assertNotNull(processInstance);
-        org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .singleResult();
         assertNull(task);
         assertProcessEnded(processInstance.getId());
     }
@@ -1459,7 +1852,8 @@ assertProcessEnded(procId);
         variableMap.put("collection", collection);
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testParalellEmptyCollection", variableMap);
         assertNotNull(processInstance);
-        org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .singleResult();
         assertNotNull(task);
         taskService.complete(task.getId());
         assertProcessEnded(processInstance.getId());
@@ -1470,13 +1864,15 @@ assertProcessEnded(procId);
 
         // Add bean temporary to process engine
 
-        Map<Object, Object> originalBeans = processEngineConfiguration.getExpressionManager().getBeans();
+        Map<Object, Object> originalBeans = processEngineConfiguration.getExpressionManager()
+            .getBeans();
 
         try {
 
             Map<Object, Object> newBeans = new HashMap<>();
             newBeans.put("SampleTask", new TestSampleServiceTask());
-            processEngineConfiguration.getExpressionManager().setBeans(newBeans);
+            processEngineConfiguration.getExpressionManager()
+                .setBeans(newBeans);
 
             Map<String, Object> params = new HashMap<>();
             params.put("sampleValues", Arrays.asList("eins", "zwei", "drei"));
@@ -1486,7 +1882,8 @@ assertProcessEnded(procId);
         } finally {
 
             // Put beans back
-            processEngineConfiguration.getExpressionManager().setBeans(originalBeans);
+            processEngineConfiguration.getExpressionManager()
+                .setBeans(originalBeans);
 
         }
     }
@@ -1499,7 +1896,10 @@ assertProcessEnded(procId);
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("parallelUserTaskMi", vars);
 
             waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
-            assertEquals(1L, historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).finished().count());
+            assertEquals(1L, historyService.createHistoricProcessInstanceQuery()
+                .processInstanceId(processInstance.getId())
+                .finished()
+                .count());
         }
     }
 
@@ -1507,9 +1907,12 @@ assertProcessEnded(procId);
     public void testZeroLoopCardinalityOnParallelUserTask() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("parallelUserTaskMi");
-            
+
             waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
-            assertEquals(1L, historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).finished().count());
+            assertEquals(1L, historyService.createHistoricProcessInstanceQuery()
+                .processInstanceId(processInstance.getId())
+                .finished()
+                .count());
         }
     }
 
@@ -1521,7 +1924,9 @@ assertProcessEnded(procId);
             runtimeService.startProcessInstanceByKey("sequentialMiSubprocess", vars);
 
             waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
-            assertEquals(1L, historyService.createHistoricProcessInstanceQuery().finished().count());
+            assertEquals(1L, historyService.createHistoricProcessInstanceQuery()
+                .finished()
+                .count());
         }
     }
 
@@ -1531,10 +1936,12 @@ assertProcessEnded(procId);
             Map<String, Object> vars = new HashMap<>();
             vars.put("messages", Collections.EMPTY_LIST);
             runtimeService.startProcessInstanceByKey("parallelMiSubprocess", vars);
-            
+
             waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
 
-            assertEquals(1L, historyService.createHistoricProcessInstanceQuery().finished().count());
+            assertEquals(1L, historyService.createHistoricProcessInstanceQuery()
+                .finished()
+                .count());
         }
     }
 
@@ -1561,7 +1968,9 @@ assertProcessEnded(procId);
         resetTestCounts();
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testExecutionListenersOnMultiInstanceUserTask");
 
-        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .list();
         for (org.flowable.task.api.Task task : tasks) {
             taskService.complete(task.getId());
         }
@@ -1581,62 +1990,82 @@ assertProcessEnded(procId);
         // Used to throw a nullpointer exception
 
         runtimeService.startProcessInstanceByKey("multiInstance");
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertEquals(0, runtimeService.createExecutionQuery()
+            .count());
     }
 
     @Deployment
     public void testEndTimeOnMiSubprocess() {
 
-        if (!processEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.AUDIT)) {
+        if (!processEngineConfiguration.getHistoryLevel()
+            .isAtLeast(HistoryLevel.AUDIT)) {
             return;
         }
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("multiInstanceSubProcessParallelTasks");
 
-        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .list();
         assertEquals(2, tasks.size());
-        assertEquals("User Task 1", tasks.get(0).getName());
-        assertEquals("User Task 1", tasks.get(1).getName());
-        
+        assertEquals("User Task 1", tasks.get(0)
+            .getName());
+        assertEquals("User Task 1", tasks.get(1)
+            .getName());
+
         waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
 
         // End time should not be set for the subprocess
-        List<HistoricActivityInstance> historicActivityInstances = historyService.createHistoricActivityInstanceQuery().activityId("subprocess1").list();
+        List<HistoricActivityInstance> historicActivityInstances = historyService.createHistoricActivityInstanceQuery()
+            .activityId("subprocess1")
+            .list();
         assertEquals(2, historicActivityInstances.size());
         for (HistoricActivityInstance historicActivityInstance : historicActivityInstances) {
             assertNotNull(historicActivityInstance.getStartTime());
             assertNull(historicActivityInstance.getEndTime());
         }
 
-        // Complete one of the user tasks. This should not trigger setting of end time of the subprocess, but due to a bug it did exactly that
-        taskService.complete(tasks.get(0).getId());
-        
+        // Complete one of the user tasks. This should not trigger setting of end time of the subprocess, but due to a bug it did exactly
+        // that
+        taskService.complete(tasks.get(0)
+            .getId());
+
         waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
-        
-        historicActivityInstances = historyService.createHistoricActivityInstanceQuery().activityId("subprocess1").list();
+
+        historicActivityInstances = historyService.createHistoricActivityInstanceQuery()
+            .activityId("subprocess1")
+            .list();
         assertEquals(2, historicActivityInstances.size());
         for (HistoricActivityInstance historicActivityInstance : historicActivityInstances) {
             assertNull(historicActivityInstance.getEndTime());
         }
 
-        taskService.complete(tasks.get(1).getId());
-        
+        taskService.complete(tasks.get(1)
+            .getId());
+
         waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
-        
-        historicActivityInstances = historyService.createHistoricActivityInstanceQuery().activityId("subprocess1").list();
+
+        historicActivityInstances = historyService.createHistoricActivityInstanceQuery()
+            .activityId("subprocess1")
+            .list();
         assertEquals(2, historicActivityInstances.size());
         for (HistoricActivityInstance historicActivityInstance : historicActivityInstances) {
             assertNull(historicActivityInstance.getEndTime());
         }
 
-        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("User Task 3").list();
+        tasks = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .taskName("User Task 3")
+            .list();
         assertEquals(2, tasks.size());
         for (org.flowable.task.api.Task task : tasks) {
             taskService.complete(task.getId());
-            
+
             waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
-            
-            historicActivityInstances = historyService.createHistoricActivityInstanceQuery().activityId("subprocess1").list();
+
+            historicActivityInstances = historyService.createHistoricActivityInstanceQuery()
+                .activityId("subprocess1")
+                .list();
             assertEquals(2, historicActivityInstances.size());
             for (HistoricActivityInstance historicActivityInstance : historicActivityInstances) {
                 assertNull(historicActivityInstance.getEndTime());
@@ -1644,15 +2073,19 @@ assertProcessEnded(procId);
         }
 
         // Finishing the tasks should also set the end time
-        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        tasks = taskService.createTaskQuery()
+            .processInstanceId(processInstance.getId())
+            .list();
         assertEquals(2, tasks.size());
         for (org.flowable.task.api.Task task : tasks) {
             taskService.complete(task.getId());
         }
-        
+
         waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
 
-        historicActivityInstances = historyService.createHistoricActivityInstanceQuery().activityId("subprocess1").list();
+        historicActivityInstances = historyService.createHistoricActivityInstanceQuery()
+            .activityId("subprocess1")
+            .list();
         assertEquals(2, historicActivityInstances.size());
         for (HistoricActivityInstance historicActivityInstance : historicActivityInstances) {
             assertNotNull(historicActivityInstance.getEndTime());
@@ -1665,11 +2098,13 @@ assertProcessEnded(procId);
         vars.put("multi_users", Collections.singletonList("testuser"));
         ProcessInstance instance = runtimeService.startProcessInstanceByKey("test_multi", vars);
         assertNotNull(instance);
-        org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
+        org.flowable.task.api.Task task = taskService.createTaskQuery()
+            .singleResult();
         assertEquals("multi", task.getTaskDefinitionKey());
         vars.put("multi_users", new ArrayList<String>()); // <-- Problem here.
         taskService.complete(task.getId(), vars);
-        List<ProcessInstance> instances = runtimeService.createProcessInstanceQuery().list();
+        List<ProcessInstance> instances = runtimeService.createProcessInstanceQuery()
+            .list();
         assertEquals(0, instances.size());
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/runtime/WatchDogAgendaFactory.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/runtime/WatchDogAgendaFactory.java
@@ -136,7 +136,7 @@ public class WatchDogAgendaFactory implements FlowableEngineAgendaFactory {
 
         @Override
         public void planMonitorParallelMultiInstanceOperation(ExecutionEntity executionEntity, List< ? extends ExecutionEntity> executions) {
-            // TODO Auto-generated method stub
+            agenda.planMonitorParallelMultiInstanceOperation(executionEntity, executions);
 
         }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/runtime/WatchDogAgendaFactory.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/runtime/WatchDogAgendaFactory.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.examples.runtime;
 
+import java.util.List;
+
 import org.flowable.common.engine.api.FlowableException;
 import org.flowable.common.engine.impl.interceptor.CommandContext;
 import org.flowable.engine.FlowableEngineAgenda;
@@ -20,7 +22,8 @@ import org.flowable.engine.impl.agenda.DefaultFlowableEngineAgenda;
 import org.flowable.engine.impl.persistence.entity.ExecutionEntity;
 
 /**
- * This class is a simple watchdog agenda implementation. It throws exception in the case when watchdog limit is exceeded for fetching operations from agenda.
+ * This class is a simple watchdog agenda implementation. It throws exception in
+ * the case when watchdog limit is exceeded for fetching operations from agenda.
  */
 public class WatchDogAgendaFactory implements FlowableEngineAgendaFactory {
 
@@ -122,13 +125,19 @@ public class WatchDogAgendaFactory implements FlowableEngineAgendaFactory {
         @Override
         public void flush() {
             // TODO Auto-generated method stub
-            
+
         }
 
         @Override
         public void close() {
             // TODO Auto-generated method stub
-            
+
+        }
+
+        @Override
+        public void planMonitorParallelMultiInstanceOperation(ExecutionEntity executionEntity, List< ? extends ExecutionEntity> executions) {
+            // TODO Auto-generated method stub
+
         }
 
     }

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testSequentialCallActivityWithList.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testSequentialCallActivityWithList.bpmn20.xml
@@ -35,7 +35,7 @@
       <extensionElements>
         <activiti:in source="element" target="element"/>
       </extensionElements>
-      <multiInstanceLoopCharacteristics isSequential="false" activiti:collection="#{list}" activiti:elementVariable="element" />      
+      <multiInstanceLoopCharacteristics isSequential="true" activiti:collection="#{list}" activiti:elementVariable="element" />      
     </callActivity>
     
     <sequenceFlow id="flow2" sourceRef="miCallActivity" targetRef="task1" />

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/DefaultJobManager.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/DefaultJobManager.java
@@ -77,7 +77,8 @@ public class DefaultJobManager implements JobManager {
 
     @Override
     public void createAsyncJob(JobEntity jobEntity, boolean exclusive) {
-        // When the async executor is activated, the job is directly passed on to the async executor thread
+        // When the async executor is activated, the job is directly passed on
+        // to the async executor thread
         if (isAsyncExecutorActive()) {
             internalCreateLockedAsyncJob(jobEntity, exclusive);
 
@@ -94,7 +95,8 @@ public class DefaultJobManager implements JobManager {
     }
 
     protected void triggerExecutorIfNeeded(JobEntity jobEntity) {
-        // When the async executor is activated, the job is directly passed on to the async executor thread
+        // When the async executor is activated, the job is directly passed on
+        // to the async executor thread
         if (isAsyncExecutorActive()) {
             hintAsyncExecutor(jobEntity);
         }
@@ -117,8 +119,7 @@ public class DefaultJobManager implements JobManager {
     private void sendTimerScheduledEvent(TimerJobEntity timerJob) {
         FlowableEventDispatcher eventDispatcher = CommandContextUtil.getEventDispatcher();
         if (eventDispatcher != null && eventDispatcher.isEnabled()) {
-            eventDispatcher.dispatchEvent(
-                    FlowableJobEventBuilder.createEntityEvent(FlowableEngineEventType.TIMER_SCHEDULED, timerJob));
+            eventDispatcher.dispatchEvent(FlowableJobEventBuilder.createEntityEvent(FlowableEngineEventType.TIMER_SCHEDULED, timerJob));
         }
     }
 
@@ -237,6 +238,9 @@ public class DefaultJobManager implements JobManager {
 
     @Override
     public void unacquire(JobInfo job) {
+        if (job == null) {
+            return;
+        }
 
         if (job instanceof HistoryJob) {
 
@@ -244,7 +248,8 @@ public class DefaultJobManager implements JobManager {
 
             HistoryJobEntity newJobEntity = jobServiceConfiguration.getHistoryJobEntityManager().create();
             copyHistoryJobInfo(newJobEntity, jobEntity);
-            newJobEntity.setId(null); // We want a new id to be assigned to this job
+            newJobEntity.setId(null); // We want a new id to be assigned to this
+                                      // job
             newJobEntity.setLockExpirationTime(null);
             newJobEntity.setLockOwner(null);
             jobServiceConfiguration.getHistoryJobEntityManager().insert(newJobEntity);
@@ -253,21 +258,25 @@ public class DefaultJobManager implements JobManager {
         } else if (job instanceof JobEntity) {
 
             // Deleting the old job and inserting it again with another id,
-            // will avoid that the job is immediately is picked up again (for example
+            // will avoid that the job is immediately is picked up again (for
+            // example
             // when doing lots of exclusive jobs for the same process instance)
 
             JobEntity jobEntity = (JobEntity) job;
 
             JobEntity newJobEntity = jobServiceConfiguration.getJobEntityManager().create();
             copyJobInfo(newJobEntity, jobEntity);
-            newJobEntity.setId(null); // We want a new id to be assigned to this job
+            newJobEntity.setId(null); // We want a new id to be assigned to this
+                                      // job
             newJobEntity.setLockExpirationTime(null);
             newJobEntity.setLockOwner(null);
             jobServiceConfiguration.getJobEntityManager().insert(newJobEntity);
             jobServiceConfiguration.getJobEntityManager().delete(jobEntity.getId());
 
-            // We're not calling triggerExecutorIfNeeded here after the insert. The unacquire happened
-            // for a reason (eg queue full or exclusive lock failure). No need to try it immediately again,
+            // We're not calling triggerExecutorIfNeeded here after the insert.
+            // The unacquire happened
+            // for a reason (eg queue full or exclusive lock failure). No need
+            // to try it immediately again,
             // as the chance of failure will be high.
 
         } else {
@@ -289,7 +298,8 @@ public class DefaultJobManager implements JobManager {
             if (historyJobEntity.getRetries() > 0) {
                 HistoryJobEntity newHistoryJobEntity = jobServiceConfiguration.getHistoryJobEntityManager().create();
                 copyHistoryJobInfo(newHistoryJobEntity, historyJobEntity);
-                newHistoryJobEntity.setId(null); // We want a new id to be assigned to this job
+                newHistoryJobEntity.setId(null); // We want a new id to be
+                                                 // assigned to this job
                 newHistoryJobEntity.setLockExpirationTime(null);
                 newHistoryJobEntity.setLockOwner(null);
                 newHistoryJobEntity.setCreateTime(jobServiceConfiguration.getClock().getCurrentTime());
@@ -297,7 +307,7 @@ public class DefaultJobManager implements JobManager {
                 newHistoryJobEntity.setRetries(newHistoryJobEntity.getRetries() - 1);
                 jobServiceConfiguration.getHistoryJobEntityManager().insert(newHistoryJobEntity);
                 jobServiceConfiguration.getHistoryJobEntityManager().deleteNoCascade(historyJobEntity);
-            
+
             } else {
                 jobServiceConfiguration.getHistoryJobEntityManager().delete(historyJobEntity);
             }
@@ -307,7 +317,8 @@ public class DefaultJobManager implements JobManager {
 
             JobEntity newJobEntity = jobServiceConfiguration.getJobEntityManager().create();
             copyJobInfo(newJobEntity, jobEntity);
-            newJobEntity.setId(null); // We want a new id to be assigned to this job
+            newJobEntity.setId(null); // We want a new id to be assigned to this
+                                      // job
             newJobEntity.setLockExpirationTime(null);
             newJobEntity.setLockOwner(null);
 
@@ -322,8 +333,10 @@ public class DefaultJobManager implements JobManager {
 
             jobServiceConfiguration.getJobEntityManager().delete(jobEntity.getId());
 
-            // We're not calling triggerExecutorIfNeeded here after the insert. The unacquire happened
-            // for a reason (eg queue full or exclusive lock failure). No need to try it immediately again,
+            // We're not calling triggerExecutorIfNeeded here after the insert.
+            // The unacquire happened
+            // for a reason (eg queue full or exclusive lock failure). No need
+            // to try it immediately again,
             // as the chance of failure will be high.
 
         }
@@ -377,7 +390,7 @@ public class DefaultJobManager implements JobManager {
             }
         }
     }
-    
+
     protected void executeJobHandler(JobEntity jobEntity) {
         VariableScope variableScope = jobServiceConfiguration.getInternalJobManager().resolveVariableScope(jobEntity);
 
@@ -409,13 +422,14 @@ public class DefaultJobManager implements JobManager {
     }
 
     protected boolean isValidTime(JobEntity timerEntity, Date newTimerDate, VariableScope variableScope) {
-        BusinessCalendar businessCalendar = jobServiceConfiguration.getBusinessCalendarManager().getBusinessCalendar(
-                getBusinessCalendarName(timerEntity, variableScope));
+        BusinessCalendar businessCalendar = jobServiceConfiguration.getBusinessCalendarManager()
+                        .getBusinessCalendar(getBusinessCalendarName(timerEntity, variableScope));
         return businessCalendar.validateDuedate(timerEntity.getRepeat(), timerEntity.getMaxIterations(), timerEntity.getEndDate(), newTimerDate);
     }
 
     protected void hintAsyncExecutor(JobEntity job) {
-        // Verify that correct properties have been set when the async executor will be hinted
+        // Verify that correct properties have been set when the async executor
+        // will be hinted
         if (job.getLockOwner() == null || job.getLockExpirationTime() == null) {
             createAsyncJob(job, job.isExclusive());
         }
@@ -428,18 +442,18 @@ public class DefaultJobManager implements JobManager {
         }
         createHintListeners(getAsyncHistoryExecutor(), historyJobEntity);
     }
-    
+
     protected void createHintListeners(AsyncExecutor asyncExecutor, JobInfoEntity job) {
         CommandContext commandContext = CommandContextUtil.getCommandContext();
         if (Context.getTransactionContext() != null) {
             JobAddedTransactionListener jobAddedTransactionListener = new JobAddedTransactionListener(job, asyncExecutor,
                             CommandContextUtil.getJobServiceConfiguration(commandContext).getCommandExecutor());
             Context.getTransactionContext().addTransactionListener(TransactionState.COMMITTED, jobAddedTransactionListener);
-            
+
         } else {
             AsyncJobAddedNotification jobAddedNotification = new AsyncJobAddedNotification(job, asyncExecutor);
             commandContext.addCloseListener(jobAddedNotification);
-            
+
         }
     }
 
@@ -465,8 +479,8 @@ public class DefaultJobManager implements JobManager {
     protected String getBusinessCalendarName(String calendarName, VariableScope variableScope) {
         String businessCalendarName = CYCLE_TYPE;
         if (StringUtils.isNotEmpty(calendarName)) {
-            businessCalendarName = (String) CommandContextUtil.getJobServiceConfiguration().getExpressionManager()
-                    .createExpression(calendarName).getValue(variableScope);
+            businessCalendarName = (String) CommandContextUtil.getJobServiceConfiguration().getExpressionManager().createExpression(calendarName)
+                            .getValue(variableScope);
         }
         return businessCalendarName;
     }
@@ -478,18 +492,19 @@ public class DefaultJobManager implements JobManager {
         triggerAsyncHistoryExecutorIfNeeded(historyJobEntity);
         return historyJobEntity;
     }
-    
+
     protected void triggerAsyncHistoryExecutorIfNeeded(HistoryJobEntity historyJobEntity) {
         CommandContext commandContext = CommandContextUtil.getCommandContext();
         AsyncHistorySession asyncHistorySession = commandContext.getSession(AsyncHistorySession.class);
         if (asyncHistorySession != null) {
             TransactionContext transactionContext = asyncHistorySession.getTransactionContext();
             if (transactionContext != null) {
-                transactionContext.addTransactionListener(TransactionState.COMMITTED, new TriggerAsyncExecutorTransactionListener(commandContext, historyJobEntity)); 
+                transactionContext.addTransactionListener(TransactionState.COMMITTED,
+                                new TriggerAsyncExecutorTransactionListener(commandContext, historyJobEntity));
             }
         }
     }
-    
+
     protected void internalCreateAsyncJob(JobEntity jobEntity, boolean exclusive) {
         fillDefaultAsyncJobInfo(jobEntity, exclusive);
     }
@@ -499,7 +514,7 @@ public class DefaultJobManager implements JobManager {
         setLockTimeAndOwner(getAsyncExecutor(), jobEntity);
     }
 
-    protected void setLockTimeAndOwner(AsyncExecutor asyncExecutor , JobInfoEntity jobInfoEntity) {
+    protected void setLockTimeAndOwner(AsyncExecutor asyncExecutor, JobInfoEntity jobInfoEntity) {
         GregorianCalendar gregorianCalendar = new GregorianCalendar();
         gregorianCalendar.setTime(jobServiceConfiguration.getClock().getCurrentTime());
         gregorianCalendar.add(Calendar.MILLISECOND, asyncExecutor.getAsyncJobLockTimeInMillis());
@@ -613,11 +628,11 @@ public class DefaultJobManager implements JobManager {
     protected boolean isAsyncExecutorActive() {
         return isExecutorActive(jobServiceConfiguration.getAsyncExecutor());
     }
-    
+
     protected boolean isAsyncHistoryExecutorActive() {
         return isExecutorActive(jobServiceConfiguration.getAsyncHistoryExecutor());
     }
-    
+
     protected boolean isExecutorActive(AsyncExecutor asyncExecutor) {
         return asyncExecutor != null && asyncExecutor.isActive();
     }
@@ -629,7 +644,7 @@ public class DefaultJobManager implements JobManager {
     protected AsyncExecutor getAsyncExecutor() {
         return jobServiceConfiguration.getAsyncExecutor();
     }
-    
+
     protected AsyncExecutor getAsyncHistoryExecutor() {
         return jobServiceConfiguration.getAsyncHistoryExecutor();
     }


### PR DESCRIPTION
Currently there was a problem when some Activity is being used with ParallelMultiInstanceActivityBehavior. The problem was that an FlowableOptimisticLockingException was being thrown and this prevents the execution of the concurrent executions(the retry of the failed job was not efficient because the whole execution is being retried which leads to retry of whole steps, gateways or even ProcessInstances). This PullRequest introduces a way to overcome this situation by using a custom Monitoring operation. The operation is "watching" the concurrent executions progress and based on it is deciding whether the parallel processing has finished.