### PR TITLE
Update Groovy to version 2.5.2

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -123,7 +123,8 @@ org.apache.httpcomponents       httpclient                  4.5.6           Apac
 org.apache.httpcomponents       httpcore                    4.4.10          Apache License, Version 2.0
 org.apache.httpcomponents       httpmime                    4.5.6           Apache License, Version 2.0
 org.apache.geronimo.bundles     json                        20090211_1      The Apache Software License, Version 2.0
-org.codehaus.groovy             groovy-all                  2.4.15          The Apache Software License, Version 2.0
+org.codehaus.groovy             groovy                      2.5.2           The Apache Software License, Version 2.0
+org.codehaus.groovy             groovy-jsr223               2.5.2           The Apache Software License, Version 2.0
 org.liquibase                   liquibase-core              3.6.2           Apache License, Version 2.0
 org.mybatis                     mybatis                     3.4.6           The Apache Software License, Version 2.0
 org.mybatis                     mybatis-spring              1.3.2           The Apache Software License, Version 2.0

--- a/docs/public-api/tools/flowable-oas-generator/pom.xml
+++ b/docs/public-api/tools/flowable-oas-generator/pom.xml
@@ -307,7 +307,7 @@
         </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
+            <artifactId>groovy-jsr223</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/docs/userguide/src/en/bpmn/ch07b-BPMN-Constructs.adoc
+++ b/docs/userguide/src/en/bpmn/ch07b-BPMN-Constructs.adoc
@@ -2470,13 +2470,13 @@ A script task is defined by specifying the *script* and the *scriptFormat*.
 
 The value of the *scriptFormat* attribute must be a name that is compatible with the link:$$http://jcp.org/en/jsr/detail?id=223$$[JSR-223] (scripting for the Java platform). By default, JavaScript is included in every JDK and as such doesn't need any additional JAR files. If you want to use another (JSR-223 compatible) scripting engine, it is sufficient to add the corresponding JAR to the classpath and use the appropriate name. For example, the Flowable unit tests often use Groovy because the syntax is similar to that of Java.
 
-Do note that the Groovy scripting engine is bundled with the groovy-all jar. Before Groovy version 2.0, the scripting engine was part of the regular Groovy JAR. As such, one must now add following dependency:
+Do note that the Groovy scripting engine is bundled with the groovy-jsr223 jar. As such, one must add the following dependency:
 
 [source,xml,linenums]
 ----
 <dependency>
     <groupId>org.codehaus.groovy</groupId>
-    <artifactId>groovy-all</artifactId>
+    <artifactId>groovy-jsr223</artifactId>
     <version>2.x.x<version>
 </dependency>
 ----

--- a/docs/userguide/src/en/cmmn/ch06-cmmn.adoc
+++ b/docs/userguide/src/en/cmmn/ch06-cmmn.adoc
@@ -608,13 +608,13 @@ image::images/cmmn.scripttask.png[align="center"]
 
 *Note*: The value of the *scriptFormat* attribute must be a name that is compatible with the link:$$http://jcp.org/en/jsr/detail?id=223$$[JSR-223] (scripting for the Java platform). By default, JavaScript is included in every JDK and as such doesn't need any additional JAR files. If you want to use another (JSR-223 compatible) scripting engine, it is sufficient to add the corresponding JAR to the classpath and use the appropriate name. For example, the Flowable unit tests often use Groovy because the syntax is similar to that of Java.
 
-Do note that the Groovy scripting engine is bundled with the groovy-all JAR. Before Groovy version 2.0, the scripting engine was part of the regular Groovy JAR. As such, one must now add following dependency:
+Do note that the Groovy scripting engine is bundled with the groovy-jsr223 JAR. As such, one must add the following dependency:
 
 [source,xml,linenums]
 ----
 <dependency>
     <groupId>org.codehaus.groovy</groupId>
-    <artifactId>groovy-all</artifactId>
+    <artifactId>groovy-jsr223</artifactId>
     <version>2.x.x<version>
 </dependency>
 ----

--- a/modules/flowable-app-engine/pom.xml
+++ b/modules/flowable-app-engine/pom.xml
@@ -116,7 +116,7 @@
         </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
+            <artifactId>groovy-jsr223</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/modules/flowable-app-rest/pom.xml
+++ b/modules/flowable-app-rest/pom.xml
@@ -673,7 +673,7 @@
     </dependency>
     <dependency>
       <groupId>org.codehaus.groovy</groupId>
-      <artifactId>groovy-all</artifactId>
+      <artifactId>groovy-jsr223</artifactId>
     </dependency>
     <dependency>
         <groupId>javax.xml.bind</groupId> <!-- Needed for swagger doc generation -->

--- a/modules/flowable-cmmn-engine/pom.xml
+++ b/modules/flowable-cmmn-engine/pom.xml
@@ -140,7 +140,7 @@
         </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
+            <artifactId>groovy-jsr223</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/modules/flowable-crystalball/pom.xml
+++ b/modules/flowable-crystalball/pom.xml
@@ -132,7 +132,7 @@
     </dependency>
     <dependency>
       <groupId>org.codehaus.groovy</groupId>
-      <artifactId>groovy-all</artifactId>
+      <artifactId>groovy-jsr223</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/modules/flowable-engine/pom.xml
+++ b/modules/flowable-engine/pom.xml
@@ -120,7 +120,7 @@
         </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
+            <artifactId>groovy-jsr223</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/modules/flowable-groovy-script-static-engine/pom.xml
+++ b/modules/flowable-groovy-script-static-engine/pom.xml
@@ -88,7 +88,7 @@
   <dependencies>
     <dependency>
       <groupId>org.codehaus.groovy</groupId>
-      <artifactId>groovy-all</artifactId>
+      <artifactId>groovy-jsr223</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/modules/flowable-spring-boot/flowable-spring-boot-samples/pom.xml
+++ b/modules/flowable-spring-boot/flowable-spring-boot-samples/pom.xml
@@ -34,7 +34,7 @@
     <dependencies>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
+            <artifactId>groovy-jsr223</artifactId>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/pom.xml
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/pom.xml
@@ -170,8 +170,7 @@
         </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy</artifactId>
-            <version>1.7.5</version>
+            <artifactId>groovy-jsr223</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-starter-integration/pom.xml
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-starter-integration/pom.xml
@@ -32,9 +32,8 @@
 
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy</artifactId>
+            <artifactId>groovy-jsr223</artifactId>
             <scope>test</scope>
-            <version>1.7.5</version>
         </dependency>
 
         <dependency>

--- a/modules/flowable-spring/pom.xml
+++ b/modules/flowable-spring/pom.xml
@@ -151,7 +151,7 @@
         </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
+            <artifactId>groovy-jsr223</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/modules/flowable-ui-task/flowable-ui-task-conf/pom.xml
+++ b/modules/flowable-ui-task/flowable-ui-task-conf/pom.xml
@@ -272,7 +272,7 @@
 
         <dependency>
         	<groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
+            <artifactId>groovy-jsr223</artifactId>
        </dependency>
 
 	</dependencies>

--- a/modules/flowable-ui-task/flowable-ui-task-rest/pom.xml
+++ b/modules/flowable-ui-task/flowable-ui-task-rest/pom.xml
@@ -166,7 +166,7 @@
         
 	  	<dependency>
         	<groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
+            <artifactId>groovy-jsr223</artifactId>
        </dependency>
 	   
 	</dependencies>

--- a/modules/flowable5-engine/pom.xml
+++ b/modules/flowable5-engine/pom.xml
@@ -54,7 +54,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.codehaus.groovy</groupId>
-			<artifactId>groovy-all</artifactId>
+			<artifactId>groovy-jsr223</artifactId>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/modules/flowable5-spring-test/pom.xml
+++ b/modules/flowable5-spring-test/pom.xml
@@ -126,7 +126,7 @@
         </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
+            <artifactId>groovy-jsr223</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/modules/flowable5-spring/pom.xml
+++ b/modules/flowable5-spring/pom.xml
@@ -128,7 +128,7 @@
         </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
+            <artifactId>groovy-jsr223</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/modules/flowable5-test/pom.xml
+++ b/modules/flowable5-test/pom.xml
@@ -47,7 +47,7 @@
     	</dependency>
 		<dependency>
 			<groupId>org.codehaus.groovy</groupId>
-			<artifactId>groovy-all</artifactId>
+			<artifactId>groovy-jsr223</artifactId>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -685,8 +685,8 @@
 			</dependency>
 			<dependency>
 				<groupId>org.codehaus.groovy</groupId>
-				<artifactId>groovy-all</artifactId>
-				<version>2.4.15</version>
+				<artifactId>groovy-jsr223</artifactId>
+				<version>2.5.2</version>
 			</dependency>
 			<dependency>
 				<groupId>org.drools</groupId>


### PR DESCRIPTION
Groovy 2.5+ does no longer provide a groovy-all jar, therefore replace the groovy-all with the groovy-jsr223 artifact (potentially breaking change for people using classes from other groovy modules e.g. groovy-xml as they will have to add these modules manually).