### PR TITLE
Java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
     dist: xenial
   - jdk: openjdk11
     dist: xenial
+  - jdk: openjdk12
   - jdk: openjdk-ea
     branches:
       only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ matrix:
       - master
     if: TRAVIS_PULL_REQUEST != false
   allow_failures:
-  - jdk: openjdk11
   - jdk: openjdk-ea
   - name: "Flowable 5 tests"
 

--- a/modules/flowable-app-rest/src/test/java/org/flowable/rest/app/FlowableRestApplicationSecurityTest.java
+++ b/modules/flowable-app-rest/src/test/java/org/flowable/rest/app/FlowableRestApplicationSecurityTest.java
@@ -73,7 +73,11 @@ public class FlowableRestApplicationSecurityTest {
             "metrics-requiredMetricName",
             "scheduledtasks",
             "httptrace",
-            "mappings"
+            "mappings",
+            "caches",
+            "caches-cache",
+            "health-component",
+            "health-component-instance"
         )
     );
 
@@ -89,7 +93,7 @@ public class FlowableRestApplicationSecurityTest {
     @Test
     public void nonAuthenticatedUserShouldNotBeAbleToAccessActuator() {
         String actuatorUrl = "http://localhost:" + serverPort + "/flowable-rest/actuator";
-        ResponseEntity<Object> entity = restTemplate.getForEntity(actuatorUrl, Object.class);
+        ResponseEntity<String> entity = restTemplate.getForEntity(actuatorUrl, String.class);
 
         assertThat(entity.getStatusCode())
             .as("GET Actuator response status")
@@ -105,7 +109,7 @@ public class FlowableRestApplicationSecurityTest {
                 continue;
             }
 
-            ResponseEntity<Object> endpointResponse = restTemplate.getForEntity(link.getHref(), Object.class);
+            ResponseEntity<String> endpointResponse = restTemplate.getForEntity(link.getHref(), String.class);
 
             assertThat(endpointResponse.getStatusCode())
                 .as("Endpoint '" + endpoint + "' response status")
@@ -126,7 +130,7 @@ public class FlowableRestApplicationSecurityTest {
 
         HttpEntity<?> request = new HttpEntity<>(createHeaders("test-user", "test"));
         String actuatorUrl = "http://localhost:" + serverPort + "/flowable-rest/actuator";
-        ResponseEntity<Object> entity = restTemplate.exchange(actuatorUrl, HttpMethod.GET, request, Object.class);
+        ResponseEntity<String> entity = restTemplate.exchange(actuatorUrl, HttpMethod.GET, request, String.class);
 
         assertThat(entity.getStatusCode())
             .as("GET Actuator response status")
@@ -148,7 +152,7 @@ public class FlowableRestApplicationSecurityTest {
                 continue;
             }
 
-            ResponseEntity<Object> endpointResponse = restTemplate.exchange(link.getHref(), HttpMethod.GET, request, Object.class);
+            ResponseEntity<String> endpointResponse = restTemplate.exchange(link.getHref(), HttpMethod.GET, request, String.class);
 
             assertThat(endpointResponse.getStatusCode())
                 .as("Endpoint '" + endpoint + "' response status")

--- a/modules/flowable-camel-cdi/pom.xml
+++ b/modules/flowable-camel-cdi/pom.xml
@@ -32,6 +32,11 @@
         <artifactId>camel-cdi</artifactId>
       </dependency>
       <dependency>
+        <groupId>javax.xml.bind</groupId>
+        <artifactId>jaxb-api</artifactId>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
           <groupId>org.jboss.arquillian.junit</groupId>
           <artifactId>arquillian-junit-container</artifactId>
           <scope>test</scope>

--- a/modules/flowable-camel/pom.xml
+++ b/modules/flowable-camel/pom.xml
@@ -42,6 +42,11 @@
       <artifactId>jcl-over-slf4j</artifactId>
     </dependency>
     <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
       <scope>test</scope>

--- a/modules/flowable-cxf/pom.xml
+++ b/modules/flowable-cxf/pom.xml
@@ -203,15 +203,6 @@
         </plugins>
       </build>
     </profile>
-    <profile>
-        <id>java9+</id>
-        <activation>
-            <jdk>[9,)</jdk>
-        </activation>
-        <properties>
-            <argLine>--add-modules java.xml.ws</argLine>
-        </properties>
-    </profile>
   </profiles>
 
   <reporting>

--- a/modules/flowable-engine-common/pom.xml
+++ b/modules/flowable-engine-common/pom.xml
@@ -189,9 +189,8 @@
             <artifactId>joda-time</artifactId>
         </dependency>
         <dependency>
-            <!-- no official JPA 2.1 Jar was ever published, so we have to use a vendor implementation :( -->
-            <groupId>org.hibernate.javax.persistence</groupId>
-            <artifactId>hibernate-jpa-2.1-api</artifactId>
+            <groupId>javax.persistence</groupId>
+            <artifactId>javax.persistence-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/modules/flowable-engine/pom.xml
+++ b/modules/flowable-engine/pom.xml
@@ -138,9 +138,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <!-- no official JPA 2.1 Jar was ever published, so we have to use a vendor implementation :( -->
-            <groupId>org.hibernate.javax.persistence</groupId>
-            <artifactId>hibernate-jpa-2.1-api</artifactId>
+            <groupId>javax.persistence</groupId>
+            <artifactId>javax.persistence-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/modules/flowable-engine/pom.xml
+++ b/modules/flowable-engine/pom.xml
@@ -154,6 +154,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>

--- a/modules/flowable-entitylink-service/pom.xml
+++ b/modules/flowable-entitylink-service/pom.xml
@@ -43,9 +43,8 @@
             <artifactId>joda-time</artifactId>
         </dependency>
         <dependency>
-            <!-- no official JPA 2.1 Jar was ever published, so we have to use a vendor implementation :( -->
-            <groupId>org.hibernate.javax.persistence</groupId>
-            <artifactId>hibernate-jpa-2.1-api</artifactId>
+            <groupId>javax.persistence</groupId>
+            <artifactId>javax.persistence-api</artifactId>
             <scope>provided</scope>
         </dependency>
 		<dependency>

--- a/modules/flowable-identitylink-service/pom.xml
+++ b/modules/flowable-identitylink-service/pom.xml
@@ -43,9 +43,8 @@
             <artifactId>joda-time</artifactId>
         </dependency>
         <dependency>
-            <!-- no official JPA 2.1 Jar was ever published, so we have to use a vendor implementation :( -->
-            <groupId>org.hibernate.javax.persistence</groupId>
-            <artifactId>hibernate-jpa-2.1-api</artifactId>
+            <groupId>javax.persistence</groupId>
+            <artifactId>javax.persistence-api</artifactId>
             <scope>provided</scope>
         </dependency>
 		<dependency>

--- a/modules/flowable-job-service/pom.xml
+++ b/modules/flowable-job-service/pom.xml
@@ -43,9 +43,8 @@
             <artifactId>joda-time</artifactId>
         </dependency>
         <dependency>
-            <!-- no official JPA 2.1 Jar was ever published, so we have to use a vendor implementation :( -->
-            <groupId>org.hibernate.javax.persistence</groupId>
-            <artifactId>hibernate-jpa-2.1-api</artifactId>
+            <groupId>javax.persistence</groupId>
+            <artifactId>javax.persistence-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/modules/flowable-ldap-configurator/pom.xml
+++ b/modules/flowable-ldap-configurator/pom.xml
@@ -42,6 +42,12 @@
 			<artifactId>flowable-idm-engine-configurator</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>javax.annotation</groupId>
+			<artifactId>javax.annotation-api</artifactId>
+			<version>1.3.2</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.flowable</groupId>
 			<artifactId>flowable-spring</artifactId>
 			<scope>test</scope>

--- a/modules/flowable-ldap-configurator/pom.xml
+++ b/modules/flowable-ldap-configurator/pom.xml
@@ -197,6 +197,16 @@
 				</plugins>
 			</build>
 		</profile>
+        <profile>
+            <id>java11+</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <properties>
+                <!-- Apache DS does not support Java 11 yet -->
+                <maven.test.skip>true</maven.test.skip>
+            </properties>
+        </profile>
 	</profiles>
 
 	<build>

--- a/modules/flowable-rest/pom.xml
+++ b/modules/flowable-rest/pom.xml
@@ -136,6 +136,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-integration/src/main/java/flowable/Application.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-integration/src/main/java/flowable/Application.java
@@ -13,7 +13,6 @@
 package flowable;
 
 import java.util.Collections;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.flowable.engine.ProcessEngine;
@@ -28,6 +27,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.IntegrationFlows;
 import org.springframework.integration.handler.GenericHandler;
+import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.support.MessageBuilder;
 
 @SpringBootApplication
@@ -71,7 +71,7 @@ public class Application {
                 .from(inboundGateway)
                 .handle(new GenericHandler<DelegateExecution>() {
                     @Override
-                    public Object handle(DelegateExecution execution, Map<String, Object> headers) {
+                    public Object handle(DelegateExecution execution, MessageHeaders headers) {
                         return MessageBuilder.withPayload(execution)
                                 .setHeader("projectId", "2143243")
                                 .setHeader("orderId", "246")

--- a/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-jpa/pom.xml
+++ b/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-jpa/pom.xml
@@ -20,6 +20,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+          <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/pom.xml
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/pom.xml
@@ -227,6 +227,12 @@
             <scope>test</scope>
         </dependency>
 
+         <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- embedded DB for testing -->
         <dependency>
             <groupId>com.h2database</groupId>

--- a/modules/flowable-spring/pom.xml
+++ b/modules/flowable-spring/pom.xml
@@ -149,9 +149,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <!-- no official JPA 2.1 Jar was ever published, so we have to use a vendor implementation :( -->
-            <groupId>org.hibernate.javax.persistence</groupId>
-            <artifactId>hibernate-jpa-2.1-api</artifactId>
+            <groupId>javax.persistence</groupId>
+            <artifactId>javax.persistence-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/modules/flowable-spring/pom.xml
+++ b/modules/flowable-spring/pom.xml
@@ -134,6 +134,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>

--- a/modules/flowable-ui-admin/flowable-ui-admin-app/src/test/java/org/flowable/ui/admin/application/FlowableAdminApplicationSecurityTest.java
+++ b/modules/flowable-ui-admin/flowable-ui-admin-app/src/test/java/org/flowable/ui/admin/application/FlowableAdminApplicationSecurityTest.java
@@ -75,8 +75,11 @@ public class FlowableAdminApplicationSecurityTest {
             "metrics-requiredMetricName",
             "scheduledtasks",
             "httptrace",
-            "mappings"
-
+            "mappings",
+            "caches",
+            "caches-cache",
+            "health-component",
+            "health-component-instance"
         )
     );
 

--- a/modules/flowable-ui-idm/flowable-ui-idm-app/src/test/java/org/flowable/ui/idm/application/FlowableIdmApplicationSecurityTest.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-app/src/test/java/org/flowable/ui/idm/application/FlowableIdmApplicationSecurityTest.java
@@ -77,8 +77,11 @@ public class FlowableIdmApplicationSecurityTest {
             "metrics-requiredMetricName",
             "scheduledtasks",
             "httptrace",
-            "mappings"
-
+            "mappings",
+            "caches",
+            "caches-cache",
+            "health-component",
+            "health-component-instance"
         )
     );
 

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/test/java/org/flowable/ui/modeler/application/FlowableModelerApplicationSecurityTest.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/test/java/org/flowable/ui/modeler/application/FlowableModelerApplicationSecurityTest.java
@@ -75,8 +75,11 @@ public class FlowableModelerApplicationSecurityTest {
             "metrics-requiredMetricName",
             "scheduledtasks",
             "httptrace",
-            "mappings"
-
+            "mappings",
+            "caches",
+            "caches-cache",
+            "health-component",
+            "health-component-instance"
         )
     );
 

--- a/modules/flowable-ui-task/flowable-ui-task-app/src/test/java/org/flowable/ui/task/application/FlowableTaskApplicationSecurityTest.java
+++ b/modules/flowable-ui-task/flowable-ui-task-app/src/test/java/org/flowable/ui/task/application/FlowableTaskApplicationSecurityTest.java
@@ -76,8 +76,11 @@ public class FlowableTaskApplicationSecurityTest {
             "scheduledtasks",
             "httptrace",
             "flowable",
-            "mappings"
-
+            "mappings",
+            "caches",
+            "caches-cache",
+            "health-component",
+            "health-component-instance"
         )
     );
 

--- a/modules/flowable-variable-service/pom.xml
+++ b/modules/flowable-variable-service/pom.xml
@@ -43,9 +43,8 @@
             <artifactId>joda-time</artifactId>
         </dependency>
         <dependency>
-            <!-- no official JPA 2.1 Jar was ever published, so we have to use a vendor implementation :( -->
-            <groupId>org.hibernate.javax.persistence</groupId>
-            <artifactId>hibernate-jpa-2.1-api</artifactId>
+            <groupId>javax.persistence</groupId>
+            <artifactId>javax.persistence-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/modules/flowable5-engine/pom.xml
+++ b/modules/flowable5-engine/pom.xml
@@ -68,9 +68,8 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<!-- no official JPA 2.1 Jar was ever published, so we have to use a vendor implementation :( -->
-			<groupId>org.hibernate.javax.persistence</groupId>
-			<artifactId>hibernate-jpa-2.1-api</artifactId>
+			<groupId>javax.persistence</groupId>
+			<artifactId>javax.persistence-api</artifactId>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/modules/flowable5-spring-test/pom.xml
+++ b/modules/flowable5-spring-test/pom.xml
@@ -119,9 +119,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <!-- no official JPA 2.1 Jar was ever published, so we have to use a vendor implementation :( -->
-            <groupId>org.hibernate.javax.persistence</groupId>
-            <artifactId>hibernate-jpa-2.1-api</artifactId>
+            <groupId>javax.persistence</groupId>
+            <artifactId>javax.persistence-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/modules/flowable5-spring-test/pom.xml
+++ b/modules/flowable5-spring-test/pom.xml
@@ -139,6 +139,11 @@
 			<version>6.5.0-SNAPSHOT</version>
 		</dependency>
         <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>

--- a/modules/flowable5-spring/pom.xml
+++ b/modules/flowable5-spring/pom.xml
@@ -121,9 +121,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <!-- no official JPA 2.1 Jar was ever published, so we have to use a vendor implementation :( -->
-            <groupId>org.hibernate.javax.persistence</groupId>
-            <artifactId>hibernate-jpa-2.1-api</artifactId>
+            <groupId>javax.persistence</groupId>
+            <artifactId>javax.persistence-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/modules/flowable5-test/pom.xml
+++ b/modules/flowable5-test/pom.xml
@@ -61,9 +61,8 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<!-- no official JPA 2.1 Jar was ever published, so we have to use a vendor implementation :( -->
-			<groupId>org.hibernate.javax.persistence</groupId>
-			<artifactId>hibernate-jpa-2.1-api</artifactId>
+			<groupId>javax.persistence</groupId>
+			<artifactId>javax.persistence-api</artifactId>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1676,15 +1676,6 @@
                 </plugins>
             </build>
 		</profile>
-        <profile>
-            <id>java9+</id>
-            <activation>
-                <jdk>[9,)</jdk>
-            </activation>
-            <properties>
-                <argLine>--add-modules java.xml.bind -XX:+UseParallelGC</argLine>
-            </properties>
-        </profile>
 	</profiles>
 
     <reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -167,10 +167,9 @@
 				<version>1.6.2</version>
 			</dependency>
 			<dependency>
-				<!-- no official JPA 2.1 Jar was ever published, so we have to use a vendor implementation :( -->
-				<groupId>org.hibernate.javax.persistence</groupId>
-				<artifactId>hibernate-jpa-2.1-api</artifactId>
-				<version>1.0.0.Final</version>
+				<groupId>javax.persistence</groupId>
+				<artifactId>javax.persistence-api</artifactId>
+				<version>2.2</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>
@@ -690,7 +689,7 @@
 			<dependency>
 				<groupId>org.hibernate</groupId>
 				<artifactId>hibernate-core</artifactId>
-				<version>5.2.16.Final</version>
+				<version>5.3.5.Final</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -18,14 +18,14 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<jdk.version>1.8</jdk.version>
-		<spring.framework.version>5.0.12.RELEASE</spring.framework.version>
-		<spring.security.version>5.0.11.RELEASE</spring.security.version>
+		<spring.framework.version>5.1.4.RELEASE</spring.framework.version>
+		<spring.security.version>5.1.3.RELEASE</spring.security.version>
 		<jackson.version>2.9.8</jackson.version>
 		<mule.version>3.8.0</mule.version>
         <camel.version>2.23.0</camel.version>
 		<cxf.version>3.3.0</cxf.version>
 		<slf4j.version>1.7.25</slf4j.version>
-		<spring.boot.version>2.0.8.RELEASE</spring.boot.version>
+		<spring.boot.version>2.1.2.RELEASE</spring.boot.version>
 
 		<junit.version>4.12</junit.version>
 		<junit.jupiter.version>5.3.2</junit.jupiter.version>


### PR DESCRIPTION
Make flowable build on Java 11 (and 12).

Requires an update to Spring and Spring Security 5.1, Spring Boot 2.1 and JPA 2.2.

Tests of flowable-ldap-configurator are skipped, because ApacheDS does not support Java 11 yet.

Travis builds on Java 11 and Java 12 are now longer allowed to fail. 