### PR TITLE
Compensation Throwing Event for Service Task  - Documentation or Implementation Bug?

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/compensate/CompensateEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/compensate/CompensateEventTest.java
@@ -49,6 +49,18 @@ public class CompensateEventTest extends PluggableFlowableTestCase {
 
     @Test
     @Deployment
+    public void testCompensateServiceTask() {
+
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("compensateProcess");
+
+        assertEquals(5, runtimeService.getVariable(processInstance.getId(), "undoBookHotel"));
+
+        Execution execution = runtimeService.createExecutionQuery().activityId("beforeEnd").singleResult();
+        runtimeService.trigger(execution.getId());
+        assertProcessEnded(processInstance.getId());
+    }
+
+    @Deployment
     public void testCompensateSubprocessWithoutActivityRef() {
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("compensateProcess");

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/event/compensate/CompensateEventTest.testCompensateServiceTask.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/event/compensate/CompensateEventTest.testCompensateServiceTask.bpmn20.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions" 
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:activiti="http://activiti.org/bpmn"
+  targetNamespace="Examples">
+	
+	<process id="compensateProcess">
+
+		<startEvent id="start" />
+		
+		<sequenceFlow sourceRef="start"	targetRef="bookHotel" />
+
+        <serviceTask id="bookHotel" activiti:expression="${true}">
+            <multiInstanceLoopCharacteristics isSequential="true">
+              <loopCardinality>5</loopCardinality>
+            </multiInstanceLoopCharacteristics>
+        </serviceTask>
+				
+        <boundaryEvent id="compensateBookHotelEvt" name="Boundary event" attachedToRef="bookHotel">
+            <compensateEventDefinition />
+        </boundaryEvent>
+			
+        <serviceTask id="undoBookHotel" isForCompensation="true"
+            activiti:class="org.flowable.engine.test.bpmn.event.compensate.helper.UndoService">
+            <extensionElements>
+                <activiti:field name="counterName" stringValue="undoBookHotel" />
+            </extensionElements>
+        </serviceTask>
+
+        <sequenceFlow sourceRef="bookHotel" targetRef="throwCompensate" />
+
+		<intermediateThrowEvent id="throwCompensate">
+            <!--
+            <compensateEventDefinition activityRef="bookHotel" />
+            -->
+			<compensateEventDefinition activityRef="undoBookHotel" />
+		</intermediateThrowEvent>
+		
+		<sequenceFlow sourceRef="throwCompensate" targetRef="beforeEnd" />
+
+		<receiveTask id="beforeEnd" />
+
+        <sequenceFlow sourceRef="beforeEnd" targetRef="end" />
+		
+		<endEvent id="end" />
+
+        <association associationDirection="One" sourceRef="compensateBookHotelEvt" targetRef="undoBookHotel" />
+	</process>
+
+</definitions>


### PR DESCRIPTION
I did not find a test case which only compensates a single service task (without a subprocess being involved). Based on the documentation in section 8.2.31 it appears for this use case the compensate throwing event should be defined like such:
`<intermediateThrowEvent id="throwCompensation">
    <compensateEventDefinition activityRef="bookHotel" />
</intermediateThrowEvent>
`


where the value in activityRef refers to the activity id of the service task that completed and will have compensation run on it. However defining the definition in this manner does not produce the expected results as the compensation handler never executes.  

The attached test case shows that defining the compensate throwing event with the activityRef attribute having a value of the id of the service task that is the compensation handler provides the expected behavior. For example:

`<intermediateThrowEvent id="throwCompensation">
    <compensateEventDefinition activityRef="undoBookHotel" />
</intermediateThrowEvent>
`


Given this it's unclear whether the example in the documentation or the behavior is incorrect. Can someone verify which is correct and possibly add this test case for future reference?

Regards,
Rob

``