### PR TITLE
Support for using multiple IdGenerator beans in the Spring Context

### DIFF
--- a/distro/src/readme.html
+++ b/distro/src/readme.html
@@ -48,6 +48,8 @@
 <p>
     It is now possible to define the custom IdGenerator for the Flowable Process engine, by creating a bean of type IdGenerator.
     If no bean is provided the StrongUuidGenerator will be used.
+    If there is a bean qualified with @Process then this one would be used, otherwise a unique global one would be used.
+    If there are more global beans then the default StrongUuidGenerator will be used.
 </p>
 
 <h3>Release Notes - Flowable - 6.3.1</h3>

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/ProcessEngineAutoConfiguration.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/ProcessEngineAutoConfiguration.java
@@ -135,8 +135,9 @@ public class ProcessEngineAutoConfiguration extends AbstractSpringEngineAutoConf
     @Bean
     @ConditionalOnMissingBean
     public SpringProcessEngineConfiguration springProcessEngineConfiguration(DataSource dataSource, PlatformTransactionManager platformTransactionManager,
-            ObjectProvider<IdGenerator> processIdGenerator,
-            @ProcessAsync ObjectProvider<AsyncExecutor> asyncExecutorProvider, 
+            @Process ObjectProvider<IdGenerator> processIdGenerator,
+            ObjectProvider<IdGenerator> globalIdGenerator,
+            @ProcessAsync ObjectProvider<AsyncExecutor> asyncExecutorProvider,
             @ProcessAsyncHistory ObjectProvider<AsyncExecutor> asyncHistoryExecutorProvider) throws IOException {
 
         SpringProcessEngineConfiguration conf = new SpringProcessEngineConfiguration();
@@ -188,8 +189,7 @@ public class ProcessEngineAutoConfiguration extends AbstractSpringEngineAutoConf
 
         conf.setHistoryLevel(flowableProperties.getHistoryLevel());
 
-        // We can't use the getIfAvailable(Supplier<T>) method because we need 4.3 and 5.0 support
-        IdGenerator idGenerator = processIdGenerator.getIfAvailable();
+        IdGenerator idGenerator = getIfAvailable(processIdGenerator, globalIdGenerator);
         if (idGenerator == null) {
             idGenerator = new StrongUuidGenerator();
         }


### PR DESCRIPTION
* When an IdGenerator bean qualified with @Process is present that this one would be used
* When a single IdGenerator bean is present then this one would be used
* When there are multiple IdGenerator beans then none would be used and the default StrongUuidGenerator would be used