### PR TITLE
Support JSON variables in the REST api

### DIFF
--- a/modules/flowable-common-rest/src/main/java/org/flowable/common/rest/variable/JsonArrayRestVariableConverter.java
+++ b/modules/flowable-common-rest/src/main/java/org/flowable/common/rest/variable/JsonArrayRestVariableConverter.java
@@ -1,0 +1,53 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.flowable.common.rest.variable;
+
+import org.flowable.common.engine.api.FlowableIllegalArgumentException;
+import java.util.ArrayList;
+
+
+public class JsonArrayRestVariableConverter implements RestVariableConverter {
+
+    @Override
+    public String getRestTypeName() {
+        return "json";
+    }
+
+    @Override
+    public Class<?> getVariableType() {
+
+        return ArrayList.class;
+    }
+
+    @Override
+    public Object getVariableValue(EngineRestVariable result) {
+        if (result.getValue() != null) {
+            return result.getValue();
+        }
+        return null;
+    }
+
+    @Override
+    public void convertVariableValue(Object variableValue, EngineRestVariable result) {
+        if (variableValue != null) {
+            if (!(variableValue instanceof java.util.ArrayList)) {
+                throw new FlowableIllegalArgumentException("Converter can only convert java.util.ArrayList");
+            }
+            result.setValue(variableValue);
+        } else {
+            result.setValue(null);
+        }
+    }
+
+}

--- a/modules/flowable-common-rest/src/main/java/org/flowable/common/rest/variable/JsonObjectRestVariableConverter.java
+++ b/modules/flowable-common-rest/src/main/java/org/flowable/common/rest/variable/JsonObjectRestVariableConverter.java
@@ -1,0 +1,52 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.flowable.common.rest.variable;
+
+import org.flowable.common.engine.api.FlowableIllegalArgumentException;
+import java.util.LinkedHashMap;
+
+
+public class JsonObjectRestVariableConverter implements RestVariableConverter {
+
+    @Override
+    public String getRestTypeName() {
+        return "json";
+    }
+
+    @Override
+    public Class<?> getVariableType() {
+        return LinkedHashMap.class;
+    }
+
+    @Override
+    public Object getVariableValue(EngineRestVariable result) {
+        if (result.getValue() != null) {
+            return result.getValue();
+        }
+        return null;
+    }
+
+    @Override
+    public void convertVariableValue(Object variableValue, EngineRestVariable result) {
+        if (variableValue != null) {
+            if (!(variableValue instanceof LinkedHashMap)) {
+                throw new FlowableIllegalArgumentException("Converter can only convert java.util.LinkedHashMap");
+            }
+            result.setValue(variableValue);
+        } else {
+            result.setValue(null);
+        }
+    }
+
+}

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/RestResponseFactory.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/RestResponseFactory.java
@@ -31,6 +31,8 @@ import org.flowable.common.rest.variable.LongRestVariableConverter;
 import org.flowable.common.rest.variable.RestVariableConverter;
 import org.flowable.common.rest.variable.ShortRestVariableConverter;
 import org.flowable.common.rest.variable.StringRestVariableConverter;
+import org.flowable.common.rest.variable.JsonObjectRestVariableConverter;
+import org.flowable.common.rest.variable.JsonArrayRestVariableConverter;
 import org.flowable.dmn.api.DmnDecisionTable;
 import org.flowable.engine.form.FormData;
 import org.flowable.engine.form.FormProperty;
@@ -1238,6 +1240,8 @@ public class RestResponseFactory {
         variableConverters.add(new DoubleRestVariableConverter());
         variableConverters.add(new BooleanRestVariableConverter());
         variableConverters.add(new DateRestVariableConverter());
+        variableConverters.add(new JsonObjectRestVariableConverter());
+        variableConverters.add(new JsonArrayRestVariableConverter());
     }
 
     protected String formatUrl(String serverRootUrl, String[] fragments, Object... arguments) {


### PR DESCRIPTION
Hi

We are using flowable-rest and want to use json variable types.
It seems that everything was put in place to support it, since we can use them in flowable-modeler and flowable-task, however in flowable-rest and flowable-admin it gives some troubles.
With this PR I try to fix three problems:
 
 1.  Creating variables of type json doesn't work using REST. I.e. this fails:
```
curl --user admin:test -X PUT --header "Content-Type: application/json" http://localhost:8080/flowable-rest/service/runtime/process-instances/.../variables -d '[{"name": "input", "type": "json", "value": {"test": 123}}]'
```
This returns:
```
{"message":"Bad request","exception":"Variable 'input' has unsupported type: 'json'."}
```

 2. Reading variables of type json will return them as `serializable`
 3. Flowable-admin also shows the variables as `serializable`

This PR will make sure that for 2 and 3 type `json` is returned and the actual json is returned instead of a placeholder.

![image](https://user-images.githubusercontent.com/2996275/45361738-4549ee00-b5d3-11e8-81ca-3802b4b32b65.png)

Do you think this fix makes sense? Should I change something?
