### PR TITLE
rootProcessInstanceId is null bug

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/ExecutionEntityImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/ExecutionEntityImpl.java
@@ -509,7 +509,7 @@ public class ExecutionEntityImpl extends AbstractBpmnEngineVariableScopeEntity i
     }
 
     protected void ensureRootProcessInstanceInitialized() {
-        if (rootProcessInstanceId == null) {
+        if (rootProcessInstanceId != null) {
             rootProcessInstance = (ExecutionEntityImpl) CommandContextUtil.getExecutionEntityManager().findById(rootProcessInstanceId);
         }
     }


### PR DESCRIPTION
Question description web site:

[https://forum.flowable.org/t/bug-in-executionentityimpl-getrootprocessinstance/2553](url)

Is it OK, that if rootProcessInstanceId is null than read rootProcessInstance? I think no.
Flowable v6.3.1

protected void ensureRootProcessInstanceInitialized() {
        if (rootProcessInstanceId == null) {
            rootProcessInstance = (ExecutionEntityImpl) CommandContextUtil.getExecutionEntityManager().findById(rootProcessInstanceId);
        }
    }