### PR TITLE
JuelExpression Can not use custom delegateInterceptor

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/el/ProcessExpressionManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/el/ProcessExpressionManager.java
@@ -34,16 +34,17 @@ public class ProcessExpressionManager extends VariableScopeExpressionManager {
     protected DelegateInterceptor delegateInterceptor;
     
     public ProcessExpressionManager() {
-        this(null);
-    }
-
-    public ProcessExpressionManager(Map<Object, Object> beans) {
-       this(new DefaultDelegateInterceptor(), beans);
+        this(null,null);
     }
     
     public ProcessExpressionManager(DelegateInterceptor delegateInterceptor, Map<Object, Object> beans) {
         super(beans);
-        this.delegateInterceptor = delegateInterceptor;
+        if (delegateInterceptor==null) {
+            this.delegateInterceptor=new DefaultDelegateInterceptor();
+        }else {
+            this.delegateInterceptor = delegateInterceptor;
+        }
+       
     }
     
     @Override

--- a/modules/flowable-spring/src/main/java/org/flowable/spring/ProcessEngineFactoryBean.java
+++ b/modules/flowable-spring/src/main/java/org/flowable/spring/ProcessEngineFactoryBean.java
@@ -64,7 +64,7 @@ public class ProcessEngineFactoryBean implements FactoryBean<ProcessEngine>, Dis
     protected void configureExpressionManager() {
         if (processEngineConfiguration.getExpressionManager() == null && applicationContext != null) {
             processEngineConfiguration.setExpressionManager(new SpringExpressionManager(applicationContext,
-                    processEngineConfiguration.getBeans()));
+                    processEngineConfiguration.getBeans(),processEngineConfiguration.getDelegateInterceptor()));
         }
     }
 

--- a/modules/flowable-spring/src/main/java/org/flowable/spring/SpringExpressionManager.java
+++ b/modules/flowable-spring/src/main/java/org/flowable/spring/SpringExpressionManager.java
@@ -27,6 +27,7 @@ import org.flowable.common.engine.impl.javax.el.ELResolver;
 import org.flowable.common.engine.impl.javax.el.ListELResolver;
 import org.flowable.common.engine.impl.javax.el.MapELResolver;
 import org.flowable.engine.impl.el.ProcessExpressionManager;
+import org.flowable.engine.impl.interceptor.DelegateInterceptor;
 import org.springframework.context.ApplicationContext;
 
 /**
@@ -44,9 +45,11 @@ public class SpringExpressionManager extends ProcessExpressionManager {
      *            the applicationContext to use. Ignored when 'beans' parameter is not null.
      * @param beans
      *            a map of custom beans to expose. If null, all beans in the application-context will be exposed.
+     * @param delegateInterceptor
+     *           If delegateInterceptor is not defined, DefaultDelegateInterceptor is used by default.        
      */
-    public SpringExpressionManager(ApplicationContext applicationContext, Map<Object, Object> beans) {
-        super(beans);
+    public SpringExpressionManager(ApplicationContext applicationContext, Map<Object, Object> beans, DelegateInterceptor delegateInterceptor) {
+        super(delegateInterceptor,beans);
         this.applicationContext = applicationContext;
     }
     


### PR DESCRIPTION
Hi @tijsrademakers 

I find that there is no way to use custom delegateInterceptor in org.flowable.engine.impl.el.JuelExpression.
I think it's a issues.


