### PR TITLE
flowable-image-generator: task names missing (box too small?)

### DIFF
--- a/modules/flowable-image-generator/src/main/java/org/flowable/image/impl/DefaultProcessDiagramCanvas.java
+++ b/modules/flowable-image-generator/src/main/java/org/flowable/image/impl/DefaultProcessDiagramCanvas.java
@@ -782,6 +782,10 @@ public class DefaultProcessDiagramCanvas {
                         lastLine = lastLine.substring(0, lastLine.length() - 4) + "...";
                     }
                     layouts.add(new TextLayout(lastLine, g.getFont(), g.getFontRenderContext()));
+                }else {
+                    // in order to avoid empty box
+                    layouts.add(layout);
+                    currentHeight += height;
                 }
                 break;
             } else {


### PR DESCRIPTION
In DefaultProcessDiagramCanvas.drawTask(), the boxHeight is computed as follows:

int boxHeight = height - 16 - ICON_PADDING - ICON_PADDING - MARKER_WIDTH - 2 - 2;

In my environment (bpmn files created using Eclipse BPMN2 Modeler with default settings), this leads to the situation, that in method drawMultilineText() the condition

currentHeight + height > boxHeight

becomes true (for a single line of text), and thus task names are completely left out.

I would suggest to add an else-block in method drawMultilineText(),
in order to draw at least one line of text.

`if(currentHeight + height > boxHeight) {
        if (!layouts.isEmpty()) {
           [...]
        } else { // at least, draw one line
            layouts.add(layout);
            currentHeight += height;
        }
        break;
}`
Changed implementation in activiti-image-generator/DefaultProcessDiagramCanvas.drawMultilineText().

empty box before the change

![image](https://user-images.githubusercontent.com/17612111/45540309-a7f2f200-b83e-11e8-8c28-2f9b93a27684.png)

box incl. label after commit
![image](https://user-images.githubusercontent.com/17612111/45540354-c9ec7480-b83e-11e8-8027-b8c13cc3c641.png)



