### PR TITLE
Increase timeouts for a lot of asynchronous tests from 5 to 7 seconds make b…

### DIFF
--- a/modules/flowable-camel/src/test/java/org/flowable/camel/revisited/AsyncProcessRevisitedTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/revisited/AsyncProcessRevisitedTest.java
@@ -63,7 +63,7 @@ public class AsyncProcessRevisitedTest extends SpringFlowableTestCase {
 
         List<Execution> executionList = runtimeService.createExecutionQuery().list();
         assertEquals(3, executionList.size());
-        waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(5000, 200);
+        waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(7000, 200);
 
         assertTrue(oneExchangeSendToFlowableReceive1.matchesMockWaitTime());
         assertTrue(oneExchangeSendToFlowableReceive2.matchesMockWaitTime());

--- a/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/BpmnTimerTaskTest.java
+++ b/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/BpmnTimerTaskTest.java
@@ -64,10 +64,10 @@ public class BpmnTimerTaskTest extends AbstractProcessEngineIntegrationTest {
         String timerJobId = timerJobs.get(0).getId();
         
         try {
-            CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 5000, 200, true);
+            CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 7000, 200, true);
             fail("should throw time limit exceeded");
         } catch (FlowableException e) {
-            assertEquals("Time limit of 5000 was exceeded", e.getMessage());
+            assertEquals("Time limit of 7000 was exceeded", e.getMessage());
         }
         
         processEngine.getProcessEngineConfiguration().setClock(clock);
@@ -76,7 +76,7 @@ public class BpmnTimerTaskTest extends AbstractProcessEngineIntegrationTest {
         assertEquals(1, timerJobs.size());
         assertEquals(timerJobId, timerJobs.get(0).getId());
         
-        JobTestHelper.waitForJobExecutorToProcessAllJobs(processEngine.getProcessEngineConfiguration(), processEngineManagementService, 5000, 200, true);
+        JobTestHelper.waitForJobExecutorToProcessAllJobs(processEngine.getProcessEngineConfiguration(), processEngineManagementService, 7000, 200, true);
         
         timerJobs = processEngineManagementService.createTimerJobQuery().processInstanceId(processInstance.getId()).list();
         assertEquals(0, timerJobs.size());

--- a/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/CmmnTimerTaskTest.java
+++ b/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/CmmnTimerTaskTest.java
@@ -74,10 +74,10 @@ public class CmmnTimerTaskTest extends AbstractProcessEngineIntegrationTest {
         assertEquals(1, timerJobs.size());
         
         try {
-            JobTestHelper.waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(processEngine.getProcessEngineConfiguration(), processEngineManagementService, 5000, 200, true);
+            JobTestHelper.waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(processEngine.getProcessEngineConfiguration(), processEngineManagementService, 7000, 200, true);
             fail("should throw time limit exceeded");
         } catch (FlowableException e) {
-            assertEquals("time limit of 5000 was exceeded", e.getMessage());
+            assertEquals("time limit of 7000 was exceeded", e.getMessage());
         }
         
         // Timer fires after 3 hours, so setting it to 3 hours + 1 second
@@ -87,7 +87,7 @@ public class CmmnTimerTaskTest extends AbstractProcessEngineIntegrationTest {
         assertEquals(1, timerJobs.size());
         assertEquals(timerJobId, timerJobs.get(0).getId());
         
-        CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 5000L, 200L, true);
+        CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 7000L, 200L, true);
         
         // User task should be active after the timer has triggered
         List<Task> tasks = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).orderByTaskName().asc().list();

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/TimerEventListenerTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/TimerEventListenerTest.java
@@ -87,7 +87,7 @@ public class TimerEventListenerTest extends FlowableCmmnTestCase {
         // Timer fires after 1 hour, so setting it to 1 hours + 1 second
         setClockTo(new Date(startTime.getTime() + (60 * 60 * 1000 + 1)));
 
-        CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 5000L, 200L, true);
+        CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 7000L, 200L, true);
 
         // User task should be active after the timer has triggered 
         assertEquals(1L, cmmnTaskService.createTaskQuery().count());
@@ -111,7 +111,7 @@ public class TimerEventListenerTest extends FlowableCmmnTestCase {
         // Timer fires after 1 day, so setting it to 1 day + 1 second
         setClockTo(new Date(startTime.getTime() + (24 * 60 * 60 * 1000 + 1)));
         
-        CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 5000L, 200L, true);
+        CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 7000L, 200L, true);
         
         // User task should be active after the timer has triggered 
         assertEquals(2L, cmmnTaskService.createTaskQuery().count());
@@ -136,7 +136,7 @@ public class TimerEventListenerTest extends FlowableCmmnTestCase {
         // Timer fires after 3 hours, so setting it to 3 hours + 1 second
         setClockTo(new Date(startTime.getTime() + (3 * 60 * 60 * 1000 + 1)));
         
-        CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 5000L, 200L, true);
+        CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 7000L, 200L, true);
         
         // User task should be active after the timer has triggered
         List<Task> tasks = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).orderByTaskName().asc().list();
@@ -163,7 +163,7 @@ public class TimerEventListenerTest extends FlowableCmmnTestCase {
         // Timer fires after 24 hours, so setting it to 24 hours + 1 second
         setClockTo(new Date(startTime.getTime() + (24 * 60 * 60 * 1000 + 1)));
         
-        CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 5000L, 200L, true);
+        CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 7000L, 200L, true);
         
         assertEquals(0L, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count());
         assertEquals(0L, cmmnRuntimeService.createCaseInstanceQuery().count());
@@ -200,7 +200,7 @@ public class TimerEventListenerTest extends FlowableCmmnTestCase {
         assertEquals(0L, cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count());
         
         setClockTo(new Date(dayBefore.getTime() + (24 * 60 * 60 * 1000)));
-        CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 5000L, 200L, true);
+        CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 7000L, 200L, true);
         
         assertEquals(0L, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE).planItemDefinitionType(TimerEventListener.class.getSimpleName().toLowerCase()).count());
@@ -231,7 +231,7 @@ public class TimerEventListenerTest extends FlowableCmmnTestCase {
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE).planItemDefinitionType(HumanTask.class.getSimpleName().toLowerCase()).count());
         
         setClockTo(new Date(startTime.getTime() + (2 * 60 * 60 * 1000)));
-        CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 5000L, 200L, true);
+        CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 7000L, 200L, true);
         
         Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
         assertEquals("A", task.getName());
@@ -264,7 +264,7 @@ public class TimerEventListenerTest extends FlowableCmmnTestCase {
                 .planItemInstanceState(PlanItemInstanceState.AVAILABLE).planItemDefinitionType(TimerEventListener.class.getSimpleName().toLowerCase()).count());
         
         setClockTo(new Date(startTime.getTime() + (3 * 60 * 60 * 1000)));
-        CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 5000L, 200L, true);
+        CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 7000L, 200L, true);
         assertCaseInstanceEnded(caseInstance);
     }
     

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/deletereason/DeleteReasonTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/deletereason/DeleteReasonTest.java
@@ -184,7 +184,7 @@ public class DeleteReasonTest extends PluggableFlowableTestCase {
         managementService.moveTimerToExecutableJob(timerJob.getId());
         managementService.executeJob(timerJob.getId());
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         assertHistoricTasksDeleteReason(processInstance, null, "A");
         assertHistoricTasksDeleteReason(processInstance, DeleteReason.BOUNDARY_EVENT_INTERRUPTING, "B", "C", "D");
@@ -205,7 +205,7 @@ public class DeleteReasonTest extends PluggableFlowableTestCase {
         managementService.moveTimerToExecutableJob(timerJob.getId());
         managementService.executeJob(timerJob.getId());
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         assertHistoricActivitiesDeleteReason(processInstance, null, "A");
         assertHistoricActivitiesDeleteReason(processInstance, DeleteReason.BOUNDARY_EVENT_INTERRUPTING, "B", "C", "theSubprocess");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ActivityEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ActivityEventsTest.java
@@ -613,7 +613,7 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
         timeToFire.add(Calendar.HOUR, 2);
         timeToFire.add(Calendar.MINUTE, 5);
         processEngineConfiguration.getClock().setCurrentTime(timeToFire.getTime());
-        waitForJobExecutorToProcessAllJobs(5000, 500);
+        waitForJobExecutorToProcessAllJobs(7000, 500);
 
         // Check timeout-events have been dispatched
         assertEquals(4, listener.getEventsReceived().size());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ErrorThrowingEventListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ErrorThrowingEventListenerTest.java
@@ -50,7 +50,7 @@ public class ErrorThrowingEventListenerTest extends PluggableFlowableTestCase {
             task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("escalatedTask").singleResult();
             assertNotNull(task);
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         } finally {
             processEngineConfiguration.getEventDispatcher().removeEventListener(listener);
@@ -74,7 +74,7 @@ public class ErrorThrowingEventListenerTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("escalatedTask").singleResult();
         assertNotNull(task);
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
     }
 
     @Test
@@ -115,7 +115,7 @@ public class ErrorThrowingEventListenerTest extends PluggableFlowableTestCase {
             task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("escalatedTask2").singleResult();
             assertNotNull(task);
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
             
         } finally {
             processEngineConfiguration.getEventDispatcher().removeEventListener(listener);
@@ -138,6 +138,6 @@ public class ErrorThrowingEventListenerTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("escalatedTask").singleResult();
         assertNotNull(task);
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/HistoricActivityEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/HistoricActivityEventsTest.java
@@ -70,7 +70,7 @@ public class HistoricActivityEventsTest extends PluggableFlowableTestCase {
 
             List<FlowableEvent> events = listener.getEventsReceived();
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
             
             int processInstanceCreated = 0;
             int mainStartActivityStarted = 0;

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/IdentityLinkEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/IdentityLinkEventsTest.java
@@ -116,7 +116,7 @@ public class IdentityLinkEventsTest extends PluggableFlowableTestCase {
         assertEquals("kermit", link.getUserId());
         assertEquals("test", link.getType());
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
     }
 
     /**
@@ -177,7 +177,7 @@ public class IdentityLinkEventsTest extends PluggableFlowableTestCase {
         event = (FlowableEntityEvent) listener.getEventsReceived().get(2);
         assertEquals(FlowableEngineEventType.ENTITY_DELETED, event.getType());
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
     }
 
     /**

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/MessageThrowingEventListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/MessageThrowingEventListenerTest.java
@@ -108,7 +108,7 @@ public class MessageThrowingEventListenerTest extends PluggableFlowableTestCase 
             org.flowable.task.api.Task boundaryTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("boundaryTask").singleResult();
             assertNotNull(boundaryTask);
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
             
         } finally {
             processEngineConfiguration.getEventDispatcher().removeEventListener(listener);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/SignalThrowingEventListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/SignalThrowingEventListenerTest.java
@@ -112,7 +112,7 @@ public class SignalThrowingEventListenerTest extends PluggableFlowableTestCase {
             org.flowable.task.api.Task boundaryTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("boundaryTask").singleResult();
             assertNotNull(boundaryTask);
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         } finally {
             processEngineConfiguration.getEventDispatcher().removeEventListener(listener);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/TaskEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/TaskEventsTest.java
@@ -117,7 +117,7 @@ public class TaskEventsTest extends PluggableFlowableTestCase {
         assertEquals(FlowableEngineEventType.ENTITY_DELETED, event.getType());
         assertExecutionDetails(event, processInstance);
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
     }
 
     @Test

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/TransactionEventListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/TransactionEventListenerTest.java
@@ -67,7 +67,7 @@ public class TransactionEventListenerTest extends PluggableFlowableTestCase {
             expectedCreatedEvents = 7;
         }
         if (processEngineConfiguration.isAsyncHistoryEnabled()) {
-            waitForHistoryJobExecutorToProcessAllJobs(5000L, 100L);
+            waitForHistoryJobExecutorToProcessAllJobs(7000L, 100L);
         }
 
         assertEquals(expectedCreatedEvents, TestTransactionEventListener.eventsReceived.get(FlowableEngineEventType.ENTITY_CREATED.name()).size());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/VariableEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/VariableEventsTest.java
@@ -389,7 +389,7 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
             taskService.setVariable(newTask.getId(), "testVariable", 123);
             taskService.setVariable(newTask.getId(), "testVariable", 456);
             
-            waitForJobExecutorToProcessAllHistoryJobs(5000, 200);
+            waitForJobExecutorToProcessAllHistoryJobs(7000, 200);
             
             taskService.removeVariable(newTask.getId(), "testVariable");
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricProcessInstanceQueryAndWithExceptionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricProcessInstanceQueryAndWithExceptionTest.java
@@ -50,7 +50,7 @@ public class HistoricProcessInstanceQueryAndWithExceptionTest extends PluggableF
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             ProcessInstance processNoException = runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY_NO_EXCEPTION);
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             HistoricProcessInstanceQuery queryNoException = historyService.createHistoricProcessInstanceQuery();
             assertEquals(1, queryNoException.count());
@@ -66,7 +66,7 @@ public class HistoricProcessInstanceQueryAndWithExceptionTest extends PluggableF
             assertEquals(1, jobQuery1.withException().count());
             assertEquals(1, jobQuery1.withException().list().size());
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
             assertEquals(1, queryWithException.withJobException().count());
             assertEquals(1, queryWithException.withJobException().list().size());
             assertEquals(processWithException1.getId(), queryWithException.withJobException().list().get(0).getId());
@@ -76,7 +76,7 @@ public class HistoricProcessInstanceQueryAndWithExceptionTest extends PluggableF
             assertEquals(2, jobQuery2.withException().count());
             assertEquals(2, jobQuery2.withException().list().size());
 
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
             assertEquals(2, queryWithException.withJobException().count());
             assertEquals(2, queryWithException.withJobException().list().size());
             assertEquals(processWithException1.getId(), queryWithException.withJobException().processDefinitionKey(PROCESS_DEFINITION_KEY_WITH_EXCEPTION_1).list().get(0).getId());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricProcessInstanceQueryVersionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricProcessInstanceQueryVersionTest.java
@@ -46,7 +46,7 @@ public class HistoricProcessInstanceQueryVersionTest extends PluggableFlowableTe
         startMap.put("anothertest", 456);
         runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY, startMap);
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
     }
 
     @AfterEach

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricTaskAndVariablesQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricTaskAndVariablesQueryTest.java
@@ -96,7 +96,7 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
                 "testGroup",
                 IdentityLinkType.PARTICIPANT
             );
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             task = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().taskAssignee("kermit").singleResult();
             assertEquals(1, task.getProcessVariables().size());
@@ -106,7 +106,7 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
             taskService.setVariable(task.getId(), "anotherProcessVar", 123);
             taskService.setVariableLocal(task.getId(), "localVar", "test");
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             task = historyService.createHistoricTaskInstanceQuery().includeTaskLocalVariables().taskAssignee("kermit").singleResult();
             assertEquals(0, task.getProcessVariables().size());
@@ -162,7 +162,7 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
             task = historyService.createHistoricTaskInstanceQuery().taskAssignee("gonzo").singleResult();
             taskService.complete(task.getId());
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
             
             task = (HistoricTaskInstance) historyService.createHistoricTaskInstanceQuery().includeTaskLocalVariables().finished().singleResult();
             variableMap = task.getTaskLocalVariables();
@@ -213,7 +213,7 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
             startMap.put("processVar", true);
             runtimeService.startProcessInstanceByKey("oneTaskProcess", startMap);
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             task = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().or().taskAssignee("kermit").taskVariableValueEquals("localVar", "nonExisting").endOr().singleResult();
             assertEquals(1, task.getProcessVariables().size());
@@ -240,7 +240,7 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
             taskService.setVariable(task.getId(), "anotherProcessVar", 123);
             taskService.setVariableLocal(task.getId(), "localVar", "test");
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             task = historyService.createHistoricTaskInstanceQuery().includeTaskLocalVariables().or().taskAssignee("kermit").taskVariableValueEquals("localVar", "nonExisting").endOr().singleResult();
             assertEquals(0, task.getProcessVariables().size());
@@ -331,7 +331,7 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
             task = historyService.createHistoricTaskInstanceQuery().taskAssignee("gonzo").singleResult();
             taskService.complete(task.getId());
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
             
             task = historyService.createHistoricTaskInstanceQuery().includeTaskLocalVariables().or().finished().taskVariableValueEquals("localVar", "nonExisting").endOr().singleResult();
             variableMap = task.getTaskLocalVariables();
@@ -356,7 +356,7 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
             startMap.put("anotherProcessVar", 999);
             runtimeService.startProcessInstanceByKey("oneTaskProcess", startMap);
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             HistoricTaskInstanceQuery query0 = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().or();
             for (int i = 0; i < 20; i++) {
@@ -383,7 +383,7 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
             
             List<HistoricTaskInstance> tasks = historyService.createHistoricTaskInstanceQuery().taskCandidateUser("kermit").list();
             assertEquals(3, tasks.size());
@@ -444,7 +444,7 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
     public void testIgnoreAssigneeValue() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             String taskId = taskService
                     .createTaskQuery()
@@ -453,7 +453,7 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
                     .get(0)
                     .getId();
             taskService.setAssignee(taskId, "kermit");
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             List<HistoricTaskInstance> tasks = historyService
                     .createHistoricTaskInstanceQuery()
@@ -488,7 +488,7 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
     public void testIgnoreAssigneeValueOr() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             String taskId = taskService
                     .createTaskQuery()
@@ -497,7 +497,7 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
                     .get(0)
                     .getId();
             taskService.setAssignee(taskId, "kermit");
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             List<HistoricTaskInstance>  tasks = historyService.createHistoricTaskInstanceQuery()
                     .or()
@@ -630,7 +630,7 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
             Map<String, Object> varMap = Collections.singletonMap("processVar", (Object) "test");
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess", varMap);
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 250);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 250);
             
             tasks = historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId()).processVariableExists("processVar").list();
             assertEquals(1, tasks.size());
@@ -648,7 +648,7 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
             
             runtimeService.setVariable(processInstance.getId(), "processVar2", "test2");
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 250);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 250);
             
             tasks = historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId())
                             .processVariableExists("processVar").processVariableValueEquals("processVar2", "test2").list();
@@ -674,7 +674,7 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
             
             HistoricTaskInstance historicTask = historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId()).withoutTaskDueDate().singleResult();
             assertNotNull(historicTask);
@@ -686,7 +686,7 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
             task.setDueDate(dueDate);
             taskService.saveTask(task);
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             assertEquals(0, historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId()).withoutTaskDueDate().count());
 
@@ -696,7 +696,7 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
             task.setDueDate(null);
             taskService.saveTask(task);
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             assertEquals(1, historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId()).withoutTaskDueDate().count());
         }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoryLevelServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoryLevelServiceTest.java
@@ -39,7 +39,7 @@ public class HistoryLevelServiceTest extends PluggableFlowableTestCase {
     // With a clean ProcessEngine, no instances should be available
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
     
-    HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 5000, 200);
+    HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
     
     assertTrue(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count() == 0);
 
@@ -55,7 +55,7 @@ public class HistoryLevelServiceTest extends PluggableFlowableTestCase {
     taskService.setVariableLocal(task.getId(), "localVar1", "test2");
     taskService.complete(task.getId());
     
-    HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 5000, 200);
+    HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
     
     assertTrue(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count() == 0);
     assertTrue(historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId()).count() == 0);
@@ -69,7 +69,7 @@ public class HistoryLevelServiceTest extends PluggableFlowableTestCase {
     // With a clean ProcessEngine, no instances should be available
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
     
-    HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 5000, 200);
+    HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
     
     assertTrue(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count() == 1);
 
@@ -89,7 +89,7 @@ public class HistoryLevelServiceTest extends PluggableFlowableTestCase {
     taskService.setVariableLocal(task.getId(), "localVar1", "test2");
     taskService.complete(task.getId());
     
-    HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 5000, 200);
+    HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
     
     assertTrue(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count() == 1);
     assertTrue(historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId()).count() == 0);
@@ -127,7 +127,7 @@ public class HistoryLevelServiceTest extends PluggableFlowableTestCase {
     // With a clean ProcessEngine, no instances should be available
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
     
-    HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 5000, 200);
+    HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
     
     assertTrue(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count() == 1);
 
@@ -147,7 +147,7 @@ public class HistoryLevelServiceTest extends PluggableFlowableTestCase {
     taskService.setVariableLocal(task.getId(), "localVar1", "test2");
     taskService.complete(task.getId());
     
-    HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 5000, 200);
+    HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
     
     assertTrue(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count() == 1);
     assertTrue(historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId()).count() == 1);
@@ -193,7 +193,7 @@ public class HistoryLevelServiceTest extends PluggableFlowableTestCase {
     // With a clean ProcessEngine, no instances should be available
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
     
-    HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 5000, 200);
+    HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
     
     assertTrue(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count() == 1);
 
@@ -213,7 +213,7 @@ public class HistoryLevelServiceTest extends PluggableFlowableTestCase {
     taskService.setVariableLocal(task.getId(), "localVar1", "test2");
     taskService.complete(task.getId());
     
-    HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 5000, 200);
+    HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
     
     assertTrue(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count() == 1);
     assertTrue(historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId()).count() == 1);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoryServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoryServiceTest.java
@@ -57,7 +57,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         assertEquals(0, historyService.createHistoricProcessInstanceQuery().count());
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
         
-        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 5000, 200);
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
         
         assertEquals(1, historyService.createHistoricProcessInstanceQuery().count());
 
@@ -66,7 +66,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         assertEquals(1, tasks.size());
         taskService.complete(tasks.get(0).getId());
         
-        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 5000, 200);
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
         
         assertEquals(1, historyService.createHistoricProcessInstanceQuery().count());
     }
@@ -82,7 +82,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         assertEquals(1, tasks.size());
         taskService.complete(tasks.get(0).getId());
 
-        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 5000, 200);
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
         
         historyService.createHistoricTaskInstanceQuery().orderByDeleteReason().asc().list();
         historyService.createHistoricTaskInstanceQuery().orderByExecutionId().asc().list();
@@ -107,7 +107,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         identityService.setAuthenticatedUserId("johndoe");
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
         
-        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 5000, 200);
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
         
         HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery().singleResult();
         assertEquals("johndoe", historicProcessInstance.getStartUserId());
@@ -117,7 +117,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         assertEquals(1, tasks.size());
         taskService.complete(tasks.get(0).getId());
         
-        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 5000, 200);
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
         historicProcessInstance = historyService.createHistoricProcessInstanceQuery().singleResult();
         assertEquals("theEnd", historicProcessInstance.getEndActivityId());
@@ -136,7 +136,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task prepareAndShipTask = taskQuery.singleResult();
         assertEquals("Prepare and Ship", prepareAndShipTask.getName());
         
-        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 5000, 200);
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
         // verify
         HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery().superProcessInstanceId(pi.getId()).singleResult();
@@ -149,7 +149,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
     public void testExcludeSubprocesses() {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("orderProcess");
         
-        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 5000, 200);
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
         HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery().excludeSubprocesses(true).singleResult();
         assertNotNull(historicProcessInstance);
@@ -168,7 +168,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey(processDefinitionKey);
         runtimeService.startProcessInstanceByKey("orderProcess");
         
-        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 5000, 200);
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
         
         HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery().processDefinitionKey(processDefinitionKey).singleResult();
         assertNotNull(historicProcessInstance);
@@ -181,7 +181,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         map.put("creditApproved", true);
         taskService.complete(task.getId(), map);
         
-        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 5000, 200);
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
         // and make sure the super process instance is set correctly on the HistoricProcessInstance
         HistoricProcessInstance historicProcessInstanceSub = historyService.createHistoricProcessInstanceQuery().processDefinitionKey("checkCreditProcess").singleResult();
@@ -201,7 +201,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         // start an instance that will not be part of the query
         runtimeService.startProcessInstanceByKey("oneTaskProcess2", "2");
 
-        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 5000, 200);
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
         
         HistoricProcessInstanceQuery processInstanceQuery = historyService.createHistoricProcessInstanceQuery().processInstanceIds(processInstanceIds);
         assertEquals(5, processInstanceQuery.count());
@@ -241,7 +241,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         String processInstanceId = runtimeService.startProcessInstanceByKey("oneTaskProcess").getId();
         runtimeService.deleteProcessInstance(processInstanceId, null);
         
-        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 5000, 200);
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
         HistoricProcessInstanceQuery processInstanceQuery = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstanceId);
         assertEquals(1, processInstanceQuery.count());
@@ -260,7 +260,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
 
         historyService.deleteHistoricProcessInstance(processInstanceId);
         
-        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 5000, 200);
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
         
         processInstanceQuery = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstanceId);
         assertEquals(0, processInstanceQuery.count());
@@ -268,7 +268,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         processInstanceId = runtimeService.startProcessInstanceByKey("oneTaskProcess").getId();
         runtimeService.deleteProcessInstance(processInstanceId, "custom message");
         
-        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 5000, 200);
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
         processInstanceQuery = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstanceId);
         assertEquals(1, processInstanceQuery.count());
@@ -295,7 +295,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         }
         runtimeService.startProcessInstanceByKey("oneTaskProcess2", "1");
         
-        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 5000, 200);
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
         HistoricProcessInstanceQuery processInstanceQuery = historyService.createHistoricProcessInstanceQuery().deploymentId(deployment.getId());
         assertEquals(5, processInstanceQuery.count());
@@ -318,7 +318,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         }
         runtimeService.startProcessInstanceByKey("oneTaskProcess2", "1");
         
-        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 5000, 200);
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
         List<String> deploymentIds = new ArrayList<>();
         deploymentIds.add(deployment.getId());
@@ -345,7 +345,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         }
         runtimeService.startProcessInstanceByKey("oneTaskProcess2", "1");
         
-        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 5000, 200);
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
         HistoricTaskInstanceQuery taskInstanceQuery = historyService.createHistoricTaskInstanceQuery().deploymentId(deployment.getId());
         assertEquals(5, taskInstanceQuery.count());
@@ -367,7 +367,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         }
         runtimeService.startProcessInstanceByKey("oneTaskProcess2", "1");
         
-        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 5000, 200);
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
         List<String> deploymentIds = new ArrayList<>();
         deploymentIds.add(deployment.getId());
@@ -397,7 +397,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         }
         runtimeService.startProcessInstanceByKey("oneTaskProcess2", "1");
         
-        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 5000, 200);
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
         HistoricTaskInstanceQuery taskInstanceQuery = historyService.createHistoricTaskInstanceQuery().or().deploymentId(deployment.getId()).endOr();
         assertEquals(5, taskInstanceQuery.count());
@@ -483,7 +483,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         }
         runtimeService.startProcessInstanceByKey("oneTaskProcess2", "1");
         
-        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 5000, 200);
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
         List<String> deploymentIds = new ArrayList<>();
         deploymentIds.add(deployment.getId());
@@ -515,7 +515,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
     public void testLocalizeTasks() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
-        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 5000, 200);
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
         List<HistoricTaskInstance> tasks = historyService.createHistoricTaskInstanceQuery().processDefinitionId(processInstance.getProcessDefinitionId()).list();
         assertEquals(1, tasks.size());
         assertEquals("my task", tasks.get(0).getName());
@@ -525,7 +525,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         dynamicBpmnService.changeLocalizationDescription("en-GB", "theTask", "My localized description", infoNode);
         dynamicBpmnService.saveProcessDefinitionInfo(processInstance.getProcessDefinitionId(), infoNode);
 
-        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 5000, 200);
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
         tasks = historyService.createHistoricTaskInstanceQuery().processDefinitionId(processInstance.getProcessDefinitionId()).list();
         assertEquals(1, tasks.size());
         assertEquals("my task", tasks.get(0).getName());
@@ -577,7 +577,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         }
         taskService.complete(taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult().getId());
         
-        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 5000, 200);
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
         assertEquals(1, historyService.createHistoricProcessInstanceQuery().variableValueEquals("rootValue", "test").count());
 
@@ -608,7 +608,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance3 = runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
         taskService.complete(taskService.createTaskQuery().processInstanceId(processInstance3.getId()).singleResult().getId());
         
-        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 5000, 200);
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
         // Test EQUAL on single string variable, should result in 2 matches
         HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery().variableValueEquals("stringVar", "abcdef");
@@ -696,7 +696,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         historyService.deleteHistoricProcessInstance(processInstance2.getId());
         historyService.deleteHistoricProcessInstance(processInstance3.getId());
         
-        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 5000, 200);
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
     }
 
     @Test
@@ -708,7 +708,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         vars.put("upper", "abcdefg");
         ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
         
-        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 5000, 200);
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
         HistoricProcessInstance instance = historyService.createHistoricProcessInstanceQuery().variableValueEqualsIgnoreCase("mixed", "abcdefg").singleResult();
         assertNotNull(instance);
@@ -781,7 +781,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         Calendar oneYearAgo = Calendar.getInstance();
         oneYearAgo.add(Calendar.YEAR, -1);
         
-        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 5000, 200);
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
         // Query on single short variable, should result in 2 matches
         HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery().variableValueEquals("dateVar", date1);
@@ -861,7 +861,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         historyService.deleteHistoricProcessInstance(processInstance2.getId());
         historyService.deleteHistoricProcessInstance(processInstance3.getId());
         
-        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 5000, 200);
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
     }
 
     @Test
@@ -869,7 +869,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
     public void testNativeHistoricProcessInstanceTest() {
         // just test that the query will be constructed and executed, details are tested in the TaskQueryTest
         runtimeService.startProcessInstanceByKey("oneTaskProcess");
-        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 5000, 200);
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
         assertEquals(1, historyService.createNativeHistoricProcessInstanceQuery().sql("SELECT count(*) FROM " + managementService.getTableName(HistoricProcessInstance.class)).count());
         assertEquals(1, historyService.createNativeHistoricProcessInstanceQuery().sql("SELECT * FROM " + managementService.getTableName(HistoricProcessInstance.class)).list().size());
         // assertEquals(1, historyService.createNativeHistoricProcessInstanceQuery().sql("SELECT * FROM " +
@@ -880,7 +880,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testNativeHistoricTaskInstanceTest() {
         runtimeService.startProcessInstanceByKey("oneTaskProcess");
-        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 5000, 200);
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
         assertEquals(1, historyService.createNativeHistoricTaskInstanceQuery().sql("SELECT count(*) FROM " + managementService.getTableName(HistoricProcessInstance.class)).count());
         assertEquals(1, historyService.createNativeHistoricTaskInstanceQuery().sql("SELECT * FROM " + managementService.getTableName(HistoricProcessInstance.class)).list().size());
         assertEquals(1, historyService.createNativeHistoricTaskInstanceQuery().sql("SELECT * FROM " + managementService.getTableName(HistoricProcessInstance.class)).listPage(0, 1).size());
@@ -890,7 +890,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testNativeHistoricActivityInstanceTest() {
         runtimeService.startProcessInstanceByKey("oneTaskProcess");
-        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 5000, 200);
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
         assertEquals(1, historyService.createNativeHistoricActivityInstanceQuery().sql("SELECT count(*) FROM " + managementService.getTableName(HistoricProcessInstance.class)).count());
         assertEquals(1, historyService.createNativeHistoricActivityInstanceQuery().sql("SELECT * FROM " + managementService.getTableName(HistoricProcessInstance.class)).list().size());
         assertEquals(1, historyService.createNativeHistoricActivityInstanceQuery().sql("SELECT * FROM " + managementService.getTableName(HistoricProcessInstance.class)).listPage(0, 1).size());
@@ -904,7 +904,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         String processDefinitionName = "The One Task Process";
         runtimeService.startProcessInstanceByKey(processDefinitionKey);
         
-        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 5000, 200);
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
         assertEquals(processDefinitionName, historyService.createHistoricProcessInstanceQuery().processDefinitionName(processDefinitionName).list().get(0).getProcessDefinitionName());
         assertEquals(1, historyService.createHistoricProcessInstanceQuery().processDefinitionName(processDefinitionName).list().size());
@@ -923,7 +923,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         String processDefinitionCategory = "ExamplesCategory";
         runtimeService.startProcessInstanceByKey(processDefinitionKey);
         
-        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 5000, 200);
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
         assertEquals(1, historyService.createHistoricProcessInstanceQuery().processDefinitionCategory(processDefinitionCategory).list().size());
         assertEquals(1, historyService.createHistoricProcessInstanceQuery().processDefinitionCategory(processDefinitionCategory).count());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/NonCascadeDeleteTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/NonCascadeDeleteTest.java
@@ -51,7 +51,7 @@ public class NonCascadeDeleteTest extends PluggableFlowableTestCase {
             // clean
             historyService.deleteHistoricProcessInstance(processInstanceId);
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         }
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/ProcessInstanceLogQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/ProcessInstanceLogQueryTest.java
@@ -62,7 +62,7 @@ public class ProcessInstanceLogQueryTest extends PluggableFlowableTestCase {
             taskService.complete(task.getId());
         }
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
     }
 
     @AfterEach

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/repository/ProcessDefinitionSuspensionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/repository/ProcessDefinitionSuspensionTest.java
@@ -300,7 +300,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableFlowableTestCase {
         // Move clock 8 days further and let job executor run
         long eightDaysSinceStartTime = oneWeekFromStartTime + (24 * 60 * 60 * 1000);
         processEngineConfiguration.getClock().setCurrentTime(new Date(eightDaysSinceStartTime));
-        waitForJobExecutorToProcessAllJobs(5000L, 200L);
+        waitForJobExecutorToProcessAllJobs(7000L, 200L);
 
         // verify job is now removed
         assertEquals(0, managementService.createJobQuery().processDefinitionId(processDefinition.getId()).count());
@@ -359,7 +359,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableFlowableTestCase {
         // Move clock 9 days further and let job executor run
         long eightDaysSinceStartTime = oneWeekFromStartTime + (2 * 24 * 60 * 60 * 1000);
         processEngineConfiguration.getClock().setCurrentTime(new Date(eightDaysSinceStartTime));
-        waitForJobExecutorToProcessAllJobs(5000L, 50L);
+        waitForJobExecutorToProcessAllJobs(7000L, 50L);
 
         // Try to start process instance. It should fail now.
         try {
@@ -415,7 +415,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableFlowableTestCase {
         // Move clock two days and let job executor run
         long twoDaysFromStart = startTime.getTime() + (2 * 24 * 60 * 60 * 1000);
         processEngineConfiguration.getClock().setCurrentTime(new Date(twoDaysFromStart));
-        waitForJobExecutorToProcessAllJobs(5000L, 50L);
+        waitForJobExecutorToProcessAllJobs(7000L, 50L);
 
         // Starting a process instance should now succeed
         runtimeService.startProcessInstanceById(processDefinition.getId());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/repository/RepositoryServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/repository/RepositoryServiceTest.java
@@ -181,7 +181,7 @@ public class RepositoryServiceTest extends PluggableFlowableTestCase {
         // definitions will be active
         Date inFourDays = new Date(startTime.getTime() + (4 * 24 * 60 * 60 * 1000));
         processEngineConfiguration.getClock().setCurrentTime(inFourDays);
-        waitForJobExecutorToProcessAllJobs(5000L, 50L);
+        waitForJobExecutorToProcessAllJobs(7000L, 50L);
 
         assertEquals(1, repositoryService.createDeploymentQuery().count());
         assertEquals(2, repositoryService.createProcessDefinitionQuery().count());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/InstanceInvolvementTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/InstanceInvolvementTest.java
@@ -108,7 +108,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         assertNoInvolvement("user3");
         assertNoInvolvement("user4");
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
     }
 
     @Test

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/RuntimeServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/RuntimeServiceTest.java
@@ -1091,7 +1091,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
             assertEquals(3, runtimeService.getVariables(processInstance.getId(), Arrays.asList("var1", "var2", "var3")).size());
             assertNotNull(runtimeService.getVariable(processInstance.getId(), "var2"));
 
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             // Verify history
             assertEquals(3, historyService.createHistoricVariableInstanceQuery().list().size());
@@ -1100,7 +1100,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
             // Remove one variable
             runtimeService.removeVariable(processInstance.getId(), "var2");
 
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             // Verify runtime
             assertEquals(2, runtimeService.getVariables(processInstance.getId()).size());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/SubTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/SubTaskTest.java
@@ -153,7 +153,7 @@ public class SubTaskTest extends PluggableFlowableTestCase {
 
             historyService.deleteHistoricProcessInstance(processInstance.getId());
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             historicTasks = historyService.createHistoricTaskInstanceQuery().taskAssignee("test").list();
             assertEquals(0, historicTasks.size());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskBatchDeleteTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskBatchDeleteTest.java
@@ -67,7 +67,7 @@ public class TaskBatchDeleteTest extends PluggableFlowableTestCase {
         processInstance = runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).singleResult();
         assertNull(processInstance);
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskIdentityLinksTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskIdentityLinksTest.java
@@ -129,7 +129,7 @@ public class TaskIdentityLinksTest extends PluggableFlowableTestCase {
 
         assertTaskEvent(taskId, 2, Event.ACTION_DELETE_USER_LINK, "kermit", IdentityLinkType.ASSIGNEE);
 
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         List<HistoricIdentityLink> history = historyService.getHistoricIdentityLinksForTask(taskId);
         assertEquals(2, history.size());
         
@@ -174,7 +174,7 @@ public class TaskIdentityLinksTest extends PluggableFlowableTestCase {
 
         assertTaskEvent(taskId, 2, Event.ACTION_DELETE_USER_LINK, "kermit", IdentityLinkType.ASSIGNEE);
 
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         List<HistoricIdentityLink> history = historyService.getHistoricIdentityLinksForTask(taskId);
         assertEquals(2, history.size());
         
@@ -219,7 +219,7 @@ public class TaskIdentityLinksTest extends PluggableFlowableTestCase {
 
         assertTaskEvent(taskId, 2, Event.ACTION_DELETE_USER_LINK, "kermit", IdentityLinkType.OWNER);
 
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         List<HistoricIdentityLink> history = historyService.getHistoricIdentityLinksForTask(taskId);
         assertEquals(2, history.size());
         Collections.sort(history, new Comparator<HistoricIdentityLink>() {
@@ -259,7 +259,7 @@ public class TaskIdentityLinksTest extends PluggableFlowableTestCase {
 
         assertTaskEvent(taskId, 1, Event.ACTION_ADD_USER_LINK, "kermit", IdentityLinkType.ASSIGNEE);
 
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         List<HistoricIdentityLink> history = historyService.getHistoricIdentityLinksForTask(taskId);
         assertEquals(1, history.size());
         HistoricIdentityLink assigned = history.get(0);
@@ -285,7 +285,7 @@ public class TaskIdentityLinksTest extends PluggableFlowableTestCase {
 
         assertTaskEvent(taskId, 0, null, null, null);
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         List<HistoricIdentityLink> history = historyService.getHistoricIdentityLinksForTask(taskId);
         assertEquals(0, history.size());
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskServiceTest.java
@@ -448,7 +448,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
             assertEquals(0, taskService.getTaskComments(taskId).size());
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
             assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskId(taskId).list().size());
 
             taskService.deleteTask(taskId, true);
@@ -479,7 +479,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
             assertEquals(0, taskService.getTaskComments(taskId).size());
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
             
             assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskId(taskId).list().size());
 
@@ -1788,7 +1788,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
             Thread.sleep(50L); // to make sure the times for ordering below are different.
             taskService.setVariable(task.getId(), "variable1", "value2");
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             HistoricActivityInstance historicActivitiInstance = historyService.createHistoricActivityInstanceQuery()
                     .processInstanceId(processInstance.getId())
@@ -1855,7 +1855,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
             taskService.deleteTask(task.getId(), "deleted for testing purposes");
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             HistoricTaskInstance historicTaskInstance = historyService.createHistoricTaskInstanceQuery().taskId(task.getId()).singleResult();
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/tenant/TenancyTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/tenant/TenancyTest.java
@@ -455,7 +455,7 @@ public class TenancyTest extends PluggableFlowableTestCase {
                 taskService.complete(task.getId());
             }
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             // Verify process instances
             assertEquals(TEST_TENANT_ID, historyService.createHistoricProcessInstanceQuery().processDefinitionId(processDefinitionIdWithTenant).list().get(0).getTenantId());
@@ -880,7 +880,7 @@ public class TenancyTest extends PluggableFlowableTestCase {
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKeyAndTenantId("process1", null, CollectionUtil.singletonMap("sendFor", "test"), tenantId);
             Assert.assertNotNull(processInstance);
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             Assert.assertEquals(1, historyService.createHistoricProcessInstanceQuery().processDefinitionKey("process2").processInstanceTenantId(tenantId).count());
             Assert.assertEquals(1, historyService.createHistoricProcessInstanceQuery().processDefinitionKey("process2").count());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/async/AsyncEmailTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/async/AsyncEmailTaskTest.java
@@ -36,7 +36,7 @@ public class AsyncEmailTaskTest extends EmailTestCase {
         List<WiserMessage> messages = wiser.getMessages();
         assertEquals(0, messages.size());
 
-        waitForJobExecutorToProcessAllJobs(5000L, 25L);
+        waitForJobExecutorToProcessAllJobs(7000L, 25L);
 
         messages = wiser.getMessages();
         assertEquals(1, messages.size());
@@ -54,7 +54,7 @@ public class AsyncEmailTaskTest extends EmailTestCase {
         List<WiserMessage> messages = wiser.getMessages();
         assertEquals(0, messages.size());
 
-        waitForJobExecutorToProcessAllJobs(5000L, 25L);
+        waitForJobExecutorToProcessAllJobs(7000L, 25L);
 
         messages = wiser.getMessages();
         assertEquals(1, messages.size());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/async/AsyncExclusiveJobsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/async/AsyncExclusiveJobsTest.java
@@ -35,7 +35,7 @@ public class AsyncExclusiveJobsTest extends PluggableFlowableTestCase {
             runtimeService.startProcessInstanceByKey("testExclusiveJobs");
             waitForJobExecutorToProcessAllJobs(20000L, 500L);
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             HistoricActivityInstance scriptTaskAInstance = historyService.createHistoricActivityInstanceQuery().activityId("scriptTaskA").singleResult();
             HistoricActivityInstance scriptTaskBInstance = historyService.createHistoricActivityInstanceQuery().activityId("scriptTaskB").singleResult();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/async/AsyncTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/async/AsyncTaskTest.java
@@ -47,7 +47,7 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
         // the service was not invoked:
         assertFalse(INVOCATION);
 
-        waitForJobExecutorToProcessAllJobs(5000L, 100L);
+        waitForJobExecutorToProcessAllJobs(7000L, 100L);
 
         // the service was invoked
         assertTrue(INVOCATION);
@@ -63,7 +63,7 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
         // the listener was not yet invoked:
         assertNull(runtimeService.getVariable(pid, "listener"));
 
-        waitForJobExecutorToProcessAllJobs(5000L, 100L);
+        waitForJobExecutorToProcessAllJobs(7000L, 100L);
 
         assertEquals(0, managementService.createJobQuery().count());
     }
@@ -79,7 +79,7 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
         // the service was not invoked:
         assertFalse(INVOCATION);
 
-        waitForJobExecutorToProcessAllJobs(5000L, 100L);
+        waitForJobExecutorToProcessAllJobs(7000L, 100L);
 
         // the service was invoked
         assertTrue(INVOCATION);
@@ -98,7 +98,7 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
         // the service was not invoked:
         assertFalse(INVOCATION);
 
-        waitForJobExecutorToProcessAllJobs(5000L, 100L);
+        waitForJobExecutorToProcessAllJobs(7000L, 100L);
 
         // the service was invoked
         assertTrue(INVOCATION);
@@ -147,7 +147,7 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
         assertEquals(2, managementService.createJobQuery().count());
 
         // let 'max-retires' on the message be reached
-        waitForJobExecutorToProcessAllJobs(5000L, 100L);
+        waitForJobExecutorToProcessAllJobs(7000L, 100L);
 
         // the service failed: the execution is still sitting in the service
         // task:
@@ -161,7 +161,7 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
 
         // now the timer triggers:
         Context.getProcessEngineConfiguration().getClock().setCurrentTime(new Date(System.currentTimeMillis() + 10000));
-        waitForJobExecutorToProcessAllJobs(5000L, 100L);
+        waitForJobExecutorToProcessAllJobs(7000L, 100L);
 
         // and we are done:
         assertNull(runtimeService.createExecutionQuery().singleResult());
@@ -182,7 +182,7 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
         // the service was not invoked:
         assertFalse(INVOCATION);
 
-        waitForJobExecutorToProcessAllJobs(5000L, 200L);
+        waitForJobExecutorToProcessAllJobs(7000L, 200L);
 
         // the service was invoked
         assertTrue(INVOCATION);
@@ -199,7 +199,7 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
 
         assertEquals(1, managementService.createJobQuery().count());
 
-        waitForJobExecutorToProcessAllJobs(5000L, 100L);
+        waitForJobExecutorToProcessAllJobs(7000L, 100L);
 
         // both the timer and the message are cancelled
         assertEquals(0, managementService.createJobQuery().count());
@@ -214,7 +214,7 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
         // now there should be one job in the database:
         assertEquals(1, managementService.createJobQuery().count());
 
-        waitForJobExecutorToProcessAllJobs(5000L, 200L);
+        waitForJobExecutorToProcessAllJobs(7000L, 200L);
 
         // the job is done
         assertEquals(0, managementService.createJobQuery().count());
@@ -269,7 +269,7 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
         }
         assertNull(runtimeService.getVariable(eid, "invoked"));
 
-        waitForJobExecutorToProcessAllJobs(5000L, 100L);
+        waitForJobExecutorToProcessAllJobs(7000L, 100L);
 
         // and the job is done
         assertEquals(0, managementService.createJobQuery().count());
@@ -300,7 +300,7 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
     public void testBasicAsyncCallActivity() {
         runtimeService.startProcessInstanceByKey("myProcess");
         Assert.assertEquals("There should be one job available.", 1, managementService.createJobQuery().count());
-        waitForJobExecutorToProcessAllJobs(5000L, 250L);
+        waitForJobExecutorToProcessAllJobs(7000L, 250L);
         assertEquals(0, managementService.createJobQuery().count());
     }
 
@@ -318,7 +318,7 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
         // there is no usertask
         assertNull(taskService.createTaskQuery().singleResult());
 
-        waitForJobExecutorToProcessAllJobs(5000L, 250L);
+        waitForJobExecutorToProcessAllJobs(7000L, 250L);
         // the listener was now invoked:
         assertNotNull(runtimeService.getVariable(pid, "listener"));
         // the task listener was now invoked:

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/callactivity/CallActivityAdvancedTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/callactivity/CallActivityAdvancedTest.java
@@ -258,7 +258,7 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
 
         // When the timer on the subprocess is fired, the complete subprocess is destroyed
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + (6 * 60 * 1000))); // + 6 minutes, timer fires on 5 minutes
-        waitForJobExecutorToProcessAllJobs(10000, 5000L);
+        waitForJobExecutorToProcessAllJobs(10000, 7000L);
 
         Task escalatedTask = taskQuery.singleResult();
         assertEquals("Escalated Task", escalatedTask.getName());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.java
@@ -377,7 +377,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
 
         // Set clock time to '1 hour and 5 seconds' ahead to fire timer
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + ((60 * 60 * 1000) + 5000)));
-        waitForJobExecutorToProcessAllJobs(5000L, 25L);
+        waitForJobExecutorToProcessAllJobs(7000L, 25L);
 
         // timer has fired
         assertEquals(0L, managementService.createJobQuery().count());
@@ -678,7 +678,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
 
         taskService.complete(task.getId());
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         
         assertProcessEnded(processInstance.getId());
         assertHistoricProcessInstanceDetails(processInstance);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageBoundaryEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageBoundaryEventTest.java
@@ -523,7 +523,7 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
 
         // After setting the clock to time '1 hour and 5 seconds', the timer should fire.
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + ((60 * 60 * 1000) + 5000)));
-        waitForJobExecutorOnCondition(5000L, 100L, new Callable<Boolean>() {
+        waitForJobExecutorOnCondition(7000L, 100L, new Callable<Boolean>() {
             @Override
             public Boolean call() throws Exception {
                 return taskService.createTaskQuery().count() == 2;

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventTest.java
@@ -79,7 +79,7 @@ public class BoundaryTimerEventTest extends PluggableFlowableTestCase {
         // After setting the clock to time '1 hour and 5 seconds', the second
         // timer should fire
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + ((60 * 60 * 1000) + 5000)));
-        waitForJobExecutorToProcessAllJobs(5000L, 25L);
+        waitForJobExecutorToProcessAllJobs(7000L, 25L);
         assertEquals(0L, jobQuery.count());
 
         // which means that the third task is reached
@@ -128,7 +128,7 @@ public class BoundaryTimerEventTest extends PluggableFlowableTestCase {
         // After setting the clock to time '1 hour and 5 seconds', the second
         // timer should fire
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + ((60 * 60 * 1000) + 5000)));
-        waitForJobExecutorToProcessAllJobs(5000L, 25L);
+        waitForJobExecutorToProcessAllJobs(7000L, 25L);
         assertEquals(0L, jobQuery.count());
 
         // start execution listener is not executed
@@ -162,7 +162,7 @@ public class BoundaryTimerEventTest extends PluggableFlowableTestCase {
         // After setting the clock to time '1 hour and 5 seconds', the second
         // timer should fire
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + ((60 * 60 * 1000) + 5000)));
-        waitForJobExecutorToProcessAllJobs(5000L, 25L);
+        waitForJobExecutorToProcessAllJobs(7000L, 25L);
         assertEquals(0L, jobQuery.count());
 
         // start execution listener is not executed

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerNonInterruptingEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerNonInterruptingEventTest.java
@@ -72,7 +72,7 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
 
         // After setting the clock to time '2 hour and 5 seconds', the second timer should fire
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + ((2 * 60 * 60 * 1000) + 5000)));
-        waitForJobExecutorToProcessAllJobs(5000L, 25L);
+        waitForJobExecutorToProcessAllJobs(7000L, 25L);
 
         // no more timers to fire
         assertEquals(0L, jobQuery.count());
@@ -114,7 +114,7 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
 
         // After setting the clock to time '1 hour and 5 seconds', the first timer should fire
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + ((60 * 60 * 1000) + 5000)));
-        waitForJobExecutorToProcessAllJobs(5000L, 25L);
+        waitForJobExecutorToProcessAllJobs(7000L, 25L);
 
         // timer has fired
         assertEquals(0L, jobQuery.count());
@@ -278,7 +278,7 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
         // timer should fire
         // processEngineConfiguration.getClock().setCurrentTime(new
         // Date(startTime.getTime() + ((60 * 60 * 1000) + 5000)));
-        // waitForJobExecutorToProcessAllJobs(5000L, 25L);
+        // waitForJobExecutorToProcessAllJobs(7000L, 25L);
         // assertEquals(0L, jobQuery.count());
 
         // which means the process has ended

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/DurationTimeTimerEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/DurationTimeTimerEventTest.java
@@ -69,7 +69,7 @@ public class DurationTimeTimerEventTest extends PluggableFlowableTestCase {
 
         processEngineConfiguration.getClock().setCurrentTime(Date.from(yesterday.plus(200, ChronoUnit.SECONDS)));
 
-        waitForJobExecutorToProcessAllJobs(5000L, 200L);
+        waitForJobExecutorToProcessAllJobs(7000L, 200L);
 
         jobQuery = managementService.createTimerJobQuery();
         assertThat(jobQuery.count()).isEqualTo(0);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/InstantTimeTimerEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/InstantTimeTimerEventTest.java
@@ -39,7 +39,7 @@ public class InstantTimeTimerEventTest extends ResourceFlowableTestCase {
         TimerJobQuery jobQuery = managementService.createTimerJobQuery();
         assertEquals(1, jobQuery.count());
 
-        waitForJobExecutorToProcessAllJobs(5000L, 200L);
+        waitForJobExecutorToProcessAllJobs(7000L, 200L);
 
         jobQuery = managementService.createTimerJobQuery();
         assertEquals(0, jobQuery.count());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/IntermediateTimerEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/IntermediateTimerEventTest.java
@@ -46,7 +46,7 @@ public class IntermediateTimerEventTest extends PluggableFlowableTestCase {
 
         // After setting the clock to time '50minutes and 5 seconds', the second timer should fire
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + ((50 * 60 * 1000) + 5000)));
-        waitForJobExecutorToProcessAllJobs(5000L, 25L);
+        waitForJobExecutorToProcessAllJobs(7000L, 25L);
 
         assertEquals(0, jobQuery.count());
         assertProcessEnded(pi.getProcessInstanceId());
@@ -245,7 +245,7 @@ public class IntermediateTimerEventTest extends PluggableFlowableTestCase {
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + ((50 * 60 * 1000) + 5000)));
         try {
             JobTestHelper.waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(
-                    this.processEngineConfiguration, this.managementService, 5000L, 250L
+                    this.processEngineConfiguration, this.managementService, 7000L, 250L
             );
 
             assertEquals(0, jobQuery.count());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/StartTimerEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/StartTimerEventTest.java
@@ -49,7 +49,7 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
 
         // After setting the clock to time '50 minutes and 5 seconds', the second timer should fire
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + ((50 * 60 * 1000) + 5000)));
-        waitForJobExecutorToProcessAllJobs(5000L, 200L);
+        waitForJobExecutorToProcessAllJobs(7000L, 200L);
 
         List<ProcessInstance> pi = runtimeService.createProcessInstanceQuery().processDefinitionKey("startTimerEventExample").list();
         assertEquals(1, pi.size());
@@ -66,7 +66,7 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
         assertEquals(1, jobQuery.count());
 
         processEngineConfiguration.getClock().setCurrentTime(new SimpleDateFormat("dd/MM/yyyy hh:mm:ss").parse("15/11/2036 11:12:30"));
-        waitForJobExecutorToProcessAllJobs(5000L, 200L);
+        waitForJobExecutorToProcessAllJobs(7000L, 200L);
 
         List<ProcessInstance> pi = runtimeService.createProcessInstanceQuery().processDefinitionKey("startTimerEventExample").list();
         assertEquals(1, pi.size());
@@ -144,7 +144,7 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
         assertEquals(1, jobQuery.count());
 
         processEngineConfiguration.getClock().setCurrentTime(new SimpleDateFormat("dd/MM/yyyy hh:mm:ss").parse("15/11/2036 11:12:30"));
-        waitForJobExecutorToProcessAllJobs(5000L, 200L);
+        waitForJobExecutorToProcessAllJobs(7000L, 200L);
 
         List<ProcessInstance> pi = runtimeService.createProcessInstanceQuery().processDefinitionKey("startTimerEventExample").list();
         assertEquals(1, pi.size());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/exclusive/ExclusiveTimerEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/exclusive/ExclusiveTimerEventTest.java
@@ -36,7 +36,7 @@ public class ExclusiveTimerEventTest extends PluggableFlowableTestCase {
 
         // After setting the clock to time '50minutes and 5 seconds', the timers should fire
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + ((50 * 60 * 1000) + 5000)));
-        waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(5000L, 500L);
+        waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(7000L, 500L);
 
         assertEquals(0, jobQuery.count());
         assertProcessEnded(pi.getProcessInstanceId());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/gateway/EventBasedGatewayTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/gateway/EventBasedGatewayTest.java
@@ -53,7 +53,7 @@ public class EventBasedGatewayTest extends PluggableFlowableTestCase {
         assertNotNull(task);
         taskService.complete(task.getId());
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         assertHistoricActivitiesDeleteReason(pi1, DeleteReason.EVENT_BASED_GATEWAY_CANCEL, "timerEvent");
     }
@@ -84,7 +84,7 @@ public class EventBasedGatewayTest extends PluggableFlowableTestCase {
 
         taskService.complete(task.getId());
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         assertHistoricActivitiesDeleteReason(processInstance, DeleteReason.EVENT_BASED_GATEWAY_CANCEL, "signalEvent");
     }
@@ -122,7 +122,7 @@ public class EventBasedGatewayTest extends PluggableFlowableTestCase {
         assertNotNull(task);
         taskService.complete(task.getId());
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         assertHistoricActivitiesDeleteReason(processInstance, DeleteReason.EVENT_BASED_GATEWAY_CANCEL, "signalEvent");
         assertHistoricActivitiesDeleteReason(processInstance, DeleteReason.EVENT_BASED_GATEWAY_CANCEL, "timerEvent");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/gateway/InclusiveGatewayTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/gateway/InclusiveGatewayTest.java
@@ -484,7 +484,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
     @Deployment
     public void testAsyncBehavior() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("async");
-        waitForJobExecutorToProcessAllJobs(5000L, 250);
+        waitForJobExecutorToProcessAllJobs(7000L, 250);
         assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/gateway/ParallelGatewayTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/gateway/ParallelGatewayTest.java
@@ -169,7 +169,7 @@ public class ParallelGatewayTest extends PluggableFlowableTestCase {
     @Deployment
     public void testAsyncBehavior() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("async");
-        waitForJobExecutorToProcessAllJobs(5000L, 250L);
+        waitForJobExecutorToProcessAllJobs(7000L, 250L);
         assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.java
@@ -422,7 +422,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertNotNull(processInstance);
         
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, 
-                        processEngineConfiguration.getManagementService(), 5000, 200);
+                        processEngineConfiguration.getManagementService(), 7000, 200);
 
         List<Task> tasks = taskService.createTaskQuery().list();
         for (Task task : tasks){
@@ -431,7 +431,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
             taskService.complete(task.getId());
             
             HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, 
-                            processEngineConfiguration.getManagementService(), 5000, 200);
+                            processEngineConfiguration.getManagementService(), 7000, 200);
         }
         
         assertProcessEnded(processInstance.getId());
@@ -451,7 +451,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertNotNull(processInstance);
         
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, 
-                        processEngineConfiguration.getManagementService(), 5000, 200);
+                        processEngineConfiguration.getManagementService(), 7000, 200);
 
         Task task = taskService.createTaskQuery().singleResult();
         assertEquals(task.getAssignee(), taskService.getVariable(task.getId(), "csAssignee"));
@@ -459,7 +459,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         taskService.complete(task.getId());
         
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, 
-                        processEngineConfiguration.getManagementService(), 5000, 200);
+                        processEngineConfiguration.getManagementService(), 7000, 200);
         
         task = taskService.createTaskQuery().singleResult();
         assertEquals(task.getAssignee(), taskService.getVariable(task.getId(), "csAssignee"));
@@ -467,7 +467,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         taskService.complete(task.getId());
         
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, 
-                        processEngineConfiguration.getManagementService(), 5000, 200);
+                        processEngineConfiguration.getManagementService(), 7000, 200);
         
         task = taskService.createTaskQuery().singleResult();
         assertEquals(task.getAssignee(), taskService.getVariable(task.getId(), "csAssignee"));
@@ -475,7 +475,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         taskService.complete(task.getId());
         
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, 
-                        processEngineConfiguration.getManagementService(), 5000, 200);
+                        processEngineConfiguration.getManagementService(), 7000, 200);
         
         assertProcessEnded(processInstance.getId());
     }
@@ -1573,7 +1573,7 @@ assertProcessEnded(procId);
             vars.put("messages", Collections.EMPTY_LIST);
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("parallelUserTaskMi", vars);
 
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
             assertEquals(1L, historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).finished().count());
         }
     }
@@ -1584,7 +1584,7 @@ assertProcessEnded(procId);
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("parallelUserTaskMi");
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
             assertEquals(1L, historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).finished().count());
         }
     }
@@ -1597,7 +1597,7 @@ assertProcessEnded(procId);
             vars.put("messages", Collections.EMPTY_LIST);
             runtimeService.startProcessInstanceByKey("sequentialMiSubprocess", vars);
 
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
             assertEquals(1L, historyService.createHistoricProcessInstanceQuery().finished().count());
         }
     }
@@ -1610,7 +1610,7 @@ assertProcessEnded(procId);
             vars.put("messages", Collections.EMPTY_LIST);
             runtimeService.startProcessInstanceByKey("parallelMiSubprocess", vars);
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             assertEquals(1L, historyService.createHistoricProcessInstanceQuery().finished().count());
         }
@@ -1680,7 +1680,7 @@ assertProcessEnded(procId);
         assertEquals("User Task 1", tasks.get(0).getName());
         assertEquals("User Task 1", tasks.get(1).getName());
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         // End time should not be set for the subprocess
         List<HistoricActivityInstance> historicActivityInstances = historyService.createHistoricActivityInstanceQuery().activityId("subprocess1").list();
@@ -1693,7 +1693,7 @@ assertProcessEnded(procId);
         // Complete one of the user tasks. This should not trigger setting of end time of the subprocess, but due to a bug it did exactly that
         taskService.complete(tasks.get(0).getId());
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         
         historicActivityInstances = historyService.createHistoricActivityInstanceQuery().activityId("subprocess1").list();
         assertEquals(2, historicActivityInstances.size());
@@ -1703,7 +1703,7 @@ assertProcessEnded(procId);
 
         taskService.complete(tasks.get(1).getId());
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         
         historicActivityInstances = historyService.createHistoricActivityInstanceQuery().activityId("subprocess1").list();
         assertEquals(2, historicActivityInstances.size());
@@ -1716,7 +1716,7 @@ assertProcessEnded(procId);
         for (org.flowable.task.api.Task task : tasks) {
             taskService.complete(task.getId());
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
             
             historicActivityInstances = historyService.createHistoricActivityInstanceQuery().activityId("subprocess1").list();
             assertEquals(2, historicActivityInstances.size());
@@ -1732,7 +1732,7 @@ assertProcessEnded(procId);
             taskService.complete(task.getId());
         }
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         historicActivityInstances = historyService.createHistoricActivityInstanceQuery().activityId("subprocess1").list();
         assertEquals(2, historicActivityInstances.size());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/servicetask/TriggerableServiceTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/servicetask/TriggerableServiceTaskTest.java
@@ -77,7 +77,7 @@ public class TriggerableServiceTaskTest extends PluggableFlowableTestCase {
         assertEquals(1, jobs.size());
         assertEquals(AsyncContinuationJobHandler.TYPE, jobs.get(0).getJobHandlerType());
         
-        waitForJobExecutorToProcessAllJobs(5000L, 250L);
+        waitForJobExecutorToProcessAllJobs(7000L, 250L);
 
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processId).activityId("service1").singleResult();
         assertNotNull(execution);
@@ -92,7 +92,7 @@ public class TriggerableServiceTaskTest extends PluggableFlowableTestCase {
         assertEquals(1, jobs.size());
         assertEquals(AsyncTriggerJobHandler.TYPE, jobs.get(0).getJobHandlerType());
         
-        waitForJobExecutorToProcessAllJobs(5000L, 250L);
+        waitForJobExecutorToProcessAllJobs(7000L, 250L);
 
         execution = runtimeService.createExecutionQuery().processInstanceId(processId).activityId("usertask1").singleResult();
         assertNotNull(execution);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/subprocess/SubProcessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/subprocess/SubProcessTest.java
@@ -76,7 +76,7 @@ public class SubProcessTest extends PluggableFlowableTestCase {
         // Setting the clock forward 2 hours 1 second (timer fires in 2 hours) and fire up the job executor
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + (2 * 60 * 60 * 1000) + 1000));
         assertEquals(1, managementService.createTimerJobQuery().count());
-        waitForJobExecutorToProcessAllJobs(5000L, 500L);
+        waitForJobExecutorToProcessAllJobs(7000L, 500L);
 
         // The subprocess should be left, and the escalated task should be active
         org.flowable.task.api.Task escalationTask = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
@@ -162,7 +162,7 @@ public class SubProcessTest extends PluggableFlowableTestCase {
         // Setting the clock forward 1 hour 1 second (timer fires in 1 hour) and
         // fire up the job executor
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + (60 * 60 * 1000) + 1000));
-        waitForJobExecutorToProcessAllJobs(5000L, 50L);
+        waitForJobExecutorToProcessAllJobs(7000L, 50L);
 
         // The inner subprocess should be destroyed, and the escalated task should be active
         org.flowable.task.api.Task escalationTask = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
@@ -322,7 +322,7 @@ public class SubProcessTest extends PluggableFlowableTestCase {
         // Firing the timer should destroy all three subprocesses and activate the task after the timer
         // processEngineConfiguration.getClock().setCurrentTime(new
         // Date(startTime.getTime() + (2 * 60 * 60 * 1000 ) + 1000));
-        // waitForJobExecutorToProcessAllJobs(5000L, 50L);
+        // waitForJobExecutorToProcessAllJobs(7000L, 50L);
         Job job = managementService.createTimerJobQuery().singleResult();
         managementService.moveTimerToExecutableJob(job.getId());
         managementService.executeJob(job.getId());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/concurrency/OptimisticLockingExceptionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/concurrency/OptimisticLockingExceptionTest.java
@@ -65,7 +65,7 @@ public class OptimisticLockingExceptionTest extends PluggableFlowableTestCase {
                 Thread.sleep(250L);
                 totalWaitTime += 250L;
 
-                if (totalWaitTime >= 5000L) {
+                if (totalWaitTime >= 7000L) {
                     break;
                 }
             }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricActivityInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricActivityInstanceTest.java
@@ -39,7 +39,7 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
     public void testHistoricActivityInstanceNoop() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("noopProcess");
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         HistoricActivityInstance historicActivityInstance = historyService.createHistoricActivityInstanceQuery().activityId("noop").singleResult();
 
@@ -57,7 +57,7 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
     public void testHistoricActivityInstanceReceive() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("receiveProcess");
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         HistoricActivityInstance historicActivityInstance = historyService.createHistoricActivityInstanceQuery().activityId("receive").singleResult();
 
@@ -72,7 +72,7 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
         Execution execution = runtimeService.createExecutionQuery().onlyChildExecutions().processInstanceId(processInstance.getId()).singleResult();
         runtimeService.trigger(execution.getId());
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         historicActivityInstance = historyService.createHistoricActivityInstanceQuery().activityId("receive").singleResult();
 
@@ -91,7 +91,7 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
         assertNotNull(processInstance);
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         HistoricActivityInstanceQuery historicActivityInstanceQuery = historyService.createHistoricActivityInstanceQuery();
 
@@ -107,7 +107,7 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
     public void testHistoricActivityInstanceQuery() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("noopProcess");
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         assertEquals(0, historyService.createHistoricActivityInstanceQuery().activityId("nonExistingActivityId").list().size());
         assertEquals(1, historyService.createHistoricActivityInstanceQuery().activityId("noop").list().size());
@@ -166,7 +166,7 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
         runtimeService.signalEventReceived("signal");
         assertProcessEnded(pi.getId());
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         assertEquals(1, historyService.createHistoricActivityInstanceQuery().activityId("noop").list().size());
         assertEquals(1, historyService.createHistoricActivityInstanceQuery().activityId("userTask").list().size());
@@ -197,7 +197,7 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
         // Start process instance
         runtimeService.startProcessInstanceByKey("taskAssigneeProcess");
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         // Get task list
         HistoricActivityInstance historicActivityInstance = historyService.createHistoricActivityInstanceQuery().activityId("theTask").singleResult();
@@ -212,7 +212,7 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
     public void testHistoricActivityInstanceCalledProcessId() {
         runtimeService.startProcessInstanceByKey("callSimpleSubProcess");
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         HistoricActivityInstance historicActivityInstance = historyService.createHistoricActivityInstanceQuery().activityId("callSubProcess").singleResult();
 
@@ -304,7 +304,7 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
 
         assertEquals(0L, runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         // Check if there is NO historic activity instance for a boundary-event that has not triggered
         HistoricActivityInstance historicActivityInstance = historyService.createHistoricActivityInstanceQuery().activityId("boundary").processInstanceId(processInstance.getId()).singleResult();
@@ -320,7 +320,7 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
         runtimeService.signalEventReceived("alert", signalExecution.getId());
         assertEquals(0L, runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         historicActivityInstance = historyService.createHistoricActivityInstanceQuery().activityId("boundary").processInstanceId(processInstance.getId()).singleResult();
 
@@ -342,7 +342,7 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
 
         assertEquals(0L, runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         HistoricActivityInstance historicActivityInstance = historyService.createHistoricActivityInstanceQuery().activityId("eventBasedgateway").processInstanceId(processInstance.getId()).singleResult();
 
@@ -364,7 +364,7 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
         taskService.complete(tasksToComplete.get(0).getId());
         taskService.complete(tasksToComplete.get(1).getId());
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         List<HistoricActivityInstance> historicActivityInstance = historyService.createHistoricActivityInstanceQuery().activityId("join").processInstanceId(processInstance.getId()).list();
 
@@ -394,7 +394,7 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
             task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         }
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         // Verify history
         List<HistoricActivityInstance> taskActivityInstances = historyService.createHistoricActivityInstanceQuery().activityType("userTask").list();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricProcessInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricProcessInstanceTest.java
@@ -57,7 +57,7 @@ public class HistoricProcessInstanceTest extends PluggableFlowableTestCase {
         processEngineConfiguration.getClock().setCurrentTime(noon);
         final ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess", "myBusinessKey");
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         assertEquals(1, historyService.createHistoricProcessInstanceQuery().unfinished().count());
         assertEquals(0, historyService.createHistoricProcessInstanceQuery().finished().count());
@@ -81,7 +81,7 @@ public class HistoricProcessInstanceTest extends PluggableFlowableTestCase {
         processEngineConfiguration.getClock().setCurrentTime(twentyFiveSecsAfterNoon);
         taskService.complete(tasks.get(0).getId());
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         historicProcessInstance = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).singleResult();
 
@@ -105,7 +105,7 @@ public class HistoricProcessInstanceTest extends PluggableFlowableTestCase {
         // delete process instance should not delete the history
         runtimeService.deleteProcessInstance(processInstance.getId(), "cancel");
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         
         HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).singleResult();
         assertNotNull(historicProcessInstance.getEndTime());
@@ -137,7 +137,7 @@ public class HistoricProcessInstanceTest extends PluggableFlowableTestCase {
         Calendar hourFromNow = Calendar.getInstance();
         hourFromNow.add(Calendar.HOUR_OF_DAY, 1);
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         // Name and name like
         assertEquals("The name", historyService.createHistoricProcessInstanceQuery().processInstanceName("The name").singleResult().getName());
@@ -150,7 +150,7 @@ public class HistoricProcessInstanceTest extends PluggableFlowableTestCase {
         // Query after update name
         runtimeService.setProcessInstanceName(processInstance.getId(), "New name");
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         
         assertEquals("New name", historyService.createHistoricProcessInstanceQuery().processInstanceName("New name").singleResult().getName());
         assertEquals(1, historyService.createHistoricProcessInstanceQuery().processInstanceName("New name").count());
@@ -190,7 +190,7 @@ public class HistoricProcessInstanceTest extends PluggableFlowableTestCase {
         // After finishing process
         taskService.complete(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getId());
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         
         assertEquals(1, historyService.createHistoricProcessInstanceQuery().finished().count());
         assertEquals(0, historyService.createHistoricProcessInstanceQuery().finishedBefore(hourAgo.getTime()).count());
@@ -217,7 +217,7 @@ public class HistoricProcessInstanceTest extends PluggableFlowableTestCase {
         Calendar hourFromNow = Calendar.getInstance();
         hourFromNow.add(Calendar.HOUR_OF_DAY, 1);
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         // Name and name like
         assertEquals("The name", historyService.createHistoricProcessInstanceQuery().or().processInstanceName("The name").processDefinitionId("undefined").endOr().singleResult().getName());
@@ -252,7 +252,7 @@ public class HistoricProcessInstanceTest extends PluggableFlowableTestCase {
         // Query after update name
         runtimeService.setProcessInstanceName(processInstance.getId(), "New name");
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         
         assertEquals("New name", historyService.createHistoricProcessInstanceQuery().or().processInstanceName("New name").processDefinitionId("undefined").endOr().singleResult().getName());
         assertEquals(1, historyService.createHistoricProcessInstanceQuery().or().processInstanceName("New name").processDefinitionId("undefined").endOr().count());
@@ -291,7 +291,7 @@ public class HistoricProcessInstanceTest extends PluggableFlowableTestCase {
         // After finishing process
         taskService.complete(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getId());
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         
         assertEquals(1, historyService.createHistoricProcessInstanceQuery().or().finished().processDefinitionId("undefined").endOr().count());
         assertEquals(0, historyService.createHistoricProcessInstanceQuery().or().finishedBefore(hourAgo.getTime()).processDefinitionId("undefined").endOr().count());
@@ -309,7 +309,7 @@ public class HistoricProcessInstanceTest extends PluggableFlowableTestCase {
     public void testHistoricProcessInstanceSorting() {
         ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("oneTaskProcess");
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         assertEquals(1, historyService.createHistoricProcessInstanceQuery().orderByProcessInstanceId().asc().list().size());
         assertEquals(1, historyService.createHistoricProcessInstanceQuery().orderByProcessInstanceStartTime().asc().list().size());
@@ -351,7 +351,7 @@ public class HistoricProcessInstanceTest extends PluggableFlowableTestCase {
             taskService.complete(task.getId());
         }
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         assertEquals(2, historyService.createHistoricProcessInstanceQuery().orderByProcessInstanceId().asc().list().size());
         assertEquals(2, historyService.createHistoricProcessInstanceQuery().orderByProcessInstanceStartTime().asc().list().size());
@@ -433,7 +433,7 @@ public class HistoricProcessInstanceTest extends PluggableFlowableTestCase {
             ProcessInstance pi = runtimeService.startProcessInstanceByKey("oneTaskProcess");
             runtimeService.deleteProcessInstance(pi.getId(), deleteReason);
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
             
             HistoricProcessInstance hpi = historyService.createHistoricProcessInstanceQuery().processInstanceId(pi.getId()).singleResult();
             assertEquals(deleteReason, hpi.getDeleteReason());
@@ -447,7 +447,7 @@ public class HistoricProcessInstanceTest extends PluggableFlowableTestCase {
             ProcessInstance pi = runtimeService.startProcessInstanceByKey("oneTaskProcess");
             runtimeService.addUserIdentityLink(pi.getId(), "kermit", "myType");
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             // Check historic links
             List<HistoricIdentityLink> historicLinks = historyService.getHistoricIdentityLinksForProcessInstance(pi.getId());
@@ -462,14 +462,14 @@ public class HistoricProcessInstanceTest extends PluggableFlowableTestCase {
             taskService.complete(taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult().getId());
             assertNull(runtimeService.createProcessInstanceQuery().processInstanceId(pi.getId()).singleResult());
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             assertEquals(1, historyService.getHistoricIdentityLinksForProcessInstance(pi.getId()).size());
 
             // When process is deleted, identitylinks shouldn't exist anymore
             historyService.deleteHistoricProcessInstance(pi.getId());
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
             
             assertEquals(0, historyService.getHistoricIdentityLinksForProcessInstance(pi.getId()).size());
         }
@@ -487,7 +487,7 @@ public class HistoricProcessInstanceTest extends PluggableFlowableTestCase {
 
             runtimeService.deleteProcessInstance(pi.getId(), "testing");
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             // The parent and child process should be present in history
             assertEquals(2L, historyService.createHistoricProcessInstanceQuery().count());
@@ -495,7 +495,7 @@ public class HistoricProcessInstanceTest extends PluggableFlowableTestCase {
             // Deleting the parent process should cascade the child-process
             historyService.deleteHistoricProcessInstance(pi.getId());
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
             
             assertEquals(0L, historyService.createHistoricProcessInstanceQuery().count());
         }
@@ -510,7 +510,7 @@ public class HistoricProcessInstanceTest extends PluggableFlowableTestCase {
         builder.name(piName);
         ProcessInstance processInstance1 = builder.start();
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance1.getProcessInstanceId()).singleResult();
         assertEquals(piName, historicProcessInstance.getName());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricTaskInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricTaskInstanceTest.java
@@ -56,7 +56,7 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         runtimeTask.setDueDate(dueDate);
         taskService.saveTask(runtimeTask);
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         String taskId = runtimeTask.getId();
         String taskDefinitionKey = runtimeTask.getTaskDefinitionKey();
@@ -79,7 +79,7 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
 
         taskService.claim(taskId, "kermit");
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         assertEquals(1, historyService.createHistoricTaskInstanceQuery().count());
         historicTaskInstance = historyService.createHistoricTaskInstanceQuery().singleResult();
@@ -89,7 +89,7 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
 
         taskService.complete(taskId);
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         assertEquals(1, historyService.createHistoricTaskInstanceQuery().count());
 
@@ -110,7 +110,7 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
 
         historyService.deleteHistoricTaskInstance(taskId);
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         assertEquals(0, historyService.createHistoricTaskInstanceQuery().count());
     }
@@ -119,7 +119,7 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
     public void testDeleteHistoricTaskInstance() throws Exception {
         // deleting unexisting historic task instance should be silently ignored
         historyService.deleteHistoricTaskInstance("unexistingId");
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
     }
 
     @Test
@@ -147,7 +147,7 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         String taskId = task.getId();
         taskService.complete(taskId);
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         // org.flowable.task.service.Task id
         assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskId(taskId).count());
@@ -289,7 +289,7 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         // Finished and Unfinished - Add anther other instance that has a running task (unfinished)
         runtimeService.startProcessInstanceByKey("HistoricTaskQueryTest");
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         assertEquals(1, historyService.createHistoricTaskInstanceQuery().finished().count());
         assertEquals(1, historyService.createHistoricTaskInstanceQuery().unfinished().count());
@@ -305,7 +305,7 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         String taskId = task.getId();
         taskService.setOwner(taskId, "kermit");
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         // task is still active
         List<HistoricIdentityLink> historicIdentityLinksForTask = historyService.getHistoricIdentityLinksForTask(task.getId());
@@ -317,17 +317,17 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
 
         // change owner
         taskService.setOwner(taskId, "gonzo");
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         historicIdentityLinksForTask = historyService.getHistoricIdentityLinksForTask(task.getId());
         assertEquals(2, historicIdentityLinksForTask.size());
 
         taskService.setOwner(taskId, null);
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         historicIdentityLinksForTask = historyService.getHistoricIdentityLinksForTask(task.getId());
         assertEquals(3, historicIdentityLinksForTask.size());
 
         taskService.complete(taskId);
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         historicIdentityLinksForTask = historyService.getHistoricIdentityLinksForTask(task.getId());
         assertEquals(3, historicIdentityLinksForTask.size());
 
@@ -340,7 +340,7 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
 
         secondTask.setOwner("fozzie");
         taskService.saveTask(secondTask);
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         historicIdentityLinksForTask = historyService.getHistoricIdentityLinksForTask(secondTask.getId());
         assertEquals(1, historicIdentityLinksForTask.size());
         assertNotNull(historicIdentityLinksForTask.get(0).getCreateTime());
@@ -364,7 +364,7 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         taskService.claim(taskId, "gonzo");
         taskService.unclaim(taskId);
 
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         
         // task is still active
         List<HistoricIdentityLink> historicIdentityLinksForTask = historyService.getHistoricIdentityLinksForTask(task.getId());
@@ -403,7 +403,7 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         // historic links should be present after the task is completed
         taskService.complete(taskId);
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         
         historicIdentityLinksForTask = historyService.getHistoricIdentityLinksForTask(task.getId());
         nullCount = 0;
@@ -439,7 +439,7 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         String secondTaskId = secondTask.getId();
         taskService.setAssignee(secondTaskId, "newKid");
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         // 4 users now participated to the process
         historicIdentityLinksForProcess = historyService.getHistoricIdentityLinksForProcessInstance(processInstance.getId());
@@ -448,7 +448,7 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         // 4 users participated after the last task (and the process) is completed
         taskService.complete(secondTaskId);
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         
         historicIdentityLinksForProcess = historyService.getHistoricIdentityLinksForProcessInstance(processInstance.getId());
         assertEquals(4, historicIdentityLinksForProcess.size());
@@ -483,7 +483,7 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         String taskId = task.getId();
         taskService.complete(taskId);
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         // org.flowable.task.service.Task id
         assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().taskId(taskId).endOr().count());
@@ -558,12 +558,12 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task adhocTask = taskService.newTask();
         taskService.saveTask(adhocTask);
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         
         assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().taskId(adhocTask.getId()).processDefinitionKey("unexistingdefinitionkey").endOr().count());
         taskService.deleteTask(adhocTask.getId(), true);
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         // Process definition key in
         List<String> includeIds = new ArrayList<>();
@@ -663,7 +663,7 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         // Finished and Unfinished - Add anther other instance that has a running task (unfinished)
         runtimeService.startProcessInstanceByKey("HistoricTaskQueryTest");
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().finished().endOr().count());
         assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().unfinished().endOr().count());
@@ -675,7 +675,7 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("TwoTaskHistoricTaskQueryTest");
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         // Running task on running process should be available
         assertEquals(1, historyService.createHistoricTaskInstanceQuery().processUnfinished().count());
@@ -684,7 +684,7 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         // Finished and running task on running process should be available
         taskService.complete(task.getId());
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         
         assertEquals(2, historyService.createHistoricTaskInstanceQuery().processUnfinished().count());
         assertEquals(0, historyService.createHistoricTaskInstanceQuery().processFinished().count());
@@ -693,7 +693,7 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         taskService.complete(task.getId());
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         
         assertEquals(0, historyService.createHistoricTaskInstanceQuery().processUnfinished().count());
         assertEquals(2, historyService.createHistoricTaskInstanceQuery().processFinished().count());
@@ -707,7 +707,7 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         String taskId = taskService.createTaskQuery().processInstanceId(instance.getId()).singleResult().getId();
         taskService.complete(taskId);
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         assertEquals(1, historyService.createHistoricTaskInstanceQuery().orderByDeleteReason().asc().count());
         assertEquals(1, historyService.createHistoricTaskInstanceQuery().orderByExecutionId().asc().count());
@@ -747,7 +747,7 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         taskService.addUserIdentityLink(task.getId(), "gonzo", "customUseridentityLink");
         assertEquals(4, taskService.getIdentityLinksForTask(task.getId()).size());
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         // Check historic identity-links when task is still active
         List<HistoricIdentityLink> historicIdentityLinks = historyService.getHistoricIdentityLinksForTask(task.getId());
@@ -785,14 +785,14 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         // Now complete the task and check if links are still there
         taskService.complete(task.getId());
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         
         assertEquals(4, historyService.getHistoricIdentityLinksForTask(task.getId()).size());
 
         // After deleting historic task, exception should be thrown when trying to get links
         historyService.deleteHistoricTaskInstance(task.getId());
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         try {
             historyService.getHistoricIdentityLinksForTask(task.getId()).size();
@@ -844,7 +844,7 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
 
         taskService.complete(task.getId());
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         
         // Check if all variables have the value for the latest revision
         HistoricTaskInstance taskInstance = historyService.createHistoricTaskInstanceQuery().taskId(task.getId()).includeProcessVariables().singleResult();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricTaskInstanceUpdateTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricTaskInstanceUpdateTest.java
@@ -40,7 +40,7 @@ public class HistoricTaskInstanceUpdateTest extends PluggableFlowableTestCase {
 
         taskService.complete(task.getId());
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         
         assertEquals(1, historyService.createHistoricTaskInstanceQuery().count());
 
@@ -62,7 +62,7 @@ public class HistoricTaskInstanceUpdateTest extends PluggableFlowableTestCase {
 
         taskService.complete(task.getId());
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         
         assertEquals(1, historyService.createHistoricTaskInstanceQuery().processInstanceId(secondInstance.getId()).count());
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricVariableInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricVariableInstanceTest.java
@@ -75,7 +75,7 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
 
             assertProcessEnded(processInstance.getId());
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             List<HistoricVariableInstance> variables = historyService.createHistoricVariableInstanceQuery().list();
             assertEquals(1, variables.size());
@@ -95,7 +95,7 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("myProc");
             assertProcessEnded(processInstance.getId());
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             List<HistoricVariableInstance> variables = historyService.createHistoricVariableInstanceQuery().list();
             assertEquals(1, variables.size());
@@ -121,7 +121,7 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
 
             assertProcessEnded(processInstance.getId());
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             List<HistoricVariableInstance> variables = historyService.createHistoricVariableInstanceQuery()
                     .processInstanceId(processInstance.getId())
@@ -149,7 +149,7 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("myProc");
             assertProcessEnded(processInstance.getId());
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             List<HistoricVariableInstance> variables = historyService.createHistoricVariableInstanceQuery()
                     .processInstanceId(processInstance.getId())
@@ -171,7 +171,7 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoSubProcessInParallelWithinSubProcess");
             assertProcessEnded(processInstance.getId());
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             List<HistoricVariableInstance> variables = historyService.createHistoricVariableInstanceQuery()
                     .processInstanceId(processInstance.getId())
@@ -198,7 +198,7 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("callSimpleSubProcess");
             assertProcessEnded(processInstance.getId());
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             assertEquals(4, historyService.createHistoricVariableInstanceQuery().count());
             assertEquals(4, historyService.createHistoricVariableInstanceQuery().list().size());
@@ -245,7 +245,7 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
             taskService.setVariableLocal(tasks.get(i).getId(), "taskVar" + i, i);
         }
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         // Verify historic variable instance queries
         List<HistoricVariableInstance> historicVariableInstances = historyService.createHistoricVariableInstanceQuery()
@@ -324,7 +324,7 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
             }
         }
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         assertEquals(2, historyService.createHistoricVariableInstanceQuery().executionIds(testProcessInstanceIds).count());
         assertEquals(2, historyService.createHistoricVariableInstanceQuery().executionIds(testProcessInstanceIds).list().size());
@@ -365,7 +365,7 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
             taskService.setVariableLocal(task.getId(), "taskVar", "taskVar");
         }
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         Set<String> processInstanceIds = new HashSet<>();
         processInstanceIds.add(processInstance.getId());
@@ -391,7 +391,7 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
         taskService.setVariableLocal(tasks.get(0).getId(), "taskVar1", "hello1");
         taskService.setVariableLocal(tasks.get(1).getId(), "taskVar2", "hello2");
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         Set<String> taskIds = new HashSet<>();
         taskIds.add(tasks.get(0).getId());
@@ -436,7 +436,7 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
             taskIds.add(task.getId());
         }
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         List<HistoricVariableInstance> historicVariableInstances = historyService.createHistoricVariableInstanceQuery().taskIds(taskIds).list();
         assertEquals(2, historicVariableInstances.size());
@@ -481,7 +481,7 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
             // now we are ended
             assertProcessEnded(pi.getId());
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             // check history
             List<HistoricDetail> updates = historyService.createHistoricDetailQuery().processInstanceId(pi.getId()).variableUpdates().list();
@@ -537,7 +537,7 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
             ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("myProcess", variables);
             assertNotNull(processInstance2);
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             // check variables
             long count = historyService.createHistoricVariableInstanceQuery().count();
@@ -546,11 +546,11 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
             // delete runtime execution of ONE process instance
             runtimeService.deleteProcessInstance(processInstance.getId(), "reason 1");
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
             
             historyService.deleteHistoricProcessInstance(processInstance.getId());
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             // recheck variables
             // this is a bug: all variables was deleted after delete a history process instance
@@ -585,7 +585,7 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("myProc", variables);
             assertNotNull(processInstance);
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             assertEquals(3, historyService.createNativeHistoricVariableInstanceQuery().sql(baseQuerySql).list().size());
 
@@ -619,7 +619,7 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("myProc", variables);
             assertNotNull(processInstance);
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             assertEquals(3, historyService.createNativeHistoricDetailQuery().sql(baseQuerySql).list().size());
 
@@ -635,7 +635,7 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
             formDatas.put("field2", "field value 2");
             formService.submitTaskFormData(task.getId(), formDatas);
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             String countSql = "select count(*) from " + tableName + " where TYPE_ = #{type} and PROC_INST_ID_ = #{pid}";
             assertEquals(2, historyService.createNativeHistoricDetailQuery().sql(countSql).parameter("type", "FormProperty").parameter("pid", processInstance.getId()).count());
@@ -659,29 +659,29 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
 
             // no type change
             runtimeService.setVariable(processInstance.getId(), "firstVar", "123");
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
             assertEquals("123", getHistoricVariable("firstVar").getValue());
             
             runtimeService.setVariable(processInstance.getId(), "firstVar", "456");
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
             assertEquals("456", getHistoricVariable("firstVar").getValue());
             
             runtimeService.setVariable(processInstance.getId(), "firstVar", "789");
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
             assertEquals("789", getHistoricVariable("firstVar").getValue());
 
             // type is changed from text to integer and back again. same result expected(?)
             runtimeService.setVariable(processInstance.getId(), "secondVar", "123");
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
             assertEquals("123", getHistoricVariable("secondVar").getValue());
             
             runtimeService.setVariable(processInstance.getId(), "secondVar", 456);
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
             // there are now 2 historic variables, so the following does not work
             assertEquals(456, getHistoricVariable("secondVar").getValue());
             
             runtimeService.setVariable(processInstance.getId(), "secondVar", "789");
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
             // there are now 3 historic variables, so the following does not work
             assertEquals("789", getHistoricVariable("secondVar").getValue());
 
@@ -708,7 +708,7 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
 
             assertProcessEnded(processInstance.getId());
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             List<HistoricVariableInstance> variables = historyService.createHistoricVariableInstanceQuery().executionId(processInstance.getId()).list();
             assertEquals(1, variables.size());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/JobExecutorExceptionsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/JobExecutorExceptionsTest.java
@@ -41,7 +41,7 @@ public class JobExecutorExceptionsTest extends PluggableFlowableTestCase {
 
         // The execution is waiting in the first usertask. This contains a
         // boundary timer event which we will execute manual for testing purposes.
-        JobTestHelper.waitForJobExecutorOnCondition(processEngineConfiguration, 5000L, 100L, new Callable<Boolean>() {
+        JobTestHelper.waitForJobExecutorOnCondition(processEngineConfiguration, 7000L, 100L, new Callable<Boolean>() {
             @Override
             public Boolean call() throws Exception {
                 return managementService.createTimerJobQuery().withException().count() == 1;

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/tasklistener/TaskListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/tasklistener/TaskListenerTest.java
@@ -69,7 +69,7 @@ public class TaskListenerTest extends PluggableFlowableTestCase {
 
         runtimeService.deleteProcessInstance(processInstance.getProcessInstanceId(), "");
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
     }
 
     /**
@@ -119,7 +119,7 @@ public class TaskListenerTest extends PluggableFlowableTestCase {
         // Manually cleanup the process instance.
         runtimeService.deleteProcessInstance(processInstance.getProcessInstanceId(), "");
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
     }
     
     @Test
@@ -147,7 +147,7 @@ public class TaskListenerTest extends PluggableFlowableTestCase {
 
         runtimeService.deleteProcessInstance(processInstance.getProcessInstanceId(), "");
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
     }
 
     @Test
@@ -192,7 +192,7 @@ public class TaskListenerTest extends PluggableFlowableTestCase {
         String eventsReceived = (String) runtimeService.getVariable(task.getProcessInstanceId(), "events");
         assertEquals("create - assignment - complete - delete", eventsReceived);
         
-        waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
     }
 
     @Test

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/groovy/GroovyScriptTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/groovy/GroovyScriptTest.java
@@ -58,8 +58,7 @@ public class GroovyScriptTest extends PluggableFlowableTestCase {
         List<Job> jobs = jobQuery.list();
         assertEquals(1, jobs.size());
 
-        // After setting the clock to time '1 hour and 5 seconds', the second timer should fire
-        waitForJobExecutorToProcessAllJobs(5000L, 100L);
+        waitForJobExecutorToProcessAllJobs(7000L, 100L);
         assertEquals(0L, jobQuery.count());
 
         assertProcessEnded(processInstance.getId());

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/task/StandaloneTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/task/StandaloneTaskTest.java
@@ -174,7 +174,7 @@ public class StandaloneTaskTest extends PluggableFlowableTestCase {
             finishVariables.put("finishedAmount", 40);
             taskService.complete(task.getId(), finishVariables);
             
-            waitForHistoryJobExecutorToProcessAllJobs(5000, 100);
+            waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             // 4. get completed variable
             List<HistoricVariableInstance> hisVarList = historyService.createHistoricVariableInstanceQuery().taskId(task.getId()).list();

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/history/async/AsyncHistoryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/history/async/AsyncHistoryTest.java
@@ -97,7 +97,7 @@ public class AsyncHistoryTest extends CustomConfigurationFlowableTestCase {
                 assertNotNull(((HistoryJobEntity) job).getAdvancedJobHandlerConfigurationByteArrayRef());
             }
 
-            waitForHistoryJobExecutorToProcessAllJobs(5000L, 100L);
+            waitForHistoryJobExecutorToProcessAllJobs(7000L, 100L);
 
             HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstanceId).singleResult();
             assertNotNull(historicProcessInstance);
@@ -160,7 +160,7 @@ public class AsyncHistoryTest extends CustomConfigurationFlowableTestCase {
         final List<HistoryJob> jobs = managementService.createHistoryJobQuery().list();
         assertTrue(jobs.size() > 0);
 
-        waitForHistoryJobExecutorToProcessAllJobs(50000L, 100L);
+        waitForHistoryJobExecutorToProcessAllJobs(70000L, 100L);
         assertNull(managementService.createHistoryJobQuery().singleResult());
 
         // 1002 -> (start, 1) + (end, 1) + (gateway, 500), + (service task, 500)
@@ -171,14 +171,14 @@ public class AsyncHistoryTest extends CustomConfigurationFlowableTestCase {
     public void testTaskAssigneeChange() {
         Task task = startOneTaskprocess();
 
-        waitForHistoryJobExecutorToProcessAllJobs(5000L, 100L);
+        waitForHistoryJobExecutorToProcessAllJobs(7000L, 100L);
         HistoricActivityInstance historicActivityInstance = historyService.createHistoricActivityInstanceQuery()
                         .activityId("theTask").singleResult();
         assertEquals("kermit", historicActivityInstance.getAssignee());
 
         task = taskService.createTaskQuery().singleResult();
         taskService.setAssignee(task.getId(), "johnDoe");
-        waitForHistoryJobExecutorToProcessAllJobs(5000L, 100L);
+        waitForHistoryJobExecutorToProcessAllJobs(7000L, 100L);
         historicActivityInstance = historyService.createHistoricActivityInstanceQuery().activityId("theTask").singleResult();
         assertEquals("johnDoe", historicActivityInstance.getAssignee());
 
@@ -189,14 +189,14 @@ public class AsyncHistoryTest extends CustomConfigurationFlowableTestCase {
     public void testTaskAssigneeChangeToNull() {
         Task task = startOneTaskprocess();
 
-        waitForHistoryJobExecutorToProcessAllJobs(5000L, 100L);
+        waitForHistoryJobExecutorToProcessAllJobs(7000L, 100L);
         HistoricActivityInstance historicActivityInstance = historyService.createHistoricActivityInstanceQuery()
                         .activityId("theTask").singleResult();
         assertEquals("kermit", historicActivityInstance.getAssignee());
 
         task = taskService.createTaskQuery().singleResult();
         taskService.setAssignee(task.getId(), null);
-        waitForHistoryJobExecutorToProcessAllJobs(5000L, 100L);
+        waitForHistoryJobExecutorToProcessAllJobs(7000L, 100L);
         historicActivityInstance = historyService.createHistoricActivityInstanceQuery().activityId("theTask").singleResult();
         assertNull(historicActivityInstance.getAssignee());
 
@@ -208,12 +208,12 @@ public class AsyncHistoryTest extends CustomConfigurationFlowableTestCase {
         Task task = startOneTaskprocess();
         taskService.setAssignee(task.getId(), null);
 
-        waitForHistoryJobExecutorToProcessAllJobs(5000L, 100L);
+        waitForHistoryJobExecutorToProcessAllJobs(7000L, 100L);
         HistoricTaskInstance historicTaskInstance = historyService.createHistoricTaskInstanceQuery().singleResult();
         assertNull(historicTaskInstance.getClaimTime());
 
         taskService.claim(historicTaskInstance.getId(), "johnDoe");
-        waitForHistoryJobExecutorToProcessAllJobs(5000L, 100L);
+        waitForHistoryJobExecutorToProcessAllJobs(7000L, 100L);
         historicTaskInstance = historyService.createHistoricTaskInstanceQuery().taskId(historicTaskInstance.getId()).singleResult();
         assertNotNull(historicTaskInstance.getClaimTime());
         assertNotNull(historicTaskInstance.getAssignee());
@@ -226,18 +226,18 @@ public class AsyncHistoryTest extends CustomConfigurationFlowableTestCase {
         Task task = startOneTaskprocess();
         assertNull(task.getOwner());
 
-        waitForHistoryJobExecutorToProcessAllJobs(5000L, 100L);
+        waitForHistoryJobExecutorToProcessAllJobs(7000L, 100L);
         HistoricTaskInstance historicTaskInstance = historyService.createHistoricTaskInstanceQuery().singleResult();
         assertNull(historicTaskInstance.getOwner());
 
         taskService.setOwner(task.getId(), "johnDoe");
 
-        waitForHistoryJobExecutorToProcessAllJobs(5000L, 100L);
+        waitForHistoryJobExecutorToProcessAllJobs(7000L, 100L);
         historicTaskInstance = historyService.createHistoricTaskInstanceQuery().singleResult();
         assertEquals("johnDoe", historicTaskInstance.getOwner());
 
         taskService.setOwner(task.getId(), null);
-        waitForHistoryJobExecutorToProcessAllJobs(5000L, 100L);
+        waitForHistoryJobExecutorToProcessAllJobs(7000L, 100L);
         historicTaskInstance = historyService.createHistoricTaskInstanceQuery().taskId(historicTaskInstance.getId()).singleResult();
         assertNull(historicTaskInstance.getOwner());
 
@@ -249,14 +249,14 @@ public class AsyncHistoryTest extends CustomConfigurationFlowableTestCase {
         Task task = startOneTaskprocess();
         assertEquals("The Task", task.getName());
 
-        waitForHistoryJobExecutorToProcessAllJobs(5000L, 100L);
+        waitForHistoryJobExecutorToProcessAllJobs(7000L, 100L);
         HistoricTaskInstance historicTaskInstance = historyService.createHistoricTaskInstanceQuery().singleResult();
         assertEquals("The Task", historicTaskInstance.getName());
 
         task.setName("new name");
         taskService.saveTask(task);
 
-        waitForHistoryJobExecutorToProcessAllJobs(5000L, 100L);
+        waitForHistoryJobExecutorToProcessAllJobs(7000L, 100L);
         historicTaskInstance = historyService.createHistoricTaskInstanceQuery().singleResult();
         assertEquals("new name", historicTaskInstance.getName());
 
@@ -268,14 +268,14 @@ public class AsyncHistoryTest extends CustomConfigurationFlowableTestCase {
         Task task = startOneTaskprocess();
         assertNull(task.getDescription());
 
-        waitForHistoryJobExecutorToProcessAllJobs(5000L, 100L);
+        waitForHistoryJobExecutorToProcessAllJobs(7000L, 100L);
         HistoricTaskInstance historicTaskInstance = historyService.createHistoricTaskInstanceQuery().singleResult();
         assertNull(historicTaskInstance.getDescription());
 
         task.setDescription("test description");
         taskService.saveTask(task);
 
-        waitForHistoryJobExecutorToProcessAllJobs(5000L, 100L);
+        waitForHistoryJobExecutorToProcessAllJobs(7000L, 100L);
         historicTaskInstance = historyService.createHistoricTaskInstanceQuery().singleResult();
         assertNotNull(historicTaskInstance.getDescription());
 
@@ -283,7 +283,7 @@ public class AsyncHistoryTest extends CustomConfigurationFlowableTestCase {
         task.setDescription(null);
         taskService.saveTask(task);
 
-        waitForHistoryJobExecutorToProcessAllJobs(5000L, 100L);
+        waitForHistoryJobExecutorToProcessAllJobs(7000L, 100L);
         historicTaskInstance = historyService.createHistoricTaskInstanceQuery().taskId(historicTaskInstance.getId()).singleResult();
         assertNull(historicTaskInstance.getDescription());
 
@@ -295,18 +295,18 @@ public class AsyncHistoryTest extends CustomConfigurationFlowableTestCase {
         Task task = startOneTaskprocess();
         assertNull(task.getDueDate());
 
-        waitForHistoryJobExecutorToProcessAllJobs(5000L, 100L);
+        waitForHistoryJobExecutorToProcessAllJobs(7000L, 100L);
         HistoricTaskInstance historicTaskInstance = historyService.createHistoricTaskInstanceQuery().singleResult();
         assertNull(historicTaskInstance.getDueDate());
 
         taskService.setDueDate(task.getId(), new Date());
 
-        waitForHistoryJobExecutorToProcessAllJobs(5000L, 100L);
+        waitForHistoryJobExecutorToProcessAllJobs(7000L, 100L);
         historicTaskInstance = historyService.createHistoricTaskInstanceQuery().singleResult();
         assertNotNull(historicTaskInstance.getDueDate());
 
         taskService.setDueDate(task.getId(), null);
-        waitForHistoryJobExecutorToProcessAllJobs(5000L, 100L);
+        waitForHistoryJobExecutorToProcessAllJobs(7000L, 100L);
         historicTaskInstance = historyService.createHistoricTaskInstanceQuery().taskId(historicTaskInstance.getId()).singleResult();
         assertNull(historicTaskInstance.getDueDate());
 
@@ -318,13 +318,13 @@ public class AsyncHistoryTest extends CustomConfigurationFlowableTestCase {
         Task task = startOneTaskprocess();
         assertEquals(Task.DEFAULT_PRIORITY, task.getPriority());
 
-        waitForHistoryJobExecutorToProcessAllJobs(5000L, 100L);
+        waitForHistoryJobExecutorToProcessAllJobs(7000L, 100L);
         HistoricTaskInstance historicTaskInstance = historyService.createHistoricTaskInstanceQuery().singleResult();
         assertEquals(Task.DEFAULT_PRIORITY, historicTaskInstance.getPriority());
 
         taskService.setPriority(task.getId(), 1);
 
-        waitForHistoryJobExecutorToProcessAllJobs(5000L, 100L);
+        waitForHistoryJobExecutorToProcessAllJobs(7000L, 100L);
         historicTaskInstance = historyService.createHistoricTaskInstanceQuery().singleResult();
         assertEquals(1, historicTaskInstance.getPriority());
 
@@ -336,14 +336,14 @@ public class AsyncHistoryTest extends CustomConfigurationFlowableTestCase {
         Task task = startOneTaskprocess();
         assertNull(task.getCategory());
 
-        waitForHistoryJobExecutorToProcessAllJobs(5000L, 100L);
+        waitForHistoryJobExecutorToProcessAllJobs(7000L, 100L);
         HistoricTaskInstance historicTaskInstance = historyService.createHistoricTaskInstanceQuery().singleResult();
         assertNull(historicTaskInstance.getCategory());
 
         task.setCategory("test category");
         taskService.saveTask(task);
 
-        waitForHistoryJobExecutorToProcessAllJobs(5000L, 100L);
+        waitForHistoryJobExecutorToProcessAllJobs(7000L, 100L);
         historicTaskInstance = historyService.createHistoricTaskInstanceQuery().singleResult();
         assertEquals("test category", historicTaskInstance.getCategory());
 
@@ -355,13 +355,13 @@ public class AsyncHistoryTest extends CustomConfigurationFlowableTestCase {
         Task task = startOneTaskprocess();
         assertNull(task.getFormKey());
 
-        waitForHistoryJobExecutorToProcessAllJobs(5000L, 100L);
+        waitForHistoryJobExecutorToProcessAllJobs(7000L, 100L);
         HistoricTaskInstance historicTaskInstance = historyService.createHistoricTaskInstanceQuery().singleResult();
         assertNull(historicTaskInstance.getFormKey());
         task.setFormKey("test form key");
         taskService.saveTask(task);
 
-        waitForHistoryJobExecutorToProcessAllJobs(5000L, 100L);
+        waitForHistoryJobExecutorToProcessAllJobs(7000L, 100L);
         historicTaskInstance = historyService.createHistoricTaskInstanceQuery().singleResult();
         assertEquals("test form key", historicTaskInstance.getFormKey());
 
@@ -385,7 +385,7 @@ public class AsyncHistoryTest extends CustomConfigurationFlowableTestCase {
         assertEquals(1, taskService.getSubTasks(parentTask1.getId()).size());
         assertEquals(0, taskService.getSubTasks(parentTask2.getId()).size());
 
-        waitForHistoryJobExecutorToProcessAllJobs(5000L, 100L);
+        waitForHistoryJobExecutorToProcessAllJobs(7000L, 100L);
 
         HistoricTaskInstance historicTaskInstance = historyService.createHistoricTaskInstanceQuery().taskId(childTask.getId()).singleResult();
         assertEquals(parentTask1.getId(), historicTaskInstance.getParentTaskId());
@@ -396,7 +396,7 @@ public class AsyncHistoryTest extends CustomConfigurationFlowableTestCase {
         assertEquals(0, taskService.getSubTasks(parentTask1.getId()).size());
         assertEquals(1, taskService.getSubTasks(parentTask2.getId()).size());
 
-        waitForHistoryJobExecutorToProcessAllJobs(5000L, 100L);
+        waitForHistoryJobExecutorToProcessAllJobs(7000L, 100L);
 
         historicTaskInstance = historyService.createHistoricTaskInstanceQuery().taskId(childTask.getId()).singleResult();
         assertEquals(parentTask2.getId(), historicTaskInstance.getParentTaskId());
@@ -446,7 +446,7 @@ public class AsyncHistoryTest extends CustomConfigurationFlowableTestCase {
 
     protected void finishOneTaskProcess(Task task) {
         taskService.complete(task.getId());
-        waitForHistoryJobExecutorToProcessAllJobs(5000L, 100L);
+        waitForHistoryJobExecutorToProcessAllJobs(7000L, 100L);
         assertNull(managementService.createHistoryJobQuery().singleResult());
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/testing/FlowableJupiterTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/testing/FlowableJupiterTest.java
@@ -70,7 +70,7 @@ class FlowableJupiterTest {
         // now there should be one job in the database:
         assertThat(managementService.createJobQuery().count()).isEqualTo(1);
 
-        testHelper.waitForJobExecutorToProcessAllJobs(5000L, 500L);
+        testHelper.waitForJobExecutorToProcessAllJobs(7000L, 500L);
 
         // the job is done
         assertThat(managementService.createJobQuery().count()).isEqualTo(0);

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/testing/FlowableRuleJunit4Test.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/testing/FlowableRuleJunit4Test.java
@@ -63,7 +63,7 @@ public class FlowableRuleJunit4Test {
         // now there should be one job in the database:
         assertEquals(1, managementService.createJobQuery().count());
 
-        JobTestHelper.waitForJobExecutorToProcessAllJobs(activitiRule, 5000L, 500L);
+        JobTestHelper.waitForJobExecutorToProcessAllJobs(activitiRule, 7000L, 500L);
 
         // the job is done
         assertEquals(0, managementService.createJobQuery().count());

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/repository/ProcessDefinitionResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/repository/ProcessDefinitionResourceTest.java
@@ -163,7 +163,7 @@ public class ProcessDefinitionResourceTest extends BaseSpringRestTestCase {
         // Force suspension by altering time
         cal.add(Calendar.HOUR, 1);
         processEngineConfiguration.getClock().setCurrentTime(cal.getTime());
-        waitForJobExecutorToProcessAllJobs(5000, 100);
+        waitForJobExecutorToProcessAllJobs(7000, 100);
 
         // Check if process-definition is suspended
         processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
@@ -260,7 +260,7 @@ public class ProcessDefinitionResourceTest extends BaseSpringRestTestCase {
         // Force activation by altering time
         cal.add(Calendar.HOUR, 1);
         processEngineConfiguration.getClock().setCurrentTime(cal.getTime());
-        waitForJobExecutorToProcessAllJobs(5000, 100);
+        waitForJobExecutorToProcessAllJobs(7000, 100);
 
         // Check if process-definition is activated
         processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();

--- a/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-starter/src/test/java/flowable/MixedAsyncExecutorsTest.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-starter/src/test/java/flowable/MixedAsyncExecutorsTest.java
@@ -87,8 +87,8 @@ public class MixedAsyncExecutorsTest {
         // Timer fires after 1 day, so setting it to 1 day + 1 second
         setClockTo(new Date(startTime.getTime() + (24 * 60 * 60 * 1000 + 1)));
 
-        CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnRule.getCmmnEngine(), 5000L, 200L, true);
-        JobTestHelper.waitForJobExecutorToProcessAllJobs(processRule, 5000L, 200L);
+        CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnRule.getCmmnEngine(), 7000L, 200L, true);
+        JobTestHelper.waitForJobExecutorToProcessAllJobs(processRule, 7000L, 200L);
 
         // User task should be active after the timer has triggered
         assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(2);

--- a/modules/flowable-spring/src/test/java/org/flowable/spring/test/servicetask/ServiceTaskSpringDelegationTest.java
+++ b/modules/flowable-spring/src/test/java/org/flowable/spring/test/servicetask/ServiceTaskSpringDelegationTest.java
@@ -38,7 +38,7 @@ public class ServiceTaskSpringDelegationTest extends SpringFlowableTestCase {
     public void testAsyncDelegateExpression() throws Exception {
         ProcessInstance procInst = runtimeService.startProcessInstanceByKey("delegateExpressionToSpringBean");
         assertTrue(JobTestHelper.areJobsAvailable(managementService));
-        waitForJobExecutorToProcessAllJobs(5000, 500);
+        waitForJobExecutorToProcessAllJobs(7000, 500);
         Thread.sleep(1000);
         assertEquals("Activiti BPMN 2.0 process engine", runtimeService.getVariable(procInst.getId(), "myVar"));
         assertEquals("fieldInjectionWorking", runtimeService.getVariable(procInst.getId(), "fieldInjection"));
@@ -56,7 +56,7 @@ public class ServiceTaskSpringDelegationTest extends SpringFlowableTestCase {
     public void testAsyncMethodExpressionOnSpringBean() {
         ProcessInstance procInst = runtimeService.startProcessInstanceByKey("methodExpressionOnSpringBean");
         assertTrue(JobTestHelper.areJobsAvailable(managementService));
-        waitForJobExecutorToProcessAllJobs(5000, 500);
+        waitForJobExecutorToProcessAllJobs(7000, 500);
         assertEquals("ACTIVITI BPMN 2.0 PROCESS ENGINE", runtimeService.getVariable(procInst.getId(), "myVar"));
     }
 

--- a/modules/flowable5-camel-test/src/test/java/org/activiti/camel/revisited/AsyncProcessRevisitedTest.java
+++ b/modules/flowable5-camel-test/src/test/java/org/activiti/camel/revisited/AsyncProcessRevisitedTest.java
@@ -53,7 +53,7 @@ public class AsyncProcessRevisitedTest extends SpringFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("asyncCamelProcessRevisited");
         List<Execution> executionList = runtimeService.createExecutionQuery().list();
         assertEquals(3, executionList.size());
-        waitForJobExecutorToProcessAllJobs(5000, 200);
+        waitForJobExecutorToProcessAllJobs(7000, 200);
         assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
     }
 }

--- a/modules/flowable5-spring-test/src/test/java/org/activiti/spring/test/servicetask/ServiceTaskSpringDelegationTest.java
+++ b/modules/flowable5-spring-test/src/test/java/org/activiti/spring/test/servicetask/ServiceTaskSpringDelegationTest.java
@@ -35,7 +35,7 @@ public class ServiceTaskSpringDelegationTest extends SpringFlowableTestCase {
     public void testAsyncDelegateExpression() throws Exception {
         ProcessInstance procInst = runtimeService.startProcessInstanceByKey("delegateExpressionToSpringBean");
         assertTrue(JobTestHelper.areJobsAvailable(managementService));
-        waitForJobExecutorToProcessAllJobs(5000, 500);
+        waitForJobExecutorToProcessAllJobs(7000, 500);
         Thread.sleep(1000);
         assertEquals("Activiti BPMN 2.0 process engine", runtimeService.getVariable(procInst.getId(), "myVar"));
         assertEquals("fieldInjectionWorking", runtimeService.getVariable(procInst.getId(), "fieldInjection"));
@@ -51,7 +51,7 @@ public class ServiceTaskSpringDelegationTest extends SpringFlowableTestCase {
     public void testAsyncMethodExpressionOnSpringBean() {
         ProcessInstance procInst = runtimeService.startProcessInstanceByKey("methodExpressionOnSpringBean");
         assertTrue(JobTestHelper.areJobsAvailable(managementService));
-        waitForJobExecutorToProcessAllJobs(5000, 500);
+        waitForJobExecutorToProcessAllJobs(7000, 500);
         assertEquals("ACTIVITI BPMN 2.0 PROCESS ENGINE", runtimeService.getVariable(procInst.getId(), "myVar"));
     }
 

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/repository/ProcessDefinitionSuspensionTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/repository/ProcessDefinitionSuspensionTest.java
@@ -291,7 +291,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableFlowableTestCase {
         // Move clock 8 days further and let job executor run
         long eightDaysSinceStartTime = oneWeekFromStartTime + (24 * 60 * 60 * 1000);
         processEngineConfiguration.getClock().setCurrentTime(new Date(eightDaysSinceStartTime));
-        waitForJobExecutorToProcessAllJobs(5000L, 50L);
+        waitForJobExecutorToProcessAllJobs(7000L, 50L);
 
         // verify job is now removed
         assertEquals(0, managementService.createTimerJobQuery().processDefinitionId(processDefinition.getId()).count());
@@ -348,7 +348,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableFlowableTestCase {
         // Move clock 9 days further and let job executor run
         long eightDaysSinceStartTime = oneWeekFromStartTime + (2 * 24 * 60 * 60 * 1000);
         processEngineConfiguration.getClock().setCurrentTime(new Date(eightDaysSinceStartTime));
-        waitForJobExecutorToProcessAllJobs(5000L, 50L);
+        waitForJobExecutorToProcessAllJobs(7000L, 50L);
 
         // Try to start process instance. It should fail now.
         try {
@@ -403,7 +403,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableFlowableTestCase {
         // Move clock two days and let job executor run
         long twoDaysFromStart = startTime.getTime() + (2 * 24 * 60 * 60 * 1000);
         processEngineConfiguration.getClock().setCurrentTime(new Date(twoDaysFromStart));
-        waitForJobExecutorToProcessAllJobs(5000L, 50L);
+        waitForJobExecutorToProcessAllJobs(7000L, 50L);
 
         // Starting a process instance should now succeed
         runtimeService.startProcessInstanceById(processDefinition.getId());
@@ -492,7 +492,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableFlowableTestCase {
 
         // Move time 3 hours and run job executor
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + (3 * hourInMs)));
-        waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(5000L, 100L);
+        waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(7000L, 100L);
         assertEquals(nrOfProcessDefinitions, repositoryService.createProcessDefinitionQuery().count());
         assertEquals(0, repositoryService.createProcessDefinitionQuery().active().count());
         assertEquals(nrOfProcessDefinitions, repositoryService.createProcessDefinitionQuery().suspended().count());

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/repository/RepositoryServiceTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/repository/RepositoryServiceTest.java
@@ -176,7 +176,7 @@ public class RepositoryServiceTest extends PluggableFlowableTestCase {
         // Move time four days forward, the timer will fire and the process definitions will be active
         Date inFourDays = new Date(startTime.getTime() + (4 * 24 * 60 * 60 * 1000));
         processEngineConfiguration.getClock().setCurrentTime(inFourDays);
-        waitForJobExecutorToProcessAllJobs(5000L, 50L);
+        waitForJobExecutorToProcessAllJobs(7000L, 50L);
 
         assertEquals(1, repositoryService.createDeploymentQuery().count());
         assertEquals(2, repositoryService.createProcessDefinitionQuery().count());

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/async/AsyncEmailTaskTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/async/AsyncEmailTaskTest.java
@@ -34,7 +34,7 @@ public class AsyncEmailTaskTest extends EmailTestCase {
         List<WiserMessage> messages = wiser.getMessages();
         assertEquals(0, messages.size());
 
-        waitForJobExecutorToProcessAllJobs(5000L, 25L);
+        waitForJobExecutorToProcessAllJobs(7000L, 25L);
 
         messages = wiser.getMessages();
         assertEquals(1, messages.size());
@@ -52,7 +52,7 @@ public class AsyncEmailTaskTest extends EmailTestCase {
         List<WiserMessage> messages = wiser.getMessages();
         assertEquals(0, messages.size());
 
-        waitForJobExecutorToProcessAllJobs(5000L, 25L);
+        waitForJobExecutorToProcessAllJobs(7000L, 25L);
 
         messages = wiser.getMessages();
         assertEquals(1, messages.size());

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/async/AsyncTaskTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/async/AsyncTaskTest.java
@@ -318,7 +318,7 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
         // now there should be one job in the database:
         assertEquals(1, managementService.createJobQuery().count());
 
-        waitForJobExecutorToProcessAllJobs(5000L, 500L);
+        waitForJobExecutorToProcessAllJobs(7000L, 500L);
 
         // the job is done
         assertEquals(0, managementService.createJobQuery().count());

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/callactivity/CallActivityAdvancedTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/callactivity/CallActivityAdvancedTest.java
@@ -240,7 +240,7 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
 
         // When the timer on the subprocess is fired, the complete subprocess is destroyed
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + (6 * 60 * 1000))); // + 6 minutes, timer fires on 5 minutes
-        waitForJobExecutorToProcessAllJobs(10000, 5000L);
+        waitForJobExecutorToProcessAllJobs(10000, 200L);
 
         org.flowable.task.api.Task escalatedTask = taskQuery.singleResult();
         assertEquals("Escalated Task", escalatedTask.getName());

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/event/end/TerminateEndEventTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/event/end/TerminateEndEventTest.java
@@ -246,7 +246,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
 
         // Set clock time to '1 hour and 5 seconds' ahead to fire timer
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + ((60 * 60 * 1000) + 5000)));
-        waitForJobExecutorToProcessAllJobs(5000L, 25L);
+        waitForJobExecutorToProcessAllJobs(7000L, 25L);
 
         // timer has fired
         assertEquals(0L, managementService.createJobQuery().count());

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/event/timer/BoundaryTimerEventTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/event/timer/BoundaryTimerEventTest.java
@@ -74,7 +74,7 @@ public class BoundaryTimerEventTest extends PluggableFlowableTestCase {
         clock.setCurrentTime(new Date(startTime.getTime() + ((60 * 60 * 1000) + 5000)));
         processEngineConfiguration.setClock(clock);
 
-        waitForJobExecutorToProcessAllJobs(5000L, 25L);
+        waitForJobExecutorToProcessAllJobs(7000L, 25L);
         assertEquals(0L, jobQuery.count());
 
         // which means that the third task is reached
@@ -96,7 +96,7 @@ public class BoundaryTimerEventTest extends PluggableFlowableTestCase {
         assertEquals("Inner subprocess task 2", tasks.get(1).getName());
 
         // Timer will fire in 2 hours
-        processEngineConfiguration.getClock().setCurrentTime(new Date(testStartTime.getTime() + ((2 * 60 * 60 * 1000) + 5000)));
+        processEngineConfiguration.getClock().setCurrentTime(new Date(testStartTime.getTime() + ((2 * 60 * 60 * 1000) + 7000)));
         Job timer = managementService.createTimerJobQuery().singleResult();
         managementService.moveTimerToExecutableJob(timer.getId());
         managementService.executeJob(timer.getId());
@@ -127,7 +127,7 @@ public class BoundaryTimerEventTest extends PluggableFlowableTestCase {
         clock.setCurrentTime(new Date(startTime.getTime() + ((60 * 60 * 1000) + 5000)));
         processEngineConfiguration.setClock(clock);
 
-        waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(5000L, 200L);
+        waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(7000L, 200L);
         assertEquals(0L, jobQuery.count());
 
         // start execution listener is not executed

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/event/timer/BoundaryTimerNonInterruptingEventTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/event/timer/BoundaryTimerNonInterruptingEventTest.java
@@ -69,7 +69,7 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
 
         // After setting the clock to time '2 hour and 5 seconds', the second timer should fire
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + ((2 * 60 * 60 * 1000) + 5000)));
-        waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(5000L, 25L);
+        waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(7000L, 25L);
 
         // no more timers to fire
         assertEquals(0L, jobQuery.count());
@@ -110,7 +110,7 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
 
         // After setting the clock to time '1 hour and 5 seconds', the first timer should fire
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + ((60 * 60 * 1000) + 5000)));
-        waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(5000L, 200L);
+        waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(7000L, 200L);
 
         // timer has fired
         assertEquals(0L, jobQuery.count());
@@ -269,7 +269,7 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
 
         // // After setting the clock to time '1 hour and 5 seconds', the second timer should fire
         // processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + ((60 * 60 * 1000) + 5000)));
-        // waitForJobExecutorToProcessAllJobs(5000L, 25L);
+        // waitForJobExecutorToProcessAllJobs(7000L, 25L);
         // assertEquals(0L, jobQuery.count());
 
         // which means the process has ended

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/event/timer/IntermediateTimerEventTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/event/timer/IntermediateTimerEventTest.java
@@ -38,7 +38,7 @@ public class IntermediateTimerEventTest extends PluggableFlowableTestCase {
 
         // After setting the clock to time '50minutes and 5 seconds', the second timer should fire
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + ((50 * 60 * 1000) + 5000)));
-        waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(5000L, 200L);
+        waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(7000L, 200L);
 
         assertEquals(0, jobQuery.count());
         assertProcessEnded(pi.getProcessInstanceId());

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/event/timer/StartTimerEventTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/event/timer/StartTimerEventTest.java
@@ -47,7 +47,7 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
 
         // After setting the clock to time '50minutes and 5 seconds', the second timer should fire
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + ((50 * 60 * 1000) + 5000)));
-        waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(5000L, 200L);
+        waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(7000L, 200L);
 
         List<ProcessInstance> pi = runtimeService.createProcessInstanceQuery().processDefinitionKey("startTimerEventExample").list();
         assertEquals(1, pi.size());
@@ -62,7 +62,7 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
         assertEquals(1, jobQuery.count());
 
         processEngineConfiguration.getClock().setCurrentTime(new SimpleDateFormat("dd/MM/yyyy hh:mm:ss").parse("15/11/2036 11:12:30"));
-        waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(5000L, 200L);
+        waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(7000L, 200L);
 
         List<ProcessInstance> pi = runtimeService.createProcessInstanceQuery().processDefinitionKey("startTimerEventExample").list();
         assertEquals(1, pi.size());
@@ -135,7 +135,7 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
         assertEquals(1, jobQuery.count());
 
         processEngineConfiguration.getClock().setCurrentTime(new SimpleDateFormat("dd/MM/yyyy hh:mm:ss").parse("15/11/2036 11:12:30"));
-        waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(5000L, 200L);
+        waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(7000L, 200L);
 
         List<ProcessInstance> pi = runtimeService.createProcessInstanceQuery().processDefinitionKey("startTimerEventExample").list();
         assertEquals(1, pi.size());

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/exclusive/ExclusiveTimerEventTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/exclusive/ExclusiveTimerEventTest.java
@@ -38,7 +38,7 @@ public class ExclusiveTimerEventTest extends PluggableFlowableTestCase {
         // After setting the clock to time '50minutes and 5 seconds', the timers should fire
         clock.setCurrentTime(new Date(startTime.getTime() + ((50 * 60 * 1000) + 5000)));
         processEngineConfiguration.setClock(clock);
-        waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(5000L, 200L);
+        waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(7000L, 200L);
 
         assertEquals(0, jobQuery.count());
         assertProcessEnded(pi.getProcessInstanceId());

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/gateway/ParallelGatewayTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/gateway/ParallelGatewayTest.java
@@ -148,7 +148,7 @@ public class ParallelGatewayTest extends PluggableFlowableTestCase {
     @Deployment
     public void testAsyncBehavior() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("async");
-        waitForJobExecutorToProcessAllJobs(5000, 500);
+        waitForJobExecutorToProcessAllJobs(7000, 500);
         assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
     }
 

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/subprocess/SubProcessTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/subprocess/SubProcessTest.java
@@ -75,7 +75,7 @@ public class SubProcessTest extends PluggableFlowableTestCase {
         // Setting the clock forward 2 hours 1 second (timer fires in 2 hours) and fire up the job executor
         clock.setCurrentTime(new Date(startTime.getTime() + (2 * 60 * 60 * 1000) + 1000));
         processEngineConfiguration.setClock(clock);
-        waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(5000L, 100L);
+        waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(7000L, 100L);
 
         // The subprocess should be left, and the escalated task should be active
         org.flowable.task.api.Task escalationTask = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
@@ -164,7 +164,7 @@ public class SubProcessTest extends PluggableFlowableTestCase {
         // Setting the clock forward 1 hour 1 second (timer fires in 1 hour) and fire up the job executor
         clock.setCurrentTime(new Date(startTime.getTime() + (60 * 60 * 1000) + 1000));
         processEngineConfiguration.setClock(clock);
-        waitForJobExecutorToProcessAllJobs(5000L, 50L);
+        waitForJobExecutorToProcessAllJobs(7000L, 50L);
 
         // The inner subprocess should be destroyed, and the escalated task should be active
         org.flowable.task.api.Task escalationTask = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();

--- a/modules/flowable5-test/src/test/java/org/activiti/standalone/testing/ActivitiRuleJunit4Test.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/standalone/testing/ActivitiRuleJunit4Test.java
@@ -63,7 +63,7 @@ public class ActivitiRuleJunit4Test {
         // now there should be one job in the database:
         assertEquals(1, managementService.createJobQuery().count());
 
-        JobTestHelper.waitForJobExecutorToProcessAllJobs(activitiRule, 5000L, 500L);
+        JobTestHelper.waitForJobExecutorToProcessAllJobs(activitiRule, 7000L, 500L);
 
         // the job is done
         assertEquals(0, managementService.createJobQuery().count());


### PR DESCRIPTION
…uild more stable on travis-ci.

This change is necessary because the maven surefire plugin option rerunFailingTestsCount does not work for junit 5 tests. (#1271)