### PR TITLE
Disallow Travis build failures on Java 10.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ matrix:
       - master
     if: TRAVIS_PULL_REQUEST != false
   allow_failures:
-  - jdk: openjdk10
   - jdk: openjdk11
   - jdk: openjdk-ea
   - name: "Flowable 5 tests"


### PR DESCRIPTION
Build on Java 10 passes, so lets keep it this way.