### PR TITLE
Update commons-lang3 version to 3.8.1

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -118,7 +118,7 @@ javax.annotation                jsr250-api                  1.0             COMM
 joda-time                       joda-time                   2.10            Apache 2
 log4j                           log4j                       1.2.17          The Apache Software License, Version 2.0
 org.apache.commons              commons-email               1.5             Apache License, Version 2.0
-org.apache.commons              commons-lang3               3.8             The Apache Software License, Version 2.0
+org.apache.commons              commons-lang3               3.8.1           The Apache Software License, Version 2.0
 org.apache.httpcomponents       httpclient                  4.5.6           Apache License, Version 2.0
 org.apache.httpcomponents       httpcore                    4.4.10          Apache License, Version 2.0
 org.apache.httpcomponents       httpmime                    4.5.6           Apache License, Version 2.0

--- a/modules/flowable-osgi/src/test/java/org/flowable/osgi/blueprint/BlueprintBasicTest.java
+++ b/modules/flowable-osgi/src/test/java/org/flowable/osgi/blueprint/BlueprintBasicTest.java
@@ -106,7 +106,7 @@ public class BlueprintBasicTest {
                 mavenBundle().groupId("org.flowable").artifactId("flowable-cmmn-model").version(FLOWABLE_VERSION),
                 mavenBundle().groupId("org.flowable").artifactId("flowable-cmmn-api").version(FLOWABLE_VERSION),
                 mavenBundle().groupId("org.flowable").artifactId("flowable-engine").version(FLOWABLE_VERSION),
-                mavenBundle().groupId("org.apache.commons").artifactId("commons-lang3").version("3.8"),
+                mavenBundle().groupId("org.apache.commons").artifactId("commons-lang3").version("3.8.1"),
                 mavenBundle().groupId("com.fasterxml.uuid").artifactId("java-uuid-generator").version("3.1.5"),
                 mavenBundle().groupId("com.fasterxml.jackson.core").artifactId("jackson-core").version("2.9.3"),
                 mavenBundle().groupId("com.fasterxml.jackson.core").artifactId("jackson-databind").version("2.9.3"),

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-lang3</artifactId>
-				<version>3.8</version>
+				<version>3.8.1</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-io</groupId>


### PR DESCRIPTION
Due to a bug `3.8.0` uses a OSGI BundleSymbolicName different from previous releases (see: https://issues.apache.org/jira/browse/LANG-1419).