### PR TITLE
Adding support to query tasks with formKey

### DIFF
--- a/modules/flowable-task-service-api/src/main/java/org/flowable/task/api/TaskInfoQuery.java
+++ b/modules/flowable-task-service-api/src/main/java/org/flowable/task/api/TaskInfoQuery.java
@@ -263,6 +263,11 @@ public interface TaskInfoQuery<T extends TaskInfoQuery<?, ?>, V extends TaskInfo
      * Only select tasks with the given category.
      */
     T taskCategory(String category);
+    
+    /**
+     * Only select tasks with form key.
+     */
+    T taskWithFormKey();
 
     /**
      * Only select tasks with the given taskDefinitionKey. The task definition key is the id of the userTask: &lt;userTask id="xxx" .../&gt;

--- a/modules/flowable-task-service/src/main/java/org/flowable/task/service/impl/HistoricTaskInstanceQueryImpl.java
+++ b/modules/flowable-task-service/src/main/java/org/flowable/task/service/impl/HistoricTaskInstanceQueryImpl.java
@@ -109,6 +109,7 @@ public class HistoricTaskInstanceQueryImpl extends AbstractVariableQueryImpl<His
     protected Date completedAfterDate;
     protected Date completedBeforeDate;
     protected String category;
+    protected boolean withFormKey;
     protected String tenantId;
     protected String tenantIdLike;
     protected boolean withoutTenantId;
@@ -1220,6 +1221,16 @@ public class HistoricTaskInstanceQueryImpl extends AbstractVariableQueryImpl<His
     }
 
     @Override
+    public HistoricTaskInstanceQuery taskWithFormKey() {
+        if (inOrStatement) {
+            currentOrQueryObject.withFormKey = true;
+        } else {
+            this.withFormKey = true;
+        }
+        return this;
+    }
+
+    @Override
     public HistoricTaskInstanceQuery taskCandidateUser(String candidateUser) {
         if (candidateUser == null) {
             throw new FlowableIllegalArgumentException("Candidate user is null");
@@ -1737,6 +1748,10 @@ public class HistoricTaskInstanceQueryImpl extends AbstractVariableQueryImpl<His
 
     public String getCategory() {
         return category;
+    }
+
+    public boolean isWithFormKey() {
+        return withFormKey;
     }
 
     public String getTenantId() {

--- a/modules/flowable-task-service/src/main/java/org/flowable/task/service/impl/TaskQueryImpl.java
+++ b/modules/flowable-task-service/src/main/java/org/flowable/task/service/impl/TaskQueryImpl.java
@@ -87,6 +87,7 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
     protected Date createTimeBefore;
     protected Date createTimeAfter;
     protected String category;
+    protected boolean withFormKey;
     protected String taskDefinitionId;
     protected String key;
     protected String keyLike;
@@ -819,6 +820,16 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
             currentOrQueryObject.category = category;
         } else {
             this.category = category;
+        }
+        return this;
+    }
+
+    @Override
+    public TaskQuery taskWithFormKey() {
+        if (orActive) {
+            currentOrQueryObject.withFormKey = true;
+        } else {
+            this.withFormKey = true;
         }
         return this;
     }
@@ -1805,6 +1816,10 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
 
     public String getCategory() {
         return category;
+    }
+
+    public boolean isWithFormKey() {
+        return withFormKey;
     }
 
     public String getProcessDefinitionKeyLike() {

--- a/modules/flowable-task-service/src/main/resources/org/flowable/task/service/db/mapping/entity/HistoricTaskInstance.xml
+++ b/modules/flowable-task-service/src/main/resources/org/flowable/task/service/db/mapping/entity/HistoricTaskInstance.xml
@@ -799,6 +799,9 @@
       <if test="category != null">
         and RES.CATEGORY_ = #{category}
       </if>
+      <if test="withFormKey">
+        and RES.FORM_KEY_ IS NOT NULL
+      </if>
       <if test="tenantId != null">
         and RES.TENANT_ID_ = #{tenantId}
       </if>
@@ -1161,6 +1164,9 @@
           </if>
           <if test="orQueryObject.category != null">
             or RES.CATEGORY_ = #{orQueryObject.category}
+          </if>
+          <if test="orQueryObject.withFormKey != null">
+            or RES.FORM_KEY_ = #{orQueryObject.withFormKey}
           </if>
           <if test="orQueryObject.tenantId != null">
             or RES.TENANT_ID_ = #{orQueryObject.tenantId}

--- a/modules/flowable-task-service/src/main/resources/org/flowable/task/service/db/mapping/entity/HistoricTaskInstance.xml
+++ b/modules/flowable-task-service/src/main/resources/org/flowable/task/service/db/mapping/entity/HistoricTaskInstance.xml
@@ -1166,7 +1166,7 @@
             or RES.CATEGORY_ = #{orQueryObject.category}
           </if>
           <if test="orQueryObject.withFormKey != null">
-            or RES.FORM_KEY_ = #{orQueryObject.withFormKey}
+            or RES.FORM_KEY_ IS NOT NULL
           </if>
           <if test="orQueryObject.tenantId != null">
             or RES.TENANT_ID_ = #{orQueryObject.tenantId}

--- a/modules/flowable-task-service/src/main/resources/org/flowable/task/service/db/mapping/entity/HistoricTaskInstance.xml
+++ b/modules/flowable-task-service/src/main/resources/org/flowable/task/service/db/mapping/entity/HistoricTaskInstance.xml
@@ -1165,7 +1165,7 @@
           <if test="orQueryObject.category != null">
             or RES.CATEGORY_ = #{orQueryObject.category}
           </if>
-          <if test="orQueryObject.withFormKey != null">
+          <if test="orQueryObject.withFormKey">
             or RES.FORM_KEY_ IS NOT NULL
           </if>
           <if test="orQueryObject.tenantId != null">

--- a/modules/flowable-task-service/src/main/resources/org/flowable/task/service/db/mapping/entity/Task.xml
+++ b/modules/flowable-task-service/src/main/resources/org/flowable/task/service/db/mapping/entity/Task.xml
@@ -1191,7 +1191,7 @@
               or RES.CATEGORY_ = #{orQueryObject.category}
             </if>
             <if test="orQueryObject.withFormKey != null">
-              or RES.FORM_KEY_ = #{orQueryObject.withFormKey}
+              or RES.FORM_KEY_ IS NOT NULL
             </if>
             <if test="orQueryObject.excludeSubtasks">
               or RES.PARENT_TASK_ID_ IS NULL

--- a/modules/flowable-task-service/src/main/resources/org/flowable/task/service/db/mapping/entity/Task.xml
+++ b/modules/flowable-task-service/src/main/resources/org/flowable/task/service/db/mapping/entity/Task.xml
@@ -1190,7 +1190,7 @@
             <if test="orQueryObject.category != null">
               or RES.CATEGORY_ = #{orQueryObject.category}
             </if>
-            <if test="orQueryObject.withFormKey != null">
+            <if test="orQueryObject.withFormKey">
               or RES.FORM_KEY_ IS NOT NULL
             </if>
             <if test="orQueryObject.excludeSubtasks">

--- a/modules/flowable-task-service/src/main/resources/org/flowable/task/service/db/mapping/entity/Task.xml
+++ b/modules/flowable-task-service/src/main/resources/org/flowable/task/service/db/mapping/entity/Task.xml
@@ -795,6 +795,9 @@
       <if test="category != null">
         and RES.CATEGORY_ = #{category}
       </if>
+      <if test="withFormKey">
+        and RES.FORM_KEY_ IS NOT NULL
+      </if>
       <if test="excludeSubtasks">
         and RES.PARENT_TASK_ID_ IS NULL
       </if>
@@ -1186,6 +1189,9 @@
             </if>
             <if test="orQueryObject.category != null">
               or RES.CATEGORY_ = #{orQueryObject.category}
+            </if>
+            <if test="orQueryObject.withFormKey != null">
+              or RES.FORM_KEY_ = #{orQueryObject.withFormKey}
             </if>
             <if test="orQueryObject.excludeSubtasks">
               or RES.PARENT_TASK_ID_ IS NULL


### PR DESCRIPTION
In Apache Syncope we embed Flowable as BPMN engine and we frequently need to query active forms, e.g. tasks where `FORM_KEY_ IS NOT NULL`.

We have a local extension of `TaskQueryImpl` with such a capability, but I thought it could be of general use.