### PR TITLE
Add search for LDAP group by group id (resolves #763)

### DIFF
--- a/docs/userguide/src/en/bpmn/ch05a-Spring-Boot.adoc
+++ b/docs/userguide/src/en/bpmn/ch05a-Spring-Boot.adoc
@@ -755,6 +755,7 @@ flowable.idm.ldap.query.all-users= # The query that is executed when searching f
 flowable.idm.ldap.query.groups-for-user= # The query that is executed when searching for the groups of a specific user.
 flowable.idm.ldap.query.user-by-full-name-like= # The query that is executed when searching for a user by full name.
 flowable.idm.ldap.query.user-by-id= # The query that is executed when searching for a user by userId.
+flowable.idm.ldap.query.group-by-id= # The query that is executed when searching for a specific group by groupId.
 flowable.idm.ldap.search-time-limit=0 # The timeout (in milliseconds) that is used when doing a search in LDAP. By default set to '0', which means 'wait forever'.
 flowable.idm.ldap.security-authentication=simple # The value that is used for the 'java.naming.security.authentication' property used to connect to the LDAP system.
 flowable.idm.ldap.server= # The server host on which the LDAP system can be reached. For example 'ldap://localhost'.

--- a/docs/userguide/src/en/bpmn/ch14-UI.adoc
+++ b/docs/userguide/src/en/bpmn/ch14-UI.adoc
@@ -595,6 +595,7 @@ flowable.idm.ldap.query.user-by-full-name-like=(&(objectClass=inetOrgPerson)(|({
 flowable.idm.ldap.query.all-users=(objectClass=inetOrgPerson)
 flowable.idm.ldap.query.groups-for-user=(&(objectClass=groupOfUniqueNames)(uniqueMember={0}))
 flowable.idm.ldap.query.all-groups=(objectClass=groupOfUniqueNames)
+flowable.idm.ldap.query.group-by-id=(&(objectClass=groupOfUniqueNames)(uniqueId={0}))
 flowable.idm.ldap.attribute.user-id=uid
 flowable.idm.ldap.attribute.first-name=cn
 flowable.idm.ldap.attribute.last-name=sn

--- a/modules/flowable-ldap/src/main/java/org/flowable/ldap/LDAPConfiguration.java
+++ b/modules/flowable-ldap/src/main/java/org/flowable/ldap/LDAPConfiguration.java
@@ -58,6 +58,7 @@ public class LDAPConfiguration {
     protected String queryUserByFullNameLike;
     protected String queryAllUsers;
     protected String queryAllGroups;
+    protected String queryGroupByGroupId;
 
     // Attribute names
     protected String userIdAttribute;
@@ -275,6 +276,20 @@ public class LDAPConfiguration {
      */
     public void setQueryAllGroups(String queryAllGroups) {
         this.queryAllGroups = queryAllGroups;
+    }
+
+    /**
+     * Query that is executed when searching for one group by a specific group id
+     */
+    public String getQueryGroupByGroupId() {
+        return queryGroupByGroupId;
+    }
+
+    /**
+     * Query that is executed when searching for one group by a specific group id
+     */
+    public void setQueryGroupByGroupId(String queryGroupByGroupId) {
+        this.queryGroupByGroupId = queryGroupByGroupId;
     }
 
     /**

--- a/modules/flowable-ldap/src/main/java/org/flowable/ldap/LDAPQueryBuilder.java
+++ b/modules/flowable-ldap/src/main/java/org/flowable/ldap/LDAPQueryBuilder.java
@@ -92,6 +92,16 @@ public class LDAPQueryBuilder {
         return searchExpression;
     }
 
+    public String buildQueryGroupsById(LDAPConfiguration ldapConfigurator, String groupId) {
+        String searchExpression;
+        if (ldapConfigurator.getQueryGroupByGroupId() != null) {
+            searchExpression = MessageFormat.format(ldapConfigurator.getQueryGroupByGroupId(), groupId);
+        } else {
+            searchExpression = groupId;
+        }
+        return searchExpression;
+    }
+
     protected SearchControls createSearchControls(LDAPConfiguration ldapConfigurator) {
         SearchControls searchControls = new SearchControls();
         searchControls.setSearchScope(SearchControls.SUBTREE_SCOPE);

--- a/modules/flowable-ldap/src/main/java/org/flowable/ldap/impl/LDAPGroupQueryImpl.java
+++ b/modules/flowable-ldap/src/main/java/org/flowable/ldap/impl/LDAPGroupQueryImpl.java
@@ -57,6 +57,8 @@ public class LDAPGroupQueryImpl extends GroupQueryImpl {
     protected List<Group> executeQuery() {
         if (getUserId() != null) {
             return findGroupsByUser(getUserId());
+        } else if (getId() != null) {
+            return findGroupsById(getId());
         } else {
             return findAllGroups();
         }
@@ -81,6 +83,11 @@ public class LDAPGroupQueryImpl extends GroupQueryImpl {
         }
 
         return groups;
+    }
+
+    protected List<Group> findGroupsById(String id) {
+        String searchExpression = ldapConfigurator.getLdapQueryBuilder().buildQueryGroupsById(ldapConfigurator, id);
+        return executeGroupQuery(searchExpression);
     }
 
     protected List<Group> findAllGroups() {

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/ldap/FlowableLdapProperties.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/ldap/FlowableLdapProperties.java
@@ -289,6 +289,17 @@ public class FlowableLdapProperties {
          */
         private String allGroups;
 
+        /**
+         * The query that is executed when searching for a group by groupId.
+         *
+         * <p>
+         *     For example: (&amp;(objectClass=organizationalRole)(cn={0}))
+         * </p>
+         *
+         * The group id will be injected as {0}
+         */
+        private String groupById;
+
         public String getUserById() {
             return userById;
         }
@@ -329,12 +340,21 @@ public class FlowableLdapProperties {
             this.allGroups = allGroups;
         }
 
+        public String getGroupById() {
+            return groupById;
+        }
+
+        public void setGroupById(String groupById) {
+            this.groupById = groupById;
+        }
+
         public void customize(LDAPConfiguration configuration) {
             configuration.setQueryUserByUserId(getUserById());
             configuration.setQueryUserByFullNameLike(getUserByFullNameLike());
             configuration.setQueryAllUsers(getAllUsers());
             configuration.setQueryGroupsForUser(getGroupsForUser());
             configuration.setQueryAllGroups(getAllGroups());
+            configuration.setQueryGroupByGroupId(getGroupById());
         }
     }
 

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/spring/boot/ldap/FlowableLdapPropertiesTest.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/spring/boot/ldap/FlowableLdapPropertiesTest.java
@@ -47,6 +47,7 @@ public class FlowableLdapPropertiesTest {
         query.setAllUsers("(&(objectClass=inetOrgPerson))");
         query.setGroupsForUser("(&(objectClass=groupOfUniqueNames)(uniqueMember={0}))");
         query.setAllGroups("(&(objectClass=groupOfUniqueNames))");
+        query.setGroupById("(&(objectClass=groupOfUniqueNames)(uniqueId={0}))");
 
         FlowableLdapProperties.Attribute attribute = properties.getAttribute();
         attribute.setUserId("id");
@@ -72,6 +73,7 @@ public class FlowableLdapPropertiesTest {
                 "queryAllUsers",
                 "queryGroupsForUser",
                 "queryAllGroups",
+                "queryGroupByGroupId",
                 "userIdAttribute",
                 "userFirstNameAttribute",
                 "userLastNameAttribute",
@@ -91,13 +93,15 @@ public class FlowableLdapPropertiesTest {
                 "queryUserByFullNameLike",
                 "queryAllUsers",
                 "queryGroupsForUser",
-                "queryAllGroups")
+                "queryAllGroups",
+                "queryGroupByGroupId")
             .containsExactly(
                 query.getUserById(),
                 query.getUserByFullNameLike(),
                 query.getAllUsers(),
                 query.getGroupsForUser(),
-                query.getAllGroups()
+                query.getAllGroups(),
+                query.getGroupById()
             );
 
         assertThat(ldapConfiguration)

--- a/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/resources/flowable-default.properties
+++ b/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/resources/flowable-default.properties
@@ -80,6 +80,7 @@ spring.datasource.hikari.maximumPoolSize=50
 #flowable.idm.ldap.query.all-users=(objectClass=inetOrgPerson)
 #flowable.idm.ldap.query.groups-for-user=(&(objectClass=groupOfUniqueNames)(uniqueMember={0}))
 #flowable.idm.ldap.query.all-groups=(objectClass=groupOfUniqueNames)
+#flowable.idm.ldap.query.group-by-id=(&(objectClass=groupOfUniqueNames)(uniqueId={0}))
 #flowable.idm.ldap.attribute.user-id=uid
 #flowable.idm.ldap.attribute.first-name=cn
 #flowable.idm.ldap.attribute.last-name=sn


### PR DESCRIPTION
Currently it's not possible to see group details or assign a privilege
to a group in case you have more than one groups. Reason therefore is
that for the LDAPQueryBuilder the group id is ignored.

New behavior is that there is a new attribute to search groups by
the specified group-id. Therefore a new search query is introduced.
For the sample application the user needs to configure
 `flowable.idm.ldap.query.group-by-id`.