### PR TITLE
Move version management for Jetty test dependencies to the root POM, …

### DIFF
--- a/modules/flowable-app-engine-rest/pom.xml
+++ b/modules/flowable-app-engine-rest/pom.xml
@@ -187,37 +187,31 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>8.1.16.v20140903</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
-            <version>8.1.16.v20140903</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-http</artifactId>
-            <version>8.1.16.v20140903</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-webapp</artifactId>
-            <version>8.1.16.v20140903</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-io</artifactId>
-            <version>8.1.16.v20140903</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-util</artifactId>
-            <version>8.1.16.v20140903</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/modules/flowable-app-engine-rest/src/test/java/org/flowable/app/rest/service/BaseSpringRestTestCase.java
+++ b/modules/flowable-app-engine-rest/src/test/java/org/flowable/app/rest/service/BaseSpringRestTestCase.java
@@ -13,6 +13,7 @@
 package org.flowable.app.rest.service;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.text.DateFormat;
@@ -33,7 +34,6 @@ import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
-import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -238,12 +238,9 @@ public class BaseSpringRestTestCase extends TestCase {
             httpResponses.add(response);
             return response;
 
-        } catch (ClientProtocolException e) {
-            Assert.fail(e.getMessage());
         } catch (IOException e) {
-            Assert.fail(e.getMessage());
+            throw new UncheckedIOException(e);
         }
-        return null;
     }
 
     public void closeResponse(CloseableHttpResponse response) {

--- a/modules/flowable-app-engine-rest/src/test/java/org/flowable/app/rest/util/TestServerUtil.java
+++ b/modules/flowable-app-engine-rest/src/test/java/org/flowable/app/rest/util/TestServerUtil.java
@@ -16,9 +16,6 @@ import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.session.HashSessionIdManager;
-import org.eclipse.jetty.server.session.HashSessionManager;
-import org.eclipse.jetty.server.session.SessionHandler;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.flowable.app.rest.WebConfigurer;
 import org.slf4j.Logger;
@@ -40,9 +37,6 @@ public class TestServerUtil {
         int port = NEXT_PORT.incrementAndGet();
         Server server = new Server(port);
 
-        HashSessionIdManager idmanager = new HashSessionIdManager();
-        server.setSessionIdManager(idmanager);
-
         AnnotationConfigWebApplicationContext applicationContext = new AnnotationConfigWebApplicationContext();
         applicationContext.register(configClasses);
         applicationContext.refresh();
@@ -62,11 +56,6 @@ public class TestServerUtil {
         WebConfigurer configurer = new WebConfigurer();
         configurer.setContext(context);
         contextHandler.addEventListener(configurer);
-
-        // Create the SessionHandler (wrapper) to handle the sessions
-        HashSessionManager manager = new HashSessionManager();
-        SessionHandler sessions = new SessionHandler(manager);
-        contextHandler.setHandler(sessions);
 
         return contextHandler;
     }

--- a/modules/flowable-cmmn-rest/pom.xml
+++ b/modules/flowable-cmmn-rest/pom.xml
@@ -180,37 +180,31 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>8.1.16.v20140903</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>8.1.16.v20140903</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-http</artifactId>
-      <version>8.1.16.v20140903</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-webapp</artifactId>
-      <version>8.1.16.v20140903</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-io</artifactId>
-      <version>8.1.16.v20140903</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-util</artifactId>
-      <version>8.1.16.v20140903</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/modules/flowable-cmmn-rest/pom.xml
+++ b/modules/flowable-cmmn-rest/pom.xml
@@ -49,6 +49,12 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+                <redirectTestOutputToFile>false</redirectTestOutputToFile>
+            </configuration>
+        </plugin>
     </plugins>
     <pluginManagement>
       <plugins>

--- a/modules/flowable-cmmn-rest/src/test/java/org/flowable/cmmn/rest/service/BaseSpringRestTestCase.java
+++ b/modules/flowable-cmmn-rest/src/test/java/org/flowable/cmmn/rest/service/BaseSpringRestTestCase.java
@@ -13,6 +13,7 @@
 package org.flowable.cmmn.rest.service;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.text.DateFormat;
@@ -269,9 +270,8 @@ public abstract class BaseSpringRestTestCase extends TestCase {
             return response;
 
         } catch (IOException e) {
-            Assert.fail(e.getMessage());
+            throw new UncheckedIOException(e);
         }
-        return null;
     }
 
     public void closeResponse(CloseableHttpResponse response) {

--- a/modules/flowable-cmmn-rest/src/test/java/org/flowable/cmmn/rest/util/TestServerUtil.java
+++ b/modules/flowable-cmmn-rest/src/test/java/org/flowable/cmmn/rest/util/TestServerUtil.java
@@ -16,9 +16,6 @@ import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.session.HashSessionIdManager;
-import org.eclipse.jetty.server.session.HashSessionManager;
-import org.eclipse.jetty.server.session.SessionHandler;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.flowable.cmmn.rest.WebConfigurer;
 import org.slf4j.Logger;
@@ -40,9 +37,6 @@ public class TestServerUtil {
         int port = NEXT_PORT.incrementAndGet();
         Server server = new Server(port);
 
-        HashSessionIdManager idmanager = new HashSessionIdManager();
-        server.setSessionIdManager(idmanager);
-
         AnnotationConfigWebApplicationContext applicationContext = new AnnotationConfigWebApplicationContext();
         applicationContext.register(configClasses);
         applicationContext.refresh();
@@ -62,11 +56,6 @@ public class TestServerUtil {
         WebConfigurer configurer = new WebConfigurer();
         configurer.setContext(context);
         contextHandler.addEventListener(configurer);
-
-        // Create the SessionHandler (wrapper) to handle the sessions
-        HashSessionManager manager = new HashSessionManager();
-        SessionHandler sessions = new SessionHandler(manager);
-        contextHandler.setHandler(sessions);
 
         return contextHandler;
     }

--- a/modules/flowable-cmmn-rest/src/test/java/org/flowable/cmmn/rest/util/TestServerUtil.java
+++ b/modules/flowable-cmmn-rest/src/test/java/org/flowable/cmmn/rest/util/TestServerUtil.java
@@ -16,6 +16,10 @@ import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.session.DefaultSessionCache;
+import org.eclipse.jetty.server.session.FileSessionDataStore;
+import org.eclipse.jetty.server.session.SessionCache;
+import org.eclipse.jetty.server.session.SessionHandler;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.flowable.cmmn.rest.WebConfigurer;
 import org.slf4j.Logger;
@@ -56,6 +60,12 @@ public class TestServerUtil {
         WebConfigurer configurer = new WebConfigurer();
         configurer.setContext(context);
         contextHandler.addEventListener(configurer);
+
+        // Create the SessionHandler (wrapper) to handle the sessions
+        SessionHandler sessionsHandler = new SessionHandler();
+        SessionCache sessionCache = new DefaultSessionCache(sessionsHandler);
+        sessionCache.setSessionDataStore(new FileSessionDataStore());
+        contextHandler.setSessionHandler(sessionsHandler);
 
         return contextHandler;
     }

--- a/modules/flowable-cmmn-rest/src/test/resources/log4j.properties
+++ b/modules/flowable-cmmn-rest/src/test/resources/log4j.properties
@@ -1,4 +1,4 @@
-log4j.rootLogger=INFO, CA
+log4j.rootLogger=WARN, CA
 
 # ConsoleAppender
 log4j.appender.CA=org.apache.log4j.ConsoleAppender

--- a/modules/flowable-content-rest/pom.xml
+++ b/modules/flowable-content-rest/pom.xml
@@ -187,37 +187,31 @@
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-server</artifactId>
-			<version>8.1.16.v20140903</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-servlet</artifactId>
-			<version>8.1.16.v20140903</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-http</artifactId>
-			<version>8.1.16.v20140903</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-webapp</artifactId>
-			<version>8.1.16.v20140903</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-io</artifactId>
-			<version>8.1.16.v20140903</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-util</artifactId>
-			<version>8.1.16.v20140903</version>
 			<scope>test</scope>
 		</dependency>
     </dependencies>

--- a/modules/flowable-content-rest/src/test/java/org/flowable/content/rest/util/TestServerUtil.java
+++ b/modules/flowable-content-rest/src/test/java/org/flowable/content/rest/util/TestServerUtil.java
@@ -16,9 +16,6 @@ import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.session.HashSessionIdManager;
-import org.eclipse.jetty.server.session.HashSessionManager;
-import org.eclipse.jetty.server.session.SessionHandler;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.flowable.content.rest.WebConfigurer;
 import org.slf4j.Logger;
@@ -40,9 +37,6 @@ public class TestServerUtil {
         int port = NEXT_PORT.incrementAndGet();
         Server server = new Server(port);
 
-        HashSessionIdManager idmanager = new HashSessionIdManager();
-        server.setSessionIdManager(idmanager);
-
         AnnotationConfigWebApplicationContext applicationContext = new AnnotationConfigWebApplicationContext();
         applicationContext.register(configClasses);
         applicationContext.refresh();
@@ -62,11 +56,6 @@ public class TestServerUtil {
         WebConfigurer configurer = new WebConfigurer();
         configurer.setContext(context);
         contextHandler.addEventListener(configurer);
-
-        // Create the SessionHandler (wrapper) to handle the sessions
-        HashSessionManager manager = new HashSessionManager();
-        SessionHandler sessions = new SessionHandler(manager);
-        contextHandler.setHandler(sessions);
 
         return contextHandler;
     }

--- a/modules/flowable-dmn-rest/pom.xml
+++ b/modules/flowable-dmn-rest/pom.xml
@@ -202,37 +202,31 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>8.1.16.v20140903</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
-            <version>8.1.16.v20140903</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-http</artifactId>
-            <version>8.1.16.v20140903</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-webapp</artifactId>
-            <version>8.1.16.v20140903</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-io</artifactId>
-            <version>8.1.16.v20140903</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-util</artifactId>
-            <version>8.1.16.v20140903</version>
             <scope>test</scope>
         </dependency>
 

--- a/modules/flowable-dmn-rest/src/test/java/org/flowable/dmn/rest/util/TestServerUtil.java
+++ b/modules/flowable-dmn-rest/src/test/java/org/flowable/dmn/rest/util/TestServerUtil.java
@@ -16,9 +16,6 @@ import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.session.HashSessionIdManager;
-import org.eclipse.jetty.server.session.HashSessionManager;
-import org.eclipse.jetty.server.session.SessionHandler;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.flowable.dmn.rest.WebConfigurer;
 import org.slf4j.Logger;
@@ -40,9 +37,6 @@ public class TestServerUtil {
         int port = NEXT_PORT.incrementAndGet();
         Server server = new Server(port);
 
-        HashSessionIdManager idmanager = new HashSessionIdManager();
-        server.setSessionIdManager(idmanager);
-
         AnnotationConfigWebApplicationContext applicationContext = new AnnotationConfigWebApplicationContext();
         applicationContext.register(configClasses);
         applicationContext.refresh();
@@ -62,11 +56,6 @@ public class TestServerUtil {
         WebConfigurer configurer = new WebConfigurer();
         configurer.setContext(context);
         contextHandler.addEventListener(configurer);
-
-        // Create the SessionHandler (wrapper) to handle the sessions
-        HashSessionManager manager = new HashSessionManager();
-        SessionHandler sessions = new SessionHandler(manager);
-        contextHandler.setHandler(sessions);
 
         return contextHandler;
     }

--- a/modules/flowable-form-rest/pom.xml
+++ b/modules/flowable-form-rest/pom.xml
@@ -192,37 +192,31 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>8.1.16.v20140903</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
-            <version>8.1.16.v20140903</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-http</artifactId>
-            <version>8.1.16.v20140903</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-webapp</artifactId>
-            <version>8.1.16.v20140903</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-io</artifactId>
-            <version>8.1.16.v20140903</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-util</artifactId>
-            <version>8.1.16.v20140903</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/modules/flowable-form-rest/src/test/java/org/flowable/form/rest/service/BaseSpringRestTestCase.java
+++ b/modules/flowable-form-rest/src/test/java/org/flowable/form/rest/service/BaseSpringRestTestCase.java
@@ -20,7 +20,6 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicHeader;
 import org.eclipse.jetty.server.Server;
-import org.flowable.common.engine.impl.identity.Authentication;
 import org.flowable.form.api.FormManagementService;
 import org.flowable.form.api.FormRepositoryService;
 import org.flowable.form.api.FormService;
@@ -40,6 +39,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.ArrayList;
@@ -216,9 +216,8 @@ public abstract class BaseSpringRestTestCase extends TestCase {
             return response;
 
         } catch (IOException e) {
-            Assert.fail(e.getMessage());
+            throw new UncheckedIOException(e);
         }
-        return null;
     }
 
     public void closeResponse(CloseableHttpResponse response) {

--- a/modules/flowable-form-rest/src/test/java/org/flowable/form/rest/util/TestServerUtil.java
+++ b/modules/flowable-form-rest/src/test/java/org/flowable/form/rest/util/TestServerUtil.java
@@ -13,9 +13,6 @@
 package org.flowable.form.rest.util;
 
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.session.HashSessionIdManager;
-import org.eclipse.jetty.server.session.HashSessionManager;
-import org.eclipse.jetty.server.session.SessionHandler;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.flowable.form.rest.WebConfigurer;
 import org.slf4j.Logger;
@@ -40,9 +37,6 @@ public class TestServerUtil {
         int port = NEXT_PORT.incrementAndGet();
         Server server = new Server(port);
 
-        HashSessionIdManager idmanager = new HashSessionIdManager();
-        server.setSessionIdManager(idmanager);
-
         AnnotationConfigWebApplicationContext applicationContext = new AnnotationConfigWebApplicationContext();
         applicationContext.register(configClasses);
         applicationContext.refresh();
@@ -62,11 +56,6 @@ public class TestServerUtil {
         WebConfigurer configurer = new WebConfigurer();
         configurer.setContext(context);
         contextHandler.addEventListener(configurer);
-
-        // Create the SessionHandler (wrapper) to handle the sessions
-        HashSessionManager manager = new HashSessionManager();
-        SessionHandler sessions = new SessionHandler(manager);
-        contextHandler.setHandler(sessions);
 
         return contextHandler;
     }

--- a/modules/flowable-http/pom.xml
+++ b/modules/flowable-http/pom.xml
@@ -15,7 +15,6 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetty.version>9.2.14.v20151106</jetty.version>
         <flowable.osgi.import.pkg>*</flowable.osgi.import.pkg>
         <flowable.artifact>
             org.flowable.http
@@ -138,13 +137,11 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
-            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/modules/flowable-http/src/test/java/org/flowable/http/bpmn/HttpServiceTaskTest.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/bpmn/HttpServiceTaskTest.java
@@ -450,7 +450,7 @@ public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
         assertEquals("text/plain", headerMap.get("Content-Type"));
         assertEquals("623b94fc-14b8-4ee6-aed7-b16b9321e29f", headerMap.get("X-Request-ID"));
         assertEquals("localhost:7000", headerMap.get("Host"));
-        assertEquals(null, headerMap.get("Test"));
+        assertEquals("", headerMap.get("Test"));
 
         // Request assertions
         Map<String, Object> request = new HashMap<>();

--- a/modules/flowable-http/src/test/java/org/flowable/http/cmmn/CmmnHttpTaskTest.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/cmmn/CmmnHttpTaskTest.java
@@ -276,7 +276,7 @@ public class CmmnHttpTaskTest {
         assertEquals("text/plain", headerMap.get("Content-Type"));
         assertEquals("623b94fc-14b8-4ee6-aed7-b16b9321e29f", headerMap.get("X-Request-ID"));
         assertEquals("localhost:7000", headerMap.get("Host"));
-        assertEquals(null, headerMap.get("Test"));
+        assertEquals("", headerMap.get("Test"));
     }
 
     @Test
@@ -315,7 +315,7 @@ public class CmmnHttpTaskTest {
         assertEquals("text/plain", headerMap.get("Content-Type"));
         assertEquals("623b94fc-14b8-4ee6-aed7-b16b9321e29f", headerMap.get("X-Request-ID"));
         assertEquals("localhost:7000", headerMap.get("Host"));
-        assertEquals(null, headerMap.get("Test"));
+        assertEquals("", headerMap.get("Test"));
     }
 
     protected CaseInstance createCaseInstance() {

--- a/modules/flowable-rest/pom.xml
+++ b/modules/flowable-rest/pom.xml
@@ -202,37 +202,31 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>9.4.6.v20170531</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
-            <version>9.4.6.v20170531</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-http</artifactId>
-            <version>9.4.6.v20170531</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-webapp</artifactId>
-            <version>9.4.6.v20170531</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-io</artifactId>
-            <version>9.4.6.v20170531</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-util</artifactId>
-            <version>9.4.6.v20170531</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/BaseSpringRestTestCase.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/BaseSpringRestTestCase.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.ArrayList;
@@ -314,9 +315,8 @@ public class BaseSpringRestTestCase {
             return response;
 
         } catch (IOException e) {
-            fail(e.getMessage(), e);
+            throw new UncheckedIOException(e);
         }
-        return null;
     }
 
     public void closeResponse(CloseableHttpResponse response) {

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
 		<slf4j.version>1.7.25</slf4j.version>
 		<spring.boot.version>2.0.6.RELEASE</spring.boot.version>
 
+		<jetty.version>9.4.12.v20180830</jetty.version>
 		<junit.version>4.12</junit.version>
 		<junit.jupiter.version>5.3.1</junit.jupiter.version>
 		<junit.vintage.version>5.3.1</junit.vintage.version>
@@ -975,6 +976,42 @@
 				<groupId>com.spotify</groupId>
 				<artifactId>dockerfile-maven-plugin</artifactId>
 				<version>1.4.0</version>
+			</dependency>
+			<dependency>
+				<groupId>org.eclipse.jetty</groupId>
+				<artifactId>jetty-server</artifactId>
+				<version>${jetty.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.eclipse.jetty</groupId>
+				<artifactId>jetty-servlet</artifactId>
+				<version>${jetty.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.eclipse.jetty</groupId>
+				<artifactId>jetty-http</artifactId>
+				<version>${jetty.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.eclipse.jetty</groupId>
+				<artifactId>jetty-webapp</artifactId>
+				<version>${jetty.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.eclipse.jetty</groupId>
+				<artifactId>jetty-io</artifactId>
+				<version>${jetty.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.eclipse.jetty</groupId>
+				<artifactId>jetty-util</artifactId>
+				<version>${jetty.version}</version>
+				<scope>test</scope>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
…so that all modules use the same Jetty version.