### PR TITLE
AppDeployer keeps publishing same version number

### DIFF
--- a/modules/flowable-app-engine/src/main/resources/org/flowable/app/db/mapping/entity/AppDefinition.xml
+++ b/modules/flowable-app-engine/src/main/resources/org/flowable/app/db/mapping/entity/AppDefinition.xml
@@ -132,7 +132,7 @@
   <select id="selectLatestAppDefinitionByKeyAndTenantId" parameterType="map" resultMap="appDefinitionResultMap">
     select *
     from ${prefix}ACT_APP_APPDEF 
-    where KEY_ = #{caseDefinitionKey} and
+    where KEY_ = #{appDefinitionKey} and
           TENANT_ID_ = #{tenantId} and
           VERSION_ = (select max(VERSION_) from ${prefix}ACT_APP_APPDEF where KEY_ = #{appDefinitionKey} and TENANT_ID_ = #{tenantId})
   </select>


### PR DESCRIPTION
This manifests in a way in which the apps are deployed without version number increases, because of the incorrect parameter causing the method AppDeployer.getMostRecentVersionOfAppDefinition to return null all the time.