### PR TITLE
Cleanup Flowable Spring Boot Security Auto configuration

### DIFF
--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/FlowableSecurityAutoConfiguration.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/FlowableSecurityAutoConfiguration.java
@@ -16,11 +16,8 @@ import org.flowable.common.engine.api.identity.AuthenticationContext;
 import org.flowable.common.engine.impl.identity.Authentication;
 import org.flowable.idm.api.IdmIdentityService;
 import org.flowable.spring.boot.idm.IdmEngineServicesAutoConfiguration;
-import org.flowable.spring.security.FlowableAuthenticationProvider;
 import org.flowable.spring.security.FlowableUserDetailsService;
 import org.flowable.spring.security.SpringSecurityAuthenticationContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
@@ -30,8 +27,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.AuthenticationProvider;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.authentication.configuration.GlobalAuthenticationConfigurerAdapter;
 import org.springframework.security.core.userdetails.UserDetailsService;
 
@@ -44,7 +39,7 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 @ConditionalOnClass({
     AuthenticationManager.class,
     IdmIdentityService.class,
-    FlowableAuthenticationProvider.class,
+    FlowableUserDetailsService.class,
     GlobalAuthenticationConfigurerAdapter.class
 })
 @ConditionalOnBean(IdmIdentityService.class)
@@ -54,36 +49,6 @@ import org.springframework.security.core.userdetails.UserDetailsService;
     ProcessEngineAutoConfiguration.class
 })
 public class FlowableSecurityAutoConfiguration {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(FlowableSecurityAutoConfiguration.class);
-
-    @Configuration
-    public static class UserDetailsServiceConfiguration
-            extends GlobalAuthenticationConfigurerAdapter {
-
-        protected final ObjectProvider<AuthenticationProvider> authenticationProviderProvider;
-        protected final ObjectProvider<UserDetailsService> userDetailsServiceProvider;
-
-        public UserDetailsServiceConfiguration(
-            ObjectProvider<AuthenticationProvider> authenticationProviderProvider,
-            ObjectProvider<UserDetailsService> userDetailsServiceProvider) {
-            this.authenticationProviderProvider = authenticationProviderProvider;
-            this.userDetailsServiceProvider = userDetailsServiceProvider;
-        }
-
-        @Override
-        public void init(AuthenticationManagerBuilder auth) throws Exception {
-            if (!auth.isConfigured()) {
-                AuthenticationProvider authenticationProvider = authenticationProviderProvider.getIfUnique();
-                if (authenticationProvider != null) {
-                    auth.authenticationProvider(authenticationProvider);
-                } else {
-                    LOGGER.warn("There is no authentication provider configured. However, there is no single one in the context."
-                        + " Please configure the global authentication provider by yourself.");
-                }
-            }
-        }
-    }
 
     @Configuration
     @ConditionalOnClass(AuthenticationContext.class)
@@ -103,11 +68,5 @@ public class FlowableSecurityAutoConfiguration {
     @ConditionalOnMissingBean(UserDetailsService.class)
     public FlowableUserDetailsService flowableUserDetailsService(IdmIdentityService identityService) {
         return new FlowableUserDetailsService(identityService);
-    }
-
-    @Bean
-    @ConditionalOnMissingBean(AuthenticationProvider.class)
-    public FlowableAuthenticationProvider flowableAuthenticationProvider(IdmIdentityService idmIdentityService, UserDetailsService userDetailsService) {
-        return new FlowableAuthenticationProvider(idmIdentityService, userDetailsService);
     }
 }

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/idm/IdmEngineAutoConfiguration.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/idm/IdmEngineAutoConfiguration.java
@@ -41,6 +41,8 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.DelegatingPasswordEncoder;
 import org.springframework.security.crypto.password.NoOpPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -85,6 +87,13 @@ public class IdmEngineAutoConfiguration extends AbstractEngineAutoConfiguration 
             String encoderType = idmProperties.getPasswordEncoder();
             if (Objects.equals("spring_bcrypt", encoderType)) {
                 encoder = new BCryptPasswordEncoder();
+            } else if (encoderType != null && encoderType.startsWith("spring_delegating")) {
+                encoder = PasswordEncoderFactories.createDelegatingPasswordEncoder();
+                if (encoderType.equals("spring_delegating_bcrypt")) {
+                    ((DelegatingPasswordEncoder) encoder).setDefaultPasswordEncoderForMatches(new BCryptPasswordEncoder());
+                } else if (encoderType.equals("spring_delegating_noop")) {
+                    ((DelegatingPasswordEncoder) encoder).setDefaultPasswordEncoderForMatches(NoOpPasswordEncoder.getInstance());
+                }
             } else {
                 encoder = NoOpPasswordEncoder.getInstance();
             }

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/ldap/FlowableLdapAutoConfiguration.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/ldap/FlowableLdapAutoConfiguration.java
@@ -12,6 +12,7 @@
  */
 package org.flowable.spring.boot.ldap;
 
+import org.flowable.idm.api.IdmIdentityService;
 import org.flowable.idm.spring.SpringIdmEngineConfiguration;
 import org.flowable.ldap.LDAPConfiguration;
 import org.flowable.ldap.LDAPGroupCache;
@@ -22,12 +23,14 @@ import org.flowable.spring.boot.ProcessEngineServicesAutoConfiguration;
 import org.flowable.spring.boot.FlowableSecurityAutoConfiguration;
 import org.flowable.spring.boot.condition.ConditionalOnLdap;
 import org.flowable.spring.boot.idm.IdmEngineServicesAutoConfiguration;
+import org.flowable.spring.security.FlowableAuthenticationProvider;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.core.userdetails.UserDetailsService;
 
 /**
  * {@link org.springframework.boot.autoconfigure.EnableAutoConfiguration} for the Flowable LDAP Integration.
@@ -82,6 +85,12 @@ public class FlowableLdapAutoConfiguration {
     public EngineConfigurationConfigurer<SpringIdmEngineConfiguration> ldapIdmEngineConfigurer(LDAPConfiguration ldapConfiguration) {
         return idmEngineConfiguration -> idmEngineConfiguration
             .setIdmIdentityService(new LDAPIdentityServiceImpl(ldapConfiguration, createCache(idmEngineConfiguration, ldapConfiguration)));
+    }
+
+    @Bean
+    public FlowableAuthenticationProvider flowableAuthenticationProvider(IdmIdentityService idmIdentitySerivce,
+        UserDetailsService userDetailsService) {
+        return new FlowableAuthenticationProvider(idmIdentitySerivce, userDetailsService);
     }
 
     protected LDAPGroupCache createCache(SpringIdmEngineConfiguration engineConfiguration, LDAPConfiguration ldapConfiguration) {

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -608,6 +608,28 @@
           "description": "Checks the version of the DB schema against the library when the engine(s) is(are) being created and throws an exception if the versions don't match."
         }
       ]
+    },
+    {
+      "name": "flowable.idm.password-encoder",
+      "values": [
+        {
+          "value": "spring_bcrypt",
+          "description": "Use the Spring security BCryptPasswordEncoder. This is for backwards compatibility. It is advised to use spring_delegating with Spring Security 5."
+        },
+        {
+          "value": "spring_delegating",
+          "description": "Use the Spring Security 5 PasswordEncoderFactories.createDelegatingPasswordEncoder(). This is the recommended for new projects."
+        },
+        {
+          "value": "spring_delegating_bcrypt",
+          "description": "Use the Spring Security 5 PasswordEncoderFactories.createDelegatingPasswordEncoder(). With BCryptPasswordEncoder as the default password encoder for matches. This should be used for backwards compatibility with older versions."
+        },
+        {
+          "value": "spring_delegating_noop",
+          "description": "Use the Spring Security 5 PasswordEncoderFactories.createDelegatingPasswordEncoder(). With NoopPasswordEncoder as the default password encoder for matches. This should be used for backwards compatibility with older versions."
+        }
+
+      ]
     }
   ]
 }

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/test/spring/boot/FlowableSecurityAutoConfigurationTest.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/test/spring/boot/FlowableSecurityAutoConfigurationTest.java
@@ -74,10 +74,10 @@ public class FlowableSecurityAutoConfigurationTest {
     }
 
     @Test
-    public void withMissingFlowableAuthenticationProvider() {
+    public void withMissingFlowableUserDetailsService() {
         contextRunner
             .withConfiguration(IDM_CONFIGURATION)
-            .withClassLoader(new FilteredClassLoader(FlowableAuthenticationProvider.class))
+            .withClassLoader(new FilteredClassLoader(FlowableUserDetailsService.class))
             .run(context -> assertThat(context)
                 .hasSingleBean(IdmIdentityService.class)
                 .doesNotHaveBean(FlowableSecurityAutoConfiguration.class));
@@ -110,9 +110,8 @@ public class FlowableSecurityAutoConfigurationTest {
                         .hasSingleBean(IdmIdentityService.class)
                         .hasSingleBean(FlowableSecurityAutoConfiguration.class)
                         .hasSingleBean(UserDetailsService.class)
-                        .hasSingleBean(AuthenticationProvider.class);
+                        .doesNotHaveBean(AuthenticationProvider.class);
                     assertThat(context.getBean(UserDetailsService.class)).isInstanceOf(FlowableUserDetailsService.class);
-                    assertThat(context.getBean(AuthenticationProvider.class)).isInstanceOf(FlowableAuthenticationProvider.class);
 
                     assertThat(Authentication.getAuthenticationContext()).isInstanceOf(SpringSecurityAuthenticationContext.class);
                 }


### PR DESCRIPTION
Flowable should only configure the `UserDetailsService`.
Spring security performs a default configuration of the authentication provider using a provided `UserDetailsService` and `PasswordEncoder`
through the `InitializeUserDetailsBeanManagerConfigurer`.
In case a global `AuthenticationProvider` is configured then Spring Security uses that through the `InitializeAuthenticationProviderBeanManagerConfigurer`.
Doing this allows easier configuration of Flowable Spring Boot applications with a custom `UserDetailsService`

Add the possibility to use the Spring Security 5 `DelegatingPasswordEncoder` through a property