### PR TITLE
Fixed method FormServiceImpl.getFormModelWithVariablesById(...) to co…

### DIFF
--- a/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/FormServiceImpl.java
+++ b/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/FormServiceImpl.java
@@ -82,8 +82,8 @@ public class FormServiceImpl extends CommonEngineServiceImpl<FormEngineConfigura
     }
 
     @Override
-    public FormInfo getFormModelWithVariablesById(String formId, String taskId,Map<String, Object> variables, String tenantId) {
-        return commandExecutor.execute(new GetFormModelWithVariablesCmd(null, formId, null, taskId, tenantId, variables));
+    public FormInfo getFormModelWithVariablesById(String formDefinitionId, String taskId,Map<String, Object> variables, String tenantId) {
+        return commandExecutor.execute(new GetFormModelWithVariablesCmd(null, null, formDefinitionId, taskId, tenantId, variables));
     }
 
     @Override

--- a/modules/flowable-form-engine/src/test/java/org/flowable/form/engine/test/FormModelTest.java
+++ b/modules/flowable-form-engine/src/test/java/org/flowable/form/engine/test/FormModelTest.java
@@ -1,0 +1,46 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.form.engine.test;
+
+import org.flowable.form.api.FormInfo;
+import org.flowable.form.model.FormField;
+import org.flowable.form.model.SimpleFormModel;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class FormModelTest extends AbstractFlowableFormTest {
+
+    @Test
+    @FormDeploymentAnnotation(resources = "org/flowable/form/engine/test/deployment/simple.form")
+    public void getSimpleFormModelWithVariables() throws Exception {
+        String formDefinitionId = repositoryService.getFormModelByKey("form1").getId();
+
+        Map<String, Object> variables = new HashMap<>();
+        variables.put("input1", "test");
+
+        FormInfo formInfo = formService.getFormModelWithVariablesById(formDefinitionId, null, variables, null);
+
+        assertEquals(formDefinitionId, formInfo.getId());
+
+        SimpleFormModel formModel = (SimpleFormModel) formInfo.getFormModel();
+        assertEquals(1, formModel.getFields().size());
+        FormField formField = formModel.getFields().get(0);
+        assertEquals("input1", formField.getId());
+        assertEquals("test", formField.getValue());
+    }
+
+}


### PR DESCRIPTION
…rrectly map formDefinitionId

Hi,

I came across the following stacktrace when using the method `formServiceImpl.getFormModelWithVariablesById(String formId, String taskId,Map<String, Object> variables, String tenantId)`

```
org.flowable.common.engine.api.FlowableObjectNotFoundException: formDefinitionKey and formDefinitionId are null

	at org.flowable.form.engine.impl.cmd.GetFormModelWithVariablesCmd.resolveFormDefinition(GetFormModelWithVariablesCmd.java:256)
	at org.flowable.form.engine.impl.cmd.GetFormModelWithVariablesCmd.execute(GetFormModelWithVariablesCmd.java:92)
	at org.flowable.form.engine.impl.cmd.GetFormModelWithVariablesCmd.execute(GetFormModelWithVariablesCmd.java:57)
	at org.flowable.common.engine.impl.interceptor.DefaultCommandInvoker.execute(DefaultCommandInvoker.java:10)
	at org.flowable.common.engine.impl.interceptor.TransactionContextInterceptor.execute(TransactionContextInterceptor.java:53)
	at org.flowable.common.engine.impl.interceptor.CommandContextInterceptor.execute(CommandContextInterceptor.java:71)
	at org.flowable.common.engine.impl.interceptor.LogInterceptor.execute(LogInterceptor.java:30)
	at org.flowable.common.engine.impl.cfg.CommandExecutorImpl.execute(CommandExecutorImpl.java:56)
	at org.flowable.common.engine.impl.cfg.CommandExecutorImpl.execute(CommandExecutorImpl.java:51)
	at org.flowable.form.engine.impl.FormServiceImpl.getFormModelWithVariablesById(FormServiceImpl.java:86)
```

The problem here is that in the method there is an incorrect mapping - from the formId to the parentDeploymentId instead of the formDefinitionId. This results in the command being run without a formDefinitionId or formDefinitionKey being defined.

I have fixed the method to correctly map the parameters, and added a unit test for this.

Please let me know if you need me to change anything.

Regards,
Paul Stapleton