### PR TITLE
Minor user-guide documentation issues

### DIFF
--- a/docs/userguide/src/en/bpmn/ch05a-Spring-Boot.adoc
+++ b/docs/userguide/src/en/bpmn/ch05a-Spring-Boot.adoc
@@ -581,6 +581,8 @@ Flowable provides a Spring Boot Actuator Endpoint that exposes information for t
 By default the `flowable` endpoint is mapped to `/actuator/flowable`.
 Spring Boot by default only exposes the `info` and `health` endpoints. In order to enable the `flowable` endpoint you need to add `management.endpoint.flowable.enabled=true` to your `application.properties`.
 
+In order to make enable Actuator endpoints you need to add a dependency on Actuator, e.g. by using {sc-flowable-starter}/flowable-spring-boot-starter-actuator/pom.xml[flowable-spring-boot-starter-actuator].
+
 `curl http://localhost:8080/actuator/flowable`
 
 [source,json]

--- a/docs/userguide/src/en/bpmn/ch07a-BPMN-Introduction.adoc
+++ b/docs/userguide/src/en/bpmn/ch07a-BPMN-Introduction.adoc
@@ -66,7 +66,7 @@ ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("myPr
 * *name*: this attribute is *optional* and maps to the _name_ property of a +ProcessDefinition+. The engine itself doesn't use this property, so it can be used for displaying a more human-friendly name in a user interface, for example.
 
 
-[[10minutetutorial]]
+[[bpm10minutetutorial]]
 
 
 === Getting started: 10 minute tutorial

--- a/docs/userguide/src/en/bpmn/ch08-Forms.adoc
+++ b/docs/userguide/src/en/bpmn/ch08-Forms.adoc
@@ -89,7 +89,7 @@ or
 TaskFormdata FormService.getTaskFormData(String taskId)
 ----
 
-By default, the build-in form engines, 'sees' the properties as well as the process variables.  So there is no need to declare task form properties if they match 1-1 with the process variables.  For example, with the following declaration:
+By default, the built-in form engine 'sees' the properties as well as the process variables.  So there is no need to declare task form properties if they match 1-1 with the process variables.  For example, with the following declaration:
 
 [source,xml,linenums]
 ----

--- a/docs/userguide/src/en/single/ch02-Engine.adoc
+++ b/docs/userguide/src/en/single/ch02-Engine.adoc
@@ -29,7 +29,7 @@ include::../bpmn/ch10-History.adoc[leveloffset=+2]
 
 *TBD*
 
-include::../bpmn/ch07a-BPMN-Introduction.adoc[leveloffset=+2,tags=bpmn20.10minutetutorial]
+include::../bpmn/ch07a-BPMN-Introduction.adoc[leveloffset=+2,tags=bpmn20.bpm10minutetutorial]
 
 include::../bpmn/ch03-Configuration.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Three unrelated minor issues in the user guide documentation. I logged these [in the forum](https://forum.flowable.org/t/some-minor-issues-with-documentation/2916), and it was suggested I log a PR, so here it is.

The changes are:

1. Added explicit statement about adding dependency on Acuator starter.
1. Changed "[[10minutetutorial]]" to "[[bpm10minutetutorial]]" as link didn't work when the value started with a number rather than a letter. Also updated cross-reference to this.
1. Fixed minor typo ("build-in" -> "built-in").

One thing  to double-check in case I've messed up is the cross-reference in ch02-Engine.adoc: it didn't work for me, either with the old name or the new name, so I'm not sure if what I've done is quite right here. Also mentioning just in case this is referred to from any other documentation.