### PR TITLE
Avoid NullPointerException when task is not found in runtime

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/GetEntityLinkParentsForTaskCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/GetEntityLinkParentsForTaskCmd.java
@@ -15,9 +15,12 @@ package org.flowable.engine.impl.cmd;
 import java.io.Serializable;
 import java.util.List;
 
+import org.flowable.common.engine.api.FlowableIllegalArgumentException;
+import org.flowable.common.engine.api.FlowableObjectNotFoundException;
 import org.flowable.common.engine.api.scope.ScopeTypes;
 import org.flowable.common.engine.impl.interceptor.Command;
 import org.flowable.common.engine.impl.interceptor.CommandContext;
+import org.flowable.engine.impl.persistence.entity.ExecutionEntity;
 import org.flowable.engine.impl.util.CommandContextUtil;
 import org.flowable.entitylink.api.EntityLink;
 import org.flowable.entitylink.api.EntityLinkType;
@@ -32,12 +35,20 @@ public class GetEntityLinkParentsForTaskCmd implements Command<List<EntityLink>>
     protected String taskId;
 
     public GetEntityLinkParentsForTaskCmd(String taskId) {
+        if (taskId == null) {
+            throw new FlowableIllegalArgumentException("taskId is required");
+        }
         this.taskId = taskId;
     }
 
     @Override
     public List<EntityLink> execute(CommandContext commandContext) {
         TaskEntity task = CommandContextUtil.getTaskService().getTask(taskId);
+
+        if (task == null) {
+            throw new FlowableObjectNotFoundException("Cannot find task with id " + taskId, ExecutionEntity.class);
+        }
+
         return CommandContextUtil.getEntityLinkService().findEntityLinksByReferenceScopeIdAndType(task.getId(), ScopeTypes.TASK, EntityLinkType.CHILD);
     }
 


### PR DESCRIPTION
Throws when doing fallbacks between runtime and history. I've also added small check for null taskIds.

Thanks!