### PR TITLE
added X_FORWARDED_PROTO==https for secure cookies when using a proxy

### DIFF
--- a/modules/flowable-ui-idm/flowable-ui-idm-conf/src/main/java/org/flowable/ui/idm/security/CustomPersistentRememberMeServices.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-conf/src/main/java/org/flowable/ui/idm/security/CustomPersistentRememberMeServices.java
@@ -41,6 +41,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.ReflectionUtils;
 
+import com.google.common.net.HttpHeaders;
+
 /**
  * Custom implementation of Spring Security's RememberMeServices.
  * <p/>
@@ -226,7 +228,12 @@ public class CustomPersistentRememberMeServices extends AbstractRememberMeServic
             cookie.setDomain(tokenDomain);
         }
 
-        cookie.setSecure(request.isSecure());
+        String xForwardedProtoHeader = request.getHeader(HttpHeaders.X_FORWARDED_PROTO);
+        if (xForwardedProtoHeader != null) {
+            cookie.setSecure(xForwardedProtoHeader.equals("https") || request.isSecure());
+        } else {
+            cookie.setSecure(request.isSecure());
+        }
 
         Method setHttpOnlyMethod = ReflectionUtils.findMethod(Cookie.class, "setHttpOnly", boolean.class);
         if (setHttpOnlyMethod != null) {

--- a/modules/flowable-ui-idm/flowable-ui-idm-conf/src/main/java/org/flowable/ui/idm/security/CustomPersistentRememberMeServices.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-conf/src/main/java/org/flowable/ui/idm/security/CustomPersistentRememberMeServices.java
@@ -41,8 +41,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.ReflectionUtils;
 
-import com.google.common.net.HttpHeaders;
-
 /**
  * Custom implementation of Spring Security's RememberMeServices.
  * <p/>
@@ -228,7 +226,7 @@ public class CustomPersistentRememberMeServices extends AbstractRememberMeServic
             cookie.setDomain(tokenDomain);
         }
 
-        String xForwardedProtoHeader = request.getHeader(HttpHeaders.X_FORWARDED_PROTO);
+        String xForwardedProtoHeader = request.getHeader("X-Forwarded-Proto");
         if (xForwardedProtoHeader != null) {
             cookie.setSecure(xForwardedProtoHeader.equals("https") || request.isSecure());
         } else {


### PR DESCRIPTION
I noticed the cookies were not secure cookies when flowable is acting behind a load balancer. So I added a check for when the header `X_FORWARDED_PROTO` is set.