### PR TITLE
flowable-1415 hide state/migration buttons after execution

### DIFF
--- a/modules/flowable-ui-admin/flowable-ui-admin-app/src/main/resources/static/display/displaymodel.html
+++ b/modules/flowable-ui-admin/flowable-ui-admin-app/src/main/resources/static/display/displaymodel.html
@@ -568,6 +568,7 @@
                                     }),
                                     success: function() {
                                         paper.clear();
+                                        $('#changeStateButton').hide();
                                         _showProcessDiagram();
                                     }
                                 });
@@ -679,6 +680,8 @@
                                         migrationMappedElements = new Array();
                                         $('#targetModel').hide();
                                         $('#migrationDivider').hide();
+                                        $('#executeMigrationDocument').hide();
+                                        $('#currentMappingValues').hide();
                                         _showProcessDiagram();
                                     }
                                 });


### PR DESCRIPTION
Just removed execution and mapping info after successful execution of state change or migration.

https://github.com/flowable/flowable-engine/issues/1415