### PR TITLE
Remove unused variable

### DIFF
--- a/modules/flowable-app-engine/src/main/java/org/flowable/app/engine/impl/db/AppDbSchemaManager.java
+++ b/modules/flowable-app-engine/src/main/java/org/flowable/app/engine/impl/db/AppDbSchemaManager.java
@@ -48,7 +48,6 @@ public class AppDbSchemaManager implements SchemaManager {
     }
     
     public void initSchema(AppEngineConfiguration appEngineConfiguration, String databaseSchemaUpdate) {
-        Liquibase liquibase = null;
         try {
             if (AppEngineConfiguration.DB_SCHEMA_UPDATE_CREATE_DROP.equals(databaseSchemaUpdate)) {
                 schemaCreate();
@@ -62,12 +61,9 @@ public class AppDbSchemaManager implements SchemaManager {
                 
             } else if (AppEngineConfiguration.DB_SCHEMA_UPDATE_FALSE.equals(databaseSchemaUpdate)) {
                schemaCheckVersion();
-                
             }
         } catch (Exception e) {
             throw new FlowableException("Error initialising app data model", e);
-        } finally {
-            closeDatabase(liquibase);
         }
     }
 


### PR DESCRIPTION
It appears that during the refactoring of database connections
(4f28b4f43cdfce3abac0497a9919d3bbabd7f306) and (5c2c28e4fe8b1a9f6a8bd551f41ed83105367f68) the code for closing the connections was moved into individual routines and is no longer needed
in the parent routine.