### PR TITLE
flowable-engine: Fix "org.apache.maven.surefire.booter.SurefireBooter…

### DIFF
--- a/modules/flowable-engine/pom.xml
+++ b/modules/flowable-engine/pom.xml
@@ -1547,6 +1547,18 @@
                 </plugins>
             </build>
         </profile>
+
+        <profile>
+            <id>java8</id>
+            <activation>
+                <jdk>1.8</jdk>
+            </activation>
+            <properties>
+                <!-- increase max heap to fix: SurefireBooterForkException: There was an error in the forked process
+                    [ERROR] GC overhead limit exceeded -->
+                <argLine>-Xmx2g</argLine>
+            </properties>
+        </profile>
     </profiles>
 
 </project>


### PR DESCRIPTION
…ForkException: There was an error in the forked process [ERROR] GC overhead limit exceeded" on Travis when using Java 8 by increasing max heap for tests.