### PR TITLE
flowable-engine: Fix occasional build failure "org.apache.maven.suref…

### DIFF
--- a/modules/flowable-engine/pom.xml
+++ b/modules/flowable-engine/pom.xml
@@ -1556,7 +1556,7 @@
             <properties>
                 <!-- increase max heap to fix: SurefireBooterForkException: There was an error in the forked process
                     [ERROR] GC overhead limit exceeded -->
-                <argLine>-Xmx2g</argLine>
+                <argLine>-Xmx3g</argLine>
             </properties>
         </profile>
     </profiles>


### PR DESCRIPTION
…ire.booter.SurefireBooterForkException: There was an error in the forked process [ERROR] GC overhead limit exceeded" on Travis when using Java 8 by increasing max heap for tests on Java 8 to 3 GB.

Seems like https://github.com/flowable/flowable-engine/commit/466f6f93d9bb949dfa118b71af4e66dd0708d004 was not enough, as there are still failures from time to time.