### PR TITLE
AbstractEngineConfiguration#initDataSource: Remove PooledDataSource#f…

### DIFF
--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/AbstractEngineConfiguration.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/AbstractEngineConfiguration.java
@@ -372,12 +372,6 @@ public abstract class AbstractEngineConfiguration {
                 }
                 dataSource = pooledDataSource;
             }
-
-            if (dataSource instanceof PooledDataSource) {
-                // ACT-233: connection pool of Ibatis is not properly
-                // initialized if this is not called!
-                ((PooledDataSource) dataSource).forceCloseAll();
-            }
         }
 
         if (databaseType == null) {


### PR DESCRIPTION
…orceCloseAll call

In the current MyBatis PooledDataSource implementation there is no reason for this call, as the setters of PooledDataSource already call #forceCloseAll internally. (Maybe the call to forceCloseAll was necessary in older MyBatis versions.)