### PR TITLE
HSQL create table command requires the 'default' before 'NOT NULL'.

### DIFF
--- a/modules/flowable-engine/src/main/resources/org/flowable/db/create/flowable.hsql.create.engine.sql
+++ b/modules/flowable-engine/src/main/resources/org/flowable/db/create/flowable.hsql.create.engine.sql
@@ -83,7 +83,7 @@ create table ACT_RE_PROCDEF (
     TENANT_ID_ varchar(255) default '',
     DERIVED_FROM_ varchar(64),
     DERIVED_FROM_ROOT_ varchar(64),
-    DERIVED_VERSION_ integer NOT NULL default 0,
+    DERIVED_VERSION_ integer default 0 NOT NULL,
     ENGINE_VERSION_ varchar(255),
     primary key (ID_)
 );


### PR DESCRIPTION
As per the HSQL documentation, the 'default' clause is required before 'NOT NULL'. This fix is required to allow the HSQL database to be created for unit testing.