### PR TITLE
Updated Date query parameter example

### DIFF
--- a/docs/public-api/tools/flowable-slate/slate/source/includes/_rest-header.md
+++ b/docs/public-api/tools/flowable-slate/slate/source/includes/_rest-header.md
@@ -87,7 +87,7 @@ Parameters added as query-string in the URL (for example, the name parameter use
 |Integer|Parameter representing an integer value. Can only contain numeric non-decimal values, between -2.147.483.648 and 2.147.483.647.
 |Long|Parameter representing a long value. Can only contain numeric non-decimal values, between -9.223.372.036.854.775.808 and 9.223.372.036.854.775.807.
 |Boolean|Parameter representing a boolean value. Can be either *true* or *false*. All other values other than these will cause a '**405 - Bad request**' response.
-|Date|Parameter representing a date value. Use the ISO-8601 date-format (see [ISO-8601 on wikipedia](http://en.wikipedia.org/wiki/ISO_8601) using both time and date-components (e.g. *2013-04-03T23:45Z*).
+|Date|Parameter representing a date value. Use the ISO-8601 date-format (see [ISO-8601 on wikipedia](http://en.wikipedia.org/wiki/ISO_8601) using both time and date-components (e.g. *2013-04-03T23:45:12Z*).
 
 
 ### JSON body parameters


### PR DESCRIPTION
ISO-8601 date without seconds is not accepted by the API.