### PR TITLE
Correct cut-n-paste error

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/IntermediateTimerEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/IntermediateTimerEventTest.java
@@ -117,7 +117,7 @@ public class IntermediateTimerEventTest extends PluggableFlowableTestCase {
         // After process start, there should be timer created
         ProcessInstance pi1 = runtimeService.startProcessInstanceByKey("intermediateTimerEventExample", variables1);
         ProcessInstance pi2 = runtimeService.startProcessInstanceByKey("intermediateTimerEventExample", variables2);
-        ProcessInstance pi3 = runtimeService.startProcessInstanceByKey("intermediateTimerEventExample", variables2);
+        ProcessInstance pi3 = runtimeService.startProcessInstanceByKey("intermediateTimerEventExample", variables3);
 
         assertEquals(1, managementService.createTimerJobQuery().processInstanceId(pi1.getId()).count());
         assertEquals(1, managementService.createTimerJobQuery().processInstanceId(pi2.getId()).count());


### PR DESCRIPTION
As part of [PR 881](https://github.com/flowable/flowable-engine/pull/881) a third condition was created but when executing it was not used.  It appears that the line above was copied but the variable was not changed to `variables3` but left as `variables2`.

Made the change and reran the test locally without issue.

I believe @martin-grofcik made the change and should probably review.

Thanks.