### PR TITLE
Update case state on case instance end

### DIFF
--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/history/async/json/transformer/CaseInstanceEndHistoryJsonTransformer.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/history/async/json/transformer/CaseInstanceEndHistoryJsonTransformer.java
@@ -59,6 +59,7 @@ public class CaseInstanceEndHistoryJsonTransformer extends AbstractNeedsHistoric
            } else {
                Date endTime = getDateFromJson(historicalData, CmmnAsyncHistoryConstants.FIELD_END_TIME);
                historicCaseInstanceEntity.setEndTime(endTime);
+               historicCaseInstanceEntity.setState(getStringFromJson(historicalData, CmmnAsyncHistoryConstants.FIELD_STATE));
                historicCaseInstanceEntityManager.update(historicCaseInstanceEntity);
                
            }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/async/AsyncCmmnHistoryTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/async/AsyncCmmnHistoryTest.java
@@ -101,7 +101,7 @@ public class AsyncCmmnHistoryTest extends CustomCmmnConfigurationFlowableTestCas
         assertNull(historicCaseInstance.getParentId());
         assertEquals("someBusinessKey", historicCaseInstance.getBusinessKey());
         assertEquals(caseInstance.getCaseDefinitionId(), historicCaseInstance.getCaseDefinitionId());
-        assertEquals(CaseInstanceState.ACTIVE, historicCaseInstance.getState());
+        assertEquals(CaseInstanceState.COMPLETED, historicCaseInstance.getState());
         assertNotNull(historicCaseInstance.getStartTime());
         assertNotNull(historicCaseInstance.getEndTime());
     }


### PR DESCRIPTION
CaseInstanceEndHistoryJsonTransformer wasn't updating the state correctly and the case was still active. Fixed unit test.