### PR TITLE
Made sure you can send objects to flowable-rest form-data

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/FormService.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/FormService.java
@@ -48,7 +48,7 @@ public interface FormService {
     /**
      * Start a new process instance with the user data that was entered as properties in a start form.
      */
-    ProcessInstance submitStartFormData(String processDefinitionId, Map<String, String> properties);
+    ProcessInstance submitStartFormData(String processDefinitionId, Map<String, Object> properties);
 
     /**
      * Start a new process instance with the user data that was entered as properties in a start form.
@@ -64,7 +64,7 @@ public interface FormService {
      * @param properties
      *            the properties to pass, can be null.
      */
-    ProcessInstance submitStartFormData(String processDefinitionId, String businessKey, Map<String, String> properties);
+    ProcessInstance submitStartFormData(String processDefinitionId, String businessKey, Map<String, Object> properties);
 
     /**
      * Retrieves all data necessary for rendering a form to complete a task. This can be used to perform rendering of the forms outside of the process engine.
@@ -84,10 +84,10 @@ public interface FormService {
     /**
      * Completes a task with the user data that was entered as properties in a task form.
      */
-    void submitTaskFormData(String taskId, Map<String, String> properties);
+    void submitTaskFormData(String taskId, Map<String, Object> properties);
 
     /** Save the data that was entered as properties in a task form. */
-    void saveFormData(String taskId, Map<String, String> properties);
+    void saveFormData(String taskId, Map<String, Object> properties);
 
     /**
      * Retrieves a user defined reference to a start form.

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/compatibility/Flowable5CompatibilityHandler.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/compatibility/Flowable5CompatibilityHandler.java
@@ -138,7 +138,7 @@ public interface Flowable5CompatibilityHandler {
 
     Object getRenderedStartForm(String processDefinitionId, String formEngineName);
 
-    ProcessInstance submitStartFormData(String processDefinitionId, String businessKey, Map<String, String> properties);
+    ProcessInstance submitStartFormData(String processDefinitionId, String businessKey, Map<String, Object> properties);
     
     TaskFormData getTaskFormData(String taskId);
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/FormServiceImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/FormServiceImpl.java
@@ -66,17 +66,17 @@ public class FormServiceImpl extends CommonEngineServiceImpl<ProcessEngineConfig
     }
 
     @Override
-    public ProcessInstance submitStartFormData(String processDefinitionId, Map<String, String> properties) {
+    public ProcessInstance submitStartFormData(String processDefinitionId, Map<String, Object> properties) {
         return commandExecutor.execute(new SubmitStartFormCmd(processDefinitionId, null, properties));
     }
 
     @Override
-    public ProcessInstance submitStartFormData(String processDefinitionId, String businessKey, Map<String, String> properties) {
+    public ProcessInstance submitStartFormData(String processDefinitionId, String businessKey, Map<String, Object> properties) {
         return commandExecutor.execute(new SubmitStartFormCmd(processDefinitionId, businessKey, properties));
     }
 
     @Override
-    public void submitTaskFormData(String taskId, Map<String, String> properties) {
+    public void submitTaskFormData(String taskId, Map<String, Object> properties) {
         commandExecutor.execute(new SubmitTaskFormCmd(taskId, properties, true));
     }
 
@@ -91,7 +91,7 @@ public class FormServiceImpl extends CommonEngineServiceImpl<ProcessEngineConfig
     }
 
     @Override
-    public void saveFormData(String taskId, Map<String, String> properties) {
+    public void saveFormData(String taskId, Map<String, Object> properties) {
         commandExecutor.execute(new SubmitTaskFormCmd(taskId, properties, false));
     }
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/SubmitStartFormCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/SubmitStartFormCmd.java
@@ -36,9 +36,9 @@ public class SubmitStartFormCmd extends NeedsActiveProcessDefinitionCmd<ProcessI
     private static final long serialVersionUID = 1L;
 
     protected final String businessKey;
-    protected Map<String, String> properties;
+    protected Map<String, Object> properties;
 
-    public SubmitStartFormCmd(String processDefinitionId, String businessKey, Map<String, String> properties) {
+    public SubmitStartFormCmd(String processDefinitionId, String businessKey, Map<String, Object> properties) {
         super(processDefinitionId);
         this.businessKey = businessKey;
         this.properties = properties;

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/SubmitTaskFormCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/SubmitTaskFormCmd.java
@@ -13,6 +13,7 @@
 
 package org.flowable.engine.impl.cmd;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.flowable.common.engine.impl.interceptor.CommandContext;
@@ -34,10 +35,10 @@ public class SubmitTaskFormCmd extends NeedsActiveTaskCmd<Void> {
     private static final long serialVersionUID = 1L;
 
     protected String taskId;
-    protected Map<String, String> properties;
+    protected Map<String, Object> properties;
     protected boolean completeTask;
 
-    public SubmitTaskFormCmd(String taskId, Map<String, String> properties, boolean completeTask) {
+    public SubmitTaskFormCmd(String taskId, Map<String, Object> properties, boolean completeTask) {
         super(taskId);
         this.taskId = taskId;
         this.properties = properties;
@@ -50,8 +51,11 @@ public class SubmitTaskFormCmd extends NeedsActiveTaskCmd<Void> {
         // Backwards compatibility
         if (task.getProcessDefinitionId() != null) {
             if (Flowable5Util.isFlowable5ProcessDefinitionId(commandContext, task.getProcessDefinitionId())) {
+                Map<String, String> backwardCompatMap = new HashMap<>();
+                properties.keySet().forEach((key) -> backwardCompatMap.put(key, String.valueOf(properties.get(key))));
+
                 Flowable5CompatibilityHandler compatibilityHandler = Flowable5Util.getFlowable5CompatibilityHandler();
-                compatibilityHandler.submitTaskFormData(taskId, properties, completeTask);
+                compatibilityHandler.submitTaskFormData(taskId, backwardCompatMap, completeTask);
                 return null;
             }
         }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/form/DefaultFormHandler.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/form/DefaultFormHandler.java
@@ -87,8 +87,8 @@ public class DefaultFormHandler implements FormHandler {
     }
 
     @Override
-    public void submitFormProperties(Map<String, String> properties, ExecutionEntity execution) {
-        Map<String, String> propertiesCopy = new HashMap<>(properties);
+    public void submitFormProperties(Map<String, Object> properties, ExecutionEntity execution) {
+        Map<String, Object> propertiesCopy = new HashMap<>(properties);
         for (FormPropertyHandler formPropertyHandler : formPropertyHandlers) {
             // submitFormProperty will remove all the keys which it takes care
             // of

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/form/DefaultStartFormHandler.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/form/DefaultStartFormHandler.java
@@ -49,7 +49,7 @@ public class DefaultStartFormHandler extends DefaultFormHandler implements Start
         return startFormData;
     }
 
-    public ExecutionEntity submitStartFormData(ExecutionEntity processInstance, Map<String, String> properties) {
+    public ExecutionEntity submitStartFormData(ExecutionEntity processInstance, Map<String, Object> properties) {
         submitFormProperties(properties, processInstance);
         return processInstance;
     }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/form/FormHandler.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/form/FormHandler.java
@@ -31,5 +31,5 @@ public interface FormHandler extends Serializable {
 
     void parseConfiguration(List<FormProperty> formProperties, String formKey, DeploymentEntity deployment, ProcessDefinition processDefinition);
 
-    void submitFormProperties(Map<String, String> properties, ExecutionEntity execution);
+    void submitFormProperties(Map<String, Object> properties, ExecutionEntity execution);
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/form/FormPropertyHandler.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/form/FormPropertyHandler.java
@@ -75,7 +75,7 @@ public class FormPropertyHandler implements Serializable {
         return formProperty;
     }
 
-    public void submitFormProperty(ExecutionEntity execution, Map<String, String> properties) {
+    public void submitFormProperty(ExecutionEntity execution, Map<String, Object> properties) {
         if (!isWritable && properties.containsKey(id)) {
             throw new FlowableException("form property '" + id + "' is not writable");
         }
@@ -87,9 +87,9 @@ public class FormPropertyHandler implements Serializable {
         Object modelValue = null;
         if (properties.containsKey(id)) {
             propertyExists = true;
-            final String propertyValue = properties.remove(id);
-            if (type != null) {
-                modelValue = type.convertFormValueToModelValue(propertyValue);
+            final Object propertyValue = properties.remove(id);
+            if (type != null && propertyValue != null ) {
+                modelValue = type.convertFormValueToModelValue(propertyValue.toString());
             } else {
                 modelValue = propertyValue;
             }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/history/DefaultHistoryManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/history/DefaultHistoryManager.java
@@ -379,10 +379,10 @@ public class DefaultHistoryManager extends AbstractHistoryManager {
     }
 
     @Override
-    public void recordFormPropertiesSubmitted(ExecutionEntity processInstance, Map<String, String> properties, String taskId) {
+    public void recordFormPropertiesSubmitted(ExecutionEntity processInstance, Map<String, Object> properties, String taskId) {
         if (isHistoryLevelAtLeast(HistoryLevel.AUDIT, processInstance.getProcessDefinitionId())) {
             for (String propertyId : properties.keySet()) {
-                String propertyValue = properties.get(propertyId);
+                Object propertyValue = properties.get(propertyId);
                 getHistoricDetailEntityManager().insertHistoricFormPropertyEntity(processInstance, propertyId, propertyValue, taskId);
             }
         }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/history/HistoryManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/history/HistoryManager.java
@@ -183,7 +183,7 @@ public interface HistoryManager {
     /**
      * Report form properties submitted, if audit history is enabled.
      */
-    void recordFormPropertiesSubmitted(ExecutionEntity processInstance, Map<String, String> properties, String taskId);
+    void recordFormPropertiesSubmitted(ExecutionEntity processInstance, Map<String, Object> properties, String taskId);
 
     /**
      * Record the creation of a new {@link IdentityLink}, if audit history is enabled.

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/history/async/AsyncHistoryManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/history/async/AsyncHistoryManager.java
@@ -500,7 +500,7 @@ public class AsyncHistoryManager extends AbstractHistoryManager {
     }
 
     @Override
-    public void recordFormPropertiesSubmitted(ExecutionEntity execution, Map<String, String> properties, String taskId) {
+    public void recordFormPropertiesSubmitted(ExecutionEntity execution, Map<String, Object> properties, String taskId) {
         if (isHistoryLevelAtLeast(HistoryLevel.AUDIT, execution.getProcessDefinitionId())) {
             Map<String, String> data = new HashMap<>();
             if (execution != null) {
@@ -518,9 +518,9 @@ public class AsyncHistoryManager extends AbstractHistoryManager {
             
             int counter = 1;
             for (String propertyId : properties.keySet()) {
-                String propertyValue = properties.get(propertyId);
+                Object propertyValue = properties.get(propertyId);
                 data.put(HistoryJsonConstants.FORM_PROPERTY_ID + counter, propertyId);
-                data.put(HistoryJsonConstants.FORM_PROPERTY_VALUE + counter, propertyValue);
+                data.put(HistoryJsonConstants.FORM_PROPERTY_VALUE + counter, propertyValue.toString());
                 counter++;
             }
             

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/HistoricDetailEntityManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/HistoricDetailEntityManager.java
@@ -25,7 +25,7 @@ import org.flowable.variable.service.impl.persistence.entity.VariableInstanceEnt
  */
 public interface HistoricDetailEntityManager extends EntityManager<HistoricDetailEntity> {
 
-    HistoricFormPropertyEntity insertHistoricFormPropertyEntity(ExecutionEntity execution, String propertyId, String propertyValue, String taskId);
+    HistoricFormPropertyEntity insertHistoricFormPropertyEntity(ExecutionEntity execution, String propertyId, Object propertyValue, String taskId);
 
     HistoricDetailVariableInstanceUpdateEntity copyAndInsertHistoricDetailVariableInstanceUpdateEntity(VariableInstanceEntity variableInstance);
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/HistoricDetailEntityManagerImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/HistoricDetailEntityManagerImpl.java
@@ -45,14 +45,14 @@ public class HistoricDetailEntityManagerImpl extends AbstractEntityManager<Histo
 
     @Override
     public HistoricFormPropertyEntity insertHistoricFormPropertyEntity(ExecutionEntity execution,
-            String propertyId, String propertyValue, String taskId) {
+            String propertyId, Object propertyValue, String taskId) {
 
         HistoricFormPropertyEntity historicFormPropertyEntity = historicDetailDataManager.createHistoricFormProperty();
         historicFormPropertyEntity.setProcessInstanceId(execution.getProcessInstanceId());
         historicFormPropertyEntity.setExecutionId(execution.getId());
         historicFormPropertyEntity.setTaskId(taskId);
         historicFormPropertyEntity.setPropertyId(propertyId);
-        historicFormPropertyEntity.setPropertyValue(propertyValue);
+        historicFormPropertyEntity.setPropertyValue(String.valueOf(propertyValue));
         historicFormPropertyEntity.setTime(getClock().getCurrentTime());
 
         ActivityInstanceEntity activityInstance = getActivityInstanceEntityManager().findUnfinishedActivityInstance(execution);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/form/FormPropertyDefaultValueTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/form/FormPropertyDefaultValueTest.java
@@ -50,7 +50,7 @@ public class FormPropertyDefaultValueTest extends PluggableFlowableTestCase {
             }
         }
 
-        Map<String, String> formDataUpdate = new HashMap<>();
+        Map<String, Object> formDataUpdate = new HashMap<>();
         formDataUpdate.put("longExpressionProperty", "1");
         formDataUpdate.put("booleanProperty", "false");
         formService.submitTaskFormData(task.getId(), formDataUpdate);
@@ -87,7 +87,7 @@ public class FormPropertyDefaultValueTest extends PluggableFlowableTestCase {
 
         // Override 2 properties. The others should pe posted as the
         // default-value
-        Map<String, String> formDataUpdate = new HashMap<>();
+        Map<String, Object> formDataUpdate = new HashMap<>();
         formDataUpdate.put("longExpressionProperty", "1");
         formDataUpdate.put("booleanProperty", "false");
         ProcessInstance processInstance = formService.submitStartFormData(processDefinitionId, formDataUpdate);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/form/FormServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/form/FormServiceTest.java
@@ -132,7 +132,7 @@ public class FormServiceTest extends PluggableFlowableTestCase {
         Object renderedStartForm = formService.getRenderedStartForm(procDefId);
         assertEquals("start form content", renderedStartForm);
 
-        Map<String, String> properties = new HashMap<>();
+        Map<String, Object> properties = new HashMap<>();
         properties.put("room", "5b");
         properties.put("speaker", "Mike");
         String processInstanceId = formService.submitStartFormData(procDefId, properties).getId();
@@ -169,7 +169,7 @@ public class FormServiceTest extends PluggableFlowableTestCase {
     @Test
     @Deployment
     public void testFormPropertyHandling() {
-        Map<String, String> properties = new HashMap<>();
+        Map<String, Object> properties = new HashMap<>();
         properties.put("room", "5b"); // default
         properties.put("speaker", "Mike"); // variable name mapping
         properties.put("duration", "45"); // type conversion
@@ -279,7 +279,7 @@ public class FormServiceTest extends PluggableFlowableTestCase {
 
         assertEquals(2, formProperties.size());
 
-        Map<String, String> properties = new HashMap<>();
+        Map<String, Object> properties = new HashMap<>();
         properties.put("street", "Broadway");
         formService.submitTaskFormData(taskId, properties);
 
@@ -349,7 +349,7 @@ public class FormServiceTest extends PluggableFlowableTestCase {
     @Test
     @Deployment
     public void testSubmitStartFormDataWithBusinessKey() {
-        Map<String, String> properties = new HashMap<>();
+        Map<String, Object> properties = new HashMap<>();
         properties.put("duration", "45");
         properties.put("speaker", "Mike");
         String procDefId = repositoryService.createProcessDefinitionQuery().singleResult().getId();
@@ -451,7 +451,7 @@ public class FormServiceTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertNotNull(task);
 
-        Map<String, String> properties = new HashMap<>();
+        Map<String, Object> properties = new HashMap<>();
         properties.put("room", "5b");
 
         formService.submitTaskFormData(task.getId(), properties);
@@ -477,7 +477,7 @@ public class FormServiceTest extends PluggableFlowableTestCase {
 
         String taskId = task.getId();
 
-        Map<String, String> properties = new HashMap<>();
+        Map<String, Object> properties = new HashMap<>();
         properties.put("room", "5b");
 
         Map<String, String> expectedVariables = new HashMap<>();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/compensate/CompensateEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/compensate/CompensateEventTest.java
@@ -191,7 +191,7 @@ public class CompensateEventTest extends PluggableFlowableTestCase {
         // get task from first subprocess
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
 
-        Map<String, String> taskFormVariables = new HashMap<>();
+        Map<String, Object> taskFormVariables = new HashMap<>();
         taskFormVariables.put("test", "begin");
         formService.submitTaskFormData(task.getId(), taskFormVariables);
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricVariableInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricVariableInstanceTest.java
@@ -639,7 +639,7 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
             assertEquals(2, historyService.createNativeHistoricDetailQuery().sql(sqlWithConditions).parameter("name", "var%").list().size());
 
             org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-            Map<String, String> formDatas = new HashMap<>();
+            Map<String, Object> formDatas = new HashMap<>();
             formDatas.put("field1", "field value 1");
             formDatas.put("field2", "field value 2");
             formService.submitTaskFormData(task.getId(), formDatas);

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/taskforms/TaskFormsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/taskforms/TaskFormsTest.java
@@ -57,7 +57,7 @@ public class TaskFormsTest extends PluggableFlowableTestCase {
         assertEquals("org/flowable/examples/taskforms/request.form", formService.getStartFormData(processDefinitionId).getFormKey());
 
         // Define variables that would be filled in through the form
-        Map<String, String> formProperties = new HashMap<>();
+        Map<String, Object> formProperties = new HashMap<>();
         formProperties.put("employeeName", "kermit");
         formProperties.put("numberOfDays", "4");
         formProperties.put("vacationMotivation", "I'm tired");

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/variables/VariablesTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/variables/VariablesTest.java
@@ -1767,7 +1767,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("taskAssigneeProcess");
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
 
-        Map<String, String> variables = new HashMap<>();
+        Map<String, Object> variables = new HashMap<>();
         variables.put("testProperty", "434");
 
         formService.submitTaskFormData(task.getId(), variables);

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/history/FullHistoryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/history/FullHistoryTest.java
@@ -466,7 +466,7 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
 
         processEngineConfiguration.getClock().setCurrentTime(startedDate);
 
-        Map<String, String> formProperties = new HashMap<>();
+        Map<String, Object> formProperties = new HashMap<>();
         formProperties.put("formProp1", "Activiti rocks");
         formProperties.put("formProp2", "12345");
 
@@ -605,7 +605,7 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
     @Test
     @Deployment(resources = { "org/flowable/engine/test/history/oneTaskProcess.bpmn20.xml" })
     public void testHistoricFormPropertiesQuery() throws Exception {
-        Map<String, String> formProperties = new HashMap<>();
+        Map<String, Object> formProperties = new HashMap<>();
         formProperties.put("stringVar", "activiti rocks!");
         formProperties.put("longVar", "12345");
 
@@ -669,7 +669,7 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
     @Deployment(resources = { "org/flowable/engine/test/history/oneTaskProcess.bpmn20.xml" })
     public void testHistoricFormPropertySorting() throws Exception {
 
-        Map<String, String> formProperties = new HashMap<>();
+        Map<String, Object> formProperties = new HashMap<>();
         formProperties.put("stringVar", "activiti rocks!");
         formProperties.put("longVar", "12345");
 
@@ -697,7 +697,7 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
     @Deployment
     public void testHistoricDetailQueryMixed() throws Exception {
 
-        Map<String, String> formProperties = new HashMap<>();
+        Map<String, Object> formProperties = new HashMap<>();
         formProperties.put("formProp1", "activiti rocks!");
         formProperties.put("formProp2", "12345");
 
@@ -899,7 +899,7 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
         assertNotNull(processInstance);
 
         // Submit form on task
-        Map<String, String> data = new HashMap<>();
+        Map<String, Object> data = new HashMap<>();
         data.put("formProp1", "Property value");
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/form/FormDataResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/form/FormDataResource.java
@@ -115,7 +115,7 @@ public class FormDataResource {
             restApiInterceptor.submitFormData(submitRequest);
         }
 
-        Map<String, String> propertyMap = new HashMap<>();
+        Map<String, Object> propertyMap = new HashMap<>();
         if (submitRequest.getProperties() != null) {
             for (RestFormProperty formProperty : submitRequest.getProperties()) {
                 propertyMap.put(formProperty.getId(), formProperty.getValue());

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/form/RestFormProperty.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/form/RestFormProperty.java
@@ -25,7 +25,7 @@ public class RestFormProperty {
     protected String id;
     protected String name;
     protected String type;
-    protected String value;
+    protected Object value;
     protected boolean readable;
     protected boolean writable;
     protected boolean required;
@@ -59,11 +59,11 @@ public class RestFormProperty {
         this.type = type;
     }
 
-    public String getValue() {
+    public Object getValue() {
         return value;
     }
 
-    public void setValue(String value) {
+    public void setValue(Object value) {
         this.value = value;
     }
 

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/form/FormDataResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/form/FormDataResourceTest.java
@@ -232,7 +232,7 @@ public class FormDataResourceTest extends BaseSpringRestTestCase {
             historyMap.put(historicVariableInstance.getVariableName(), historicVariableInstance);
         }
 
-        assertEquals("123", historyMap.get("room").getValue());
+        assertEquals(123, historyMap.get("room").getValue());
         assertEquals(processInstanceId, historyMap.get("room").getProcessInstanceId());
 
         processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess", variableMap);
@@ -261,7 +261,7 @@ public class FormDataResourceTest extends BaseSpringRestTestCase {
             historyMap.put(historicVariableInstance.getVariableName(), historicVariableInstance);
         }
 
-        assertEquals("123", historyMap.get("room").getValue());
+        assertEquals(123, historyMap.get("room").getValue());
         assertEquals(processInstanceId, historyMap.get("room").getProcessInstanceId());
         assertEquals("up", historyMap.get("direction").getValue());
 

--- a/modules/flowable-spring/src/test/java/org/flowable/spring/test/usertask/UserTaskSpringTest.java
+++ b/modules/flowable-spring/src/test/java/org/flowable/spring/test/usertask/UserTaskSpringTest.java
@@ -46,8 +46,8 @@ public class UserTaskSpringTest extends SpringFlowableTestCase {
         assertEquals("startDate", formProperties.get(1).getId());
         assertEquals("vacationMotivation", formProperties.get(2).getId());
 
-        Map<String, String> startProperties = new HashMap<>();
-        startProperties.put("numberOfDays", "10");
+        Map<String, Object> startProperties = new HashMap<>();
+        startProperties.put("numberOfDays", 10);
         startProperties.put("startDate", "02-02-2018 12:00");
         startProperties.put("vacationMotivation", "Badly needed");
         ProcessInstance processInstance = formService.submitStartFormData(processDefinition.getId(), startProperties);
@@ -62,8 +62,8 @@ public class UserTaskSpringTest extends SpringFlowableTestCase {
         assertEquals("vacationApproved", formProperties.get(0).getId());
         assertEquals("managerMotivation", formProperties.get(1).getId());
 
-        Map<String, String> taskProperties = new HashMap<>();
-        taskProperties.put("vacationApproved", "true");
+        Map<String, Object> taskProperties = new HashMap<>();
+        taskProperties.put("vacationApproved", true);
         formService.submitTaskFormData(requestTask.getId(), taskProperties);
 
         assertNull(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).singleResult());

--- a/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/types/JsonType.java
+++ b/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/types/JsonType.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -11,6 +11,8 @@
  * limitations under the License.
  */
 package org.flowable.variable.service.impl.types;
+
+import java.util.LinkedHashMap;
 
 import org.flowable.variable.api.types.ValueFields;
 import org.flowable.variable.api.types.VariableType;
@@ -62,18 +64,20 @@ public class JsonType implements VariableType {
 
     @Override
     public void setValue(Object value, ValueFields valueFields) {
-        valueFields.setTextValue(value != null ? value.toString() : null);
+        valueFields.setTextValue(value != null ? objectMapper.valueToTree(value).toString() : null);
     }
 
     @Override
     public boolean isAbleToStore(Object value) {
-        if (value == null) {
+        if (value == null || value instanceof LinkedHashMap) {
             return true;
         }
+
         if (JsonNode.class.isAssignableFrom(value.getClass())) {
             JsonNode jsonValue = (JsonNode) value;
             return jsonValue.toString().length() <= maxLength;
         }
+
         return false;
     }
 }

--- a/modules/flowable5-compatibility/src/main/java/org/flowable/compatibility/DefaultFlowable5CompatibilityHandler.java
+++ b/modules/flowable5-compatibility/src/main/java/org/flowable/compatibility/DefaultFlowable5CompatibilityHandler.java
@@ -716,10 +716,14 @@ public class DefaultFlowable5CompatibilityHandler implements Flowable5Compatibil
     }
 
     @Override
-    public ProcessInstance submitStartFormData(String processDefinitionId, String businessKey, Map<String, String> properties) {
+    public ProcessInstance submitStartFormData(String processDefinitionId, String businessKey, Map<String, Object> properties) {
         org.activiti.engine.impl.identity.Authentication.setAuthenticatedUserId(Authentication.getAuthenticatedUserId());
+
+        // go back to Map<String, String> for backward compat
+        Map<String, String> compatMap = new HashMap<>();
+        properties.keySet().forEach((e) -> compatMap.put(e, String.valueOf(properties.get(e))));
         try {
-            return new Flowable5ProcessInstanceWrapper(getProcessEngine().getFormService().submitStartFormData(processDefinitionId, businessKey, properties));
+            return new Flowable5ProcessInstanceWrapper(getProcessEngine().getFormService().submitStartFormData(processDefinitionId, businessKey, compatMap));
         } catch (org.activiti.engine.ActivitiException e) {
             handleActivitiException(e);
             return null;


### PR DESCRIPTION
When sending a JSON object to the form-data endpoint /flowable-rest/service/form/form-data:
```sh
curl -H "Content-Type: application/json" --request POST -u rest:rest -d '{ "taskId": "<< TASKID >>", "properties": [{ "id": "test", "value": { "test": true }, "type": "json" }, { "id": "stringtest", "value": "thisstringhere", "type": "string" }, { "id": "boolval", "value": true, "type": "boolean" }] }' http://localhost:8080/flowable-rest/service/form/form-data
```

You get this error:
```json
{
  "message": "Bad request",
  "exception": "JSON parse error: Cannot deserialize instance of `java.lang.String` out of START_OBJECT token; nested exception is com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot deserialize instance of `java.lang.String` out of START_OBJECT token\n at [Source: (PushbackInputStream); line: 1, column: 113] (through reference chain: org.flowable.rest.service.api.form.SubmitFormRequest[\"properties\"]->java.util.ArrayList[0]->org.flowable.rest.service.api.form.RestFormProperty[\"value\"])"
}
```

This PR makes sure the `form-data` endpoint can receive JSON Nodes and that the VariableTypes correctly recognizes the object as JSON Node. Also, as far as I could tell, every variable entered into the form-data got treated as a `String`, so a boolean would have been saved as `"true"`.

### Before
|Name|Type|Value|
|---|---|---|
|aBoolean|String|"true"|
|jsonVal|Serializable|(Binary)|


### After
|Name|Type|Value|
|---|---|---|
|aBoolean|boolean|true|
|jsonVal|json|{"test": true}|