### PR TITLE
async history ordering test fix

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoryServiceTaskLogTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoryServiceTaskLogTest.java
@@ -971,15 +971,13 @@ public class HistoryServiceTaskLogTest {
                 List<HistoricTaskLogEntry> logEntries = historicTaskLogEntryQuery.
                     list();
                 assertThat(logEntries.size()).isEqualTo(3);
-                assertThat(logEntries).extracting(HistoricTaskLogEntry::getTaskId).containsExactly(anotherTask.getId(), task.getId(), task.getId());
-    
+
                 assertThat(
                     historicTaskLogEntryQuery.count()
                 ).isEqualTo(3l);
     
                 List<HistoricTaskLogEntry> pagedLogEntries = historicTaskLogEntryQuery.listPage(1, 1);
                 assertThat(pagedLogEntries.size()).isEqualTo(1);
-                assertThat(pagedLogEntries.get(0)).isEqualToComparingFieldByField(logEntries.get(1));
             }
             
         } finally {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoryServiceTaskLogTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoryServiceTaskLogTest.java
@@ -978,8 +978,8 @@ public class HistoryServiceTaskLogTest {
     
                 List<HistoricTaskLogEntry> pagedLogEntries = historicTaskLogEntryQuery.listPage(1, 1);
                 assertThat(pagedLogEntries.size()).isEqualTo(1);
+                assertThat(pagedLogEntries.get(0).getLogNumber()).isEqualTo(logEntries.get(1).getLogNumber());
             }
-            
         } finally {
             deleteTaskWithLogEntries(taskService, managementService, processEngineConfiguration, anotherTask.getId());
         }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoryServiceTaskLogTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoryServiceTaskLogTest.java
@@ -971,6 +971,9 @@ public class HistoryServiceTaskLogTest {
                 List<HistoricTaskLogEntry> logEntries = historicTaskLogEntryQuery.
                     list();
                 assertThat(logEntries.size()).isEqualTo(3);
+                assertThat(logEntries).extracting(HistoricTaskLogEntry::getLogNumber).containsExactly(
+                    allLogEntries.get(1).getLogNumber(), allLogEntries.get(2).getLogNumber(), allLogEntries.get(3).getLogNumber()
+                );
 
                 assertThat(
                     historicTaskLogEntryQuery.count()


### PR DESCRIPTION
http://qa.flowable.org/job/Flowable6Postgres_AsyncHistory/466/testReport/junit/org.flowable.engine.test.api.history/HistoryServiceTaskLogTest/queryForTaskLogEntriesByLogNumber_TaskService__HistoryService__ManagementService__ProcessEngineConfiguration_/