### PR TITLE
change task form response encoding from iso-8859 to utf-8

### DIFF
--- a/docker/all-in-one/Dockerfile
+++ b/docker/all-in-one/Dockerfile
@@ -3,8 +3,8 @@ ADD wait-for-something.sh .
 
 RUN addgroup tomcat && adduser -s /bin/false -G tomcat -h /opt/tomcat -D tomcat
 
-RUN wget http://www-eu.apache.org/dist/tomcat/tomcat-8/v8.5.34/bin/apache-tomcat-8.5.34.tar.gz -O /tmp/tomcat.tar.gz
-RUN cd /tmp && tar xvfz tomcat.tar.gz && cp -Rv /tmp/apache-tomcat-8.5.34/* /opt/tomcat/ && rm -Rf /tmp/apache-tomcat-8.5.34
+RUN wget http://www-eu.apache.org/dist/tomcat/tomcat-8/v8.5.37/bin/apache-tomcat-8.5.37.tar.gz -O /tmp/tomcat.tar.gz
+RUN cd /tmp && tar xvfz tomcat.tar.gz && cp -Rv /tmp/apache-tomcat-8.5.37/* /opt/tomcat/ && rm -Rf /tmp/apache-tomcat-8.5.37
 
 COPY assets/flowable-idm.war.original /opt/tomcat/webapps/flowable-idm.war
 COPY assets/flowable-modeler.war.original /opt/tomcat/webapps/flowable-modeler.war

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricTaskInstanceResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricTaskInstanceResource.java
@@ -89,7 +89,7 @@ public class HistoricTaskInstanceResource extends HistoricTaskInstanceBaseResour
             @ApiResponse(code = 200, message = "Indicates request was successful and the task form is returned"),
             @ApiResponse(code = 404, message = "Indicates the requested task was not found.")
     })
-    @GetMapping(value = "/history/historic-task-instances/{taskId}/form", produces = "application/json")
+    @GetMapping(value = "/history/historic-task-instances/{taskId}/form", produces = "application/json;charset=UTF-8")
     public String getTaskForm(@ApiParam(name = "taskId") @PathVariable String taskId, HttpServletRequest request) {
         HistoricTaskInstance task = getHistoricTaskInstanceFromRequest(taskId);
         if (StringUtils.isEmpty(task.getFormKey())) {

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/task/TaskResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/task/TaskResource.java
@@ -171,7 +171,7 @@ public class TaskResource extends TaskBaseResource {
             @ApiResponse(code = 200, message = "Indicates request was successful and the task form is returned"),
             @ApiResponse(code = 404, message = "Indicates the requested task was not found.")
     })
-    @GetMapping(value = "/runtime/tasks/{taskId}/form", produces = "application/json")
+    @GetMapping(value = "/runtime/tasks/{taskId}/form", produces = "application/json;charset=UTF-8")
     public String getTaskForm(@ApiParam(name = "taskId") @PathVariable String taskId, HttpServletRequest request) {
         Task task = getTaskFromRequest(taskId);
         if (StringUtils.isEmpty(task.getFormKey())) {


### PR DESCRIPTION
```sh
curl -i --user admin:test 'http://localhost:8080/flowable-task/process-api/history/historic-task-instances/02a5fd98-0f25-11e9-bfd4-0242ac110002/form'
```

![image](https://user-images.githubusercontent.com/4054836/51459175-a1e3c380-1d92-11e9-9e0b-59ffaa017c96.png)

The original code returns with `Content-Type: application/json;charset=ISO-8859-1`, change to utf8.

also tomcat 8.5.34 download link is broken, change to 8.5.37