### PR TITLE
Update MyBatis to version 3.5.0 and MyBatis-Spring to version 2.0.0

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -126,8 +126,8 @@ org.apache.geronimo.bundles     json                        20090211_1      The 
 org.codehaus.groovy             groovy                      2.5.5           The Apache Software License, Version 2.0
 org.codehaus.groovy             groovy-jsr223               2.5.5           The Apache Software License, Version 2.0
 org.liquibase                   liquibase-core              3.6.2           Apache License, Version 2.0
-org.mybatis                     mybatis                     3.4.6           The Apache Software License, Version 2.0
-org.mybatis                     mybatis-spring              1.3.2           The Apache Software License, Version 2.0
+org.mybatis                     mybatis                     3.5.0           The Apache Software License, Version 2.0
+org.mybatis                     mybatis-spring              2.0.0           The Apache Software License, Version 2.0
 org.mvel                        mvel2                       2.2.6.Final     The Apache Software License, Version 2.0
 org.slf4j                       jcl-over-slf4j              1.7.25          MIT License
 org.slf4j                       slf4j-api                   1.7.25          MIT License

--- a/pom.xml
+++ b/pom.xml
@@ -721,12 +721,12 @@
 			<dependency>
 				<groupId>org.mybatis</groupId>
 				<artifactId>mybatis</artifactId>
-				<version>3.4.6</version>
+				<version>3.5.0</version>
 			</dependency>
 			<dependency>
               <groupId>org.mybatis</groupId>
               <artifactId>mybatis-spring</artifactId>
-              <version>1.3.2</version>
+              <version>2.0.0</version>
             </dependency>
             <dependency>
                 <groupId>com.zaxxer</groupId>


### PR DESCRIPTION
MyBatis 3.5.0 release notes: https://github.com/mybatis/mybatis-3/releases/tag/mybatis-3.5.0

MyBatis-Spring 2.0.0 release notes: https://github.com/mybatis/spring/releases/tag/mybatis-spring-2.0.0