### PR TITLE
BUG - NPE when attempting to save a task 

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskServiceTest.java
@@ -1512,6 +1512,14 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().taskId(task.getId()).singleResult();
         assertNull(task.getDueDate());
 
+        // Call saveTask to update due date
+        task = taskService.createTaskQuery().taskId(task.getId()).includeIdentityLinks().singleResult();
+        now = new Date();
+        task.setDueDate(now);
+        taskService.saveTask(task);
+        task = taskService.createTaskQuery().taskId(task.getId()).singleResult();
+        assertEquals(now, task.getDueDate());
+
         taskService.deleteTask(task.getId(), true);
     }
 


### PR DESCRIPTION
We are seeing a NPE when attempting to save a task in the following manner after upgrading to version 6.4.1 from 6.4.0. Attached is a test case to illustrating the NPE.

Task flowableTask = taskService.createTaskQuery().taskId(task.id()).includeIdentityLinks().singleResult();
flowableTask.setDueDate(dueDate);
...
taskService.saveTask(flowableTask);

In stepping through the call path it appears the original persistent state of the task entity has a null value since finding a task using this query does not result in the task entity being stored in the cache (and the original persistent state being populated). The NPE occurs in the TaskEntityManagerImpl.wasPersisted() method as a result of no null check prior to calling getOriginalPersistentState(). Adding a null check resolves the NPE, however it results in either no events being dispatched or too many events being dispatched (in the method TaskEntityManagerImpl.logTaskUpdateEvents()) depending on how the null check is defined. Given this, it's unclear on the best way to resolve this issue.


