### PR TITLE
Fix gather completed flows function's bug : RuntimeDisplayJsonClientResource.java

### DIFF
--- a/modules/flowable-ui-task/flowable-ui-task-rest/src/main/java/org/flowable/ui/task/rest/runtime/RuntimeDisplayJsonClientResource.java
+++ b/modules/flowable-ui-task/flowable-ui-task-rest/src/main/java/org/flowable/ui/task/rest/runtime/RuntimeDisplayJsonClientResource.java
@@ -598,7 +598,7 @@ public class RuntimeDisplayJsonClientResource {
                     List<SequenceFlow> outgoingFlows = ((FlowNode) activity).getOutgoingFlows();
                     for (SequenceFlow flow : outgoingFlows) {
                         String destinationFlowId = flow.getTargetRef();
-                        if (destinationFlowId.equals(activities.get(index + 1))) {
+                        if (activities.contains(destinationFlowId)) {
                             completedFlows.add(flow.getId());
                         }
                     }


### PR DESCRIPTION
If model is using Parallel Gateway and execute, some sequences flow after parallel gateway are missing because of destination flow id check code.
Code just check next activity. I have modified check code that destination flow id is in activity list