### PR TITLE
Update CXF to version 3.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 		<jackson.version>2.9.8</jackson.version>
 		<mule.version>3.8.0</mule.version>
         <camel.version>2.23.0</camel.version>
-		<cxf.version>3.2.7</cxf.version>
+		<cxf.version>3.3.0</cxf.version>
 		<slf4j.version>1.7.25</slf4j.version>
 		<spring.boot.version>2.0.8.RELEASE</spring.boot.version>
 


### PR DESCRIPTION
CXF now works with Java 11, see: https://cxf.apache.org/docs/33-migration-guide.html

If this pull request is merged it should be possible to enable the CXF tests on Java 11 (for https://github.com/flowable/flowable-engine/pull/1249).