### PR TITLE
Update Tomcat server download URL used in Dockerfile of flowable/all-in-one Docker image.

### DIFF
--- a/docker/all-in-one/Dockerfile
+++ b/docker/all-in-one/Dockerfile
@@ -3,7 +3,7 @@ ADD wait-for-something.sh .
 
 RUN addgroup tomcat && adduser -s /bin/false -G tomcat -h /opt/tomcat -D tomcat
 
-RUN wget http://www-eu.apache.org/dist/tomcat/tomcat-8/v8.5.34/bin/apache-tomcat-8.5.34.tar.gz -O /tmp/tomcat.tar.gz
+RUN wget http://archive.apache.org/dist/tomcat/tomcat-8/v8.5.34/bin/apache-tomcat-8.5.34.tar.gz -O /tmp/tomcat.tar.gz
 RUN cd /tmp && tar xvfz tomcat.tar.gz && cp -Rv /tmp/apache-tomcat-8.5.34/* /opt/tomcat/ && rm -Rf /tmp/apache-tomcat-8.5.34
 
 COPY assets/flowable-idm.war.original /opt/tomcat/webapps/flowable-idm.war


### PR DESCRIPTION
Current download URL of Tomcat server used in [`Dockerfile`](https://github.com/flowable/flowable-engine/commit/972ae04a36683e1f55b6d5ff2d114243d6e7cba2#diff-72b672a534ff193a81d25496b5d02d1b) (`flowable/all-in-one` docker image)  returns 404:
http://www-eu.apache.org/dist/tomcat/tomcat-8/v8.5.34/bin/apache-tomcat-8.5.34.tar.gz
 Thus, building the docker image now fails.

Apparently, this Apache mirror site keeps only recent versions. 

The PR updates the download url so that it uses [http://archive.apache.org](http://archive.apache.org) , instead of [http://www-eu.apache.org](http://www-eu.apache.org).  
This should ensure reproducible future builds.