### PR TITLE
Add MS-SQLServer support in flowable docker images

### DIFF
--- a/modules/flowable-app-rest/pom.xml
+++ b/modules/flowable-app-rest/pom.xml
@@ -501,6 +501,12 @@
           <artifactId>postgresql</artifactId>
           <scope>compile</scope>
         </dependency>
+        <dependency>
+          <groupId>com.microsoft.sqlserver</groupId>
+          <artifactId>mssql-jdbc</artifactId>
+          <version>7.0.0.jre8</version>
+          <scope>compile</scope>
+        </dependency>
       </dependencies>
       <build>
         <plugins>

--- a/modules/flowable-ui-admin/flowable-ui-admin-app/pom.xml
+++ b/modules/flowable-ui-admin/flowable-ui-admin-app/pom.xml
@@ -204,6 +204,12 @@
                     <artifactId>postgresql</artifactId>
                     <scope>compile</scope>
                 </dependency>
+                <dependency>
+                    <groupId>com.microsoft.sqlserver</groupId>
+                    <artifactId>mssql-jdbc</artifactId>
+                    <version>7.0.0.jre8</version>
+                    <scope>compile</scope>
+                </dependency>
             </dependencies>
         </profile>
 
@@ -214,6 +220,12 @@
                 <dependency>
                     <groupId>org.postgresql</groupId>
                     <artifactId>postgresql</artifactId>
+                    <scope>compile</scope>
+                </dependency>
+                <dependency>
+                    <groupId>com.microsoft.sqlserver</groupId>
+                    <artifactId>mssql-jdbc</artifactId>
+                    <version>7.0.0.jre8</version>
                     <scope>compile</scope>
                 </dependency>
             </dependencies>

--- a/modules/flowable-ui-idm/flowable-ui-idm-app/pom.xml
+++ b/modules/flowable-ui-idm/flowable-ui-idm-app/pom.xml
@@ -329,6 +329,12 @@
                     <artifactId>postgresql</artifactId>
                     <scope>compile</scope>
                 </dependency>
+                <dependency>
+                    <groupId>com.microsoft.sqlserver</groupId>
+                    <artifactId>mssql-jdbc</artifactId>
+                    <version>7.0.0.jre8</version>
+                    <scope>compile</scope>
+                </dependency>
             </dependencies>
         </profile>
         <!-- docker image build and push -->
@@ -338,6 +344,12 @@
                 <dependency>
                     <groupId>org.postgresql</groupId>
                     <artifactId>postgresql</artifactId>
+                    <scope>compile</scope>
+                </dependency>
+                <dependency>
+                    <groupId>com.microsoft.sqlserver</groupId>
+                    <artifactId>mssql-jdbc</artifactId>
+                    <version>7.0.0.jre8</version>
                     <scope>compile</scope>
                 </dependency>
             </dependencies>

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/pom.xml
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/pom.xml
@@ -363,6 +363,12 @@
                     <artifactId>postgresql</artifactId>
                     <scope>compile</scope>
                 </dependency>
+                <dependency>
+                    <groupId>com.microsoft.sqlserver</groupId>
+                    <artifactId>mssql-jdbc</artifactId>
+                    <version>7.0.0.jre8</version>
+                    <scope>compile</scope>
+                </dependency>
             </dependencies>
         </profile>
         <!-- docker image build and push -->
@@ -372,6 +378,12 @@
                 <dependency>
                     <groupId>org.postgresql</groupId>
                     <artifactId>postgresql</artifactId>
+                    <scope>compile</scope>
+                </dependency>
+                <dependency>
+                    <groupId>com.microsoft.sqlserver</groupId>
+                    <artifactId>mssql-jdbc</artifactId>
+                    <version>7.0.0.jre8</version>
                     <scope>compile</scope>
                 </dependency>
             </dependencies>

--- a/modules/flowable-ui-task/flowable-ui-task-app/pom.xml
+++ b/modules/flowable-ui-task/flowable-ui-task-app/pom.xml
@@ -432,6 +432,12 @@
                     <artifactId>postgresql</artifactId>
                     <scope>compile</scope>
                 </dependency>
+                <dependency>
+                    <groupId>com.microsoft.sqlserver</groupId>
+                    <artifactId>mssql-jdbc</artifactId>
+                    <version>7.0.0.jre8</version>
+                    <scope>compile</scope>
+                </dependency>
             </dependencies>
         </profile>
         <!-- docker image build and push -->
@@ -441,6 +447,12 @@
                 <dependency>
                     <groupId>org.postgresql</groupId>
                     <artifactId>postgresql</artifactId>
+                    <scope>compile</scope>
+                </dependency>
+                <dependency>
+                    <groupId>com.microsoft.sqlserver</groupId>
+                    <artifactId>mssql-jdbc</artifactId>
+                    <version>7.0.0.jre8</version>
                     <scope>compile</scope>
                 </dependency>
             </dependencies>


### PR DESCRIPTION
Currently, when running any docker image and setting `SPRING_DATASOURCE_DRIVER-CLASS-NAME` to `com.microsoft.sqlserver.jdbc.SQLServerDriver`, the app encounters an exception:
```java
.....
.....
java.lang.IllegalStateException: Cannot load driver class: com.microsoft.sqlserver.jdbc.SQLServerDriver
```
This is expected, as only Postgres driver is present in the classpath. 

**This PR** adds SQL Server JDBC driver dependency  to the following modules:
- flowable-ui-admin
- flowable-ui-idm
- flowable-ui-modeler
- flowable-ui-task
- flowable-app-rest

The dependency was added to the build profiles : `docker` and `docker-deps`