### PR TITLE
Expose method to query task log entries

### DIFF
--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/BpmnRestApiInterceptor.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/BpmnRestApiInterceptor.java
@@ -46,6 +46,7 @@ import org.flowable.rest.service.api.history.HistoricActivityInstanceQueryReques
 import org.flowable.rest.service.api.history.HistoricDetailQueryRequest;
 import org.flowable.rest.service.api.history.HistoricProcessInstanceQueryRequest;
 import org.flowable.rest.service.api.history.HistoricTaskInstanceQueryRequest;
+import org.flowable.rest.service.api.history.HistoricTaskLogEntryQueryRequest;
 import org.flowable.rest.service.api.history.HistoricVariableInstanceQueryRequest;
 import org.flowable.rest.service.api.identity.GroupRequest;
 import org.flowable.rest.service.api.identity.UserRequest;
@@ -64,6 +65,7 @@ import org.flowable.task.api.Task;
 import org.flowable.task.api.TaskQuery;
 import org.flowable.task.api.history.HistoricTaskInstance;
 import org.flowable.task.api.history.HistoricTaskInstanceQuery;
+import org.flowable.task.api.history.HistoricTaskLogEntryQuery;
 import org.flowable.variable.api.history.HistoricVariableInstance;
 import org.flowable.variable.api.history.HistoricVariableInstanceQuery;
 
@@ -164,7 +166,9 @@ public interface BpmnRestApiInterceptor {
     void accessHistoryVariableInfoById(HistoricVariableInstance historicVariableInstance);
     
     void accessHistoryVariableInfoWithQuery(HistoricVariableInstanceQuery historicVariableInstanceQuery, HistoricVariableInstanceQueryRequest request);
-    
+
+    void accessHistoricTaskLogWithQuery(HistoricTaskLogEntryQuery historicTaskLogEntryQuery, HistoricTaskLogEntryQueryRequest request);
+
     void accessGroupInfoById(Group group);
     
     void accessGroupInfoWithQuery(GroupQuery groupQuery);

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/RestResponseFactory.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/RestResponseFactory.java
@@ -74,6 +74,7 @@ import org.flowable.rest.service.api.history.HistoricDetailResponse;
 import org.flowable.rest.service.api.history.HistoricIdentityLinkResponse;
 import org.flowable.rest.service.api.history.HistoricProcessInstanceResponse;
 import org.flowable.rest.service.api.history.HistoricTaskInstanceResponse;
+import org.flowable.rest.service.api.history.HistoricTaskLogEntryResponse;
 import org.flowable.rest.service.api.history.HistoricVariableInstanceResponse;
 import org.flowable.rest.service.api.identity.GroupResponse;
 import org.flowable.rest.service.api.identity.MembershipResponse;
@@ -93,6 +94,7 @@ import org.flowable.rest.service.api.runtime.process.ProcessInstanceResponse;
 import org.flowable.rest.service.api.runtime.task.TaskResponse;
 import org.flowable.task.api.Task;
 import org.flowable.task.api.history.HistoricTaskInstance;
+import org.flowable.task.api.history.HistoricTaskLogEntry;
 import org.flowable.variable.api.history.HistoricVariableInstance;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -837,6 +839,34 @@ public class RestResponseFactory {
             }
         }
         return result;
+    }
+
+    public List<HistoricTaskLogEntryResponse> createHistoricTaskLogEntryResponseList(List<HistoricTaskLogEntry> logEntries) {
+        RestUrlBuilder urlBuilder = createUrlBuilder();
+        List<HistoricTaskLogEntryResponse> responseList = new ArrayList<>();
+        for (HistoricTaskLogEntry instance : logEntries) {
+            responseList.add(createHistoricTaskLogEntryResponse(instance, urlBuilder));
+        }
+        return responseList;
+    }
+
+    public HistoricTaskLogEntryResponse createHistoricTaskLogEntryResponse(HistoricTaskLogEntry logEntry, RestUrlBuilder urlBuilder) {
+        HistoricTaskLogEntryResponse response = new HistoricTaskLogEntryResponse();
+        response.setLogNumber(logEntry.getLogNumber());
+        response.setType(logEntry.getType());
+        response.setTaskId(logEntry.getTaskId());
+        response.setTimeStamp(logEntry.getTimeStamp());
+        response.setUserId(logEntry.getUserId());
+        response.setData(logEntry.getData());
+        response.setExecutionId(logEntry.getExecutionId());
+        response.setProcessInstanceId(logEntry.getProcessInstanceId());
+        response.setProcessDefinitionId(logEntry.getProcessDefinitionId());
+        response.setScopeId(logEntry.getScopeId());
+        response.setScopeDefinitionId(logEntry.getScopeDefinitionId());
+        response.setSubScopeId(logEntry.getSubScopeId());
+        response.setScopeType(logEntry.getScopeType());
+        response.setTenantId(logEntry.getTenantId());
+        return response;
     }
 
     public List<HistoricActivityInstanceResponse> createHistoricActivityInstanceResponseList(List<HistoricActivityInstance> activityInstances) {

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/RestUrls.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/RestUrls.java
@@ -57,6 +57,7 @@ public final class RestUrls {
     public static final String SEGMENT_HISTORIC_TASK_INSTANCE_RESOURCE = "historic-task-instances";
     public static final String SEGMENT_HISTORIC_ACTIVITY_INSTANCE_RESOURCE = "historic-activity-instances";
     public static final String SEGMENT_HISTORIC_VARIABLE_INSTANCE_RESOURCE = "historic-variable-instances";
+    public static final String SEGMENT_HISTORIC_TASK_LOG_ENTRIES = "historic-task-log-entries";
     public static final String SEGMENT_HISTORIC_DETAIL_RESOURCE = "historic-detail";
     public static final String SEGMENT_FORM_DATA = "form-data";
     public static final String SEGMENT_TABLES = "tables";
@@ -402,7 +403,12 @@ public final class RestUrls {
      * URL template for a historic task instance form: <i>history/historic-task-instances/{0:taskId}/form</i>
      */
     public static final String[] URL_HISTORIC_TASK_INSTANCE_FORM = { SEGMENT_HISTORY_RESOURCES, SEGMENT_HISTORIC_TASK_INSTANCE_RESOURCE, "{0}", SEGMENT_FORM };
-    
+
+    /**
+     * URL template for a historic task log entries form: <i>history/historic-task-log-entries</i>
+     */
+    public static final String[] URL_HISTORIC_TASK_LOG_ENTRIES = { SEGMENT_HISTORY_RESOURCES, SEGMENT_HISTORIC_TASK_LOG_ENTRIES };
+
     /**
      * URL template for historic activity instance query: <i>history/historic-activity-instances</i>
      */

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricTaskLogCollectionResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricTaskLogCollectionResource.java
@@ -13,19 +13,10 @@
 
 package org.flowable.rest.service.api.history;
 
-import static org.flowable.common.rest.api.PaginateListUtil.paginateList;
-
-import java.util.HashMap;
 import java.util.Map;
 
-import org.flowable.common.engine.api.query.QueryProperty;
 import org.flowable.common.rest.api.DataResponse;
 import org.flowable.common.rest.api.RequestUtil;
-import org.flowable.engine.HistoryService;
-import org.flowable.rest.service.api.RestResponseFactory;
-import org.flowable.task.api.history.HistoricTaskLogEntryQuery;
-import org.flowable.task.service.impl.HistoricTaskLogEntryQueryProperty;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -44,20 +35,7 @@ import io.swagger.annotations.Authorization;
  */
 @RestController
 @Api(tags = { "Historic Task Log Entries" }, description = "Manage Historic Task Log Entries", authorizations = { @Authorization(value = "basicAuth") })
-public class HistoricTaskLogCollectionResource {
-
-    private static Map<String, QueryProperty> allowedSortProperties = new HashMap<>();
-
-    static {
-        allowedSortProperties.put("logNumber", HistoricTaskLogEntryQueryProperty.LOG_NUMBER);
-        allowedSortProperties.put("timeStamp", HistoricTaskLogEntryQueryProperty.TIME_STAMP);
-    }
-
-    @Autowired
-    protected RestResponseFactory restResponseFactory;
-
-    @Autowired
-    protected HistoryService historyService;
+public class HistoricTaskLogCollectionResource extends HistoricTaskLogEntryBaseResource {
 
     @ApiOperation(value = "List historic task log entries", tags = { "History Task" }, nickname = "getHistoricTaskLogEntries")
     @ApiImplicitParams({
@@ -81,64 +59,64 @@ public class HistoricTaskLogCollectionResource {
         @ApiResponse(code = 404, message = "Indicates an parameter was passed in the wrong format. The status-message contains additional information.") })
     @GetMapping(value = "/history/historic-task-log-entries", produces = "application/json")
     public DataResponse<HistoricTaskLogEntryResponse> getHistoricTaskLogEntries(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams) {
-        HistoricTaskLogEntryQuery query = this.historyService.createHistoricTaskLogEntryQuery();
+        HistoricTaskLogEntryQueryRequest request = new HistoricTaskLogEntryQueryRequest();
 
         if (allRequestParams.containsKey("taskId")) {
-            query.taskId(allRequestParams.get("taskId"));
+            request.setTaskId(allRequestParams.get("taskId"));
         }
 
         if (allRequestParams.containsKey("type")) {
-            query.type(allRequestParams.get("type"));
+            request.setType(allRequestParams.get("type"));
         }
 
         if (allRequestParams.containsKey("userId")) {
-            query.userId(allRequestParams.get("userId"));
+            request.setUserId(allRequestParams.get("userId"));
         }
 
         if (allRequestParams.containsKey("processInstanceId")) {
-            query.processInstanceId(allRequestParams.get("processInstanceId"));
+            request.setProcessInstanceId(allRequestParams.get("processInstanceId"));
         }
 
         if (allRequestParams.containsKey("processDefinitionId")) {
-            query.processDefinitionId(allRequestParams.get("processDefinitionId"));
+            request.setProcessDefinitionId(allRequestParams.get("processDefinitionId"));
         }
 
         if (allRequestParams.containsKey("scopeId")) {
-            query.scopeId(allRequestParams.get("scopeId"));
+            request.setScopeId(allRequestParams.get("scopeId"));
         }
 
         if (allRequestParams.containsKey("scopeDefinitionId")) {
-            query.scopeDefinitionId(allRequestParams.get("scopeDefinitionId"));
+            request.setScopeDefinitionId(allRequestParams.get("scopeDefinitionId"));
         }
 
         if (allRequestParams.containsKey("subScopeId")) {
-            query.subScopeId(allRequestParams.get("subScopeId"));
+            request.setSubScopeId(allRequestParams.get("subScopeId"));
         }
 
         if (allRequestParams.containsKey("scopeType")) {
-            query.scopeType(allRequestParams.get("scopeType"));
+            request.setScopeType(allRequestParams.get("scopeType"));
         }
 
         if (allRequestParams.containsKey("from")) {
-            query.from(RequestUtil.getDate(allRequestParams, "from"));
+            request.setFrom(RequestUtil.getDate(allRequestParams, "from"));
         }
 
         if (allRequestParams.containsKey("to")) {
-            query.to(RequestUtil.getDate(allRequestParams, "to"));
+            request.setTo(RequestUtil.getDate(allRequestParams, "to"));
         }
 
         if (allRequestParams.containsKey("tenantId")) {
-            query.tenantId(allRequestParams.get("tenantId"));
+            request.setTenantId(allRequestParams.get("tenantId"));
         }
 
         if (allRequestParams.containsKey("fromLogNumber")) {
-            query.fromLogNumber(Long.parseLong(allRequestParams.get("fromLogNumber")));
+            request.setFromLogNumber(Long.parseLong(allRequestParams.get("fromLogNumber")));
         }
 
         if (allRequestParams.containsKey("toLogNumber")) {
-            query.toLogNumber(Long.parseLong(allRequestParams.get("toLogNumber")));
+            request.setToLogNumber(Long.parseLong(allRequestParams.get("toLogNumber")));
         }
 
-        return paginateList(allRequestParams, query, "logNumber", allowedSortProperties, restResponseFactory::createHistoricTaskLogEntryResponseList);
+        return getQueryResponse(request, allRequestParams);
     }
 }

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricTaskLogCollectionResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricTaskLogCollectionResource.java
@@ -1,0 +1,144 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.flowable.rest.service.api.history;
+
+import static org.flowable.common.rest.api.PaginateListUtil.paginateList;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.flowable.common.engine.api.query.QueryProperty;
+import org.flowable.common.rest.api.DataResponse;
+import org.flowable.common.rest.api.RequestUtil;
+import org.flowable.engine.HistoryService;
+import org.flowable.rest.service.api.RestResponseFactory;
+import org.flowable.task.api.history.HistoricTaskLogEntryQuery;
+import org.flowable.task.service.impl.HistoricTaskLogEntryQueryProperty;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+
+/**
+ * @author Luis Belloch
+ */
+@RestController
+@Api(tags = { "Historic Task Log Entries" }, description = "Manage Historic Task Log Entries", authorizations = { @Authorization(value = "basicAuth") })
+public class HistoricTaskLogCollectionResource {
+
+    private static Map<String, QueryProperty> allowedSortProperties = new HashMap<>();
+
+    static {
+        allowedSortProperties.put("logNumber", HistoricTaskLogEntryQueryProperty.LOG_NUMBER);
+        allowedSortProperties.put("timeStamp", HistoricTaskLogEntryQueryProperty.TIME_STAMP);
+    }
+
+    @Autowired
+    protected RestResponseFactory restResponseFactory;
+
+    @Autowired
+    protected HistoryService historyService;
+
+    @ApiOperation(value = "List historic task log entries", tags = { "History Task" }, nickname = "getHistoricTaskLogEntries")
+    @ApiImplicitParams({
+        @ApiImplicitParam(name = "taskId", dataType = "string", value = "An id of the historic task instance.", paramType = "query"),
+        @ApiImplicitParam(name = "type", dataType = "string", value = "The type of the log entry.", paramType = "query"),
+        @ApiImplicitParam(name = "userId", dataType = "string", value = "The user who produced the task change.", paramType = "query"),
+        @ApiImplicitParam(name = "processInstanceId", dataType = "string", value = "The process instance id of the historic task log entry.", paramType = "query"),
+        @ApiImplicitParam(name = "processDefinitionId", dataType = "string", value = "The process definition id of the historic task log entry.", paramType = "query"),
+        @ApiImplicitParam(name = "scopeId", dataType = "string", value = "Only return historic task log entries with the given scopeId.", paramType = "query"),
+        @ApiImplicitParam(name = "scopeDefinitionId", dataType = "string", value = "Only return historic task log entries with the given scopeDefinitionId.", paramType = "query"),
+        @ApiImplicitParam(name = "subScopeId", dataType = "string", value = "Only return historic task log entries with the given subScopeId", paramType = "query"),
+        @ApiImplicitParam(name = "scopeType", dataType = "string", value = "Only return historic task log entries with the given scopeType.", paramType = "query"),
+        @ApiImplicitParam(name = "from", dataType = "string", format = "date-time", value = "Return task log entries starting from a date.", paramType = "query"),
+        @ApiImplicitParam(name = "to", dataType = "string", format = "date-time", value = "Return task log entries up to a date.", paramType = "query"),
+        @ApiImplicitParam(name = "tenantId", dataType = "string", value = "Only return historic task log entries with the given tenantId.", paramType = "query"),
+        @ApiImplicitParam(name = "fromLogNumber", dataType = "string", value = "Return task log entries starting from a log number", paramType = "query"),
+        @ApiImplicitParam(name = "toLogNumber", dataType = "string", value = "Return task log entries up to specific a log number", paramType = "query"),
+    })
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "Indicates that historic task log entries could be queried."),
+        @ApiResponse(code = 404, message = "Indicates an parameter was passed in the wrong format. The status-message contains additional information.") })
+    @GetMapping(value = "/history/historic-task-log-entries", produces = "application/json")
+    public DataResponse<HistoricTaskLogEntryResponse> getHistoricTaskLogEntries(@ApiParam(hidden = true) @RequestParam Map<String, String> allRequestParams) {
+        HistoricTaskLogEntryQuery query = this.historyService.createHistoricTaskLogEntryQuery();
+
+        if (allRequestParams.containsKey("taskId")) {
+            query.taskId(allRequestParams.get("taskId"));
+        }
+
+        if (allRequestParams.containsKey("type")) {
+            query.type(allRequestParams.get("type"));
+        }
+
+        if (allRequestParams.containsKey("userId")) {
+            query.userId(allRequestParams.get("userId"));
+        }
+
+        if (allRequestParams.containsKey("processInstanceId")) {
+            query.processInstanceId(allRequestParams.get("processInstanceId"));
+        }
+
+        if (allRequestParams.containsKey("processDefinitionId")) {
+            query.processDefinitionId(allRequestParams.get("processDefinitionId"));
+        }
+
+        if (allRequestParams.containsKey("scopeId")) {
+            query.scopeId(allRequestParams.get("scopeId"));
+        }
+
+        if (allRequestParams.containsKey("scopeDefinitionId")) {
+            query.scopeDefinitionId(allRequestParams.get("scopeDefinitionId"));
+        }
+
+        if (allRequestParams.containsKey("subScopeId")) {
+            query.subScopeId(allRequestParams.get("subScopeId"));
+        }
+
+        if (allRequestParams.containsKey("scopeType")) {
+            query.scopeType(allRequestParams.get("scopeType"));
+        }
+
+        if (allRequestParams.containsKey("from")) {
+            query.from(RequestUtil.getDate(allRequestParams, "from"));
+        }
+
+        if (allRequestParams.containsKey("to")) {
+            query.to(RequestUtil.getDate(allRequestParams, "to"));
+        }
+
+        if (allRequestParams.containsKey("tenantId")) {
+            query.tenantId(allRequestParams.get("tenantId"));
+        }
+
+        if (allRequestParams.containsKey("fromLogNumber")) {
+            query.fromLogNumber(Long.parseLong(allRequestParams.get("fromLogNumber")));
+        }
+
+        if (allRequestParams.containsKey("toLogNumber")) {
+            query.toLogNumber(Long.parseLong(allRequestParams.get("toLogNumber")));
+        }
+
+        return paginateList(allRequestParams, query, "logNumber", allowedSortProperties, restResponseFactory::createHistoricTaskLogEntryResponseList);
+    }
+}

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricTaskLogEntryBaseResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricTaskLogEntryBaseResource.java
@@ -1,0 +1,118 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.flowable.rest.service.api.history;
+
+import static org.flowable.common.rest.api.PaginateListUtil.paginateList;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.flowable.common.engine.api.query.QueryProperty;
+import org.flowable.common.rest.api.DataResponse;
+import org.flowable.common.rest.api.RequestUtil;
+import org.flowable.engine.HistoryService;
+import org.flowable.rest.service.api.BpmnRestApiInterceptor;
+import org.flowable.rest.service.api.RestResponseFactory;
+import org.flowable.task.api.history.HistoricTaskLogEntryQuery;
+import org.flowable.task.service.impl.HistoricTaskLogEntryQueryProperty;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * @author Luis Belloch
+ */
+public class HistoricTaskLogEntryBaseResource {
+
+    private static Map<String, QueryProperty> allowedSortProperties = new HashMap<>();
+
+    static {
+        allowedSortProperties.put("logNumber", HistoricTaskLogEntryQueryProperty.LOG_NUMBER);
+        allowedSortProperties.put("timeStamp", HistoricTaskLogEntryQueryProperty.TIME_STAMP);
+    }
+
+    @Autowired
+    protected RestResponseFactory restResponseFactory;
+
+    @Autowired
+    protected HistoryService historyService;
+
+    @Autowired(required = false)
+    protected BpmnRestApiInterceptor restApiInterceptor;
+
+    protected DataResponse<HistoricTaskLogEntryResponse> getQueryResponse(HistoricTaskLogEntryQueryRequest request, Map<String, String> allRequestParams) {
+        HistoricTaskLogEntryQuery query = this.historyService.createHistoricTaskLogEntryQuery();
+
+        if (request.getTaskId() != null) {
+            query.taskId(allRequestParams.get("taskId"));
+        }
+
+        if (request.getType() != null) {
+            query.type(allRequestParams.get("type"));
+        }
+
+        if (request.getUserId() != null) {
+            query.userId(allRequestParams.get("userId"));
+        }
+
+        if (request.getProcessInstanceId() != null) {
+            query.processInstanceId(allRequestParams.get("processInstanceId"));
+        }
+
+        if (request.getProcessDefinitionId() != null) {
+            query.processDefinitionId(allRequestParams.get("processDefinitionId"));
+        }
+
+        if (request.getScopeId() != null) {
+            query.scopeId(allRequestParams.get("scopeId"));
+        }
+
+        if (request.getScopeDefinitionId() != null) {
+            query.scopeDefinitionId(allRequestParams.get("scopeDefinitionId"));
+        }
+
+        if (request.getSubScopeId() != null) {
+            query.subScopeId(allRequestParams.get("subScopeId"));
+        }
+
+        if (request.getScopeType() != null) {
+            query.scopeType(allRequestParams.get("scopeType"));
+        }
+
+        if (request.getFrom() != null) {
+            query.from(RequestUtil.getDate(allRequestParams, "from"));
+        }
+
+        if (request.getTo() != null) {
+            query.to(RequestUtil.getDate(allRequestParams, "to"));
+        }
+
+        if (request.getTenantId() != null) {
+            query.tenantId(allRequestParams.get("tenantId"));
+        }
+
+        if (request.getFromLogNumber() != null) {
+            query.fromLogNumber(Long.parseLong(allRequestParams.get("fromLogNumber")));
+        }
+
+        if (request.getToLogNumber() != null) {
+            query.toLogNumber(Long.parseLong(allRequestParams.get("toLogNumber")));
+        }
+
+        if (restApiInterceptor != null) {
+            restApiInterceptor.accessHistoricTaskLogWithQuery(query, request);
+        }
+
+        return paginateList(allRequestParams, query, "logNumber", allowedSortProperties, restResponseFactory::createHistoricTaskLogEntryResponseList);
+    }
+}
+

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricTaskLogEntryQueryRequest.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricTaskLogEntryQueryRequest.java
@@ -1,0 +1,138 @@
+package org.flowable.rest.service.api.history;
+
+import java.util.Date;
+
+import org.flowable.common.rest.api.PaginateRequest;
+
+/**
+ * @author Luis Belloch
+ */
+public class HistoricTaskLogEntryQueryRequest extends PaginateRequest {
+
+    protected String taskId;
+    protected String type;
+    protected String userId;
+    protected String processInstanceId;
+    protected String processDefinitionId;
+    protected String scopeId;
+    protected String scopeDefinitionId;
+    protected String subScopeId;
+    protected String scopeType;
+    protected Date from;
+    protected Date to;
+    protected String tenantId;
+    protected Long fromLogNumber;
+    protected Long toLogNumber;
+
+    public String getTaskId() {
+        return taskId;
+    }
+
+    public void setTaskId(String taskId) {
+        this.taskId = taskId;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public String getProcessInstanceId() {
+        return processInstanceId;
+    }
+
+    public void setProcessInstanceId(String processInstanceId) {
+        this.processInstanceId = processInstanceId;
+    }
+
+    public String getProcessDefinitionId() {
+        return processDefinitionId;
+    }
+
+    public void setProcessDefinitionId(String processDefinitionId) {
+        this.processDefinitionId = processDefinitionId;
+    }
+
+    public String getScopeId() {
+        return scopeId;
+    }
+
+    public void setScopeId(String scopeId) {
+        this.scopeId = scopeId;
+    }
+
+    public String getScopeDefinitionId() {
+        return scopeDefinitionId;
+    }
+
+    public void setScopeDefinitionId(String scopeDefinitionId) {
+        this.scopeDefinitionId = scopeDefinitionId;
+    }
+
+    public String getSubScopeId() {
+        return subScopeId;
+    }
+
+    public void setSubScopeId(String subScopeId) {
+        this.subScopeId = subScopeId;
+    }
+
+    public String getScopeType() {
+        return scopeType;
+    }
+
+    public void setScopeType(String scopeType) {
+        this.scopeType = scopeType;
+    }
+
+    public Date getFrom() {
+        return from;
+    }
+
+    public void setFrom(Date from) {
+        this.from = from;
+    }
+
+    public Date getTo() {
+        return to;
+    }
+
+    public void setTo(Date to) {
+        this.to = to;
+    }
+
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    public void setTenantId(String tenantId) {
+        this.tenantId = tenantId;
+    }
+
+    public Long getFromLogNumber() {
+        return fromLogNumber;
+    }
+
+    public void setFromLogNumber(Long fromLogNumber) {
+        this.fromLogNumber = fromLogNumber;
+    }
+
+    public Long getToLogNumber() {
+        return toLogNumber;
+    }
+
+    public void setToLogNumber(Long toLogNumber) {
+        this.toLogNumber = toLogNumber;
+    }
+}

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricTaskLogEntryResponse.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricTaskLogEntryResponse.java
@@ -1,0 +1,154 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.flowable.rest.service.api.history;
+
+import java.util.Date;
+
+import org.flowable.common.rest.util.DateToStringSerializer;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+/**
+ * @author Luis Belloch
+ */
+public class HistoricTaskLogEntryResponse {
+
+    protected Long logNumber;
+    protected String type;
+    protected String taskId;
+    @JsonSerialize(using = DateToStringSerializer.class, as = Date.class)
+    protected Date timeStamp;
+    protected String userId;
+    protected String data;
+    protected String executionId;
+    protected String processInstanceId;
+    protected String processDefinitionId;
+    protected String scopeId;
+    protected String scopeDefinitionId;
+    protected String subScopeId;
+    protected String scopeType;
+    protected String tenantId;
+
+    public Long getLogNumber() {
+        return logNumber;
+    }
+
+    public void setLogNumber(Long logNumber) {
+        this.logNumber = logNumber;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getTaskId() {
+        return taskId;
+    }
+
+    public void setTaskId(String taskId) {
+        this.taskId = taskId;
+    }
+
+    public Date getTimeStamp() {
+        return timeStamp;
+    }
+
+    public void setTimeStamp(Date timeStamp) {
+        this.timeStamp = timeStamp;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public String getData() {
+        return data;
+    }
+
+    public void setData(String data) {
+        this.data = data;
+    }
+
+    public String getExecutionId() {
+        return executionId;
+    }
+
+    public void setExecutionId(String executionId) {
+        this.executionId = executionId;
+    }
+
+    public String getProcessInstanceId() {
+        return processInstanceId;
+    }
+
+    public void setProcessInstanceId(String processInstanceId) {
+        this.processInstanceId = processInstanceId;
+    }
+
+    public String getProcessDefinitionId() {
+        return processDefinitionId;
+    }
+
+    public void setProcessDefinitionId(String processDefinitionId) {
+        this.processDefinitionId = processDefinitionId;
+    }
+
+    public String getScopeId() {
+        return scopeId;
+    }
+
+    public void setScopeId(String scopeId) {
+        this.scopeId = scopeId;
+    }
+
+    public String getScopeDefinitionId() {
+        return scopeDefinitionId;
+    }
+
+    public void setScopeDefinitionId(String scopeDefinitionId) {
+        this.scopeDefinitionId = scopeDefinitionId;
+    }
+
+    public String getSubScopeId() {
+        return subScopeId;
+    }
+
+    public void setSubScopeId(String subScopeId) {
+        this.subScopeId = subScopeId;
+    }
+
+    public String getScopeType() {
+        return scopeType;
+    }
+
+    public void setScopeType(String scopeType) {
+        this.scopeType = scopeType;
+    }
+
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    public void setTenantId(String tenantId) {
+        this.tenantId = tenantId;
+    }
+}

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/conf/ApplicationConfiguration.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/conf/ApplicationConfiguration.java
@@ -12,11 +12,14 @@
  */
 package org.flowable.rest.conf;
 
+import org.flowable.rest.conf.engine.EngineConfiguration;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 
 @Configuration
-@ComponentScan(basePackages = { "org.flowable.rest.conf.common", "org.flowable.rest.conf.engine" })
+@ComponentScan(basePackages = { "org.flowable.rest.conf.common" })
+@Import(EngineConfiguration.class)
 public class ApplicationConfiguration {
 
 }

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/conf/ApplicationWithTaskLogging.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/conf/ApplicationWithTaskLogging.java
@@ -1,3 +1,16 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.flowable.rest.conf;
 
 import org.flowable.rest.conf.engine.EngineConfigurationWithTaskLogging;

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/conf/ApplicationWithTaskLogging.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/conf/ApplicationWithTaskLogging.java
@@ -1,0 +1,13 @@
+package org.flowable.rest.conf;
+
+import org.flowable.rest.conf.engine.EngineConfigurationWithTaskLogging;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+@Configuration
+@ComponentScan(basePackages = { "org.flowable.rest.conf.common" })
+@Import(EngineConfigurationWithTaskLogging.class)
+public class ApplicationWithTaskLogging {
+
+}

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/conf/engine/EngineConfigurationWithTaskLogging.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/conf/engine/EngineConfigurationWithTaskLogging.java
@@ -1,0 +1,15 @@
+package org.flowable.rest.conf.engine;
+
+import org.flowable.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class EngineConfigurationWithTaskLogging extends EngineConfiguration {
+
+    @Override
+    public ProcessEngineConfigurationImpl processEngineConfiguration() {
+        ProcessEngineConfigurationImpl configuration = super.processEngineConfiguration();
+        configuration.setEnableHistoricTaskLogging(true);
+        return configuration;
+    }
+}

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/conf/engine/EngineConfigurationWithTaskLogging.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/conf/engine/EngineConfigurationWithTaskLogging.java
@@ -1,3 +1,16 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.flowable.rest.conf.engine;
 
 import org.flowable.engine.impl.cfg.ProcessEngineConfigurationImpl;

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/history/HistoricTaskLogCollectionResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/history/HistoricTaskLogCollectionResourceTest.java
@@ -1,0 +1,144 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.flowable.rest.service.api.history;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.Calendar;
+import java.util.List;
+
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.flowable.engine.runtime.ProcessInstance;
+import org.flowable.engine.test.Deployment;
+import org.flowable.rest.conf.ApplicationWithTaskLogging;
+import org.flowable.rest.service.BaseSpringRestTestCase;
+import org.flowable.rest.service.api.RestUrls;
+import org.flowable.task.api.Task;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * @author Luis Belloch
+ */
+public class HistoricTaskLogCollectionResourceTest extends BaseSpringRestTestCase {
+
+    @Override
+    protected Class<?> getConfigurationClass() {
+        return ApplicationWithTaskLogging.class;
+    }
+
+    @Test
+    @Deployment(resources = { "org/flowable/rest/api/history/HistoricTaskLogCollectionResourceTest.bpmn20.xml" })
+    public void itCanQueryByTaskId() throws Exception {
+        Calendar startTime = Calendar.getInstance();
+        ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("oneTaskProcess", "testBusinessKey");
+
+        Task task1 = taskService.createTaskQuery().processInstanceId(processInstance1.getId()).singleResult();
+        taskService.setVariableLocal(task1.getId(), "local", "foo");
+        taskService.setOwner(task1.getId(), "test");
+        taskService.setDueDate(task1.getId(), startTime.getTime());
+
+        ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("oneTaskProcess", "testBusinessKey");
+        Task task2 = taskService.createTaskQuery().processInstanceId(processInstance2.getId()).singleResult();
+        taskService.setOwner(task2.getId(), "test");
+
+        JsonNode list = queryTaskLogEntries("?taskId=" + encode(task1.getId()) + "&sort=logNumber&order=asc");
+        expectSequence(list,
+            asList(task1.getId(), task1.getId(), task1.getId()),
+            asList("USER_TASK_CREATED", "USER_TASK_OWNER_CHANGED", "USER_TASK_DUEDATE_CHANGED"));
+    }
+
+    @Test
+    @Deployment(resources = { "org/flowable/rest/api/history/HistoricTaskLogCollectionResourceTest.bpmn20.xml" })
+    public void whenTaskIdDoesNotExistItReturnsEmptyList() throws Exception {
+        JsonNode list = queryTaskLogEntries("?taskId=FOOBAR_4242");
+        assertEquals(0, list.size());
+    }
+
+    @Test
+    @Deployment(resources = { "org/flowable/rest/api/history/HistoricTaskLogCollectionResourceTest.bpmn20.xml" })
+    public void itCanQueryByProcessInstanceId() throws Exception {
+        ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("oneTaskProcess", "testBusinessKey");
+        Task task1 = taskService.createTaskQuery().processInstanceId(processInstance1.getId()).singleResult();
+        taskService.complete(task1.getId());
+        Task task2 = taskService.createTaskQuery().processInstanceId(processInstance1.getId()).singleResult();
+
+        ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("oneTaskProcess", "testBusinessKey");
+        Task task3 = taskService.createTaskQuery().processInstanceId(processInstance2.getId()).singleResult();
+
+        JsonNode list1 = queryTaskLogEntries("?processInstanceId=" + encode(processInstance1.getId()) + "&sort=logNumber&order=asc");
+        expectSequence(list1, asList(task1.getId(), task1.getId(), task2.getId()), asList("USER_TASK_CREATED", "USER_TASK_COMPLETED", "USER_TASK_CREATED"));
+
+        JsonNode list2 = queryTaskLogEntries("?processInstanceId=" + encode(processInstance2.getId()) + "&sort=logNumber&order=asc");
+        expectSequence(list2, asList(task3.getId()), asList("USER_TASK_CREATED"));
+    }
+
+    @Test
+    @Deployment(resources = { "org/flowable/rest/api/history/HistoricTaskLogCollectionResourceTest.bpmn20.xml" })
+    public void itCanQueryUsingFromToDates() throws IOException {
+        Calendar startTime = Calendar.getInstance();
+        processEngineConfiguration.getClock().setCurrentTime(startTime.getTime());
+
+        ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("oneTaskProcess", "testBusinessKey");
+
+        Task task1 = taskService.createTaskQuery().processInstanceId(processInstance1.getId()).singleResult();
+        taskService.setDueDate(task1.getId(), startTime.getTime());
+
+        ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("oneTaskProcess", "testBusinessKey");
+        Task task2 = taskService.createTaskQuery().processInstanceId(processInstance2.getId()).singleResult();
+        taskService.setOwner(task2.getId(), "test");
+
+        startTime.add(Calendar.DAY_OF_YEAR, 2);
+        processEngineConfiguration.getClock().setCurrentTime(startTime.getTime());
+
+        taskService.setOwner(task1.getId(), "test");
+
+        processEngineConfiguration.getClock().reset();
+
+        JsonNode listAfter = queryTaskLogEntries("?taskId=" + encode(task1.getId()) + "&sort=logNumber&order=asc&from=" + dateFormat.format(startTime.getTime()));
+        expectSequence(listAfter,
+            asList(task1.getId()),
+            asList("USER_TASK_OWNER_CHANGED"));
+
+        startTime.add(Calendar.DAY_OF_YEAR, -1);
+        JsonNode listBefore = queryTaskLogEntries("?taskId=" + encode(task1.getId()) + "&sort=logNumber&order=asc&to=" + dateFormat.format(startTime.getTime()));
+        expectSequence(listBefore,
+            asList(task1.getId(), task1.getId()),
+            asList("USER_TASK_CREATED", "USER_TASK_DUEDATE_CHANGED"));
+    }
+
+    protected JsonNode queryTaskLogEntries(String queryString) throws IOException {
+        String url = RestUrls.createRelativeResourceUrl(RestUrls.URL_HISTORIC_TASK_LOG_ENTRIES) + queryString;
+        CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + url), HttpStatus.SC_OK);
+        JsonNode rootNode = objectMapper.readTree(response.getEntity().getContent());
+        assertTrue(rootNode.has("data"));
+        return rootNode.get("data");
+    }
+
+    protected void expectSequence(JsonNode list, List<String> ids, List<String> types) {
+        assertEquals(ids.size(), list.size());
+        List<String> resultingIds = list.findValuesAsText("taskId");
+        assertThat(resultingIds, is(ids));
+        List<String> resultingTypes = list.findValuesAsText("type");
+        assertThat(resultingTypes, is(types));
+    }
+}

--- a/modules/flowable-rest/src/test/resources/org/flowable/rest/api/history/HistoricTaskLogCollectionResourceTest.bpmn20.xml
+++ b/modules/flowable-rest/src/test/resources/org/flowable/rest/api/history/HistoricTaskLogCollectionResourceTest.bpmn20.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:activiti="http://activiti.org/bpmn"
+  targetNamespace="OneTaskCategory">
+
+  <process id="oneTaskProcess" name="The One Task Process">
+    <documentation>One task process description</documentation>
+  
+    <startEvent id="theStart" />
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="processTask" />
+    <userTask id="processTask" name="Process task" activiti:assignee="kermit">
+       <documentation>Process task description</documentation>
+    </userTask>
+    <sequenceFlow id="flow2" sourceRef="processTask" targetRef="processTask2" />
+    <userTask id="processTask2" name="Process task 2" activiti:assignee="fozzie">
+       <documentation>Process task description</documentation>
+    </userTask>    
+    <sequenceFlow id="flow3" sourceRef="processTask2" targetRef="theEnd" />
+    <endEvent id="theEnd" />
+    
+  </process>
+
+</definitions>


### PR DESCRIPTION
- Added resource to hold REST query method at `/history/historic-task-log-entries`
- Modified test configuration to allow enabling task history logging