### PR TITLE
Config to remove LGTM alerts from library code

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,0 +1,3 @@
+path_classifiers:
+  library:
+    - "**/src/main/resources/static/libs/"


### PR DESCRIPTION
Here is an [LGTM](https://lgtm.com/projects/g/flowable/flowable-engine/overview/) config which classifies anything under `**/src/main/resources/static/libs/` as library code. This should remove about 400 alerts.

@jbarrez This is as we discussed. I'm happy to add more paths as needed, if you feel there are more alerts coming from library code. Let me know.