### PR TITLE
Added database backed content storage to content engine.

### DIFF
--- a/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/ContentEngineConfiguration.java
+++ b/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/ContentEngineConfiguration.java
@@ -48,6 +48,8 @@ import org.flowable.content.engine.impl.persistence.entity.TableDataManager;
 import org.flowable.content.engine.impl.persistence.entity.TableDataManagerImpl;
 import org.flowable.content.engine.impl.persistence.entity.data.ContentItemDataManager;
 import org.flowable.content.engine.impl.persistence.entity.data.impl.MybatisContentItemDataManager;
+import org.flowable.content.engine.impl.storage.db.SimpleDatabaseContentStorage;
+import org.flowable.content.engine.impl.storage.db.entity.StorageItemEntityManager;
 import org.flowable.content.engine.impl.storage.fs.SimpleFileSystemContentStorage;
 
 public class ContentEngineConfiguration extends AbstractEngineConfiguration implements ContentEngineConfigurationApi {
@@ -80,6 +82,7 @@ public class ContentEngineConfiguration extends AbstractEngineConfiguration impl
 
     // ENTITY MANAGERS /////////////////////////////////////////////////
     protected ContentItemEntityManager contentItemEntityManager;
+    protected StorageItemEntityManager storageEntityManager;
     protected TableDataManager tableDataManager;
 
     public static ContentEngineConfiguration createContentEngineConfigurationFromResourceDefault() {
@@ -196,6 +199,8 @@ public class ContentEngineConfiguration extends AbstractEngineConfiguration impl
                 }
     
                 contentStorage = new SimpleFileSystemContentStorage(contentRootFile);
+            } else if (contentStorageType.equals(SimpleDatabaseContentStorage.STORE_NAME)) {
+                contentStorage = new SimpleDatabaseContentStorage(this);
             } else {
                 throw new RuntimeException("Unknown content storage type '" + contentStorageType + "'");
             }

--- a/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/ContentEngineConfiguration.java
+++ b/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/ContentEngineConfiguration.java
@@ -42,13 +42,13 @@ import org.flowable.content.engine.impl.cfg.StandaloneInMemContentEngineConfigur
 import org.flowable.content.engine.impl.cmd.SchemaOperationsContentEngineBuild;
 import org.flowable.content.engine.impl.db.ContentDbSchemaManager;
 import org.flowable.content.engine.impl.db.EntityDependencyOrder;
-import org.flowable.content.engine.impl.fs.SimpleFileSystemContentStorage;
 import org.flowable.content.engine.impl.persistence.entity.ContentItemEntityManager;
 import org.flowable.content.engine.impl.persistence.entity.ContentItemEntityManagerImpl;
 import org.flowable.content.engine.impl.persistence.entity.TableDataManager;
 import org.flowable.content.engine.impl.persistence.entity.TableDataManagerImpl;
 import org.flowable.content.engine.impl.persistence.entity.data.ContentItemDataManager;
 import org.flowable.content.engine.impl.persistence.entity.data.impl.MybatisContentItemDataManager;
+import org.flowable.content.engine.impl.storage.fs.SimpleFileSystemContentStorage;
 
 public class ContentEngineConfiguration extends AbstractEngineConfiguration implements ContentEngineConfigurationApi {
 
@@ -71,6 +71,10 @@ public class ContentEngineConfiguration extends AbstractEngineConfiguration impl
     // ADDITIONAL SERVICES /////////////////////////////////////////////
 
     protected ContentStorage contentStorage;
+    protected String contentStorageType;
+    
+    // Used when the ContentStorage
+    
     protected String contentRootFolder;
     protected boolean createContentRootFolder = true;
 
@@ -176,20 +180,25 @@ public class ContentEngineConfiguration extends AbstractEngineConfiguration impl
 
     public void initContentStorage() {
         if (contentStorage == null) {
-            if (contentRootFolder == null) {
-                contentRootFolder = System.getProperty("user.home") + File.separator + "content";
+          
+            if (contentStorageType.equals(SimpleFileSystemContentStorage.STORE_NAME)) {
+                if (contentRootFolder == null) {
+                    contentRootFolder = System.getProperty("user.home") + File.separator + "content";
+                }
+    
+                File contentRootFile = new File(contentRootFolder);
+                if (createContentRootFolder && !contentRootFile.exists()) {
+                    contentRootFile.mkdirs();
+                }
+    
+                if (contentRootFile != null && contentRootFile.exists()) {
+                    logger.info("Content file system root : {}", contentRootFile.getAbsolutePath());
+                }
+    
+                contentStorage = new SimpleFileSystemContentStorage(contentRootFile);
+            } else {
+                throw new RuntimeException("Unknown content storage type '" + contentStorageType + "'");
             }
-
-            File contentRootFile = new File(contentRootFolder);
-            if (createContentRootFolder && !contentRootFile.exists()) {
-                contentRootFile.mkdirs();
-            }
-
-            if (contentRootFile != null && contentRootFile.exists()) {
-                logger.info("Content file system root : {}", contentRootFile.getAbsolutePath());
-            }
-
-            contentStorage = new SimpleFileSystemContentStorage(contentRootFile);
         }
     }
 
@@ -445,6 +454,15 @@ public class ContentEngineConfiguration extends AbstractEngineConfiguration impl
         return this;
     }
 
+    public String getContentStorageType() {
+        return contentStorageType;
+    }
+  
+    public ContentEngineConfiguration setContentStorageType(String contentStorageType) {
+        this.contentStorageType = contentStorageType;
+        return this;
+    }
+    
     public String getContentRootFolder() {
         return contentRootFolder;
     }

--- a/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/cmd/SaveContentItemCmd.java
+++ b/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/cmd/SaveContentItemCmd.java
@@ -81,14 +81,21 @@ public class SaveContentItemCmd implements Command<Void>, Serializable {
             }
 
             ContentStorage contentStorage = contentEngineConfiguration.getContentStorage();
-            ContentObject createContentObject = contentStorage.createContentObject(inputStream, metaData);
-            contentItemEntity.setContentStoreId(createContentObject.getId());
+            String contentStoreId = contentItemEntity.getContentStoreId();
+            ContentObject contentObject;
+            if (contentStoreId != null) {
+                contentObject = contentStorage.updateContentObject(contentStoreId, inputStream, metaData);
+            } else {
+                contentObject = contentStorage.createContentObject(inputStream, metaData);
+                contentItemEntity.setContentStoreId(contentObject.getId());
+            }
+            
             contentItemEntity.setContentStoreName(contentStorage.getContentStoreName());
             contentItemEntity.setContentAvailable(true);
 
             // After storing the stream, store the length to be accessible without having to consult the
             // underlying content storage to get file size
-            contentItemEntity.setContentSize(createContentObject.getContentLength());
+            contentItemEntity.setContentSize(contentObject.getContentLength());
 
             // Make lastModified timestamp update whenever the content changes
             contentItemEntity.setLastModified(contentEngineConfiguration.getClock().getCurrentTime());

--- a/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/db/EntityDependencyOrder.java
+++ b/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/db/EntityDependencyOrder.java
@@ -18,6 +18,7 @@ import java.util.List;
 
 import org.flowable.common.engine.impl.persistence.entity.Entity;
 import org.flowable.content.engine.impl.persistence.entity.ContentItemEntityImpl;
+import org.flowable.content.engine.impl.storage.db.entity.StorageItemEntityImpl;
 
 public class EntityDependencyOrder {
 
@@ -25,6 +26,7 @@ public class EntityDependencyOrder {
     public static List<Class<? extends Entity>> INSERT_ORDER = new ArrayList<>();
 
     static {
+        DELETE_ORDER.add(StorageItemEntityImpl.class);
         DELETE_ORDER.add(ContentItemEntityImpl.class);
         INSERT_ORDER = new ArrayList<>(DELETE_ORDER);
         Collections.reverse(INSERT_ORDER);

--- a/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/persistence/entity/TableDataManagerImpl.java
+++ b/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/persistence/entity/TableDataManagerImpl.java
@@ -32,6 +32,7 @@ import org.flowable.common.engine.impl.persistence.entity.Entity;
 import org.flowable.content.engine.ContentEngineConfiguration;
 import org.flowable.content.engine.impl.TablePageQueryImpl;
 import org.flowable.content.engine.impl.persistence.AbstractManager;
+import org.flowable.content.engine.impl.storage.db.entity.StorageItemEntity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,8 +51,8 @@ public class TableDataManagerImpl extends AbstractManager implements TableDataMa
     public static Map<Class<? extends Entity>, String> entityToTableNameMap = new HashMap<>();
 
     static {
-
         entityToTableNameMap.put(ContentItemEntity.class, "ACT_CO_CONTENT_ITEM");
+        entityToTableNameMap.put(StorageItemEntity.class, "ACT_CO_STORAGE_ITEM");
     }
 
     protected DbSqlSession getDbSqlSession() {

--- a/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/storage/db/DatabaseContentObject.java
+++ b/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/storage/db/DatabaseContentObject.java
@@ -1,0 +1,53 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.content.engine.impl.storage.db;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import org.flowable.content.api.ContentObject;
+
+/**
+ * {@link ContentObject}, backed by a byte array.
+ * 
+ * @author Jorge Moraleda
+ */
+public class DatabaseContentObject implements ContentObject {
+
+    protected byte[] data;
+    protected InputStream inputStream;
+    protected String id;
+
+    public DatabaseContentObject(byte[] data, String id) {
+        this.data = data;
+        this.id = id;
+    }
+    
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public long getContentLength() {
+        return data.length;
+    }
+
+    @Override
+    public InputStream getContent() {
+        if (inputStream == null)
+            inputStream = new ByteArrayInputStream(data);
+           
+        return inputStream;
+    }
+
+}

--- a/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/storage/db/MybatisStorageItemDataManager.java
+++ b/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/storage/db/MybatisStorageItemDataManager.java
@@ -1,0 +1,38 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.content.engine.impl.storage.db;
+
+import org.flowable.content.engine.ContentEngineConfiguration;
+import org.flowable.content.engine.impl.persistence.entity.data.AbstractContentDataManager;
+import org.flowable.content.engine.impl.storage.db.entity.StorageItemEntity;
+import org.flowable.content.engine.impl.storage.db.entity.StorageItemEntityImpl;
+/**
+ * @author Jorge Moraleda
+ */
+public class MybatisStorageItemDataManager extends AbstractContentDataManager<StorageItemEntity> implements StorageItemDataManager {
+
+    public MybatisStorageItemDataManager(ContentEngineConfiguration ContentEngineConfiguration) {
+        super(ContentEngineConfiguration);
+    }
+
+    @Override
+    public Class<? extends StorageItemEntity> getManagedEntityClass() {
+        return StorageItemEntityImpl.class;
+    }
+
+    @Override
+    public StorageItemEntity create() {
+        return new StorageItemEntityImpl();
+    }
+
+}

--- a/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/storage/db/SimpleDatabaseContentStorage.java
+++ b/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/storage/db/SimpleDatabaseContentStorage.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.flowable.content.engine.impl.storage.db;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import org.apache.commons.io.IOUtils;
+import org.flowable.common.engine.api.FlowableException;
+import org.flowable.common.engine.api.FlowableIllegalArgumentException;
+import org.flowable.common.engine.api.FlowableObjectNotFoundException;
+import org.flowable.content.api.ContentObject;
+import org.flowable.content.api.ContentStorage;
+import org.flowable.content.engine.ContentEngineConfiguration;
+import org.flowable.content.engine.impl.storage.db.entity.StorageItemEntity;
+import org.flowable.content.engine.impl.storage.db.entity.StorageItemEntityManager;
+import org.flowable.content.engine.impl.storage.db.entity.StorageItemEntityManagerImpl;
+import com.fasterxml.uuid.EthernetAddress;
+import com.fasterxml.uuid.Generators;
+import com.fasterxml.uuid.impl.TimeBasedGenerator;
+
+/**
+ * Implementation of {@link ContentStorage} that persists its data to a table in the database
+ * 
+ * @author Jorge Moraleda
+ */
+public class SimpleDatabaseContentStorage implements ContentStorage {
+
+    private static TimeBasedGenerator UUID_GENERATOR = Generators.timeBasedGenerator(EthernetAddress.fromInterface());
+
+    public static final String STORE_NAME = "database";
+    private StorageItemDataManager storageItemDataManager;
+    private StorageItemEntityManager storageItemEntityManager;
+    
+    public SimpleDatabaseContentStorage(ContentEngineConfiguration contentEngineConfiguration) {     
+        this.storageItemDataManager = new MybatisStorageItemDataManager(contentEngineConfiguration);
+        this.storageItemEntityManager = new StorageItemEntityManagerImpl(contentEngineConfiguration, storageItemDataManager);
+    }
+
+    @Override
+    public ContentObject createContentObject(InputStream contentStream,
+            Map<String, Object> metaData) {
+        StorageItemEntity storageItemEntity = storageItemEntityManager.create();
+        storageItemEntity.setId( UUID_GENERATOR.generate().toString() );
+        addContentToEntity(storageItemEntity, contentStream);
+        storageItemEntityManager.insert(storageItemEntity);
+        return makeDatabaseContentObject(storageItemEntity);
+    }
+
+    @Override
+    public ContentObject updateContentObject(String id, InputStream contentStream, Map<String, Object> metaDataString) {
+        StorageItemEntity storageItemEntity = retrieveExistingEntity(id);
+        addContentToEntity(storageItemEntity, contentStream);
+        storageItemEntityManager.update(storageItemEntity);
+        return makeDatabaseContentObject(storageItemEntity);
+    }
+
+    @Override
+    public ContentObject getContentObject(String id) {
+        StorageItemEntity storageItemEntity = retrieveExistingEntity(id);
+        return makeDatabaseContentObject(storageItemEntity);
+    }
+
+    @Override
+    public void deleteContentObject(String id) {
+        storageItemEntityManager.delete(id);
+    }
+    
+    protected void addContentToEntity(StorageItemEntity storageItemEntity, InputStream contentStream) {
+        try {
+            storageItemEntity.setBytes( IOUtils.toByteArray(contentStream) );
+        } catch (IOException e) {
+            throw new FlowableException(e.getMessage());
+        }
+    }
+    
+    protected DatabaseContentObject makeDatabaseContentObject(StorageItemEntity storageItemEntity) {
+        return new DatabaseContentObject(storageItemEntity.getBytes(), storageItemEntity.getId());
+    }
+    
+    protected StorageItemEntity retrieveExistingEntity(String id) {
+        if (id == null) {
+            throw new FlowableIllegalArgumentException("Storage id is null");
+        }
+        StorageItemEntity storageItemEntity = storageItemEntityManager.findById(id);
+        if (storageItemEntity == null) {
+            throw new FlowableObjectNotFoundException("no Storage Item found with id '" + id  + "'");
+        }
+        return storageItemEntity;
+    }
+
+    @Override
+    public String getContentStoreName() {
+        return STORE_NAME;
+    }
+
+    @Override
+    public Map<String, Object> getMetaData() {
+        // Currently not yet supported
+        return null;
+    }
+
+}

--- a/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/storage/db/StorageItem.java
+++ b/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/storage/db/StorageItem.java
@@ -1,0 +1,22 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.flowable.content.engine.impl.storage.db;
+
+/**
+ * @author Jorge Moraleda
+ */
+public interface StorageItem {
+    byte[] getBytes();
+    void setBytes(byte[] bytes);
+}

--- a/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/storage/db/StorageItemDataManager.java
+++ b/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/storage/db/StorageItemDataManager.java
@@ -1,0 +1,18 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.content.engine.impl.storage.db;
+
+import org.flowable.common.engine.impl.persistence.entity.data.DataManager;
+import org.flowable.content.engine.impl.storage.db.entity.StorageItemEntity;
+
+public interface StorageItemDataManager extends DataManager<StorageItemEntity> {}

--- a/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/storage/db/entity/StorageItemEntity.java
+++ b/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/storage/db/entity/StorageItemEntity.java
@@ -1,0 +1,22 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.flowable.content.engine.impl.storage.db.entity;
+
+import org.flowable.common.engine.impl.persistence.entity.Entity;
+import org.flowable.content.engine.impl.storage.db.StorageItem;
+
+/**
+ * @author Jorge Moraleda
+ */
+public interface StorageItemEntity extends StorageItem, Entity {}

--- a/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/storage/db/entity/StorageItemEntityImpl.java
+++ b/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/storage/db/entity/StorageItemEntityImpl.java
@@ -1,0 +1,50 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.flowable.content.engine.impl.storage.db.entity;
+
+import java.io.Serializable;
+import org.flowable.content.engine.impl.persistence.entity.AbstractContentEngineNoRevisionEntity;
+
+/**
+ * @author Jorge Moraleda
+ */
+public class StorageItemEntityImpl extends AbstractContentEngineNoRevisionEntity implements StorageItemEntity, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    protected byte[] bytes;
+
+    public StorageItemEntityImpl() {}
+
+    @Override
+    public String toString() {
+        return "StorageEntity[id=" + id + "]";
+    }
+
+    @Override
+    public byte[] getBytes() {
+        return bytes;
+    }
+
+    @Override
+    public void setBytes(byte[] bytes) {
+        this.bytes = bytes;
+    }
+
+    @Override
+    public Object getPersistentState() {
+        return StorageItemEntityImpl.class;
+    }
+
+}

--- a/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/storage/db/entity/StorageItemEntityManager.java
+++ b/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/storage/db/entity/StorageItemEntityManager.java
@@ -1,0 +1,17 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.content.engine.impl.storage.db.entity;
+
+import org.flowable.common.engine.impl.persistence.entity.EntityManager;
+
+public interface StorageItemEntityManager extends EntityManager<StorageItemEntity> {}

--- a/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/storage/db/entity/StorageItemEntityManagerImpl.java
+++ b/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/storage/db/entity/StorageItemEntityManagerImpl.java
@@ -1,0 +1,46 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.flowable.content.engine.impl.storage.db.entity;
+
+import org.flowable.common.engine.impl.persistence.entity.data.DataManager;
+import org.flowable.content.engine.ContentEngineConfiguration;
+import org.flowable.content.engine.impl.persistence.entity.AbstractEntityManager;
+import org.flowable.content.engine.impl.storage.db.StorageItemDataManager;
+
+/**
+ * @author Jorge Moraleda
+ */
+public class StorageItemEntityManagerImpl extends AbstractEntityManager<StorageItemEntity> implements StorageItemEntityManager {
+
+    protected StorageItemDataManager storageDataManager;
+
+    public StorageItemEntityManagerImpl(ContentEngineConfiguration contentEngineConfiguration, StorageItemDataManager storageDataManager) {
+        super(contentEngineConfiguration);
+        this.storageDataManager = storageDataManager;
+    }
+
+    @Override
+    protected DataManager<StorageItemEntity> getDataManager() {
+        return storageDataManager;
+    }
+
+    public StorageItemDataManager getstorageDataManager() {
+        return storageDataManager;
+    }
+
+    public void setstorageDataManager(StorageItemDataManager storageDataManager) {
+        this.storageDataManager = storageDataManager;
+    }
+
+}

--- a/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/storage/fs/FileSystemContentObject.java
+++ b/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/storage/fs/FileSystemContentObject.java
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.flowable.content.engine.impl.fs;
+package org.flowable.content.engine.impl.storage.fs;
 
 import java.io.File;
 import java.io.FileInputStream;

--- a/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/storage/fs/FileSystemContentStorage.java
+++ b/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/storage/fs/FileSystemContentStorage.java
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.flowable.content.engine.impl.fs;
+package org.flowable.content.engine.impl.storage.fs;
 
 import java.io.File;
 import java.io.FileNotFoundException;

--- a/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/storage/fs/PathConverter.java
+++ b/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/storage/fs/PathConverter.java
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.flowable.content.engine.impl.fs;
+package org.flowable.content.engine.impl.storage.fs;
 
 import java.io.File;
 import java.math.BigInteger;

--- a/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/storage/fs/SimpleFileSystemContentStorage.java
+++ b/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/storage/fs/SimpleFileSystemContentStorage.java
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.flowable.content.engine.impl.fs;
+package org.flowable.content.engine.impl.storage.fs;
 
 import com.fasterxml.uuid.EthernetAddress;
 import com.fasterxml.uuid.Generators;
@@ -58,6 +58,8 @@ public class SimpleFileSystemContentStorage implements ContentStorage {
     public static final String PROCESS_INSTANCE_PREFIX = "proc";
     public static final String CASE_PREFIX = "case";
     public static final String UNCATEGORIZED_PREFIX = "uncategorized";
+
+    public static final String STORE_NAME = "file";
 
     protected File contentFolderRoot;
     protected File taskFolder;
@@ -244,7 +246,7 @@ public class SimpleFileSystemContentStorage implements ContentStorage {
 
     @Override
     public String getContentStoreName() {
-        return "file";
+        return STORE_NAME;
     }
 
     protected File getContentFile(Map<String, Object> metaData, String contentId) {

--- a/modules/flowable-content-engine/src/main/resources/org/flowable/content/db/liquibase/flowable-content-db-changelog.xml
+++ b/modules/flowable-content-engine/src/main/resources/org/flowable/content/db/liquibase/flowable-content-db-changelog.xml
@@ -63,5 +63,16 @@
             <column name="SCOPE_TYPE_"/>
         </createIndex>
     </changeSet>
+    
+    <changeSet id="3" author="flowable">
+        <createTable tableName="ACT_CO_STORAGE_ITEM">
+            <column name="ID_" type="varchar(255)">
+                <constraints primaryKey="true" nullable="false" />
+            </column>
+            <column name="DATA_BYTES_" type="longblob">
+                <constraints nullable="true" />
+            </column>
+        </createTable>
+    </changeSet>
 
 </databaseChangeLog>

--- a/modules/flowable-content-engine/src/main/resources/org/flowable/content/db/mapping/entity/StorageItem.xml
+++ b/modules/flowable-content-engine/src/main/resources/org/flowable/content/db/mapping/entity/StorageItem.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?> 
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd"> 
+  
+<mapper namespace="org.flowable.content.engine.impl.storage.db.entity.StorageItemEntityImpl">
+  
+  <!-- DATA INSERT -->
+
+  <insert id="insertStorageItem" parameterType="org.flowable.content.engine.impl.storage.db.entity.StorageItemEntityImpl">
+    insert into ${prefix}ACT_CO_STORAGE_ITEM(ID_, DATA_BYTES_)
+    values (#{id, jdbcType=VARCHAR}, #{bytes, jdbcType=${blobType}})  
+  </insert>
+  
+  <!-- DATA UPDATE -->
+
+  <update id="updateStorageItem" parameterType="org.flowable.content.engine.impl.storage.db.entity.StorageItemEntityImpl">
+    update ${prefix}ACT_CO_STORAGE_ITEM
+    set
+      DATA_BYTES_ = #{bytes, jdbcType=${blobType}}
+    where ID_ = #{id, jdbcType=VARCHAR}
+  </update>
+
+  <!-- DATA DELETE -->
+  
+  <delete id="deleteStorageItem" parameterType="string">
+    delete from ${prefix}ACT_CO_STORAGE_ITEM where ID_ = #{id}
+  </delete>
+  
+  <!-- DATA RESULTMAP -->
+
+  <resultMap id="StorageItemResultMap" type="org.flowable.content.engine.impl.storage.db.entity.StorageItemEntityImpl">
+    <id property="id" column="ID_" jdbcType="VARCHAR" />
+    <result property="bytes" column="DATA_BYTES_" jdbcType="${blobType}"/>
+  </resultMap>
+  
+  <!-- DATA SELECT -->
+
+  <select id="selectStorageItem" parameterType="string" resultMap="StorageItemResultMap">
+    select * from ${prefix}ACT_CO_STORAGE_ITEM where ID_ = #{id, jdbcType=VARCHAR}
+  </select>
+  
+</mapper>

--- a/modules/flowable-content-engine/src/main/resources/org/flowable/content/db/mapping/mappings.xml
+++ b/modules/flowable-content-engine/src/main/resources/org/flowable/content/db/mapping/mappings.xml
@@ -10,5 +10,6 @@
     <mapper resource="org/flowable/content/db/mapping/common.xml" />
     <mapper resource="org/flowable/content/db/mapping/entity/ContentItem.xml" />
     <mapper resource="org/flowable/content/db/mapping/entity/TableData.xml" />
+    <mapper resource="org/flowable/content/db/mapping/entity/StorageItem.xml" />    
   </mappers>
 </configuration>

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/content/ContentEngineAutoConfiguration.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/content/ContentEngineAutoConfiguration.java
@@ -75,8 +75,10 @@ public class ContentEngineAutoConfiguration extends AbstractEngineAutoConfigurat
         configureEngine(configuration, dataSource);
 
         FlowableContentProperties.Storage storage = contentProperties.getStorage();
-        configuration.setContentRootFolder(storage.getRootFolder());
-        configuration.setCreateContentRootFolder(storage.getCreateRoot());
+        configuration.setContentStorageType(storage.getType());
+        FlowableContentProperties.Storage.File file = storage.getFile();
+        configuration.setContentRootFolder(file.getRootFolder());
+        configuration.setCreateContentRootFolder(file.getCreateRoot());
 
         return configuration;
     }

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/content/FlowableContentProperties.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/content/FlowableContentProperties.java
@@ -63,29 +63,58 @@ public class FlowableContentProperties {
     public static class Storage {
 
         /**
-         * Root folder location where content files will be stored, for example, task attachments or form file uploads.
+         * Type of content storage engine
          */
-        private String rootFolder;
-
+        private String type = "file";
+ 
         /**
-         * If the root folder doesn't exist, should it be created?
+         * The storage properties for the file system content configuration.
          */
-        private boolean createRoot = true;
+        @NestedConfigurationProperty
+        private final File file = new File();
 
-        public String getRootFolder() {
-            return rootFolder;
+        public String getType() {
+            return type;
         }
 
-        public void setRootFolder(String rootFolder) {
-            this.rootFolder = rootFolder;
+        public void setType(String type) {
+            this.type = type;
         }
-
-        public boolean getCreateRoot() {
-            return createRoot;
+        
+        public File getFile() {
+            return file;
         }
+        
+        /**
+         * The file storage configuration for the content engine.
+         */
+        public static class File {
 
-        public void setCreateRoot(Boolean createRoot) {
-            this.createRoot = createRoot;
+            /**
+             * Root folder location where content files will be stored, for example, task attachments or form file uploads.
+             */
+            private String rootFolder;
+
+            /**
+             * If the root folder doesn't exist, should it be created?
+             */
+            private boolean createRoot = true;
+
+            public String getRootFolder() {
+                return rootFolder;
+            }
+
+            public void setRootFolder(String rootFolder) {
+                this.rootFolder = rootFolder;
+            }
+
+            public boolean getCreateRoot() {
+                return createRoot;
+            }
+
+            public void setCreateRoot(Boolean createRoot) {
+                this.createRoot = createRoot;
+            }
         }
     }
 }

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -186,7 +186,7 @@
       "deprecation": {
         "level": "error",
         "reason": "Using improved setup for Spring Boot.",
-        "replacement": "flowable.content.storage.root-folder"
+        "replacement": "flowable.content.storage.file.root-folder"
       }
     },
     {
@@ -195,7 +195,25 @@
       "deprecation": {
         "level": "error",
         "reason": "Using improved setup for Spring Boot.",
-        "replacement": "flowable.content.storage.create-root"
+        "replacement": "flowable.content.storage.file.create-root"
+      }
+    },
+    {
+      "name": "flowable.content.storage.root-folder",
+      "type": "java.lang.String",
+      "deprecation": {
+        "level": "error",
+        "reason": "Using improved setup for Spring Boot.",
+        "replacement": "flowable.content.storage.file.root-folder"
+      }
+    },
+    {
+      "name": "flowable.content.storage.create-root",
+      "type": "java.lang.Boolean",
+      "deprecation": {
+        "level": "error",
+        "reason": "Using improved setup for Spring Boot.",
+        "replacement": "flowable.content.storage.file.create-root"
       }
     },
     {


### PR DESCRIPTION
I implemented the feature we discussed a few days ago at https://github.com/flowable/flowable-engine/issues/1575.

Now there are two content storage implementations in the content engine and which one is chosen depends on configuration. The alternatives are:

      flowable.content.storage.type=file

or

      flowable.content.storage.type=database

`file` is the default if the property is not given and uses the existing `SimpleFileSystemContentStorage`. So adding this feature will not break any existing deployment.

`database` will make the content engine use a new `SimpleDatabaseContentStorage` where the persisted data is stored in a new table in the database: `ACT_CO_STORAGE_ITEM`.

Implementation details: 

1. For `SimpleFileSystemContentStorage` I have renamed the properties: `flowable.content.storage.root-folder` and `flowable.content.storage.create-root` as `flowable.content.storage.fs.root-folder` and `flowable.content.storage.fs.create-root`. Using the older names still works, but will issue a deprecation warning in the logs.

1. No additional configuration beyond specifying `flowable.content.storage.type=database` is required to use the database backed content storage.

1. The new table in the database `ACT_CO_STORAGE_ITEM` uses liquibase and mybatis just as the rest of the flowable system, so it will be created automatically as needed. I have *not* updated the global scripts to add it, though.

1. `SimpleDatabaseContentStorage` does not implement the `getMetaData` method of the `ContentStorage` interface. This is the same that `SimpleFileSystemContentStorage` does. See note below.

-----------------

NOTE on the last comment: Evidently the `getMetaData` method of interface `ContentStorage` is not being used anywhere since there is no implementation for it.

In fact, if I understand the intention correctly, the method itself is not correctly specified in the interface, since it should take a `String id` parameter to retrieve the metadata for a given item, but as currently specified it receives no parameters.

I wonder if the `getMetaData` method of interface  should be fixed by adding a `String id` parameter or deleted from the interface altogether. Does it serve any purpose? Since all the MetaData is available in the `ContentItem`, and I see no need to store it redundantly in the `StorageItem`.

Thank you for a great project. 