### PR TITLE
Fixed ContentStorage leak when changing the Data associated with an existing item in the Content Engine

### DIFF
--- a/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/cmd/SaveContentItemCmd.java
+++ b/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/cmd/SaveContentItemCmd.java
@@ -81,14 +81,21 @@ public class SaveContentItemCmd implements Command<Void>, Serializable {
             }
 
             ContentStorage contentStorage = contentEngineConfiguration.getContentStorage();
-            ContentObject createContentObject = contentStorage.createContentObject(inputStream, metaData);
-            contentItemEntity.setContentStoreId(createContentObject.getId());
+            String contentStoreId = contentItemEntity.getContentStoreId();
+            ContentObject contentObject;
+            if (contentStoreId != null) {
+                contentObject = contentStorage.updateContentObject(contentStoreId, inputStream, metaData);
+            } else {
+                contentObject = contentStorage.createContentObject(inputStream, metaData);
+                contentItemEntity.setContentStoreId(contentObject.getId());
+            }
+            
             contentItemEntity.setContentStoreName(contentStorage.getContentStoreName());
             contentItemEntity.setContentAvailable(true);
 
             // After storing the stream, store the length to be accessible without having to consult the
             // underlying content storage to get file size
-            contentItemEntity.setContentSize(createContentObject.getContentLength());
+            contentItemEntity.setContentSize(contentObject.getContentLength());
 
             // Make lastModified timestamp update whenever the content changes
             contentItemEntity.setLastModified(contentEngineConfiguration.getClock().getCurrentTime());


### PR DESCRIPTION
Fixes bug https://github.com/flowable/flowable-engine/issues/1586

Problem: The SaveContentItemCmd in the Content Engine created a new entry in the `contentStorage` when changing an item's `contentData`. The old `contentData` remained as a leaked object in the `contentStorage`.

In this fix, when a `contentData` already exists in the `contentStorage` associated with the content item, the existing `contentData` object is updated rather than a new one being created.
