### PR TITLE
Revert "Update Mockito to version 2.24.0 (#1571)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 		<junit.jupiter.version>5.3.2</junit.jupiter.version>
 		<junit.vintage.version>5.3.2</junit.vintage.version>
 		<junit.platform.version>1.3.2</junit.platform.version>
-		<mockito.version>2.24.0</mockito.version>
+		<mockito.version>2.23.4</mockito.version>
 
         <checkstyle.config.location>checkstyle/flowable-checkstyle.xml</checkstyle.config.location>
         <checkstyle.suppressions.location>/checkstyle/flowable-suppressions.xml</checkstyle.suppressions.location>


### PR DESCRIPTION
This reverts commit 3ff0874f6715f065d233723f7de3f5889e905480.

The reason is that the tests in the different UI apps are now failing due to conflicting versions of ByteBuddy. We are importing the spring-boot-dependencies in the pom and the apps are using that. This leads to having Mockito 2.24.0 and ByteBuddy 1.7.11 (defined in the spring-boot-dependencies). Mockito 2.24.0 needs ByteBuddy 1.9.7.

Tests are also failing on Java 12 EA when using Mockito 2.24.0 with ByteBuddy 1.9.7. Failure is: "Mockito cannot mock this class: interface java.util.Map. Mockito can only mock non-private & non-final classes."