### PR TITLE
MessageEventDefinitionWithExtensionElementsTest#testParseMessagedDefi…

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/MessageEventDefinitionWithExtensionElementsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/MessageEventDefinitionWithExtensionElementsTest.java
@@ -12,8 +12,7 @@
  */
 package org.flowable.engine.test.bpmn.event;
 
-import java.util.Collection;
-import java.util.Iterator;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -35,29 +34,16 @@ public class MessageEventDefinitionWithExtensionElementsTest {
         BpmnModel bpmnModelMock = Mockito.mock(BpmnModel.class);
         Message messageMock = Mockito.mock(Message.class);
 
-        @SuppressWarnings("unchecked")
-        Map<String, List<ExtensionElement>> messageExtensionElementMapMock = Mockito.mock(Map.class);
-        Collection<List<ExtensionElement>> messageExtensionElementListCollectionMock = Mockito.mock(List.class);
-        Iterator<List<ExtensionElement>> collectionIteratorMock = Mockito.mock(Iterator.class);
-        List<ExtensionElement> messageExtensionElementListMock = Mockito.mock(List.class);
-        Iterator<ExtensionElement> extensionElementIteratorMock = Mockito.mock(Iterator.class);
         ExtensionElement extensionElementMock = Mockito.mock(ExtensionElement.class);
+        Map<String, List<ExtensionElement>> messageExtensionElementMap = 
+                Collections.singletonMap("messageId", Collections.singletonList(extensionElementMock));
 
         Mockito.when(bpmnParseMock.getBpmnModel()).thenReturn(bpmnModelMock);
         Mockito.when(messageEventDefinitionMock.getMessageRef()).thenReturn("messageId");
         Mockito.when(bpmnModelMock.containsMessageId("messageId")).thenReturn(true);
         Mockito.when(bpmnModelMock.getMessage("messageId")).thenReturn(messageMock);
         Mockito.when(messageMock.getName()).thenReturn("MessageWithExtensionElements");
-        Mockito.when(messageMock.getExtensionElements()).thenReturn(messageExtensionElementMapMock);
-        Mockito.when(messageExtensionElementMapMock.values()).thenReturn(messageExtensionElementListCollectionMock);
-
-        Mockito.when(messageExtensionElementListCollectionMock.iterator()).thenReturn(collectionIteratorMock);
-        Mockito.when(collectionIteratorMock.hasNext()).thenReturn(true, false);
-        Mockito.when(collectionIteratorMock.next()).thenReturn(messageExtensionElementListMock);
-        Mockito.when(collectionIteratorMock.next()).thenReturn(messageExtensionElementListMock);
-        Mockito.when(messageExtensionElementListMock.iterator()).thenReturn(extensionElementIteratorMock);
-        Mockito.when(extensionElementIteratorMock.hasNext()).thenReturn(true,false);
-        Mockito.when(extensionElementIteratorMock.next()).thenReturn(extensionElementMock);
+        Mockito.when(messageMock.getExtensionElements()).thenReturn(messageExtensionElementMap);
 
         MessageEventDefinitionParseHandler handler = new MessageEventDefinitionParseHandler();
         handler.parse(bpmnParseMock, messageEventDefinitionMock);

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/event/MessageEventDefinitionWithExtensionElementsTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/event/MessageEventDefinitionWithExtensionElementsTest.java
@@ -12,6 +12,7 @@
  */
 package org.activiti.engine.test.bpmn.event;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -32,8 +33,7 @@ public class MessageEventDefinitionWithExtensionElementsTest {
         MessageEventDefinition messageEventDefinitionMock = Mockito.mock(MessageEventDefinition.class);
         BpmnModel bpmnModelMock = Mockito.mock(BpmnModel.class);
         Message messageMock = Mockito.mock(Message.class);
-        @SuppressWarnings("unchecked")
-        Map<String, List<ExtensionElement>> extensionElementMap = Mockito.mock(Map.class);
+        Map<String, List<ExtensionElement>> extensionElementMap = Collections.emptyMap();
 
         Mockito.when(bpmnParseMock.getBpmnModel()).thenReturn(bpmnModelMock);
         Mockito.when(messageEventDefinitionMock.getMessageRef()).thenReturn("messageId");


### PR DESCRIPTION
…nitionWithExtension: Do not mock java.util.* classes which is bad practice and unsupported by Mockito.

See: https://github.com/flowable/flowable-engine/pull/1249#issuecomment-462141102