### PR TITLE
Speed-up (travis) build of flowable-engine and cmmn-engine on Java 9+…

### DIFF
--- a/modules/flowable-cmmn-engine/pom.xml
+++ b/modules/flowable-cmmn-engine/pom.xml
@@ -183,6 +183,12 @@
     <build>
         <plugins>
             <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>${argLine} -Xmx3g</argLine>
+                </configuration>
+            </plugin>
+            <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <archive>
@@ -500,16 +506,6 @@
                     </plugin>
                 </plugins>
             </build>
-        </profile>
-        
-        <profile>
-            <id>java8</id>
-            <activation>
-                <jdk>1.8</jdk>
-            </activation>
-            <properties>
-                <argLine>-Xmx3g</argLine>
-            </properties>
         </profile>
     </profiles>
 

--- a/modules/flowable-engine/pom.xml
+++ b/modules/flowable-engine/pom.xml
@@ -276,6 +276,7 @@
                         <exclude>${exclude.tests2}</exclude>
                     </excludes>
                     <runOrder>alphabetical</runOrder>
+                    <argLine>${argLine} -Xmx3g</argLine>
                 </configuration>
             </plugin>
             <plugin>
@@ -1557,18 +1558,6 @@
                     </plugin>
                 </plugins>
             </build>
-        </profile>
-
-        <profile>
-            <id>java8</id>
-            <activation>
-                <jdk>1.8</jdk>
-            </activation>
-            <properties>
-                <!-- increase max heap to fix: SurefireBooterForkException: There was an error in the forked process
-                    [ERROR] GC overhead limit exceeded -->
-                <argLine>-Xmx3g</argLine>
-            </properties>
         </profile>
     </profiles>
 

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <checkstyle.suppressions.location>/checkstyle/flowable-suppressions.xml</checkstyle.suppressions.location>
 
         <!-- JVM params for test execution -->
-		<argLine>-Duser.language=en</argLine>
+		<argLine>-Duser.language=en -XX:+UseParallelGC</argLine>
 
 		<!-- OSGi bundles properties -->
 		<flowable.artifact />
@@ -1682,7 +1682,7 @@
                 <jdk>[9,)</jdk>
             </activation>
             <properties>
-                <argLine>--add-modules java.xml.bind</argLine>
+                <argLine>--add-modules java.xml.bind -XX:+UseParallelGC</argLine>
             </properties>
         </profile>
 	</profiles>


### PR DESCRIPTION
… by increasing the maximum memory for unit tests to 3 GB.

Currently travis builds using Java 9+ take are around ten minutes longer that Java 8 builds, despite doing less (Mule tests are skipped on Java 9+).