### PR TITLE
flowable-ldap-configurator: Remove javax.annotation-api test dependen…

### DIFF
--- a/modules/flowable-ldap-configurator/pom.xml
+++ b/modules/flowable-ldap-configurator/pom.xml
@@ -42,12 +42,6 @@
 			<artifactId>flowable-idm-engine-configurator</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>javax.annotation</groupId>
-			<artifactId>javax.annotation-api</artifactId>
-			<version>1.3.2</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.flowable</groupId>
 			<artifactId>flowable-spring</artifactId>
 			<scope>test</scope>


### PR DESCRIPTION
…cy, which is no longer necessary after the move to UnboundID LDAP for tests.