### PR TITLE
Fix for issue #1479

### DIFF
--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/RestResponseFactory.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/RestResponseFactory.java
@@ -1129,7 +1129,8 @@ public class RestResponseFactory {
         response.setId(user.getId());
         response.setEmail(user.getEmail());
         response.setUrl(urlBuilder.buildUrl(RestUrls.URL_USER, user.getId()));
-
+        response.setTenantId(user.getTenantId());
+        
         if (incudePassword) {
             response.setPassword(user.getPassword());
         }


### PR DESCRIPTION
Tenant Id attribute not returned for REST API /identity/users #1479