### PR TITLE
Simplify Junit assertion'

### DIFF
--- a/modules/flowable-camel-cdi/src/test/java/org/flowable/camel/cdi/named/CdiCustomContextTest.java
+++ b/modules/flowable-camel-cdi/src/test/java/org/flowable/camel/cdi/named/CdiCustomContextTest.java
@@ -13,6 +13,7 @@
 package org.flowable.camel.cdi.named;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 
 import java.util.Collections;
@@ -94,7 +95,7 @@ public class CdiCustomContextTest extends NamedCamelCdiFlowableTestCase {
         String instanceId = (String) exchange.getProperty("PROCESS_ID_PROPERTY");
         List<ProcessInstance> processInstances = processEngine.getRuntimeService().createProcessInstanceQuery().list();
         ProcessInstance processInstance = processEngine.getRuntimeService().createProcessInstanceQuery().processInstanceId(instanceId).singleResult();
-        assertEquals(false, processInstance.isEnded());
+        assertFalse(processInstance.isEnded());
 
         tpl.sendBodyAndProperty("direct:receive", null, FlowableProducer.PROCESS_ID_PROPERTY, instanceId);
 

--- a/modules/flowable-camel-cdi/src/test/java/org/flowable/camel/cdi/named/CdiCustomNonDefaultNamedContextTest.java
+++ b/modules/flowable-camel-cdi/src/test/java/org/flowable/camel/cdi/named/CdiCustomNonDefaultNamedContextTest.java
@@ -13,6 +13,7 @@
 package org.flowable.camel.cdi.named;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 
 import java.util.Collections;
@@ -97,7 +98,7 @@ public class CdiCustomNonDefaultNamedContextTest extends NamedCamelCdiFlowableTe
         String instanceId = (String) exchange.getProperty("PROCESS_ID_PROPERTY");
 
         ProcessInstance processInstance = processEngine.getRuntimeService().createProcessInstanceQuery().processInstanceId(instanceId).singleResult();
-        assertEquals(false, processInstance.isEnded());
+        assertFalse(processInstance.isEnded());
 
         tpl.sendBodyAndProperty("direct:receive", null, FlowableProducer.PROCESS_ID_PROPERTY, instanceId);
 

--- a/modules/flowable-camel-cdi/src/test/java/org/flowable/camel/cdi/std/CdiSimpleProcessTest.java
+++ b/modules/flowable-camel-cdi/src/test/java/org/flowable/camel/cdi/std/CdiSimpleProcessTest.java
@@ -13,6 +13,7 @@
 package org.flowable.camel.cdi.std;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 
 import java.util.Collections;
@@ -89,7 +90,7 @@ public class CdiSimpleProcessTest extends StdCamelCdiFlowableTestCase {
         String instanceId = (String) exchange.getProperty("PROCESS_ID_PROPERTY");
 
         ProcessInstance processInstance = processEngine.getRuntimeService().createProcessInstanceQuery().processInstanceId(instanceId).singleResult();
-        assertEquals(false,processInstance.isEnded());
+        assertFalse(processInstance.isEnded());
 
         tpl.sendBodyAndProperty("direct:receive", null, FlowableProducer.PROCESS_ID_PROPERTY, instanceId);
 

--- a/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/DecisionTaskJsonConverterTest.java
+++ b/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/DecisionTaskJsonConverterTest.java
@@ -58,12 +58,11 @@ public class DecisionTaskJsonConverterTest extends AbstractConverterTest {
     }
 
     protected void assertThatFieldExtension(DecisionTask decisionTask, String fieldName, Object fieldValue) {
-        assertTrue(decisionTask.getFieldExtensions().stream().
-            filter(field -> field.getFieldName().equals(fieldName)).
-            findFirst().
-            orElseThrow(AssertionError::new).
-            getStringValue().equals(fieldValue)
-        );
+        assertEquals(decisionTask.getFieldExtensions().stream().
+                filter(field -> field.getFieldName().equals(fieldName)).
+                findFirst().
+                orElseThrow(AssertionError::new).
+                getStringValue(), fieldValue);
     }
 
 }

--- a/modules/flowable-cmmn-rest/src/test/java/org/flowable/cmmn/rest/service/api/history/HistoricVariableInstanceCollectionResourceTest.java
+++ b/modules/flowable-cmmn-rest/src/test/java/org/flowable/cmmn/rest/service/api/history/HistoricVariableInstanceCollectionResourceTest.java
@@ -98,7 +98,7 @@ public class HistoricVariableInstanceCollectionResourceTest extends BaseSpringRe
                 if (variableName.equals(name)) {
                     variableFound = true;
                     if (variableValue instanceof Boolean) {
-                        assertTrue("Variable value is not equal", variableNode.get("value").asBoolean() == (Boolean) variableValue);
+                        assertEquals("Variable value is not equal", variableNode.get("value").asBoolean(), (boolean) (Boolean) variableValue);
                     } else if (variableValue instanceof Integer) {
                         assertEquals("Variable value is not equal", variableNode.get("value").asInt(), (int) (Integer) variableValue);
                     } else {

--- a/modules/flowable-cmmn-rest/src/test/java/org/flowable/cmmn/rest/service/api/history/HistoricVariableInstanceQueryResourceTest.java
+++ b/modules/flowable-cmmn-rest/src/test/java/org/flowable/cmmn/rest/service/api/history/HistoricVariableInstanceQueryResourceTest.java
@@ -149,7 +149,7 @@ public class HistoricVariableInstanceQueryResourceTest extends BaseSpringRestTes
                 if (variableName.equals(name)) {
                     variableFound = true;
                     if (variableValue instanceof Boolean) {
-                        assertTrue("Variable value is not equal", variableNode.get("value").asBoolean() == (Boolean) variableValue);
+                        assertEquals("Variable value is not equal", variableNode.get("value").asBoolean(), (boolean) (Boolean) variableValue);
                     } else if (variableValue instanceof Integer) {
                         assertEquals("Variable value is not equal", variableNode.get("value").asInt(), (int) (Integer) variableValue);
                     } else {

--- a/modules/flowable-content-engine/src/test/java/org/flowable/content/engine/test/ContentItemTest.java
+++ b/modules/flowable-content-engine/src/test/java/org/flowable/content/engine/test/ContentItemTest.java
@@ -285,7 +285,7 @@ public class ContentItemTest extends AbstractFlowableContentTest {
         ContentItem storedContentItem = contentService.createContentItemQuery().id(initialContentItem.getId()).singleResult();
         assertNotNull(storedContentItem);
         assertEquals(initialContentItem.getId(), storedContentItem.getId());
-        assertTrue(initialContentItem.getLastModified().getTime() == storedContentItem.getLastModified().getTime());
+        assertEquals(initialContentItem.getLastModified().getTime(), storedContentItem.getLastModified().getTime());
 
         long storeTS = System.currentTimeMillis();
         contentService.saveContentItem(storedContentItem, this.getClass().getClassLoader().getResourceAsStream("test.txt"));

--- a/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/impl/replay/ReplayEventLogTest.java
+++ b/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/impl/replay/ReplayEventLogTest.java
@@ -14,6 +14,7 @@ package org.flowable.crystalball.simulator.impl.replay;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.util.ArrayList;
@@ -114,7 +115,7 @@ public class ReplayEventLogTest {
                 .processDefinitionKey(USERTASK_PROCESS)
                 .singleResult();
         assertNotNull(replayProcessInstance);
-        assertFalse(replayProcessInstance.getId().equals(processInstance.getId()));
+        assertNotEquals(replayProcessInstance.getId(), processInstance.getId());
         assertEquals(TEST_VALUE, runtimeService.getVariable(replayProcessInstance.getId(), TEST_VARIABLE));
         // there should be one task
         assertEquals(1, taskService.createTaskQuery().taskDefinitionKey("userTask").count());

--- a/modules/flowable-dmn-engine-configurator/src/test/java/org/flowable/dmn/test/history/HistoryTest.java
+++ b/modules/flowable-dmn-engine-configurator/src/test/java/org/flowable/dmn/test/history/HistoryTest.java
@@ -14,6 +14,7 @@ package org.flowable.dmn.test.history;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
@@ -52,7 +53,7 @@ public class HistoryTest extends AbstractFlowableDmnEngineConfiguratorTest {
             DmnHistoricDecisionExecution decisionExecution = dmnHistoryService.createHistoricDecisionExecutionQuery().processInstanceIdWithChildren(processInstance.getId()).singleResult();
             assertEquals("decision1", decisionExecution.getDecisionKey());
             String subProcessInstanceId = decisionExecution.getInstanceId();
-            assertFalse(subProcessInstanceId.equals(processInstance.getId()));
+            assertNotEquals(subProcessInstanceId, processInstance.getId());
             
             decisionExecution = dmnHistoryService.createHistoricDecisionExecutionQuery().instanceId(processInstance.getId()).singleResult();
             assertNull(decisionExecution);

--- a/modules/flowable-http/src/test/java/org/flowable/http/cmmn/CmmnHttpTaskTest.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/cmmn/CmmnHttpTaskTest.java
@@ -18,6 +18,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import java.io.IOException;
 import java.net.SocketTimeoutException;
@@ -276,7 +277,7 @@ public class CmmnHttpTaskTest {
         assertEquals("text/plain", headerMap.get("Content-Type"));
         assertEquals("623b94fc-14b8-4ee6-aed7-b16b9321e29f", headerMap.get("X-Request-ID"));
         assertEquals("localhost:7000", headerMap.get("Host"));
-        assertEquals(null, headerMap.get("Test"));
+        assertNull(headerMap.get("Test"));
     }
 
     @Test
@@ -315,7 +316,7 @@ public class CmmnHttpTaskTest {
         assertEquals("text/plain", headerMap.get("Content-Type"));
         assertEquals("623b94fc-14b8-4ee6-aed7-b16b9321e29f", headerMap.get("X-Request-ID"));
         assertEquals("localhost:7000", headerMap.get("Host"));
-        assertEquals(null, headerMap.get("Test"));
+        assertNull(headerMap.get("Test"));
     }
 
     protected CaseInstance createCaseInstance() {

--- a/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/IdentityServiceTest.java
+++ b/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/IdentityServiceTest.java
@@ -14,8 +14,10 @@
 package org.flowable.idm.engine.test.api.identity;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -191,7 +193,7 @@ public class IdentityServiceTest extends PluggableFlowableIdmTestCase {
 
         // Fetch and update the user
         user = idmIdentityService.createUserQuery().userId("johndoe").singleResult();
-        assertTrue(Arrays.equals("niceface".getBytes(), picture.getBytes()), "byte arrays differ");
+        assertArrayEquals("niceface".getBytes(), picture.getBytes(), "byte arrays differ");
         assertEquals("image/string", picture.getMimeType());
 
         // interface definition states that setting picture to null should delete it
@@ -465,7 +467,7 @@ public class IdentityServiceTest extends PluggableFlowableIdmTestCase {
         user.setFirstName("John Doe");
         idmIdentityService.saveUser(user);
         User johndoe = idmIdentityService.createUserQuery().userId("johndoe").list().get(0);
-        assertFalse(johndoe.getPassword().equals("xxx"));
+        assertNotEquals("xxx", johndoe.getPassword());
         assertEquals("John Doe", johndoe.getFirstName());
         assertTrue(idmIdentityService.checkPassword("johndoe", "xxx"));
 

--- a/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/PasswordEncoderTest.java
+++ b/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/PasswordEncoderTest.java
@@ -13,6 +13,7 @@
 package org.flowable.idm.engine.test.api.identity;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.flowable.idm.api.PasswordEncoder;
@@ -44,7 +45,7 @@ public class PasswordEncoderTest extends PluggableFlowableIdmTestCase {
         User johndoe = idmIdentityService.createUserQuery().userId("johndoe").list().get(0);
         LOGGER.info("Hash Password = {}", johndoe.getPassword());
 
-        assertFalse("xxx".equals(johndoe.getPassword()));
+        assertNotEquals("xxx", johndoe.getPassword());
         assertTrue(idmIdentityService.checkPassword("johndoe", "xxx"));
         assertFalse(idmIdentityService.checkPassword("johndoe", "invalid pwd"));
 
@@ -104,7 +105,7 @@ public class PasswordEncoderTest extends PluggableFlowableIdmTestCase {
         String salt = idmIdentityService.createUserQuery().userId("johndoe1").list().get(0).getPassword();
         assertTrue(idmIdentityService.checkPassword("johndoe1", "xxx"));
 
-        assertFalse(noSalt.equals(salt));
+        assertNotEquals(noSalt, salt);
         idmIdentityService.deleteUser("johndoe1");
 
         idmEngineConfiguration.setPasswordEncoder(passwordEncoder);

--- a/modules/flowable-idm-spring/src/test/java/org/flowable/spring/test/authentication/SpringPasswordEncoderTest.java
+++ b/modules/flowable-idm-spring/src/test/java/org/flowable/spring/test/authentication/SpringPasswordEncoderTest.java
@@ -15,6 +15,7 @@ package org.flowable.spring.test.authentication;
 import static junit.framework.TestCase.assertTrue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 
 import org.flowable.idm.api.IdmIdentityService;
 import org.flowable.idm.api.PasswordEncoder;
@@ -79,7 +80,7 @@ public class SpringPasswordEncoderTest {
         User johndoe = autoWiredIdmIdentityService.createUserQuery().userId("johndoe").list().get(0);
         LOGGER.info("Hash Password = {}", johndoe.getPassword());
 
-        assertFalse("xxx".equals(johndoe.getPassword()));
+        assertNotEquals("xxx", johndoe.getPassword());
         assertTrue(autoWiredIdmIdentityService.checkPassword("johndoe", "xxx"));
         assertFalse(autoWiredIdmIdentityService.checkPassword("johndoe", "invalid pwd"));
 

--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/DecisionTaskConverterTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/DecisionTaskConverterTest.java
@@ -55,11 +55,10 @@ public class DecisionTaskConverterTest extends AbstractConverterTest {
     }
 
     protected void assertThatFieldExtension(ServiceTask serviceTask, String fieldName, Object fieldValue) {
-        assertTrue(serviceTask.getFieldExtensions().stream().
-            filter(field -> field.getFieldName().equals(fieldName)).
-            findFirst().
-            orElseThrow(AssertionError::new).
-            getStringValue().equals(fieldValue)
-        );
+        assertEquals(serviceTask.getFieldExtensions().stream().
+                filter(field -> field.getFieldName().equals(fieldName)).
+                findFirst().
+                orElseThrow(AssertionError::new).
+                getStringValue(), fieldValue);
     }
 }

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/api/history/HistoricDetailCollectionResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/api/history/HistoricDetailCollectionResourceTest.java
@@ -113,7 +113,7 @@ public class HistoricDetailCollectionResourceTest extends BaseSpringRestTestCase
                 if (variableName.equals(name)) {
                     variableFound = true;
                     if (variableValue instanceof Boolean) {
-                        assertTrue("Variable value is not equal", variableNode.get("value").asBoolean() == (Boolean) variableValue);
+                        assertEquals("Variable value is not equal", variableNode.get("value").asBoolean(), (boolean) (Boolean) variableValue);
                     } else if (variableValue instanceof Integer) {
                         assertEquals("Variable value is not equal", variableNode.get("value").asInt(), (int) (Integer) variableValue);
                     } else {

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/history/HistoricDetailQueryResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/history/HistoricDetailQueryResourceTest.java
@@ -141,7 +141,7 @@ public class HistoricDetailQueryResourceTest extends BaseSpringRestTestCase {
                 if (variableName.equals(name)) {
                     variableFound = true;
                     if (variableValue instanceof Boolean) {
-                        assertTrue("Variable value is not equal", variableNode.get("value").asBoolean() == (Boolean) variableValue);
+                        assertEquals("Variable value is not equal", variableNode.get("value").asBoolean(), (boolean) (Boolean) variableValue);
                     } else if (variableValue instanceof Integer) {
                         assertEquals("Variable value is not equal", variableNode.get("value").asInt(), (int) (Integer) variableValue);
                     } else {

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/history/HistoricVariableInstanceCollectionResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/history/HistoricVariableInstanceCollectionResourceTest.java
@@ -103,7 +103,7 @@ public class HistoricVariableInstanceCollectionResourceTest extends BaseSpringRe
                 if (variableName.equals(name)) {
                     variableFound = true;
                     if (variableValue instanceof Boolean) {
-                        assertTrue("Variable value is not equal", variableNode.get("value").asBoolean() == (Boolean) variableValue);
+                        assertEquals("Variable value is not equal", variableNode.get("value").asBoolean(), (boolean) (Boolean) variableValue);
                     } else if (variableValue instanceof Integer) {
                         assertEquals("Variable value is not equal", variableNode.get("value").asInt(), (int) (Integer) variableValue);
                     } else {

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/history/HistoricVariableInstanceQueryResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/history/HistoricVariableInstanceQueryResourceTest.java
@@ -154,7 +154,7 @@ public class HistoricVariableInstanceQueryResourceTest extends BaseSpringRestTes
                 if (variableName.equals(name)) {
                     variableFound = true;
                     if (variableValue instanceof Boolean) {
-                        assertTrue("Variable value is not equal", variableNode.get("value").asBoolean() == (Boolean) variableValue);
+                        assertEquals("Variable value is not equal", variableNode.get("value").asBoolean(), (boolean) (Boolean) variableValue);
                     } else if (variableValue instanceof Integer) {
                         assertEquals("Variable value is not equal", variableNode.get("value").asInt(), (int) (Integer) variableValue);
                     } else {


### PR DESCRIPTION
For example, instead of "assertEquals(true, <sometest>"
use "assertTrue(<sometest>)"