### PR TITLE
Remove unnecessary maven-surefire-plugin configuration in modules.

### DIFF
--- a/modules/flowable-engine/pom.xml
+++ b/modules/flowable-engine/pom.xml
@@ -279,7 +279,6 @@
                         <exclude>${exclude.tests}</exclude>
                         <exclude>${exclude.tests2}</exclude>
                     </excludes>
-                    <runOrder>alphabetical</runOrder>
                     <argLine>${argLine} -Xmx3g</argLine>
                 </configuration>
             </plugin>
@@ -785,13 +784,11 @@
                         <configuration>
                             <excludes>
                                 <exclude>**/*TestCase.java</exclude>
-
                                 <!-- Disabling tests that run exclusively 
                                     using standalone config -->
                                 <exclude>**/ProcessDiagramRetrievalTest.java</exclude>
                                 <exclude>org/flowable/standalone/**</exclude>
                             </excludes>
-                            <runOrder>alphabetical</runOrder>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -860,13 +857,11 @@
                         <configuration>
                             <excludes>
                                 <exclude>**/*TestCase.java</exclude>
-
                                 <!-- Disabling tests that run exclusively 
                                     using standalone config -->
                                 <exclude>**/ProcessDiagramRetrievalTest.java</exclude>
                                 <exclude>org/flowable/standalone/**</exclude>
                             </excludes>
-                            <runOrder>alphabetical</runOrder>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -922,7 +917,6 @@
                                 <exclude>org/flowable/standalone/**</exclude>
                                 <exclude>**/FlowableJupiterSubclassTest.java</exclude>
                             </excludes>
-                            <runOrder>alphabetical</runOrder>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -1113,7 +1107,6 @@
                                 <exclude>org/flowable/standalone/**</exclude>
                                 <exclude>**/FlowableJupiterSubclassTest.java</exclude>
                             </excludes>
-                            <runOrder>alphabetical</runOrder>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -1175,7 +1168,6 @@
                                 <exclude>**/ProcessInstanceLogQueryTest.java</exclude>
                                 <exclude>**/FlowableJupiterSubclassTest.java</exclude>
                             </excludes>
-                            <runOrder>alphabetical</runOrder>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -1221,7 +1213,6 @@
                                 <exclude>**/RepeatingServiceTaskTest.java</exclude>
                                 <exclude>org/flowable/standalone/**</exclude>
                             </excludes>
-                            <runOrder>alphabetical</runOrder>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -1244,7 +1235,6 @@
                                 <include>**/JdbcMetaDataTest.java</include>
                             </includes>
                             <excludes />
-                            <runOrder>alphabetical</runOrder>
                         </configuration>
                     </plugin>
                     <plugin>

--- a/modules/flowable-entitylink-service-api/pom.xml
+++ b/modules/flowable-entitylink-service-api/pom.xml
@@ -29,12 +29,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<configuration>
-					<runOrder>alphabetical</runOrder>
-				</configuration>
-			</plugin>
-			<plugin>
 				<artifactId>maven-jar-plugin</artifactId>
 				<configuration>
 					<archive>

--- a/modules/flowable-entitylink-service/pom.xml
+++ b/modules/flowable-entitylink-service/pom.xml
@@ -99,12 +99,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<configuration>
-					<runOrder>alphabetical</runOrder>
-				</configuration>
-			</plugin>
-			<plugin>
 				<artifactId>maven-jar-plugin</artifactId>
 				<configuration>
 					<archive>

--- a/modules/flowable-http/pom.xml
+++ b/modules/flowable-http/pom.xml
@@ -41,7 +41,6 @@
                         <propertyName>http.workingDirectory</propertyName>
                         <buildDirectory>${project.build.directory}</buildDirectory>
                     </systemPropertyVariables>
-                    <runOrder>alphabetical</runOrder>
                 </configuration>
             </plugin>
             <plugin>

--- a/modules/flowable-identitylink-service-api/pom.xml
+++ b/modules/flowable-identitylink-service-api/pom.xml
@@ -29,12 +29,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<configuration>
-					<runOrder>alphabetical</runOrder>
-				</configuration>
-			</plugin>
-			<plugin>
 				<artifactId>maven-jar-plugin</artifactId>
 				<configuration>
 					<archive>

--- a/modules/flowable-identitylink-service/pom.xml
+++ b/modules/flowable-identitylink-service/pom.xml
@@ -99,12 +99,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<configuration>
-					<runOrder>alphabetical</runOrder>
-				</configuration>
-			</plugin>
-			<plugin>
 				<artifactId>maven-jar-plugin</artifactId>
 				<configuration>
 					<archive>

--- a/modules/flowable-job-service-api/pom.xml
+++ b/modules/flowable-job-service-api/pom.xml
@@ -29,12 +29,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<configuration>
-					<runOrder>alphabetical</runOrder>
-				</configuration>
-			</plugin>
-			<plugin>
 				<artifactId>maven-jar-plugin</artifactId>
 				<configuration>
 					<archive>

--- a/modules/flowable-job-service/pom.xml
+++ b/modules/flowable-job-service/pom.xml
@@ -107,12 +107,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<configuration>
-					<runOrder>alphabetical</runOrder>
-				</configuration>
-			</plugin>
-			<plugin>
 				<artifactId>maven-jar-plugin</artifactId>
 				<configuration>
 					<archive>

--- a/modules/flowable-job-spring-service/pom.xml
+++ b/modules/flowable-job-spring-service/pom.xml
@@ -36,12 +36,6 @@
     <build>
         <plugins>
             <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <runOrder>alphabetical</runOrder>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <archive>

--- a/modules/flowable-mule/pom.xml
+++ b/modules/flowable-mule/pom.xml
@@ -41,7 +41,6 @@
             <propertyName>mule.workingDirectory</propertyName>
             <buildDirectory>${project.build.directory}</buildDirectory>
           </systemPropertyVariables>
-          <runOrder>alphabetical</runOrder>
         </configuration>
       </plugin>
       <plugin>

--- a/modules/flowable-spring/pom.xml
+++ b/modules/flowable-spring/pom.xml
@@ -348,7 +348,6 @@
                                 <exclude>**/JobExecutorTest.java</exclude> <!-- https://activiti.atlassian.net/browse/ACT-427 -->
                                 <exclude>**/HistoricTaskInstanceUpdateTest.java</exclude> <!-- https://activiti.atlassian.net/browse/ACT-485 -->
                             </excludes>
-                            <runOrder>alphabetical</runOrder>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/modules/flowable-task-service-api/pom.xml
+++ b/modules/flowable-task-service-api/pom.xml
@@ -33,12 +33,6 @@
     <build>
         <plugins>
             <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <runOrder>alphabetical</runOrder>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <archive>

--- a/modules/flowable-task-service/pom.xml
+++ b/modules/flowable-task-service/pom.xml
@@ -103,12 +103,6 @@
     <build>
         <plugins>
             <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <runOrder>alphabetical</runOrder>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <archive>

--- a/modules/flowable-ui-admin/flowable-ui-admin-app/pom.xml
+++ b/modules/flowable-ui-admin/flowable-ui-admin-app/pom.xml
@@ -454,17 +454,6 @@
             </plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<configuration>
-					<argLine>-Xmx256m</argLine>
-					<forkCount>1</forkCount>
-					<reuseForks>false</reuseForks>
-					<!-- Force alphabetical order to have a reproducible build -->
-					<runOrder>alphabetical</runOrder>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-war-plugin</artifactId>
 				<version>2.4</version>
 			</plugin>

--- a/modules/flowable-ui-admin/pom.xml
+++ b/modules/flowable-ui-admin/pom.xml
@@ -54,20 +54,6 @@
         </dependencies>
     </dependencyManagement>
 
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <argLine>-Xmx256m</argLine>
-                    <forkCount>1</forkCount>
-                    <reuseForks>true</reuseForks>
-                    <!-- Force alphabetical order to have a reproducible build -->
-                    <runOrder>alphabetical</runOrder>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
     <profiles>
         <profile>
             <id>docker</id>

--- a/modules/flowable-ui-idm/pom.xml
+++ b/modules/flowable-ui-idm/pom.xml
@@ -50,20 +50,6 @@
         </dependencies>
     </dependencyManagement>
 
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <argLine>-Xmx256m</argLine>
-                    <forkCount>1</forkCount>
-                    <reuseForks>true</reuseForks>
-                    <!-- Force alphabetical order to have a reproducible build -->
-                    <runOrder>alphabetical</runOrder>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
     <profiles>
         <profile>
             <id>docker</id>

--- a/modules/flowable-ui-modeler/pom.xml
+++ b/modules/flowable-ui-modeler/pom.xml
@@ -44,20 +44,6 @@
 	 </dependencies>
 	</dependencyManagement>
 
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-			<argLine>-Xmx256m</argLine>
-			<forkCount>1</forkCount>
-			<reuseForks>true</reuseForks>
-			<!-- Force alphabetical order to have a reproducible build -->
-			<runOrder>alphabetical</runOrder>
-		</configuration>
-      </plugin>
-    </plugins>
-  </build>
     <profiles>
         <profile>
             <id>docker</id>

--- a/modules/flowable-ui-task/pom.xml
+++ b/modules/flowable-ui-task/pom.xml
@@ -57,20 +57,6 @@
         </dependencies>
     </dependencyManagement>
 
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <argLine>-Xmx256m</argLine>
-                    <forkCount>1</forkCount>
-                    <reuseForks>true</reuseForks>
-                    <!-- Force alphabetical order to have a reproducible build -->
-                    <runOrder>alphabetical</runOrder>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
     <profiles>
         <profile>
             <id>docker</id>

--- a/modules/flowable-variable-service-api/pom.xml
+++ b/modules/flowable-variable-service-api/pom.xml
@@ -29,12 +29,6 @@
     <build>
         <plugins>
             <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <runOrder>alphabetical</runOrder>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <archive>

--- a/modules/flowable-variable-service/pom.xml
+++ b/modules/flowable-variable-service/pom.xml
@@ -102,12 +102,6 @@
     <build>
         <plugins>
             <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <runOrder>alphabetical</runOrder>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <archive>

--- a/modules/flowable5-engine/pom.xml
+++ b/modules/flowable5-engine/pom.xml
@@ -185,7 +185,6 @@
 						<exclude>**/*TestCase.java</exclude>
 						<exclude>**/RepeatingServiceTaskTest.java</exclude>
 					</excludes>
-					<runOrder>alphabetical</runOrder>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -509,12 +508,10 @@
 						<configuration>
 							<excludes>
 								<exclude>**/*TestCase.java</exclude>
-
 								<!-- Disabling tests that run exclusively using standalone config -->
 								<exclude>**/ProcessDiagramRetrievalTest.java</exclude>
 								<exclude>org/activiti/standalone/**</exclude>
 							</excludes>
-							<runOrder>alphabetical</runOrder>
 						</configuration>
 					</plugin>
 				</plugins>
@@ -579,12 +576,10 @@
 						<configuration>
 							<excludes>
 								<exclude>**/*TestCase.java</exclude>
-
 								<!-- Disabling tests that run exclusively using standalone config -->
 								<exclude>**/ProcessDiagramRetrievalTest.java</exclude>
 								<exclude>org/activiti/standalone/**</exclude>
 							</excludes>
-							<runOrder>alphabetical</runOrder>
 						</configuration>
 					</plugin>
 				</plugins>
@@ -637,7 +632,6 @@
 								<exclude>**/RepeatingServiceTaskTest.java</exclude>
 								<exclude>org/activiti/standalone/**</exclude>
 							</excludes>
-							<runOrder>alphabetical</runOrder>
 						</configuration>
 					</plugin>
 				</plugins>
@@ -732,7 +726,6 @@
 								<exclude>**/RepeatingServiceTaskTest.java</exclude>
 								<exclude>org/activiti/standalone/**</exclude>
 							</excludes>
-							<runOrder>alphabetical</runOrder>
 						</configuration>
 					</plugin>
 				</plugins>
@@ -780,7 +773,6 @@
 								<exclude>**/ProcessInstanceLogQueryTest.java</exclude>
 								<exclude>org/activiti/standalone/**</exclude>
 							</excludes>
-							<runOrder>alphabetical</runOrder>
 						</configuration>
 					</plugin>
 				</plugins>
@@ -803,7 +795,6 @@
 								<include>**/JdbcMetaDataTest.java</include>
 							</includes>
 							<excludes />
-							<runOrder>alphabetical</runOrder>
 						</configuration>
 					</plugin>
 					<plugin>

--- a/modules/flowable5-mule-test/pom.xml
+++ b/modules/flowable5-mule-test/pom.xml
@@ -41,7 +41,6 @@
             <propertyName>mule.workingDirectory</propertyName>
             <buildDirectory>${project.build.directory}</buildDirectory>
           </systemPropertyVariables>
-          <runOrder>alphabetical</runOrder>
         </configuration>
       </plugin>
       <plugin>

--- a/modules/flowable5-spring-test/pom.xml
+++ b/modules/flowable5-spring-test/pom.xml
@@ -287,7 +287,6 @@
                                 <exclude>**/JobExecutorTest.java</exclude> <!-- https://activiti.atlassian.net/browse/ACT-427 -->
                                 <exclude>**/HistoricTaskInstanceUpdateTest.java</exclude> <!-- https://activiti.atlassian.net/browse/ACT-485 -->
                             </excludes>
-                            <runOrder>alphabetical</runOrder>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
Alphabetical test run order is already defined in root POM.