### PR TITLE
Update to Camel 3

### DIFF
--- a/modules/flowable-camel-cdi/pom.xml
+++ b/modules/flowable-camel-cdi/pom.xml
@@ -32,6 +32,16 @@
         <artifactId>camel-cdi</artifactId>
       </dependency>
       <dependency>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-direct</artifactId>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-seda</artifactId>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>javax.xml.bind</groupId>
         <artifactId>jaxb-api</artifactId>
         <scope>test</scope>

--- a/modules/flowable-camel-cdi/pom.xml
+++ b/modules/flowable-camel-cdi/pom.xml
@@ -49,6 +49,7 @@
       <dependency>
           <groupId>org.jboss.arquillian.junit</groupId>
           <artifactId>arquillian-junit-container</artifactId>
+          <version>1.1.15.Final</version>
           <scope>test</scope>
       </dependency>
       <dependency>
@@ -62,17 +63,10 @@
           <scope>test</scope>
       </dependency>
       <dependency>
-          <groupId>org.jboss.spec</groupId>
-          <artifactId>jboss-javaee-6.0</artifactId>
-          <version>2.0.0.Final</version>
-          <type>pom</type>
-          <scope>provided</scope>
-          <exclusions>
-              <exclusion>
-                  <artifactId>xalan</artifactId>
-                  <groupId>org.apache.xalan</groupId>
-              </exclusion>
-          </exclusions>
+        <groupId>javax.enterprise</groupId>
+        <artifactId>cdi-api</artifactId>
+        <version>2.0</version>
+        <scope>provided</scope>
       </dependency>
   </dependencies>
 
@@ -92,32 +86,28 @@
       <dependencies>
         <dependency>
           <groupId>org.jboss.arquillian.container</groupId>
-          <artifactId>arquillian-weld-ee-embedded-1.1</artifactId>
+          <artifactId>arquillian-weld-embedded</artifactId>
+          <version>2.0.0.Final</version>
           <scope>test</scope>
         </dependency>
         <dependency>
           <groupId>org.jboss.weld</groupId>
-          <artifactId>weld-core</artifactId>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.jboss.weld</groupId>
-          <artifactId>weld-api</artifactId>
+          <artifactId>weld-core-impl</artifactId>
           <scope>test</scope>
         </dependency>
         <dependency>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-simple</artifactId>
+          <version>${slf4j.version}</version>
           <scope>test</scope>
         </dependency>
       </dependencies>
-      
       <dependencyManagement>
         <dependencies>
           <dependency>
             <groupId>org.jboss.weld</groupId>
             <artifactId>weld-core-bom</artifactId>
-            <version>1.1.33.Final</version>
+            <version>3.1.1.Final</version>
             <type>pom</type>
             <scope>import</scope>
           </dependency>

--- a/modules/flowable-camel-cdi/src/test/java/org/flowable/camel/cdi/named/CdiCustomContextTest.java
+++ b/modules/flowable-camel-cdi/src/test/java/org/flowable/camel/cdi/named/CdiCustomContextTest.java
@@ -76,7 +76,7 @@ public class CdiCustomContextTest extends NamedCamelCdiFlowableTestCase {
     public void tearDown() throws Exception {
         List<Route> routes = camelContext.getRoutes();
         for (Route r : routes) {
-            camelContext.stopRoute(r.getId());
+            camelContext.getRouteController().stopRoute(r.getId());
             camelContext.removeRoute(r.getId());
         }
     }

--- a/modules/flowable-camel-cdi/src/test/java/org/flowable/camel/cdi/named/CdiCustomNonDefaultNamedContextTest.java
+++ b/modules/flowable-camel-cdi/src/test/java/org/flowable/camel/cdi/named/CdiCustomNonDefaultNamedContextTest.java
@@ -79,7 +79,7 @@ public class CdiCustomNonDefaultNamedContextTest extends NamedCamelCdiFlowableTe
     public void tearDown() throws Exception {
         List<Route> routes = camelContext.getRoutes();
         for (Route r : routes) {
-            camelContext.stopRoute(r.getId());
+            camelContext.getRouteController().stopRoute(r.getId());
             camelContext.removeRoute(r.getId());
         }
     }

--- a/modules/flowable-camel-cdi/src/test/java/org/flowable/camel/cdi/std/CdiAsyncPingTest.java
+++ b/modules/flowable-camel-cdi/src/test/java/org/flowable/camel/cdi/std/CdiAsyncPingTest.java
@@ -53,7 +53,7 @@ public class CdiAsyncPingTest extends StdCamelCdiFlowableTestCase {
     public void tearDown() throws Exception {
         List<Route> routes = camelContext.getRoutes();
         for (Route r : routes) {
-            camelContext.stopRoute(r.getId());
+            camelContext.getRouteController().stopRoute(r.getId());
             camelContext.removeRoute(r.getId());
         }
     }

--- a/modules/flowable-camel-cdi/src/test/java/org/flowable/camel/cdi/std/CdiCamelVariableBodyMapTest.java
+++ b/modules/flowable-camel-cdi/src/test/java/org/flowable/camel/cdi/std/CdiCamelVariableBodyMapTest.java
@@ -65,7 +65,7 @@ public class CdiCamelVariableBodyMapTest extends StdCamelCdiFlowableTestCase {
     public void tearDown() throws Exception {
         List<Route> routes = camelContext.getRoutes();
         for (Route r : routes) {
-            camelContext.stopRoute(r.getId());
+            camelContext.getRouteController().stopRoute(r.getId());
             camelContext.removeRoute(r.getId());
         }
     }

--- a/modules/flowable-camel-cdi/src/test/java/org/flowable/camel/cdi/std/CdiCamelVariableBodyTest.java
+++ b/modules/flowable-camel-cdi/src/test/java/org/flowable/camel/cdi/std/CdiCamelVariableBodyTest.java
@@ -62,7 +62,7 @@ public class CdiCamelVariableBodyTest extends StdCamelCdiFlowableTestCase {
     public void tearDown() throws Exception {
         List<Route> routes = camelContext.getRoutes();
         for (Route r : routes) {
-            camelContext.stopRoute(r.getId());
+            camelContext.getRouteController().stopRoute(r.getId());
             camelContext.removeRoute(r.getId());
         }
     }

--- a/modules/flowable-camel-cdi/src/test/java/org/flowable/camel/cdi/std/CdiSimpleProcessTest.java
+++ b/modules/flowable-camel-cdi/src/test/java/org/flowable/camel/cdi/std/CdiSimpleProcessTest.java
@@ -72,7 +72,7 @@ public class CdiSimpleProcessTest extends StdCamelCdiFlowableTestCase {
     public void tearDown() throws Exception {
         List<Route> routes = camelContext.getRoutes();
         for (Route r : routes) {
-            camelContext.stopRoute(r.getId());
+            camelContext.getRouteController().stopRoute(r.getId());
             camelContext.removeRoute(r.getId());
         }
     }

--- a/modules/flowable-camel/pom.xml
+++ b/modules/flowable-camel/pom.xml
@@ -25,10 +25,6 @@
       <artifactId>camel-spring</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
       <scope>provided</scope>
@@ -42,8 +38,9 @@
       <artifactId>jcl-over-slf4j</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
+      <version>2.3.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -75,6 +72,26 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-direct</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-seda</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-log</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-mock</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/modules/flowable-camel/src/main/java/org/flowable/camel/ExchangeUtils.java
+++ b/modules/flowable-camel/src/main/java/org/flowable/camel/ExchangeUtils.java
@@ -106,12 +106,7 @@ public class ExchangeUtils {
             }
         }
 
-        Object camelBody = null;
-        if (exchange.hasOut()) {
-            camelBody = exchange.getOut().getBody();
-        } else {
-            camelBody = exchange.getIn().getBody();
-        }
+        Object camelBody = exchange.getMessage().getBody();
 
         if (camelBody instanceof Map<?, ?>) {
             Map<?, ?> camelBodyMap = (Map<?, ?>) camelBody;

--- a/modules/flowable-camel/src/main/java/org/flowable/camel/FlowableComponent.java
+++ b/modules/flowable-camel/src/main/java/org/flowable/camel/FlowableComponent.java
@@ -16,8 +16,8 @@ import java.util.Map;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.Endpoint;
-import org.apache.camel.impl.DefaultComponent;
-import org.apache.camel.util.IntrospectionSupport;
+import org.apache.camel.support.DefaultComponent;
+import org.apache.camel.util.PropertiesHelper;
 import org.flowable.engine.IdentityService;
 import org.flowable.engine.RepositoryService;
 import org.flowable.engine.RuntimeService;
@@ -74,7 +74,7 @@ public class FlowableComponent extends DefaultComponent {
         ae.setCopyVariablesToBodyAsMap(this.copyVariablesToBodyAsMap);
         ae.setCopyCamelBodyToBody(this.copyCamelBodyToBody);
 
-        Map<String, Object> returnVars = IntrospectionSupport.extractProperties(parameters, "var.return.");
+        Map<String, Object> returnVars = PropertiesHelper.extractProperties(parameters, "var.return.");
         if (returnVars != null && returnVars.size() > 0) {
             ae.getReturnVarMap().putAll(returnVars);
         }

--- a/modules/flowable-camel/src/main/java/org/flowable/camel/FlowableConsumer.java
+++ b/modules/flowable-camel/src/main/java/org/flowable/camel/FlowableConsumer.java
@@ -13,7 +13,7 @@
 package org.flowable.camel;
 
 import org.apache.camel.Processor;
-import org.apache.camel.impl.DefaultConsumer;
+import org.apache.camel.support.DefaultConsumer;
 
 public class FlowableConsumer extends DefaultConsumer {
 

--- a/modules/flowable-camel/src/main/java/org/flowable/camel/FlowableEndpoint.java
+++ b/modules/flowable-camel/src/main/java/org/flowable/camel/FlowableEndpoint.java
@@ -21,7 +21,7 @@ import org.apache.camel.Consumer;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.Producer;
-import org.apache.camel.impl.DefaultEndpoint;
+import org.apache.camel.support.DefaultEndpoint;
 import org.apache.commons.lang3.StringUtils;
 import org.flowable.common.engine.api.FlowableException;
 import org.flowable.engine.IdentityService;

--- a/modules/flowable-camel/src/main/java/org/flowable/camel/FlowableProducer.java
+++ b/modules/flowable-camel/src/main/java/org/flowable/camel/FlowableProducer.java
@@ -15,7 +15,7 @@ package org.flowable.camel;
 import java.util.Map;
 
 import org.apache.camel.Exchange;
-import org.apache.camel.impl.DefaultProducer;
+import org.apache.camel.support.DefaultProducer;
 import org.flowable.common.engine.api.FlowableException;
 import org.flowable.engine.IdentityService;
 import org.flowable.engine.RepositoryService;

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/AsyncPingTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/AsyncPingTest.java
@@ -59,7 +59,7 @@ public class AsyncPingTest extends SpringFlowableTestCase {
     public void tearDown() throws Exception {
         List<Route> routes = camelContext.getRoutes();
         for (Route r : routes) {
-            camelContext.stopRoute(r.getId());
+            camelContext.getRouteController().stopRoute(r.getId());
             camelContext.removeRoute(r.getId());
         }
     }

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/AsyncProcessTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/AsyncProcessTest.java
@@ -60,7 +60,7 @@ public class AsyncProcessTest extends SpringFlowableTestCase {
     public void tearDown() throws Exception {
         List<Route> routes = camelContext.getRoutes();
         for (Route r : routes) {
-            camelContext.stopRoute(r.getId());
+            camelContext.getRouteController().stopRoute(r.getId());
             camelContext.removeRoute(r.getId());
         }
     }

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/CamelVariableBodyMapTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/CamelVariableBodyMapTest.java
@@ -59,7 +59,7 @@ public class CamelVariableBodyMapTest extends SpringFlowableTestCase {
     public void tearDown() throws Exception {
         List<Route> routes = camelContext.getRoutes();
         for (Route r : routes) {
-            camelContext.stopRoute(r.getId());
+            camelContext.getRouteController().stopRoute(r.getId());
             camelContext.removeRoute(r.getId());
         }
     }

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/CamelVariableBodyTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/CamelVariableBodyTest.java
@@ -58,7 +58,7 @@ public class CamelVariableBodyTest extends SpringFlowableTestCase {
     public void tearDown() throws Exception {
         List<Route> routes = camelContext.getRoutes();
         for (Route r : routes) {
-            camelContext.stopRoute(r.getId());
+            camelContext.getRouteController().stopRoute(r.getId());
             camelContext.removeRoute(r.getId());
         }
     }

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/CustomContextTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/CustomContextTest.java
@@ -70,7 +70,7 @@ public class CustomContextTest extends SpringFlowableTestCase {
     public void tearDown() throws Exception {
         List<Route> routes = camelContext.getRoutes();
         for (Route r : routes) {
-            camelContext.stopRoute(r.getId());
+            camelContext.getRouteController().stopRoute(r.getId());
             camelContext.removeRoute(r.getId());
         }
     }

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/EmptyProcessTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/EmptyProcessTest.java
@@ -54,7 +54,7 @@ public class EmptyProcessTest extends SpringFlowableTestCase {
     public void tearDown() throws Exception {
         List<Route> routes = camelContext.getRoutes();
         for (Route r : routes) {
-            camelContext.stopRoute(r.getId());
+            camelContext.getRouteController().stopRoute(r.getId());
             camelContext.removeRoute(r.getId());
         }
     }

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/MultipleInstanceRoute.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/MultipleInstanceRoute.java
@@ -48,7 +48,7 @@ public class MultipleInstanceRoute extends SpringFlowableTestCase {
     public void tearDown() throws Exception {
         List<Route> routes = camelContext.getRoutes();
         for (Route r : routes) {
-            camelContext.stopRoute(r.getId());
+            camelContext.getRouteController().stopRoute(r.getId());
             camelContext.removeRoute(r.getId());
         }
     }

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/ParallelProcessTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/ParallelProcessTest.java
@@ -54,7 +54,7 @@ public class ParallelProcessTest extends SpringFlowableTestCase {
     public void tearDown() throws Exception {
         List<Route> routes = camelContext.getRoutes();
         for (Route r : routes) {
-            camelContext.stopRoute(r.getId());
+            camelContext.getRouteController().stopRoute(r.getId());
             camelContext.removeRoute(r.getId());
         }
     }

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/SimpleProcessTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/SimpleProcessTest.java
@@ -65,7 +65,7 @@ public class SimpleProcessTest extends SpringFlowableTestCase {
     public void tearDown() throws Exception {
         List<Route> routes = camelContext.getRoutes();
         for (Route r : routes) {
-            camelContext.stopRoute(r.getId());
+            camelContext.getRouteController().stopRoute(r.getId());
             camelContext.removeRoute(r.getId());
         }
     }

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/SimpleSpringProcessTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/SimpleSpringProcessTest.java
@@ -55,7 +55,7 @@ public class SimpleSpringProcessTest extends SpringFlowableTestCase {
                 from("direct:start").to("flowable:camelProcess");
                 from("direct:receive").to("flowable:camelProcess:receive");
                 from("flowable:camelProcess:serviceTask2?copyVariablesToBodyAsMap=true").to("mock:service2");
-                from("flowable:camelProcess:serviceTask1").setBody().simple("property[var1]").to("mock:service1").setProperty("var2").constant("var2").setBody().mvel("properties");
+                from("flowable:camelProcess:serviceTask1").setBody().simple("${exchangeProperty[var1]}").to("mock:service1").setProperty("var2").constant("var2").setBody().mvel("properties");
             }
         });
 
@@ -69,7 +69,7 @@ public class SimpleSpringProcessTest extends SpringFlowableTestCase {
     public void tearDown() throws Exception {
         List<Route> routes = camelContext.getRoutes();
         for (Route r : routes) {
-            camelContext.stopRoute(r.getId());
+            camelContext.getRouteController().stopRoute(r.getId());
             camelContext.removeRoute(r.getId());
         }
     }

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/TestReturnValueFromFlowable.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/TestReturnValueFromFlowable.java
@@ -67,7 +67,7 @@ public class TestReturnValueFromFlowable extends SpringFlowableTestCase {
     public void tearDown() throws Exception {
         List<Route> routes = camelContext.getRoutes();
         for (Route r : routes) {
-            camelContext.stopRoute(r.getId());
+            camelContext.getRouteController().stopRoute(r.getId());
             camelContext.removeRoute(r.getId());
         }
     }

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/examples/ping/PingPongTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/examples/ping/PingPongTest.java
@@ -41,7 +41,7 @@ public class PingPongTest extends SpringFlowableTestCase {
 
             @Override
             public void configure() throws Exception {
-                from("flowable:PingPongProcess:ping").transform().simple("${property.input} World");
+                from("flowable:PingPongProcess:ping").transform().simple("${exchangeProperty.input} World");
             }
         });
     }

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/exception/CamelExceptionTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/exception/CamelExceptionTest.java
@@ -68,7 +68,7 @@ public class CamelExceptionTest extends SpringFlowableTestCase {
     public void tearDown() throws Exception {
         List<Route> routes = camelContext.getRoutes();
         for (Route r : routes) {
-            camelContext.stopRoute(r.getId());
+            camelContext.getRouteController().stopRoute(r.getId());
             camelContext.removeRoute(r.getId());
         }
     }

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/revisited/AsyncProcessRevisitedTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/revisited/AsyncProcessRevisitedTest.java
@@ -65,8 +65,8 @@ public class AsyncProcessRevisitedTest extends SpringFlowableTestCase {
         assertEquals(3, executionList.size());
         waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(7000, 200);
 
-        assertTrue(oneExchangeSendToFlowableReceive1.matchesMockWaitTime());
-        assertTrue(oneExchangeSendToFlowableReceive2.matchesMockWaitTime());
+        assertTrue(oneExchangeSendToFlowableReceive1.matchesWaitTime());
+        assertTrue(oneExchangeSendToFlowableReceive2.matchesWaitTime());
         assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
     }
 }

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/variables/CamelVariableTransferTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/variables/CamelVariableTransferTest.java
@@ -104,7 +104,7 @@ public class CamelVariableTransferTest extends SpringFlowableTestCase {
     public void tearDown() throws Exception {
         List<Route> routes = camelContext.getRoutes();
         for (Route r : routes) {
-            camelContext.stopRoute(r.getId());
+            camelContext.getRouteController().stopRoute(r.getId());
             camelContext.removeRoute(r.getId());
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 		<jackson.version>2.10.2</jackson.version>
 		<jakarta-jms.version>2.0.3</jakarta-jms.version>
 		<mule.version>3.8.0</mule.version>
-        <camel.version>2.25.0</camel.version>
+        <camel.version>3.0.0</camel.version>
 		<cxf.version>3.3.5</cxf.version>
 		<slf4j.version>1.7.30</slf4j.version>
 		<spring.boot.version>2.2.5.RELEASE</spring.boot.version>
@@ -1032,7 +1032,27 @@
 			</dependency>
 			<dependency>
 				<groupId>org.apache.camel</groupId>
+				<artifactId>camel-direct</artifactId>
+				<version>${camel.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.camel</groupId>
+				<artifactId>camel-seda</artifactId>
+				<version>${camel.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.camel</groupId>
+				<artifactId>camel-log</artifactId>
+				<version>${camel.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.camel</groupId>
 				<artifactId>camel-mvel</artifactId>
+				<version>${camel.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.camel</groupId>
+				<artifactId>camel-mock</artifactId>
 				<version>${camel.version}</version>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
Camel `3.0.0` was just released. Support for Camel `2.x` will end soon.

This pull request updates the `flowable-camel` and the `flowable-camel-cdi` modules to use the new Camel 3 API.