### PR TITLE
Flowable Admin: Terminate BPMN Process Instance does no longer work i…

### DIFF
--- a/modules/flowable-ui-admin/flowable-ui-admin-app/src/main/resources/static/scripts/process-instance-controllers.js
+++ b/modules/flowable-ui-admin/flowable-ui-admin-app/src/main/resources/static/scripts/process-instance-controllers.js
@@ -563,7 +563,7 @@ flowableAdminApp.controller('ProcessInstanceController', ['$scope', '$rootScope'
     }]);
 
 flowableAdminApp.controller('DeleteProcessModalInstanceCtrl',
-    ['$rootScope', '$scope', '$modalInstance', '$http', 'process', function ($rootScope, $scope, $modalInstance, $http, process, action) {
+    ['$rootScope', '$scope', '$modalInstance', '$http', 'process', 'action', function ($rootScope, $scope, $modalInstance, $http, process, action) {
 
         $scope.process = process;
         $scope.action = action;


### PR DESCRIPTION
…n 6.4.1 (fixes #1626)

Restores the termination functionality, but may break other things. I'm backend developer, so I have no idea if this is the correct fix.