### PR TITLE
Adjusting DefaultAutoDeployment to close inputStream after deploy

### DIFF
--- a/modules/flowable-app-engine-spring/src/main/java/org/flowable/app/spring/autodeployment/DefaultAutoDeploymentStrategy.java
+++ b/modules/flowable-app-engine-spring/src/main/java/org/flowable/app/spring/autodeployment/DefaultAutoDeploymentStrategy.java
@@ -14,6 +14,7 @@
 package org.flowable.app.spring.autodeployment;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.zip.ZipInputStream;
 
 import org.flowable.app.api.AppRepositoryService;
@@ -62,11 +63,11 @@ public class DefaultAutoDeploymentStrategy extends AbstractAutoDeploymentStrateg
 
                 final AppDeploymentBuilder deploymentBuilder = repositoryService.createDeployment().enableDuplicateFiltering().name(resourceName);
 
-                try {
+                try(InputStream resourceInputStream = resource.getInputStream()) {
                     if (resourceName.endsWith(".bar") || resourceName.endsWith(".zip")) {
-                        deploymentBuilder.addZipInputStream(new ZipInputStream(resource.getInputStream()));
+                        deploymentBuilder.addZipInputStream(new ZipInputStream(resourceInputStream));
                     } else {
-                        deploymentBuilder.addInputStream(resourceName, resource.getInputStream());
+                        deploymentBuilder.addInputStream(resourceName, resourceInputStream);
                     }
 
                 } catch (IOException e) {

--- a/modules/flowable-app-engine-spring/src/test/java/org/flowable/app/spring/test/autodeployment/AbstractAutoDeploymentStrategyTest.java
+++ b/modules/flowable-app-engine-spring/src/test/java/org/flowable/app/spring/test/autodeployment/AbstractAutoDeploymentStrategyTest.java
@@ -58,7 +58,7 @@ public class AbstractAutoDeploymentStrategyTest {
     protected File fileMock3;
 
     @Mock
-    private InputStream inputStreamMock;
+    protected InputStream inputStreamMock;
 
     @Mock
     private AppDeployment deploymentMock;

--- a/modules/flowable-app-engine-spring/src/test/java/org/flowable/app/spring/test/autodeployment/DefaultAutoDeploymentStrategyTest.java
+++ b/modules/flowable-app-engine-spring/src/test/java/org/flowable/app/spring/test/autodeployment/DefaultAutoDeploymentStrategyTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import java.io.IOException;
 import java.io.InputStream;
 
 import org.flowable.app.spring.autodeployment.DefaultAutoDeploymentStrategy;
@@ -55,7 +56,7 @@ public class DefaultAutoDeploymentStrategyTest extends AbstractAutoDeploymentStr
     }
 
     @Test
-    public void testDeployResources() {
+    public void testDeployResources() throws IOException {
         final Resource[] resources = new Resource[] { resourceMock1, resourceMock2, resourceMock3 };
         classUnderTest.deployResources(resources, repositoryServiceMock);
 
@@ -66,10 +67,11 @@ public class DefaultAutoDeploymentStrategyTest extends AbstractAutoDeploymentStr
         verify(deploymentBuilderMock, times(1)).addInputStream(eq(resourceName1), isA(InputStream.class));
         verify(deploymentBuilderMock, times(1)).addInputStream(eq(resourceName2), isA(InputStream.class));
         verify(deploymentBuilderMock, times(3)).deploy();
+        verify(inputStreamMock, times(3)).close();
     }
 
     @Test
-    public void testDeployResourcesNoResources() {
+    public void testDeployResourcesNoResources() throws IOException {
         final Resource[] resources = new Resource[] {};
         classUnderTest.deployResources(resources, repositoryServiceMock);
 
@@ -77,6 +79,7 @@ public class DefaultAutoDeploymentStrategyTest extends AbstractAutoDeploymentStr
         verify(deploymentBuilderMock, never()).addInputStream(isA(String.class), isA(InputStream.class));
         verify(deploymentBuilderMock, never()).addInputStream(eq(resourceName2), isA(InputStream.class));
         verify(deploymentBuilderMock, never()).deploy();
+        verify(inputStreamMock, never()).close();
     }
 
 }

--- a/modules/flowable-cmmn-spring/src/main/java/org/flowable/cmmn/spring/autodeployment/DefaultAutoDeploymentStrategy.java
+++ b/modules/flowable-cmmn-spring/src/main/java/org/flowable/cmmn/spring/autodeployment/DefaultAutoDeploymentStrategy.java
@@ -19,6 +19,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.Resource;
 
+import java.io.InputStream;
+
 /**
  * Default implementation of {@link AutoDeploymentStrategy} that groups all {@link Resource}s into a single deployment.
  * This implementation is equivalent to the previously used implementation.
@@ -48,7 +50,9 @@ public class DefaultAutoDeploymentStrategy extends AbstractAutoDeploymentStrateg
             final CmmnDeploymentBuilder deploymentBuilder = repositoryService.createDeployment().enableDuplicateFiltering().name(deploymentNameHint);
 
             for (final Resource resource : resources) {
-                deploymentBuilder.addInputStream(determineResourceName(resource), resource.getInputStream());
+                try(InputStream resourceInputStream = resource.getInputStream()) {
+                    deploymentBuilder.addInputStream(determineResourceName(resource), resourceInputStream);
+                }
             }
 
             deploymentBuilder.deploy();

--- a/modules/flowable-cmmn-spring/src/test/java/org/flowable/spring/test/autodeployment/AbstractAutoDeploymentStrategyTest.java
+++ b/modules/flowable-cmmn-spring/src/test/java/org/flowable/spring/test/autodeployment/AbstractAutoDeploymentStrategyTest.java
@@ -58,7 +58,7 @@ public class AbstractAutoDeploymentStrategyTest {
     protected File fileMock3;
 
     @Mock
-    private InputStream inputStreamMock;
+    protected InputStream inputStreamMock;
 
     @Mock
     private CmmnDeployment deploymentMock;

--- a/modules/flowable-cmmn-spring/src/test/java/org/flowable/spring/test/autodeployment/DefaultAutoDeploymentStrategyTest.java
+++ b/modules/flowable-cmmn-spring/src/test/java/org/flowable/spring/test/autodeployment/DefaultAutoDeploymentStrategyTest.java
@@ -57,7 +57,7 @@ public class DefaultAutoDeploymentStrategyTest extends AbstractAutoDeploymentStr
     }
 
     @Test
-    public void testDeployResources() {
+    public void testDeployResources() throws IOException {
         final Resource[] resources = new Resource[] { resourceMock1, resourceMock2 };
         classUnderTest.deployResources(deploymentNameHint, resources, repositoryServiceMock);
 
@@ -66,10 +66,11 @@ public class DefaultAutoDeploymentStrategyTest extends AbstractAutoDeploymentStr
         verify(deploymentBuilderMock, times(1)).addInputStream(eq(resourceName1), isA(InputStream.class));
         verify(deploymentBuilderMock, times(1)).addInputStream(eq(resourceName2), isA(InputStream.class));
         verify(deploymentBuilderMock, times(1)).deploy();
+        verify(inputStreamMock, times(2)).close();
     }
 
     @Test
-    public void testDeployResourcesNoResources() {
+    public void testDeployResourcesNoResources() throws IOException {
         final Resource[] resources = new Resource[] {};
         classUnderTest.deployResources(deploymentNameHint, resources, repositoryServiceMock);
 
@@ -78,6 +79,7 @@ public class DefaultAutoDeploymentStrategyTest extends AbstractAutoDeploymentStr
         verify(deploymentBuilderMock, never()).addInputStream(isA(String.class), isA(InputStream.class));
         verify(deploymentBuilderMock, never()).addInputStream(eq(resourceName2), isA(InputStream.class));
         verify(deploymentBuilderMock, times(1)).deploy();
+        verify(inputStreamMock, never()).close();
     }
 
     @Test
@@ -87,6 +89,7 @@ public class DefaultAutoDeploymentStrategyTest extends AbstractAutoDeploymentStr
 
         final Resource[] resources = new Resource[] { resourceMock3 };
         classUnderTest.deployResources(deploymentNameHint, resources, repositoryServiceMock);
+        verify(inputStreamMock, times(1)).close();
     }
 
 }

--- a/modules/flowable-dmn-spring/src/main/java/org/flowable/dmn/spring/autodeployment/DefaultAutoDeploymentStrategy.java
+++ b/modules/flowable-dmn-spring/src/main/java/org/flowable/dmn/spring/autodeployment/DefaultAutoDeploymentStrategy.java
@@ -19,6 +19,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.Resource;
 
+import java.io.InputStream;
+
 /**
  * Default implementation of {@link AutoDeploymentStrategy} that groups all {@link Resource}s into a single deployment.
  * This implementation is equivalent to the previously used implementation.
@@ -48,7 +50,9 @@ public class DefaultAutoDeploymentStrategy extends AbstractAutoDeploymentStrateg
             final DmnDeploymentBuilder deploymentBuilder = repositoryService.createDeployment().enableDuplicateFiltering().name(deploymentNameHint);
 
             for (final Resource resource : resources) {
-                deploymentBuilder.addInputStream(determineResourceName(resource), resource.getInputStream());
+                try(InputStream resourceInputStream = resource.getInputStream()) {
+                    deploymentBuilder.addInputStream(determineResourceName(resource), resourceInputStream);
+                }
             }
 
             deploymentBuilder.deploy();

--- a/modules/flowable-dmn-spring/src/test/java/org/flowable/spring/test/autodeployment/AbstractAutoDeploymentStrategyTest.java
+++ b/modules/flowable-dmn-spring/src/test/java/org/flowable/spring/test/autodeployment/AbstractAutoDeploymentStrategyTest.java
@@ -58,7 +58,7 @@ public class AbstractAutoDeploymentStrategyTest {
     protected File fileMock3;
 
     @Mock
-    private InputStream inputStreamMock;
+    protected InputStream inputStreamMock;
 
     @Mock
     private DmnDeployment deploymentMock;

--- a/modules/flowable-dmn-spring/src/test/java/org/flowable/spring/test/autodeployment/DefaultAutoDeploymentStrategyTest.java
+++ b/modules/flowable-dmn-spring/src/test/java/org/flowable/spring/test/autodeployment/DefaultAutoDeploymentStrategyTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import java.io.IOException;
 import java.io.InputStream;
 
 import org.flowable.dmn.spring.autodeployment.DefaultAutoDeploymentStrategy;
@@ -55,7 +56,7 @@ public class DefaultAutoDeploymentStrategyTest extends AbstractAutoDeploymentStr
     }
 
     @Test
-    public void testDeployResources() {
+    public void testDeployResources() throws IOException {
         final Resource[] resources = new Resource[] { resourceMock1, resourceMock2 };
         classUnderTest.deployResources(deploymentNameHint, resources, repositoryServiceMock);
 
@@ -65,10 +66,11 @@ public class DefaultAutoDeploymentStrategyTest extends AbstractAutoDeploymentStr
         verify(deploymentBuilderMock, times(1)).addInputStream(eq(resourceName1), isA(InputStream.class));
         verify(deploymentBuilderMock, times(1)).addInputStream(eq(resourceName2), isA(InputStream.class));
         verify(deploymentBuilderMock, times(1)).deploy();
+        verify(inputStreamMock, times(2)).close();
     }
 
     @Test
-    public void testDeployResourcesNoResources() {
+    public void testDeployResourcesNoResources() throws IOException {
         final Resource[] resources = new Resource[] {};
         classUnderTest.deployResources(deploymentNameHint, resources, repositoryServiceMock);
 
@@ -78,6 +80,7 @@ public class DefaultAutoDeploymentStrategyTest extends AbstractAutoDeploymentStr
         verify(deploymentBuilderMock, never()).addInputStream(isA(String.class), isA(InputStream.class));
         verify(deploymentBuilderMock, never()).addInputStream(eq(resourceName2), isA(InputStream.class));
         verify(deploymentBuilderMock, times(1)).deploy();
+        verify(inputStreamMock, never()).close();
     }
 
 }

--- a/modules/flowable-form-spring/src/main/java/org/flowable/form/spring/autodeployment/DefaultAutoDeploymentStrategy.java
+++ b/modules/flowable-form-spring/src/main/java/org/flowable/form/spring/autodeployment/DefaultAutoDeploymentStrategy.java
@@ -19,6 +19,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.Resource;
 
+import java.io.InputStream;
+
 /**
  * Default implementation of {@link AutoDeploymentStrategy} that groups all {@link Resource}s into a single deployment. This implementation is equivalent to the previously used implementation.
  * 
@@ -47,7 +49,9 @@ public class DefaultAutoDeploymentStrategy extends AbstractAutoDeploymentStrateg
 
             for (final Resource resource : resources) {
                 final String resourceName = determineResourceName(resource);
-                deploymentBuilder.addInputStream(resourceName, resource.getInputStream());
+                try(InputStream resourceInputStream = resource.getInputStream()) {
+                    deploymentBuilder.addInputStream(resourceName, resourceInputStream);
+                }
             }
 
             deploymentBuilder.deploy();

--- a/modules/flowable-form-spring/src/test/java/org/flowable/spring/test/autodeployment/AbstractAutoDeploymentStrategyTest.java
+++ b/modules/flowable-form-spring/src/test/java/org/flowable/spring/test/autodeployment/AbstractAutoDeploymentStrategyTest.java
@@ -60,7 +60,7 @@ public class AbstractAutoDeploymentStrategyTest {
     protected File fileMock3;
 
     @Mock
-    private InputStream inputStreamMock;
+    protected InputStream inputStreamMock;
 
     @Mock
     private FormDeployment deploymentMock;

--- a/modules/flowable-form-spring/src/test/java/org/flowable/spring/test/autodeployment/DefaultAutoDeploymentStrategyTest.java
+++ b/modules/flowable-form-spring/src/test/java/org/flowable/spring/test/autodeployment/DefaultAutoDeploymentStrategyTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import java.io.IOException;
 import java.io.InputStream;
 
 import org.flowable.form.spring.autodeployment.DefaultAutoDeploymentStrategy;
@@ -55,7 +56,7 @@ public class DefaultAutoDeploymentStrategyTest extends AbstractAutoDeploymentStr
     }
 
     @Test
-    public void testDeployResources() {
+    public void testDeployResources() throws IOException {
         final Resource[] resources = new Resource[] { resourceMock1, resourceMock2 };
         classUnderTest.deployResources(deploymentNameHint, resources, repositoryServiceMock);
 
@@ -65,10 +66,11 @@ public class DefaultAutoDeploymentStrategyTest extends AbstractAutoDeploymentStr
         verify(deploymentBuilderMock, times(1)).addInputStream(eq(resourceName1), isA(InputStream.class));
         verify(deploymentBuilderMock, times(1)).addInputStream(eq(resourceName2), isA(InputStream.class));
         verify(deploymentBuilderMock, times(1)).deploy();
+        verify(inputStreamMock, times(2)).close();
     }
 
     @Test
-    public void testDeployResourcesNoResources() {
+    public void testDeployResourcesNoResources() throws IOException {
         final Resource[] resources = new Resource[] {};
         classUnderTest.deployResources(deploymentNameHint, resources, repositoryServiceMock);
 
@@ -78,6 +80,7 @@ public class DefaultAutoDeploymentStrategyTest extends AbstractAutoDeploymentStr
         verify(deploymentBuilderMock, never()).addInputStream(isA(String.class), isA(InputStream.class));
         verify(deploymentBuilderMock, never()).addInputStream(eq(resourceName2), isA(InputStream.class));
         verify(deploymentBuilderMock, times(1)).deploy();
+        verify(inputStreamMock, never()).close();
     }
 
 }

--- a/modules/flowable-spring/src/main/java/org/flowable/spring/configurator/DefaultAutoDeploymentStrategy.java
+++ b/modules/flowable-spring/src/main/java/org/flowable/spring/configurator/DefaultAutoDeploymentStrategy.java
@@ -13,6 +13,7 @@
 
 package org.flowable.spring.configurator;
 
+import java.io.InputStream;
 import java.util.zip.ZipInputStream;
 
 import org.flowable.engine.RepositoryService;
@@ -51,10 +52,12 @@ public class DefaultAutoDeploymentStrategy extends AbstractAutoDeploymentStrateg
 
             for (final Resource resource : resources) {
                 final String resourceName = determineResourceName(resource);
-                if (resourceName.endsWith(".bar") || resourceName.endsWith(".zip") || resourceName.endsWith(".jar")) {
-                    deploymentBuilder.addZipInputStream(new ZipInputStream(resource.getInputStream()));
-                } else {
-                    deploymentBuilder.addInputStream(resourceName, resource.getInputStream());
+                try(InputStream resourceInputStream = resource.getInputStream()) {
+                    if (resourceName.endsWith(".bar") || resourceName.endsWith(".zip") || resourceName.endsWith(".jar")) {
+                        deploymentBuilder.addZipInputStream(new ZipInputStream(resourceInputStream));
+                    } else {
+                        deploymentBuilder.addInputStream(resourceName, resourceInputStream);
+                    }
                 }
 
             }

--- a/modules/flowable-spring/src/test/java/org/flowable/spring/test/autodeployment/AbstractAutoDeploymentStrategyTest.java
+++ b/modules/flowable-spring/src/test/java/org/flowable/spring/test/autodeployment/AbstractAutoDeploymentStrategyTest.java
@@ -70,7 +70,7 @@ public class AbstractAutoDeploymentStrategyTest {
     protected File fileMock5;
 
     @Mock
-    private InputStream inputStreamMock;
+    protected InputStream inputStreamMock;
 
     @Mock
     private Deployment deploymentMock;

--- a/modules/flowable-spring/src/test/java/org/flowable/spring/test/autodeployment/DefaultAutoDeploymentStrategyTest.java
+++ b/modules/flowable-spring/src/test/java/org/flowable/spring/test/autodeployment/DefaultAutoDeploymentStrategyTest.java
@@ -58,7 +58,7 @@ public class DefaultAutoDeploymentStrategyTest extends AbstractAutoDeploymentStr
     }
 
     @Test
-    public void testDeployResources() {
+    public void testDeployResources() throws IOException {
         final Resource[] resources = new Resource[] { resourceMock1, resourceMock2, resourceMock3, resourceMock4, resourceMock5 };
         classUnderTest.deployResources(deploymentNameHint, resources, repositoryServiceMock);
 
@@ -69,10 +69,11 @@ public class DefaultAutoDeploymentStrategyTest extends AbstractAutoDeploymentStr
         verify(deploymentBuilderMock, times(1)).addInputStream(eq(resourceName2), isA(InputStream.class));
         verify(deploymentBuilderMock, times(3)).addZipInputStream(isA(ZipInputStream.class));
         verify(deploymentBuilderMock, times(1)).deploy();
+        verify(inputStreamMock, times(5)).close();
     }
 
     @Test
-    public void testDeployResourcesNoResources() {
+    public void testDeployResourcesNoResources() throws IOException {
         final Resource[] resources = new Resource[] {};
         classUnderTest.deployResources(deploymentNameHint, resources, repositoryServiceMock);
 
@@ -83,6 +84,7 @@ public class DefaultAutoDeploymentStrategyTest extends AbstractAutoDeploymentStr
         verify(deploymentBuilderMock, never()).addInputStream(eq(resourceName2), isA(InputStream.class));
         verify(deploymentBuilderMock, never()).addZipInputStream(isA(ZipInputStream.class));
         verify(deploymentBuilderMock, times(1)).deploy();
+        verify(inputStreamMock, never()).close();
     }
 
     @Test
@@ -92,6 +94,7 @@ public class DefaultAutoDeploymentStrategyTest extends AbstractAutoDeploymentStr
 
         final Resource[] resources = new Resource[] { resourceMock3 };
         classUnderTest.deployResources(deploymentNameHint, resources, repositoryServiceMock);
+        verify(inputStreamMock, times(1)).close();
     }
 
 }

--- a/modules/flowable5-spring-test/src/test/java/org/activiti/spring/test/autodeployment/AbstractAutoDeploymentStrategyTest.java
+++ b/modules/flowable5-spring-test/src/test/java/org/activiti/spring/test/autodeployment/AbstractAutoDeploymentStrategyTest.java
@@ -70,7 +70,7 @@ public class AbstractAutoDeploymentStrategyTest {
     protected File fileMock5;
 
     @Mock
-    private InputStream inputStreamMock;
+    protected InputStream inputStreamMock;
 
     @Mock
     private Deployment deploymentMock;

--- a/modules/flowable5-spring-test/src/test/java/org/activiti/spring/test/autodeployment/DefaultAutoDeploymentStrategyTest.java
+++ b/modules/flowable5-spring-test/src/test/java/org/activiti/spring/test/autodeployment/DefaultAutoDeploymentStrategyTest.java
@@ -59,7 +59,7 @@ public class DefaultAutoDeploymentStrategyTest extends AbstractAutoDeploymentStr
     }
 
     @Test
-    public void testDeployResources() {
+    public void testDeployResources() throws IOException {
         final Resource[] resources = new Resource[] { resourceMock1, resourceMock2, resourceMock3, resourceMock4, resourceMock5 };
         classUnderTest.deployResources(deploymentNameHint, resources, repositoryServiceMock);
 
@@ -70,10 +70,11 @@ public class DefaultAutoDeploymentStrategyTest extends AbstractAutoDeploymentStr
         verify(deploymentBuilderMock, times(1)).addInputStream(eq(resourceName2), isA(InputStream.class));
         verify(deploymentBuilderMock, times(3)).addZipInputStream(isA(ZipInputStream.class));
         verify(deploymentBuilderMock, times(1)).deploy();
+        verify(inputStreamMock, times(5)).close();
     }
 
     @Test
-    public void testDeployResourcesNoResources() {
+    public void testDeployResourcesNoResources() throws IOException {
         final Resource[] resources = new Resource[] {};
         classUnderTest.deployResources(deploymentNameHint, resources, repositoryServiceMock);
 
@@ -84,6 +85,7 @@ public class DefaultAutoDeploymentStrategyTest extends AbstractAutoDeploymentStr
         verify(deploymentBuilderMock, never()).addInputStream(eq(resourceName2), isA(InputStream.class));
         verify(deploymentBuilderMock, never()).addZipInputStream(isA(ZipInputStream.class));
         verify(deploymentBuilderMock, times(1)).deploy();
+        verify(inputStreamMock, never()).close();
     }
 
     @Test(expected = ActivitiException.class)

--- a/modules/flowable5-spring/src/main/java/org/activiti/spring/autodeployment/DefaultAutoDeploymentStrategy.java
+++ b/modules/flowable5-spring/src/main/java/org/activiti/spring/autodeployment/DefaultAutoDeploymentStrategy.java
@@ -14,6 +14,7 @@
 package org.activiti.spring.autodeployment;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.zip.ZipInputStream;
 
 import org.activiti.engine.ActivitiException;
@@ -48,11 +49,11 @@ public class DefaultAutoDeploymentStrategy extends AbstractAutoDeploymentStrateg
         for (final Resource resource : resources) {
             final String resourceName = determineResourceName(resource);
 
-            try {
+            try(InputStream resourceInputStream = resource.getInputStream()) {
                 if (resourceName.endsWith(".bar") || resourceName.endsWith(".zip") || resourceName.endsWith(".jar")) {
-                    deploymentBuilder.addZipInputStream(new ZipInputStream(resource.getInputStream()));
+                    deploymentBuilder.addZipInputStream(new ZipInputStream(resourceInputStream));
                 } else {
-                    deploymentBuilder.addInputStream(resourceName, resource.getInputStream());
+                    deploymentBuilder.addInputStream(resourceName, resourceInputStream);
                 }
             } catch (IOException e) {
                 throw new ActivitiException("couldn't auto deploy resource '" + resource + "': " + e.getMessage(), e);


### PR DESCRIPTION
I was having some trouble with the hot deployment on Apache Tomcat after integrate my application with Flowable.

I that case, Flowable was letting all my resources/processes/*.bpmn20.xml files opened, preventing the Tomcat server to made the deployment. Needing to stop the server before make a new deploy.

After some advices here: [https://github.com/flowable/flowable-engine/pull/1668](https://github.com/flowable/flowable-engine/pull/1668)

I made this new request, to correct the deployment method and adjust  their tests.