### PR TITLE
Fix querying with order by on SQL Server + add profile for running tests with SQL Server on CI

### DIFF
--- a/modules/flowable-cmmn-engine/pom.xml
+++ b/modules/flowable-cmmn-engine/pom.xml
@@ -492,6 +492,28 @@
         </profile>
 
         <profile>
+            <id>mssql</id>
+            <activation>
+                <property>
+                    <name>databasemssql</name>
+                    <value>mssql</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>net.sourceforge.jtds</groupId>
+                    <artifactId>jtds</artifactId>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>com.microsoft.sqlserver</groupId>
+                    <artifactId>mssql-jdbc</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <profile>
             <id>distro</id>
             <build>
                 <plugins>

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/test/FlowableCmmnTestCase.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/test/FlowableCmmnTestCase.java
@@ -18,6 +18,8 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Instant;
+import java.time.temporal.ChronoField;
 import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -119,7 +121,8 @@ public abstract class FlowableCmmnTestCase {
     }
     
     protected Date setClockFixedToCurrentTime() {
-        Date date = new Date();
+        // SQL Server rounds the milliseconds, on order to be stable we set them to 0
+        Date date = Date.from(Instant.now().with(ChronoField.MILLI_OF_SECOND, 0));
         cmmnEngineConfiguration.getClock().setCurrentTime(date);
         return date;
     }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/async/AsyncCmmnHistoryTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/async/AsyncCmmnHistoryTest.java
@@ -21,6 +21,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.time.Instant;
+import java.time.temporal.ChronoField;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
@@ -351,7 +353,7 @@ public class AsyncCmmnHistoryTest extends CustomCmmnConfigurationFlowableTestCas
         assertThat(historicTaskInstance.getDueDate()).isNull();
 
         // Set due date
-        Date dueDate = new Date();
+        Date dueDate = Date.from(Instant.now().with(ChronoField.MILLI_OF_SECOND, 0));
         cmmnTaskService.setDueDate(task.getId(), dueDate);
 
         waitForAsyncHistoryExecutorToProcessAllJobs();

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/PlanItemInstanceQueryTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/PlanItemInstanceQueryTest.java
@@ -386,7 +386,7 @@ public class PlanItemInstanceQueryTest extends FlowableCmmnTestCase {
 
     @Test
     public void testLastDisabledBeforeAndAfter() {
-        Date now = new Date();
+        Date now = setClockFixedToCurrentTime();
         setClockTo(now);
         startInstances(3);
 

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/db/DbSqlSession.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/db/DbSqlSession.java
@@ -184,7 +184,8 @@ public class DbSqlSession implements Session {
         if (parameterToUse == null) {
             parameterToUse = new ListQueryParameterObject();
         }
-        return selectListWithRawParameter(statement, parameter, false);
+        parameterToUse.setDatabaseType(dbSqlSessionFactory.getDatabaseType());
+        return selectListWithRawParameter(statement, parameterToUse, false);
     }
 
     @SuppressWarnings("rawtypes")

--- a/pom.xml
+++ b/pom.xml
@@ -965,6 +965,11 @@
 				<version>1.3.0</version>
 			</dependency>
 			<dependency>
+				<groupId>com.microsoft.sqlserver</groupId>
+				<artifactId>mssql-jdbc</artifactId>
+				<version>6.4.0.jre8</version>
+			</dependency>
+			<dependency>
 				<groupId>org.assertj</groupId>
 				<artifactId>assertj-core</artifactId>
 				<version>3.12.2</version>


### PR DESCRIPTION

Fix for SQL Server is to make sure that the databaseType is set on the ListQueryParameterObject when listing without cache
Adapt test cases to use time without milliseconds. The reason for this is that SQL Server rounds the milliseconds