### PR TITLE
Add the ability to set and edit Tenant ID for users in IDM

### DIFF
--- a/modules/flowable-ui-common/src/main/java/org/flowable/ui/common/model/UserRepresentation.java
+++ b/modules/flowable-ui-common/src/main/java/org/flowable/ui/common/model/UserRepresentation.java
@@ -27,6 +27,7 @@ public class UserRepresentation extends AbstractRepresentation {
     protected String lastName;
     protected String email;
     protected String fullName;
+    protected String tenantId;
     protected List<GroupRepresentation> groups = new ArrayList<>();
     protected List<String> privileges = new ArrayList<>();
 
@@ -39,6 +40,7 @@ public class UserRepresentation extends AbstractRepresentation {
         setFirstName(user.getFirstName());
         setLastName(user.getLastName());
         setFullName((user.getFirstName() != null ? user.getFirstName() : "") + " " + (user.getLastName() != null ? user.getLastName() : ""));
+        setTenantId(user.getTenantId());
         setEmail(user.getEmail());
     }
 
@@ -82,6 +84,17 @@ public class UserRepresentation extends AbstractRepresentation {
         this.fullName = fullName;
     }
 
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    public void setTenantId(String tenantId) {
+        if (tenantId == null || tenantId.isEmpty())
+            this.tenantId = null;
+        else
+            this.tenantId = tenantId;
+    }
+    
     public List<GroupRepresentation> getGroups() {
         return groups;
     }

--- a/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/resources/static/i18n/en.json
+++ b/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/resources/static/i18n/en.json
@@ -130,6 +130,7 @@
          "ID": "ID",
          "EMAIL": "Email",
          "NAME": "Name",
+         "TENANT": "Tenant",
          "CREATED": "Created",
          "TYPE": "Type",
          "EXTERNAL-ID": "External id",

--- a/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/resources/static/i18n/es.json
+++ b/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/resources/static/i18n/es.json
@@ -130,6 +130,7 @@
          "ID": "Identificador",
          "EMAIL": "Email",
          "NAME": "Nombre",
+         "TENANT": "Inquilino",
          "CREATED": "Creado",
          "TYPE": "Tipo",
          "EXTERNAL-ID": "Identificador externo",

--- a/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/resources/static/i18n/fr.json
+++ b/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/resources/static/i18n/fr.json
@@ -130,6 +130,7 @@
          "ID": "ID",
          "EMAIL": "E-mail",
          "NAME": "Nom",
+         "TENANT": "Tenancier",
          "CREATED": "Créé",
          "TYPE": "Type",
          "EXTERNAL-ID": "Identifiant externe",

--- a/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/resources/static/scripts/idm-user-mgmt-controller.js
+++ b/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/resources/static/scripts/idm-user-mgmt-controller.js
@@ -241,6 +241,7 @@ flowableApp.controller('IdmCreateUserPopupController', ['$rootScope', '$scope', 
                 firstName: model.user.firstName,
                 lastName: model.user.lastName,
                 password: model.user.password,
+                tenantId: model.user.tenantId,
             };
 
             $http({method: 'POST', url: FLOWABLE.CONFIG.contextRoot + '/app/rest/admin/users', data: data}).
@@ -283,6 +284,7 @@ flowableApp.controller('IdmCreateUserPopupController', ['$rootScope', '$scope', 
                 email: model.user.email,
                 firstName: model.user.firstName,
                 lastName: model.user.lastName,
+                tenantId: model.user.tenantId,
             };
 
             $http({method: 'PUT', url: FLOWABLE.CONFIG.contextRoot + '/app/rest/admin/users/' + $scope.model.user.id, data: data}).

--- a/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/resources/static/views/idm-user-mgmt.html
+++ b/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/resources/static/views/idm-user-mgmt.html
@@ -77,12 +77,14 @@
                             <th width="20%">{{'IDM.USER-MGMT.ID' | translate}}</th>
                             <th width="30%">{{'IDM.USER-MGMT.EMAIL' | translate}}</th>
                             <th width="30%">{{'IDM.USER-MGMT.NAME' | translate}}</th>
+                            <th width="20%">{{'IDM.USER-MGMT.TENANT' | translate}}</th>
                         </tr>
                         <tr ng-repeat="user in model.users.data" ng-click="toggleUserSelection(user)" ng-class="{'selected': model.selectedUsers[user.id]}">
                             <td class="control"><input type="checkbox" ng-checked="model.selectedUsers[user.id]"></td>
                             <td>{{user.id}}</td>
                             <td>{{user.email}}</td>
                             <td>{{user.fullName}}</td>
+                            <td>{{user.tenantId}}</td>
                         </tr>
                     </table>
                 </div>

--- a/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/resources/static/views/popup/idm-user-create.html
+++ b/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/resources/static/views/popup/idm-user-create.html
@@ -53,6 +53,12 @@
                             <input type="text" class="form-control" ng-model="model.user.lastName">
                         </div>
                     </div>
+                    <div class="col-xs-12">
+                        <div class="form-group">
+                            <label class="control-label">{{'IDM.USER-MGMT.POPUP.CREATE-TENANT' | translate}}</label>
+                            <input type="text" class="form-control" ng-model="model.user.tenantId">
+                        </div>
+                    </div>
 
                 </form>
 

--- a/modules/flowable-ui-idm/flowable-ui-idm-logic/src/main/java/org/flowable/ui/idm/model/UpdateUsersRepresentation.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-logic/src/main/java/org/flowable/ui/idm/model/UpdateUsersRepresentation.java
@@ -26,6 +26,7 @@ public class UpdateUsersRepresentation extends AbstractRepresentation {
     protected String firstName;
     protected String lastName;
     protected String email;
+    protected String tenantId;
     protected String password;
     protected List<String> users = new ArrayList<>();
 
@@ -64,7 +65,18 @@ public class UpdateUsersRepresentation extends AbstractRepresentation {
     public void setEmail(String email) {
         this.email = email;
     }
+    
+    public String getTenantId() {
+        return tenantId;
+    }
 
+    public void setTenantId(String tenantId) {
+        if (tenantId == null || tenantId.isEmpty())
+            this.tenantId = null;
+        else
+            this.tenantId = tenantId;
+    }
+    
     public String getPassword() {
         return password;
     }

--- a/modules/flowable-ui-idm/flowable-ui-idm-logic/src/main/java/org/flowable/ui/idm/service/UserService.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-logic/src/main/java/org/flowable/ui/idm/service/UserService.java
@@ -27,12 +27,16 @@ public interface UserService {
     long getUserCount(String filter, String sort, Integer start, String groupId);
 
     void updateUserDetails(String userId, String firstName, String lastName, String email);
+    
+    void updateUserDetails(String userId, String firstName, String lastName, String email, String tenantId);
 
     void bulkUpdatePassword(List<String> userIds, String newPassword);
 
     void deleteUser(String userId);
 
     User createNewUser(String id, String firstName, String lastName, String email, String password);
+    
+    User createNewUser(String id, String firstName, String lastName, String email, String password, String tenantId);
 
     UserInformation getUserInformation(String userId);
 

--- a/modules/flowable-ui-idm/flowable-ui-idm-logic/src/main/java/org/flowable/ui/idm/service/UserServiceImpl.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-logic/src/main/java/org/flowable/ui/idm/service/UserServiceImpl.java
@@ -70,11 +70,16 @@ public class UserServiceImpl extends AbstractIdmService implements UserService {
     }
 
     public void updateUserDetails(String userId, String firstName, String lastName, String email) {
+        updateUserDetails(userId, firstName, lastName, email, null);
+    }
+
+    public void updateUserDetails(String userId, String firstName, String lastName, String email, String tenantId) {
         User user = identityService.createUserQuery().userId(userId).singleResult();
         if (user != null) {
             user.setFirstName(firstName);
             user.setLastName(lastName);
             user.setEmail(email);
+            user.setTenantId(tenantId);
             identityService.saveUser(user);
         }
     }
@@ -105,9 +110,14 @@ public class UserServiceImpl extends AbstractIdmService implements UserService {
     }
 
     public User createNewUser(String id, String firstName, String lastName, String email, String password) {
+        return createNewUser(id, firstName, lastName, email, password, null);
+    }
+
+    @Override
+    public User createNewUser(String id, String firstName, String lastName, String email, String password, String tenantId) {
         if (StringUtils.isBlank(id) ||
-                StringUtils.isBlank(password) ||
-                StringUtils.isBlank(firstName)) {
+            StringUtils.isBlank(password) ||
+            StringUtils.isBlank(firstName)) {
             throw new BadRequestException("Id, password and first name are required");
         }
 
@@ -119,6 +129,7 @@ public class UserServiceImpl extends AbstractIdmService implements UserService {
         user.setFirstName(firstName);
         user.setLastName(lastName);
         user.setEmail(email);
+        user.setTenantId(tenantId);
         identityService.saveUser(user);
 
         User savedUser = identityService.createUserQuery().userEmail(email).singleResult();

--- a/modules/flowable-ui-idm/flowable-ui-idm-rest/src/main/java/org/flowable/ui/idm/rest/app/IdmUsersResource.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-rest/src/main/java/org/flowable/ui/idm/rest/app/IdmUsersResource.java
@@ -73,7 +73,8 @@ public class IdmUsersResource {
     public void updateUserDetails(@PathVariable String userId, @RequestBody UpdateUsersRepresentation updateUsersRepresentation) {
         userService.updateUserDetails(userId, updateUsersRepresentation.getFirstName(),
                 updateUsersRepresentation.getLastName(),
-                updateUsersRepresentation.getEmail());
+                updateUsersRepresentation.getEmail(),
+                updateUsersRepresentation.getTenantId());
     }
 
     @ResponseStatus(value = HttpStatus.OK)
@@ -90,11 +91,13 @@ public class IdmUsersResource {
 
     @RequestMapping(value = "/rest/admin/users", method = RequestMethod.POST)
     public UserRepresentation createNewUser(@RequestBody CreateUserRepresentation userRepresentation) {
-        return new UserRepresentation(userService.createNewUser(userRepresentation.getId(),
+        return new UserRepresentation(userService.createNewUser(
+                userRepresentation.getId(),
                 userRepresentation.getFirstName(),
                 userRepresentation.getLastName(),
                 userRepresentation.getEmail(),
-                userRepresentation.getPassword()));
+                userRepresentation.getPassword(),
+                userRepresentation.getTenantId()));
     }
 
 }


### PR DESCRIPTION
I'm extending a previous pull request by @mattydebie ( https://github.com/flowable/flowable-engine/pull/1444 ). To make it easier to accept the PRs, I've decided to take a more gradual approach and split this into the non-controversial part of being able to edit the tenant ID within IDM and the work-in-progress part where the tenant ID is passed along with the requests.