### PR TITLE
Improve user creation checks in IDM

### DIFF
--- a/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/resources/static/scripts/idm-user-mgmt-controller.js
+++ b/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/resources/static/scripts/idm-user-mgmt-controller.js
@@ -264,7 +264,7 @@ flowableApp.controller('IdmCreateUserPopupController', ['$rootScope', '$scope', 
                     if (status == 403) {
                         $scope.model.errorMessage = "Forbidden";
                     } else if (status == 409) {
-                        $scope.model.errorMessage = "A user with that email address already exists";
+                        $scope.model.errorMessage = "A user with that ID or email address already exists";
                     } else {
                         $scope.$hide();
                     }

--- a/modules/flowable-ui-idm/flowable-ui-idm-logic/src/main/java/org/flowable/ui/idm/service/UserServiceImpl.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-logic/src/main/java/org/flowable/ui/idm/service/UserServiceImpl.java
@@ -121,7 +121,11 @@ public class UserServiceImpl extends AbstractIdmService implements UserService {
             throw new BadRequestException("Id, password and first name are required");
         }
 
-        if (email != null && identityService.createUserQuery().userEmail(email).count() > 0) {
+        if (StringUtils.isNotBlank(email) && identityService.createUserQuery().userEmail(email).count() > 0) {
+            throw new ConflictingRequestException("User already registered", "ACCOUNT.SIGNUP.ERROR.ALREADY-REGISTERED");
+        }
+        
+        if (identityService.createUserQuery().userId(id).count() > 0) {
             throw new ConflictingRequestException("User already registered", "ACCOUNT.SIGNUP.ERROR.ALREADY-REGISTERED");
         }
 


### PR DESCRIPTION
I noticed that the code which creates users does not check for duplicate user IDs and attempts to create such a duplicate. This ends with an exception complaining about violations of DB constraints.

This PR does the following:
1. Check that an user with this ID does not already exist and if it does, throw an exception. I left the duplicate email check in place for backwards compatibility.
2. Changes the UI error message a bit to reflect the nature of the error
3. Slightly change handling of blank email field, the original code ignores it if it's null (likely for creation of email-less service accounts such as 'rest'), but UI sends an empty String if no email is entered. Curiously, it also sends null if the address is invalid. So let's check it with StringUtils instead so that duplicate empty emails do not trigger the duplicate email check. I can of course also set an empty String to null if you think this is a better idea.