### PR TITLE
Fixed support for includeCaseVariables when retrieving historic cases

### DIFF
--- a/modules/flowable-cmmn-rest/src/main/java/org/flowable/cmmn/rest/service/api/CmmnRestResponseFactory.java
+++ b/modules/flowable-cmmn-rest/src/main/java/org/flowable/cmmn/rest/service/api/CmmnRestResponseFactory.java
@@ -558,6 +558,12 @@ public class CmmnRestResponseFactory {
         result.setStartTime(caseInstance.getStartTime());
         result.setStartUserId(caseInstance.getStartUserId());
         result.setUrl(urlBuilder.buildUrl(CmmnRestUrls.URL_HISTORIC_CASE_INSTANCE, caseInstance.getId()));
+        if (caseInstance.getCaseVariables() != null) {
+            Map<String, Object> variableMap = caseInstance.getCaseVariables();
+            for (String name : variableMap.keySet()) {
+                result.addVariable(createRestVariable(name, variableMap.get(name), RestVariableScope.LOCAL, caseInstance.getId(), VARIABLE_HISTORY_CASE, false, urlBuilder));
+            }
+        }
         result.setTenantId(caseInstance.getTenantId());
         return result;
     }

--- a/modules/flowable-cmmn-rest/src/main/java/org/flowable/cmmn/rest/service/api/history/caze/HistoricCaseInstanceBaseResource.java
+++ b/modules/flowable-cmmn-rest/src/main/java/org/flowable/cmmn/rest/service/api/history/caze/HistoricCaseInstanceBaseResource.java
@@ -105,6 +105,11 @@ public class HistoricCaseInstanceBaseResource {
                 query.unfinished();
             }
         }
+        if (queryRequest.getIncludeCaseVariables() != null) {
+            if (queryRequest.getIncludeCaseVariables()) {
+                query.includeCaseVariables();
+            }
+        }
         if (queryRequest.getVariables() != null) {
             addVariables(query, queryRequest.getVariables());
         }


### PR DESCRIPTION
I have noticed that the Rest API /cmmn-api/cmmn-history/historic-case-instances?includeCaseVariables=true is not working.

The result is returned without any case variables being included - the parameter is being ignored.
It seems that the implementation for the parameter includeCaseVariables is missing. I have added the missing logic, by repeating the same code from the historic-process-instances Rest API.

Please let me know if anything else is needed.

Thanks,
Paul