### PR TITLE
Fix fetching of the new user after creation

### DIFF
--- a/modules/flowable-ui-idm/flowable-ui-idm-logic/src/main/java/org/flowable/ui/idm/service/UserServiceImpl.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-logic/src/main/java/org/flowable/ui/idm/service/UserServiceImpl.java
@@ -136,7 +136,7 @@ public class UserServiceImpl extends AbstractIdmService implements UserService {
         user.setTenantId(tenantId);
         identityService.saveUser(user);
 
-        User savedUser = identityService.createUserQuery().userEmail(email).singleResult();
+        User savedUser = identityService.createUserQuery().userId(id).singleResult();
         savedUser.setPassword(password);
         identityService.updateUserPassword(savedUser);
 


### PR DESCRIPTION
I omitted to change the way newly-created users are fetched in the previous PR #1712, so this is a little bugfix. Let's fetch them by the ID (necessarily unique because of DB constraints) instead of email. Presently the code is throwing an error if there are multiple service accounts without an email, because the query returns more than a single result.