### PR TITLE
Add support for unaqcuiring jobs on AsyncExecutor shutdown

### DIFF
--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/DefaultAsyncJobExecutor.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/DefaultAsyncJobExecutor.java
@@ -117,26 +117,20 @@ public class DefaultAsyncJobExecutor extends AbstractAsyncExecutor {
         } catch (RejectedExecutionException e) {
             unacquireJobAfterRejection(job);
 
-            // Job queue full, returning false so (if wanted) the acquiring can
-            // be throttled
+            // Job queue full, returning false so (if wanted) the acquiring can be throttled
             return false;
         }
     }
 
     protected void unacquireJobAfterRejection(final JobInfo job) {
         // When a RejectedExecutionException is caught, this means that the
-        // queue for holding the jobs
-        // that are to be executed is full and can't store more.
-        // The job is now 'unlocked', meaning that the lock owner/time is set to
-        // null,
-        // so other executors can pick the job up (or this async executor, the
-        // next time the
+        // queue for holding the jobs that are to be executed is full and can't store more.
+        // The job is now 'unlocked', meaning that the lock owner/time is set to null,
+        // so other executors can pick the job up (or this async executor, the next time the
         // acquire query is executed.
 
-        // This can happen while already in a command context (for example in a
-        // transaction listener
-        // after the async executor has been hinted that a new async job is
-        // created)
+        // This can happen while already in a command context (for example in a transaction listener
+        // after the async executor has been hinted that a new async job is created)
         // or not (when executed in the acquire thread runnable)
 
         CommandContext commandContext = Context.getCommandContext();

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/DefaultAsyncJobExecutor.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/DefaultAsyncJobExecutor.java
@@ -335,8 +335,7 @@ public class DefaultAsyncJobExecutor extends AbstractAsyncExecutor {
         if (threadPoolQueue != null) {
             return threadPoolQueue.remainingCapacity();
         } else {
-            // return plenty of remaining capacity if there's no thread pool
-            // queue
+            // return plenty of remaining capacity if there's no thread pool queue
             return 99;
         }
     }

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/cmd/UnacquireOwnedJobsCmd.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/cmd/UnacquireOwnedJobsCmd.java
@@ -34,7 +34,9 @@ public class UnacquireOwnedJobsCmd implements Command<Void> {
     public Void execute(CommandContext commandContext) {
         JobQueryImpl jobQuery = new JobQueryImpl(commandContext);
         jobQuery.lockOwner(lockOwner);
-        jobQuery.jobTenantId(tenantId);
+        if (tenantId != null) {
+            jobQuery.jobTenantId(tenantId);
+        }
         List<Job> jobs = CommandContextUtil.getJobEntityManager(commandContext).findJobsByQueryCriteria(jobQuery);
         for (Job job : jobs) {
             CommandContextUtil.getJobManager(commandContext).unacquire(job);

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/cmd/UnacquireOwnedJobsCmd.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/cmd/UnacquireOwnedJobsCmd.java
@@ -34,9 +34,8 @@ public class UnacquireOwnedJobsCmd implements Command<Void> {
     public Void execute(CommandContext commandContext) {
         JobQueryImpl jobQuery = new JobQueryImpl(commandContext);
         jobQuery.lockOwner(lockOwner);
-        if (tenantId != null) {
-            jobQuery.jobTenantId(tenantId);
-        }
+        jobQuery.jobTenantId(tenantId);
+
         List<Job> jobs = CommandContextUtil.getJobEntityManager(commandContext).findJobsByQueryCriteria(jobQuery);
         for (Job job : jobs) {
             CommandContextUtil.getJobManager(commandContext).unacquire(job);


### PR DESCRIPTION
Relates to this forum post: https://forum.flowable.org/t/unacquire-jobs-when-asyncexecutor-shutdown-method-is-called/3855

Also, found that the unacquire method is called on the start of the AsyncExecutor. This PR, makes it to be called on the shutdown as well.