### PR TITLE
Update Groovy to version 2.5.7.

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -123,8 +123,8 @@ org.apache.httpcomponents       httpclient                  4.5.8           Apac
 org.apache.httpcomponents       httpcore                    4.4.11          Apache License, Version 2.0
 org.apache.httpcomponents       httpmime                    4.5.8           Apache License, Version 2.0
 org.apache.geronimo.bundles     json                        20090211_1      The Apache Software License, Version 2.0
-org.codehaus.groovy             groovy                      2.5.6           The Apache Software License, Version 2.0
-org.codehaus.groovy             groovy-jsr223               2.5.6           The Apache Software License, Version 2.0
+org.codehaus.groovy             groovy                      2.5.7           The Apache Software License, Version 2.0
+org.codehaus.groovy             groovy-jsr223               2.5.7           The Apache Software License, Version 2.0
 org.liquibase                   liquibase-core              3.6.3           Apache License, Version 2.0
 org.mybatis                     mybatis                     3.5.1           The Apache Software License, Version 2.0
 org.mybatis                     mybatis-spring              2.0.1           The Apache Software License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -703,7 +703,7 @@
 			<dependency>
 				<groupId>org.codehaus.groovy</groupId>
 				<artifactId>groovy-jsr223</artifactId>
-				<version>2.5.6</version>
+				<version>2.5.7</version>
 			</dependency>
 			<dependency>
 				<groupId>org.drools</groupId>


### PR DESCRIPTION
With this update the travis build passes on Java 13.