### PR TITLE
Http task configuration through spring boot, config to use system properties

### DIFF
--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/HttpClientConfig.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/HttpClientConfig.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.cmmn.engine;
 
+import java.time.Duration;
+
 /**
  * @author Harsha Teja Kanna
  */
@@ -24,6 +26,8 @@ public class HttpClientConfig {
     protected int requestRetryLimit = 3;
     // https settings
     protected boolean disableCertVerify;
+
+    protected boolean useSystemProperties = false;
 
     public int getConnectTimeout() {
         return connectTimeout;
@@ -65,6 +69,14 @@ public class HttpClientConfig {
         this.disableCertVerify = disableCertVerify;
     }
 
+    public void setUseSystemProperties(boolean useSystemProperties) {
+        this.useSystemProperties = useSystemProperties;
+    }
+
+    public boolean isUseSystemProperties() {
+        return useSystemProperties;
+    }
+
     public void merge(HttpClientConfig other) {
         if (this.connectTimeout != other.getConnectTimeout()) {
             setConnectTimeout(other.getConnectTimeout());
@@ -85,5 +97,22 @@ public class HttpClientConfig {
         if (this.disableCertVerify != other.isDisableCertVerify()) {
             setDisableCertVerify(other.isDisableCertVerify());
         }
+
+        if (this.useSystemProperties != other.isUseSystemProperties()) {
+            setUseSystemProperties(other.isUseSystemProperties());
+        }
     }
+
+    public void setConnectionRequestTimeout(Duration connectionRequestTimeout) {
+        setConnectionRequestTimeout(Math.toIntExact(connectionRequestTimeout.toMillis()));
+    }
+
+    public void setConnectTimeout(Duration connectTimeout) {
+        setConnectTimeout(Math.toIntExact(connectTimeout.toMillis()));
+    }
+
+    public void setSocketTimeout(Duration socketTimeout) {
+        setSocketTimeout(Math.toIntExact(socketTimeout.toMillis()));
+    }
+
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/cfg/HttpClientConfig.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/cfg/HttpClientConfig.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.cfg;
 
+import java.time.Duration;
+
 /**
  * @author Harsha Teja Kanna
  */
@@ -24,6 +26,8 @@ public class HttpClientConfig {
     protected int requestRetryLimit = 3;
     // https settings
     protected boolean disableCertVerify;
+
+    protected boolean useSystemProperties = false;
 
     public int getConnectTimeout() {
         return connectTimeout;
@@ -65,6 +69,14 @@ public class HttpClientConfig {
         this.disableCertVerify = disableCertVerify;
     }
 
+    public void setUseSystemProperties(boolean useSystemProperties) {
+        this.useSystemProperties = useSystemProperties;
+    }
+
+    public boolean isUseSystemProperties() {
+        return useSystemProperties;
+    }
+
     public void merge(HttpClientConfig other) {
         if (this.connectTimeout != other.getConnectTimeout()) {
             setConnectTimeout(other.getConnectTimeout());
@@ -85,5 +97,22 @@ public class HttpClientConfig {
         if (this.disableCertVerify != other.isDisableCertVerify()) {
             setDisableCertVerify(other.isDisableCertVerify());
         }
+
+        if (this.useSystemProperties != other.isUseSystemProperties()) {
+            setUseSystemProperties(other.isUseSystemProperties());
+        }
     }
+
+    public void setConnectionRequestTimeout(Duration connectionRequestTimeout) {
+        setConnectionRequestTimeout(Math.toIntExact(connectionRequestTimeout.toMillis()));
+    }
+
+    public void setConnectTimeout(Duration connectTimeout) {
+        setConnectTimeout(Math.toIntExact(connectTimeout.toMillis()));
+    }
+
+    public void setSocketTimeout(Duration socketTimeout) {
+        setSocketTimeout(Math.toIntExact(socketTimeout.toMillis()));
+    }
+
 }

--- a/modules/flowable-http/src/main/java/org/flowable/http/bpmn/impl/HttpActivityBehaviorImpl.java
+++ b/modules/flowable-http/src/main/java/org/flowable/http/bpmn/impl/HttpActivityBehaviorImpl.java
@@ -136,6 +136,11 @@ public class HttpActivityBehaviorImpl extends AbstractBpmnActivityBehavior {
         }
         httpClientBuilder.setRetryHandler(new DefaultHttpRequestRetryHandler(retryCount, false));
 
+        // client builder settings
+        if (config.isUseSystemProperties()) {
+            httpClientBuilder.useSystemProperties();
+        }
+
         this.httpActivityExecutor = new HttpActivityExecutor(httpClientBuilder, new ProcessErrorPropagator(), 
                 CommandContextUtil.getProcessEngineConfiguration().getObjectMapper());
     }

--- a/modules/flowable-http/src/main/java/org/flowable/http/cmmn/impl/CmmnHttpActivityBehaviorImpl.java
+++ b/modules/flowable-http/src/main/java/org/flowable/http/cmmn/impl/CmmnHttpActivityBehaviorImpl.java
@@ -126,6 +126,11 @@ public class CmmnHttpActivityBehaviorImpl extends CoreCmmnActivityBehavior {
         }
         httpClientBuilder.setRetryHandler(new DefaultHttpRequestRetryHandler(retryCount, false));
 
+        // client builder settings
+        if (config.isUseSystemProperties()) {
+            httpClientBuilder.useSystemProperties();
+        }
+
         this.httpActivityExecutor = new HttpActivityExecutor(httpClientBuilder, new NopErrorPropagator(), 
                 CommandContextUtil.getCmmnEngineConfiguration().getObjectMapper());
     }

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/FlowableHttpProperties.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/FlowableHttpProperties.java
@@ -1,0 +1,100 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.spring.boot;
+
+import java.time.Duration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Flowable http properties for use in http tasks
+ *
+ * @author Valentin Rentschler
+ */
+@ConfigurationProperties(prefix = "flowable.http")
+public class FlowableHttpProperties {
+
+    /**
+     * Whether to use system properties (e.g. http.proxyPort).
+     */
+    protected boolean useSystemProperties = false;
+
+    /**
+     * Connect timeout for the http client
+     */
+    protected Duration connectTimeout = Duration.ofMillis(5000);
+    /**
+     * Socket timeout for the http client
+     */
+    protected Duration socketTimeout = Duration.ofMillis(5000);
+    /**
+     * Connection Request Timeout for the http client
+     */
+    protected Duration connectionRequestTimeout = Duration.ofMillis(5000);
+    /**
+     * Request retry limit for the http client
+     */
+    protected int requestRetryLimit = 3;
+    /**
+     * Whether to disable certificate validation for the http client
+     */
+    protected boolean disableCertVerify = false;
+
+    public boolean isUseSystemProperties() {
+        return useSystemProperties;
+    }
+
+    public void setUseSystemProperties(boolean useSystemProperties) {
+        this.useSystemProperties = useSystemProperties;
+    }
+
+    public Duration getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    public void setConnectTimeout(Duration connectTimeout) {
+        this.connectTimeout = connectTimeout;
+    }
+
+    public Duration getSocketTimeout() {
+        return socketTimeout;
+    }
+
+    public void setSocketTimeout(Duration socketTimeout) {
+        this.socketTimeout = socketTimeout;
+    }
+
+    public Duration getConnectionRequestTimeout() {
+        return connectionRequestTimeout;
+    }
+
+    public void setConnectionRequestTimeout(Duration connectionRequestTimeout) {
+        this.connectionRequestTimeout = connectionRequestTimeout;
+    }
+
+    public int getRequestRetryLimit() {
+        return requestRetryLimit;
+    }
+
+    public void setRequestRetryLimit(int requestRetryLimit) {
+        this.requestRetryLimit = requestRetryLimit;
+    }
+
+    public boolean isDisableCertVerify() {
+        return disableCertVerify;
+    }
+
+    public void setDisableCertVerify(boolean disableCertVerify) {
+        this.disableCertVerify = disableCertVerify;
+    }
+}

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/ProcessEngineAutoConfiguration.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/ProcessEngineAutoConfiguration.java
@@ -64,6 +64,7 @@ import org.springframework.transaction.PlatformTransactionManager;
 @EnableConfigurationProperties({
     FlowableProperties.class,
     FlowableMailProperties.class,
+    FlowableHttpProperties.class,
     FlowableProcessProperties.class,
     FlowableAppProperties.class,
     FlowableIdmProperties.class
@@ -86,15 +87,18 @@ public class ProcessEngineAutoConfiguration extends AbstractSpringEngineAutoConf
     protected final FlowableAppProperties appProperties;
     protected final FlowableIdmProperties idmProperties;
     protected final FlowableMailProperties mailProperties;
+    protected final FlowableHttpProperties httpProperties;
 
     public ProcessEngineAutoConfiguration(FlowableProperties flowableProperties, FlowableProcessProperties processProperties,
-                    FlowableAppProperties appProperties, FlowableIdmProperties idmProperties, FlowableMailProperties mailProperties) {
+        FlowableAppProperties appProperties, FlowableIdmProperties idmProperties, FlowableMailProperties mailProperties,
+        FlowableHttpProperties httpProperties) {
         
         super(flowableProperties);
         this.processProperties = processProperties;
         this.appProperties = appProperties;
         this.idmProperties = idmProperties;
         this.mailProperties = mailProperties;
+        this.httpProperties = httpProperties;
     }
 
     /**
@@ -184,6 +188,13 @@ public class ProcessEngineAutoConfiguration extends AbstractSpringEngineAutoConf
         conf.setMailServerForceTo(mailProperties.getForceTo());
         conf.setMailServerUseSSL(mailProperties.isUseSsl());
         conf.setMailServerUseTLS(mailProperties.isUseTls());
+
+        conf.getHttpClientConfig().setUseSystemProperties(httpProperties.isUseSystemProperties());
+        conf.getHttpClientConfig().setConnectionRequestTimeout(httpProperties.getConnectionRequestTimeout());
+        conf.getHttpClientConfig().setConnectTimeout(httpProperties.getConnectTimeout());
+        conf.getHttpClientConfig().setDisableCertVerify(httpProperties.isDisableCertVerify());
+        conf.getHttpClientConfig().setRequestRetryLimit(httpProperties.getRequestRetryLimit());
+        conf.getHttpClientConfig().setSocketTimeout(httpProperties.getSocketTimeout());
 
         conf.setEnableProcessDefinitionHistoryLevel(processProperties.isEnableProcessDefinitionHistoryLevel());
         conf.setProcessDefinitionCacheLimit(processProperties.getDefinitionCacheLimit());

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/cmmn/CmmnEngineAutoConfiguration.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/cmmn/CmmnEngineAutoConfiguration.java
@@ -26,6 +26,7 @@ import org.flowable.spring.SpringProcessEngineConfiguration;
 import org.flowable.spring.boot.AbstractSpringEngineAutoConfiguration;
 import org.flowable.spring.boot.BaseEngineConfigurationWithConfigurers;
 import org.flowable.spring.boot.EngineConfigurationConfigurer;
+import org.flowable.spring.boot.FlowableHttpProperties;
 import org.flowable.spring.boot.FlowableJobConfiguration;
 import org.flowable.spring.boot.FlowableProperties;
 import org.flowable.spring.boot.ProcessEngineAutoConfiguration;
@@ -62,7 +63,8 @@ import org.springframework.transaction.PlatformTransactionManager;
     FlowableProperties.class,
     FlowableIdmProperties.class,
     FlowableCmmnProperties.class,
-    FlowableAppProperties.class
+    FlowableAppProperties.class,
+    FlowableHttpProperties.class
 })
 @AutoConfigureAfter(value = {
     AppEngineAutoConfiguration.class,
@@ -81,11 +83,14 @@ public class CmmnEngineAutoConfiguration extends AbstractSpringEngineAutoConfigu
 
     protected final FlowableCmmnProperties cmmnProperties;
     protected final FlowableIdmProperties idmProperties;
+    protected final FlowableHttpProperties httpProperties;
 
-    public CmmnEngineAutoConfiguration(FlowableProperties flowableProperties, FlowableCmmnProperties cmmnProperties, FlowableIdmProperties idmProperties) {
+    public CmmnEngineAutoConfiguration(FlowableProperties flowableProperties, FlowableCmmnProperties cmmnProperties, FlowableIdmProperties idmProperties,
+        FlowableHttpProperties httpProperties) {
         super(flowableProperties);
         this.cmmnProperties = cmmnProperties;
         this.idmProperties = idmProperties;
+        this.httpProperties = httpProperties;
     }
 
     /**
@@ -140,6 +145,13 @@ public class CmmnEngineAutoConfiguration extends AbstractSpringEngineAutoConfigu
         configuration.setDisableIdmEngine(!idmProperties.isEnabled());
 
         configuration.setAsyncExecutorActivate(flowableProperties.isAsyncExecutorActivate());
+
+        configuration.getHttpClientConfig().setUseSystemProperties(httpProperties.isUseSystemProperties());
+        configuration.getHttpClientConfig().setConnectionRequestTimeout(httpProperties.getConnectionRequestTimeout());
+        configuration.getHttpClientConfig().setConnectTimeout(httpProperties.getConnectTimeout());
+        configuration.getHttpClientConfig().setDisableCertVerify(httpProperties.isDisableCertVerify());
+        configuration.getHttpClientConfig().setRequestRetryLimit(httpProperties.getRequestRetryLimit());
+        configuration.getHttpClientConfig().setSocketTimeout(httpProperties.getSocketTimeout());
 
         //TODO Can it have different then the Process engine?
         configuration.setHistoryLevel(flowableProperties.getHistoryLevel());

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/test/spring/boot/cmmn/CmmnEngineAutoConfigurationTest.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/test/spring/boot/cmmn/CmmnEngineAutoConfigurationTest.java
@@ -33,6 +33,7 @@ import org.flowable.cmmn.api.CmmnRepositoryService;
 import org.flowable.cmmn.api.repository.CaseDefinition;
 import org.flowable.cmmn.api.repository.CmmnDeployment;
 import org.flowable.cmmn.engine.CmmnEngine;
+import org.flowable.cmmn.engine.HttpClientConfig;
 import org.flowable.cmmn.spring.SpringCmmnEngineConfiguration;
 import org.flowable.engine.ProcessEngine;
 import org.flowable.engine.ProcessEngineConfiguration;
@@ -71,6 +72,30 @@ public class CmmnEngineAutoConfigurationTest {
             CmmnEngineAutoConfiguration.class
         ))
         .withUserConfiguration(CustomUserEngineConfigurerConfiguration.class);
+
+    @Test
+    public void httpProperties() {
+        contextRunner.withPropertyValues(
+            "flowable.http.useSystemProperties=true",
+            "flowable.http.connectTimeout=PT0.250S",
+            "flowable.http.socketTimeout=PT0.500S",
+            "flowable.http.connectionRequestTimeout=PT1S",
+            "flowable.http.requestRetryLimit=1",
+            "flowable.http.disableCertVerify=true"
+        ).run(context -> {
+            CmmnEngine cmmnEngine = context.getBean(CmmnEngine.class);
+            HttpClientConfig httpClientConfig = cmmnEngine.getCmmnEngineConfiguration().getHttpClientConfig();
+
+            assertThat(httpClientConfig.isUseSystemProperties()).isTrue();
+            assertThat(httpClientConfig.getConnectTimeout()).isEqualTo(250);
+            assertThat(httpClientConfig.getSocketTimeout()).isEqualTo(500);
+            assertThat(httpClientConfig.getConnectionRequestTimeout()).isEqualTo(1000);
+            assertThat(httpClientConfig.getRequestRetryLimit()).isEqualTo(1);
+            assertThat(httpClientConfig.isDisableCertVerify()).isTrue();
+
+            deleteDeployments(cmmnEngine);
+        });
+    }
 
     @Test
     public void standaloneCmmnEngineWithBasicDataSource() {


### PR DESCRIPTION
Motivation was to be able to set the 'useSystemProperties' setting on the http client builder. This enables the configuration of proxy settings through system properties (amongst other things).