### PR TITLE
flowable-ui-task: Do not duplicate flowable-content-api and flowable-…

### DIFF
--- a/modules/flowable-ui-task/pom.xml
+++ b/modules/flowable-ui-task/pom.xml
@@ -24,16 +24,6 @@
         <dependencies>
             <dependency>
                 <groupId>org.flowable</groupId>
-                <artifactId>flowable-content-api</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.flowable</groupId>
-                <artifactId>flowable-content-engine</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.flowable</groupId>
                 <artifactId>flowable-ui-task-logic</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
…content-engine dependency management already done in flowable-root pom.