### PR TITLE
flowable-ui-idm-app, flowable-ui-modeler-app and flowable-ui-task-app…

### DIFF
--- a/modules/flowable-ui-idm/flowable-ui-idm-app/pom.xml
+++ b/modules/flowable-ui-idm/flowable-ui-idm-app/pom.xml
@@ -99,10 +99,6 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/pom.xml
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/pom.xml
@@ -152,11 +152,6 @@
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
-		</dependency>
 
 		<!-- JODA TIME -->
 		<dependency>

--- a/modules/flowable-ui-task/flowable-ui-task-app/pom.xml
+++ b/modules/flowable-ui-task/flowable-ui-task-app/pom.xml
@@ -202,10 +202,6 @@
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>javax.servlet-api</artifactId>
-		</dependency>
 
 		<!-- JODA TIME -->
 		<dependency>


### PR DESCRIPTION
… do not use the servlet api directly so remove their javax.servlet-api dependencies.