### PR TITLE
Support MySQL version prior to 5.6.4.

### DIFF
--- a/modules/flowable-content-engine/src/main/resources/org/flowable/content/db/liquibase/flowable-content-db-changelog.xml
+++ b/modules/flowable-content-engine/src/main/resources/org/flowable/content/db/liquibase/flowable-content-db-changelog.xml
@@ -32,9 +32,9 @@
                 <constraints nullable="true" />
             </column>
            	<column name="CONTENT_AVAILABLE_" type="boolean" defaultValueBoolean="false" />
-            <column name="CREATED_" type="timestamp(6)" />
+            <column name="CREATED_" type="timestamp" />
             <column name="CREATED_BY_" type="varchar(255)" />
-            <column name="LAST_MODIFIED_" type="timestamp(6)" />
+            <column name="LAST_MODIFIED_" type="timestamp" />
             <column name="LAST_MODIFIED_BY_" type="varchar(255)" />
             <column name="CONTENT_SIZE_" type="bigint" defaultValueNumeric="0" />
             <column name="TENANT_ID_" type="varchar(255)" />


### PR DESCRIPTION
https://github.com/flowable/flowable-engine/issues/1818

Removing precision param from timestamp as having a parm will make older of MySQL break content module.