### PR TITLE
replace AbstractEngineConfiguration defaultTenantValue with defaultTenantProvider

### DIFF
--- a/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/ProcessTaskTest.java
+++ b/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/ProcessTaskTest.java
@@ -41,6 +41,7 @@ import org.flowable.cmmn.engine.test.CmmnDeployment;
 import org.flowable.common.engine.api.FlowableException;
 import org.flowable.common.engine.api.FlowableObjectNotFoundException;
 import org.flowable.common.engine.api.scope.ScopeTypes;
+import org.flowable.common.engine.impl.DefaultTenantProvider;
 import org.flowable.common.engine.impl.history.HistoryLevel;
 import org.flowable.common.engine.impl.util.CollectionUtil;
 import org.flowable.engine.history.HistoricProcessInstance;
@@ -793,7 +794,7 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
             tenantId("defaultFlowable").
             deploy();
         
-        String originalDefaultTenantValue = this.processEngineConfiguration.getDefaultTenantValue();
+        DefaultTenantProvider originalDefaultTenantProvider = this.processEngineConfiguration.getDefaultTenantProvider();
         this.processEngineConfiguration.setFallbackToDefaultTenant(true);
         this.processEngineConfiguration.setDefaultTenantValue("defaultFlowable");
         
@@ -822,7 +823,7 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
             
         } finally {
             this.processEngineConfiguration.setFallbackToDefaultTenant(false);
-            this.processEngineConfiguration.setDefaultTenantValue(originalDefaultTenantValue);
+            this.processEngineConfiguration.setDefaultTenantProvider(originalDefaultTenantProvider);
             processEngineRepositoryService.deleteDeployment(deployment.getId(), true);
         }
     }
@@ -838,7 +839,7 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
             tenantId("tenant1").
             deploy();
         
-        String originalDefaultTenantValue = this.processEngineConfiguration.getDefaultTenantValue();
+        DefaultTenantProvider originalDefaultTenantProvider = this.processEngineConfiguration.getDefaultTenantProvider();
         this.processEngineConfiguration.setFallbackToDefaultTenant(true);
         this.processEngineConfiguration.setDefaultTenantValue("defaultFlowable");
         
@@ -851,7 +852,7 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
             
         } finally {
             this.processEngineConfiguration.setFallbackToDefaultTenant(false);
-            this.processEngineConfiguration.setDefaultTenantValue(originalDefaultTenantValue);
+            this.processEngineConfiguration.setDefaultTenantProvider(originalDefaultTenantProvider);
             processEngineRepositoryService.deleteDeployment(deployment.getId(), true);
         }
     }

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/runtime/CaseInstanceHelperImpl.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/runtime/CaseInstanceHelperImpl.java
@@ -103,9 +103,9 @@ public class CaseInstanceHelperImpl implements CaseInstanceHelper {
 
                 if (caseDefinition == null) {
                     if (caseInstanceBuilder.isFallbackToDefaultTenant() || cmmnEngineConfiguration.isFallbackToDefaultTenant()) {
-                        if (StringUtils.isNotEmpty(cmmnEngineConfiguration.getDefaultTenantValue())) {
-                            caseDefinition = caseDefinitionEntityManager.findLatestCaseDefinitionByKeyAndTenantId(caseDefinitionKey, 
-                                            cmmnEngineConfiguration.getDefaultTenantValue());
+                        String defaultTenant = cmmnEngineConfiguration.getDefaultTenantProvider().getDefaultTenant(tenantId, ScopeTypes.CMMN, caseDefinitionKey);
+                        if (StringUtils.isNotEmpty(defaultTenant)) {
+                            caseDefinition = caseDefinitionEntityManager.findLatestCaseDefinitionByKeyAndTenantId(caseDefinitionKey, defaultTenant);
                             caseInstanceBuilder.overrideCaseDefinitionTenantId(tenantId);
                             
                         } else {

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CaseTaskTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CaseTaskTest.java
@@ -33,6 +33,7 @@ import org.flowable.cmmn.engine.test.CmmnDeployment;
 import org.flowable.cmmn.engine.test.FlowableCmmnTestCase;
 import org.flowable.common.engine.api.FlowableObjectNotFoundException;
 import org.flowable.common.engine.api.scope.ScopeTypes;
+import org.flowable.common.engine.impl.DefaultTenantProvider;
 import org.flowable.common.engine.impl.history.HistoryLevel;
 import org.flowable.entitylink.api.EntityLink;
 import org.flowable.entitylink.api.EntityLinkType;
@@ -468,7 +469,7 @@ public class CaseTaskTest extends FlowableCmmnTestCase {
                         .deploy()
                         .getId();
 
-        String originalDefaultTenantValue = cmmnEngineConfiguration.getDefaultTenantValue();
+        DefaultTenantProvider originalDefaultTenantProvider = cmmnEngineConfiguration.getDefaultTenantProvider();
         cmmnEngineConfiguration.setFallbackToDefaultTenant(true);
         cmmnEngineConfiguration.setDefaultTenantValue("defaultFlowable");
         try {
@@ -484,7 +485,7 @@ public class CaseTaskTest extends FlowableCmmnTestCase {
 
         } finally {
             cmmnEngineConfiguration.setFallbackToDefaultTenant(false);
-            cmmnEngineConfiguration.setDefaultTenantValue(originalDefaultTenantValue);
+            cmmnEngineConfiguration.setDefaultTenantProvider(originalDefaultTenantProvider);
             cmmnRepositoryService.deleteDeployment(tenantDeploymentId, true);
         }
     }
@@ -492,7 +493,7 @@ public class CaseTaskTest extends FlowableCmmnTestCase {
     @Test
     @CmmnDeployment(resources="org/flowable/cmmn/test/runtime/CaseTaskTest.testGlobalFallbackToDefaultTenant.cmmn", tenantId="defaultFlowable")
     public void testGlobalFallbackToDefaultTenantNoDefinition() {
-        String originalDefaultTenantValue = cmmnEngineConfiguration.getDefaultTenantValue();
+        DefaultTenantProvider originalDefaultTenantProvider = cmmnEngineConfiguration.getDefaultTenantProvider();
         cmmnEngineConfiguration.setFallbackToDefaultTenant(true);
         cmmnEngineConfiguration.setDefaultTenantValue("defaultFlowable");
         try {
@@ -508,7 +509,7 @@ public class CaseTaskTest extends FlowableCmmnTestCase {
 
         } finally {
             cmmnEngineConfiguration.setFallbackToDefaultTenant(false);
-            cmmnEngineConfiguration.setDefaultTenantValue(originalDefaultTenantValue);
+            cmmnEngineConfiguration.setDefaultTenantProvider(originalDefaultTenantProvider);
         }
     }
 

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CmmnRuntimeServiceTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CmmnRuntimeServiceTest.java
@@ -26,6 +26,7 @@ import org.flowable.cmmn.engine.test.FlowableCmmnTestCase;
 import org.flowable.cmmn.engine.test.impl.CmmnJobTestHelper;
 import org.flowable.common.engine.api.FlowableIllegalArgumentException;
 import org.flowable.common.engine.api.FlowableObjectNotFoundException;
+import org.flowable.common.engine.impl.DefaultTenantProvider;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -190,7 +191,7 @@ public class CmmnRuntimeServiceTest extends FlowableCmmnTestCase {
     @Test
     @CmmnDeployment(resources = "org/flowable/cmmn/test/runtime/oneTaskCase.cmmn", tenantId="defaultFlowable")
     public void createCaseInstanceWithGlobalFallbackAndDefaultTenantValue() {
-        String originalDefaultTenantValue = cmmnEngineConfiguration.getDefaultTenantValue();
+        DefaultTenantProvider originalDefaultTenantProvider = cmmnEngineConfiguration.getDefaultTenantProvider();
         cmmnEngineConfiguration.setFallbackToDefaultTenant(true);
         cmmnEngineConfiguration.setDefaultTenantValue("defaultFlowable");
         try {
@@ -204,7 +205,7 @@ public class CmmnRuntimeServiceTest extends FlowableCmmnTestCase {
             
         } finally {
             cmmnEngineConfiguration.setFallbackToDefaultTenant(false);
-            cmmnEngineConfiguration.setDefaultTenantValue(originalDefaultTenantValue);
+            cmmnEngineConfiguration.setDefaultTenantProvider(originalDefaultTenantProvider);
         }
     }
 
@@ -223,7 +224,7 @@ public class CmmnRuntimeServiceTest extends FlowableCmmnTestCase {
     @Test
     @CmmnDeployment(resources = "org/flowable/cmmn/test/runtime/oneTaskCase.cmmn", tenantId="tenant1")
     public void createCaseInstanceWithGlobalFallbackDefinitionNotFound() {
-        String originalDefaultTenantValue = cmmnEngineConfiguration.getDefaultTenantValue();
+        DefaultTenantProvider originalDefaultTenantProvider = cmmnEngineConfiguration.getDefaultTenantProvider();
         cmmnEngineConfiguration.setFallbackToDefaultTenant(true);
         cmmnEngineConfiguration.setDefaultTenantValue("defaultFlowable");
         
@@ -237,7 +238,7 @@ public class CmmnRuntimeServiceTest extends FlowableCmmnTestCase {
             
         } finally {
             cmmnEngineConfiguration.setFallbackToDefaultTenant(false);
-            cmmnEngineConfiguration.setDefaultTenantValue(originalDefaultTenantValue);
+            cmmnEngineConfiguration.setDefaultTenantProvider(originalDefaultTenantProvider);
         }
     }
 

--- a/modules/flowable-dmn-engine-configurator/src/test/java/org/flowable/dmn/engine/test/MixedDeploymentTest.java
+++ b/modules/flowable-dmn-engine-configurator/src/test/java/org/flowable/dmn/engine/test/MixedDeploymentTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import org.flowable.common.engine.api.FlowableException;
 import org.flowable.common.engine.api.FlowableObjectNotFoundException;
+import org.flowable.common.engine.impl.DefaultTenantProvider;
 import org.flowable.common.engine.impl.interceptor.EngineConfigurationConstants;
 import org.flowable.dmn.api.DmnDecisionTable;
 import org.flowable.dmn.api.DmnHistoricDecisionExecution;
@@ -228,7 +229,7 @@ public class MixedDeploymentTest extends AbstractFlowableDmnEngineConfiguratorTe
         DmnEngineConfiguration dmnEngineConfiguration = (DmnEngineConfiguration) processEngineConfiguration.getEngineConfigurations().get(
                         EngineConfigurationConstants.KEY_DMN_ENGINE_CONFIG);
         
-        String originalDefaultTenantValue = dmnEngineConfiguration.getDefaultTenantValue();
+        DefaultTenantProvider originalDefaultTenantProvider = dmnEngineConfiguration.getDefaultTenantProvider();
         dmnEngineConfiguration.setFallbackToDefaultTenant(true);
         dmnEngineConfiguration.setDefaultTenantValue("defaultFlowable");
         
@@ -258,7 +259,7 @@ public class MixedDeploymentTest extends AbstractFlowableDmnEngineConfiguratorTe
             
         } finally {
             dmnEngineConfiguration.setFallbackToDefaultTenant(false);
-            dmnEngineConfiguration.setDefaultTenantValue(originalDefaultTenantValue);
+            dmnEngineConfiguration.setDefaultTenantProvider(originalDefaultTenantProvider);
             this.repositoryService.deleteDeployment(deployment.getId(), true);
             deleteAllDmnDeployments();
         }

--- a/modules/flowable-dmn-engine-configurator/src/test/java/org/flowable/dmn/test/runtime/DecisionTaskTest.java
+++ b/modules/flowable-dmn-engine-configurator/src/test/java/org/flowable/dmn/test/runtime/DecisionTaskTest.java
@@ -22,6 +22,7 @@ import org.flowable.cmmn.engine.CmmnEngineConfiguration;
 import org.flowable.cmmn.engine.test.CmmnDeployment;
 import org.flowable.cmmn.engine.test.FlowableCmmnRule;
 import org.flowable.common.engine.api.FlowableException;
+import org.flowable.common.engine.impl.DefaultTenantProvider;
 import org.flowable.common.engine.impl.interceptor.EngineConfigurationConstants;
 import org.flowable.dmn.api.DmnHistoricDecisionExecution;
 import org.flowable.dmn.engine.DmnEngineConfiguration;
@@ -327,7 +328,7 @@ public class DecisionTaskTest {
         DmnEngineConfiguration dmnEngineConfiguration = (DmnEngineConfiguration) cmmnEngineConfiguration.getEngineConfigurations().get(
                         EngineConfigurationConstants.KEY_DMN_ENGINE_CONFIG);
         
-        String originalDefaultTenantValue = dmnEngineConfiguration.getDefaultTenantValue();
+        DefaultTenantProvider originalDefaultTenantProvider = dmnEngineConfiguration.getDefaultTenantProvider();
         dmnEngineConfiguration.setFallbackToDefaultTenant(true);
         dmnEngineConfiguration.setDefaultTenantValue("defaultFlowable");
         
@@ -355,7 +356,7 @@ public class DecisionTaskTest {
             
         } finally {
             dmnEngineConfiguration.setFallbackToDefaultTenant(false);
-            dmnEngineConfiguration.setDefaultTenantValue(originalDefaultTenantValue);
+            dmnEngineConfiguration.setDefaultTenantProvider(originalDefaultTenantProvider);
             cmmnRule.getCmmnRepositoryService().deleteDeployment(cmmnDeployment.getId(), true);
         }
     }

--- a/modules/flowable-engine-common-api/src/main/java/org/flowable/common/engine/api/scope/ScopeTypes.java
+++ b/modules/flowable-engine-common-api/src/main/java/org/flowable/common/engine/api/scope/ScopeTypes.java
@@ -14,11 +14,14 @@ package org.flowable.common.engine.api.scope;
 
 /**
  * @author Joram Barrez
+ * @author Valentin Zickner
  */
 public interface ScopeTypes {
 
     String APP = "app";
     String BPMN = "bpmn";
     String CMMN = "cmmn";
+    String DMN = "dmn";
+    String FORM = "form";
     String TASK = "task";
 }

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/AbstractEngineConfiguration.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/AbstractEngineConfiguration.java
@@ -259,11 +259,11 @@ public abstract class AbstractEngineConfiguration {
      * Set to true if by default lookups should fallback to the default tenant (an empty string by default or a defined tenant value)
      */
     protected boolean fallbackToDefaultTenant;
-    
+
     /**
-     * Default tenant value that is used when looking up definitions when the global or local fallback to default tenant value is true
+     * Default tenant provider that is executed when looking up definitions, in case the global or local fallback to default tenant value is true
      */
-    protected String defaultTenantValue = NO_TENANT_ID;
+    protected DefaultTenantProvider defaultTenantProvider = (tenantId, scope, scopeKey) -> NO_TENANT_ID;
 
     /**
      * Enables the MyBatis plugin that logs the execution time of sql statements.
@@ -1477,12 +1477,26 @@ public abstract class AbstractEngineConfiguration {
         return this;
     }
 
+    /**
+     * @return name of the default tenant
+     * @deprecated use {@link AbstractEngineConfiguration#getDefaultTenantProvider()} instead
+     */
+    @Deprecated
     public String getDefaultTenantValue() {
-        return defaultTenantValue;
+        return getDefaultTenantProvider().getDefaultTenant(null, null, null);
     }
 
     public AbstractEngineConfiguration setDefaultTenantValue(String defaultTenantValue) {
-        this.defaultTenantValue = defaultTenantValue;
+        this.defaultTenantProvider = (tenantId, scope, scopeKey) -> defaultTenantValue;
+        return this;
+    }
+
+    public DefaultTenantProvider getDefaultTenantProvider() {
+        return defaultTenantProvider;
+    }
+
+    public AbstractEngineConfiguration setDefaultTenantProvider(DefaultTenantProvider defaultTenantProvider) {
+        this.defaultTenantProvider = defaultTenantProvider;
         return this;
     }
 

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/DefaultTenantProvider.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/DefaultTenantProvider.java
@@ -1,0 +1,10 @@
+package org.flowable.common.engine.impl;
+
+/**
+ * @author Valentin Zickner
+ */
+public interface DefaultTenantProvider {
+
+    String getDefaultTenant(String tenantId, String scope, String scopeKey);
+
+}

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/CallActivityBehavior.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/CallActivityBehavior.java
@@ -328,10 +328,11 @@ public class CallActivityBehavior extends AbstractBpmnActivityBehavior implement
         } else {
             processDefinition = processDefinitionEntityManager.findLatestProcessDefinitionByKeyAndTenantId(processDefinitionKey, tenantId);
             if (processDefinition == null && ((this.fallbackToDefaultTenant != null && this.fallbackToDefaultTenant) || processEngineConfiguration.isFallbackToDefaultTenant())) {
-                
-                if (StringUtils.isNotEmpty(processEngineConfiguration.getDefaultTenantValue())) {
+
+                String defaultTenant = processEngineConfiguration.getDefaultTenantProvider().getDefaultTenant(tenantId, ScopeTypes.BPMN, processDefinitionKey);
+                if (StringUtils.isNotEmpty(defaultTenant)) {
                     processDefinition = processDefinitionEntityManager.findLatestProcessDefinitionByKeyAndTenantId(
-                                    processDefinitionKey, processEngineConfiguration.getDefaultTenantValue());
+                                    processDefinitionKey, defaultTenant);
                 } else {
                     processDefinition = processDefinitionEntityManager.findLatestProcessDefinitionByKey(processDefinitionKey);
                 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/StartProcessInstanceCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/StartProcessInstanceCmd.java
@@ -26,6 +26,7 @@ import org.flowable.bpmn.model.StartEvent;
 import org.flowable.bpmn.model.ValuedDataObject;
 import org.flowable.common.engine.api.FlowableIllegalArgumentException;
 import org.flowable.common.engine.api.FlowableObjectNotFoundException;
+import org.flowable.common.engine.api.scope.ScopeTypes;
 import org.flowable.common.engine.impl.interceptor.Command;
 import org.flowable.common.engine.impl.interceptor.CommandContext;
 import org.flowable.engine.ProcessEngineConfiguration;
@@ -207,9 +208,9 @@ public class StartProcessInstanceCmd<T> implements Command<ProcessInstance>, Ser
             processDefinition = processDefinitionEntityManager.findLatestProcessDefinitionByKeyAndTenantId(processDefinitionKey, tenantId);
             if (processDefinition == null) {
                 if (fallbackToDefaultTenant || processEngineConfiguration.isFallbackToDefaultTenant()) {
-                    if (StringUtils.isNotEmpty(processEngineConfiguration.getDefaultTenantValue())) {
-                        processDefinition = processDefinitionEntityManager.findLatestProcessDefinitionByKeyAndTenantId(processDefinitionKey, 
-                                        processEngineConfiguration.getDefaultTenantValue());
+                    String defaultTenant = processEngineConfiguration.getDefaultTenantProvider().getDefaultTenant(tenantId, ScopeTypes.BPMN, processDefinitionKey);
+                    if (StringUtils.isNotEmpty(defaultTenant)) {
+                        processDefinition = processDefinitionEntityManager.findLatestProcessDefinitionByKeyAndTenantId(processDefinitionKey, defaultTenant);
                         if (processDefinition != null) {
                             overrideDefinitionTenantId = tenantId;
                         }

--- a/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/cmd/AbstractGetFormInstanceModelCmd.java
+++ b/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/cmd/AbstractGetFormInstanceModelCmd.java
@@ -26,6 +26,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.flowable.common.engine.api.FlowableException;
 import org.flowable.common.engine.api.FlowableObjectNotFoundException;
 import org.flowable.common.engine.api.delegate.Expression;
+import org.flowable.common.engine.api.scope.ScopeTypes;
 import org.flowable.common.engine.impl.el.VariableContainerWrapper;
 import org.flowable.common.engine.impl.interceptor.Command;
 import org.flowable.common.engine.impl.interceptor.CommandContext;
@@ -270,8 +271,9 @@ public class AbstractGetFormInstanceModelCmd implements Command<FormInstanceInfo
             formDefinitionEntity = formDefinitionEntityManager.findLatestFormDefinitionByKeyAndTenantId(formDefinitionKey, tenantId);
             
             if (formDefinitionEntity == null && (fallbackToDefaultTenant || formEngineConfiguration.isFallbackToDefaultTenant())) {
-                if (StringUtils.isNotEmpty(formEngineConfiguration.getDefaultTenantValue())) {
-                    formDefinitionEntity = formDefinitionEntityManager.findLatestFormDefinitionByKeyAndTenantId(formDefinitionKey, formEngineConfiguration.getDefaultTenantValue());
+                String defaultTenant = formEngineConfiguration.getDefaultTenantProvider().getDefaultTenant(tenantId, ScopeTypes.FORM, formDefinitionKey);;
+                if (StringUtils.isNotEmpty(defaultTenant)) {
+                    formDefinitionEntity = formDefinitionEntityManager.findLatestFormDefinitionByKeyAndTenantId(formDefinitionKey, defaultTenant);
                 } else {
                     formDefinitionEntity = formDefinitionEntityManager.findLatestFormDefinitionByKey(formDefinitionKey);
                 }
@@ -314,8 +316,9 @@ public class AbstractGetFormInstanceModelCmd implements Command<FormInstanceInfo
             }
             
             if (formDefinitionEntity == null && (fallbackToDefaultTenant || formEngineConfiguration.isFallbackToDefaultTenant())) {
-                if (StringUtils.isNotEmpty(formEngineConfiguration.getDefaultTenantValue())) {
-                    formDefinitionEntity = formDefinitionEntityManager.findLatestFormDefinitionByKeyAndTenantId(formDefinitionKey, formEngineConfiguration.getDefaultTenantValue());
+                String defaultTenant = formEngineConfiguration.getDefaultTenantProvider().getDefaultTenant(tenantId, ScopeTypes.FORM, formDefinitionKey);;
+                if (StringUtils.isNotEmpty(defaultTenant)) {
+                    formDefinitionEntity = formDefinitionEntityManager.findLatestFormDefinitionByKeyAndTenantId(formDefinitionKey, defaultTenant);
                 } else {
                     formDefinitionEntity = formDefinitionEntityManager.findLatestFormDefinitionByKey(formDefinitionKey);
                 }

--- a/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/cmd/GetFormModelCmd.java
+++ b/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/cmd/GetFormModelCmd.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 import org.flowable.common.engine.api.FlowableObjectNotFoundException;
+import org.flowable.common.engine.api.scope.ScopeTypes;
 import org.flowable.common.engine.impl.interceptor.Command;
 import org.flowable.common.engine.impl.interceptor.CommandContext;
 import org.flowable.form.api.FormDeployment;
@@ -88,8 +89,9 @@ public class GetFormModelCmd implements Command<FormInfo>, Serializable {
             formDefinitionEntity = formDefinitionEntityManager.findLatestFormDefinitionByKeyAndTenantId(formDefinitionKey, tenantId);
             
             if (formDefinitionEntity == null && (fallbackToDefaultTenant || formEngineConfiguration.isFallbackToDefaultTenant())) {
-                if (StringUtils.isNotEmpty(formEngineConfiguration.getDefaultTenantValue())) {
-                    formDefinitionEntity = formDefinitionEntityManager.findLatestFormDefinitionByKeyAndTenantId(formDefinitionKey, formEngineConfiguration.getDefaultTenantValue());
+                String defaultTenant = formEngineConfiguration.getDefaultTenantProvider().getDefaultTenant(tenantId, ScopeTypes.FORM, formDefinitionKey);
+                if (StringUtils.isNotEmpty(defaultTenant)) {
+                    formDefinitionEntity = formDefinitionEntityManager.findLatestFormDefinitionByKeyAndTenantId(formDefinitionKey, defaultTenant);
                 } else {
                     formDefinitionEntity = formDefinitionEntityManager.findLatestFormDefinitionByKey(formDefinitionKey);
                 }
@@ -132,8 +134,9 @@ public class GetFormModelCmd implements Command<FormInfo>, Serializable {
             }
             
             if (formDefinitionEntity == null && (fallbackToDefaultTenant || formEngineConfiguration.isFallbackToDefaultTenant())) {
-                if (StringUtils.isNotEmpty(formEngineConfiguration.getDefaultTenantValue())) {
-                    formDefinitionEntity = formDefinitionEntityManager.findLatestFormDefinitionByKeyAndTenantId(formDefinitionKey, formEngineConfiguration.getDefaultTenantValue());
+                String defaultTenant = formEngineConfiguration.getDefaultTenantProvider().getDefaultTenant(tenantId, ScopeTypes.FORM, formDefinitionKey);
+                if (StringUtils.isNotEmpty(defaultTenant)) {
+                    formDefinitionEntity = formDefinitionEntityManager.findLatestFormDefinitionByKeyAndTenantId(formDefinitionKey, defaultTenant);
                 } else {
                     formDefinitionEntity = formDefinitionEntityManager.findLatestFormDefinitionByKey(formDefinitionKey);
                 }

--- a/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/cmd/GetFormModelWithVariablesCmd.java
+++ b/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/cmd/GetFormModelWithVariablesCmd.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.flowable.common.engine.api.FlowableException;
 import org.flowable.common.engine.api.FlowableObjectNotFoundException;
 import org.flowable.common.engine.api.delegate.Expression;
+import org.flowable.common.engine.api.scope.ScopeTypes;
 import org.flowable.common.engine.impl.el.VariableContainerWrapper;
 import org.flowable.common.engine.impl.interceptor.Command;
 import org.flowable.common.engine.impl.interceptor.CommandContext;
@@ -233,8 +234,9 @@ public class GetFormModelWithVariablesCmd implements Command<FormInfo>, Serializ
             formDefinitionEntity = formDefinitionEntityManager.findLatestFormDefinitionByKeyAndTenantId(formDefinitionKey, tenantId);
             
             if (formDefinitionEntity == null && (fallbackToDefaultTenant || formEngineConfiguration.isFallbackToDefaultTenant())) {
-                if (StringUtils.isNotEmpty(formEngineConfiguration.getDefaultTenantValue())) {
-                    formDefinitionEntity = formDefinitionEntityManager.findLatestFormDefinitionByKeyAndTenantId(formDefinitionKey, formEngineConfiguration.getDefaultTenantValue());
+                String defaultTenant = formEngineConfiguration.getDefaultTenantProvider().getDefaultTenant(tenantId, ScopeTypes.FORM, formDefinitionKey);
+                if (StringUtils.isNotEmpty(defaultTenant)) {
+                    formDefinitionEntity = formDefinitionEntityManager.findLatestFormDefinitionByKeyAndTenantId(formDefinitionKey, defaultTenant);
                 } else {
                     formDefinitionEntity = formDefinitionEntityManager.findLatestFormDefinitionByKey(formDefinitionKey);
                 }
@@ -277,8 +279,9 @@ public class GetFormModelWithVariablesCmd implements Command<FormInfo>, Serializ
             }
             
             if (formDefinitionEntity == null && (fallbackToDefaultTenant || formEngineConfiguration.isFallbackToDefaultTenant())) {
-                if (StringUtils.isNotEmpty(formEngineConfiguration.getDefaultTenantValue())) {
-                    formDefinitionEntity = formDefinitionEntityManager.findLatestFormDefinitionByKeyAndTenantId(formDefinitionKey, formEngineConfiguration.getDefaultTenantValue());
+                String defaultTenant = formEngineConfiguration.getDefaultTenantProvider().getDefaultTenant(tenantId, ScopeTypes.FORM, formDefinitionKey);
+                if (StringUtils.isNotEmpty(defaultTenant)) {
+                    formDefinitionEntity = formDefinitionEntityManager.findLatestFormDefinitionByKeyAndTenantId(formDefinitionKey, defaultTenant);
                 } else {
                     formDefinitionEntity = formDefinitionEntityManager.findLatestFormDefinitionByKey(formDefinitionKey);
                 }

--- a/modules/flowable-form-engine/src/test/java/org/flowable/form/engine/test/FormInstanceTest.java
+++ b/modules/flowable-form-engine/src/test/java/org/flowable/form/engine/test/FormInstanceTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertNull;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.flowable.common.engine.impl.DefaultTenantProvider;
 import org.flowable.common.engine.impl.identity.Authentication;
 import org.flowable.form.api.FormInfo;
 import org.flowable.form.api.FormInstance;
@@ -146,7 +147,7 @@ public class FormInstanceTest extends AbstractFlowableFormTest {
     @Test
     @FormDeploymentAnnotation(resources = "org/flowable/form/engine/test/deployment/simple.form", tenantId="defaultFlowable")
     public void submitSimpleFormWithGlobalFallbackTenant() throws Exception {
-        String originalDefaultTenantValue = formEngineConfiguration.getDefaultTenantValue();
+        DefaultTenantProvider originalDefaultTenantProvider = formEngineConfiguration.getDefaultTenantProvider();
         formEngineConfiguration.setFallbackToDefaultTenant(true);
         formEngineConfiguration.setDefaultTenantValue("defaultFlowable");
         try {
@@ -185,7 +186,7 @@ public class FormInstanceTest extends AbstractFlowableFormTest {
             
         } finally {
             formEngineConfiguration.setFallbackToDefaultTenant(false);
-            formEngineConfiguration.setDefaultTenantValue(originalDefaultTenantValue);
+            formEngineConfiguration.setDefaultTenantProvider(originalDefaultTenantProvider);
         }
     }
 

--- a/modules/flowable-form-engine/src/test/java/org/flowable/form/engine/test/FormModelTest.java
+++ b/modules/flowable-form-engine/src/test/java/org/flowable/form/engine/test/FormModelTest.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.flowable.common.engine.api.FlowableObjectNotFoundException;
+import org.flowable.common.engine.impl.DefaultTenantProvider;
 import org.flowable.form.api.FormInfo;
 import org.flowable.form.model.FormField;
 import org.flowable.form.model.SimpleFormModel;
@@ -94,7 +95,7 @@ public class FormModelTest extends AbstractFlowableFormTest {
     @Test
     @FormDeploymentAnnotation(resources = "org/flowable/form/engine/test/deployment/simple.form", tenantId="defaultFlowable")
     public void getSimpleFormModelWithFallbackCustomTenantWithVariables() throws Exception {
-        String originalDefaultTenantValue = formEngineConfiguration.getDefaultTenantValue();
+        DefaultTenantProvider originalDefaultTenantValue = formEngineConfiguration.getDefaultTenantProvider();
         formEngineConfiguration.setDefaultTenantValue("defaultFlowable");
         try {
             String formDefinitionId = repositoryService.getFormModelByKey("form1", "flowable", true).getId();
@@ -108,14 +109,14 @@ public class FormModelTest extends AbstractFlowableFormTest {
             assertFormModel(formInfo);
             
         } finally {
-            formEngineConfiguration.setDefaultTenantValue(originalDefaultTenantValue);
+            formEngineConfiguration.setDefaultTenantProvider(originalDefaultTenantValue);
         }
     }
     
     @Test
     @FormDeploymentAnnotation(resources = "org/flowable/form/engine/test/deployment/simple.form", tenantId="flowable")
     public void getSimpleFormModelWithFallbackCustomTenantNotExistingWithVariables() throws Exception {
-        String originalDefaultTenantValue = formEngineConfiguration.getDefaultTenantValue();
+        DefaultTenantProvider originalDefaultTenantProvider = formEngineConfiguration.getDefaultTenantProvider();
         formEngineConfiguration.setDefaultTenantValue("defaultFlowable");
         try {
             try {
@@ -138,14 +139,14 @@ public class FormModelTest extends AbstractFlowableFormTest {
             }
             
         } finally {
-            formEngineConfiguration.setDefaultTenantValue(originalDefaultTenantValue);
+            formEngineConfiguration.setDefaultTenantProvider(originalDefaultTenantProvider);
         }
     }
     
     @Test
     @FormDeploymentAnnotation(resources = "org/flowable/form/engine/test/deployment/simple.form", tenantId="defaultFlowable")
     public void getSimpleFormModelWithGlobalFallbackCustomTenantWithVariables() throws Exception {
-        String originalDefaultTenantValue = formEngineConfiguration.getDefaultTenantValue();
+        DefaultTenantProvider originalDefaultTenantProvider = formEngineConfiguration.getDefaultTenantProvider();
         formEngineConfiguration.setFallbackToDefaultTenant(true);
         formEngineConfiguration.setDefaultTenantValue("defaultFlowable");
         try {
@@ -161,14 +162,14 @@ public class FormModelTest extends AbstractFlowableFormTest {
             
         } finally {
             formEngineConfiguration.setFallbackToDefaultTenant(false);
-            formEngineConfiguration.setDefaultTenantValue(originalDefaultTenantValue);
+            formEngineConfiguration.setDefaultTenantProvider(originalDefaultTenantProvider);
         }
     }
     
     @Test
     @FormDeploymentAnnotation(resources = "org/flowable/form/engine/test/deployment/simple.form", tenantId="flowable")
     public void getSimpleFormModelWithGlobalFallbackCustomTenantNotExistingWithVariables() throws Exception {
-        String originalDefaultTenantValue = formEngineConfiguration.getDefaultTenantValue();
+        DefaultTenantProvider originalDefaultTenantProvider = formEngineConfiguration.getDefaultTenantProvider();
         formEngineConfiguration.setFallbackToDefaultTenant(true);
         formEngineConfiguration.setDefaultTenantValue("defaultFlowable");
         try {
@@ -193,7 +194,7 @@ public class FormModelTest extends AbstractFlowableFormTest {
             
         } finally {
             formEngineConfiguration.setFallbackToDefaultTenant(false);
-            formEngineConfiguration.setDefaultTenantValue(originalDefaultTenantValue);
+            formEngineConfiguration.setDefaultTenantProvider(originalDefaultTenantProvider);
         }
     }
     


### PR DESCRIPTION
* introduce new getter and setter for defaultTenantProvider
* migrate existing getter usages to defaultTenantProvider
* implement fallback for existing defaultTenantValue getter and setter
* deprecate AbstractEngineConfiguration#setDefaultTenantValue in favor of AbstractEngineConfiguration#setDefaultTenantProvider