### PR TITLE
Flowable-modeler: Fix description documentation package.

### DIFF
--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/resources/static/i18n/en.json
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/resources/static/i18n/en.json
@@ -70,7 +70,7 @@
         "DOCUMENTATIONPACKAGE" : {
           "DOCUMENTATION" : {
             "TITLE" : "Documentation",
-            "DESCRIPTION" : "The descriptive name of the BPMN element."
+            "DESCRIPTION" : "Documentation of the BPMN element."
           }
         },
         "CATEGORYPACKAGE" : {


### PR DESCRIPTION
Before this change the description of the documentation package was a copy of the description of the name package.