### PR TITLE
Update Groovy to version 3.0

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -128,8 +128,8 @@ org.apache.httpcomponents       httpclient                  4.5.12          Apac
 org.apache.httpcomponents       httpcore                    4.4.13          Apache License, Version 2.0
 org.apache.httpcomponents       httpmime                    4.5.12          Apache License, Version 2.0
 org.apache.geronimo.bundles     json                        20090211_1      The Apache Software License, Version 2.0
-org.codehaus.groovy             groovy                      2.5.12          The Apache Software License, Version 2.0
-org.codehaus.groovy             groovy-jsr223               2.5.12          The Apache Software License, Version 2.0
+org.codehaus.groovy             groovy                      3.0.5           The Apache Software License, Version 2.0
+org.codehaus.groovy             groovy-jsr223               3.0.5           The Apache Software License, Version 2.0
 org.liquibase                   liquibase-core              3.8.0           Apache License, Version 2.0
 org.mybatis                     mybatis                     3.5.5           The Apache Software License, Version 2.0
 org.mybatis                     mybatis-spring              2.0.5           The Apache Software License, Version 2.0

--- a/docs/userguide/src/en/bpmn/ch07b-BPMN-Constructs.adoc
+++ b/docs/userguide/src/en/bpmn/ch07b-BPMN-Constructs.adoc
@@ -2486,7 +2486,7 @@ Do note that the Groovy scripting engine is bundled with the groovy-jsr223 jar. 
 <dependency>
     <groupId>org.codehaus.groovy</groupId>
     <artifactId>groovy-jsr223</artifactId>
-    <version>2.x.x<version>
+    <version>3.x.x<version>
 </dependency>
 ----
 

--- a/docs/userguide/src/en/cmmn/ch06-cmmn.adoc
+++ b/docs/userguide/src/en/cmmn/ch06-cmmn.adoc
@@ -615,7 +615,7 @@ Do note that the Groovy scripting engine is bundled with the groovy-jsr223 JAR. 
 <dependency>
     <groupId>org.codehaus.groovy</groupId>
     <artifactId>groovy-jsr223</artifactId>
-    <version>2.x.x<version>
+    <version>3.x.x<version>
 </dependency>
 ----
 

--- a/docs/userguide/src/zh_CN/bpmn/ch07b-BPMN-Constructs.adoc
+++ b/docs/userguide/src/zh_CN/bpmn/ch07b-BPMN-Constructs.adoc
@@ -2459,14 +2459,14 @@ image::images/bpmn.scripttask.png[align="center"]
 
 **scriptFormat**属性的值，必须是兼容link:$$http://jcp.org/en/jsr/detail?id=223$$[JSR-223]（Java平台脚本）的名字。默认情况下，JavaScript包含在每一个JDK中，因此不需要添加任何JAR文件。如果想使用其它（兼容JSR-223的）脚本引擎，则需要在classpath中添加相应的jar，并使用适当的名字。例如，Flowable单元测试经常使用Groovy，因为其语法与Java十分相似。
 
-请注意Groovy脚本引擎与groovy-all JAR捆绑在一起。在Groovy 2.0版本以前，脚本引擎是Groovy JAR的一部分。因此，必须添加如下依赖：
+请注意Groovy脚本引擎与groovy-jsr223 JAR捆绑在一起。在Groovy 3.0版本以前，脚本引擎是Groovy JAR的一部分。因此，必须添加如下依赖：
 
 [source,xml,linenums]
 ----
 <dependency>
     <groupId>org.codehaus.groovy</groupId>
-    <artifactId>groovy-all</artifactId>
-    <version>2.x.x<version>
+    <artifactId>groovy-jsr223</artifactId>
+    <version>3.x.x<version>
 </dependency>
 ----
 

--- a/docs/userguide/src/zh_CN/cmmn/ch06-cmmn.adoc
+++ b/docs/userguide/src/zh_CN/cmmn/ch06-cmmn.adoc
@@ -740,7 +740,7 @@ image::images/cmmn.scripttask.png[align="center"]
 <dependency>
     <groupId>org.codehaus.groovy</groupId>
     <artifactId>groovy-jsr223</artifactId>
-    <version>2.x.x<version>
+    <version>3.x.x<version>
 </dependency>
 ----
 

--- a/pom.xml
+++ b/pom.xml
@@ -777,7 +777,7 @@
 			<dependency>
 				<groupId>org.codehaus.groovy</groupId>
 				<artifactId>groovy-jsr223</artifactId>
-				<version>2.5.12</version>
+				<version>3.0.5</version>
 			</dependency>
 			<dependency>
 				<groupId>org.drools</groupId>


### PR DESCRIPTION
According to https://mail-archives.apache.org/mod_mbox/groovy-dev/201906.mbox/%3C1561798530556-0.post%40n5.nabble.com%3E it won't be long until the GA release, so let's see if it is a seamless update for flowable.

Currently using `3.0.0-rc-3`.