### PR TITLE
Oracle JDK 8 is no longer available on new Travis CI images, so repla…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: java
 
 matrix:
   include:
-  - jdk: oraclejdk8
+  - jdk: openjdk8
   - name: "Flowable 5 tests"
-    jdk: oraclejdk8
+    jdk: openjdk8
     install: true
     script:
       cd scripts && ./run-flowable5-tests.sh


### PR DESCRIPTION
…ce it with Open JDK 8.