### PR TITLE
Add declarative CORS support

### DIFF
--- a/docs/userguide/src/en/bpmn/ch05a-Spring-Boot.adoc
+++ b/docs/userguide/src/en/bpmn/ch05a-Spring-Boot.adoc
@@ -1,4 +1,4 @@
-
+z
 [[springSpringBoot]]
 
 
@@ -782,6 +782,12 @@ flowable.http.socket-timeout=5s # Socket timeout for the http client
 flowable.http.connection-request-timeout=5s # Connection Request Timeout for the http client
 flowable.http.request-retry-limit=3 # Request retry limit for the http client
 flowable.http.disable-cert-verify=false # Whether to disable certificate validation for the http client
+
+# Flowable REST
+flowable.rest.app.corsAllowCredentials=true # Whether to include credentials in a CORS request
+flowable.rest.app.corsAllowedOrigins=* # Comma-separated URLs to accept CORS requests from
+flowable.rest.app.corsAllowedHeaders=* # Comma-separated HTTP headers to allow in a CORS request
+flowable.rest.app.corsAllowedMethods=DELETE,GET,PATCH,POST,PUT # Comma-separated HTTP verbs to allow in a CORS request
 
 # Actuator
 management.endpoint.flowable.cache.time-to-live=0ms # Maximum time that a response can be cached.

--- a/docs/userguide/src/en/bpmn/ch05a-Spring-Boot.adoc
+++ b/docs/userguide/src/en/bpmn/ch05a-Spring-Boot.adoc
@@ -784,11 +784,12 @@ flowable.http.request-retry-limit=3 # Request retry limit for the http client
 flowable.http.disable-cert-verify=false # Whether to disable certificate validation for the http client
 
 # Flowable REST
-flowable.rest.app.corsEnabled=true # Whether to enable CORS requests at all. If false, the other properties have no effect
-flowable.rest.app.corsAllowCredentials=true # Whether to include credentials in a CORS request
-flowable.rest.app.corsAllowedOrigins=* # Comma-separated URLs to accept CORS requests from
-flowable.rest.app.corsAllowedHeaders=* # Comma-separated HTTP headers to allow in a CORS request
-flowable.rest.app.corsAllowedMethods=DELETE,GET,PATCH,POST,PUT # Comma-separated HTTP verbs to allow in a CORS request
+flowable.rest.app.cors-enabled=true # Whether to enable CORS requests at all. If false, the other properties have no effect
+flowable.rest.app.cors-allow-credentials=true # Whether to include credentials in a CORS request
+flowable.rest.app.cors-allowed-origins=* # Comma-separated URLs to accept CORS requests from
+flowable.rest.app.cors-allowed-headers=* # Comma-separated HTTP headers to allow in a CORS request
+flowable.rest.app.cors-allowed-methods=DELETE,GET,PATCH,POST,PUT # Comma-separated HTTP verbs to allow in a CORS request
+flowable.rest.app.cors-exposed-headers=* # Comma-separated list of headers to expose in CORS response
 
 # Actuator
 management.endpoint.flowable.cache.time-to-live=0ms # Maximum time that a response can be cached.

--- a/docs/userguide/src/en/bpmn/ch05a-Spring-Boot.adoc
+++ b/docs/userguide/src/en/bpmn/ch05a-Spring-Boot.adoc
@@ -1,4 +1,4 @@
-z
+
 [[springSpringBoot]]
 
 
@@ -784,6 +784,7 @@ flowable.http.request-retry-limit=3 # Request retry limit for the http client
 flowable.http.disable-cert-verify=false # Whether to disable certificate validation for the http client
 
 # Flowable REST
+flowable.rest.app.corsEnabled=true # Whether to enable CORS requests at all. If false, the other properties have no effect
 flowable.rest.app.corsAllowCredentials=true # Whether to include credentials in a CORS request
 flowable.rest.app.corsAllowedOrigins=* # Comma-separated URLs to accept CORS requests from
 flowable.rest.app.corsAllowedHeaders=* # Comma-separated HTTP headers to allow in a CORS request

--- a/docs/userguide/src/zh_CN/bpmn/ch05a-Spring-Boot.adoc
+++ b/docs/userguide/src/zh_CN/bpmn/ch05a-Spring-Boot.adoc
@@ -786,11 +786,12 @@ flowable.http.request-retry-limit=3 #  请求http客户端的重试限制
 flowable.http.disable-cert-verify=false # 是否禁用http客户端的证书验证
 
 # Flowable REST
-flowable.rest.app.corsEnabled=true # Whether to enable CORS requests at all. If false, the other properties have no effect
-flowable.rest.app.corsAllowCredentials=true # Whether to include credentials in a CORS request
-flowable.rest.app.corsAllowedOrigins=* # Comma-separated URLs to accept CORS requests from
-flowable.rest.app.corsAllowedHeaders=* # Comma-separated HTTP headers to allow in a CORS request
-flowable.rest.app.corsAllowedMethods=DELETE,GET,PATCH,POST,PUT # Comma-separated HTTP verbs to allow in a CORS request
+flowable.rest.app.cors-enabled=true # Whether to enable CORS requests at all. If false, the other properties have no effect
+flowable.rest.app.cors-allow-credentials=true # Whether to include credentials in a CORS request
+flowable.rest.app.cors-allowed-origins=* # Comma-separated URLs to accept CORS requests from
+flowable.rest.app.cors-allowed-headers=* # Comma-separated HTTP headers to allow in a CORS request
+flowable.rest.app.cors-allowed-methods=DELETE,GET,PATCH,POST,PUT # Comma-separated HTTP verbs to allow in a CORS request
+flowable.rest.app.cors-exposed-headers=* # Comma-separated list of headers to expose in CORS response
 
 # Actuator
 management.endpoint.flowable.cache.time-to-live=0ms # 缓存响应的最大时间。

--- a/docs/userguide/src/zh_CN/bpmn/ch05a-Spring-Boot.adoc
+++ b/docs/userguide/src/zh_CN/bpmn/ch05a-Spring-Boot.adoc
@@ -785,6 +785,12 @@ flowable.http.connection-request-timeout=5s #  http客户端的连接请求超�
 flowable.http.request-retry-limit=3 #  请求http客户端的重试限制
 flowable.http.disable-cert-verify=false # 是否禁用http客户端的证书验证
 
+# Flowable REST
+flowable.rest.app.corsAllowCredentials=true # Whether to include credentials in a CORS request
+flowable.rest.app.corsAllowedOrigins=* # Comma-separated URLs to accept CORS requests from
+flowable.rest.app.corsAllowedHeaders=* # Comma-separated HTTP headers to allow in a CORS request
+flowable.rest.app.corsAllowedMethods=DELETE,GET,PATCH,POST,PUT # Comma-separated HTTP verbs to allow in a CORS request
+
 # Actuator
 management.endpoint.flowable.cache.time-to-live=0ms # 缓存响应的最大时间。
 management.endpoint.flowable.enabled=true # 是否启用flowable端点。

--- a/docs/userguide/src/zh_CN/bpmn/ch05a-Spring-Boot.adoc
+++ b/docs/userguide/src/zh_CN/bpmn/ch05a-Spring-Boot.adoc
@@ -786,6 +786,7 @@ flowable.http.request-retry-limit=3 #  请求http客户端的重试限制
 flowable.http.disable-cert-verify=false # 是否禁用http客户端的证书验证
 
 # Flowable REST
+flowable.rest.app.corsEnabled=true # Whether to enable CORS requests at all. If false, the other properties have no effect
 flowable.rest.app.corsAllowCredentials=true # Whether to include credentials in a CORS request
 flowable.rest.app.corsAllowedOrigins=* # Comma-separated URLs to accept CORS requests from
 flowable.rest.app.corsAllowedHeaders=* # Comma-separated HTTP headers to allow in a CORS request

--- a/modules/flowable-app-rest/src/main/java/org/flowable/rest/app/properties/RestAppProperties.java
+++ b/modules/flowable-app-rest/src/main/java/org/flowable/rest/app/properties/RestAppProperties.java
@@ -12,6 +12,9 @@
  */
 package org.flowable.rest.app.properties;
 
+import java.util.Collections;
+import java.util.Set;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
@@ -19,6 +22,7 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty;
  * Properties for the rest app.
  *
  * @author Filip Hrisafov
+ * @author Tim Stephenson
  */
 @ConfigurationProperties(prefix = "flowable.rest.app")
 public class RestAppProperties {
@@ -40,6 +44,26 @@ public class RestAppProperties {
      * Enable/disable whether the docs are available on /docs
      */
     private boolean swaggerDocsEnabled = true;
+
+    /**
+     * Allow/disallow CORS credentials.
+     */
+    private boolean corsAllowCredentials = false;
+
+    /**
+     * Allowed CORS origins, use * for all, but not in production. Default empty.
+     */
+    private Set<String> corsAllowedOrigins;
+
+    /**
+     * Allowed CORS headers, use * for all, but not in production. Default empty.
+     */
+    private Set<String> corsAllowedHeaders;
+
+    /**
+     * Allowed CORS methods, use * for all, but not in production. Default empty.
+     */
+    private Set<String> corsAllowedMethods;
 
     @NestedConfigurationProperty
     private final Admin admin = new Admin();
@@ -71,6 +95,38 @@ public class RestAppProperties {
 
     public void setSwaggerDocsEnabled(boolean swaggerDocsEnabled) {
         this.swaggerDocsEnabled = swaggerDocsEnabled;
+    }
+
+    public boolean isCorsAllowCredentials() {
+        return corsAllowCredentials;
+    }
+
+    public void setCorsAllowCredentials(boolean corsCorsAllowCredentials) {
+        this.corsAllowCredentials = corsCorsAllowCredentials;
+    }
+
+    public Set<String> getCorsAllowedOrigins() {
+        return corsAllowedOrigins == null ? Collections.emptySet() : corsAllowedOrigins;
+    }
+
+    public void setCorsAllowedOrigins(Set<String> corsAllowedOrigins) {
+        this.corsAllowedOrigins = corsAllowedOrigins;
+    }
+
+    public Set<String> getCorsAllowedHeaders() {
+        return corsAllowedHeaders == null ? Collections.emptySet() : corsAllowedHeaders;
+    }
+
+    public void setCorsAllowedHeaders(Set<String> corsAllowedHeaders) {
+        this.corsAllowedHeaders = corsAllowedHeaders;
+    }
+
+    public Set<String> getCorsAllowedMethods() {
+        return corsAllowedMethods == null ? Collections.emptySet() : corsAllowedMethods;
+    }
+
+    public void setCorsAllowedMethods(Set<String> corsAllowedMethods) {
+        this.corsAllowedMethods = corsAllowedMethods;
     }
 
     public Admin getAdmin() {

--- a/modules/flowable-app-rest/src/main/java/org/flowable/rest/app/properties/RestAppProperties.java
+++ b/modules/flowable-app-rest/src/main/java/org/flowable/rest/app/properties/RestAppProperties.java
@@ -46,6 +46,11 @@ public class RestAppProperties {
     private boolean swaggerDocsEnabled = true;
 
     /**
+     * Enable/disable CORS filter.
+     */
+    private boolean corsEnabled = false;
+
+    /**
      * Allow/disallow CORS credentials.
      */
     private boolean corsAllowCredentials = false;
@@ -59,6 +64,11 @@ public class RestAppProperties {
      * Allowed CORS headers, use * for all, but not in production. Default empty.
      */
     private Set<String> corsAllowedHeaders;
+
+    /**
+     * Exposed CORS headers, use * for all, but not in production. Default empty.
+     */
+    private Set<String> corsExposedHeaders;
 
     /**
      * Allowed CORS methods, use * for all, but not in production. Default empty.
@@ -97,6 +107,14 @@ public class RestAppProperties {
         this.swaggerDocsEnabled = swaggerDocsEnabled;
     }
 
+    public boolean isCorsEnabled() {
+        return corsEnabled;
+    }
+
+    public void setCorsEnabled(boolean corsEnabled) {
+        this.corsEnabled = corsEnabled;
+    }
+
     public boolean isCorsAllowCredentials() {
         return corsAllowCredentials;
     }
@@ -119,6 +137,14 @@ public class RestAppProperties {
 
     public void setCorsAllowedHeaders(Set<String> corsAllowedHeaders) {
         this.corsAllowedHeaders = corsAllowedHeaders;
+    }
+
+    public Set<String> getCorsExposedHeaders() {
+        return corsExposedHeaders;
+    }
+
+    public void setCorsExposedHeaders(Set<String> corsExposedHeaders) {
+        this.corsExposedHeaders = corsExposedHeaders;
     }
 
     public Set<String> getCorsAllowedMethods() {

--- a/modules/flowable-app-rest/src/main/java/org/flowable/rest/app/properties/RestAppProperties.java
+++ b/modules/flowable-app-rest/src/main/java/org/flowable/rest/app/properties/RestAppProperties.java
@@ -140,7 +140,7 @@ public class RestAppProperties {
     }
 
     public Set<String> getCorsExposedHeaders() {
-        return corsExposedHeaders;
+        return corsExposedHeaders == null ? Collections.emptySet() : corsExposedHeaders;
     }
 
     public void setCorsExposedHeaders(Set<String> corsExposedHeaders) {

--- a/modules/flowable-app-rest/src/main/java/org/flowable/rest/conf/PropertyBasedCorsFilter.java
+++ b/modules/flowable-app-rest/src/main/java/org/flowable/rest/conf/PropertyBasedCorsFilter.java
@@ -1,0 +1,50 @@
+package org.flowable.rest.conf;
+
+import org.flowable.rest.app.properties.RestAppProperties;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+/**
+ * Configures Cross-Origin Resource Sharing (CORS) based on injected properties.
+ *
+ * @author Tim Stephenson
+ */
+public class PropertyBasedCorsFilter extends AbstractHttpConfigurer<PropertyBasedCorsFilter, HttpSecurity> {
+    
+    protected final RestAppProperties restAppProperties;
+
+    public PropertyBasedCorsFilter(RestAppProperties restAppProperties) {
+        this.restAppProperties = restAppProperties;
+    }
+
+    @Override
+    public void configure(HttpSecurity http) throws Exception {
+        CorsFilter corsFilter = corsFilter(restAppProperties);
+        http.addFilterBefore(corsFilter, UsernamePasswordAuthenticationFilter.class);
+    }
+
+    private CorsFilter corsFilter(RestAppProperties restAppProperties) {
+        CorsConfiguration config = new CorsConfiguration();
+        if (restAppProperties.isCorsAllowCredentials()) {
+            config.setAllowCredentials(true);
+        }
+
+        for (String origin : restAppProperties.getCorsAllowedOrigins()) {
+            config.addAllowedOrigin(origin);
+        }
+        for (String header : restAppProperties.getCorsAllowedHeaders()) {
+            config.addAllowedHeader(header);
+        }
+        for (String method : restAppProperties.getCorsAllowedMethods()) {
+            config.addAllowedMethod(method);
+        }
+        
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return new CorsFilter(source);
+    }
+}

--- a/modules/flowable-app-rest/src/main/java/org/flowable/rest/conf/PropertyBasedCorsFilter.java
+++ b/modules/flowable-app-rest/src/main/java/org/flowable/rest/conf/PropertyBasedCorsFilter.java
@@ -39,10 +39,13 @@ public class PropertyBasedCorsFilter extends AbstractHttpConfigurer<PropertyBase
         for (String header : restAppProperties.getCorsAllowedHeaders()) {
             config.addAllowedHeader(header);
         }
+        for (String exposedHeader : restAppProperties.getCorsExposedHeaders()) {
+            config.addExposedHeader(exposedHeader);
+        }
         for (String method : restAppProperties.getCorsAllowedMethods()) {
             config.addAllowedMethod(method);
         }
-        
+
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", config);
         return new CorsFilter(source);

--- a/modules/flowable-app-rest/src/main/java/org/flowable/rest/conf/SecurityConfiguration.java
+++ b/modules/flowable-app-rest/src/main/java/org/flowable/rest/conf/SecurityConfiguration.java
@@ -50,14 +50,17 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .sessionManagement()
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
+                .apply(new PropertyBasedCorsFilter(restAppProperties))
+                .and()
                 .csrf().disable();
-        
+
+
         // Swagger docs
         if (isSwaggerDocsEnabled()) {
             httpSecurity
                 .authorizeRequests()
                 .antMatchers("/docs/**").permitAll();
-            
+
         } else {
             httpSecurity
                 .authorizeRequests()
@@ -82,7 +85,6 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
             .authorizeRequests()
             .anyRequest()
             .authenticated().and().httpBasic();
-            
         }
     }
     
@@ -97,5 +99,4 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
     protected boolean isSwaggerDocsEnabled() {
         return restAppProperties.isSwaggerDocsEnabled();
     }
-    
 }

--- a/modules/flowable-app-rest/src/main/java/org/flowable/rest/conf/SecurityConfiguration.java
+++ b/modules/flowable-app-rest/src/main/java/org/flowable/rest/conf/SecurityConfiguration.java
@@ -50,10 +50,11 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .sessionManagement()
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
-                .apply(new PropertyBasedCorsFilter(restAppProperties))
-                .and()
                 .csrf().disable();
 
+        if (restAppProperties.isCorsEnabled()) {
+            httpSecurity.apply(new PropertyBasedCorsFilter(restAppProperties));
+        }
 
         // Swagger docs
         if (isSwaggerDocsEnabled()) {


### PR DESCRIPTION
Background: I have a number of web applications built on the micro-frontend pattern that need process and decision engine support. I'd like to use the out-of-the-box Flowable rest container to fulfil that need but currently it does not provide CORS support. So I have to re-package the jar and container just to add a tiny amount of what I'd say is really just configuration.

This PR modifies the `SecurityConfiguration` to add the Spring CORS filter configured via application properties.