### PR TITLE
Make some timer tests more stable in slow environments (e.g. Travis CI).

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventTest.java
@@ -79,7 +79,7 @@ public class BoundaryTimerEventTest extends PluggableFlowableTestCase {
         // After setting the clock to time '1 hour and 5 seconds', the second
         // timer should fire
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + ((60 * 60 * 1000) + 5000)));
-        waitForJobExecutorToProcessAllJobs(7000L, 25L);
+        waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(7000L, 25L);
         assertEquals(0L, jobQuery.count());
 
         // which means that the third task is reached
@@ -128,7 +128,7 @@ public class BoundaryTimerEventTest extends PluggableFlowableTestCase {
         // After setting the clock to time '1 hour and 5 seconds', the second
         // timer should fire
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + ((60 * 60 * 1000) + 5000)));
-        waitForJobExecutorToProcessAllJobs(7000L, 25L);
+        waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(7000L, 25L);
         assertEquals(0L, jobQuery.count());
 
         // start execution listener is not executed

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerNonInterruptingEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerNonInterruptingEventTest.java
@@ -72,7 +72,7 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
 
         // After setting the clock to time '2 hour and 5 seconds', the second timer should fire
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + ((2 * 60 * 60 * 1000) + 5000)));
-        waitForJobExecutorToProcessAllJobs(7000L, 25L);
+        waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(7000L, 25L);
 
         // no more timers to fire
         assertEquals(0L, jobQuery.count());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/DurationTimeTimerEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/DurationTimeTimerEventTest.java
@@ -72,7 +72,7 @@ public class DurationTimeTimerEventTest extends PluggableFlowableTestCase {
 
         processEngineConfiguration.getClock().setCurrentTime(Date.from(yesterday.plus(200, ChronoUnit.SECONDS)));
 
-        waitForJobExecutorToProcessAllJobs(7000L, 200L);
+        waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(7000L, 200L);
 
         jobQuery = managementService.createTimerJobQuery();
         assertThat(jobQuery.count()).isEqualTo(0);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/InstantTimeTimerEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/InstantTimeTimerEventTest.java
@@ -62,7 +62,7 @@ public class InstantTimeTimerEventTest extends ResourceFlowableTestCase {
         processEngineConfiguration.getClock().setCurrentTime(nowCal.getTime());
         
         try {
-            waitForJobExecutorToProcessAllJobs(10000L, 25L);
+            waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(10000L, 25L);
             assertEquals(0L, jobQuery.count());
             
             assertProcessEnded(pi.getId());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/IntermediateTimerEventRepeatWithEndTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/IntermediateTimerEventRepeatWithEndTest.java
@@ -82,7 +82,7 @@ public class IntermediateTimerEventRepeatWithEndTest extends PluggableFlowableTe
         Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
         assertNotNull(timerJob);
 
-        waitForJobExecutorToProcessAllJobs(2000, 500);
+        waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(5000, 200);
 
         // Expected that job isn't executed because the timer is in t0");
         Job timerJobAfter = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
@@ -92,7 +92,7 @@ public class IntermediateTimerEventRepeatWithEndTest extends PluggableFlowableTe
         nextTimeCal.add(Calendar.MINUTE, 5);
         processEngineConfiguration.getClock().setCurrentTime(nextTimeCal.getTime());
 
-        waitForJobExecutorToProcessAllJobs(2000, 200);
+        waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(5000, 200);
         // expect to execute because the time is reached.
 
         List<Job> jobs = managementService.createTimerJobQuery().list();
@@ -109,7 +109,7 @@ public class IntermediateTimerEventRepeatWithEndTest extends PluggableFlowableTe
         nextTimeCal.add(Calendar.MINUTE, 5);
         processEngineConfiguration.getClock().setCurrentTime(nextTimeCal.getTime());
 
-        waitForJobExecutorToProcessAllJobs(2000, 500);
+        waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(5000, 200);
         // expect to execute because the end time is reached.
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/IntermediateTimerEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/IntermediateTimerEventTest.java
@@ -49,7 +49,7 @@ public class IntermediateTimerEventTest extends PluggableFlowableTestCase {
 
         // After setting the clock to time '50minutes and 5 seconds', the second timer should fire
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + ((50 * 60 * 1000) + 5000)));
-        waitForJobExecutorToProcessAllJobs(7000L, 25L);
+        waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(7000L, 25L);
 
         assertEquals(0, jobQuery.count());
         assertProcessEnded(pi.getProcessInstanceId());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/compatibility/StartTimerEventRepeatCompatibilityTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/compatibility/StartTimerEventRepeatCompatibilityTest.java
@@ -113,11 +113,7 @@ public class StartTimerEventRepeatCompatibilityTest extends TimerEventCompatibil
 
         // ADVANCE THE CLOCK SO that all 10 repeats to be executed (last execution)
         moveByMinutes(60 * 24);
-        try {
-            waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(2000, 200);
-        } catch (Exception e) {
-            fail("Because the maximum number of repeats is reached it will not be executed other jobs");
-        }
+        waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(5000, 200);
 
         // After the 10nth startEvent Execution should have 10 process instances started
         // (since the first one was not completed)

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/gateway/InclusiveGatewayTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/gateway/InclusiveGatewayTest.java
@@ -486,7 +486,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
     @Deployment
     public void testAsyncBehavior() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("async");
-        waitForJobExecutorToProcessAllJobs(7000L, 250);
+        waitForJobExecutorToProcessAllJobs(10000L, 250);
         assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
     }
 


### PR DESCRIPTION
This should fix occasional test failures observed in builds of recent pull requests.