### PR TITLE
Fix Javadoc error "The code being documented uses modules but the pac…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1129,6 +1129,9 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
 					<version>3.1.1</version>
+					<configuration>
+						<source>${jdk.version}</source>
+					</configuration>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
…kages defined in https://docs.oracle.com/javase/8/docs/api/ are in the unnamed module." on Java 11+.
