### PR TITLE
flowable-app-rest: Remove tomcat7-maven-plugin (which should not be n…

### DIFF
--- a/modules/flowable-app-rest/pom.xml
+++ b/modules/flowable-app-rest/pom.xml
@@ -23,18 +23,6 @@
 
     <plugins>
       <plugin>
-	    <groupId>org.apache.tomcat.maven</groupId>
-        <artifactId>tomcat7-maven-plugin</artifactId>
-		<configuration>
-		  <port>8080</port>
-		  <path>/flowable-rest</path>
-          <warDirectory>${project.build.directory}/${project.build.finalName}</warDirectory>
-          <systemProperties>
-		    <com.sun.management.jmxremote.port>4000</com.sun.management.jmxremote.port>
-          </systemProperties>
-		</configuration>
-      </plugin>
-      <plugin>
         <artifactId>maven-clean-plugin</artifactId>
         <version>3.0.0</version>
         <configuration>


### PR DESCRIPTION
…ecessary after the move to spring boot) to fix maven warning:

>[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.flowable:flowable-app-rest:war:6.5.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.tomcat.maven:tomcat7-maven-plugin is missing. @ line 25, column 15
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 

If the plugin is still considered useful, we should specify a version to fix the warning.