### PR TITLE
Update Jackson to version 2.10.1

### DIFF
--- a/modules/flowable-http/src/main/java/org/flowable/http/HttpActivityExecutor.java
+++ b/modules/flowable-http/src/main/java/org/flowable/http/HttpActivityExecutor.java
@@ -53,6 +53,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.MissingNode;
 
 /**
  * An executor behavior for HTTP requests.
@@ -116,6 +117,9 @@ public class HttpActivityExecutor {
                 if (!response.isBodyResponseHandled()) {
                     String varName = StringUtils.isNotEmpty(responseVariableName) ? responseVariableName : request.getPrefix() + "ResponseBody";
                     Object varValue = request.isSaveResponseAsJson() && response.getBody() != null ? objectMapper.readTree(response.getBody()) : response.getBody();
+                    if (varValue instanceof MissingNode) {
+                        varValue = null;
+                    }
                     if (request.isSaveResponseTransient()) {
                         variableContainer.setTransientVariable(varName, varValue);
                     } else {

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 		<jdk.version>1.8</jdk.version>
 		<spring.framework.version>5.1.10.RELEASE</spring.framework.version>
 		<spring.security.version>5.1.6.RELEASE</spring.security.version>
-		<jackson.version>2.9.10</jackson.version>
+		<jackson.version>2.10.1</jackson.version>
 		<mule.version>3.8.0</mule.version>
     <camel.version>2.24.0</camel.version>
 		<cxf.version>3.3.4</cxf.version>


### PR DESCRIPTION
Jackson 2.10 was just released and will be used by Spring 5.2 and Spring Boot 2.2.