### PR TITLE
Allow MyBatis mapping file to be customized.

### DIFF
--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/AbstractEngineConfiguration.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/AbstractEngineConfiguration.java
@@ -181,6 +181,7 @@ public abstract class AbstractEngineConfiguration {
 
     public int DEFAULT_MAX_NR_OF_STATEMENTS_BULK_INSERT_SQL_SERVER = 60; // currently Execution has most params (31). 2000 / 31 = 64.
 
+    protected String mybatisMappingFile;
     protected Set<Class<?>> customMybatisMappers;
     protected Set<String> customMybatisXMLMappers;
     protected List<Interceptor> customMybatisInterceptors;
@@ -835,6 +836,14 @@ public abstract class AbstractEngineConfiguration {
         } else {
             return this.getClass().getClassLoader().getResourceAsStream(resource);
         }
+    }
+
+    public void setMybatisMappingFile(String file) {
+        this.mybatisMappingFile = file;
+    }
+
+    public String getMybatisMappingFile() {
+        return mybatisMappingFile;
     }
 
     public abstract InputStream getMyBatisXmlConfigurationStream();

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -930,6 +930,10 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     protected Set<String> flowable5CustomMybatisXMLMappers;
     protected Object flowable5ExpressionManager;
 
+    public ProcessEngineConfigurationImpl() {
+        mybatisMappingFile = DEFAULT_MYBATIS_MAPPING_FILE;
+    }
+
     // buildProcessEngine
     // ///////////////////////////////////////////////////////
 
@@ -1185,7 +1189,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     @Override
     public InputStream getMyBatisXmlConfigurationStream() {
-        return getResourceAsStream(DEFAULT_MYBATIS_MAPPING_FILE);
+        return getResourceAsStream(mybatisMappingFile);
     }
 
     @Override


### PR DESCRIPTION
Our use of flowable requires some default mybatis type handlers to be overriden. Based upon the mybatis documentation the only way to do this is by specifying the overides in the mapping file as documented here:
https://mybatis.org/mybatis-3/configuration.html#typeHandlers

This PR therefore introduces new methods to allow for the location of the mybatis mapping file to be chosen.

Change-Id: Iff9af696a950c5d79b0ea4c2fa96582a5c3b1842

#### Check List:
* Unit tests: YES / NO / NA
* Documentation: YES / NO / NA
