### PR TITLE
Remove redundant length (second) argument on substring()

### DIFF
--- a/modules/flowable-common-rest/src/main/java/org/flowable/common/rest/api/RequestUtil.java
+++ b/modules/flowable-common-rest/src/main/java/org/flowable/common/rest/api/RequestUtil.java
@@ -59,7 +59,7 @@ public class RequestUtil {
             } else {
                 int inset = 6;
                 String s0 = input.substring(0, input.length() - inset);
-                String s1 = input.substring(input.length() - inset, input.length());
+                String s1 = input.substring(input.length() - inset);
                 input = s0 + "GMT" + s1;
             }
             try {

--- a/modules/flowable-content-engine-configurator/src/test/java/org/flowable/content/engine/configurator/test/ContentEngineConfiguratorTest.java
+++ b/modules/flowable-content-engine-configurator/src/test/java/org/flowable/content/engine/configurator/test/ContentEngineConfiguratorTest.java
@@ -127,7 +127,7 @@ public class ContentEngineConfiguratorTest {
                 int index = contentTypeHeader.indexOf("name=");
                 int semicolonIndex = contentTypeHeader.indexOf(";");
                 contentTypes.add(contentTypeHeader.substring(0, Math.min(semicolonIndex, index)));
-                names.add(contentTypeHeader.substring(index + 5 , contentTypeHeader.length()));
+                names.add(contentTypeHeader.substring(index + 5));
             }
         }
 

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/util/ReflectUtil.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/util/ReflectUtil.java
@@ -222,7 +222,7 @@ public abstract class ReflectUtil {
      * Returns the setter-method for the given field name or null if no setter exists.
      */
     public static Method getSetter(String fieldName, Class<?> clazz, Class<?> fieldType) {
-        String setterName = "set" + Character.toTitleCase(fieldName.charAt(0)) + fieldName.substring(1, fieldName.length());
+        String setterName = "set" + Character.toTitleCase(fieldName.charAt(0)) + fieldName.substring(1);
         try {
             // Using getMethods(), getMethod(...) expects exact parameter type
             // matching and ignores inheritance-tree.

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/util/ReflectUtil.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/util/ReflectUtil.java
@@ -191,7 +191,7 @@ public abstract class ReflectUtil {
      */
     public static Method getSetter(String fieldName, Class<?> clazz, Class<?> fieldType) {
         String setterName = "set" + Character.toTitleCase(fieldName.charAt(0)) +
-                fieldName.substring(1, fieldName.length());
+                fieldName.substring(1);
         try {
             // Using getMethods(), getMethod(...) expects exact parameter type
             // matching and ignores inheritance-tree.


### PR DESCRIPTION
substring(x) defaults to the end of the string

#### Check List:
* Unit tests: existing test passes
* Documentation: NA
