### PR TITLE
flowable-spring-boot/pom.xml: Remove the Spring Milestone and Spring …

### DIFF
--- a/modules/flowable-spring-boot/pom.xml
+++ b/modules/flowable-spring-boot/pom.xml
@@ -140,42 +140,4 @@
             </build>
         </profile>
     </profiles>
-
-    <repositories>
-        <repository>
-            <id>spring-snapshots</id>
-            <name>Spring Snapshots</name>
-            <url>http://repo.spring.io/snapshot</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>spring-milestones</id>
-            <name>Spring Milestones</name>
-            <url>http://repo.spring.io/milestone</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>spring-snapshots</id>
-            <name>Spring Snapshots</name>
-            <url>http://repo.spring.io/snapshot</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </pluginRepository>
-        <pluginRepository>
-            <id>spring-milestones</id>
-            <name>Spring Milestones</name>
-            <url>http://repo.spring.io/milestone</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </pluginRepository>
-    </pluginRepositories>
-
 </project>


### PR DESCRIPTION
…Snapshots repositories, as this causes dependencies to be downloaded from here instead of from maven central.

This can cause errors like:

>[ERROR] Failed to execute goal on project flowable-ui-common: Could not resolve dependencies for project org.flowable:flowable-ui-common:jar:6.5.0-SNAPSHOT: The following artifacts could not be resolved: com.fasterxml.jackson.datatype:jackson-datatype-json-org:jar:2.10.0, com.fasterxml.jackson.datatype:jackson-datatype-hppc:jar:2.10.0, com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.10.0: Could not find artifact com.fasterxml.jackson.datatype:jackson-datatype-json-org:jar:2.10.0 in spring-snapshots (http://repo.spring.io/snapshot) -> [Help 1]

Source: https://github.com/flowable/flowable-engine/pull/1947/checks?check_run_id=237630742

**Edit:**

The failure above was not caused by the spring repositories. It looks like a `2.10.0` release of `jackson-datatype-json-org` is still missing (see: https://github.com/FasterXML/jackson-datatype-json-org/issues/17). I still think adding the repositories is unnecessary and not a good practice.
