### PR TITLE
Flowable-app-rest: Add version for tomcat7-maven-plugin to fix maven …

### DIFF
--- a/modules/flowable-app-rest/pom.xml
+++ b/modules/flowable-app-rest/pom.xml
@@ -412,6 +412,7 @@
           <plugin>
             <groupId>org.apache.tomcat.maven</groupId>
             <artifactId>tomcat7-maven-plugin</artifactId>
+            <version>2.2</version>
             <configuration>
               <path>/flowable-rest</path>
               <port>8080</port>
@@ -438,6 +439,7 @@
           <plugin>
             <groupId>org.apache.tomcat.maven</groupId>
             <artifactId>tomcat7-maven-plugin</artifactId>
+            <version>2.2</version>
             <configuration>
               <path>/flowable-rest</path>
               <port>8080</port>


### PR DESCRIPTION
…warning:

"Some problems were encountered while building the effective model for org.flowable:flowable-app-rest:war:6.5.0-SNAPSHOT 'build.plugins.plugin.version' for org.apache.tomcat.maven:tomcat7-maven-plugin is missing."