### PR TITLE
Fixes BPMN Deadletter-jobs REST API documentation

### DIFF
--- a/docs/userguide/src/en/bpmn/ch15-REST.adoc
+++ b/docs/userguide/src/en/bpmn/ch15-REST.adoc
@@ -6303,7 +6303,7 @@ POST management/deadletter-jobs/{jobId}
 [source,json,linenums]
 ----
 {
-  "action" : "execute"
+  "action" : "move"
 }
 ----
 

--- a/docs/userguide/src/zh_CN/bpmn/ch15-REST.adoc
+++ b/docs/userguide/src/zh_CN/bpmn/ch15-REST.adoc
@@ -6303,7 +6303,7 @@ POST management/deadletter-jobs/{jobId}
 [source,json,linenums]
 ----
 {
-  "action" : "execute"
+  "action" : "move"
 }
 ----
 


### PR DESCRIPTION
Fixes BPMN Deadletter-jobs REST API documentation regarding Deadletter Jobs resuming.
Replace execute action with move action in the payload (only 'move' action is supported)

#### Check List:
* Unit tests: NA
* Documentation: YES
