### PR TITLE
remove warnings due to unspecified plugin versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,10 +29,14 @@
 
 		<junit.version>4.12</junit.version>
 		<junit.jupiter.version>5.5.2</junit.jupiter.version>
+		<maven.deploy.plugin.version>2.8.2</maven.deploy.plugin.version>
+		<maven.resources.plugin.version>3.1.0</maven.resources.plugin.version>
 		<mockito.version>3.1.0</mockito.version>
 
 		<oracle.jdbc.version>12.1.0.1</oracle.jdbc.version>
 		<oracle.jdbc.artifact>ojdbc7</oracle.jdbc.artifact>
+
+		<spotify.docker.plugin.version>1.4.10</spotify.docker.plugin.version>
 
         <checkstyle.config.location>checkstyle/flowable-checkstyle.xml</checkstyle.config.location>
         <checkstyle.suppressions.location>/checkstyle/flowable-suppressions.xml</checkstyle.suppressions.location>
@@ -999,11 +1003,6 @@
 				<version>2.9.0</version>
 				<scope>test</scope>
 			</dependency>
-			<dependency>
-				<groupId>com.spotify</groupId>
-				<artifactId>dockerfile-maven-plugin</artifactId>
-				<version>1.4.10</version>
-			</dependency>
 		</dependencies>
 	</dependencyManagement>
 
@@ -1114,6 +1113,30 @@
 		<pluginManagement>
 			<plugins>
 				<plugin>
+					<groupId>com.spotify</groupId>
+					<artifactId>dockerfile-maven-plugin</artifactId>
+					<version>${spotify.docker.plugin.version}</version>
+					<dependencies>
+						<dependency>
+							<groupId>com.spotify</groupId>
+							<artifactId>dockerfile-maven-plugin</artifactId>
+							<version>${spotify.docker.plugin.version}</version>
+						</dependency>
+					</dependencies>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-deploy-plugin</artifactId>
+					<version>${maven.deploy.plugin.version}</version>
+					<dependencies>
+						<dependency>
+							<groupId>org.apache.maven.plugins</groupId>
+							<artifactId>maven-deploy-plugin</artifactId>
+							<version>${maven.deploy.plugin.version}</version>
+						</dependency>
+					</dependencies>
+				</plugin>
+				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-jar-plugin</artifactId>
 					<version>3.1.2</version>
@@ -1132,6 +1155,18 @@
 					<configuration>
 						<source>${jdk.version}</source>
 					</configuration>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-resources-plugin</artifactId>
+					<version>${maven.resources.plugin.version}</version>
+					<dependencies>
+						<dependency>
+							<groupId>org.apache.maven.plugins</groupId>
+							<artifactId>maven-resources-plugin</artifactId>
+							<version>${maven.resources.plugin.version}</version>
+						</dependency>
+					</dependencies>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Building the `flowable-app-rest` docker container produced the following warnings:
```
[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.flowable:flowable-app-rest:war:6.5.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-resources-plugin is missing. @ org.flowable:flowable-app-rest:[unknown-version], /home/tstephen/git/flowable-engine/modules/flowable-app-rest/pom.xml, line 503, column 19
[WARNING] 'build.plugins.plugin.version' for com.spotify:dockerfile-maven-plugin is missing. @ org.flowable:flowable-app-rest:[unknown-version], /home/tstephen/git/flowable-engine/modules/flowable-app-rest/pom.xml, line 528, column 19
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ org.flowable:flowable-app-rest:[unknown-version], /home/tstephen/git/flowable-engine/modules/flowable-app-rest/pom.xml, line 497, column 19
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
```

I resolved these with the change to the root pom file in this commit. The versions I chose were as follows: 
- *dockerfile plugin:* the version erroneously specified as a dependency instead of a plugin dependency
- *resources and deploy plugins:* the latest available release versions on Maven Central.

The app rest container now builds without warnings. 

#### Check List:
* Unit tests: NA
* Documentation: NA
