### PR TITLE
support auto-complete condition for case plan model and stage

### DIFF
--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/EvaluateCriteriaOperation.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/EvaluateCriteriaOperation.java
@@ -408,8 +408,9 @@ public class EvaluateCriteriaOperation extends AbstractCaseInstanceOperation {
     }
 
     protected boolean isStageCompletable(PlanItemInstanceEntity stagePlanItemInstanceEntity, Stage stage) {
+        boolean autoComplete = ExpressionUtil.evaluateAutoComplete(commandContext, stagePlanItemInstanceEntity, stage);
         CompletionEvaluationResult completionEvaluationResult = PlanItemInstanceContainerUtil
-            .shouldPlanItemContainerComplete(commandContext, stagePlanItemInstanceEntity, stage.isAutoComplete());
+            .shouldPlanItemContainerComplete(commandContext, stagePlanItemInstanceEntity, autoComplete);
 
         if (completionEvaluationResult.isCompletable()) {
             stagePlanItemInstanceEntity.setCompletable(true);
@@ -419,7 +420,9 @@ public class EvaluateCriteriaOperation extends AbstractCaseInstanceOperation {
     }
 
     protected boolean evaluatePlanModelComplete() {
-        boolean isAutoComplete = CaseDefinitionUtil.getCase(caseInstanceEntity.getCaseDefinitionId()).getPlanModel().isAutoComplete();
+        boolean isAutoComplete = ExpressionUtil.evaluateAutoComplete(commandContext, caseInstanceEntity,
+            CaseDefinitionUtil.getCase(caseInstanceEntity.getCaseDefinitionId()).getPlanModel());
+
         CompletionEvaluationResult completionEvaluationResult = PlanItemInstanceContainerUtil
             .shouldPlanItemContainerComplete(commandContext, caseInstanceEntity, isAutoComplete);
 

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/util/ExpressionUtil.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/util/ExpressionUtil.java
@@ -16,6 +16,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.flowable.cmmn.engine.impl.persistence.entity.PlanItemInstanceEntity;
 import org.flowable.cmmn.model.PlanItem;
 import org.flowable.cmmn.model.PlanItemControl;
+import org.flowable.cmmn.model.Stage;
 import org.flowable.common.engine.api.FlowableException;
 import org.flowable.common.engine.api.delegate.Expression;
 import org.flowable.common.engine.api.variable.VariableContainer;
@@ -98,4 +99,18 @@ public class ExpressionUtil {
         return false;
     }
 
+    /**
+     * Returns true, if the given stage has an auto-complete condition which evaluates to true or if not, is in auto-complete mode permanently.
+     *
+     * @param commandContext the command context in which the method is invoked
+     * @param variableContainer the variable container (most likely the plan item representing the stage or case plan model) used to evaluate the condition against
+     * @param stage the stage model object to get its auto-complete condition from
+     * @return true, if the stage is in auto-complete, either statically or if the condition evaluates to true
+     */
+    public static boolean evaluateAutoComplete(CommandContext commandContext, VariableContainer variableContainer, Stage stage) {
+        if (StringUtils.isNotEmpty(stage.getAutoCompleteCondition())) {
+            return evaluateBooleanExpression(commandContext, variableContainer, stage.getAutoCompleteCondition());
+        }
+        return stage.isAutoComplete();
+    }
 }

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/util/PlanItemInstanceContainerUtil.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/util/PlanItemInstanceContainerUtil.java
@@ -144,7 +144,8 @@ public class PlanItemInstanceContainerUtil {
                         boolean childContainerIsAutocomplete = false;
                         if (PlanItemDefinitionType.STAGE.equals(planItemInstance.getPlanItemDefinitionType())) {
                             Stage stage = (Stage) planItemInstance.getPlanItem().getPlanItemDefinition();
-                            childContainerIsAutocomplete = stage.isAutoComplete();
+
+                            childContainerIsAutocomplete = ExpressionUtil.evaluateAutoComplete(commandContext, planItemInstance, stage);
                         }
 
                         CompletionEvaluationResult childPlanItemInstanceCompletionEvaluationResult =

--- a/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/runtime/AutoCompleteEvaluationTest.testAutoCompleteCondition.cmmn
+++ b/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/runtime/AutoCompleteEvaluationTest.testAutoCompleteCondition.cmmn
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:flowable="http://flowable.org/cmmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:design="http://flowable.org/design" targetNamespace="http://flowable.org/cmmn">
+    <case id="autoCompleteTest" name="AutoComplete Test" flowable:initiatorVariableName="initiator" flowable:candidateStarterGroups="flowableUser">
+        <casePlanModel id="onecaseplanmodel1" name="Case plan model" flowable:formFieldValidation="false" flowable:autoCompleteCondition="${vars:getOrDefault('enablePlanModelAutoComplete', false)}">
+            <extensionElements>
+                <flowable:work-form-field-validation><![CDATA[false]]></flowable:work-form-field-validation>
+                <design:stencilid><![CDATA[CasePlanModel]]></design:stencilid>
+            </extensionElements>
+            <planItem id="planItem3" name="Stage A" definitionRef="expandedStage1"></planItem>
+            <planItem id="planItem4" name="Task C" definitionRef="humanTask2">
+                <itemControl>
+                    <manualActivationRule></manualActivationRule>
+                </itemControl>
+            </planItem>
+            <stage id="expandedStage1" name="Stage A" flowable:autoCompleteCondition="${vars:getOrDefault('enableStageAutoComplete', false)}" flowable:includeInStageOverview="true">
+                <extensionElements>
+                    <flowable:start-form-field-validation><![CDATA[false]]></flowable:start-form-field-validation>
+                    <design:stencilid><![CDATA[ExpandedStage]]></design:stencilid>
+                </extensionElements>
+                <planItem id="planItem1" name="Task A" definitionRef="humanTask1">
+                    <itemControl>
+                        <manualActivationRule></manualActivationRule>
+                    </itemControl>
+                </planItem>
+                <planItem id="planItem2" name="Task B" definitionRef="humanTask3">
+                    <itemControl>
+                        <extensionElements>
+                            <flowable:parentCompletionRule type="ignoreAfterFirstCompletionIfAvailableOrEnabled" />
+                        </extensionElements>
+                        <repetitionRule flowable:counterVariable="repetitionCounter"></repetitionRule>
+                        <requiredRule></requiredRule>
+                        <manualActivationRule></manualActivationRule>
+                    </itemControl>
+                </planItem>
+                <humanTask id="humanTask1" name="Task A" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
+                    <extensionElements>
+                        <flowable:start-form-field-validation><![CDATA[false]]></flowable:start-form-field-validation>
+                        <design:stencilid><![CDATA[HumanTask]]></design:stencilid>
+                        <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+                    </extensionElements>
+                </humanTask>
+                <humanTask id="humanTask3" name="Task B" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
+                    <extensionElements>
+                        <flowable:start-form-field-validation><![CDATA[false]]></flowable:start-form-field-validation>
+                        <design:stencilid><![CDATA[HumanTask]]></design:stencilid>
+                        <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+                    </extensionElements>
+                </humanTask>
+            </stage>
+            <humanTask id="humanTask2" name="Task C" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
+                <extensionElements>
+                    <flowable:start-form-field-validation><![CDATA[false]]></flowable:start-form-field-validation>
+                    <design:stencilid><![CDATA[HumanTask]]></design:stencilid>
+                    <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+                </extensionElements>
+            </humanTask>
+        </casePlanModel>
+    </case>
+    <cmmndi:CMMNDI>
+        <cmmndi:CMMNDiagram id="CMMNDiagram_autoCompleteTest">
+            <cmmndi:CMMNShape id="CMMNShape_onecaseplanmodel1" cmmnElementRef="onecaseplanmodel1">
+                <dc:Bounds height="337.0" width="639.0" x="30.0" y="45.0"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_planItem3" cmmnElementRef="planItem3">
+                <dc:Bounds height="170.0" width="370.0" x="76.0" y="106.0"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_planItem1" cmmnElementRef="planItem1">
+                <dc:Bounds height="80.0" width="100.0" x="121.0" y="151.0"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_planItem2" cmmnElementRef="planItem2">
+                <dc:Bounds height="80.0" width="100.0" x="271.0" y="151.0"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_planItem4" cmmnElementRef="planItem4">
+                <dc:Bounds height="80.0" width="100.0" x="511.0" y="151.0"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+        </cmmndi:CMMNDiagram>
+    </cmmndi:CMMNDI>
+</definitions>

--- a/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/runtime/PlanItemCompletionTest.testComplexCompletionWithAutocompletion.cmmn
+++ b/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/runtime/PlanItemCompletionTest.testComplexCompletionWithAutocompletion.cmmn
@@ -7,7 +7,7 @@
                 <design:stencilid><![CDATA[CasePlanModel]]></design:stencilid>
             </extensionElements>
             <planItem id="planItem9" name="Stage A" definitionRef="expandedStage1"></planItem>
-            <stage id="expandedStage1" name="Stage A" autoComplete="true" flowable:includeInStageOverview="true">
+            <stage id="expandedStage1" name="Stage A" flowable:autoCompleteCondition="${vars:getOrDefault('autocompleteEnabled', false)}" flowable:includeInStageOverview="true">
                 <extensionElements>
                     <flowable:start-form-field-validation><![CDATA[false]]></flowable:start-form-field-validation>
                     <design:stencilid><![CDATA[ExpandedStage]]></design:stencilid>


### PR DESCRIPTION
Support the evaluation of an optional auto-complete condition on a case plan model or stage at runtime whenever the plan item is evaluated for completion.

#### Check List:
* Unit tests: YES
* Documentation: NA
