### PR TITLE
Optimize CMMN unit tests with a more robust lookup for plan item instances used for starting or triggering

### DIFF
--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/test/AbstractFlowableCmmnTestCase.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/test/AbstractFlowableCmmnTestCase.java
@@ -181,6 +181,24 @@ public abstract class AbstractFlowableCmmnTestCase {
             .list();
     }
 
+    protected List<PlanItemInstance> getCompletedPlanItemInstances(String caseInstanceId) {
+        return cmmnRuntimeService.createPlanItemInstanceQuery()
+            .caseInstanceId(caseInstanceId)
+            .planItemInstanceStateCompleted()
+            .includeEnded()
+            .orderByName().asc()
+            .list();
+    }
+
+    protected List<PlanItemInstance> getTerminatedPlanItemInstances(String caseInstanceId) {
+        return cmmnRuntimeService.createPlanItemInstanceQuery()
+            .caseInstanceId(caseInstanceId)
+            .orderByName().asc()
+            .planItemInstanceStateTerminated()
+            .includeEnded()
+            .list();
+    }
+
     protected String getPlanItemInstanceIdByName(List<PlanItemInstance> planItemInstances, String name) {
         return getPlanItemInstanceByName(planItemInstances, name, null).getId();
     }

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/test/AbstractFlowableCmmnTestCase.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/test/AbstractFlowableCmmnTestCase.java
@@ -36,7 +36,6 @@ import org.flowable.cmmn.engine.CmmnEngine;
 import org.flowable.cmmn.engine.CmmnEngineConfiguration;
 import org.flowable.cmmn.engine.test.impl.CmmnJobTestHelper;
 import org.flowable.cmmn.engine.test.impl.CmmnTestRunner;
-import org.flowable.cmmn.model.PlanItem;
 import org.junit.After;
 import org.junit.runner.RunWith;
 
@@ -172,6 +171,15 @@ public abstract class AbstractFlowableCmmnTestCase {
         if (!planItemInstanceStates.isEmpty()) {
             fail(planItemInstanceStates.size() + " plan item instance(s) found with name " + name + ", but should be 0");
         }
+    }
+
+    protected List<PlanItemInstance> getAllPlanItemInstances(String caseInstanceId) {
+        return cmmnRuntimeService.createPlanItemInstanceQuery()
+            .caseInstanceId(caseInstanceId)
+            .orderByName().asc()
+            .orderByEndTime().asc()
+            .includeEnded()
+            .list();
     }
 
     protected List<PlanItemInstance> getPlanItemInstances(String caseInstanceId) {

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/AutoCompleteEvaluationTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/AutoCompleteEvaluationTest.java
@@ -39,10 +39,7 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
             .variable("enableStageAutoComplete", true)
             .start();
 
-        List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .orderByName().asc()
-            .list();
+        List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
         assertEquals(4, planItemInstances.size());
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
@@ -51,20 +48,17 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
         assertPlanItemInstanceState(planItemInstances, "Task C", ENABLED);
 
         // start and complete Task B which will auto-complete Stage A
-        cmmnRuntimeService.startPlanItemInstance(planItemInstances.get(2).getId());
-        cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(2).getId());
+        cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task B"));
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task B"));
 
-        planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .orderByName().asc()
-            .list();
+        planItemInstances = getPlanItemInstances(caseInstance.getId());
 
         assertEquals(1, planItemInstances.size());
         assertPlanItemInstanceState(planItemInstances, "Task C", ENABLED);
 
         // start and complete Task C -> will complete the case
-        cmmnRuntimeService.startPlanItemInstance(planItemInstances.get(0).getId());
-        cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(0).getId());
+        cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task C"));
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task C"));
 
         assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().count());
         assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
@@ -79,10 +73,7 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
             .variable("enableStageAutoComplete", true)
             .start();
 
-        List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .orderByName().asc()
-            .list();
+        List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
         assertEquals(4, planItemInstances.size());
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
@@ -91,15 +82,12 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
         assertPlanItemInstanceState(planItemInstances, "Task C", ENABLED);
 
         // start Task A, nothing yet happens
-        cmmnRuntimeService.startPlanItemInstance(planItemInstances.get(1).getId());
+        cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task A"));
 
         // start Task B which will still not yet auto-complete Stage A
-        cmmnRuntimeService.startPlanItemInstance(planItemInstances.get(2).getId());
+        cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task B"));
 
-        planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .orderByName().asc()
-            .list();
+        planItemInstances = getPlanItemInstances(caseInstance.getId());
 
         assertEquals(4, planItemInstances.size());
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
@@ -108,12 +96,9 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
         assertPlanItemInstanceState(planItemInstances, "Task C", ENABLED);
 
         // now also complete Task B -> still no auto-complete, as Task A is still active, even if not required
-        cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(2).getId());
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task B"));
 
-        planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .orderByName().asc()
-            .list();
+        planItemInstances = getPlanItemInstances(caseInstance.getId());
 
         assertEquals(4, planItemInstances.size());
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
@@ -122,19 +107,16 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
         assertPlanItemInstanceState(planItemInstances, "Task C", ENABLED);
 
         // now also complete Task A -> Stage A should now get auto-completed
-        cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(1).getId());
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task A"));
 
-        planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .orderByName().asc()
-            .list();
+        planItemInstances = getPlanItemInstances(caseInstance.getId());
 
         assertEquals(1, planItemInstances.size());
         assertPlanItemInstanceState(planItemInstances, "Task C", ENABLED);
 
         // start and complete Task C -> will complete the case
-        cmmnRuntimeService.startPlanItemInstance(planItemInstances.get(0).getId());
-        cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(0).getId());
+        cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task C"));
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task C"));
 
         assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().count());
         assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
@@ -150,10 +132,7 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
             .variable("enablePlanModelAutoComplete", true)
             .start();
 
-        List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .orderByName().asc()
-            .list();
+        List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
         assertEquals(4, planItemInstances.size());
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
@@ -162,13 +141,8 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
         assertPlanItemInstanceState(planItemInstances, "Task C", ENABLED);
 
         // start and complete Task B which will auto-complete Stage A and even the full case as Task C is optional and the case itself is on auto-complete
-        cmmnRuntimeService.startPlanItemInstance(planItemInstances.get(2).getId());
-        cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(2).getId());
-
-        planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .orderByName().asc()
-            .list();
+        cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task B"));
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task B"));
 
         assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().count());
         assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
@@ -184,10 +158,7 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
             .variable("enablePlanModelAutoComplete", true)
             .start();
 
-        List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .orderByName().asc()
-            .list();
+        List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
         assertEquals(4, planItemInstances.size());
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
@@ -196,15 +167,12 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
         assertPlanItemInstanceState(planItemInstances, "Task C", ENABLED);
 
         // start Task A, nothing yet happens
-        cmmnRuntimeService.startPlanItemInstance(planItemInstances.get(1).getId());
+        cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task A"));
 
         // start Task B which will still not yet auto-complete Stage A
-        cmmnRuntimeService.startPlanItemInstance(planItemInstances.get(2).getId());
+        cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task B"));
 
-        planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .orderByName().asc()
-            .list();
+        planItemInstances = getPlanItemInstances(caseInstance.getId());
 
         assertEquals(4, planItemInstances.size());
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
@@ -213,12 +181,9 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
         assertPlanItemInstanceState(planItemInstances, "Task C", ENABLED);
 
         // now also complete Task B -> still no auto-complete, as Task A is still active, even if not required
-        cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(2).getId());
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task B"));
 
-        planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .orderByName().asc()
-            .list();
+        planItemInstances = getPlanItemInstances(caseInstance.getId());
 
         assertEquals(4, planItemInstances.size());
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
@@ -227,21 +192,18 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
         assertPlanItemInstanceState(planItemInstances, "Task C", ENABLED);
 
         // start Task C which will prevent the case from being completed directly, if Stage A completes
-        cmmnRuntimeService.startPlanItemInstance(planItemInstances.get(3).getId());
+        cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task C"));
 
         // now also complete Task A -> Stage A should now get auto-completed
-        cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(1).getId());
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task A"));
 
-        planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .orderByName().asc()
-            .list();
+        planItemInstances = getPlanItemInstances(caseInstance.getId());
 
         assertEquals(1, planItemInstances.size());
         assertPlanItemInstanceState(planItemInstances, "Task C", ACTIVE);
 
         // complete Task C -> will complete the case
-        cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(0).getId());
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task C"));
 
         assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().count());
         assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
@@ -256,10 +218,7 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
             .caseDefinitionKey("autoCompleteTest")
             .start();
 
-        List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .orderByName().asc()
-            .list();
+        List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
         assertEquals(4, planItemInstances.size());
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
@@ -268,13 +227,10 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
         assertPlanItemInstanceState(planItemInstances, "Task C", ENABLED);
 
         // start and complete Task B which would complete Stage A, but we don't have auto-completion on yet
-        cmmnRuntimeService.startPlanItemInstance(planItemInstances.get(2).getId());
-        cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(2).getId());
+        cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task B"));
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task B"));
 
-        planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .orderByName().asc()
-            .list();
+        planItemInstances = getPlanItemInstances(caseInstance.getId());
 
         assertEquals(4, planItemInstances.size());
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
@@ -285,17 +241,14 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
         // setting the stage now dynamically on auto-complete should directly complete Stage A
         cmmnRuntimeService.setVariable(caseInstance.getId(), "enableStageAutoComplete", true);
 
-        planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .orderByName().asc()
-            .list();
+        planItemInstances = getPlanItemInstances(caseInstance.getId());
 
         assertEquals(1, planItemInstances.size());
         assertPlanItemInstanceState(planItemInstances, "Task C", ENABLED);
 
         // start and complete Task C -> will complete the case
-        cmmnRuntimeService.startPlanItemInstance(planItemInstances.get(0).getId());
-        cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(0).getId());
+        cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task C"));
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task C"));
 
         assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().count());
         assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
@@ -309,10 +262,7 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
             .caseDefinitionKey("autoCompleteTest")
             .start();
 
-        List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .orderByName().asc()
-            .list();
+        List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
         assertEquals(4, planItemInstances.size());
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
@@ -321,15 +271,12 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
         assertPlanItemInstanceState(planItemInstances, "Task C", ENABLED);
 
         // start Task A, nothing yet happens
-        cmmnRuntimeService.startPlanItemInstance(planItemInstances.get(1).getId());
+        cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task A"));
 
         // start Task B which will still not yet auto-complete Stage A
-        cmmnRuntimeService.startPlanItemInstance(planItemInstances.get(2).getId());
+        cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task B"));
 
-        planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .orderByName().asc()
-            .list();
+        planItemInstances = getPlanItemInstances(caseInstance.getId());
 
         assertEquals(4, planItemInstances.size());
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
@@ -338,12 +285,9 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
         assertPlanItemInstanceState(planItemInstances, "Task C", ENABLED);
 
         // now also complete Task B -> still no auto-complete, as Task A is still active, even if not required
-        cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(2).getId());
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task B"));
 
-        planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .orderByName().asc()
-            .list();
+        planItemInstances = getPlanItemInstances(caseInstance.getId());
 
         assertEquals(4, planItemInstances.size());
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
@@ -352,19 +296,16 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
         assertPlanItemInstanceState(planItemInstances, "Task C", ENABLED);
 
         // now also complete Task A -> Stage A will get completed, even without auto-completion as we set Task B to be ignored in Enabled state after first completion
-        cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(1).getId());
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task A"));
 
-        planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .orderByName().asc()
-            .list();
+        planItemInstances = getPlanItemInstances(caseInstance.getId());
 
         assertEquals(1, planItemInstances.size());
         assertPlanItemInstanceState(planItemInstances, "Task C", ENABLED);
 
         // start and complete Task C -> will complete the case
-        cmmnRuntimeService.startPlanItemInstance(planItemInstances.get(0).getId());
-        cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(0).getId());
+        cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task C"));
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task C"));
 
         assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().count());
         assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
@@ -379,10 +320,7 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
             .variable("enableStageAutoComplete", true)
             .start();
 
-        List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .orderByName().asc()
-            .list();
+        List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
         assertEquals(4, planItemInstances.size());
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
@@ -391,13 +329,10 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
         assertPlanItemInstanceState(planItemInstances, "Task C", ENABLED);
 
         // start and complete Task B which will auto-complete Stage A, but not yet the case as we haven't set the auto-complete flag there yet
-        cmmnRuntimeService.startPlanItemInstance(planItemInstances.get(2).getId());
-        cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(2).getId());
+        cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task B"));
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task B"));
 
-        planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .orderByName().asc()
-            .list();
+        planItemInstances = getPlanItemInstances(caseInstance.getId());
 
         assertEquals(1, planItemInstances.size());
         assertPlanItemInstanceState(planItemInstances, "Task C", ENABLED);
@@ -418,10 +353,7 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
             .variable("enableStageAutoComplete", true)
             .start();
 
-        List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .orderByName().asc()
-            .list();
+        List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
         assertEquals(4, planItemInstances.size());
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
@@ -430,15 +362,12 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
         assertPlanItemInstanceState(planItemInstances, "Task C", ENABLED);
 
         // start Task A, nothing yet happens
-        cmmnRuntimeService.startPlanItemInstance(planItemInstances.get(1).getId());
+        cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task A"));
 
         // start Task B which will still not yet auto-complete Stage A
-        cmmnRuntimeService.startPlanItemInstance(planItemInstances.get(2).getId());
+        cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task B"));
 
-        planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .orderByName().asc()
-            .list();
+        planItemInstances = getPlanItemInstances(caseInstance.getId());
 
         assertEquals(4, planItemInstances.size());
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
@@ -447,12 +376,9 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
         assertPlanItemInstanceState(planItemInstances, "Task C", ENABLED);
 
         // now also complete Task B -> still no auto-complete, as Task A is still active, even if not required
-        cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(2).getId());
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task B"));
 
-        planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .orderByName().asc()
-            .list();
+        planItemInstances = getPlanItemInstances(caseInstance.getId());
 
         assertEquals(4, planItemInstances.size());
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
@@ -461,15 +387,12 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
         assertPlanItemInstanceState(planItemInstances, "Task C", ENABLED);
 
         // start Task C which will prevent the case from being completed directly, if Stage A completes
-        cmmnRuntimeService.startPlanItemInstance(planItemInstances.get(3).getId());
+        cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task C"));
 
         // now also complete Task A -> Stage A should now get auto-completed
-        cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(1).getId());
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task A"));
 
-        planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .orderByName().asc()
-            .list();
+        planItemInstances = getPlanItemInstances(caseInstance.getId());
 
         assertEquals(1, planItemInstances.size());
         assertPlanItemInstanceState(planItemInstances, "Task C", ACTIVE);
@@ -478,7 +401,7 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.setVariable(caseInstance.getId(), "enablePlanModelAutoComplete", true);
 
         // complete Task C -> will complete the case
-        cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(0).getId());
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task C"));
 
         assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().count());
         assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CaseCompletableReEvaluationTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CaseCompletableReEvaluationTest.java
@@ -38,29 +38,23 @@ public class CaseCompletableReEvaluationTest extends FlowableCmmnTestCase {
     public void testCaseReEvaluationOfCompletableFlag() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("evaluateCaseCompletableFlagTest").start();
 
-        List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .orderByName().asc()
-            .list();
+        List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
         assertEquals(2, planItemInstances.size());
         assertPlanItemInstanceState(planItemInstances, "Complete case if completable", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ENABLED);
 
         // start task A -> the case must not be completable anymore
-        cmmnRuntimeService.startPlanItemInstance(planItemInstances.get(1).getId());
+        cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task A"));
 
-        planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .orderByName().asc()
-            .list();
+        planItemInstances = getPlanItemInstances(caseInstance.getId());
 
         assertEquals(2, planItemInstances.size());
         assertPlanItemInstanceState(planItemInstances, "Complete case if completable", UNAVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
 
         // complete task A which will complete the case
-        cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(1).getId());
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task A"));
 
         assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().count());
         assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CaseCompletionExitSentryTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CaseCompletionExitSentryTest.java
@@ -44,10 +44,7 @@ public class CaseCompletionExitSentryTest extends FlowableCmmnTestCase {
     public void testCompleteCaseThroughExitSentryWithAvailableUserListener() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("exitSentryTestCaseTwo").start();
 
-        List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .orderByName().asc()
-            .list();
+        List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
         assertEquals(4, planItemInstances.size());
         assertPlanItemInstanceState(planItemInstances, "Complete case", AVAILABLE);
@@ -56,7 +53,7 @@ public class CaseCompletionExitSentryTest extends FlowableCmmnTestCase {
         assertPlanItemInstanceState(planItemInstances, "Task A", ENABLED);
 
         // trigger the user event listener to manually complete the case (not forcing it though)
-        cmmnRuntimeService.completeUserEventListenerInstance(planItemInstances.get(1).getId());
+        cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByName(planItemInstances, "Complete case if completable"));
 
         assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().count());
         assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
@@ -72,10 +69,7 @@ public class CaseCompletionExitSentryTest extends FlowableCmmnTestCase {
     public void testCompleteCaseThroughExitSentryWithException() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("exitSentryTestCaseTwo").start();
 
-        List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .orderByName().asc()
-            .list();
+        List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
         assertEquals(4, planItemInstances.size());
         assertPlanItemInstanceState(planItemInstances, "Complete case", AVAILABLE);
@@ -84,12 +78,9 @@ public class CaseCompletionExitSentryTest extends FlowableCmmnTestCase {
         assertPlanItemInstanceState(planItemInstances, "Task A", ENABLED);
 
         // manually start Task A to have an active plan item, making the case not completable
-        cmmnRuntimeService.startPlanItemInstance(planItemInstances.get(3).getId());
+        cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task A"));
 
-        planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .orderByName().asc()
-            .list();
+        planItemInstances = getPlanItemInstances(caseInstance.getId());
 
         assertEquals(4, planItemInstances.size());
         assertPlanItemInstanceState(planItemInstances, "Complete case", AVAILABLE);
@@ -99,17 +90,17 @@ public class CaseCompletionExitSentryTest extends FlowableCmmnTestCase {
 
         try {
             // trigger the user event listener to manually complete the case, which should lead into an exception
-            cmmnRuntimeService.completeUserEventListenerInstance(planItemInstances.get(0).getId());
+            cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByName(planItemInstances, "Complete case"));
             Assert.fail("Must lead into an exception");
         } catch (FlowableIllegalArgumentException e) {
             assertTrue(e.getMessage().startsWith("Cannot exit case with 'complete' event type"));
         }
 
         // now complete Task A to make the stage completable
-        cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(3).getId());
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task A"));
 
         // trigger the user event listener again as the stage should not be completable
-        cmmnRuntimeService.completeUserEventListenerInstance(planItemInstances.get(0).getId());
+        cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByName(planItemInstances, "Complete case"));
 
         assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().count());
         assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
@@ -125,10 +116,7 @@ public class CaseCompletionExitSentryTest extends FlowableCmmnTestCase {
     public void testCompleteCaseThroughExitSentryWithForceComplete() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("exitSentryTestCaseTwo").start();
 
-        List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .orderByName().asc()
-            .list();
+        List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
         assertEquals(4, planItemInstances.size());
         assertPlanItemInstanceState(planItemInstances, "Complete case", AVAILABLE);
@@ -137,12 +125,9 @@ public class CaseCompletionExitSentryTest extends FlowableCmmnTestCase {
         assertPlanItemInstanceState(planItemInstances, "Task A", ENABLED);
 
         // manually start Task A to have an active plan item, making the case not completable
-        cmmnRuntimeService.startPlanItemInstance(planItemInstances.get(3).getId());
+        cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task A"));
 
-        planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .orderByName().asc()
-            .list();
+        planItemInstances = getPlanItemInstances(caseInstance.getId());
 
         assertEquals(4, planItemInstances.size());
         assertPlanItemInstanceState(planItemInstances, "Complete case", AVAILABLE);
@@ -151,7 +136,7 @@ public class CaseCompletionExitSentryTest extends FlowableCmmnTestCase {
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
 
         // trigger the user event listener to manually complete the case with a force to complete
-        cmmnRuntimeService.completeUserEventListenerInstance(planItemInstances.get(2).getId());
+        cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByName(planItemInstances, "Force complete case"));
 
         assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().count());
         assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());


### PR DESCRIPTION
#### Check List:
* Unit tests: YES
* Documentation: NA
