### PR TITLE
Extend the repetition rule with additional attributes

### DIFF
--- a/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/CmmnXmlConstants.java
+++ b/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/CmmnXmlConstants.java
@@ -172,6 +172,10 @@ public interface CmmnXmlConstants {
     String ATTRIBUTE_CATEGORY = "category";
 
     String ATTRIBUTE_REPETITION_COUNTER_VARIABLE_NAME = "counterVariable";
+    String ATTRIBUTE_REPETITION_MAX_INSTANCE_COUNT_NAME = "maxInstanceCount";
+    String ATTRIBUTE_REPETITION_COLLECTION_VARIABLE_NAME = "collectionVariable";
+    String ATTRIBUTE_REPETITION_ELEMENT_VARIABLE_NAME = "elementVariable";
+    String ATTRIBUTE_REPETITION_ELEMENT_INDEX_VARIABLE_NAME = "elementIndexVariable";
 
     String ATTRIBUTE_TASK_SCRIPT_AUTO_STORE_VARIABLE = "autoStoreVariables";
 

--- a/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/RepetitionRuleXmlConverter.java
+++ b/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/RepetitionRuleXmlConverter.java
@@ -20,6 +20,7 @@ import org.flowable.cmmn.model.RepetitionRule;
 
 /**
  * @author Joram Barrez
+ * @author Micha Kiener
  */
 public class RepetitionRuleXmlConverter extends CaseElementXmlConverter {
     
@@ -39,8 +40,21 @@ public class RepetitionRuleXmlConverter extends CaseElementXmlConverter {
             
             RepetitionRule repetitionRule = new RepetitionRule();
             repetitionRule.setName(xtr.getAttributeValue(null, CmmnXmlConstants.ATTRIBUTE_NAME));
+
             repetitionRule.setRepetitionCounterVariableName(xtr.getAttributeValue(CmmnXmlConstants.FLOWABLE_EXTENSIONS_NAMESPACE, 
                     CmmnXmlConstants.ATTRIBUTE_REPETITION_COUNTER_VARIABLE_NAME));
+
+            repetitionRule.setMaxInstanceCount(xtr.getAttributeValue(CmmnXmlConstants.FLOWABLE_EXTENSIONS_NAMESPACE,
+                CmmnXmlConstants.ATTRIBUTE_REPETITION_MAX_INSTANCE_COUNT_NAME));
+
+            repetitionRule.setCollectionVariableName(xtr.getAttributeValue(CmmnXmlConstants.FLOWABLE_EXTENSIONS_NAMESPACE,
+                CmmnXmlConstants.ATTRIBUTE_REPETITION_COLLECTION_VARIABLE_NAME));
+
+            repetitionRule.setElementVariableName(xtr.getAttributeValue(CmmnXmlConstants.FLOWABLE_EXTENSIONS_NAMESPACE,
+                CmmnXmlConstants.ATTRIBUTE_REPETITION_ELEMENT_VARIABLE_NAME));
+
+            repetitionRule.setElementIndexVariableName(xtr.getAttributeValue(CmmnXmlConstants.FLOWABLE_EXTENSIONS_NAMESPACE,
+                CmmnXmlConstants.ATTRIBUTE_REPETITION_ELEMENT_INDEX_VARIABLE_NAME));
             
             PlanItemControl planItemControl = (PlanItemControl) conversionHelper.getCurrentCmmnElement();
             planItemControl.setRepetitionRule(repetitionRule);

--- a/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/export/PlanItemControlExport.java
+++ b/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/export/PlanItemControlExport.java
@@ -27,6 +27,7 @@ import org.flowable.cmmn.model.RequiredRule;
 /**
  * @author Tijs Rademakers
  * @author Joram Barrez
+ * @author Micha Kiener
  */
 public class PlanItemControlExport implements CmmnXmlConstants {
 
@@ -72,6 +73,22 @@ public class PlanItemControlExport implements CmmnXmlConstants {
             if (StringUtils.isNotEmpty(repetitionRule.getRepetitionCounterVariableName())) {
                 xtw.writeAttribute(FLOWABLE_EXTENSIONS_PREFIX, FLOWABLE_EXTENSIONS_NAMESPACE,
                         ATTRIBUTE_REPETITION_COUNTER_VARIABLE_NAME, repetitionRule.getRepetitionCounterVariableName());
+            }
+            if (StringUtils.isNotEmpty(repetitionRule.getMaxInstanceCount())) {
+                xtw.writeAttribute(FLOWABLE_EXTENSIONS_PREFIX, FLOWABLE_EXTENSIONS_NAMESPACE,
+                    ATTRIBUTE_REPETITION_MAX_INSTANCE_COUNT_NAME, repetitionRule.getMaxInstanceCount());
+            }
+            if (StringUtils.isNotEmpty(repetitionRule.getCollectionVariableName())) {
+                xtw.writeAttribute(FLOWABLE_EXTENSIONS_PREFIX, FLOWABLE_EXTENSIONS_NAMESPACE,
+                    ATTRIBUTE_REPETITION_COLLECTION_VARIABLE_NAME, repetitionRule.getCollectionVariableName());
+            }
+            if (StringUtils.isNotEmpty(repetitionRule.getElementVariableName())) {
+                xtw.writeAttribute(FLOWABLE_EXTENSIONS_PREFIX, FLOWABLE_EXTENSIONS_NAMESPACE,
+                    ATTRIBUTE_REPETITION_ELEMENT_VARIABLE_NAME, repetitionRule.getElementVariableName());
+            }
+            if (StringUtils.isNotEmpty(repetitionRule.getElementIndexVariableName())) {
+                xtw.writeAttribute(FLOWABLE_EXTENSIONS_PREFIX, FLOWABLE_EXTENSIONS_NAMESPACE,
+                    ATTRIBUTE_REPETITION_ELEMENT_INDEX_VARIABLE_NAME, repetitionRule.getElementIndexVariableName());
             }
             if (StringUtils.isNotEmpty(repetitionRule.getCondition())) {
                 xtw.writeStartElement(ELEMENT_CONDITION);

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/RepetitionRuleExtendedAttributesConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/RepetitionRuleExtendedAttributesConverterTest.java
@@ -12,7 +12,6 @@
  */
 package org.flowable.test.cmmn.converter;
 
-import static org.flowable.cmmn.model.RepetitionRule.DEFAULT_REPETITION_MAX_INSTANCE_COUNT_VALUE;
 import static org.flowable.cmmn.model.RepetitionRule.MAX_INSTANCE_COUNT_ONE;
 import static org.flowable.cmmn.model.RepetitionRule.MAX_INSTANCE_COUNT_UNLIMITED;
 import static org.junit.Assert.assertEquals;
@@ -59,7 +58,7 @@ public class RepetitionRuleExtendedAttributesConverterTest extends AbstractConve
         Map<String, CaseElement> caseElements = cmmnModel.getCases().get(0).getAllCaseElements();
 
         assertRepetitionRuleAttributes(caseElements, "Task A", null,
-            null, null, DEFAULT_REPETITION_MAX_INSTANCE_COUNT_VALUE);
+            null, null, null);
 
         assertRepetitionRuleAttributes(caseElements, "Task B", null,
             null, null, MAX_INSTANCE_COUNT_ONE);
@@ -68,10 +67,10 @@ public class RepetitionRuleExtendedAttributesConverterTest extends AbstractConve
             null, null, MAX_INSTANCE_COUNT_UNLIMITED);
 
         assertRepetitionRuleAttributes(caseElements, "Task D", null,
-            null, null, DEFAULT_REPETITION_MAX_INSTANCE_COUNT_VALUE);
+            null, null, null);
 
         assertRepetitionRuleAttributes(caseElements, "Task E", "entriesForTaskE",
-            "item", "itemIndex", DEFAULT_REPETITION_MAX_INSTANCE_COUNT_VALUE);
+            "item", "itemIndex", null);
     }
 
     protected void assertRepetitionRuleAttributes(Map<String, CaseElement> caseElements, String planItemName,

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/RepetitionRuleExtendedAttributesConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/RepetitionRuleExtendedAttributesConverterTest.java
@@ -12,8 +12,6 @@
  */
 package org.flowable.test.cmmn.converter;
 
-import static org.flowable.cmmn.model.RepetitionRule.DEFAULT_REPETITION_ELEMENT_INDEX_VARIABLE_NAME;
-import static org.flowable.cmmn.model.RepetitionRule.DEFAULT_REPETITION_ELEMENT_VARIABLE_NAME;
 import static org.flowable.cmmn.model.RepetitionRule.DEFAULT_REPETITION_MAX_INSTANCE_COUNT_VALUE;
 import static org.flowable.cmmn.model.RepetitionRule.MAX_INSTANCE_COUNT_ONE;
 import static org.flowable.cmmn.model.RepetitionRule.MAX_INSTANCE_COUNT_UNLIMITED;
@@ -61,16 +59,16 @@ public class RepetitionRuleExtendedAttributesConverterTest extends AbstractConve
         Map<String, CaseElement> caseElements = cmmnModel.getCases().get(0).getAllCaseElements();
 
         assertRepetitionRuleAttributes(caseElements, "Task A", null,
-            DEFAULT_REPETITION_ELEMENT_VARIABLE_NAME, DEFAULT_REPETITION_ELEMENT_INDEX_VARIABLE_NAME, DEFAULT_REPETITION_MAX_INSTANCE_COUNT_VALUE);
+            null, null, DEFAULT_REPETITION_MAX_INSTANCE_COUNT_VALUE);
 
         assertRepetitionRuleAttributes(caseElements, "Task B", null,
-            DEFAULT_REPETITION_ELEMENT_VARIABLE_NAME, DEFAULT_REPETITION_ELEMENT_INDEX_VARIABLE_NAME, MAX_INSTANCE_COUNT_ONE);
+            null, null, MAX_INSTANCE_COUNT_ONE);
 
         assertRepetitionRuleAttributes(caseElements, "Task C", null,
-            DEFAULT_REPETITION_ELEMENT_VARIABLE_NAME, DEFAULT_REPETITION_ELEMENT_INDEX_VARIABLE_NAME, MAX_INSTANCE_COUNT_UNLIMITED);
+            null, null, MAX_INSTANCE_COUNT_UNLIMITED);
 
         assertRepetitionRuleAttributes(caseElements, "Task D", null,
-            DEFAULT_REPETITION_ELEMENT_VARIABLE_NAME, DEFAULT_REPETITION_ELEMENT_INDEX_VARIABLE_NAME, DEFAULT_REPETITION_MAX_INSTANCE_COUNT_VALUE);
+            null, null, DEFAULT_REPETITION_MAX_INSTANCE_COUNT_VALUE);
 
         assertRepetitionRuleAttributes(caseElements, "Task E", "entriesForTaskE",
             "item", "itemIndex", DEFAULT_REPETITION_MAX_INSTANCE_COUNT_VALUE);

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/RepetitionRuleExtendedAttributesConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/RepetitionRuleExtendedAttributesConverterTest.java
@@ -1,0 +1,101 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.test.cmmn.converter;
+
+import static org.flowable.cmmn.model.RepetitionRule.DEFAULT_REPETITION_ELEMENT_INDEX_VARIABLE_NAME;
+import static org.flowable.cmmn.model.RepetitionRule.DEFAULT_REPETITION_ELEMENT_VARIABLE_NAME;
+import static org.flowable.cmmn.model.RepetitionRule.DEFAULT_REPETITION_MAX_INSTANCE_COUNT_VALUE;
+import static org.flowable.cmmn.model.RepetitionRule.MAX_INSTANCE_COUNT_ONE;
+import static org.flowable.cmmn.model.RepetitionRule.MAX_INSTANCE_COUNT_UNLIMITED;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.flowable.cmmn.model.CaseElement;
+import org.flowable.cmmn.model.CmmnModel;
+import org.flowable.cmmn.model.PlanItem;
+import org.flowable.cmmn.model.RepetitionRule;
+import org.junit.Test;
+
+/**
+ * Testing to read and write the extended repetition rule attributes.
+ *
+ * @author Micha Kiener
+ */
+public class RepetitionRuleExtendedAttributesConverterTest extends AbstractConverterTest {
+
+    private static final String CMMN_RESOURCE = "org/flowable/test/cmmn/converter/repetitionRuleExtension.cmmn";
+
+    @Test
+    public void convertXMLToModel() throws Exception {
+        CmmnModel cmmnModel = readXMLFile(CMMN_RESOURCE);
+        validateModel(cmmnModel);
+    }
+
+    @Test
+    public void convertModelToXML() throws Exception {
+        CmmnModel cmmnModel = readXMLFile(CMMN_RESOURCE);
+        CmmnModel parsedModel = exportAndReadXMLFile(cmmnModel);
+        validateModel(parsedModel);
+    }
+
+    public void validateModel(CmmnModel cmmnModel) {
+        assertNotNull(cmmnModel);
+        assertNotNull(cmmnModel.getCases());
+        assertEquals(1, cmmnModel.getCases().size());
+
+        Map<String, CaseElement> caseElements = cmmnModel.getCases().get(0).getAllCaseElements();
+
+        assertRepetitionRuleAttributes(caseElements, "Task A", null,
+            DEFAULT_REPETITION_ELEMENT_VARIABLE_NAME, DEFAULT_REPETITION_ELEMENT_INDEX_VARIABLE_NAME, DEFAULT_REPETITION_MAX_INSTANCE_COUNT_VALUE);
+
+        assertRepetitionRuleAttributes(caseElements, "Task B", null,
+            DEFAULT_REPETITION_ELEMENT_VARIABLE_NAME, DEFAULT_REPETITION_ELEMENT_INDEX_VARIABLE_NAME, MAX_INSTANCE_COUNT_ONE);
+
+        assertRepetitionRuleAttributes(caseElements, "Task C", null,
+            DEFAULT_REPETITION_ELEMENT_VARIABLE_NAME, DEFAULT_REPETITION_ELEMENT_INDEX_VARIABLE_NAME, MAX_INSTANCE_COUNT_UNLIMITED);
+
+        assertRepetitionRuleAttributes(caseElements, "Task D", null,
+            DEFAULT_REPETITION_ELEMENT_VARIABLE_NAME, DEFAULT_REPETITION_ELEMENT_INDEX_VARIABLE_NAME, DEFAULT_REPETITION_MAX_INSTANCE_COUNT_VALUE);
+
+        assertRepetitionRuleAttributes(caseElements, "Task E", "entriesForTaskE",
+            "item", "itemIndex", DEFAULT_REPETITION_MAX_INSTANCE_COUNT_VALUE);
+    }
+
+    protected void assertRepetitionRuleAttributes(Map<String, CaseElement> caseElements, String planItemName,
+        String collectionVariableName, String elementVariableName, String elementIndexVariableName, String maxInstanceCount) {
+        List<CaseElement> planItems = caseElements.values().stream()
+            .filter(caseElement -> caseElement instanceof PlanItem && planItemName.equals(caseElement.getName()))
+            .collect(Collectors.toList());
+
+        if (planItems.size() == 0) {
+            fail("No plan item found with name " + planItemName);
+        }
+
+        if (planItems.size() > 1) {
+            fail("More than one plan item found with name " + planItemName + ", make sure it is unique for testing purposes");
+        }
+
+        RepetitionRule repetitionRule = ((PlanItem) planItems.get(0)).getItemControl().getRepetitionRule();
+        assertNotNull("no repetition rule found for plan item with name '" + planItemName + "'", repetitionRule);
+
+        assertEquals(collectionVariableName, repetitionRule.getCollectionVariableName());
+        assertEquals(elementVariableName, repetitionRule.getElementVariableName());
+        assertEquals(elementIndexVariableName, repetitionRule.getElementIndexVariableName());
+        assertEquals(maxInstanceCount, repetitionRule.getMaxInstanceCount());
+    }
+}

--- a/modules/flowable-cmmn-converter/src/test/resources/org/flowable/test/cmmn/converter/repetitionRuleExtension.cmmn
+++ b/modules/flowable-cmmn-converter/src/test/resources/org/flowable/test/cmmn/converter/repetitionRuleExtension.cmmn
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:flowable="http://flowable.org/cmmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:design="http://flowable.org/design" targetNamespace="http://flowable.org/cmmn">
+    <case id="repetitionRuleExtensionModelTest" name="Repetition Rule Extension Model Test" flowable:initiatorVariableName="initiator" flowable:candidateStarterGroups="flowableUser">
+        <casePlanModel id="onecaseplanmodel1" name="Case plan model" flowable:formFieldValidation="false">
+            <extensionElements>
+                <flowable:work-form-field-validation><![CDATA[false]]></flowable:work-form-field-validation>
+                <design:stencilid><![CDATA[CasePlanModel]]></design:stencilid>
+            </extensionElements>
+            <planItem id="planItem1" name="Task A" definitionRef="humanTask1">
+                <itemControl>
+                    <repetitionRule flowable:counterVariable="repetitionCounter"></repetitionRule>
+                </itemControl>
+            </planItem>
+            <planItem id="planItem2" name="Task B" definitionRef="humanTask2">
+                <itemControl>
+                    <repetitionRule flowable:counterVariable="repetitionCounter" flowable:maxInstanceCount="one"></repetitionRule>
+                </itemControl>
+            </planItem>
+            <planItem id="planItem3" name="Task C" definitionRef="humanTask3">
+                <itemControl>
+                    <repetitionRule flowable:counterVariable="repetitionCounter" flowable:maxInstanceCount="unlimited"></repetitionRule>
+                </itemControl>
+            </planItem>
+            <planItem id="planItem4" name="Task D" definitionRef="humanTask4">
+                <itemControl>
+                    <repetitionRule flowable:counterVariable="repetitionCounter"></repetitionRule>
+                </itemControl>
+            </planItem>
+            <planItem id="planItem5" name="Task E" definitionRef="humanTask5">
+                <itemControl>
+                    <repetitionRule flowable:counterVariable="repetitionCounter"
+                                    flowable:collectionVariable="entriesForTaskE" flowable:elementVariable="item" flowable:elementIndexVariable="itemIndex"></repetitionRule>
+                </itemControl>
+            </planItem>
+            <humanTask id="humanTask1" name="Task A" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
+                <extensionElements>
+                    <flowable:start-form-field-validation><![CDATA[false]]></flowable:start-form-field-validation>
+                    <design:stencilid><![CDATA[HumanTask]]></design:stencilid>
+                    <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+                </extensionElements>
+            </humanTask>
+            <humanTask id="humanTask2" name="Task B" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
+                <extensionElements>
+                    <flowable:start-form-field-validation><![CDATA[false]]></flowable:start-form-field-validation>
+                    <design:stencilid><![CDATA[HumanTask]]></design:stencilid>
+                    <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+                </extensionElements>
+            </humanTask>
+            <humanTask id="humanTask3" name="Task C" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
+                <extensionElements>
+                    <flowable:start-form-field-validation><![CDATA[false]]></flowable:start-form-field-validation>
+                    <design:stencilid><![CDATA[HumanTask]]></design:stencilid>
+                    <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+                </extensionElements>
+            </humanTask>
+            <humanTask id="humanTask4" name="Task D" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
+                <extensionElements>
+                    <flowable:start-form-field-validation><![CDATA[false]]></flowable:start-form-field-validation>
+                    <design:stencilid><![CDATA[HumanTask]]></design:stencilid>
+                    <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+                </extensionElements>
+            </humanTask>
+            <humanTask id="humanTask5" name="Task E" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
+                <extensionElements>
+                    <flowable:start-form-field-validation><![CDATA[false]]></flowable:start-form-field-validation>
+                    <design:stencilid><![CDATA[HumanTask]]></design:stencilid>
+                    <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+                </extensionElements>
+            </humanTask>
+        </casePlanModel>
+    </case>
+    <cmmndi:CMMNDI>
+        <cmmndi:CMMNDiagram id="CMMNDiagram_repetitionRuleExtensionModelTest">
+            <cmmndi:CMMNShape id="CMMNShape_onecaseplanmodel1" cmmnElementRef="onecaseplanmodel1">
+                <dc:Bounds height="291.0" width="581.0" x="30.0" y="45.0"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_planItem1" cmmnElementRef="planItem1">
+                <dc:Bounds height="80.0" width="100.0" x="75.0" y="90.0"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_planItem2" cmmnElementRef="planItem2">
+                <dc:Bounds height="80.0" width="100.0" x="210.0" y="90.0"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_planItem3" cmmnElementRef="planItem3">
+                <dc:Bounds height="80.0" width="100.0" x="345.0" y="90.0"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_planItem4" cmmnElementRef="planItem4">
+                <dc:Bounds height="80.0" width="100.0" x="75.0" y="211.0"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_planItem5" cmmnElementRef="planItem5">
+                <dc:Bounds height="80.0" width="100.0" x="210.0" y="211.0"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+        </cmmndi:CMMNDiagram>
+    </cmmndi:CMMNDI>
+</definitions>

--- a/modules/flowable-cmmn-model/src/main/java/org/flowable/cmmn/model/RepetitionRule.java
+++ b/modules/flowable-cmmn-model/src/main/java/org/flowable/cmmn/model/RepetitionRule.java
@@ -22,7 +22,6 @@ public class RepetitionRule extends PlanItemRule {
     public static final String MAX_INSTANCE_COUNT_UNLIMITED = "unlimited";
 
     public static final String DEFAULT_REPETITION_COUNTER_VARIABLE_NAME = "repetitionCounter";
-    public static final String DEFAULT_REPETITION_MAX_INSTANCE_COUNT_VALUE = MAX_INSTANCE_COUNT_ONE;
 
     protected String repetitionCounterVariableName;
     protected String collectionVariableName;
@@ -66,9 +65,6 @@ public class RepetitionRule extends PlanItemRule {
     }
 
     public String getMaxInstanceCount() {
-        if (maxInstanceCount == null) {
-            return DEFAULT_REPETITION_MAX_INSTANCE_COUNT_VALUE;
-        }
         return maxInstanceCount;
     }
 

--- a/modules/flowable-cmmn-model/src/main/java/org/flowable/cmmn/model/RepetitionRule.java
+++ b/modules/flowable-cmmn-model/src/main/java/org/flowable/cmmn/model/RepetitionRule.java
@@ -22,8 +22,6 @@ public class RepetitionRule extends PlanItemRule {
     public static final String MAX_INSTANCE_COUNT_UNLIMITED = "unlimited";
 
     public static final String DEFAULT_REPETITION_COUNTER_VARIABLE_NAME = "repetitionCounter";
-    public static final String DEFAULT_REPETITION_ELEMENT_VARIABLE_NAME = "item";
-    public static final String DEFAULT_REPETITION_ELEMENT_INDEX_VARIABLE_NAME = "itemIndex";
     public static final String DEFAULT_REPETITION_MAX_INSTANCE_COUNT_VALUE = MAX_INSTANCE_COUNT_ONE;
 
     protected String repetitionCounterVariableName;
@@ -52,9 +50,6 @@ public class RepetitionRule extends PlanItemRule {
     }
 
     public String getElementVariableName() {
-        if (elementVariableName == null) {
-            return DEFAULT_REPETITION_ELEMENT_VARIABLE_NAME;
-        }
         return elementVariableName;
     }
 
@@ -63,9 +58,6 @@ public class RepetitionRule extends PlanItemRule {
     }
 
     public String getElementIndexVariableName() {
-        if (elementIndexVariableName == null) {
-            return DEFAULT_REPETITION_ELEMENT_INDEX_VARIABLE_NAME;
-        }
         return elementIndexVariableName;
     }
 

--- a/modules/flowable-cmmn-model/src/main/java/org/flowable/cmmn/model/RepetitionRule.java
+++ b/modules/flowable-cmmn-model/src/main/java/org/flowable/cmmn/model/RepetitionRule.java
@@ -14,29 +14,84 @@ package org.flowable.cmmn.model;
 
 /**
  * @author Joram Barrez
+ * @author Micha Kiener
  */
 public class RepetitionRule extends PlanItemRule {
-    
+
+    public static final String MAX_INSTANCE_COUNT_ONE = "one";
+    public static final String MAX_INSTANCE_COUNT_UNLIMITED = "unlimited";
+
     public static final String DEFAULT_REPETITION_COUNTER_VARIABLE_NAME = "repetitionCounter";
-    
+    public static final String DEFAULT_REPETITION_ELEMENT_VARIABLE_NAME = "item";
+    public static final String DEFAULT_REPETITION_ELEMENT_INDEX_VARIABLE_NAME = "itemIndex";
+    public static final String DEFAULT_REPETITION_MAX_INSTANCE_COUNT_VALUE = MAX_INSTANCE_COUNT_ONE;
+
     protected String repetitionCounterVariableName;
+    protected String collectionVariableName;
+    protected String elementVariableName;
+    protected String elementIndexVariableName;
+    protected String maxInstanceCount;
 
     public String getRepetitionCounterVariableName() {
-        if (repetitionCounterVariableName != null) {
-            return repetitionCounterVariableName;
-        } else {
+        if (repetitionCounterVariableName == null) {
             return DEFAULT_REPETITION_COUNTER_VARIABLE_NAME;
         }
+        return repetitionCounterVariableName;
     }
 
     public void setRepetitionCounterVariableName(String repetitionCounterVariableName) {
         this.repetitionCounterVariableName = repetitionCounterVariableName;
     }
 
+    public String getCollectionVariableName() {
+        return collectionVariableName;
+    }
+
+    public void setCollectionVariableName(String collectionVariableName) {
+        this.collectionVariableName = collectionVariableName;
+    }
+
+    public String getElementVariableName() {
+        if (elementVariableName == null) {
+            return DEFAULT_REPETITION_ELEMENT_VARIABLE_NAME;
+        }
+        return elementVariableName;
+    }
+
+    public void setElementVariableName(String elementVariableName) {
+        this.elementVariableName = elementVariableName;
+    }
+
+    public String getElementIndexVariableName() {
+        if (elementIndexVariableName == null) {
+            return DEFAULT_REPETITION_ELEMENT_INDEX_VARIABLE_NAME;
+        }
+        return elementIndexVariableName;
+    }
+
+    public void setElementIndexVariableName(String elementIndexVariableName) {
+        this.elementIndexVariableName = elementIndexVariableName;
+    }
+
+    public String getMaxInstanceCount() {
+        if (maxInstanceCount == null) {
+            return DEFAULT_REPETITION_MAX_INSTANCE_COUNT_VALUE;
+        }
+        return maxInstanceCount;
+    }
+
+    public void setMaxInstanceCount(String maxInstanceCount) {
+        this.maxInstanceCount = maxInstanceCount;
+    }
+
     @Override
     public String toString() {
         return "RepetitionRule{" +
-                "repetitionCounterVariableName='" + repetitionCounterVariableName + '\'' +
-                "} " + super.toString();
+                " maxInstanceCount='" + maxInstanceCount + "'" +
+                " repetitionCounterVariableName='" + repetitionCounterVariableName + "'" +
+                " collectionVariableName='" + collectionVariableName + "'" +
+                " elementVariableName='" + elementVariableName + "'" +
+                " elementIndexVariableName='" + elementIndexVariableName + "'" +
+                " } " + super.toString();
     }
 }


### PR DESCRIPTION
With the extended attributes, the repetition rule can be controlled in a more fine-grained way, for instance avoiding to create endless instances, if an entry-criterion with an if-part is satisfied.

#### Check List:
* Unit tests: YES
* Documentation: NA
