### PR TITLE
fix scope type of job handling CMMN history cleanup

### DIFF
--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/HandleHistoryCleanupTimerJobCmd.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/HandleHistoryCleanupTimerJobCmd.java
@@ -20,6 +20,7 @@ import org.flowable.cmmn.api.CmmnManagementService;
 import org.flowable.cmmn.engine.CmmnEngineConfiguration;
 import org.flowable.cmmn.engine.impl.job.CmmnHistoryCleanupJobHandler;
 import org.flowable.cmmn.engine.impl.util.CommandContextUtil;
+import org.flowable.common.engine.api.scope.ScopeTypes;
 import org.flowable.common.engine.impl.calendar.BusinessCalendar;
 import org.flowable.common.engine.impl.calendar.CycleBusinessCalendar;
 import org.flowable.common.engine.impl.interceptor.Command;
@@ -48,7 +49,8 @@ public class HandleHistoryCleanupTimerJobCmd implements Command<Object>, Seriali
             timerJob.setJobType(JobEntity.JOB_TYPE_TIMER);
             timerJob.setRevision(1);
             timerJob.setJobHandlerType(CmmnHistoryCleanupJobHandler.TYPE);
-            
+            timerJob.setScopeType(ScopeTypes.CMMN);
+
             BusinessCalendar businessCalendar = cmmnEngineConfiguration.getBusinessCalendarManager().getBusinessCalendar(CycleBusinessCalendar.NAME);
             timerJob.setDuedate(businessCalendar.resolveDuedate(cmmnEngineConfiguration.getHistoryCleaningTimeCycleConfig()));
             timerJob.setRepeat(cmmnEngineConfiguration.getHistoryCleaningTimeCycleConfig());


### PR DESCRIPTION
While manually testing the CMMN history cleanup feature, I stumbled upon the following exception, and noticed that no cleanup had happened for the cases (no problem at all with a similar manual test of the BPMN history cleanup feature): `org.flowable.common.engine.api.FlowableException: No job handler registered for type cmmn-history-cleanup in job config for engine: bpmn`
After investigation, I found out that the cleanup timer job was missing the CMMN scope type. Problem appears to be solved when this scope type is properly set.

#### Check List:
* Unit tests: NO (but would gladly do so when we identify how to reproduce the issue in an automated test)
* Documentation: NA
