### PR TITLE
make plan item completion utility function independent of the returned order

### DIFF
--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/test/AbstractFlowableCmmnTestCase.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/test/AbstractFlowableCmmnTestCase.java
@@ -13,6 +13,7 @@
 package org.flowable.cmmn.engine.test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -193,7 +194,37 @@ public abstract class AbstractFlowableCmmnTestCase {
         }
     }
 
-    protected void completePlanItems(String caseInstanceId, String planItemName, int expectedCount, int numberToComplete) {
+    protected void completePlanItemsWithItemValues(String caseInstanceId, String planItemName, int expectedTotalCount, Object... itemValues) {
+        List<PlanItemInstance> tasks = cmmnRuntimeService.createPlanItemInstanceQuery()
+            .caseInstanceId(caseInstanceId)
+            .planItemInstanceName(planItemName)
+            .planItemInstanceStateActive()
+            .orderByCreateTime().asc()
+            .list();
+
+        assertEquals(expectedTotalCount, tasks.size());
+        assertNotNull(itemValues);
+        assertTrue(itemValues.length <= expectedTotalCount);
+
+        for (Object itemValue : itemValues) {
+            if (!completePlanItemWithItemValue(tasks, itemValue)) {
+                fail("Could not find plan item instance with 'item' value of '" + itemValue + "'");
+            }
+        }
+    }
+
+    protected boolean completePlanItemWithItemValue(List<PlanItemInstance> planItemInstances, Object itemValue) {
+        for (PlanItemInstance planItemInstance : planItemInstances) {
+            Object itemValueVar = cmmnRuntimeService.getLocalVariable(planItemInstance.getId(), "item");
+            if (itemValue.equals(itemValueVar)) {
+                cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
+                return true;
+            }
+        }
+        return false;
+    }
+
+    protected void completeAllPlanItems(String caseInstanceId, String planItemName, int expectedCount) {
         List<PlanItemInstance> tasks = cmmnRuntimeService.createPlanItemInstanceQuery()
             .caseInstanceId(caseInstanceId)
             .planItemInstanceName(planItemName)
@@ -202,10 +233,8 @@ public abstract class AbstractFlowableCmmnTestCase {
             .list();
 
         assertEquals(expectedCount, tasks.size());
-        assertTrue(numberToComplete <= expectedCount);
-        int completedCount = 0;
-        while (completedCount < numberToComplete) {
-            cmmnRuntimeService.triggerPlanItemInstance(tasks.get(completedCount++).getId());
+        for (PlanItemInstance task : tasks) {
+            cmmnRuntimeService.triggerPlanItemInstance(task.getId());
         }
     }
 

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/PlanItemRepetitionWithCollectionVariableAndConditionTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/PlanItemRepetitionWithCollectionVariableAndConditionTest.java
@@ -175,7 +175,7 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionTest extends Fl
         assertPlanItemLocalVariables(caseInstance.getId(), "Task B", taskOutputList, Arrays.asList(0, 1, 2, 3));
 
         // complete all active tasks
-        completePlanItems(caseInstance.getId(), "Task B", 4, 4);
+        completeAllPlanItems(caseInstance.getId(), "Task B", 4);
         planItemInstances = getPlanItemInstances(caseInstance.getId());
         assertEquals(3, planItemInstances.size());
 
@@ -195,7 +195,7 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionTest extends Fl
         assertPlanItemLocalVariables(caseInstance.getId(), "Task B", taskOutputList, Arrays.asList(0, 1));
 
         // now let's complete all Tasks B -> nothing must happen additionally
-        completePlanItems(caseInstance.getId(), "Task B", 2, 2);
+        completeAllPlanItems(caseInstance.getId(), "Task B", 2);
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
         assertEquals(3, planItemInstances.size());
@@ -235,7 +235,7 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionTest extends Fl
         assertPlanItemLocalVariables(caseInstance.getId(), "Task B", taskOutputList, Arrays.asList(0, 1, 2, 3));
 
         // only complete two active Task B
-        completePlanItems(caseInstance.getId(), "Task B", 4, 2);
+        completePlanItemsWithItemValues(caseInstance.getId(), "Task B", 4, "A", "B");
         planItemInstances = getPlanItemInstances(caseInstance.getId());
         assertEquals(5, planItemInstances.size());
 
@@ -255,7 +255,7 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionTest extends Fl
         assertPlanItemLocalVariables(caseInstance.getId(), "Task B", Arrays.asList("C", "D", "E", "F"), Arrays.asList(2, 3, 0, 1));
 
         // now let's complete all Tasks B -> nothing must happen additionally
-        completePlanItems(caseInstance.getId(), "Task B", 4, 4);
+        completeAllPlanItems(caseInstance.getId(), "Task B", 4);
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
         assertEquals(3, planItemInstances.size());

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/PlanItemRepetitionWithCollectionVariableTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/PlanItemRepetitionWithCollectionVariableTest.java
@@ -107,7 +107,7 @@ public class PlanItemRepetitionWithCollectionVariableTest extends FlowableCmmnTe
         assertPlanItemLocalVariables(caseInstance.getId(), "Task B", taskOutputList, Arrays.asList(0, 1, 2, 3));
 
         // complete all active tasks
-        completePlanItems(caseInstance.getId(), "Task B", 4, 4);
+        completeAllPlanItems(caseInstance.getId(), "Task B", 4);
         planItemInstances = getPlanItemInstances(caseInstance.getId());
         assertEquals(3, planItemInstances.size());
 
@@ -127,7 +127,7 @@ public class PlanItemRepetitionWithCollectionVariableTest extends FlowableCmmnTe
         assertPlanItemLocalVariables(caseInstance.getId(), "Task B", taskOutputList, Arrays.asList(0, 1));
 
         // now let's complete all Tasks B -> nothing must happen additionally
-        completePlanItems(caseInstance.getId(), "Task B", 2, 2);
+        completeAllPlanItems(caseInstance.getId(), "Task B", 2);
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
         assertEquals(3, planItemInstances.size());
@@ -164,7 +164,7 @@ public class PlanItemRepetitionWithCollectionVariableTest extends FlowableCmmnTe
         assertPlanItemLocalVariables(caseInstance.getId(), "Task B", taskOutputList, Arrays.asList(0, 1, 2, 3));
 
         // only complete two active Task B
-        completePlanItems(caseInstance.getId(), "Task B", 4, 2);
+        completePlanItemsWithItemValues(caseInstance.getId(), "Task B", 4, "A", "B");
         planItemInstances = getPlanItemInstances(caseInstance.getId());
         assertEquals(5, planItemInstances.size());
 
@@ -184,7 +184,7 @@ public class PlanItemRepetitionWithCollectionVariableTest extends FlowableCmmnTe
         assertPlanItemLocalVariables(caseInstance.getId(), "Task B", Arrays.asList("C", "D", "E", "F"), Arrays.asList(2, 3, 0, 1));
 
         // now let's complete all Tasks B -> nothing must happen additionally
-        completePlanItems(caseInstance.getId(), "Task B", 4, 4);
+        completeAllPlanItems(caseInstance.getId(), "Task B", 4);
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
         assertEquals(3, planItemInstances.size());


### PR DESCRIPTION
making tests predictable, independent of the result order, if the DB is super fast.

#### Check List:
* Unit tests: YES
* Documentation: NA
