### PR TITLE
Turn complex create method into builder API for plan item instance creation

### DIFF
--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/AbstractMovePlanItemInstanceToTerminalStateOperation.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/AbstractMovePlanItemInstanceToTerminalStateOperation.java
@@ -50,7 +50,7 @@ public abstract class AbstractMovePlanItemInstanceToTerminalStateOperation exten
         if (isRepeatingOnDelete(originalState, plannedNewState) && !isWaitingForRepetitionPlanItemInstanceExists(planItemInstanceEntity)) {
 
             // Create new repeating instance
-            PlanItemInstanceEntity newPlanItemInstanceEntity = copyAndInsertPlanItemInstance(commandContext, planItemInstanceEntity, true);
+            PlanItemInstanceEntity newPlanItemInstanceEntity = copyAndInsertPlanItemInstance(commandContext, planItemInstanceEntity, true, false);
 
             if (planItemInstanceEntity.getPlanItem() != null && planItemInstanceEntity.getPlanItem().getPlanItemDefinition() instanceof EventListener) {
                 CommandContextUtil.getAgenda(commandContext).planCreatePlanItemInstanceOperation(newPlanItemInstanceEntity);

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/EvaluateCriteriaOperation.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/EvaluateCriteriaOperation.java
@@ -657,14 +657,16 @@ public class EvaluateCriteriaOperation extends AbstractCaseInstanceOperation {
                             List<PlanItemInstanceEntity> parentPlanItemInstances = existingPlanItemInstancesMap.get(parentPlanItem.getId());
 
                             if (parentPlanItemInstances == null || parentPlanItemInstances.isEmpty()) {
-                                PlanItemInstanceEntity parentPlanItemInstance = planItemInstanceEntityManager.createChildPlanItemInstance(
-                                    parentPlanItem,
-                                    caseInstanceEntity.getCaseDefinitionId(),
-                                    caseInstanceEntity.getId(),
-                                    previousParentPlanItemInstance != null ? previousParentPlanItemInstance.getId() : null,
-                                    caseInstanceEntity.getTenantId(),
-                                    null,
-                                    true);
+                                PlanItemInstanceEntity parentPlanItemInstance = planItemInstanceEntityManager
+                                    .createPlanItemInstanceBuilder()
+                                    .planItem(parentPlanItem)
+                                    .caseDefinitionId(caseInstanceEntity.getCaseDefinitionId())
+                                    .caseInstanceId(caseInstanceEntity.getId())
+                                    .stagePlanItemInstanceId(previousParentPlanItemInstance != null ? previousParentPlanItemInstance.getId() : null)
+                                    .tenantId(caseInstanceEntity.getTenantId())
+                                    .addToParent(true)
+                                    .create();
+
                                 parentPlanItemInstancesToActivate.add(parentPlanItemInstance);
 
                                 previousParentPlanItemInstance = parentPlanItemInstance;
@@ -684,15 +686,17 @@ public class EvaluateCriteriaOperation extends AbstractCaseInstanceOperation {
                         }
 
                         // Creating plan item instance for the activated plan item
-                        PlanItemInstanceEntity entryDependentPlanItemInstance = planItemInstanceEntityManager.createChildPlanItemInstance(
-                            entryDependentPlanItem,
-                            caseInstanceEntity.getCaseDefinitionId(),
-                            caseInstanceEntity.getId(),
-                            previousParentPlanItemInstance != null ? previousParentPlanItemInstance.getId() : null,
+                        PlanItemInstanceEntity entryDependentPlanItemInstance = planItemInstanceEntityManager
+                            .createPlanItemInstanceBuilder()
+                            .planItem(entryDependentPlanItem)
+                            .caseDefinitionId(caseInstanceEntity.getCaseDefinitionId())
+                            .caseInstanceId(caseInstanceEntity.getId())
+                            .stagePlanItemInstanceId(previousParentPlanItemInstance != null ? previousParentPlanItemInstance.getId() : null)
                             // previous is closest parent stage plan item instance
-                            caseInstanceEntity.getTenantId(),
-                            null,
-                            true);
+                            .tenantId(caseInstanceEntity.getTenantId())
+                            .addToParent(true)
+                            .create();
+
                         CommandContextUtil.getAgenda(commandContext).planCreatePlanItemInstanceOperation(entryDependentPlanItemInstance);
 
                         // Special care needed in case the plan item instance is repeating
@@ -737,7 +741,7 @@ public class EvaluateCriteriaOperation extends AbstractCaseInstanceOperation {
     }
 
     protected PlanItemInstanceEntity createPlanItemInstanceDuplicateForRepetition(PlanItemInstanceEntity planItemInstanceEntity) {
-        PlanItemInstanceEntity childPlanItemInstanceEntity = copyAndInsertPlanItemInstance(commandContext, planItemInstanceEntity, false);
+        PlanItemInstanceEntity childPlanItemInstanceEntity = copyAndInsertPlanItemInstance(commandContext, planItemInstanceEntity, false, false);
 
         String oldState = childPlanItemInstanceEntity.getState();
         String newState = PlanItemInstanceState.WAITING_FOR_REPETITION;
@@ -761,7 +765,7 @@ public class EvaluateCriteriaOperation extends AbstractCaseInstanceOperation {
             localVariables.put(repetitionRule.getElementIndexVariableName(), index);
         }
 
-        PlanItemInstanceEntity childPlanItemInstanceEntity = copyAndInsertPlanItemInstance(commandContext, planItemInstanceEntity, localVariables, false);
+        PlanItemInstanceEntity childPlanItemInstanceEntity = copyAndInsertPlanItemInstance(commandContext, planItemInstanceEntity, localVariables, false, false);
 
         String oldState = childPlanItemInstanceEntity.getState();
         String newState = PlanItemInstanceState.ACTIVE;

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/callback/DefaultInternalCmmnJobManager.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/callback/DefaultInternalCmmnJobManager.java
@@ -81,15 +81,15 @@ public class DefaultInternalCmmnJobManager implements InternalJobManager {
             PlanItemInstanceEntity planItemInstanceEntity = (PlanItemInstanceEntity) variableScope;
             
             // Create new plan item instance based on the data of the original one
-            PlanItemInstanceEntity newPlanItemInstanceEntity = cmmnEngineConfiguration.getPlanItemInstanceEntityManager()
-                    .createChildPlanItemInstance(planItemInstanceEntity.getPlanItem(), 
-                            planItemInstanceEntity.getCaseDefinitionId(), 
-                            planItemInstanceEntity.getCaseInstanceId(), 
-                            planItemInstanceEntity.getStageInstanceId(), 
-                            planItemInstanceEntity.getTenantId(),
-                            null,
-                            true);
-            
+            PlanItemInstanceEntity newPlanItemInstanceEntity = cmmnEngineConfiguration.getPlanItemInstanceEntityManager().createPlanItemInstanceBuilder()
+                .planItem(planItemInstanceEntity.getPlanItem())
+                .caseDefinitionId(planItemInstanceEntity.getCaseDefinitionId())
+                .caseInstanceId(planItemInstanceEntity.getCaseInstanceId())
+                .stagePlanItemInstanceId(planItemInstanceEntity.getStageInstanceId())
+                .tenantId(planItemInstanceEntity.getTenantId())
+                .addToParent(true)
+                .create();
+
             // The plan item instance state needs to be set to available manually. 
             // Leaving it to empty will automatically make it available it and execute the behavior,
             // creating a duplicate timer. The job server logic will take care of scheduling the repeating timer.
@@ -103,8 +103,6 @@ public class DefaultInternalCmmnJobManager implements InternalJobManager {
 
             // Switch job references to new plan item instance
             timerJobEntity.setSubScopeId(newPlanItemInstanceEntity.getId());
-
         }
     }
-
 }

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/persistence/entity/PlanItemInstanceBuilder.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/persistence/entity/PlanItemInstanceBuilder.java
@@ -1,0 +1,91 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.cmmn.engine.impl.persistence.entity;
+
+import java.util.Map;
+
+import org.flowable.cmmn.model.PlanItem;
+
+/**
+ * A plan item instance builder used to create new plan item instances with different options.
+ *
+ * @author Micha Kiener
+ */
+public interface PlanItemInstanceBuilder {
+
+    /**
+     * Set the plan item for the new instance to be based on. This is a mandatory information to be set.
+     *
+     * @param planItem the plan item to base the new instance on
+     * @return the builder instance for method chaining
+     */
+    PlanItemInstanceBuilder planItem(PlanItem planItem);
+
+    /**
+     * Set the id of the case definition this plan item instance is part of. This is a mandatory information to be set.
+     *
+     * @param caseDefinitionId the id of the case definition the plan item is a part of
+     * @return the builder instance for method chaining
+     */
+    PlanItemInstanceBuilder caseDefinitionId(String caseDefinitionId);
+
+    /**
+     * Set the id of the case instance the plan item instance is a direct or indirect child of. This is a mandatory information to be set.
+     * @param caseInstanceId the id of the case instance the new plan item instance is a part of
+     * @return the builder instance for method chaining
+     */
+    PlanItemInstanceBuilder caseInstanceId(String caseInstanceId);
+
+    /**
+     * Set the id of the stage plan item instace the new plan item instance is a direct child of.
+     * @param stagePlanItemInstanceId the id of the parent stage instance id for the new plan item instance
+     * @return the builder instance for method chaining
+     */
+    PlanItemInstanceBuilder stagePlanItemInstanceId(String stagePlanItemInstanceId);
+
+    /**
+     * Set the id of the tenant for the new plan item instance.
+     * @param tenantId the id of the tenant the new plan item instance belongs to
+     * @return the builder instance for method chaining
+     */
+    PlanItemInstanceBuilder tenantId(String tenantId);
+
+    /**
+     * Optionally add any variables to be set on the new plan item instance as local variables.
+     * @param localVariables an optional map of variables to set as local values for the new plan item instance
+     * @return the builder instance for method chaining
+     */
+    PlanItemInstanceBuilder localVariables(Map<String, Object> localVariables);
+
+    /**
+     * Set true, if the new plan item instance to be created should be added to its parent, false otherwise.
+     * @param addToParent true, if the plan item instance should be added to its parent
+     * @return the builder instance for method chaining
+     */
+    PlanItemInstanceBuilder addToParent(boolean addToParent);
+
+    /**
+     * Invoke this method to suppress any exceptions thrown when evaluating the plan item name expression. This might be necessary, if not all of the necessary
+     * values are already available when creating the plan item instance and evaluating its name expression.
+     * By default, this is NOT set and an exception while evaluating the name expression will lead into an exception.
+     * @param silentNameExpressionEvaluation true, if the name expression evaluation should ignore any exception thrown
+     * @return the builder instance for method chaining
+     */
+    PlanItemInstanceBuilder silentNameExpressionEvaluation(boolean silentNameExpressionEvaluation);
+
+    /**
+     * Checks for all necessary values to be present within the builder, creates a new plan item instance and returns it.
+     * @return the newly created plan item instance
+     */
+    PlanItemInstanceEntity create();
+}

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/persistence/entity/PlanItemInstanceBuilderImpl.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/persistence/entity/PlanItemInstanceBuilderImpl.java
@@ -81,8 +81,35 @@ public class PlanItemInstanceBuilderImpl  implements PlanItemInstanceBuilder {
     @Override
     public PlanItemInstanceEntity create() {
         validateData();
-        return planItemInstanceEntityManager.createChildPlanItemInstance(planItem, caseDefinitionId, caseInstanceId, stagePlanItemInstanceId, tenantId,
-            localVariables, addToParent, silentNameExpressionEvaluation);
+        return planItemInstanceEntityManager.createChildPlanItemInstance(this);
+    }
+
+    public PlanItem getPlanItem() {
+        return planItem;
+    }
+    public String getCaseDefinitionId() {
+        return caseDefinitionId;
+    }
+    public String getCaseInstanceId() {
+        return caseInstanceId;
+    }
+    public String getStagePlanItemInstanceId() {
+        return stagePlanItemInstanceId;
+    }
+    public String getTenantId() {
+        return tenantId;
+    }
+    public Map<String, Object> getLocalVariables() {
+        return localVariables;
+    }
+    public boolean hasLocalVariables() {
+        return localVariables != null && localVariables.size() > 0;
+    }
+    public boolean isAddToParent() {
+        return addToParent;
+    }
+    public boolean isSilentNameExpressionEvaluation() {
+        return silentNameExpressionEvaluation;
     }
 
     protected void validateData() {

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/persistence/entity/PlanItemInstanceBuilderImpl.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/persistence/entity/PlanItemInstanceBuilderImpl.java
@@ -1,0 +1,99 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.cmmn.engine.impl.persistence.entity;
+
+import java.util.Map;
+
+import org.flowable.cmmn.model.PlanItem;
+import org.flowable.common.engine.api.FlowableIllegalArgumentException;
+
+/**
+ * Implements the plan item instance builder API.
+ *
+ * @author Micha Kiener
+ */
+public class PlanItemInstanceBuilderImpl  implements PlanItemInstanceBuilder {
+
+    protected final PlanItemInstanceEntityManagerImpl planItemInstanceEntityManager;
+    protected PlanItem planItem;
+    protected String caseDefinitionId;
+    protected String caseInstanceId;
+    protected String stagePlanItemInstanceId;
+    protected String tenantId;
+    protected Map<String, Object> localVariables;
+    protected boolean addToParent;
+    protected boolean silentNameExpressionEvaluation;
+
+    public PlanItemInstanceBuilderImpl(PlanItemInstanceEntityManagerImpl planItemInstanceEntityManager) {
+        this.planItemInstanceEntityManager = planItemInstanceEntityManager;
+    }
+
+    @Override
+    public PlanItemInstanceBuilder planItem(PlanItem planItem) {
+        this.planItem = planItem;
+        return this;
+    }
+    @Override
+    public PlanItemInstanceBuilder caseDefinitionId(String caseDefinitionId) {
+        this.caseDefinitionId = caseDefinitionId;
+        return this;
+    }
+    @Override
+    public PlanItemInstanceBuilder caseInstanceId(String caseInstanceId) {
+        this.caseInstanceId = caseInstanceId;
+        return this;
+    }
+    @Override
+    public PlanItemInstanceBuilder stagePlanItemInstanceId(String stagePlanItemInstanceId) {
+        this.stagePlanItemInstanceId = stagePlanItemInstanceId;
+        return this;
+    }
+    @Override
+    public PlanItemInstanceBuilder tenantId(String tenantId) {
+        this.tenantId = tenantId;
+        return this;
+    }
+    @Override
+    public PlanItemInstanceBuilder localVariables(Map<String, Object> localVariables) {
+        this.localVariables = localVariables;
+        return this;
+    }
+    @Override
+    public PlanItemInstanceBuilder addToParent(boolean addToParent) {
+        this.addToParent = addToParent;
+        return this;
+    }
+    @Override
+    public PlanItemInstanceBuilder silentNameExpressionEvaluation(boolean silentNameExpressionEvaluation) {
+        this.silentNameExpressionEvaluation = silentNameExpressionEvaluation;
+        return this;
+    }
+    @Override
+    public PlanItemInstanceEntity create() {
+        validateData();
+        return planItemInstanceEntityManager.createChildPlanItemInstance(planItem, caseDefinitionId, caseInstanceId, stagePlanItemInstanceId, tenantId,
+            localVariables, addToParent, silentNameExpressionEvaluation);
+    }
+
+    protected void validateData() {
+        if (planItem == null) {
+            throw new FlowableIllegalArgumentException("The plan item must be provided when creating a new plan item instance");
+        }
+        if (caseDefinitionId == null) {
+            throw new FlowableIllegalArgumentException("The case definition id must be provided when creating a new plan item instance");
+        }
+        if (caseInstanceId == null) {
+            throw new FlowableIllegalArgumentException("The case instance id must be provided when creating a new plan item instance");
+        }
+    }
+}

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/persistence/entity/PlanItemInstanceEntityManager.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/persistence/entity/PlanItemInstanceEntityManager.java
@@ -13,21 +13,22 @@
 package org.flowable.cmmn.engine.impl.persistence.entity;
 
 import java.util.List;
-import java.util.Map;
 
 import org.flowable.cmmn.api.runtime.PlanItemInstance;
 import org.flowable.cmmn.api.runtime.PlanItemInstanceQuery;
-import org.flowable.cmmn.model.PlanItem;
 import org.flowable.common.engine.impl.persistence.entity.EntityManager;
 
 /**
  * @author Joram Barrez
  */
 public interface PlanItemInstanceEntityManager extends EntityManager<PlanItemInstanceEntity> {
-    
-    PlanItemInstanceEntity createChildPlanItemInstance(PlanItem planItem, String caseDefinitionId, String caseInstanceId,
-        String stagePlanItemInstanceId, String tenantId, Map<String, Object> localVariables, boolean addToParent);
-    
+
+    /**
+     * Returns a builder to create a new plan item instance.
+     * @return the plan item instance builder
+     */
+    PlanItemInstanceBuilder createPlanItemInstanceBuilder();
+
     PlanItemInstanceQuery createPlanItemInstanceQuery();
 
     long countByCriteria(PlanItemInstanceQuery planItemInstanceQuery);

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/util/ExpressionUtil.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/util/ExpressionUtil.java
@@ -119,6 +119,23 @@ public class ExpressionUtil {
     }
 
     /**
+     * Returns true, if the given plan item instance has a repetition rule which is based on a collection variable, false, if there is no repetition rule at
+     * all or if it is not based on a collection variable.
+     *
+     * @param planItem the plan item to check for a repetition rule based on a collection
+     * @return true, if the plan item has a repetition rule based on a collection variable
+     */
+    public static boolean hasRepetitionOnCollection(PlanItem planItem) {
+        if (planItem.getItemControl() == null) {
+            return false;
+        }
+        if (planItem.getItemControl().getRepetitionRule() == null) {
+            return false;
+        }
+        return planItem.getItemControl().getRepetitionRule().hasCollectionVariable();
+    }
+
+    /**
      * Evaluates the collection variable name or expression given by the plan items repetition rule and returns its evaluated collection as a list.
      *
      * @param commandContext the command context to be used for evaluating the expression

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/DynamicPlanItemNameWithRepetitionBasedOnJsonArrayTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/DynamicPlanItemNameWithRepetitionBasedOnJsonArrayTest.java
@@ -13,6 +13,7 @@
 package org.flowable.cmmn.test.itemcontrol;
 
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.ACTIVE;
+import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.AVAILABLE;
 import static org.junit.Assert.assertEquals;
 
 import java.util.List;
@@ -51,6 +52,62 @@ public class DynamicPlanItemNameWithRepetitionBasedOnJsonArrayTest extends Flowa
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
         assertEquals(3, planItemInstances.size());
+        assertPlanItemInstanceState(planItemInstances, "Task (A / 0 - FooValue)", ACTIVE);
+        assertPlanItemInstanceState(planItemInstances, "Task (B / 1 - FooValue)", ACTIVE);
+        assertPlanItemInstanceState(planItemInstances, "Task (C / 2 - FooValue)", ACTIVE);
+    }
+
+    @Test
+    @CmmnDeployment
+    public void testDynamicNameWithRepetitionCollectionNoFallbackExpression() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        ArrayNode arrayNode = objectMapper.createArrayNode();
+
+        arrayNode.addObject().put("name", "A").put("bar", "a");
+        arrayNode.addObject().put("name", "B").put("bar", "b");
+        arrayNode.addObject().put("name", "C").put("bar", "c");
+
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+            .caseDefinitionKey("dynamicPlanItemNameTestOnJsonArray")
+            .variable("myCollection", arrayNode)
+            .variable("foo", "FooValue")
+            .start();
+
+        List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
+        assertEquals(3, planItemInstances.size());
+        assertPlanItemInstanceState(planItemInstances, "Task (A / 0 - FooValue)", ACTIVE);
+        assertPlanItemInstanceState(planItemInstances, "Task (B / 1 - FooValue)", ACTIVE);
+        assertPlanItemInstanceState(planItemInstances, "Task (C / 2 - FooValue)", ACTIVE);
+    }
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/itemcontrol/DynamicPlanItemNameWithRepetitionBasedOnJsonArrayTest.testDynamicNameWithRepetitionCollectionNoFallbackExpression.cmmn")
+    public void testDynamicNameWithRepetitionCollectionNoFallbackExpressionWithAvailablePlanItem() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        ArrayNode arrayNode = objectMapper.createArrayNode();
+
+        arrayNode.addObject().put("name", "A").put("bar", "a");
+        arrayNode.addObject().put("name", "B").put("bar", "b");
+        arrayNode.addObject().put("name", "C").put("bar", "c");
+
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+            .caseDefinitionKey("dynamicPlanItemNameTestOnJsonArray")
+            .variable("foo", "FooValue")
+            .start();
+
+        List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
+        assertEquals(1, planItemInstances.size());
+
+        // as we don't have the collection yet available, the name must use the expression as fallback without any exception, as the item / itemIndex local
+        // variables are not available on the available plan item instance
+        assertPlanItemInstanceState(planItemInstances, "Task (${item.name} / ${itemIndex} - ${foo})", AVAILABLE);
+
+        // now kick-off the repetition by setting the collection variable
+        cmmnRuntimeService.setVariable(caseInstance.getId(), "myCollection", arrayNode);
+
+        planItemInstances = getPlanItemInstances(caseInstance.getId());
+        assertEquals(3, planItemInstances.size());
+
         assertPlanItemInstanceState(planItemInstances, "Task (A / 0 - FooValue)", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task (B / 1 - FooValue)", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task (C / 2 - FooValue)", ACTIVE);

--- a/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/itemcontrol/DynamicPlanItemNameWithRepetitionBasedOnJsonArrayTest.testDynamicNameWithRepetitionCollectionNoFallbackExpression.cmmn
+++ b/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/itemcontrol/DynamicPlanItemNameWithRepetitionBasedOnJsonArrayTest.testDynamicNameWithRepetitionCollectionNoFallbackExpression.cmmn
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:flowable="http://flowable.org/cmmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:design="http://flowable.org/design" targetNamespace="http://flowable.org/cmmn">
+    <case id="dynamicPlanItemNameTestOnJsonArray" name="Dynamic Plan Item Name Test" flowable:initiatorVariableName="initiator" flowable:candidateStarterGroups="flowableUser">
+        <casePlanModel id="onecaseplanmodel1" name="Case plan model" flowable:formFieldValidation="false">
+            <extensionElements>
+                <flowable:work-form-field-validation><![CDATA[false]]></flowable:work-form-field-validation>
+                <design:stencilid><![CDATA[CasePlanModel]]></design:stencilid>
+            </extensionElements>
+            <planItem id="planItem1" name="Task (${item.name} / ${itemIndex} - ${foo})" definitionRef="humanTask1">
+                <itemControl>
+                    <repetitionRule flowable:counterVariable="repetitionCounter" flowable:collectionVariable="myCollection" flowable:elementVariable="item" flowable:elementIndexVariable="itemIndex"></repetitionRule>
+                </itemControl>
+            </planItem>
+            <humanTask id="humanTask1" name="Task (${item.name} / ${itemIndex} - ${foo})" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
+                <extensionElements>
+                    <flowable:start-form-field-validation><![CDATA[false]]></flowable:start-form-field-validation>
+                    <design:stencilid><![CDATA[HumanTask]]></design:stencilid>
+                    <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+                </extensionElements>
+            </humanTask>
+        </casePlanModel>
+    </case>
+    <cmmndi:CMMNDI>
+        <cmmndi:CMMNDiagram id="CMMNDiagram_dynamicPlanItemNameTest">
+            <cmmndi:CMMNShape id="CMMNShape_onecaseplanmodel1" cmmnElementRef="onecaseplanmodel1">
+                <dc:Bounds height="221.0" width="581.0" x="30.0" y="45.0"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_planItem1" cmmnElementRef="planItem1">
+                <dc:Bounds height="80.0" width="100.0" x="270.5" y="115.5"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+        </cmmndi:CMMNDiagram>
+    </cmmndi:CMMNDI>
+</definitions>


### PR DESCRIPTION
Create a builder API for plan item instance creation with a new mode for silent name expression evaluation.

#### Check List:
* Unit tests: YES
* Documentation: NA
