### PR TITLE
Add startableByUserOrGroups to the ProcessDefinitionQuery and CaseDefinitionQuery

### DIFF
--- a/modules/flowable-cmmn-api/src/main/java/org/flowable/cmmn/api/repository/CaseDefinitionQuery.java
+++ b/modules/flowable-cmmn-api/src/main/java/org/flowable/cmmn/api/repository/CaseDefinitionQuery.java
@@ -13,6 +13,7 @@
 
 package org.flowable.cmmn.api.repository;
 
+import java.util.Collection;
 import java.util.Set;
 
 import org.flowable.common.engine.api.query.Query;
@@ -61,6 +62,8 @@ public interface CaseDefinitionQuery extends Query<CaseDefinitionQuery, CaseDefi
     CaseDefinitionQuery caseDefinitionResourceNameLike(String resourceNameLike);
     
     CaseDefinitionQuery startableByUser(String userId);
+
+    CaseDefinitionQuery startableByUserOrGroups(String userId, Collection<String> groups);
 
     CaseDefinitionQuery caseDefinitionTenantId(String tenantId);
 

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/repository/CaseDefinitionQueryImpl.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/repository/CaseDefinitionQueryImpl.java
@@ -13,6 +13,7 @@
 
 package org.flowable.cmmn.engine.impl.repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
@@ -43,6 +44,8 @@ public class CaseDefinitionQueryImpl extends AbstractQuery<CaseDefinitionQuery, 
     protected String resourceName;
     protected String resourceNameLike;
     protected String authorizationUserId;
+    protected Collection<String> authorizationGroups;
+    protected boolean authorizationGroupsSet;
     protected Integer version;
     protected Integer versionGt;
     protected Integer versionGte;
@@ -255,8 +258,10 @@ public class CaseDefinitionQueryImpl extends AbstractQuery<CaseDefinitionQuery, 
         return this;
     }
     
-    public List<String> getAuthorizationGroups() {
-        if (authorizationUserId == null) {
+    public Collection<String> getAuthorizationGroups() {
+        if (authorizationGroupsSet) {
+            return authorizationGroups;
+        } else if (authorizationUserId == null) {
             return null;
         }
         return CommandContextUtil.getCmmnEngineConfiguration().getCandidateManager().getGroupsForCandidateUser(authorizationUserId);
@@ -268,6 +273,17 @@ public class CaseDefinitionQueryImpl extends AbstractQuery<CaseDefinitionQuery, 
             throw new FlowableIllegalArgumentException("userId is null");
         }
         this.authorizationUserId = userId;
+        return this;
+    }
+
+    @Override
+    public CaseDefinitionQuery startableByUserOrGroups(String userId, Collection<String> groups) {
+        if (userId == null && (groups == null || groups.isEmpty())) {
+            throw new FlowableIllegalArgumentException("userId is null and groups are null or empty");
+        }
+        this.authorizationUserId = userId;
+        this.authorizationGroups = groups;
+        this.authorizationGroupsSet = true;
         return this;
     }
 
@@ -408,6 +424,10 @@ public class CaseDefinitionQueryImpl extends AbstractQuery<CaseDefinitionQuery, 
 
     public boolean isWithoutTenantId() {
         return withoutTenantId;
+    }
+
+    public boolean isIncludeAuthorization() {
+        return authorizationUserId != null || (authorizationGroups != null && !authorizationGroups.isEmpty());
     }
 
 }

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/repository/CaseDefinitionQueryImpl.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/repository/CaseDefinitionQueryImpl.java
@@ -259,6 +259,8 @@ public class CaseDefinitionQueryImpl extends AbstractQuery<CaseDefinitionQuery, 
     }
     
     public Collection<String> getAuthorizationGroups() {
+        // if authorizationGroupsSet is true then startableByUserOrGroups was called
+        // and the groups passed in that methods have precedence
         if (authorizationGroupsSet) {
             return authorizationGroups;
         } else if (authorizationUserId == null) {

--- a/modules/flowable-cmmn-engine/src/main/resources/org/flowable/cmmn/db/mapping/entity/CaseDefinition.xml
+++ b/modules/flowable-cmmn-engine/src/main/resources/org/flowable/cmmn/db/mapping/entity/CaseDefinition.xml
@@ -250,17 +250,22 @@
       <if test="withoutTenantId">
         and (RES.TENANT_ID_ = '' or RES.TENANT_ID_ is null)
       </if>
-      <if test="authorizationUserId != null">
-        AND (exists (select ID_  from ${prefix}ACT_RU_IDENTITYLINK  IDN where IDN.SCOPE_DEFINITION_ID_ = RES.ID_ and IDN.SCOPE_TYPE_ = 'cmmn' and IDN.USER_ID_ = #{authorizationUserId})
-        <if test="authorizationGroups != null &amp;&amp; authorizationGroups.size() &gt; 0">
-         OR exists (select ID_ from ${prefix}ACT_RU_IDENTITYLINK  IDN where IDN.SCOPE_DEFINITION_ID_ = RES.ID_ and IDN.SCOPE_TYPE_ = 'cmmn' and IDN.GROUP_ID_ IN
-            <foreach item="group" index="index" collection="authorizationGroups" 
-                     open="(" separator="," close=")">
-              #{group}
-            </foreach>
-         )
-         </if>
-        )
+      <if test="includeAuthorization">
+          AND
+          <trim prefix="(" prefixOverrides="OR" suffix=")">
+             <if test="authorizationUserId != null">
+                 exists (select ID_  from ${prefix}ACT_RU_IDENTITYLINK  IDN where IDN.SCOPE_DEFINITION_ID_ = RES.ID_ and IDN.SCOPE_TYPE_ = 'cmmn' and IDN.USER_ID_ = #{authorizationUserId})
+             </if>
+              <if test="authorizationGroups != null &amp;&amp; authorizationGroups.size() &gt; 0">
+                  OR exists (select ID_ from ${prefix}ACT_RU_IDENTITYLINK  IDN where IDN.SCOPE_DEFINITION_ID_ = RES.ID_ and IDN.SCOPE_TYPE_ = 'cmmn' and IDN.GROUP_ID_ IN
+                  <foreach item="group" index="index" collection="authorizationGroups"
+                           open="(" separator="," close=")">
+                      #{group}
+                  </foreach>
+                  )
+              </if>
+
+          </trim>
       </if>
     </where>
   </sql>

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/ProcessDefinitionQueryImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/ProcessDefinitionQueryImpl.java
@@ -13,6 +13,7 @@
 
 package org.flowable.engine.impl;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
@@ -56,6 +57,8 @@ public class ProcessDefinitionQueryImpl extends AbstractQuery<ProcessDefinitionQ
     protected boolean latest;
     protected SuspensionState suspensionState;
     protected String authorizationUserId;
+    protected Collection<String> authorizationGroups;
+    protected boolean authorizationGroupsSet;
     protected String procDefId;
     protected String tenantId;
     protected String tenantIdLike;
@@ -304,8 +307,10 @@ public class ProcessDefinitionQueryImpl extends AbstractQuery<ProcessDefinitionQ
         return this;
     }
 
-    public List<String> getAuthorizationGroups() {
-        if (authorizationUserId == null) {
+    public Collection<String> getAuthorizationGroups() {
+        if (authorizationGroupsSet) {
+            return authorizationGroups;
+        } else if (authorizationUserId == null) {
             return null;
         }
         return CommandContextUtil.getProcessEngineConfiguration().getCandidateManager().getGroupsForCandidateUser(authorizationUserId);
@@ -317,6 +322,17 @@ public class ProcessDefinitionQueryImpl extends AbstractQuery<ProcessDefinitionQ
             throw new FlowableIllegalArgumentException("userId is null");
         }
         this.authorizationUserId = userId;
+        return this;
+    }
+
+    @Override
+    public ProcessDefinitionQuery startableByUserOrGroups(String userId, Collection<String> groups) {
+        if (userId == null && (groups == null || groups.isEmpty())) {
+            throw new FlowableIllegalArgumentException("userId is null and groups are null or empty");
+        }
+        this.authorizationUserId = userId;
+        this.authorizationGroups = groups;
+        this.authorizationGroupsSet = true;
         return this;
     }
 
@@ -485,5 +501,9 @@ public class ProcessDefinitionQueryImpl extends AbstractQuery<ProcessDefinitionQ
 
     public String getEventSubscriptionType() {
         return eventSubscriptionType;
+    }
+
+    public boolean isIncludeAuthorization() {
+        return authorizationUserId != null || (authorizationGroups != null && !authorizationGroups.isEmpty());
     }
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/ProcessDefinitionQueryImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/ProcessDefinitionQueryImpl.java
@@ -309,6 +309,8 @@ public class ProcessDefinitionQueryImpl extends AbstractQuery<ProcessDefinitionQ
 
     public Collection<String> getAuthorizationGroups() {
         if (authorizationGroupsSet) {
+            // if authorizationGroupsSet is true then startableByUserOrGroups was called
+            // and the groups passed in that methods have precedence
             return authorizationGroups;
         } else if (authorizationUserId == null) {
             return null;

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/repository/ProcessDefinitionQuery.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/repository/ProcessDefinitionQuery.java
@@ -13,6 +13,7 @@
 
 package org.flowable.engine.repository;
 
+import java.util.Collection;
 import java.util.Set;
 
 import org.flowable.common.engine.api.FlowableIllegalArgumentException;
@@ -122,6 +123,11 @@ public interface ProcessDefinitionQuery extends Query<ProcessDefinitionQuery, Pr
      * Only selects process definitions which given userId is authorized to start
      */
     ProcessDefinitionQuery startableByUser(String userId);
+
+    /**
+     * Only selects process definition which the given userId or groups are authorized to start.
+     */
+    ProcessDefinitionQuery startableByUserOrGroups(String userId, Collection<String> groups);
 
     /**
      * Only selects process definitions which are suspended

--- a/modules/flowable-engine/src/main/resources/org/flowable/db/mapping/entity/ProcessDefinition.xml
+++ b/modules/flowable-engine/src/main/resources/org/flowable/db/mapping/entity/ProcessDefinition.xml
@@ -253,17 +253,21 @@
       <if test="eventSubscriptionType != null">
         and exists(select 1 from ${prefix}ACT_RU_EVENT_SUBSCR EVT where RES.ID_ = EVT.CONFIGURATION_ and EVT.EVENT_TYPE_ = #{eventSubscriptionType} and EVT.EVENT_NAME_ = #{eventSubscriptionName}) 
       </if>
-      <if test="authorizationUserId != null">
-        AND (exists (select ID_  from ${prefix}ACT_RU_IDENTITYLINK  IDN where IDN.PROC_DEF_ID_ = RES.ID_ and IDN.USER_ID_ = #{authorizationUserId})
-        <if test="authorizationGroups != null &amp;&amp; authorizationGroups.size() &gt; 0">
-         OR exists (select ID_ from ${prefix}ACT_RU_IDENTITYLINK  IDN where IDN.PROC_DEF_ID_ = RES.ID_ and IDN.GROUP_ID_ IN
-            <foreach item="group" index="index" collection="authorizationGroups" 
-                     open="(" separator="," close=")">
-              #{group}
-            </foreach>
-         )
-         </if>
-        )
+      <if test="includeAuthorization">
+          AND
+          <trim prefix="(" prefixOverrides="OR" suffix=")">
+              <if test="authorizationUserId != null">
+                  exists (select ID_  from ${prefix}ACT_RU_IDENTITYLINK  IDN where IDN.PROC_DEF_ID_ = RES.ID_ and IDN.USER_ID_ = #{authorizationUserId})
+              </if>
+              <if test="authorizationGroups != null &amp;&amp; authorizationGroups.size() &gt; 0">
+                  OR exists (select ID_ from ${prefix}ACT_RU_IDENTITYLINK  IDN where IDN.PROC_DEF_ID_ = RES.ID_ and IDN.GROUP_ID_ IN
+                  <foreach item="group" index="index" collection="authorizationGroups"
+                           open="(" separator="," close=")">
+                      #{group}
+                  </foreach>
+                  )
+              </if>
+          </trim>
       </if>
     </where>
   </sql>


### PR DESCRIPTION

When startableByUserOrGroups is used then the process and cmmn CandidateManager(s) will not be invoked to get the groups for the authorized user

#### Check List:
* Unit tests: YES
* Documentation: NA
