### PR TITLE
Fixing removal of remaining plan item in waiting for repetition state

### DIFF
--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/persistence/entity/PlanItemInstanceEntityManagerImpl.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/persistence/entity/PlanItemInstanceEntityManagerImpl.java
@@ -14,6 +14,7 @@
 package org.flowable.cmmn.engine.impl.persistence.entity;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -192,8 +193,9 @@ public class PlanItemInstanceEntityManagerImpl
         // if the plan item has repetition, we don't remove any event listeners for entry dependencies, as they might trigger in the future and re-create
         // the plan item as it has repetition and therefore, we also don't remove any exit sentry dependant event listeners, as if in the future, the plan
         // item becomes active again, those event listeners might trigger again to terminate it, so we need them to stay in place
+        // furthermore, don't investigate into not-yet-created child plan items having event listeners as they might become active at a later state
         if (ExpressionUtil.hasRepetitionRule(planItem)) {
-            eventListenerDependencies = new ArrayList<>();
+            return Collections.emptyList();
         } else {
             eventListenerDependencies = Stream.concat(
                 planItem.getEntryDependencies().stream().filter(p -> p.getPlanItemDefinition() instanceof EventListener),

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/persistence/entity/PlanItemInstanceEntityManagerImpl.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/persistence/entity/PlanItemInstanceEntityManagerImpl.java
@@ -30,6 +30,7 @@ import org.flowable.cmmn.engine.impl.persistence.entity.data.PlanItemInstanceDat
 import org.flowable.cmmn.engine.impl.runtime.PlanItemInstanceQueryImpl;
 import org.flowable.cmmn.engine.impl.util.CaseInstanceUtil;
 import org.flowable.cmmn.engine.impl.util.CommandContextUtil;
+import org.flowable.cmmn.engine.impl.util.ExpressionUtil;
 import org.flowable.cmmn.model.EventListener;
 import org.flowable.cmmn.model.PlanFragment;
 import org.flowable.cmmn.model.PlanItem;
@@ -185,11 +186,20 @@ public class PlanItemInstanceEntityManagerImpl
 
 
     protected List<PlanItem> gatherEventListenerDependencies(CommandContext commandContext, PlanItem planItem, PlanItemInstanceEntity planItemInstanceEntity) {
+        // first collect the event listeners
+        List<PlanItem> eventListenerDependencies;
 
-        List<PlanItem> eventListenerDependencies = Stream.concat(
-            planItem.getEntryDependencies().stream().filter(p -> p.getPlanItemDefinition() instanceof EventListener),
-            planItem.getExitDependencies().stream().filter(p -> p.getPlanItemDefinition() instanceof EventListener))
-            .collect(Collectors.toList());
+        // if the plan item has repetition, we don't remove any event listeners for entry dependencies, as they might trigger in the future and re-create
+        // the plan item as it has repetition and therefore, we also don't remove any exit sentry dependant event listeners, as if in the future, the plan
+        // item becomes active again, those event listeners might trigger again to terminate it, so we need them to stay in place
+        if (ExpressionUtil.hasRepetitionRule(planItem)) {
+            eventListenerDependencies = new ArrayList<>();
+        } else {
+            eventListenerDependencies = Stream.concat(
+                planItem.getEntryDependencies().stream().filter(p -> p.getPlanItemDefinition() instanceof EventListener),
+                planItem.getExitDependencies().stream().filter(p -> p.getPlanItemDefinition() instanceof EventListener))
+                .collect(Collectors.toList());
+        }
 
         // Special case: if the current plan item is a stage, we need to also verify all event listeners
         // that reference a child plan item of this stage. Normally this will happen automatically, unless

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/runtime/StateTransition.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/runtime/StateTransition.java
@@ -36,7 +36,9 @@ public class StateTransition {
     
     static {
         addPlanItemTransition(null, PlanItemTransition.CREATE);
-        addPlanItemTransition(PlanItemInstanceState.WAITING_FOR_REPETITION, PlanItemTransition.CREATE);
+        addPlanItemTransition(PlanItemInstanceState.WAITING_FOR_REPETITION,
+            PlanItemTransition.CREATE,
+            PlanItemTransition.EXIT);
         
         addPlanItemTransition(PlanItemInstanceState.AVAILABLE,
                 PlanItemTransition.START, 

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/CrossBoundaryActivationWithExitEventTypeCombinationTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/CrossBoundaryActivationWithExitEventTypeCombinationTest.java
@@ -1,0 +1,134 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.cmmn.test.itemcontrol;
+
+import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.ACTIVE;
+import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.AVAILABLE;
+import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.ENABLED;
+import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.UNAVAILABLE;
+import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.WAITING_FOR_REPETITION;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.flowable.cmmn.api.runtime.CaseInstance;
+import org.flowable.cmmn.api.runtime.PlanItemInstance;
+import org.flowable.cmmn.engine.test.CmmnDeployment;
+import org.flowable.cmmn.engine.test.FlowableCmmnTestCase;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CrossBoundaryActivationWithExitEventTypeCombinationTest extends FlowableCmmnTestCase {
+
+    @Test
+    @CmmnDeployment
+    public void testCrossBoundaryActivationWithExitEventTypeCombinationTest() {
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+            .caseDefinitionKey("crossBoundaryRepetitionTestCase")
+            .start();
+
+        List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
+        assertEquals(6, planItemInstances.size());
+
+        assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
+        assertPlanItemInstanceState(planItemInstances, "Stage B", AVAILABLE);
+        assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE, WAITING_FOR_REPETITION);
+        assertPlanItemInstanceState(planItemInstances, "Task B", ENABLED);
+        assertPlanItemInstanceState(planItemInstances, "complete stage", UNAVAILABLE);
+
+        // complete Task A and the user listener to go to Stage B
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE));
+        planItemInstances = getPlanItemInstances(caseInstance.getId());
+        cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "complete stage", AVAILABLE));
+
+        planItemInstances = getPlanItemInstances(caseInstance.getId());
+        assertEquals(4, planItemInstances.size());
+
+        assertPlanItemInstanceState(planItemInstances, "Stage B", ACTIVE, WAITING_FOR_REPETITION);
+        assertPlanItemInstanceState(planItemInstances, "Decision", ACTIVE);
+        assertPlanItemInstanceState(planItemInstances, "Follow-up", AVAILABLE);
+
+        // complete Decision with declined to activate a cross-boundary plan item in Stage A and terminate Stage B
+        cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(getPlanItemInstanceIdByNameAndState(planItemInstances, "Decision", ACTIVE))
+            .variable("approval", "declined")
+            .trigger();
+
+        planItemInstances = getPlanItemInstances(caseInstance.getId());
+        assertEquals(6, planItemInstances.size());
+
+        assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
+        assertPlanItemInstanceState(planItemInstances, "Stage B", WAITING_FOR_REPETITION);
+        assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE, WAITING_FOR_REPETITION);
+        assertPlanItemInstanceState(planItemInstances, "Task B", ENABLED);
+        assertPlanItemInstanceState(planItemInstances, "complete stage", UNAVAILABLE);
+
+
+        // complete Task A and the user listener to go to Stage B
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE));
+        planItemInstances = getPlanItemInstances(caseInstance.getId());
+        cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "complete stage", AVAILABLE));
+
+        planItemInstances = getPlanItemInstances(caseInstance.getId());
+        assertEquals(4, planItemInstances.size());
+
+        assertPlanItemInstanceState(planItemInstances, "Stage B", ACTIVE, WAITING_FOR_REPETITION);
+        assertPlanItemInstanceState(planItemInstances, "Decision", ACTIVE);
+        assertPlanItemInstanceState(planItemInstances, "Follow-up", AVAILABLE);
+
+        // complete Decision with declined to activate a cross-boundary plan item in Stage A and terminate Stage B (again)
+        cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(getPlanItemInstanceIdByNameAndState(planItemInstances, "Decision", ACTIVE))
+            .variable("approval", "declined")
+            .trigger();
+
+        planItemInstances = getPlanItemInstances(caseInstance.getId());
+        assertEquals(6, planItemInstances.size());
+
+        assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
+        assertPlanItemInstanceState(planItemInstances, "Stage B", WAITING_FOR_REPETITION);
+        assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE, WAITING_FOR_REPETITION);
+        assertPlanItemInstanceState(planItemInstances, "Task B", ENABLED);
+        assertPlanItemInstanceState(planItemInstances, "complete stage", UNAVAILABLE);
+
+        // complete Task A and the user listener to go to Stage B
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE));
+        planItemInstances = getPlanItemInstances(caseInstance.getId());
+        cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "complete stage", AVAILABLE));
+
+        planItemInstances = getPlanItemInstances(caseInstance.getId());
+        assertEquals(4, planItemInstances.size());
+
+        assertPlanItemInstanceState(planItemInstances, "Stage B", ACTIVE, WAITING_FOR_REPETITION);
+        assertPlanItemInstanceState(planItemInstances, "Decision", ACTIVE);
+        assertPlanItemInstanceState(planItemInstances, "Follow-up", AVAILABLE);
+
+        // complete Decision with declined to activate a cross-boundary plan item in Stage A and terminate Stage B
+        cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(getPlanItemInstanceIdByNameAndState(planItemInstances, "Decision", ACTIVE))
+            .variable("approval", "approved")
+            .trigger();
+
+        planItemInstances = getPlanItemInstances(caseInstance.getId());
+        assertEquals(3, planItemInstances.size());
+
+        assertPlanItemInstanceState(planItemInstances, "Stage B", ACTIVE, WAITING_FOR_REPETITION);
+        assertPlanItemInstanceState(planItemInstances, "Follow-up", ACTIVE);
+
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Follow-up", ACTIVE));
+
+        planItemInstances = getPlanItemInstances(caseInstance.getId());
+        assertEquals(0, planItemInstances.size());
+
+        assertCaseInstanceEnded(caseInstance);
+        Assert.assertEquals(0L, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count());
+        Assert.assertEquals(0L, cmmnRuntimeService.createCaseInstanceQuery().count());
+    }
+}

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/CrossBoundaryActivationWithExitEventTypeCombinationTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/CrossBoundaryActivationWithExitEventTypeCombinationTest.java
@@ -28,6 +28,11 @@ import org.flowable.cmmn.engine.test.FlowableCmmnTestCase;
 import org.junit.Assert;
 import org.junit.Test;
 
+/**
+ * Testing the exit event type combination with cross boundary activation and event listeners.
+ *
+ * @author Micha Kiener
+ */
 public class CrossBoundaryActivationWithExitEventTypeCombinationTest extends FlowableCmmnTestCase {
 
     @Test

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/OrphanEventListenerRemovalCombinedWithRepetitionTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/OrphanEventListenerRemovalCombinedWithRepetitionTest.java
@@ -1,0 +1,95 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.cmmn.test.itemcontrol;
+
+import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.ACTIVE;
+import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.AVAILABLE;
+import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.WAITING_FOR_REPETITION;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.flowable.cmmn.api.runtime.CaseInstance;
+import org.flowable.cmmn.api.runtime.PlanItemInstance;
+import org.flowable.cmmn.engine.test.CmmnDeployment;
+import org.flowable.cmmn.engine.test.FlowableCmmnTestCase;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Testing the removal of orphaned event listeners in combination with repetition, inner stages and plan items.
+ *
+ * @author Micha Kiener
+ */
+public class OrphanEventListenerRemovalCombinedWithRepetitionTest extends FlowableCmmnTestCase {
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/itemcontrol/OrphanEventListenerRemovalCombinedWithRepetitionTest.testRemovalOfOrphanedEventListeners.cmmn")
+    public void testRemovalOfOrphanedEventListenersWithOutherStart() {
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+            .caseDefinitionKey("nestedRepetitionPlanItemsWithOrphanedEventListeners")
+            .start();
+
+        List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
+        assertEquals(5, planItemInstances.size());
+
+        assertPlanItemInstanceState(planItemInstances, "Stage A", AVAILABLE);
+        assertPlanItemInstanceState(planItemInstances, "start Task A 1", AVAILABLE);
+        assertPlanItemInstanceState(planItemInstances, "start Task A 2", AVAILABLE);
+        assertPlanItemInstanceState(planItemInstances, "start Stage A", AVAILABLE);
+        assertPlanItemInstanceState(planItemInstances, "kill Stage A", AVAILABLE);
+
+        // start with the outer stage
+        cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "start Stage A", AVAILABLE));
+
+        planItemInstances = getPlanItemInstances(caseInstance.getId());
+        assertEquals(5, planItemInstances.size());
+
+        assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
+        assertPlanItemInstanceState(planItemInstances, "Stage B", AVAILABLE);
+        assertPlanItemInstanceState(planItemInstances, "start Task A 1", AVAILABLE);
+        assertPlanItemInstanceState(planItemInstances, "start Task A 2", AVAILABLE);
+        assertPlanItemInstanceState(planItemInstances, "kill Stage A", AVAILABLE);
+
+        // now kill Stage A, also killing Stage B and Task A (although never started), but must not kill the user tasks
+        cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "kill Stage A", AVAILABLE));
+
+        planItemInstances = getPlanItemInstances(caseInstance.getId());
+        assertEquals(2, planItemInstances.size());
+
+        assertPlanItemInstanceState(planItemInstances, "start Task A 1", AVAILABLE);
+        assertPlanItemInstanceState(planItemInstances, "start Task A 2", AVAILABLE);
+
+        // starting Task A through both event listeners must also start the stages again
+        cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "start Task A 1", AVAILABLE));
+        planItemInstances = getPlanItemInstances(caseInstance.getId());
+        assertEquals(1, planItemInstances.size());
+        assertPlanItemInstanceState(planItemInstances, "start Task A 2", AVAILABLE);
+        cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "start Task A 2", AVAILABLE));
+
+        planItemInstances = getPlanItemInstances(caseInstance.getId());
+        assertEquals(4, planItemInstances.size());
+
+        assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
+        assertPlanItemInstanceState(planItemInstances, "Stage B", ACTIVE);
+        assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE, WAITING_FOR_REPETITION);
+
+        // completing Task A must complete the case as there is no more way to activate it again, even though it has repetition
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE));
+
+        planItemInstances = getPlanItemInstances(caseInstance.getId());
+        assertCaseInstanceEnded(caseInstance);
+        Assert.assertEquals(0L, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count());
+        Assert.assertEquals(0L, cmmnRuntimeService.createCaseInstanceQuery().count());
+    }
+}

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/OrphanEventListenerRemovalCombinedWithRepetitionTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/OrphanEventListenerRemovalCombinedWithRepetitionTest.java
@@ -35,7 +35,7 @@ public class OrphanEventListenerRemovalCombinedWithRepetitionTest extends Flowab
 
     @Test
     @CmmnDeployment(resources = "org/flowable/cmmn/test/itemcontrol/OrphanEventListenerRemovalCombinedWithRepetitionTest.testRemovalOfOrphanedEventListeners.cmmn")
-    public void testRemovalOfOrphanedEventListenersWithOutherStart() {
+    public void testRemovalOfOrphanedEventListenersWithOuterStart() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
             .caseDefinitionKey("nestedRepetitionPlanItemsWithOrphanedEventListeners")
             .start();
@@ -87,7 +87,105 @@ public class OrphanEventListenerRemovalCombinedWithRepetitionTest extends Flowab
         // completing Task A must complete the case as there is no more way to activate it again, even though it has repetition
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE));
 
+        assertCaseInstanceEnded(caseInstance);
+        Assert.assertEquals(0L, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count());
+        Assert.assertEquals(0L, cmmnRuntimeService.createCaseInstanceQuery().count());
+    }
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/itemcontrol/OrphanEventListenerRemovalCombinedWithRepetitionTest.testRemovalOfOrphanedEventListeners.cmmn")
+    public void testRemovalOfOrphanedEventListenersWithInnerStart() {
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+            .caseDefinitionKey("nestedRepetitionPlanItemsWithOrphanedEventListeners")
+            .start();
+
+        List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
+        assertEquals(5, planItemInstances.size());
+
+        assertPlanItemInstanceState(planItemInstances, "Stage A", AVAILABLE);
+        assertPlanItemInstanceState(planItemInstances, "start Task A 1", AVAILABLE);
+        assertPlanItemInstanceState(planItemInstances, "start Task A 2", AVAILABLE);
+        assertPlanItemInstanceState(planItemInstances, "start Stage A", AVAILABLE);
+        assertPlanItemInstanceState(planItemInstances, "kill Stage A", AVAILABLE);
+
+        // start with the inner task directly
+        cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "start Task A 1", AVAILABLE));
+        cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "start Task A 2", AVAILABLE));
+
         planItemInstances = getPlanItemInstances(caseInstance.getId());
+        assertEquals(5, planItemInstances.size());
+
+        assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
+        assertPlanItemInstanceState(planItemInstances, "Stage B", ACTIVE);
+        assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE, WAITING_FOR_REPETITION);
+        assertPlanItemInstanceState(planItemInstances, "kill Stage A", AVAILABLE);
+
+        // now kill Stage A, also killing Stage B and Task A (although never started), but must not kill the user tasks
+        cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "kill Stage A", AVAILABLE));
+
+        assertCaseInstanceEnded(caseInstance);
+        Assert.assertEquals(0L, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count());
+        Assert.assertEquals(0L, cmmnRuntimeService.createCaseInstanceQuery().count());
+    }
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/itemcontrol/OrphanEventListenerRemovalCombinedWithRepetitionTwoTest.testRemovalOfOrphanedEventListeners.cmmn")
+    public void testRemovalOfOrphanedEventListenersWithOuterStartAndInnerExitEventListener() {
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+            .caseDefinitionKey("nestedRepetitionPlanItemsWithOrphanedEventListenersTwo")
+            .start();
+
+        List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
+        assertEquals(6, planItemInstances.size());
+
+        assertPlanItemInstanceState(planItemInstances, "Stage A", AVAILABLE);
+        assertPlanItemInstanceState(planItemInstances, "start Task A 1", AVAILABLE);
+        assertPlanItemInstanceState(planItemInstances, "start Task A 2", AVAILABLE);
+        assertPlanItemInstanceState(planItemInstances, "start Stage A", AVAILABLE);
+        assertPlanItemInstanceState(planItemInstances, "kill Stage A", AVAILABLE);
+        assertPlanItemInstanceState(planItemInstances, "kill Task A", AVAILABLE);
+
+        // start with the outer stage
+        cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "start Stage A", AVAILABLE));
+
+        planItemInstances = getPlanItemInstances(caseInstance.getId());
+        assertEquals(6, planItemInstances.size());
+
+        assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
+        assertPlanItemInstanceState(planItemInstances, "Stage B", AVAILABLE);
+        assertPlanItemInstanceState(planItemInstances, "start Task A 1", AVAILABLE);
+        assertPlanItemInstanceState(planItemInstances, "start Task A 2", AVAILABLE);
+        assertPlanItemInstanceState(planItemInstances, "kill Stage A", AVAILABLE);
+        assertPlanItemInstanceState(planItemInstances, "kill Task A", AVAILABLE);
+
+        // now kill Stage A, also killing Stage B and Task A (although never started), but must not kill the user tasks
+        cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "kill Stage A", AVAILABLE));
+
+        planItemInstances = getPlanItemInstances(caseInstance.getId());
+        assertEquals(3, planItemInstances.size());
+
+        assertPlanItemInstanceState(planItemInstances, "start Task A 1", AVAILABLE);
+        assertPlanItemInstanceState(planItemInstances, "start Task A 2", AVAILABLE);
+        assertPlanItemInstanceState(planItemInstances, "kill Task A", AVAILABLE);
+
+        // starting Task A through both event listeners must also start the stages again
+        cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "start Task A 1", AVAILABLE));
+        planItemInstances = getPlanItemInstances(caseInstance.getId());
+        assertEquals(2, planItemInstances.size());
+        assertPlanItemInstanceState(planItemInstances, "start Task A 2", AVAILABLE);
+        cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "start Task A 2", AVAILABLE));
+
+        planItemInstances = getPlanItemInstances(caseInstance.getId());
+        assertEquals(5, planItemInstances.size());
+
+        assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
+        assertPlanItemInstanceState(planItemInstances, "Stage B", ACTIVE);
+        assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE, WAITING_FOR_REPETITION);
+        assertPlanItemInstanceState(planItemInstances, "kill Task A", AVAILABLE);
+
+        // completing Task A must complete the case as there is no more way to activate it again, even though it has repetition
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE));
+
         assertCaseInstanceEnded(caseInstance);
         Assert.assertEquals(0L, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count());
         Assert.assertEquals(0L, cmmnRuntimeService.createCaseInstanceQuery().count());

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/StageTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/StageTest.java
@@ -271,7 +271,7 @@ public class StageTest extends FlowableCmmnTestCase {
         assertPlanItemInstanceState(planItemInstances, "Hidden", PlanItemInstanceState.TERMINATED);
         assertPlanItemInstanceState(planItemInstances, "Close", PlanItemInstanceState.ACTIVE, PlanItemInstanceState.WAITING_FOR_REPETITION);
         assertPlanItemInstanceState(planItemInstances, "Draft", PlanItemInstanceState.COMPLETED);
-        assertPlanItemInstanceState(planItemInstances, "Close Task", PlanItemInstanceState.COMPLETED, PlanItemInstanceState.WAITING_FOR_REPETITION);
+        assertPlanItemInstanceState(planItemInstances, "Close Task", PlanItemInstanceState.COMPLETED, PlanItemInstanceState.TERMINATED);
         assertPlanItemInstanceState(planItemInstances, "Service task 1", PlanItemInstanceState.TERMINATED);
         assertPlanItemInstanceState(planItemInstances, "Service task 2", PlanItemInstanceState.COMPLETED);
         assertPlanItemInstanceState(planItemInstances, "Reopen Task", PlanItemInstanceState.ACTIVE);
@@ -291,7 +291,7 @@ public class StageTest extends FlowableCmmnTestCase {
         assertPlanItemInstanceState(planItemInstances, "Hidden", PlanItemInstanceState.TERMINATED, PlanItemInstanceState.ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Close", PlanItemInstanceState.TERMINATED, PlanItemInstanceState.WAITING_FOR_REPETITION);
         assertPlanItemInstanceState(planItemInstances, "Draft", PlanItemInstanceState.COMPLETED);
-        assertPlanItemInstanceState(planItemInstances, "Close Task", PlanItemInstanceState.COMPLETED, PlanItemInstanceState.WAITING_FOR_REPETITION, PlanItemInstanceState.AVAILABLE);
+        assertPlanItemInstanceState(planItemInstances, "Close Task", PlanItemInstanceState.COMPLETED, PlanItemInstanceState.TERMINATED, PlanItemInstanceState.AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Service task 1", PlanItemInstanceState.TERMINATED, PlanItemInstanceState.COMPLETED, PlanItemInstanceState.WAITING_FOR_REPETITION);
         assertPlanItemInstanceState(planItemInstances, "Service task 2", PlanItemInstanceState.COMPLETED);
         assertPlanItemInstanceState(planItemInstances, "Reopen Task", PlanItemInstanceState.COMPLETED, PlanItemInstanceState.TERMINATED);
@@ -506,7 +506,7 @@ public class StageTest extends FlowableCmmnTestCase {
 
         planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery().includeEnded().caseInstanceId(caseInstance.getId()).list();
         assertPlanItemInstanceState(planItemInstances, "stage1", PlanItemInstanceState.TERMINATED);
-        assertPlanItemInstanceState(planItemInstances, "stage2", PlanItemInstanceState.TERMINATED, PlanItemInstanceState.WAITING_FOR_REPETITION);
+        assertPlanItemInstanceState(planItemInstances, "stage2", PlanItemInstanceState.TERMINATED, PlanItemInstanceState.TERMINATED);
 
         List<UserEventListenerInstance> userEventListenerInstances = cmmnRuntimeService.createUserEventListenerInstanceQuery().
             caseInstanceId(caseInstance.getId()).list();

--- a/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/itemcontrol/CrossBoundaryActivationWithExitEventTypeCombinationTest.testCrossBoundaryActivationWithExitEventTypeCombinationTest.cmmn
+++ b/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/itemcontrol/CrossBoundaryActivationWithExitEventTypeCombinationTest.testCrossBoundaryActivationWithExitEventTypeCombinationTest.cmmn
@@ -1,0 +1,239 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:flowable="http://flowable.org/cmmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:design="http://flowable.org/design" targetNamespace="http://flowable.org/cmmn">
+    <case id="crossBoundaryRepetitionTestCase" name="Cross boundary repetition test case" flowable:initiatorVariableName="initiator" flowable:candidateStarterGroups="flowableUser">
+        <casePlanModel id="onecaseplanmodel1" name="Case plan model" flowable:formFieldValidation="false">
+            <extensionElements>
+                <flowable:work-form-field-validation><![CDATA[false]]></flowable:work-form-field-validation>
+                <design:stencilid><![CDATA[CasePlanModel]]></design:stencilid>
+            </extensionElements>
+            <planItem id="planItem4" name="Stage A" definitionRef="expandedStage1">
+                <itemControl>
+                    <repetitionRule flowable:counterVariable="repetitionCounter"></repetitionRule>
+                </itemControl>
+                <exitCriterion id="exitCriterion2" flowable:sentryRef="sentry4" flowable:exitEventType="complete"></exitCriterion>
+            </planItem>
+            <planItem id="planItem7" name="Stage B" definitionRef="expandedStage2">
+                <itemControl>
+                    <repetitionRule flowable:counterVariable="repetitionCounter"></repetitionRule>
+                </itemControl>
+                <entryCriterion id="entryCriterion4" flowable:sentryRef="sentry6"></entryCriterion>
+                <exitCriterion id="exitCriterion1" flowable:sentryRef="sentry5" flowable:exitType="activeInstances"></exitCriterion>
+            </planItem>
+            <sentry id="sentry4" flowable:triggerMode="onEvent">
+                <extensionElements>
+                    <design:stencilid xmlns:design="http://flowable.org/design"><![CDATA[ExitCriterion]]></design:stencilid>
+                </extensionElements>
+                <planItemOnPart id="sentryOnPart2" sourceRef="planItem3">
+                    <standardEvent>occur</standardEvent>
+                </planItemOnPart>
+            </sentry>
+            <sentry id="sentry5" flowable:triggerMode="onEvent">
+                <extensionElements>
+                    <design:stencilid xmlns:design="http://flowable.org/design"><![CDATA[ExitCriterion]]></design:stencilid>
+                </extensionElements>
+                <planItemOnPart id="sentryOnPart4" sourceRef="planItem5">
+                    <standardEvent>complete</standardEvent>
+                </planItemOnPart>
+                <ifPart>
+                    <condition><![CDATA[${vars:getOrDefault('approval', null) == 'declined'}]]></condition>
+                </ifPart>
+            </sentry>
+            <sentry id="sentry6">
+                <extensionElements>
+                    <design:stencilid xmlns:design="http://flowable.org/design"><![CDATA[EntryCriterion]]></design:stencilid>
+                </extensionElements>
+                <planItemOnPart id="sentryOnPart5" sourceRef="planItem4">
+                    <standardEvent>complete</standardEvent>
+                </planItemOnPart>
+            </sentry>
+            <stage id="expandedStage1" name="Stage A" flowable:includeInStageOverview="true">
+                <extensionElements>
+                    <flowable:start-form-field-validation><![CDATA[false]]></flowable:start-form-field-validation>
+                    <design:stencilid><![CDATA[ExpandedStage]]></design:stencilid>
+                </extensionElements>
+                <planItem id="planItem1" name="Task A" definitionRef="humanTask3">
+                    <itemControl>
+                        <repetitionRule flowable:counterVariable="repetitionCounter" flowable:maxInstanceCount="1"></repetitionRule>
+                    </itemControl>
+                    <entryCriterion id="entryCriterion2" flowable:sentryRef="sentry1"></entryCriterion>
+                    <entryCriterion id="entryCriterion3" flowable:sentryRef="sentry2"></entryCriterion>
+                </planItem>
+                <planItem id="planItem2" name="Task B" definitionRef="humanTask4">
+                    <itemControl>
+                        <manualActivationRule></manualActivationRule>
+                    </itemControl>
+                </planItem>
+                <planItem id="planItem3" name="complete stage" definitionRef="userEventListener1"></planItem>
+                <sentry id="sentry1" flowable:triggerMode="onEvent">
+                    <extensionElements>
+                        <design:stencilid xmlns:design="http://flowable.org/design"><![CDATA[EntryCriterion]]></design:stencilid>
+                    </extensionElements>
+                    <planItemOnPart id="sentryOnPart1" sourceRef="planItem5">
+                        <standardEvent>complete</standardEvent>
+                    </planItemOnPart>
+                    <ifPart>
+                        <condition><![CDATA[${vars:getOrDefault('approval', null) == 'declined'}]]></condition>
+                    </ifPart>
+                </sentry>
+                <sentry id="sentry2" flowable:triggerMode="onEvent">
+                    <extensionElements>
+                        <design:stencilid xmlns:design="http://flowable.org/design"><![CDATA[EntryCriterion]]></design:stencilid>
+                    </extensionElements>
+                    <ifPart>
+                        <condition><![CDATA[${vars:getOrDefault('initialize', true)}]]></condition>
+                    </ifPart>
+                </sentry>
+                <humanTask id="humanTask3" name="Task A" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
+                    <extensionElements>
+                        <flowable:start-form-field-validation><![CDATA[false]]></flowable:start-form-field-validation>
+                        <design:stencilid><![CDATA[HumanTask]]></design:stencilid>
+                        <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+                        <flowable:planItemLifecycleListener targetState="active" expression="${planItemInstance.setVariable('initialize', false)}"></flowable:planItemLifecycleListener>
+                    </extensionElements>
+                </humanTask>
+                <humanTask id="humanTask4" name="Task B" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
+                    <extensionElements>
+                        <flowable:start-form-field-validation><![CDATA[false]]></flowable:start-form-field-validation>
+                        <design:stencilid><![CDATA[HumanTask]]></design:stencilid>
+                        <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+                    </extensionElements>
+                </humanTask>
+                <userEventListener id="userEventListener1" name="complete stage" flowable:availableCondition="${cmmn:isStageCompletable()}">
+                    <extensionElements>
+                        <flowable:start-form-field-validation><![CDATA[false]]></flowable:start-form-field-validation>
+                        <design:stencilid><![CDATA[UserEventListener]]></design:stencilid>
+                        <design:stencilsuperid><![CDATA[EventListener]]></design:stencilsuperid>
+                    </extensionElements>
+                </userEventListener>
+            </stage>
+            <stage id="expandedStage2" name="Stage B" flowable:includeInStageOverview="true">
+                <extensionElements>
+                    <flowable:start-form-field-validation><![CDATA[false]]></flowable:start-form-field-validation>
+                    <design:stencilid><![CDATA[ExpandedStage]]></design:stencilid>
+                </extensionElements>
+                <planItem id="planItem5" name="Decision" definitionRef="humanTask1"></planItem>
+                <planItem id="planItem6" name="Follow-up" definitionRef="humanTask2">
+                    <entryCriterion id="entryCriterion1" flowable:sentryRef="sentry3"></entryCriterion>
+                </planItem>
+                <sentry id="sentry3" flowable:triggerMode="onEvent">
+                    <extensionElements>
+                        <design:stencilid xmlns:design="http://flowable.org/design"><![CDATA[EntryCriterion]]></design:stencilid>
+                    </extensionElements>
+                    <planItemOnPart id="sentryOnPart3" sourceRef="planItem5">
+                        <standardEvent>complete</standardEvent>
+                    </planItemOnPart>
+                    <ifPart>
+                        <condition><![CDATA[${vars:getOrDefault('approval', null) == 'approved'}]]></condition>
+                    </ifPart>
+                </sentry>
+                <humanTask id="humanTask1" name="Decision" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
+                    <extensionElements>
+                        <flowable:start-form-field-validation><![CDATA[false]]></flowable:start-form-field-validation>
+                        <design:stencilid><![CDATA[HumanTask]]></design:stencilid>
+                        <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+                    </extensionElements>
+                </humanTask>
+                <humanTask id="humanTask2" name="Follow-up" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
+                    <extensionElements>
+                        <flowable:start-form-field-validation><![CDATA[false]]></flowable:start-form-field-validation>
+                        <design:stencilid><![CDATA[HumanTask]]></design:stencilid>
+                        <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+                    </extensionElements>
+                </humanTask>
+            </stage>
+        </casePlanModel>
+    </case>
+    <cmmndi:CMMNDI>
+        <cmmndi:CMMNDiagram id="CMMNDiagram_crossBoundaryRepetitionTestCase">
+            <cmmndi:CMMNShape id="CMMNShape_onecaseplanmodel1" cmmnElementRef="onecaseplanmodel1">
+                <dc:Bounds height="541.0" width="581.0" x="30.0" y="45.0"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_planItem4" cmmnElementRef="planItem4">
+                <dc:Bounds height="164.0" width="509.0" x="61.0" y="91.0"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_exitCriterion2" cmmnElementRef="exitCriterion2">
+                <dc:Bounds height="28.0" width="18.0" x="561.0" y="159.0"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_planItem1" cmmnElementRef="planItem1">
+                <dc:Bounds height="80.0" width="100.0" x="106.0" y="136.0"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_entryCriterion2" cmmnElementRef="entryCriterion2">
+                <dc:Bounds height="28.0" width="18.0" x="147.0" y="202.0"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_entryCriterion3" cmmnElementRef="entryCriterion3">
+                <dc:Bounds height="28.0" width="18.0" x="97.0" y="162.0"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_planItem2" cmmnElementRef="planItem2">
+                <dc:Bounds height="80.0" width="100.0" x="270.5" y="136.0"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_planItem3" cmmnElementRef="planItem3">
+                <dc:Bounds height="30.500999999999976" width="30.49799999999999" x="429.75100000000003" y="157.7495"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_planItem7" cmmnElementRef="planItem7">
+                <dc:Bounds height="170.0" width="370.0" x="61.5" y="346.0"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_entryCriterion4" cmmnElementRef="entryCriterion4">
+                <dc:Bounds height="28.0" width="18.0" x="306.5" y="332.0"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_exitCriterion1" cmmnElementRef="exitCriterion1">
+                <dc:Bounds height="28.0" width="18.0" x="52.5" y="417.0"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_planItem5" cmmnElementRef="planItem5">
+                <dc:Bounds height="80.0" width="100.0" x="106.0" y="391.0"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_planItem6" cmmnElementRef="planItem6">
+                <dc:Bounds height="80.0" width="100.0" x="270.5" y="391.0"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_entryCriterion1" cmmnElementRef="entryCriterion1">
+                <dc:Bounds height="28.0" width="18.0" x="261.5" y="417.0"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNEdge id="CMMNEdge_connector1" cmmnElementRef="planItem5" targetCMMNElementRef="entryCriterion1">
+                <di:waypoint x="205.95" y="431.0"></di:waypoint>
+                <di:waypoint x="238.25" y="431.0"></di:waypoint>
+                <di:waypoint x="238.25" y="431.0"></di:waypoint>
+                <di:waypoint x="261.5" y="431.0"></di:waypoint>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNEdge>
+            <cmmndi:CMMNEdge id="CMMNEdge_connector2" cmmnElementRef="planItem5" targetCMMNElementRef="exitCriterion1">
+                <di:waypoint x="105.99999999997857" y="431.0"></di:waypoint>
+                <di:waypoint x="82.0" y="431.0"></di:waypoint>
+                <di:waypoint x="82.0" y="431.0"></di:waypoint>
+                <di:waypoint x="70.43185364954535" y="431.0"></di:waypoint>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNEdge>
+            <cmmndi:CMMNEdge id="CMMNEdge_connector3" cmmnElementRef="planItem5" targetCMMNElementRef="entryCriterion2">
+                <di:waypoint x="156.0" y="391.0"></di:waypoint>
+                <di:waypoint x="156.0" y="303.5"></di:waypoint>
+                <di:waypoint x="156.0" y="303.5"></di:waypoint>
+                <di:waypoint x="156.0" y="229.8843958605079"></di:waypoint>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNEdge>
+            <cmmndi:CMMNEdge id="CMMNEdge_connector4" cmmnElementRef="planItem3" targetCMMNElementRef="exitCriterion2">
+                <di:waypoint x="460.696969485591" y="173.21938007846492"></di:waypoint>
+                <di:waypoint x="561.01160273644" y="173.0179484766424"></di:waypoint>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNEdge>
+            <cmmndi:CMMNEdge id="CMMNEdge_connector5" cmmnElementRef="planItem4" targetCMMNElementRef="entryCriterion4">
+                <di:waypoint x="315.5" y="254.95"></di:waypoint>
+                <di:waypoint x="315.5" y="300.5"></di:waypoint>
+                <di:waypoint x="315.5" y="300.5"></di:waypoint>
+                <di:waypoint x="315.5" y="332.0"></di:waypoint>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNEdge>
+        </cmmndi:CMMNDiagram>
+    </cmmndi:CMMNDI>
+</definitions>

--- a/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/itemcontrol/OrphanEventListenerRemovalCombinedWithRepetitionTest.testRemovalOfOrphanedEventListeners.cmmn
+++ b/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/itemcontrol/OrphanEventListenerRemovalCombinedWithRepetitionTest.testRemovalOfOrphanedEventListeners.cmmn
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:flowable="http://flowable.org/cmmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:design="http://flowable.org/design" targetNamespace="http://flowable.org/cmmn">
+    <case id="nestedRepetitionPlanItemsWithOrphanedEventListeners" name="Nested repetition plan items with orphaned event listeners" flowable:initiatorVariableName="initiator" flowable:candidateStarterGroups="flowableUser">
+        <casePlanModel id="onecaseplanmodel1" name="Case plan model" flowable:formFieldValidation="false">
+            <extensionElements>
+                <flowable:work-form-field-validation><![CDATA[false]]></flowable:work-form-field-validation>
+                <design:stencilid><![CDATA[CasePlanModel]]></design:stencilid>
+            </extensionElements>
+            <planItem id="planItem3" name="Stage A" definitionRef="expandedStage1">
+                <entryCriterion id="entryCriterion2" flowable:sentryRef="sentry4"></entryCriterion>
+                <exitCriterion id="exitCriterion1" flowable:sentryRef="sentry3"></exitCriterion>
+            </planItem>
+            <planItem id="planItem4" name="start Task A 1" definitionRef="userEventListener1"></planItem>
+            <planItem id="planItem5" name="kill Stage A" definitionRef="userEventListener2"></planItem>
+            <planItem id="planItem6" name="start Task A 2" definitionRef="userEventListener3"></planItem>
+            <planItem id="planItem7" name="start Stage A" definitionRef="userEventListener4"></planItem>
+            <sentry id="sentry4">
+                <extensionElements>
+                    <design:stencilid xmlns:design="http://flowable.org/design"><![CDATA[EntryCriterion]]></design:stencilid>
+                </extensionElements>
+                <planItemOnPart id="sentryOnPart3" sourceRef="planItem7">
+                    <standardEvent>occur</standardEvent>
+                </planItemOnPart>
+            </sentry>
+            <sentry id="sentry3">
+                <extensionElements>
+                    <design:stencilid xmlns:design="http://flowable.org/design"><![CDATA[ExitCriterion]]></design:stencilid>
+                </extensionElements>
+                <planItemOnPart id="sentryOnPart4" sourceRef="planItem5">
+                    <standardEvent>occur</standardEvent>
+                </planItemOnPart>
+            </sentry>
+            <stage id="expandedStage1" name="Stage A" flowable:includeInStageOverview="true">
+                <extensionElements>
+                    <flowable:start-form-field-validation><![CDATA[false]]></flowable:start-form-field-validation>
+                    <design:stencilid><![CDATA[ExpandedStage]]></design:stencilid>
+                </extensionElements>
+                <planItem id="planItem2" name="Stage B" definitionRef="expandedStage2">
+                    <itemControl>
+                        <repetitionRule flowable:counterVariable="repetitionCounter"></repetitionRule>
+                    </itemControl>
+                    <entryCriterion id="entryCriterion3" flowable:sentryRef="sentry2"></entryCriterion>
+                </planItem>
+                <sentry id="sentry2">
+                    <extensionElements>
+                        <design:stencilid xmlns:design="http://flowable.org/design"><![CDATA[EntryCriterion]]></design:stencilid>
+                    </extensionElements>
+                    <ifPart>
+                        <condition><![CDATA[${false}]]></condition>
+                    </ifPart>
+                </sentry>
+                <stage id="expandedStage2" name="Stage B" flowable:includeInStageOverview="true">
+                    <extensionElements>
+                        <flowable:start-form-field-validation><![CDATA[false]]></flowable:start-form-field-validation>
+                        <design:stencilid><![CDATA[ExpandedStage]]></design:stencilid>
+                    </extensionElements>
+                    <planItem id="planItem1" name="Task A" definitionRef="humanTask1">
+                        <itemControl>
+                            <repetitionRule flowable:counterVariable="repetitionCounter"></repetitionRule>
+                        </itemControl>
+                        <entryCriterion id="entryCriterion1" flowable:sentryRef="sentry1"></entryCriterion>
+                    </planItem>
+                    <sentry id="sentry1">
+                        <extensionElements>
+                            <design:stencilid xmlns:design="http://flowable.org/design"><![CDATA[EntryCriterion]]></design:stencilid>
+                        </extensionElements>
+                        <planItemOnPart id="sentryOnPart1" sourceRef="planItem4">
+                            <standardEvent>occur</standardEvent>
+                        </planItemOnPart>
+                        <planItemOnPart id="sentryOnPart2" sourceRef="planItem6">
+                            <standardEvent>occur</standardEvent>
+                        </planItemOnPart>
+                    </sentry>
+                    <humanTask id="humanTask1" name="Task A" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
+                        <extensionElements>
+                            <flowable:start-form-field-validation><![CDATA[false]]></flowable:start-form-field-validation>
+                            <design:stencilid><![CDATA[HumanTask]]></design:stencilid>
+                            <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+                        </extensionElements>
+                    </humanTask>
+                </stage>
+            </stage>
+            <userEventListener id="userEventListener1" name="start Task A 1">
+                <extensionElements>
+                    <flowable:start-form-field-validation><![CDATA[false]]></flowable:start-form-field-validation>
+                    <design:stencilid><![CDATA[UserEventListener]]></design:stencilid>
+                    <design:stencilsuperid><![CDATA[EventListener]]></design:stencilsuperid>
+                </extensionElements>
+            </userEventListener>
+            <userEventListener id="userEventListener2" name="kill Stage A">
+                <extensionElements>
+                    <flowable:start-form-field-validation><![CDATA[false]]></flowable:start-form-field-validation>
+                    <design:stencilid><![CDATA[UserEventListener]]></design:stencilid>
+                    <design:stencilsuperid><![CDATA[EventListener]]></design:stencilsuperid>
+                </extensionElements>
+            </userEventListener>
+            <userEventListener id="userEventListener3" name="start Task A 2">
+                <extensionElements>
+                    <flowable:start-form-field-validation><![CDATA[false]]></flowable:start-form-field-validation>
+                    <design:stencilid><![CDATA[UserEventListener]]></design:stencilid>
+                    <design:stencilsuperid><![CDATA[EventListener]]></design:stencilsuperid>
+                </extensionElements>
+            </userEventListener>
+            <userEventListener id="userEventListener4" name="start Stage A">
+                <extensionElements>
+                    <flowable:start-form-field-validation><![CDATA[false]]></flowable:start-form-field-validation>
+                    <design:stencilid><![CDATA[UserEventListener]]></design:stencilid>
+                    <design:stencilsuperid><![CDATA[EventListener]]></design:stencilsuperid>
+                </extensionElements>
+            </userEventListener>
+        </casePlanModel>
+    </case>
+    <cmmndi:CMMNDI>
+        <cmmndi:CMMNDiagram id="CMMNDiagram_nestedRepetitionPlanItemsWithOrphanedEventListeners">
+            <cmmndi:CMMNShape id="CMMNShape_onecaseplanmodel1" cmmnElementRef="onecaseplanmodel1">
+                <dc:Bounds height="403.0" width="581.0" x="30.0" y="45.0"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_planItem3" cmmnElementRef="planItem3">
+                <dc:Bounds height="254.0" width="419.0" x="76.0" y="76.0"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_entryCriterion2" cmmnElementRef="entryCriterion2">
+                <dc:Bounds height="28.0" width="18.0" x="356.0" y="316.0"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_exitCriterion1" cmmnElementRef="exitCriterion1">
+                <dc:Bounds height="28.0" width="18.0" x="486.0" y="192.0"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_planItem2" cmmnElementRef="planItem2">
+                <dc:Bounds height="170.0" width="370.0" x="106.0" y="118.5"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_entryCriterion3" cmmnElementRef="entryCriterion3">
+                <dc:Bounds height="28.0" width="18.0" x="97.0" y="188.5"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_planItem1" cmmnElementRef="planItem1">
+                <dc:Bounds height="80.0" width="100.0" x="166.0" y="166.0"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_entryCriterion1" cmmnElementRef="entryCriterion1">
+                <dc:Bounds height="28.0" width="18.0" x="210.0" y="232.0"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_planItem4" cmmnElementRef="planItem4">
+                <dc:Bounds height="30.500999999999976" width="30.49799999999999" x="94.751" y="379.7495"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_planItem5" cmmnElementRef="planItem5">
+                <dc:Bounds height="30.500999999999976" width="30.498000000000047" x="544.751" y="379.7495"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_planItem6" cmmnElementRef="planItem6">
+                <dc:Bounds height="30.500999999999976" width="30.49799999999999" x="203.751" y="379.7495"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_planItem7" cmmnElementRef="planItem7">
+                <dc:Bounds height="30.500999999999976" width="30.49799999999999" x="349.75100000000003" y="379.7495"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNEdge id="CMMNEdge_connector1" cmmnElementRef="planItem4" targetCMMNElementRef="entryCriterion1">
+                <di:waypoint x="110.249" y="379.7495"></di:waypoint>
+                <di:waypoint x="110.249" y="305.0"></di:waypoint>
+                <di:waypoint x="212.32723029889246" y="249.60187874935556"></di:waypoint>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNEdge>
+            <cmmndi:CMMNEdge id="CMMNEdge_connector2" cmmnElementRef="planItem5" targetCMMNElementRef="exitCriterion1">
+                <di:waypoint x="560.249" y="379.7495"></di:waypoint>
+                <di:waypoint x="560.249" y="206.0"></di:waypoint>
+                <di:waypoint x="503.9222864404842" y="206.0"></di:waypoint>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNEdge>
+            <cmmndi:CMMNEdge id="CMMNEdge_connector3" cmmnElementRef="planItem6" targetCMMNElementRef="entryCriterion1">
+                <di:waypoint x="219.2224053186827" y="379.74951376448945"></di:waypoint>
+                <di:waypoint x="219.0232129267271" y="259.8433919321281"></di:waypoint>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNEdge>
+            <cmmndi:CMMNEdge id="CMMNEdge_connector4" cmmnElementRef="planItem7" targetCMMNElementRef="entryCriterion2">
+                <di:waypoint x="365.1893867207212" y="379.7495721669004"></di:waypoint>
+                <di:waypoint x="365.05291931386097" y="343.8066237404874"></di:waypoint>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNEdge>
+        </cmmndi:CMMNDiagram>
+    </cmmndi:CMMNDI>
+</definitions>

--- a/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/itemcontrol/OrphanEventListenerRemovalCombinedWithRepetitionTwoTest.testRemovalOfOrphanedEventListeners.cmmn
+++ b/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/itemcontrol/OrphanEventListenerRemovalCombinedWithRepetitionTwoTest.testRemovalOfOrphanedEventListeners.cmmn
@@ -1,0 +1,223 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:flowable="http://flowable.org/cmmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:design="http://flowable.org/design" targetNamespace="http://flowable.org/cmmn">
+    <case id="nestedRepetitionPlanItemsWithOrphanedEventListenersTwo" name="Nested repetition plan items with orphaned event listeners two" flowable:initiatorVariableName="initiator" flowable:candidateStarterGroups="flowableUser">
+        <casePlanModel id="onecaseplanmodel1" name="Case plan model" flowable:formFieldValidation="false">
+            <extensionElements>
+                <flowable:work-form-field-validation><![CDATA[false]]></flowable:work-form-field-validation>
+                <design:stencilid><![CDATA[CasePlanModel]]></design:stencilid>
+            </extensionElements>
+            <planItem id="planItem3" name="Stage A" definitionRef="expandedStage1">
+                <entryCriterion id="entryCriterion2" flowable:sentryRef="sentry5"></entryCriterion>
+                <exitCriterion id="exitCriterion1" flowable:sentryRef="sentry4"></exitCriterion>
+            </planItem>
+            <planItem id="planItem4" name="start Task A 1" definitionRef="userEventListener1"></planItem>
+            <planItem id="planItem5" name="kill Stage A" definitionRef="userEventListener2"></planItem>
+            <planItem id="planItem6" name="start Task A 2" definitionRef="userEventListener3"></planItem>
+            <planItem id="planItem7" name="start Stage A" definitionRef="userEventListener4"></planItem>
+            <planItem id="planItem8" name="kill Task A" definitionRef="userEventListener5">
+                <itemControl>
+                    <extensionElements>
+                        <flowable:parentCompletionRule type="ignore"></flowable:parentCompletionRule>
+                    </extensionElements>
+                </itemControl>
+            </planItem>
+            <sentry id="sentry5">
+                <extensionElements>
+                    <design:stencilid xmlns:design="http://flowable.org/design"><![CDATA[EntryCriterion]]></design:stencilid>
+                </extensionElements>
+                <planItemOnPart id="sentryOnPart4" sourceRef="planItem7">
+                    <standardEvent>occur</standardEvent>
+                </planItemOnPart>
+            </sentry>
+            <sentry id="sentry4">
+                <extensionElements>
+                    <design:stencilid xmlns:design="http://flowable.org/design"><![CDATA[ExitCriterion]]></design:stencilid>
+                </extensionElements>
+                <planItemOnPart id="sentryOnPart5" sourceRef="planItem5">
+                    <standardEvent>occur</standardEvent>
+                </planItemOnPart>
+            </sentry>
+            <stage id="expandedStage1" name="Stage A" flowable:includeInStageOverview="true">
+                <extensionElements>
+                    <flowable:start-form-field-validation><![CDATA[false]]></flowable:start-form-field-validation>
+                    <design:stencilid><![CDATA[ExpandedStage]]></design:stencilid>
+                </extensionElements>
+                <planItem id="planItem2" name="Stage B" definitionRef="expandedStage2">
+                    <itemControl>
+                        <repetitionRule flowable:counterVariable="repetitionCounter"></repetitionRule>
+                    </itemControl>
+                    <entryCriterion id="entryCriterion3" flowable:sentryRef="sentry3"></entryCriterion>
+                </planItem>
+                <sentry id="sentry3">
+                    <extensionElements>
+                        <design:stencilid xmlns:design="http://flowable.org/design"><![CDATA[EntryCriterion]]></design:stencilid>
+                    </extensionElements>
+                    <ifPart>
+                        <condition><![CDATA[${false}]]></condition>
+                    </ifPart>
+                </sentry>
+                <stage id="expandedStage2" name="Stage B" flowable:includeInStageOverview="true">
+                    <extensionElements>
+                        <flowable:start-form-field-validation><![CDATA[false]]></flowable:start-form-field-validation>
+                        <design:stencilid><![CDATA[ExpandedStage]]></design:stencilid>
+                    </extensionElements>
+                    <planItem id="planItem1" name="Task A" definitionRef="humanTask1">
+                        <itemControl>
+                            <repetitionRule flowable:counterVariable="repetitionCounter"></repetitionRule>
+                        </itemControl>
+                        <entryCriterion id="entryCriterion1" flowable:sentryRef="sentry1"></entryCriterion>
+                        <exitCriterion id="exitCriterion2" flowable:sentryRef="sentry2"></exitCriterion>
+                    </planItem>
+                    <sentry id="sentry1">
+                        <extensionElements>
+                            <design:stencilid xmlns:design="http://flowable.org/design"><![CDATA[EntryCriterion]]></design:stencilid>
+                        </extensionElements>
+                        <planItemOnPart id="sentryOnPart1" sourceRef="planItem4">
+                            <standardEvent>occur</standardEvent>
+                        </planItemOnPart>
+                        <planItemOnPart id="sentryOnPart2" sourceRef="planItem6">
+                            <standardEvent>occur</standardEvent>
+                        </planItemOnPart>
+                    </sentry>
+                    <sentry id="sentry2">
+                        <extensionElements>
+                            <design:stencilid xmlns:design="http://flowable.org/design"><![CDATA[ExitCriterion]]></design:stencilid>
+                        </extensionElements>
+                        <planItemOnPart id="sentryOnPart3" sourceRef="planItem8">
+                            <standardEvent>occur</standardEvent>
+                        </planItemOnPart>
+                    </sentry>
+                    <humanTask id="humanTask1" name="Task A" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
+                        <extensionElements>
+                            <flowable:start-form-field-validation><![CDATA[false]]></flowable:start-form-field-validation>
+                            <design:stencilid><![CDATA[HumanTask]]></design:stencilid>
+                            <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+                        </extensionElements>
+                    </humanTask>
+                </stage>
+            </stage>
+            <userEventListener id="userEventListener1" name="start Task A 1">
+                <extensionElements>
+                    <flowable:start-form-field-validation><![CDATA[false]]></flowable:start-form-field-validation>
+                    <design:stencilid><![CDATA[UserEventListener]]></design:stencilid>
+                    <design:stencilsuperid><![CDATA[EventListener]]></design:stencilsuperid>
+                </extensionElements>
+            </userEventListener>
+            <userEventListener id="userEventListener2" name="kill Stage A">
+                <extensionElements>
+                    <flowable:start-form-field-validation><![CDATA[false]]></flowable:start-form-field-validation>
+                    <design:stencilid><![CDATA[UserEventListener]]></design:stencilid>
+                    <design:stencilsuperid><![CDATA[EventListener]]></design:stencilsuperid>
+                </extensionElements>
+            </userEventListener>
+            <userEventListener id="userEventListener3" name="start Task A 2">
+                <extensionElements>
+                    <flowable:start-form-field-validation><![CDATA[false]]></flowable:start-form-field-validation>
+                    <design:stencilid><![CDATA[UserEventListener]]></design:stencilid>
+                    <design:stencilsuperid><![CDATA[EventListener]]></design:stencilsuperid>
+                </extensionElements>
+            </userEventListener>
+            <userEventListener id="userEventListener4" name="start Stage A">
+                <extensionElements>
+                    <flowable:start-form-field-validation><![CDATA[false]]></flowable:start-form-field-validation>
+                    <design:stencilid><![CDATA[UserEventListener]]></design:stencilid>
+                    <design:stencilsuperid><![CDATA[EventListener]]></design:stencilsuperid>
+                </extensionElements>
+            </userEventListener>
+            <userEventListener id="userEventListener5" name="kill Task A">
+                <extensionElements>
+                    <flowable:start-form-field-validation><![CDATA[false]]></flowable:start-form-field-validation>
+                    <design:stencilid><![CDATA[UserEventListener]]></design:stencilid>
+                    <design:stencilsuperid><![CDATA[EventListener]]></design:stencilsuperid>
+                </extensionElements>
+            </userEventListener>
+        </casePlanModel>
+    </case>
+    <cmmndi:CMMNDI>
+        <cmmndi:CMMNDiagram id="CMMNDiagram_nestedRepetitionPlanItemsWithOrphanedEventListenersTwo">
+            <cmmndi:CMMNShape id="CMMNShape_onecaseplanmodel1" cmmnElementRef="onecaseplanmodel1">
+                <dc:Bounds height="403.0" width="581.0" x="30.0" y="45.0"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_planItem3" cmmnElementRef="planItem3">
+                <dc:Bounds height="254.0" width="419.0" x="76.0" y="76.0"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_entryCriterion2" cmmnElementRef="entryCriterion2">
+                <dc:Bounds height="28.0" width="18.0" x="356.0" y="316.0"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_exitCriterion1" cmmnElementRef="exitCriterion1">
+                <dc:Bounds height="28.0" width="18.0" x="486.0" y="270.0"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_planItem2" cmmnElementRef="planItem2">
+                <dc:Bounds height="170.0" width="370.0" x="106.0" y="118.5"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_entryCriterion3" cmmnElementRef="entryCriterion3">
+                <dc:Bounds height="28.0" width="18.0" x="97.0" y="188.5"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_planItem1" cmmnElementRef="planItem1">
+                <dc:Bounds height="80.0" width="100.0" x="166.0" y="166.0"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_entryCriterion1" cmmnElementRef="entryCriterion1">
+                <dc:Bounds height="28.0" width="18.0" x="210.0" y="232.0"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_exitCriterion2" cmmnElementRef="exitCriterion2">
+                <dc:Bounds height="28.0" width="18.0" x="257.0" y="192.0"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_planItem4" cmmnElementRef="planItem4">
+                <dc:Bounds height="30.500999999999976" width="30.49799999999999" x="94.751" y="379.7495"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_planItem5" cmmnElementRef="planItem5">
+                <dc:Bounds height="30.500999999999976" width="30.498000000000047" x="544.751" y="379.7495"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_planItem6" cmmnElementRef="planItem6">
+                <dc:Bounds height="30.500999999999976" width="30.49799999999999" x="203.751" y="379.7495"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_planItem7" cmmnElementRef="planItem7">
+                <dc:Bounds height="30.500999999999976" width="30.49799999999999" x="349.75100000000003" y="379.7495"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape id="CMMNShape_planItem8" cmmnElementRef="planItem8">
+                <dc:Bounds height="30.500999999999976" width="30.498000000000047" x="544.751" y="190.7495"></dc:Bounds>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNEdge id="CMMNEdge_connector1" cmmnElementRef="planItem4" targetCMMNElementRef="entryCriterion1">
+                <di:waypoint x="110.249" y="379.7495"></di:waypoint>
+                <di:waypoint x="110.249" y="305.0"></di:waypoint>
+                <di:waypoint x="212.32723029889246" y="249.60187874935556"></di:waypoint>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNEdge>
+            <cmmndi:CMMNEdge id="CMMNEdge_connector2" cmmnElementRef="planItem5" targetCMMNElementRef="exitCriterion1">
+                <di:waypoint x="560.249" y="379.7495"></di:waypoint>
+                <di:waypoint x="560.249" y="284.0"></di:waypoint>
+                <di:waypoint x="503.9222864404842" y="284.0"></di:waypoint>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNEdge>
+            <cmmndi:CMMNEdge id="CMMNEdge_connector3" cmmnElementRef="planItem6" targetCMMNElementRef="entryCriterion1">
+                <di:waypoint x="219.2224053186827" y="379.74951376448945"></di:waypoint>
+                <di:waypoint x="219.0232129267271" y="259.8433919321281"></di:waypoint>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNEdge>
+            <cmmndi:CMMNEdge id="CMMNEdge_connector4" cmmnElementRef="planItem7" targetCMMNElementRef="entryCriterion2">
+                <di:waypoint x="365.1893867207212" y="379.7495721669004"></di:waypoint>
+                <di:waypoint x="365.05291931386097" y="343.8066237404874"></di:waypoint>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNEdge>
+            <cmmndi:CMMNEdge id="CMMNEdge_connector5" cmmnElementRef="planItem8" targetCMMNElementRef="exitCriterion2">
+                <di:waypoint x="544.7510035207101" y="206.23730625045403"></di:waypoint>
+                <di:waypoint x="274.91404541273107" y="206.0076151529157"></di:waypoint>
+                <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+            </cmmndi:CMMNEdge>
+        </cmmndi:CMMNDiagram>
+    </cmmndi:CMMNDI>
+</definitions>


### PR DESCRIPTION
Also terminate orphaned plan items in waiting-for-repetition state, if their parent gets terminated, but adapt the search for orphaned event listeners, if such plan items have repetition, as they might get activated later on again.

#### Check List:
* Unit tests: YES
* Documentation: NA
