### PR TITLE
add support for custom ProcessDefinitionInfo cache

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -268,6 +268,7 @@ import org.flowable.engine.impl.migration.ProcessInstanceMigrationManagerImpl;
 import org.flowable.engine.impl.persistence.deploy.DeploymentManager;
 import org.flowable.engine.impl.persistence.deploy.ProcessDefinitionCacheEntry;
 import org.flowable.engine.impl.persistence.deploy.ProcessDefinitionInfoCache;
+import org.flowable.engine.impl.persistence.deploy.ProcessDefinitionInfoCacheObject;
 import org.flowable.engine.impl.persistence.entity.ActivityInstanceEntityManager;
 import org.flowable.engine.impl.persistence.entity.ActivityInstanceEntityManagerImpl;
 import org.flowable.engine.impl.persistence.entity.AttachmentEntityManager;
@@ -531,7 +532,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     protected DeploymentCache<ProcessDefinitionCacheEntry> processDefinitionCache;
 
     protected int processDefinitionInfoCacheLimit = -1; // By default, no limit
-    protected ProcessDefinitionInfoCache processDefinitionInfoCache;
+    protected DeploymentCache<ProcessDefinitionInfoCacheObject> processDefinitionInfoCache;
 
     protected int knowledgeBaseCacheLimit = -1;
     protected DeploymentCache<Object> knowledgeBaseCache;
@@ -3475,6 +3476,15 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     public ProcessEngineConfigurationImpl setProcessDefinitionCache(DeploymentCache<ProcessDefinitionCacheEntry> processDefinitionCache) {
         this.processDefinitionCache = processDefinitionCache;
         return this;
+    }
+
+    public ProcessEngineConfigurationImpl setProcessDefinitionInfoCache(DeploymentCache<ProcessDefinitionInfoCacheObject> processDefinitionInfoCache){
+        this.processDefinitionInfoCache = processDefinitionInfoCache;
+        return this;
+    }
+
+    public DeploymentCache<ProcessDefinitionInfoCacheObject> getProcessDefinitionInfoCache() {
+        return processDefinitionInfoCache;
     }
 
     public int getKnowledgeBaseCacheLimit() {

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/deploy/DeploymentManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/deploy/DeploymentManager.java
@@ -44,7 +44,7 @@ import org.flowable.engine.repository.ProcessDefinition;
 public class DeploymentManager {
 
     protected DeploymentCache<ProcessDefinitionCacheEntry> processDefinitionCache;
-    protected ProcessDefinitionInfoCache processDefinitionInfoCache;
+    protected DeploymentCache<ProcessDefinitionInfoCacheObject> processDefinitionInfoCache;
     protected DeploymentCache<Object> appResourceCache;
     protected DeploymentCache<Object> knowledgeBaseCache; // Needs to be object to avoid an import to Drools in this core class
     protected List<EngineDeployer> deployers;
@@ -237,11 +237,11 @@ public class DeploymentManager {
         this.processDefinitionCache = processDefinitionCache;
     }
 
-    public ProcessDefinitionInfoCache getProcessDefinitionInfoCache() {
+    public DeploymentCache<ProcessDefinitionInfoCacheObject> getProcessDefinitionInfoCache() {
         return processDefinitionInfoCache;
     }
 
-    public void setProcessDefinitionInfoCache(ProcessDefinitionInfoCache processDefinitionInfoCache) {
+    public void setProcessDefinitionInfoCache(DeploymentCache<ProcessDefinitionInfoCacheObject> processDefinitionInfoCache) {
         this.processDefinitionInfoCache = processDefinitionInfoCache;
     }
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/deploy/ProcessDefinitionInfoCache.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/deploy/ProcessDefinitionInfoCache.java
@@ -22,6 +22,7 @@ import org.flowable.common.engine.impl.context.Context;
 import org.flowable.common.engine.impl.interceptor.Command;
 import org.flowable.common.engine.impl.interceptor.CommandContext;
 import org.flowable.common.engine.impl.interceptor.CommandExecutor;
+import org.flowable.common.engine.impl.persistence.deploy.DeploymentCache;
 import org.flowable.engine.impl.persistence.entity.ProcessDefinitionInfoEntity;
 import org.flowable.engine.impl.persistence.entity.ProcessDefinitionInfoEntityManager;
 import org.flowable.engine.impl.util.CommandContextUtil;
@@ -36,7 +37,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
  * 
  * @author Tijs Rademakers
  */
-public class ProcessDefinitionInfoCache {
+public class ProcessDefinitionInfoCache implements DeploymentCache<ProcessDefinitionInfoCacheObject> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ProcessDefinitionInfoCache.class);
 
@@ -87,6 +88,11 @@ public class ProcessDefinitionInfoCache {
         }
 
         return infoCacheObject;
+    }
+
+    @Override
+    public boolean contains(String id) {
+        return cache.containsKey(id);
     }
 
     public void add(String id, ProcessDefinitionInfoCacheObject obj) {

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/deploy/ProcessDefinitionInfoCacheObject.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/deploy/ProcessDefinitionInfoCacheObject.java
@@ -14,10 +14,14 @@ package org.flowable.engine.impl.persistence.deploy;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import java.io.Serializable;
+
 /**
  * @author Tijs Rademakers
  */
-public class ProcessDefinitionInfoCacheObject {
+public class ProcessDefinitionInfoCacheObject implements Serializable {
+
+    private static final long serialVersionUID = -5250476147064451489L;
 
     protected String id;
     protected int revision;

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/deploy/CustomProcessDefinitionInfoCache.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/deploy/CustomProcessDefinitionInfoCache.java
@@ -1,0 +1,42 @@
+package org.flowable.standalone.deploy;
+
+import org.flowable.common.engine.impl.persistence.deploy.DeploymentCache;
+import org.flowable.engine.impl.persistence.deploy.ProcessDefinitionInfoCacheObject;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class CustomProcessDefinitionInfoCache implements DeploymentCache<ProcessDefinitionInfoCacheObject> {
+
+    private final Map<String, ProcessDefinitionInfoCacheObject> cache = new HashMap<>();
+
+    @Override
+    public ProcessDefinitionInfoCacheObject get(String id) {
+        return cache.get(id);
+    }
+
+    @Override
+    public boolean contains(String id) {
+        return cache.containsKey(id);
+    }
+
+    @Override
+    public void add(String id, ProcessDefinitionInfoCacheObject object) {
+        cache.put(id, object);
+    }
+
+    @Override
+    public void remove(String id) {
+        cache.remove(id);
+    }
+
+    @Override
+    public void clear() {
+        cache.clear();
+    }
+
+    //for testing purpose
+    public int size(){
+        return cache.size();
+    }
+}

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/deploy/CustomProcessDefinitionInfoCache.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/deploy/CustomProcessDefinitionInfoCache.java
@@ -1,3 +1,15 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.flowable.standalone.deploy;
 
 import org.flowable.common.engine.impl.persistence.deploy.DeploymentCache;

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/deploy/CustomProcessDefinitionInfoCacheTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/deploy/CustomProcessDefinitionInfoCacheTest.java
@@ -1,0 +1,27 @@
+package org.flowable.standalone.deploy;
+
+import org.flowable.engine.impl.test.ResourceFlowableTestCase;
+import org.flowable.engine.repository.Deployment;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+public class CustomProcessDefinitionInfoCacheTest extends ResourceFlowableTestCase {
+    public CustomProcessDefinitionInfoCacheTest() {
+        super("org/flowable/standalone/deploy/custom.procedefinitioninfo.cache.test.flowable.cfg.xml");
+    }
+
+    @Test
+    public void testCustomProcessDefinitionInfoCache() throws IOException {
+        final CustomProcessDefinitionInfoCache processDefinitionInfoCache =
+                (CustomProcessDefinitionInfoCache)processEngineConfiguration.getProcessDefinitionInfoCache();
+        assertEquals(0, processDefinitionInfoCache.size());
+        String processDefinitionTemplate = DeploymentCacheTestUtil.readTemplateFile("/org/flowable/standalone/deploy/processDefinitionInfoCacheTest.bpmn20.xml");
+        repositoryService.createDeployment().addString("Process 1.bpmn20.xml", processDefinitionTemplate).deploy();
+        assertTrue(processDefinitionInfoCache.size() > 0);
+        // Cleanup
+        for (Deployment deployment : repositoryService.createDeploymentQuery().list()) {
+            repositoryService.deleteDeployment(deployment.getId(), true);
+        }
+    }
+}

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/deploy/CustomProcessDefinitionInfoCacheTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/deploy/CustomProcessDefinitionInfoCacheTest.java
@@ -1,3 +1,15 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.flowable.standalone.deploy;
 
 import org.flowable.engine.impl.test.ResourceFlowableTestCase;

--- a/modules/flowable-engine/src/test/resources/org/flowable/standalone/deploy/custom.procedefinitioninfo.cache.test.flowable.cfg.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/standalone/deploy/custom.procedefinitioninfo.cache.test.flowable.cfg.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans   http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <bean id="processEngineConfiguration" class="org.flowable.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration">
+
+        <property name="jdbcUrl" value="${jdbc.url:jdbc:h2:mem:flowable;DB_CLOSE_DELAY=1000;MVCC=TRUE}" />
+        <property name="jdbcDriver" value="${jdbc.driver:org.h2.Driver}" />
+        <property name="jdbcUsername" value="${jdbc.username:sa}" />
+        <property name="jdbcPassword" value="${jdbc.password:}" />
+
+        <property name="databaseSchemaUpdate" value="true" />
+
+        <property name="processDefinitionInfoCache">
+            <bean class="org.flowable.standalone.deploy.CustomProcessDefinitionInfoCache" />
+        </property>
+        <property name="enableProcessDefinitionInfoCache" value="true"/>
+
+    </bean>
+
+</beans>

--- a/modules/flowable-engine/src/test/resources/org/flowable/standalone/deploy/processDefinitionInfoCacheTest.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/standalone/deploy/processDefinitionInfoCacheTest.bpmn20.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions
+        xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+        xmlns:activiti="http://activiti.org/bpmn"
+        targetNamespace="Examples">
+
+    <process id="procDefInfoCache" name="Process Definition Info Cache" isExecutable="true">
+        <startEvent id="theStart" />
+        <sequenceFlow id="flow1" sourceRef="theStart" targetRef="theTask" />
+        <userTask id="theTask" name="my task" />
+        <sequenceFlow id="flow2" sourceRef="theTask" targetRef="theEnd" />
+        <endEvent id="theEnd" />
+    </process>
+
+</definitions>


### PR DESCRIPTION
Support for custom ProcessDefinitionInfoCache very much like ProcessDefinitionCache
so that it can be leveraged in distributed environment as discussed [here](https://forum.flowable.org/t/distributed-cache-for-processdefinitioninfocache/2419) 

#### Check List:
* Unit tests: YES 
* Documentation: NO
