### PR TITLE
Added support for BusinessKeyLike to (Historic)ProcessInstanceQuery

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/history/HistoricProcessInstanceQuery.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/history/HistoricProcessInstanceQuery.java
@@ -76,6 +76,11 @@ public interface HistoricProcessInstanceQuery extends Query<HistoricProcessInsta
     HistoricProcessInstanceQuery processInstanceBusinessKey(String processInstanceBusinessKey);
 
     /**
+     * Only select historic process instances with a business key like the given value.
+     */
+    HistoricProcessInstanceQuery processInstanceBusinessKeyLike(String businessKeyLike);
+
+    /**
      * Only select historic process instances that are defined by a process definition with the given deployment identifier.
      */
     HistoricProcessInstanceQuery deploymentId(String deploymentId);

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/ExecutionQueryImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/ExecutionQueryImpl.java
@@ -77,6 +77,7 @@ public class ExecutionQueryImpl extends AbstractVariableQueryImpl<ExecutionQuery
     protected boolean excludeSubprocesses;
     protected SuspensionState suspensionState;
     protected String businessKey;
+    protected String businessKeyLike;
     protected boolean includeChildExecutionsWithBusinessKeyQuery;
     protected boolean isActive;
     protected String involvedUser;
@@ -946,6 +947,10 @@ public class ExecutionQueryImpl extends AbstractVariableQueryImpl<ExecutionQuery
 
     public String getBusinessKey() {
         return businessKey;
+    }
+    
+    public String getBusinessKeyLike() {
+        return businessKeyLike;
     }
 
     public String getExecutionId() {

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/HistoricProcessInstanceQueryImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/HistoricProcessInstanceQueryImpl.java
@@ -59,6 +59,7 @@ public class HistoricProcessInstanceQueryImpl extends AbstractVariableQueryImpl<
     protected String processInstanceId;
     protected String processDefinitionId;
     protected String businessKey;
+    protected String businessKeyLike;
     protected String deploymentId;
     protected List<String> deploymentIds;
     protected boolean finished;
@@ -202,6 +203,16 @@ public class HistoricProcessInstanceQueryImpl extends AbstractVariableQueryImpl<
             this.currentOrQueryObject.businessKey = businessKey;
         } else {
             this.businessKey = businessKey;
+        }
+        return this;
+    }
+
+    @Override
+    public HistoricProcessInstanceQuery processInstanceBusinessKeyLike(String businessKeyLike) {
+        if (inOrStatement) {
+            this.currentOrQueryObject.businessKeyLike = businessKeyLike;
+        } else {
+            this.businessKeyLike = businessKeyLike;
         }
         return this;
     }
@@ -829,6 +840,10 @@ public class HistoricProcessInstanceQueryImpl extends AbstractVariableQueryImpl<
 
     public String getBusinessKey() {
         return businessKey;
+    }
+
+    public String getBusinessKeyLike() {
+        return businessKeyLike;
     }
 
     public boolean isOpen() {

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/ProcessInstanceQueryImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/ProcessInstanceQueryImpl.java
@@ -52,6 +52,7 @@ public class ProcessInstanceQueryImpl extends AbstractVariableQueryImpl<ProcessI
     private static final long serialVersionUID = 1L;
     protected String executionId;
     protected String businessKey;
+    protected String businessKeyLike;
     protected boolean includeChildExecutionsWithBusinessKeyQuery;
     protected String processDefinitionId;
     protected Set<String> processDefinitionIds;
@@ -168,6 +169,16 @@ public class ProcessInstanceQueryImpl extends AbstractVariableQueryImpl<ProcessI
 
         this.businessKey = businessKey;
         this.processDefinitionKey = processDefinitionKey;
+        return this;
+    }
+
+    @Override
+    public ProcessInstanceQuery processInstanceBusinessKeyLike(String businessKeyLike) {
+        if (inOrStatement) {
+            this.currentOrQueryObject.businessKeyLike = businessKeyLike;
+        } else {
+            this.businessKeyLike = businessKeyLike;
+        }
         return this;
     }
 
@@ -849,6 +860,10 @@ public class ProcessInstanceQueryImpl extends AbstractVariableQueryImpl<ProcessI
 
     public String getBusinessKey() {
         return businessKey;
+    }
+
+    public String getBusinessKeyLike() {
+        return businessKeyLike;
     }
 
     public boolean isIncludeChildExecutionsWithBusinessKeyQuery() {

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/runtime/ProcessInstanceQuery.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/runtime/ProcessInstanceQuery.java
@@ -45,6 +45,11 @@ public interface ProcessInstanceQuery extends Query<ProcessInstanceQuery, Proces
     ProcessInstanceQuery processInstanceBusinessKey(String processInstanceBusinessKey, String processDefinitionKey);
 
     /**
+     * Select process instances with a business key like the given value.
+     */
+    ProcessInstanceQuery processInstanceBusinessKeyLike(String businessKeyLike);
+
+    /**
      * Only select process instances that have the given tenant id.
      */
     ProcessInstanceQuery processInstanceTenantId(String tenantId);

--- a/modules/flowable-engine/src/main/resources/org/flowable/db/mapping/entity/Execution.xml
+++ b/modules/flowable-engine/src/main/resources/org/flowable/db/mapping/entity/Execution.xml
@@ -760,6 +760,12 @@
       <if test="businessKey != null and includeChildExecutionsWithBusinessKeyQuery">
         and INST.BUSINESS_KEY_ = #{businessKey}
       </if>
+      <if test="businessKeyLike != null and !includeChildExecutionsWithBusinessKeyQuery">
+        and RES.BUSINESS_KEY_ like #{businessKeyLike}${wildcardEscapeClause}
+      </if>
+      <if test="businessKeyLike != null and includeChildExecutionsWithBusinessKeyQuery">
+        and INST.BUSINESS_KEY_ like #{businessKeyLike}${wildcardEscapeClause}
+      </if>
       <if test="activityId != null">
         and RES.ACT_ID_ = #{activityId} and RES.IS_ACTIVE_ = #{isActive}
       </if>

--- a/modules/flowable-engine/src/main/resources/org/flowable/db/mapping/entity/HistoricProcessInstance.xml
+++ b/modules/flowable-engine/src/main/resources/org/flowable/db/mapping/entity/HistoricProcessInstance.xml
@@ -694,6 +694,9 @@
       <if test="businessKey != null">
         and ${queryTablePrefix}BUSINESS_KEY_ = #{businessKey}
       </if>
+      <if test="businessKeyLike != null">
+        and ${queryTablePrefix}BUSINESS_KEY_ like #{businessKeyLike}${wildcardEscapeClause}
+      </if>
       <if test="startedBefore != null">
         and ${queryTablePrefix}START_TIME_ &lt;= #{startedBefore}
       </if>
@@ -781,6 +784,9 @@
       </if>
       <if test="orQueryObject.businessKey != null">
         or ${queryTablePrefix}BUSINESS_KEY_ = #{orQueryObject.businessKey}
+      </if>
+      <if test="orQueryObject.businessKeyLike != null">
+        or ${queryTablePrefix}BUSINESS_KEY_ like #{orQueryObject.businessKeyLike}${wildcardEscapeClause}
       </if>
       <if test="orQueryObject.startedBefore != null">
         or ${queryTablePrefix}START_TIME_ &lt;= #{orQueryObject.startedBefore}

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ProcessInstanceQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ProcessInstanceQueryTest.java
@@ -285,6 +285,19 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
     }
 
     @Test
+    public void testQueryByBusinessKeyLike() {
+        processInstanceIds.add(runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY, "1A").getId());
+        processInstanceIds.add(runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY, "A1").getId());
+        assertEquals(1, runtimeService.createProcessInstanceQuery().processInstanceBusinessKeyLike("%0").count());
+        assertEquals(3, runtimeService.createProcessInstanceQuery().processInstanceBusinessKeyLike("1%").count());
+        assertEquals(3, runtimeService.createProcessInstanceQuery().processInstanceBusinessKeyLike("%1").count());
+        assertEquals(4, runtimeService.createProcessInstanceQuery().processInstanceBusinessKeyLike("%1%").count());
+        assertEquals(2, runtimeService.createProcessInstanceQuery().processInstanceBusinessKeyLike("%A%").count());
+        assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceBusinessKeyLike("%B%").count());
+    }
+    
+
+    @Test
     public void testQueryByInvalidBusinessKey() {
         assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceBusinessKey("invalid").count());
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricProcessInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricProcessInstanceTest.java
@@ -279,7 +279,8 @@ public class HistoricProcessInstanceTest extends PluggableFlowableTestCase {
         assertEquals(0, historyService.createHistoricProcessInstanceQuery().or().processDefinitionId("undefined").processDefinitionKeyIn(Arrays.asList("undefined1", "undefined2")).endOr().count());
         assertEquals(1, historyService.createHistoricProcessInstanceQuery().or().processDefinitionKey("oneTaskProcess").processDefinitionId("undefined").endOr().count());
         assertEquals(1, historyService.createHistoricProcessInstanceQuery().or().processInstanceBusinessKey("businessKey123").processDefinitionId("undefined").endOr().count());
-
+        assertEquals(1, historyService.createHistoricProcessInstanceQuery().or().processInstanceBusinessKeyLike("b%123").processDefinitionId("undefined").endOr().count());
+        
         List<String> excludeIds = new ArrayList<>();
         excludeIds.add("unexistingProcessDefinition");
 

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricProcessInstanceBaseResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricProcessInstanceBaseResource.java
@@ -115,6 +115,9 @@ public class HistoricProcessInstanceBaseResource {
         if (queryRequest.getProcessBusinessKey() != null) {
             query.processInstanceBusinessKey(queryRequest.getProcessBusinessKey());
         }
+        if (queryRequest.getProcessBusinessKeyLike() != null) {
+            query.processInstanceBusinessKeyLike(queryRequest.getProcessBusinessKeyLike());
+        }
         if (queryRequest.getInvolvedUser() != null) {
             query.involvedUser(queryRequest.getInvolvedUser());
         }

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricProcessInstanceCollectionResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricProcessInstanceCollectionResource.java
@@ -52,6 +52,7 @@ public class HistoricProcessInstanceCollectionResource extends HistoricProcessIn
             @ApiImplicitParam(name = "processDefinitionVersion", dataType = "string", value = "The process definition version of the historic process instance.", paramType = "query"),
             @ApiImplicitParam(name = "deploymentId", dataType = "string", value = "The deployment id of the historic process instance.", paramType = "query"),
             @ApiImplicitParam(name = "businessKey", dataType = "string", value = "The business key of the historic process instance.", paramType = "query"),
+            @ApiImplicitParam(name = "businessKeyLike", dataType = "string", value = "Only return instances with a businessKey like this key.", paramType = "query"),
             @ApiImplicitParam(name = "involvedUser", dataType = "string", value = "An involved user of the historic process instance.", paramType = "query"),
             @ApiImplicitParam(name = "finished", dataType = "boolean", value = "Indication if the historic process instance is finished.", paramType = "query"),
             @ApiImplicitParam(name = "superProcessInstanceId", dataType = "string", value = "An optional parent process id of the historic process instance.", paramType = "query"),
@@ -118,6 +119,10 @@ public class HistoricProcessInstanceCollectionResource extends HistoricProcessIn
 
         if (allRequestParams.get("businessKey") != null) {
             queryRequest.setProcessBusinessKey(allRequestParams.get("businessKey"));
+        }
+        
+        if (allRequestParams.get("businessKeyLike") != null) {
+            queryRequest.setProcessBusinessKeyLike(allRequestParams.get("businessKeyLike"));
         }
 
         if (allRequestParams.get("involvedUser") != null) {

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricProcessInstanceQueryRequest.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricProcessInstanceQueryRequest.java
@@ -33,6 +33,7 @@ public class HistoricProcessInstanceQueryRequest extends PaginateRequest {
     private String processInstanceNameLike;
     private String processInstanceNameLikeIgnoreCase;
     private String processBusinessKey;
+    private String processBusinessKeyLike;
     private String processDefinitionId;
     private String processDefinitionKey;
     private List<String> processDefinitionKeyIn;
@@ -105,6 +106,14 @@ public class HistoricProcessInstanceQueryRequest extends PaginateRequest {
 
     public void setProcessBusinessKey(String processBusinessKey) {
         this.processBusinessKey = processBusinessKey;
+    }
+    
+    public String getProcessBusinessKeyLike() {
+        return processBusinessKeyLike;
+    }
+
+    public void setProcessBusinessKeyLike(String processBusinessKeyLike) {
+        this.processBusinessKeyLike = processBusinessKeyLike;
     }
 
     public String getProcessDefinitionId() {

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/process/BaseProcessInstanceResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/process/BaseProcessInstanceResource.java
@@ -117,6 +117,9 @@ public class BaseProcessInstanceResource {
         if (queryRequest.getProcessBusinessKey() != null) {
             query.processInstanceBusinessKey(queryRequest.getProcessBusinessKey());
         }
+        if (queryRequest.getProcessBusinessKeyLike() != null) {
+            query.processInstanceBusinessKeyLike(queryRequest.getProcessBusinessKeyLike());
+        }
         if (queryRequest.getStartedBy() != null) {
             query.startedBy(queryRequest.getStartedBy());
         }

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/process/ProcessInstanceCollectionResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/process/ProcessInstanceCollectionResource.java
@@ -79,6 +79,7 @@ public class ProcessInstanceCollectionResource extends BaseProcessInstanceResour
             @ApiImplicitParam(name = "processDefinitionVersion", dataType = "integer", value = "Only return process instances with the given process definition version.", paramType = "query"),
             @ApiImplicitParam(name = "processDefinitionEngineVersion", dataType = "string", value = "Only return process instances with the given process definition engine version.", paramType = "query"),
             @ApiImplicitParam(name = "businessKey", dataType = "string", value = "Only return process instances with the given businessKey.", paramType = "query"),
+            @ApiImplicitParam(name = "businessKeyLike", dataType = "string", value = "Only return process instancess with the businessKey like the given key.", paramType = "query"),
             @ApiImplicitParam(name = "startedBy", dataType = "string", value = "Only return process instances started by the given user.", paramType = "query"),
             @ApiImplicitParam(name = "startedBefore", dataType = "string", format = "date-time", value = "Only return process instances started before the given date.", paramType = "query"),
             @ApiImplicitParam(name = "startedAfter", dataType = "string", format = "date-time", value = "Only return process instances started after the given date.", paramType = "query"),
@@ -142,6 +143,10 @@ public class ProcessInstanceCollectionResource extends BaseProcessInstanceResour
 
         if (allRequestParams.containsKey("businessKey")) {
             queryRequest.setProcessBusinessKey(allRequestParams.get("businessKey"));
+        }
+        
+        if (allRequestParams.containsKey("businessKeyLike")) {
+            queryRequest.setProcessBusinessKeyLike(allRequestParams.get("businessKeyLike"));
         }
         
         if (allRequestParams.containsKey("startedBy")) {

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/process/ProcessInstanceQueryRequest.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/process/ProcessInstanceQueryRequest.java
@@ -34,6 +34,7 @@ public class ProcessInstanceQueryRequest extends PaginateRequest {
     private String processInstanceNameLike;
     private String processInstanceNameLikeIgnoreCase;
     private String processBusinessKey;
+    private String processBusinessKeyLike;
     private String processDefinitionId;
     private Set<String> processDefinitionIds;
     private String processDefinitionKey;
@@ -108,6 +109,14 @@ public class ProcessInstanceQueryRequest extends PaginateRequest {
         this.processBusinessKey = processBusinessKey;
     }
 
+    public String getProcessBusinessKeyLike() {
+        return processBusinessKeyLike;
+    }
+
+    public void setProcessBusinessKeyLike(String processBusinessKeyLike) {
+        this.processBusinessKeyLike = processBusinessKeyLike;
+    }
+    
     public String getProcessDefinitionId() {
         return processDefinitionId;
     }

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/ProcessInstanceCollectionResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/ProcessInstanceCollectionResourceTest.java
@@ -139,6 +139,9 @@ public class ProcessInstanceCollectionResourceTest extends BaseSpringRestTestCas
 
         url = RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_COLLECTION) + "?businessKey=anotherBusinessKey";
         assertResultsPresentInDataResponse(url);
+        
+        url = RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_COLLECTION) + "?businessKeyLike=" + encode("%BusinessKey");
+        assertResultsPresentInDataResponse(url, id);
 
         // Process definition key
         url = RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_COLLECTION) + "?processDefinitionKey=processOne";


### PR DESCRIPTION
Added support for processInstance BusinessKeyLike to HistoricProcessInstaceQuery and ProcessInstanceQuery including REST api. This is discussed at https://forum.flowable.org/t/proposal-for-new-method-processinstancebusinesskeylike-to-historicprocessinstancequery/4886

