### PR TITLE
Spelling fixes

### DIFF
--- a/docs/docusaurus/docs/cmmn/ch03-API.md
+++ b/docs/docusaurus/docs/cmmn/ch03-API.md
@@ -62,7 +62,7 @@ The base exception in Flowable is the org.flowable.engine.common.api.FlowableExc
 
 In the example above, when an id is passed for which no task exists, an exception will be thrown. Also, since the javadoc **explicitly states that taskId cannot be null, an FlowableIllegalArgumentException will be thrown when null is passed**.
 
-Even though we want to avoid a big exception hierarchy, the following subclasses are thrown in specific cases. All other errors that occur during process-execution or API-invocation that don’t fit into the possible exceptions below are thrown as regular FlowableExceptionss.
+Even though we want to avoid a big exception hierarchy, the following subclasses are thrown in specific cases. All other errors that occur during process-execution or API-invocation that don’t fit into the possible exceptions below are thrown as regular FlowableExceptions.
 
 -   FlowableWrongDbException: Thrown when the Flowable engine discovers a mismatch between the database schema version and the engine version.
 

--- a/docs/docusaurus/website/versioned_docs/version-6.4.2/bpmn/ch11-History.md
+++ b/docs/docusaurus/website/versioned_docs/version-6.4.2/bpmn/ch11-History.md
@@ -68,7 +68,7 @@ The next example, gets all variable-updates that have been done in process with 
       .orderByVariableName().asc()
       .list()
 
-This example gets all [form-properties](#formProperties) that were submitted in any task or when starting the process with id "123". Only HistoricFormPropertiess will be returned by this query.
+This example gets all [form-properties](#formProperties) that were submitted in any task or when starting the process with id "123". Only HistoricFormProperties will be returned by this query.
 
     historyService.createHistoricDetailQuery()
       .formProperties()


### PR DESCRIPTION
FWIW, `completeable` really should be `completable` but it is this way 124 times in ~33 files (doc, java, and sql).  The correct spelling is also found 184 times in ~24 files (most often in CMMN related files).  Obviously no changes were made for this inconsistency.

#### Check List:
* Unit tests:  NA
* Documentation:  NA
