### PR TITLE
Flowable Modeler: Add textVar field to Mail Task (closes #2018).

### DIFF
--- a/modules/flowable-json-converter/src/main/java/org/flowable/editor/constants/StencilConstants.java
+++ b/modules/flowable-json-converter/src/main/java/org/flowable/editor/constants/StencilConstants.java
@@ -242,6 +242,7 @@ public interface StencilConstants {
     final String PROPERTY_MAILTASK_TEXT = "mailtasktext";
     final String PROPERTY_MAILTASK_HTML = "mailtaskhtml";
     final String PROPERTY_MAILTASK_HTML_VAR = "mailtaskhtmlvar";
+    final String PROPERTY_MAILTASK_TEXT_VAR = "mailtasktextvar";
     final String PROPERTY_MAILTASK_CHARSET = "mailtaskcharset";
 
     final String PROPERTY_CALLACTIVITY_CALLEDELEMENT = "callactivitycalledelement";

--- a/modules/flowable-json-converter/src/main/java/org/flowable/editor/language/json/converter/MailTaskJsonConverter.java
+++ b/modules/flowable-json-converter/src/main/java/org/flowable/editor/language/json/converter/MailTaskJsonConverter.java
@@ -63,6 +63,7 @@ public class MailTaskJsonConverter extends BaseBpmnJsonConverter {
         addField(PROPERTY_MAILTASK_TEXT, elementNode, task);
         addField(PROPERTY_MAILTASK_HTML, elementNode, task);
         addField(PROPERTY_MAILTASK_HTML_VAR, elementNode, task);
+        addField(PROPERTY_MAILTASK_TEXT_VAR, elementNode, task);
         addField(PROPERTY_MAILTASK_CHARSET, elementNode, task);
 
         return task;

--- a/modules/flowable-json-converter/src/main/java/org/flowable/editor/language/json/converter/ServiceTaskJsonConverter.java
+++ b/modules/flowable-json-converter/src/main/java/org/flowable/editor/language/json/converter/ServiceTaskJsonConverter.java
@@ -71,6 +71,7 @@ public class ServiceTaskJsonConverter extends BaseBpmnJsonConverter implements D
             setPropertyFieldValue(PROPERTY_MAILTASK_TEXT, serviceTask, propertiesNode);
             setPropertyFieldValue(PROPERTY_MAILTASK_HTML, serviceTask, propertiesNode);
             setPropertyFieldValue(PROPERTY_MAILTASK_HTML_VAR, serviceTask, propertiesNode);
+            setPropertyFieldValue(PROPERTY_MAILTASK_TEXT_VAR, serviceTask, propertiesNode);
             setPropertyFieldValue(PROPERTY_MAILTASK_CHARSET, serviceTask, propertiesNode);
 
         } else if ("camel".equalsIgnoreCase(serviceTask.getType())) {

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/resources/static/i18n/en.json
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-app/src/main/resources/static/i18n/en.json
@@ -399,6 +399,10 @@
           "MAILTASKTEXT" : {
             "TITLE" : "Text",
             "DESCRIPTION" : "The content of the e-mail, in case one needs to send plain none-rich e-mails. Can be used in combination with html, for e-mail clients that don't support rich content. The client will then fall back to this text-only alternative."
+          },
+          "MAILTASKTEXTVAR" : {
+            "TITLE" : "TextVar",
+            "DESCRIPTION" : "The name of a process variable that holds the text that is the content of the e-mail, in case one needs to send plain none-rich e-mails. Can be used in combination with html, for e-mail clients that don't support rich content. The client will then fall back to this text-only alternative."
           }
         },
         "MAILTASKHTMLPACKAGE" : {

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/resources/stencilset_bpmn.json
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/resources/stencilset_bpmn.json
@@ -593,6 +593,13 @@
       "value" : "",
       "description" : "BPMN.PROPERTYPACKAGES.MAILTASKTEXTPACKAGE.MAILTASKTEXT.DESCRIPTION",
       "popular" : true
+    }, {
+      "id" : "mailtasktextvar",
+      "type" : "String",
+      "title" : "BPMN.PROPERTYPACKAGES.MAILTASKTEXTPACKAGE.MAILTASKTEXTVAR.TITLE",
+      "value" : "",
+      "description" : "BPMN.PROPERTYPACKAGES.MAILTASKTEXTPACKAGE.MAILTASKTEXTVAR.DESCRIPTION",
+      "popular" : true
     } ]
   }, {
     "name" : "mailtaskhtmlpackage",


### PR DESCRIPTION
A slightly modified copy of https://github.com/flowable/flowable-engine/commit/7a27027ac779073ad2785d92c5ff4236b8f251bc (which added `htmlVar`) to add `textVar` as well.