### PR TITLE
Remove unused jackson-datatype-hppc dependency.

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -89,11 +89,9 @@ Quartz
 This software includes unchanged copies of the following libraries:
 
 aopalliance                     aopalliance                 1.0             Public Domain
-com.carrotsearch                hppc                        0.7.1           The Apache Software License, Version 2.0
 com.fasterxml.jackson.core      jackson-annotations         2.10.2          The Apache Software License, Version 2.0
 com.fasterxml.jackson.core      jackson-core                2.10.2          The Apache Software License, Version 2.0
 com.fasterxml.jackson.core      jackson-databind            2.10.2          The Apache Software License, Version 2.0
-com.fasterxml.jackson.datatype  jackson-datatype-hppc       2.10.2          The Apache Software License, Version 2.0
 com.fasterxml.jackson.datatype  jackson-datatype-joda       2.10.2          The Apache Software License, Version 2.0
 com.fasterxml.jackson.datatype  jackson-datatype-json-org   2.10.2          The Apache Software License, Version 2.0
 com.google.guava                guava                       28.2-jre        The Apache Software License, Version 2.0

--- a/modules/flowable-ui-admin/flowable-ui-admin-logic/pom.xml
+++ b/modules/flowable-ui-admin/flowable-ui-admin-logic/pom.xml
@@ -94,10 +94,6 @@
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.datatype</groupId>
-			<artifactId>jackson-datatype-hppc</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.fasterxml.jackson.datatype</groupId>
 			<artifactId>jackson-datatype-joda</artifactId>
 		</dependency>
 

--- a/modules/flowable-ui-admin/flowable-ui-admin-rest/pom.xml
+++ b/modules/flowable-ui-admin/flowable-ui-admin-rest/pom.xml
@@ -77,10 +77,6 @@
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.datatype</groupId>
-			<artifactId>jackson-datatype-hppc</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.fasterxml.jackson.datatype</groupId>
 			<artifactId>jackson-datatype-joda</artifactId>
 		</dependency>
 

--- a/modules/flowable-ui-common/pom.xml
+++ b/modules/flowable-ui-common/pom.xml
@@ -146,10 +146,6 @@
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-hppc</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-joda</artifactId>
     </dependency>
     

--- a/modules/flowable-ui-idm/flowable-ui-idm-rest/pom.xml
+++ b/modules/flowable-ui-idm/flowable-ui-idm-rest/pom.xml
@@ -49,10 +49,6 @@
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.datatype</groupId>
-			<artifactId>jackson-datatype-hppc</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.fasterxml.jackson.datatype</groupId>
 			<artifactId>jackson-datatype-joda</artifactId>
 		</dependency>
 

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/pom.xml
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/pom.xml
@@ -102,10 +102,6 @@
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.datatype</groupId>
-			<artifactId>jackson-datatype-hppc</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.fasterxml.jackson.datatype</groupId>
 			<artifactId>jackson-datatype-joda</artifactId>
 		</dependency>
 

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-rest/pom.xml
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-rest/pom.xml
@@ -77,10 +77,6 @@
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.datatype</groupId>
-			<artifactId>jackson-datatype-hppc</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.fasterxml.jackson.datatype</groupId>
 			<artifactId>jackson-datatype-joda</artifactId>
 		</dependency>
 

--- a/modules/flowable-ui-task/flowable-ui-task-conf/pom.xml
+++ b/modules/flowable-ui-task/flowable-ui-task-conf/pom.xml
@@ -174,10 +174,6 @@
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-hppc</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-joda</artifactId>
         </dependency>
 

--- a/modules/flowable-ui-task/flowable-ui-task-logic/pom.xml
+++ b/modules/flowable-ui-task/flowable-ui-task-logic/pom.xml
@@ -114,10 +114,6 @@
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.datatype</groupId>
-			<artifactId>jackson-datatype-hppc</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.fasterxml.jackson.datatype</groupId>
 			<artifactId>jackson-datatype-joda</artifactId>
 		</dependency>
 

--- a/modules/flowable-ui-task/flowable-ui-task-rest/pom.xml
+++ b/modules/flowable-ui-task/flowable-ui-task-rest/pom.xml
@@ -85,10 +85,6 @@
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.datatype</groupId>
-			<artifactId>jackson-datatype-hppc</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.fasterxml.jackson.datatype</groupId>
 			<artifactId>jackson-datatype-joda</artifactId>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1020,11 +1020,6 @@
 			</dependency>
 			<dependency>
 				<groupId>com.fasterxml.jackson.datatype</groupId>
-				<artifactId>jackson-datatype-hppc</artifactId>
-				<version>${jackson.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>com.fasterxml.jackson.datatype</groupId>
 				<artifactId>jackson-datatype-joda</artifactId>
 				<version>${jackson.version}</version>
 			</dependency>


### PR DESCRIPTION
Flowable does not use `High Performance Primitive Collections for Java` (https://github.com/carrotsearch/hppc) so this dependency can be removed.