### PR TITLE
Unnecessary null check

### DIFF
--- a/modules/flowable-cmmn-model/src/main/java/org/flowable/cmmn/model/ParentCompletionRule.java
+++ b/modules/flowable-cmmn-model/src/main/java/org/flowable/cmmn/model/ParentCompletionRule.java
@@ -14,12 +14,12 @@ package org.flowable.cmmn.model;
 
 public class ParentCompletionRule extends PlanItemRule {
     
-    public final static String DEFAULT = "default";
-    public final static String IGNORE = "ignore";
-    public final static String IGNORE_IF_AVAILABLE = "ignoreIfAvailable";
-    public final static String IGNORE_IF_AVAILABLE_OR_ENABLED = "ignoreIfAvailableOrEnabled";
-    public final static String IGNORE_AFTER_FIRST_COMPLETION = "ignoreAfterFirstCompletion";
-    public final static String IGNORE_AFTER_FIRST_COMPLETION_IF_AVAILABLE_OR_ENABLED = "ignoreAfterFirstCompletionIfAvailableOrEnabled";
+    public static final String DEFAULT = "default";
+    public static final String IGNORE = "ignore";
+    public static final String IGNORE_IF_AVAILABLE = "ignoreIfAvailable";
+    public static final String IGNORE_IF_AVAILABLE_OR_ENABLED = "ignoreIfAvailableOrEnabled";
+    public static final String IGNORE_AFTER_FIRST_COMPLETION = "ignoreAfterFirstCompletion";
+    public static final String IGNORE_AFTER_FIRST_COMPLETION_IF_AVAILABLE_OR_ENABLED = "ignoreAfterFirstCompletionIfAvailableOrEnabled";
 
     protected String type;
     

--- a/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/el/util/CollectionUtil.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/el/util/CollectionUtil.java
@@ -124,12 +124,12 @@ public class CollectionUtil {
         // elements to check
         if (DMNParseUtil.isParseableCollection(value)) {
             Collection valueCollection = DMNParseUtil.parseCollection(value, targetCollection);
-            return valueCollection != null && CollectionUtils.containsAny(targetCollection, valueCollection);
+            return CollectionUtils.containsAny(targetCollection, valueCollection);
         } else if (DMNParseUtil.isJavaCollection(value)) {
             return CollectionUtils.containsAny(targetCollection, (Collection) value);
         } else if (DMNParseUtil.isArrayNode(value)) {
             Collection valueCollection = DMNParseUtil.getCollectionFromArrayNode((ArrayNode) value);
-            return valueCollection != null && CollectionUtils.containsAny(targetCollection, valueCollection);
+            return CollectionUtils.containsAny(targetCollection, valueCollection);
         } else {
             Object formattedValue = DMNParseUtil.getFormattedValue(value, targetCollection);
             return targetCollection.contains(formattedValue);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/multiinstance/CounterExecutionListener.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/multiinstance/CounterExecutionListener.java
@@ -37,7 +37,7 @@ public class CounterExecutionListener implements ExecutionListener {
         String nrOfCompletedInstances = null == nrOfCompletedInstancesObj ? null : nrOfCompletedInstancesObj.toString();
         LOGGER.debug("Invoke into executionEnd method and execution is {}", execution.getVariables());
         
-        if (nrOfCompletedInstances != null && nrOfInstances.equals(nrOfCompletedInstances)) {
+        if (nrOfInstances.equals(nrOfCompletedInstances)) {
             ProcessEngineConfigurationImpl processEngineConfiguration = CommandContextUtil.getProcessEngineConfiguration();
             
             if (processEngineConfiguration.getHistoryManager().isHistoryEnabled()) {


### PR DESCRIPTION
Both `equals()` and `containsAny()` handle nulls correctly

#### Check List:
* Unit tests:  NA
* Documentation:  NA
