### PR TITLE
Lower case the test string for contains() to ever be true

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/mail/EmailSendTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/mail/EmailSendTaskTest.java
@@ -51,7 +51,7 @@ public class EmailSendTaskTest extends PluggableFlowableTestCase {
                 wiser.start();
                 serverUpAndRunning = true;
             } catch (RuntimeException e) { // Fix for slow port-closing Jenkins
-                if (e.getMessage().toLowerCase().contains("BindException")) {
+                if (e.getMessage().toLowerCase().contains("bindexception")) {
                     Thread.sleep(250L);
                 }
             }


### PR DESCRIPTION
As originally written the test will always return false.

#### Check List:
* Unit tests:  NA
* Documentation:  NA
