### PR TITLE
add support for letsencrypt cert issuer

### DIFF
--- a/k8s/flowable/templates/ingress.yaml
+++ b/k8s/flowable/templates/ingress.yaml
@@ -9,9 +9,13 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/ssl-redirect: "{{ .Values.ingress.sslRedirect }}"
+    {{- if .Values.ingress.clusterIssuer }}
+    cert-manager.io/cluster-issuer: "{{ .Values.ingress.clusterIssuer }}"
+    {{- end }}
 spec:
   rules:
-  - http:
+  - host: {{ .Values.host.external }}
+    http:
       paths:
       {{- if .Values.idm.enabled }}
       - path: /{{ .Values.idm.ingressPath }}/?(.*)
@@ -43,4 +47,10 @@ spec:
           serviceName: {{ .Values.rest.service.name }}
           servicePort: 8080
       {{- end }}
+  {{- if .Values.ingress.clusterIssuer }}
+  tls:
+  - hosts:
+    - {{ .Values.host.external }}
+    secretName: {{ .Values.ingress.secretName | default "flowable-tls" }}
+  {{- end }}
 {{- end }}

--- a/k8s/flowable/values.yaml
+++ b/k8s/flowable/values.yaml
@@ -19,6 +19,10 @@ cloudSql:
 ingress:
   enabled: true
   sslRedirect: false
+  # To enable LetsEncrypt signed certificates rather than self-signed ones
+  # you must deploy a ClusterIssuer object and specify the provateKeySecretRef's
+  # name here
+  #clusterIssuer: "letsencrypt-prod"
 
 idm:
   enabled: true


### PR DESCRIPTION
#### Check List:
* Unit tests: NO
* Documentation: YES

The existing Helm chart can be configured via the sslRedirect property to serve both http and https. However this is limited by using a self-signed certificate. 

This PR adds an extra property to the `values.yaml` (disabled by default) and the necessary changes to the ingress to allow LetsEncrypt certificates to be issued.

To take advantage of this you will need to install a cert manager to your cluster:

```
    kubectl create namespace cert-manager
    kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.12.0/cert-manager.yaml
```

and then `apply` a ClusterIssuer resource such as this:

```
apiVersion: cert-manager.io/v1alpha2
kind: ClusterIssuer
metadata:
  name: letsencrypt-prod
  namespace: cert-manager
spec:
  acme:
    # Email address used for registration - CHANGEME!
    email: info@flowable.org
    server: https://acme-v02.api.letsencrypt.org/directory
    privateKeySecretRef:
      # Name of a secret used to store the ACME account private key
      name: letsencrypt-prod
    # Add a single challenge solver, HTTP01 using nginx
    solvers:
    - http01:
        ingress:
          class: nginx
``` 

Finally, deploy the chart with whatever values you already have and the additional `clusterIssuer` containing the correct name of your `privateKeySecretRef` (in the example above this would be letencrypt-prod. 