### PR TITLE
Travis: Remove OpenJDK EA build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,11 @@ matrix:
   - jdk: openjdk11
     dist: xenial
   - jdk: openjdk13
-  - jdk: openjdk-ea
     branches:
       only:
       - master
     if: TRAVIS_PULL_REQUEST != false
   allow_failures:
-  - jdk: openjdk-ea
   - name: "Flowable 5 tests"
 
 cache:


### PR DESCRIPTION
This build always fails, because Flowable tests use Groovy. Groovy uses ASM. ASM checks the class version in use (incremented with each Java version) and does not support future Java versions.