### PR TITLE
Copy retry code for setting up the test mail server from org.flowable…

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/mail/EmailServiceTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/mail/EmailServiceTaskTest.java
@@ -39,9 +39,20 @@ public class EmailServiceTaskTest extends PluggableFlowableTestCase {
 
     @BeforeEach
     protected void setUp() throws Exception {
-        wiser = new Wiser();
-        wiser.setPort(5025);
-        wiser.start();
+        boolean serverUpAndRunning = false;
+        while (!serverUpAndRunning) {
+            wiser = new Wiser();
+            wiser.setPort(5025);
+
+            try {
+                wiser.start();
+                serverUpAndRunning = true;
+            } catch (RuntimeException e) { // Fix for slow port-closing CI Servers
+                if (e.getMessage().toLowerCase().contains("bindexception")) {
+                    Thread.sleep(250L);
+                }
+            }
+        }
     }
 
     @AfterEach


### PR DESCRIPTION
….engine.test.bpmn.mail.EmailTestCase to org.flowable.examples.bpmn.mail.EmailTestCase, to fix occasional failures on CI servers (Github Actions and Travis CI).

E.g.: https://github.com/PascalSchumacher/flowable-engine/runs/421599992

Another solution would be to extend `org.flowable.engine.test.bpmn.mail.EmailTestCase` instead of copying the code. I did not do it, because this class is not available to flowable users. Happy to update the pull request if you prefer that solution.
