### PR TITLE
Add order by method for sorting tasks by category

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskQueryTest.java
@@ -3139,6 +3139,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(12, taskService.createTaskQuery().orderByExecutionId().asc().list().size());
         assertEquals(12, taskService.createTaskQuery().orderByTaskCreateTime().asc().list().size());
         assertEquals(12, taskService.createTaskQuery().orderByTaskDueDate().asc().list().size());
+        assertEquals(12, taskService.createTaskQuery().orderByCategory().asc().list().size());
 
         assertEquals(12, taskService.createTaskQuery().orderByTaskId().desc().list().size());
         assertEquals(12, taskService.createTaskQuery().orderByTaskName().desc().list().size());
@@ -3149,6 +3150,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertEquals(12, taskService.createTaskQuery().orderByExecutionId().desc().list().size());
         assertEquals(12, taskService.createTaskQuery().orderByTaskCreateTime().desc().list().size());
         assertEquals(12, taskService.createTaskQuery().orderByTaskDueDate().desc().list().size());
+        assertEquals(12, taskService.createTaskQuery().orderByCategory().desc().list().size());
 
         assertEquals(6, taskService.createTaskQuery().orderByTaskId().taskName("testTask").asc().list().size());
         assertEquals(6, taskService.createTaskQuery().orderByTaskId().taskName("testTask").desc().list().size());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricTaskInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricTaskInstanceTest.java
@@ -775,6 +775,7 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         assertEquals(1, historyService.createHistoricTaskInstanceQuery().orderByTaskPriority().asc().count());
         assertEquals(1, historyService.createHistoricTaskInstanceQuery().orderByTaskAssignee().asc().count());
         assertEquals(1, historyService.createHistoricTaskInstanceQuery().orderByTaskId().asc().count());
+        assertEquals(1, historyService.createHistoricTaskInstanceQuery().orderByCategory().asc().count());
 
         assertEquals(1, historyService.createHistoricTaskInstanceQuery().orderByDeleteReason().desc().count());
         assertEquals(1, historyService.createHistoricTaskInstanceQuery().orderByExecutionId().desc().count());
@@ -788,6 +789,7 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         assertEquals(1, historyService.createHistoricTaskInstanceQuery().orderByTaskPriority().desc().count());
         assertEquals(1, historyService.createHistoricTaskInstanceQuery().orderByTaskAssignee().desc().count());
         assertEquals(1, historyService.createHistoricTaskInstanceQuery().orderByTaskId().desc().count());
+        assertEquals(1, historyService.createHistoricTaskInstanceQuery().orderByCategory().desc().count());
     }
 
     @Test

--- a/modules/flowable-task-service-api/src/main/java/org/flowable/task/api/TaskInfoQuery.java
+++ b/modules/flowable-task-service-api/src/main/java/org/flowable/task/api/TaskInfoQuery.java
@@ -753,4 +753,9 @@ public interface TaskInfoQuery<T extends TaskInfoQuery<?, ?>, V extends TaskInfo
      */
     T orderByDueDateNullsLast();
 
+    /**
+     * Order by category (needs to be followed by {@link #asc()} or {@link #desc()}).
+     */
+    T orderByCategory();
+
 }

--- a/modules/flowable-task-service/src/main/java/org/flowable/task/service/impl/HistoricTaskInstanceQueryImpl.java
+++ b/modules/flowable-task-service/src/main/java/org/flowable/task/service/impl/HistoricTaskInstanceQueryImpl.java
@@ -1632,6 +1632,12 @@ public class HistoricTaskInstanceQueryImpl extends AbstractVariableQueryImpl<His
     }
 
     @Override
+    public HistoricTaskInstanceQuery orderByCategory() {
+        orderBy(HistoricTaskInstanceQueryProperty.CATEGORY);
+        return this;
+    }
+
+    @Override
     public HistoricTaskInstanceQueryImpl orderByDeleteReason() {
         orderBy(HistoricTaskInstanceQueryProperty.DELETE_REASON);
         return this;

--- a/modules/flowable-task-service/src/main/java/org/flowable/task/service/impl/HistoricTaskInstanceQueryProperty.java
+++ b/modules/flowable-task-service/src/main/java/org/flowable/task/service/impl/HistoricTaskInstanceQueryProperty.java
@@ -46,6 +46,7 @@ public class HistoricTaskInstanceQueryProperty implements QueryProperty {
     public static final HistoricTaskInstanceQueryProperty SCOPE_DEFINITION_ID = new HistoricTaskInstanceQueryProperty("RES.SCOPE_DEFINITION_ID_");
     public static final HistoricTaskInstanceQueryProperty SCOPE_ID = new HistoricTaskInstanceQueryProperty("RES.SCOPE_ID_");
     public static final HistoricTaskInstanceQueryProperty SCOPE_TYPE = new HistoricTaskInstanceQueryProperty("RES.SCOPE_TYPE_");
+    public static final HistoricTaskInstanceQueryProperty CATEGORY = new HistoricTaskInstanceQueryProperty("RES.CATEGORY_");
 
     public static final HistoricTaskInstanceQueryProperty INCLUDED_VARIABLE_TIME = new HistoricTaskInstanceQueryProperty("VAR.LAST_UPDATED_TIME_");
 

--- a/modules/flowable-task-service/src/main/java/org/flowable/task/service/impl/TaskQueryImpl.java
+++ b/modules/flowable-task-service/src/main/java/org/flowable/task/service/impl/TaskQueryImpl.java
@@ -1638,6 +1638,11 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
     }
 
     @Override
+    public TaskQuery orderByCategory() {
+        return orderBy(TaskQueryProperty.CATEGORY);
+    }
+
+    @Override
     public TaskQuery orderByTenantId() {
         return orderBy(TaskQueryProperty.TENANT_ID);
     }

--- a/modules/flowable-task-service/src/main/java/org/flowable/task/service/impl/TaskQueryProperty.java
+++ b/modules/flowable-task-service/src/main/java/org/flowable/task/service/impl/TaskQueryProperty.java
@@ -42,6 +42,7 @@ public class TaskQueryProperty implements QueryProperty {
     public static final TaskQueryProperty DUE_DATE = new TaskQueryProperty("RES.DUE_DATE_");
     public static final TaskQueryProperty TENANT_ID = new TaskQueryProperty("RES.TENANT_ID_");
     public static final TaskQueryProperty TASK_DEFINITION_KEY = new TaskQueryProperty("RES.TASK_DEF_KEY_");
+    public static final TaskQueryProperty CATEGORY = new TaskQueryProperty("RES.CATEGORY_");
 
     private String name;
 


### PR DESCRIPTION
- add property for category
- add method to the interface
- add implementations
- add usage in tests
- category is an optional field and allows to 'tag' tasks as belonging to a certain category
- corresponding tag is flowable:category
- see #2113