### PR TITLE
Use assertj fluent style

### DIFF
--- a/modules/flowable-app-engine-spring/src/test/java/org/flowable/app/spring/test/autodeployment/DefaultAutoDeploymentStrategyTest.java
+++ b/modules/flowable-app-engine-spring/src/test/java/org/flowable/app/spring/test/autodeployment/DefaultAutoDeploymentStrategyTest.java
@@ -13,9 +13,7 @@
 
 package org.flowable.app.spring.test.autodeployment;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.never;
@@ -44,14 +42,14 @@ public class DefaultAutoDeploymentStrategyTest extends AbstractAutoDeploymentStr
     public void before() throws Exception {
         super.before();
         classUnderTest = new DefaultAutoDeploymentStrategy();
-        assertNotNull(classUnderTest);
+        assertThat(classUnderTest).isNotNull();
     }
 
     @Test
     public void testHandlesMode() {
-        assertTrue(classUnderTest.handlesMode(DefaultAutoDeploymentStrategy.DEPLOYMENT_MODE));
-        assertFalse(classUnderTest.handlesMode("other-mode"));
-        assertFalse(classUnderTest.handlesMode(null));
+        assertThat(classUnderTest.handlesMode(DefaultAutoDeploymentStrategy.DEPLOYMENT_MODE)).isTrue();
+        assertThat(classUnderTest.handlesMode("other-mode")).isFalse();
+        assertThat(classUnderTest.handlesMode(null)).isFalse();
     }
 
     @Test

--- a/modules/flowable-app-engine-spring/src/test/java/org/flowable/app/spring/test/autodeployment/SpringAutoDeployTest.java
+++ b/modules/flowable-app-engine-spring/src/test/java/org/flowable/app/spring/test/autodeployment/SpringAutoDeployTest.java
@@ -15,8 +15,6 @@ package org.flowable.app.spring.test.autodeployment;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import java.sql.Driver;
 import java.util.HashMap;
@@ -130,34 +128,34 @@ public class SpringAutoDeployTest {
         Set<String> expectedAppDefinitionKeys = new HashSet<>();
         expectedAppDefinitionKeys.add("simpleApp");
 
-        assertEquals(expectedAppDefinitionKeys, appDefinitionKeys);
+        assertThat(appDefinitionKeys).isEqualTo(expectedAppDefinitionKeys);
     }
 
     @Test
     public void testNoRedeploymentForSpringContainerRestart() throws Exception {
         createAppContextWithoutDeploymentMode();
         AppDeploymentQuery deploymentQuery = repositoryService.createDeploymentQuery();
-        assertEquals(1, deploymentQuery.count());
+        assertThat(deploymentQuery.count()).isEqualTo(1);
         AppDefinitionQuery appDefinitionQuery = repositoryService.createAppDefinitionQuery();
-        assertEquals(1, appDefinitionQuery.count());
+        assertThat(appDefinitionQuery.count()).isEqualTo(1);
 
         // Creating a new app context with same resources doesn't lead to more deployments
         createAppContextWithoutDeploymentMode();
-        assertEquals(1, deploymentQuery.count());
-        assertEquals(1, appDefinitionQuery.count());
+        assertThat(deploymentQuery.count()).isEqualTo(1);
+        assertThat(appDefinitionQuery.count()).isEqualTo(1);
     }
 
     // Updating the form file should lead to a new deployment when restarting the Spring container
     @Test
     public void testResourceRedeploymentAfterAppDefinitionChange() throws Exception {
         createAppContextWithoutDeploymentMode();
-        assertEquals(1, repositoryService.createDeploymentQuery().count());
+        assertThat(repositoryService.createDeploymentQuery().count()).isEqualTo(1);
         applicationContext.close();
 
         String filePath = "org/flowable/app/spring/test/autodeployment/simple.app";
         String originalAppFileContent = IoUtil.readFileAsString(filePath);
         String updatedAppFileContent = originalAppFileContent.replace("Simple app", "My simple app");
-        assertTrue(updatedAppFileContent.length() > originalAppFileContent.length());
+        assertThat(updatedAppFileContent.length() > originalAppFileContent.length()).isTrue();
         IoUtil.writeStringToFile(updatedAppFileContent, filePath);
 
         // Classic produced/consumer problem here:
@@ -174,15 +172,15 @@ public class SpringAutoDeployTest {
 
         // Assertions come AFTER the file write! Otherwise the form file is
         // messed up if the assertions fail.
-        assertEquals(2, repositoryService.createDeploymentQuery().count());
-        assertEquals(2, repositoryService.createAppDefinitionQuery().count());
+        assertThat(repositoryService.createDeploymentQuery().count()).isEqualTo(2);
+        assertThat(repositoryService.createAppDefinitionQuery().count()).isEqualTo(2);
     }
 
     @Test
     public void testAutoDeployWithDeploymentModeDefault() {
         createAppContextWithDefaultDeploymentMode();
-        assertEquals(1, repositoryService.createDeploymentQuery().count());
-        assertEquals(1, repositoryService.createAppDefinitionQuery().count());
+        assertThat(repositoryService.createDeploymentQuery().count()).isEqualTo(1);
+        assertThat(repositoryService.createAppDefinitionQuery().count()).isEqualTo(1);
     }
 
     @Test
@@ -222,15 +220,15 @@ public class SpringAutoDeployTest {
     @Test
     public void testAutoDeployWithDeploymentModeSingleResource() {
         createAppContextWithSingleResourceDeploymentMode();
-        assertEquals(1, repositoryService.createDeploymentQuery().count());
-        assertEquals(1, repositoryService.createAppDefinitionQuery().count());
+        assertThat(repositoryService.createDeploymentQuery().count()).isEqualTo(1);
+        assertThat(repositoryService.createAppDefinitionQuery().count()).isEqualTo(1);
     }
 
     @Test
     public void testAutoDeployWithDeploymentModeResourceParentFolder() {
         createAppContextWithResourceParenFolderDeploymentMode();
-        assertEquals(2, repositoryService.createDeploymentQuery().count());
-        assertEquals(2, repositoryService.createAppDefinitionQuery().count());
+        assertThat(repositoryService.createDeploymentQuery().count()).isEqualTo(2);
+        assertThat(repositoryService.createAppDefinitionQuery().count()).isEqualTo(2);
     }
 
     // --Helper methods

--- a/modules/flowable-app-engine/src/test/java/org/flowable/app/engine/test/cfg/ForceCloseMybatisConnectionPoolTest.java
+++ b/modules/flowable-app-engine/src/test/java/org/flowable/app/engine/test/cfg/ForceCloseMybatisConnectionPoolTest.java
@@ -12,8 +12,7 @@
  */
 package org.flowable.app.engine.test.cfg;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.ibatis.datasource.pooled.PoolState;
 import org.apache.ibatis.datasource.pooled.PooledDataSource;
@@ -41,14 +40,14 @@ public class ForceCloseMybatisConnectionPoolTest {
 
         PooledDataSource pooledDataSource = (PooledDataSource) appEngineConfiguration.getDataSource();
         PoolState state = pooledDataSource.getPoolState();
-        assertTrue(state.getIdleConnectionCount() > 0);
+        assertThat(state.getIdleConnectionCount()).isPositive();
 
         // then
         // if the  engine is closed
         appEngine.close();
 
         // the idle connections are closed
-        assertEquals(0, state.getIdleConnectionCount());
+        assertThat(state.getIdleConnectionCount()).isEqualTo(0);
     }
 
     @Test
@@ -64,17 +63,17 @@ public class ForceCloseMybatisConnectionPoolTest {
 
         PooledDataSource pooledDataSource = (PooledDataSource) appEngineConfiguration.getDataSource();
         PoolState state = pooledDataSource.getPoolState();
-        assertTrue(state.getIdleConnectionCount() > 0);
+        assertThat(state.getIdleConnectionCount()).isPositive();
 
         // then
         // if the  engine is closed
         appEngine.close();
 
         // the idle connections are not closed
-        assertTrue(state.getIdleConnectionCount() > 0);
+        assertThat(state.getIdleConnectionCount()).isPositive();
 
         pooledDataSource.forceCloseAll();
-        assertEquals(0, state.getIdleConnectionCount());
+        assertThat(state.getIdleConnectionCount()).isEqualTo(0);
     }
 
 }

--- a/modules/flowable-app-engine/src/test/java/org/flowable/app/engine/test/persistence/EntitiesTest.java
+++ b/modules/flowable-app-engine/src/test/java/org/flowable/app/engine/test/persistence/EntitiesTest.java
@@ -12,8 +12,7 @@
  */
 package org.flowable.app.engine.test.persistence;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -37,7 +36,7 @@ public class EntitiesTest {
     @Test
     public void verifyMappedEntitiesExist() {
         Set<String> mappedResources = getMappedResources();
-        assertTrue(mappedResources.size() > 0);
+        assertThat(mappedResources.size()).isPositive();
         for (String mappedResource : mappedResources) {
             getAndAssertEntityInterfaceClass(mappedResource);
             getAndAssertEntityImplClass(mappedResource);
@@ -48,8 +47,10 @@ public class EntitiesTest {
     public void verifyEntitiesInEntityDependencyOrder() {
         Set<String> mappedResources = getMappedResources();
         for (String mappedResource : mappedResources) {
-            assertTrue("No insert entry in EntityDependencyOrder for " + mappedResource, EntityDependencyOrder.INSERT_ORDER.contains(getAndAssertEntityImplClass(mappedResource)));
-            assertTrue("No delete entry in EntityDependencyOrder for " + mappedResource, EntityDependencyOrder.DELETE_ORDER.contains(getAndAssertEntityImplClass(mappedResource)));
+            assertThat(EntityDependencyOrder.INSERT_ORDER.contains(getAndAssertEntityImplClass(mappedResource)))
+                .as("No insert entry in EntityDependencyOrder for " + mappedResource).isTrue();
+            assertThat(EntityDependencyOrder.DELETE_ORDER.contains(getAndAssertEntityImplClass(mappedResource)))
+                .as("No delete entry in EntityDependencyOrder for " + mappedResource).isTrue();
         }
     }
     
@@ -57,14 +58,15 @@ public class EntitiesTest {
     public void verifyEntitiesInTableDataManager() {
         Set<String> mappedResources = getMappedResources();
         for (String mappedResource : mappedResources) {
-            assertTrue("No entry in TableDataManagerImpl for " + mappedResource, TableDataManagerImpl.entityToTableNameMap.containsKey(getAndAssertEntityInterfaceClass(mappedResource)));
+            assertThat(TableDataManagerImpl.entityToTableNameMap.containsKey(getAndAssertEntityInterfaceClass(mappedResource)))
+                .as("No entry in TableDataManagerImpl for " + mappedResource).isTrue();
         }
     }
     
     protected Class getAndAssertEntityInterfaceClass(String mappedResource) {
         try {
             Class c = Class.forName("org.flowable.app.engine.impl.persistence.entity." + mappedResource + "Entity");
-            assertNotNull(c);
+            assertThat(c).isNotNull();
             return c;
         } catch (Exception e) {
             throw new AssertionError("Entity interface class for " + mappedResource + " not found", e);
@@ -74,7 +76,7 @@ public class EntitiesTest {
     protected Class getAndAssertEntityImplClass(String mappedResource) {
         try {
             Class c = Class.forName("org.flowable.app.engine.impl.persistence.entity." + mappedResource + "EntityImpl");
-            assertNotNull(c);
+            assertThat(c).isNotNull();
             return c;
         } catch (Exception e) {
             throw new AssertionError("Entity interface class for " + mappedResource + " not found", e);
@@ -105,7 +107,7 @@ public class EntitiesTest {
             
             resources.remove("TableData"); // not an entity
             
-            assertTrue(resources.size() > 0);
+            assertThat(resources.size()).isPositive();
             return resources;
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/modules/flowable-app-engine/src/test/java/org/flowable/app/engine/test/repository/CaseDefinitionCategoryTest.java
+++ b/modules/flowable-app-engine/src/test/java/org/flowable/app/engine/test/repository/CaseDefinitionCategoryTest.java
@@ -12,9 +12,7 @@
  */
 package org.flowable.app.engine.test.repository;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
@@ -51,13 +49,13 @@ public class CaseDefinitionCategoryTest extends FlowableAppTestCase {
     @Test
     public void testUpdateCategory() {
         AppDefinition appDefinition = appRepositoryService.createAppDefinitionQuery().deploymentId(deploymentId1).singleResult();
-        assertNull(appDefinition.getCategory());
+        assertThat(appDefinition.getCategory()).isNull();
         
         appRepositoryService.setAppDefinitionCategory(appDefinition.getId(), "testCategory");
         appDefinition = appRepositoryService.createAppDefinitionQuery().deploymentId(deploymentId1).singleResult();
-        assertEquals("testCategory", appDefinition.getCategory());
+        assertThat(appDefinition.getCategory()).isEqualTo("testCategory");
         
         appDefinition = appRepositoryService.createAppDefinitionQuery().deploymentId(deploymentId1).appDefinitionCategory("testCategory").singleResult();
-        assertNotNull(appDefinition);
+        assertThat(appDefinition).isNotNull();
     }
 }

--- a/modules/flowable-app-engine/src/test/java/org/flowable/app/engine/test/repository/CaseDefinitionQueryTest.java
+++ b/modules/flowable-app-engine/src/test/java/org/flowable/app/engine/test/repository/CaseDefinitionQueryTest.java
@@ -12,9 +12,8 @@
  */
 package org.flowable.app.engine.test.repository;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -82,59 +81,60 @@ public class CaseDefinitionQueryTest extends FlowableAppTestCase {
 
     @Test
     public void testQueryNoParams() {
-        assertEquals(4, appRepositoryService.createAppDefinitionQuery().list().size());
-        assertEquals(4, appRepositoryService.createAppDefinitionQuery().count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().list()).hasSize(4);
+        assertThat(appRepositoryService.createAppDefinitionQuery().count()).isEqualTo(4);
     }
 
     @Test
     public void testQueryByDeploymentId() {
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().deploymentId(deploymentId1).list().size());
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().deploymentId(deploymentId1).count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().deploymentId(deploymentId1).list()).hasSize(1);
+        assertThat(appRepositoryService.createAppDefinitionQuery().deploymentId(deploymentId1).count()).isEqualTo(1);
 
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().deploymentId(deploymentId2).list().size());
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().deploymentId(deploymentId2).count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().deploymentId(deploymentId2).list()).hasSize(1);
+        assertThat(appRepositoryService.createAppDefinitionQuery().deploymentId(deploymentId2).count()).isEqualTo(1);
 
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().deploymentId(deploymentId3).list().size());
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().deploymentId(deploymentId3).count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().deploymentId(deploymentId3).list()).hasSize(1);
+        assertThat(appRepositoryService.createAppDefinitionQuery().deploymentId(deploymentId3).count()).isEqualTo(1);
         
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().deploymentId(deploymentId4).list().size());
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().deploymentId(deploymentId4).count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().deploymentId(deploymentId4).list()).hasSize(1);
+        assertThat(appRepositoryService.createAppDefinitionQuery().deploymentId(deploymentId4).count()).isEqualTo(1);
     }
 
     @Test
     public void testQueryByInvalidDeploymentId() {
-        assertEquals(0, appRepositoryService.createAppDefinitionQuery().deploymentId("invalid").list().size());
-        assertEquals(0, appRepositoryService.createAppDefinitionQuery().deploymentId("invalid").count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().deploymentId("invalid").list()).hasSize(0);
+        assertThat(appRepositoryService.createAppDefinitionQuery().deploymentId("invalid").count()).isEqualTo(0);
     }
 
     @Test
     public void testQueryByDeploymentIds() {
-        assertEquals(4, appRepositoryService.createAppDefinitionQuery().deploymentIds(new HashSet<>(Arrays.asList(deploymentId1, deploymentId2, deploymentId3, deploymentId4))).list().size());
-        assertEquals(4, appRepositoryService.createAppDefinitionQuery().deploymentIds(new HashSet<>(Arrays.asList(deploymentId1, deploymentId2, deploymentId3, deploymentId4))).count());
+        assertThat(appRepositoryService.createAppDefinitionQuery()
+            .deploymentIds(new HashSet<>(Arrays.asList(deploymentId1, deploymentId2, deploymentId3, deploymentId4))).list()).hasSize(4);
+        assertThat(appRepositoryService.createAppDefinitionQuery()
+            .deploymentIds(new HashSet<>(Arrays.asList(deploymentId1, deploymentId2, deploymentId3, deploymentId4))).count()).isEqualTo(4);
 
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().deploymentIds(new HashSet<>(Collections.singletonList(deploymentId1))).list().size());
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().deploymentIds(new HashSet<>(Collections.singletonList(deploymentId1))).count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().deploymentIds(new HashSet<>(Collections.singletonList(deploymentId1))).list()).hasSize(1);
+        assertThat(appRepositoryService.createAppDefinitionQuery().deploymentIds(new HashSet<>(Collections.singletonList(deploymentId1))).count()).isEqualTo(1);
 
-        assertEquals(2, appRepositoryService.createAppDefinitionQuery().deploymentIds(new HashSet<>(Arrays.asList(deploymentId2, deploymentId3))).list().size());
-        assertEquals(2, appRepositoryService.createAppDefinitionQuery().deploymentIds(new HashSet<>(Arrays.asList(deploymentId2, deploymentId3))).count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().deploymentIds(new HashSet<>(Arrays.asList(deploymentId2, deploymentId3))).list()).hasSize(2);
+        assertThat(appRepositoryService.createAppDefinitionQuery().deploymentIds(new HashSet<>(Arrays.asList(deploymentId2, deploymentId3))).count())
+            .isEqualTo(2);
 
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().deploymentIds(new HashSet<>(Collections.singletonList(deploymentId3))).list().size());
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().deploymentIds(new HashSet<>(Collections.singletonList(deploymentId3))).count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().deploymentIds(new HashSet<>(Collections.singletonList(deploymentId3))).list()).hasSize(1);
+        assertThat(appRepositoryService.createAppDefinitionQuery().deploymentIds(new HashSet<>(Collections.singletonList(deploymentId3))).count()).isEqualTo(1);
     }
 
     @Test
     public void testQueryByInvalidDeploymentIds() {
-        assertEquals(0, appRepositoryService.createAppDefinitionQuery().deploymentIds(new HashSet<>(Collections.singletonList("invalid"))).list().size());
-        assertEquals(0, appRepositoryService.createAppDefinitionQuery().deploymentIds(new HashSet<>(Collections.singletonList("invalid"))).count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().deploymentIds(new HashSet<>(Collections.singletonList("invalid"))).list()).hasSize(0);
+        assertThat(appRepositoryService.createAppDefinitionQuery().deploymentIds(new HashSet<>(Collections.singletonList("invalid"))).count()).isEqualTo(0);
     }
 
     @Test
     public void testQueryByEmptyDeploymentIds() {
-        try {
+        assertThrows(FlowableIllegalArgumentException.class, () -> {
             appRepositoryService.createAppDefinitionQuery().deploymentIds(new HashSet<>()).list();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        });
     }
 
     @Test
@@ -143,23 +143,23 @@ public class CaseDefinitionQueryTest extends FlowableAppTestCase {
         List<String> appDefinitionIdsDeployment2 = getAppDefinitionIds(deploymentId2);
         List<String> appDefinitionIdsDeployment3 = getAppDefinitionIds(deploymentId3);
 
-        assertNotNull(appRepositoryService.createAppDefinitionQuery().appDefinitionId(appDefinitionIdsDeployment1.get(0)).singleResult());
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().appDefinitionId(appDefinitionIdsDeployment1.get(0)).list().size());
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().appDefinitionId(appDefinitionIdsDeployment1.get(0)).count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionId(appDefinitionIdsDeployment1.get(0)).singleResult()).isNotNull();
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionId(appDefinitionIdsDeployment1.get(0)).list()).hasSize(1);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionId(appDefinitionIdsDeployment1.get(0)).count()).isEqualTo(1);
 
-        assertNotNull(appRepositoryService.createAppDefinitionQuery().appDefinitionId(appDefinitionIdsDeployment2.get(0)).singleResult());
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().appDefinitionId(appDefinitionIdsDeployment2.get(0)).list().size());
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().appDefinitionId(appDefinitionIdsDeployment2.get(0)).count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionId(appDefinitionIdsDeployment2.get(0)).singleResult()).isNotNull();
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionId(appDefinitionIdsDeployment2.get(0)).list()).hasSize(1);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionId(appDefinitionIdsDeployment2.get(0)).count()).isEqualTo(1);
 
-        assertNotNull(appRepositoryService.createAppDefinitionQuery().appDefinitionId(appDefinitionIdsDeployment3.get(0)).singleResult());
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().appDefinitionId(appDefinitionIdsDeployment3.get(0)).list().size());
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().appDefinitionId(appDefinitionIdsDeployment3.get(0)).count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionId(appDefinitionIdsDeployment3.get(0)).singleResult()).isNotNull();
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionId(appDefinitionIdsDeployment3.get(0)).list()).hasSize(1);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionId(appDefinitionIdsDeployment3.get(0)).count()).isEqualTo(1);
     }
 
     @Test
     public void testQueryByInvalidAppDefinitionId() {
-        assertEquals(0, appRepositoryService.createAppDefinitionQuery().appDefinitionId("invalid").list().size());
-        assertEquals(0, appRepositoryService.createAppDefinitionQuery().appDefinitionId("invalid").count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionId("invalid").list()).hasSize(0);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionId("invalid").count()).isEqualTo(0);
     }
 
     @Test
@@ -167,301 +167,302 @@ public class CaseDefinitionQueryTest extends FlowableAppTestCase {
         List<String> appDefinitionIdsDeployment1 = getAppDefinitionIds(deploymentId1);
         List<String> appDefinitionIdsDeployment2 = getAppDefinitionIds(deploymentId2);
 
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().appDefinitionIds(new HashSet<>(appDefinitionIdsDeployment1)).list().size());
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().appDefinitionIds(new HashSet<>(appDefinitionIdsDeployment1)).count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionIds(new HashSet<>(appDefinitionIdsDeployment1)).list()).hasSize(1);;
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionIds(new HashSet<>(appDefinitionIdsDeployment1)).count()).isEqualTo(1);
 
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().appDefinitionIds(new HashSet<>(appDefinitionIdsDeployment2)).list().size());
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().appDefinitionIds(new HashSet<>(appDefinitionIdsDeployment2)).count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionIds(new HashSet<>(appDefinitionIdsDeployment2)).list()).hasSize(1);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionIds(new HashSet<>(appDefinitionIdsDeployment2)).count()).isEqualTo(1);
     }
 
     @Test
     public void testQueryByEmptyAppDefinitionIds() {
-        try {
+        assertThrows(FlowableIllegalArgumentException.class, () -> {
             appRepositoryService.createAppDefinitionQuery().appDefinitionIds(new HashSet<>()).list();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        });
     }
 
     @Test
     public void testQueryByInvalidAppDefinitionIds() {
-        assertEquals(0, appRepositoryService.createAppDefinitionQuery().appDefinitionIds(new HashSet<>(Arrays.asList("invalid1", "invalid2"))).list().size());
-        assertEquals(0, appRepositoryService.createAppDefinitionQuery().appDefinitionIds(new HashSet<>(Arrays.asList("invalid1", "invalid2"))).count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionIds(new HashSet<>(Arrays.asList("invalid1", "invalid2"))).list()).hasSize(0);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionIds(new HashSet<>(Arrays.asList("invalid1", "invalid2"))).count()).isEqualTo(0);
     }
 
     @Test
     public void testQueryByAppDefinitionCategory() {
-        assertEquals(4, appRepositoryService.createAppDefinitionQuery().appDefinitionCategory("http://flowable.org/app").list().size());
-        assertEquals(4, appRepositoryService.createAppDefinitionQuery().appDefinitionCategory("http://flowable.org/app").count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionCategory("http://flowable.org/app").list()).hasSize(4);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionCategory("http://flowable.org/app").count()).isEqualTo(4);
     }
 
     @Test
     public void testQueryByInvalidAppDefinitionCategory() {
-        assertEquals(0, appRepositoryService.createAppDefinitionQuery().appDefinitionCategory("invalid").list().size());
-        assertEquals(0, appRepositoryService.createAppDefinitionQuery().appDefinitionCategory("invalid").count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionCategory("invalid").list()).hasSize(0);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionCategory("invalid").count()).isEqualTo(0);
     }
 
     @Test
     public void testQueryByAppDefinitionCategoryLike() {
-        assertEquals(4, appRepositoryService.createAppDefinitionQuery().appDefinitionCategoryLike("http%").list().size());
-        assertEquals(4, appRepositoryService.createAppDefinitionQuery().appDefinitionCategoryLike("http%").count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionCategoryLike("http%").list()).hasSize(4);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionCategoryLike("http%").count()).isEqualTo(4);
     }
 
     @Test
     public void testQueryByInvalidAppDefinitionCategoryLike() {
-        assertEquals(0, appRepositoryService.createAppDefinitionQuery().appDefinitionCategoryLike("invalid%").list().size());
-        assertEquals(0, appRepositoryService.createAppDefinitionQuery().appDefinitionCategoryLike("invalid%n").count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionCategoryLike("invalid%").list()).hasSize(0);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionCategoryLike("invalid%n").count()).isEqualTo(0);
     }
 
     @Test
     public void testQueryByAppDefinitionCategoryNotEquals() {
-        assertEquals(4, appRepositoryService.createAppDefinitionQuery().appDefinitionCategoryNotEquals("another").list().size());
-        assertEquals(4, appRepositoryService.createAppDefinitionQuery().appDefinitionCategoryNotEquals("another").count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionCategoryNotEquals("another").list()).hasSize(4);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionCategoryNotEquals("another").count()).isEqualTo(4);
 
-        assertEquals(0, appRepositoryService.createAppDefinitionQuery().appDefinitionCategoryNotEquals("http://flowable.org/app").list().size());
-        assertEquals(0, appRepositoryService.createAppDefinitionQuery().appDefinitionCategoryNotEquals("http://flowable.org/app").count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionCategoryNotEquals("http://flowable.org/app").list()).hasSize(0);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionCategoryNotEquals("http://flowable.org/app").count()).isEqualTo(0);
     }
 
     @Test
     public void testQueryByAppDefinitionName() {
-        assertEquals(3, appRepositoryService.createAppDefinitionQuery().appDefinitionName("Test app").list().size());
-        assertEquals(3, appRepositoryService.createAppDefinitionQuery().appDefinitionName("Test app").count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionName("Test app").list()).hasSize(3);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionName("Test app").count()).isEqualTo(3);
 
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().appDefinitionName("Full info app").list().size());
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().appDefinitionName("Full info app").count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionName("Full info app").list()).hasSize(1);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionName("Full info app").count()).isEqualTo(1);
 
-        assertEquals(deploymentId2, appRepositoryService.createAppDefinitionQuery().appDefinitionName("Full info app").singleResult().getDeploymentId());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionName("Full info app").singleResult().getDeploymentId())
+            .isEqualTo(deploymentId2);
     }
 
     @Test
     public void testQueryByInvalidAppDefinitionName() {
-        assertEquals(0, appRepositoryService.createAppDefinitionQuery().appDefinitionName("Case 3").list().size());
-        assertEquals(0, appRepositoryService.createAppDefinitionQuery().appDefinitionName("Case 3").count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionName("Case 3").list()).hasSize(0);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionName("Case 3").count()).isEqualTo(0);
     }
 
     @Test
     public void testQueryByAppDefinitionNameLike() {
-        assertEquals(4, appRepositoryService.createAppDefinitionQuery().appDefinitionNameLike("%app").list().size());
-        assertEquals(4, appRepositoryService.createAppDefinitionQuery().appDefinitionNameLike("%app").count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionNameLike("%app").list()).hasSize(4);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionNameLike("%app").count()).isEqualTo(4);
 
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().appDefinitionNameLike("Full%").list().size());
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().appDefinitionNameLike("Full%").count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionNameLike("Full%").list()).hasSize(1);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionNameLike("Full%").count()).isEqualTo(1);
 
-        assertEquals(0, appRepositoryService.createAppDefinitionQuery().appDefinitionNameLike("invalid%").list().size());
-        assertEquals(0, appRepositoryService.createAppDefinitionQuery().appDefinitionNameLike("invalid%").count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionNameLike("invalid%").list()).hasSize(0);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionNameLike("invalid%").count()).isEqualTo(0);
     }
 
     @Test
     public void testQueryByAppDefinitionKey() {
-        assertEquals(3, appRepositoryService.createAppDefinitionQuery().appDefinitionKey("testApp").list().size());
-        assertEquals(3, appRepositoryService.createAppDefinitionQuery().appDefinitionKey("testApp").count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionKey("testApp").list()).hasSize(3);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionKey("testApp").count()).isEqualTo(3);
 
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().appDefinitionKey("fullInfoApp").list().size());
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().appDefinitionKey("fullInfoApp").count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionKey("fullInfoApp").list()).hasSize(1);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionKey("fullInfoApp").count()).isEqualTo(1);
     }
 
     @Test
     public void testQueryByInvalidAppDefinitionKey() {
-        assertEquals(0, appRepositoryService.createAppDefinitionQuery().appDefinitionKey("invalid").list().size());
-        assertEquals(0, appRepositoryService.createAppDefinitionQuery().appDefinitionKey("invalid").count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionKey("invalid").list()).hasSize(0);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionKey("invalid").count()).isEqualTo(0);
     }
 
     @Test
     public void testQueryByAppDefinitionKeyLike() {
-        assertEquals(4, appRepositoryService.createAppDefinitionQuery().appDefinitionKeyLike("%App").list().size());
-        assertEquals(4, appRepositoryService.createAppDefinitionQuery().appDefinitionKeyLike("%App").count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionKeyLike("%App").list()).hasSize(4);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionKeyLike("%App").count()).isEqualTo(4);
 
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().appDefinitionKeyLike("full%").list().size());
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().appDefinitionKeyLike("full%").count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionKeyLike("full%").list()).hasSize(1);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionKeyLike("full%").count()).isEqualTo(1);
     }
 
     @Test
     public void testQueryByInvalidAppDefinitionKeyLike() {
-        assertEquals(0, appRepositoryService.createAppDefinitionQuery().appDefinitionKeyLike("%invalid").list().size());
-        assertEquals(0, appRepositoryService.createAppDefinitionQuery().appDefinitionKeyLike("%invalid").count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionKeyLike("%invalid").list()).hasSize(0);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionKeyLike("%invalid").count()).isEqualTo(0);
     }
 
     @Test
     public void testQueryByAppDefinitionVersion() {
-        assertEquals(2, appRepositoryService.createAppDefinitionQuery().appDefinitionVersion(1).list().size());
-        assertEquals(2, appRepositoryService.createAppDefinitionQuery().appDefinitionVersion(1).count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersion(1).list()).hasSize(2);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersion(1).count()).isEqualTo(2);
 
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().appDefinitionVersion(2).list().size());
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().appDefinitionVersion(2).count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersion(2).list()).hasSize(1);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersion(2).count()).isEqualTo(1);
 
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().appDefinitionVersion(2).list().size());
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().appDefinitionVersion(2).count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersion(2).list()).hasSize(1);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersion(2).count()).isEqualTo(1);
 
-        assertEquals(0, appRepositoryService.createAppDefinitionQuery().appDefinitionVersion(4).list().size());
-        assertEquals(0, appRepositoryService.createAppDefinitionQuery().appDefinitionVersion(4).count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersion(4).list()).hasSize(0);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersion(4).count()).isEqualTo(0);
     }
 
     @Test
     public void testQueryByAppDefinitionVersionGreaterThan() {
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().appDefinitionVersionGreaterThan(2).list().size());
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().appDefinitionVersionGreaterThan(2).count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersionGreaterThan(2).list()).hasSize(1);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersionGreaterThan(2).count()).isEqualTo(1);
 
-        assertEquals(0, appRepositoryService.createAppDefinitionQuery().appDefinitionVersionGreaterThan(3).list().size());
-        assertEquals(0, appRepositoryService.createAppDefinitionQuery().appDefinitionVersionGreaterThan(3).count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersionGreaterThan(3).list()).hasSize(0);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersionGreaterThan(3).count()).isEqualTo(0);
     }
 
     @Test
     public void testQueryByAppDefinitionVersionGreaterThanOrEquals() {
-        assertEquals(2, appRepositoryService.createAppDefinitionQuery().appDefinitionVersionGreaterThanOrEquals(2).list().size());
-        assertEquals(2, appRepositoryService.createAppDefinitionQuery().appDefinitionVersionGreaterThanOrEquals(2).count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersionGreaterThanOrEquals(2).list()).hasSize(2);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersionGreaterThanOrEquals(2).count()).isEqualTo(2);
 
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().appDefinitionVersionGreaterThanOrEquals(3).list().size());
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().appDefinitionVersionGreaterThanOrEquals(3).count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersionGreaterThanOrEquals(3).list()).hasSize(1);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersionGreaterThanOrEquals(3).count()).isEqualTo(1);
 
-        assertEquals(0, appRepositoryService.createAppDefinitionQuery().appDefinitionVersionGreaterThanOrEquals(4).list().size());
-        assertEquals(0, appRepositoryService.createAppDefinitionQuery().appDefinitionVersionGreaterThanOrEquals(4).count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersionGreaterThanOrEquals(4).list()).hasSize(0);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersionGreaterThanOrEquals(4).count()).isEqualTo(0);
     }
 
     @Test
     public void testQueryByAppDefinitionVersionLowerThan() {
-        assertEquals(2, appRepositoryService.createAppDefinitionQuery().appDefinitionVersionLowerThan(2).list().size());
-        assertEquals(2, appRepositoryService.createAppDefinitionQuery().appDefinitionVersionLowerThan(2).count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersionLowerThan(2).list()).hasSize(2);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersionLowerThan(2).count()).isEqualTo(2);
 
-        assertEquals(3, appRepositoryService.createAppDefinitionQuery().appDefinitionVersionLowerThan(3).list().size());
-        assertEquals(3, appRepositoryService.createAppDefinitionQuery().appDefinitionVersionLowerThan(3).count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersionLowerThan(3).list()).hasSize(3);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersionLowerThan(3).count()).isEqualTo(3);
     }
 
     @Test
     public void testQueryByAppDefinitionVersionLowerThanOrEquals() {
-        assertEquals(3, appRepositoryService.createAppDefinitionQuery().appDefinitionVersionLowerThanOrEquals(2).list().size());
-        assertEquals(3, appRepositoryService.createAppDefinitionQuery().appDefinitionVersionLowerThanOrEquals(2).count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersionLowerThanOrEquals(2).list()).hasSize(3);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersionLowerThanOrEquals(2).count()).isEqualTo(3);
 
-        assertEquals(4, appRepositoryService.createAppDefinitionQuery().appDefinitionVersionLowerThanOrEquals(3).list().size());
-        assertEquals(4, appRepositoryService.createAppDefinitionQuery().appDefinitionVersionLowerThanOrEquals(3).count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersionLowerThanOrEquals(3).list()).hasSize(4);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersionLowerThanOrEquals(3).count()).isEqualTo(4);
 
-        assertEquals(4, appRepositoryService.createAppDefinitionQuery().appDefinitionVersionLowerThanOrEquals(4).list().size());
-        assertEquals(4, appRepositoryService.createAppDefinitionQuery().appDefinitionVersionLowerThanOrEquals(4).count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersionLowerThanOrEquals(4).list()).hasSize(4);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersionLowerThanOrEquals(4).count()).isEqualTo(4);
     }
 
     @Test
     public void testQueryByLatestVersion() {
-        assertEquals(2, appRepositoryService.createAppDefinitionQuery().latestVersion().list().size());
-        assertEquals(2, appRepositoryService.createAppDefinitionQuery().latestVersion().count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().latestVersion().list()).hasSize(2);
+        assertThat(appRepositoryService.createAppDefinitionQuery().latestVersion().count()).isEqualTo(2);
     }
 
     @Test
     public void testQueryByLatestVersionAndKey() {
         AppDefinition appDefinition = appRepositoryService.createAppDefinitionQuery().appDefinitionKey("testApp").latestVersion().singleResult();
-        assertNotNull(appDefinition);
-        assertEquals(3, appDefinition.getVersion());
-        assertEquals(deploymentId4, appDefinition.getDeploymentId());
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().appDefinitionKey("testApp").latestVersion().list().size());
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().appDefinitionKey("testApp").latestVersion().count());
+        assertThat(appDefinition).isNotNull();
+        assertThat(appDefinition.getVersion()).isEqualTo(3);
+        assertThat(appDefinition.getDeploymentId()).isEqualTo(deploymentId4);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionKey("testApp").latestVersion().list()).hasSize(1);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionKey("testApp").latestVersion().count()).isEqualTo(1);
     }
 
     @Test
     public void testQueryByAppDefinitionResourceName() {
-        assertEquals(3, appRepositoryService.createAppDefinitionQuery().appDefinitionResourceName("org/flowable/app/engine/test/test.app").list().size());
-        assertEquals(3, appRepositoryService.createAppDefinitionQuery().appDefinitionResourceName("org/flowable/app/engine/test/test.app").count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionResourceName("org/flowable/app/engine/test/test.app").list()).hasSize(3);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionResourceName("org/flowable/app/engine/test/test.app").count()).isEqualTo(3);
 
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().appDefinitionResourceName("org/flowable/app/engine/test/fullinfo.app").list().size());
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().appDefinitionResourceName("org/flowable/app/engine/test/fullinfo.app").count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionResourceName("org/flowable/app/engine/test/fullinfo.app").list()).hasSize(1);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionResourceName("org/flowable/app/engine/test/fullinfo.app").count()).isEqualTo(1);
 
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().appDefinitionResourceName("org/flowable/app/engine/test/test.app").latestVersion().list().size());
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().appDefinitionResourceName("org/flowable/app/engine/test/test.app").latestVersion().count());
+        assertThat(
+            appRepositoryService.createAppDefinitionQuery().appDefinitionResourceName("org/flowable/app/engine/test/test.app").latestVersion().list()).hasSize(1);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionResourceName("org/flowable/app/engine/test/test.app").latestVersion().count())
+            .isEqualTo(1);
     }
 
     @Test
     public void testQueryByInvalidAppDefinitionResourceName() {
-        assertEquals(0, appRepositoryService.createAppDefinitionQuery().appDefinitionResourceName("invalid.app").list().size());
-        assertEquals(0, appRepositoryService.createAppDefinitionQuery().appDefinitionResourceName("invalid.app").count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionResourceName("invalid.app").list()).hasSize(0);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionResourceName("invalid.app").count()).isEqualTo(0);
     }
 
     @Test
     public void testQueryByAppDefinitionResourceNameLike() {
-        assertEquals(4, appRepositoryService.createAppDefinitionQuery().appDefinitionResourceNameLike("%.app").list().size());
-        assertEquals(4, appRepositoryService.createAppDefinitionQuery().appDefinitionResourceNameLike("%.app").count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionResourceNameLike("%.app").list()).hasSize(4);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionResourceNameLike("%.app").count()).isEqualTo(4);
 
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().appDefinitionResourceNameLike("%full%").list().size());
-        assertEquals(1, appRepositoryService.createAppDefinitionQuery().appDefinitionResourceNameLike("%full%").count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionResourceNameLike("%full%").list()).hasSize(1);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionResourceNameLike("%full%").count()).isEqualTo(1);
     }
 
     @Test
     public void testQueryByInvalidAppDefinitionResourceNameLike() {
-        assertEquals(0, appRepositoryService.createAppDefinitionQuery().appDefinitionResourceNameLike("%invalid%").list().size());
-        assertEquals(0, appRepositoryService.createAppDefinitionQuery().appDefinitionResourceNameLike("%invalid%").count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionResourceNameLike("%invalid%").list()).hasSize(0);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionResourceNameLike("%invalid%").count()).isEqualTo(0);
     }
 
     @Test
     public void testQueryOrderByAppDefinitionCategory() {
-        assertEquals(4, appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionCategory().asc().list().size());
-        assertEquals(4, appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionCategory().asc().count());
-        assertEquals(4, appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionCategory().desc().list().size());
-        assertEquals(4, appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionCategory().desc().count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionCategory().asc().list()).hasSize(4);
+        assertThat(appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionCategory().asc().count()).isEqualTo(4);
+        assertThat(appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionCategory().desc().list()).hasSize(4);
+        assertThat(appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionCategory().desc().count()).isEqualTo(4);
     }
 
     @Test
     public void testQueryOrderByCaseDefinitionKey() {
-        assertEquals(4, appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionKey().asc().list().size());
-        assertEquals(4, appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionKey().asc().count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionKey().asc().list()).hasSize(4);
+        assertThat(appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionKey().asc().count()).isEqualTo(4);
         List<AppDefinition> appDefinitions = appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionKey().asc().list();
         for (int i = 0; i < appDefinitions.size(); i++) {
             if (i > 0) {
-                assertEquals("testApp", appDefinitions.get(i).getKey());
+                assertThat(appDefinitions.get(i).getKey()).isEqualTo("testApp");
             } else {
-                assertEquals("fullInfoApp", appDefinitions.get(i).getKey());
+                assertThat(appDefinitions.get(i).getKey()).isEqualTo("fullInfoApp");
             }
         }
 
-        assertEquals(4, appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionKey().desc().list().size());
-        assertEquals(4, appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionKey().desc().count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionKey().desc().list()).hasSize(4);
+        assertThat(appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionKey().desc().count()).isEqualTo(4);
         appDefinitions = appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionKey().desc().list();
         for (int i = 0; i < appDefinitions.size(); i++) {
             if (i <= 2) {
-                assertEquals("testApp", appDefinitions.get(i).getKey());
+                assertThat(appDefinitions.get(i).getKey()).isEqualTo("testApp");
             } else {
-                assertEquals("fullInfoApp", appDefinitions.get(i).getKey());
+                assertThat(appDefinitions.get(i).getKey()).isEqualTo("fullInfoApp");
             }
         }
     }
 
     @Test
     public void testQueryOrderByAppDefinitionId() {
-        assertEquals(4, appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionId().asc().list().size());
-        assertEquals(4, appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionId().asc().count());
-        assertEquals(4, appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionId().desc().list().size());
-        assertEquals(4, appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionId().desc().count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionId().asc().list()).hasSize(4);
+        assertThat(appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionId().asc().count()).isEqualTo(4);
+        assertThat(appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionId().desc().list()).hasSize(4);
+        assertThat(appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionId().desc().count()).isEqualTo(4);
     }
 
     @Test
     public void testQueryOrderByAppDefinitionName() {
-        assertEquals(4, appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionName().asc().list().size());
-        assertEquals(4, appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionName().asc().count());
-        assertEquals(4, appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionName().desc().list().size());
-        assertEquals(4, appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionName().desc().count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionName().asc().list()).hasSize(4);
+        assertThat(appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionName().asc().count()).isEqualTo(4);
+        assertThat(appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionName().desc().list()).hasSize(4);
+        assertThat(appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionName().desc().count()).isEqualTo(4);
     }
 
     @Test
     public void testQueryOrderByAppDefinitionDeploymentId() {
-        assertEquals(4, appRepositoryService.createAppDefinitionQuery().orderByDeploymentId().asc().list().size());
-        assertEquals(4, appRepositoryService.createAppDefinitionQuery().orderByDeploymentId().asc().count());
-        assertEquals(4, appRepositoryService.createAppDefinitionQuery().orderByDeploymentId().desc().list().size());
-        assertEquals(4, appRepositoryService.createAppDefinitionQuery().orderByDeploymentId().desc().count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().orderByDeploymentId().asc().list()).hasSize(4);
+        assertThat(appRepositoryService.createAppDefinitionQuery().orderByDeploymentId().asc().count()).isEqualTo(4);
+        assertThat(appRepositoryService.createAppDefinitionQuery().orderByDeploymentId().desc().list()).hasSize(4);
+        assertThat(appRepositoryService.createAppDefinitionQuery().orderByDeploymentId().desc().count()).isEqualTo(4);
     }
 
     @Test
     public void testQueryOrderByAppDefinitionVersion() {
-        assertEquals(4, appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionVersion().asc().list().size());
-        assertEquals(4, appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionVersion().asc().count());
-        assertEquals(4, appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionVersion().desc().list().size());
-        assertEquals(4, appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionVersion().desc().count());
+        assertThat(appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionVersion().asc().list()).hasSize(4);
+        assertThat(appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionVersion().asc().count()).isEqualTo(4);
+        assertThat(appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionVersion().desc().list()).hasSize(4);
+        assertThat(appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionVersion().desc().count()).isEqualTo(4);
 
         List<AppDefinition> appDefinitions = appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionVersion().desc().list();
-        assertEquals(3, appDefinitions.get(0).getVersion());
-        assertEquals(2, appDefinitions.get(1).getVersion());
-        assertEquals(1, appDefinitions.get(2).getVersion());
-        assertEquals(1, appDefinitions.get(3).getVersion());
+        assertThat(appDefinitions.get(0).getVersion()).isEqualTo(3);
+        assertThat(appDefinitions.get(1).getVersion()).isEqualTo(2);
+        assertThat(appDefinitions.get(2).getVersion()).isEqualTo(1);
+        assertThat(appDefinitions.get(3).getVersion()).isEqualTo(1);
 
         appDefinitions = appRepositoryService.createAppDefinitionQuery().latestVersion().orderByAppDefinitionVersion().asc().list();
-        assertEquals(1, appDefinitions.get(0).getVersion());
-        assertEquals("fullInfoApp", appDefinitions.get(0).getKey());
-        assertEquals(3, appDefinitions.get(1).getVersion());
-        assertEquals("testApp", appDefinitions.get(1).getKey());
+        assertThat(appDefinitions.get(0).getVersion()).isEqualTo(1);
+        assertThat(appDefinitions.get(0).getKey()).isEqualTo("fullInfoApp");
+        assertThat(appDefinitions.get(1).getVersion()).isEqualTo(3);
+        assertThat(appDefinitions.get(1).getKey()).isEqualTo("testApp");
     }
 
     private List<String> getAppDefinitionIds(String deploymentId) {

--- a/modules/flowable-app-engine/src/test/java/org/flowable/app/engine/test/repository/CaseDefinitionQueryTest.java
+++ b/modules/flowable-app-engine/src/test/java/org/flowable/app/engine/test/repository/CaseDefinitionQueryTest.java
@@ -13,7 +13,8 @@
 package org.flowable.app.engine.test.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -132,9 +133,8 @@ public class CaseDefinitionQueryTest extends FlowableAppTestCase {
 
     @Test
     public void testQueryByEmptyDeploymentIds() {
-        assertThrows(FlowableIllegalArgumentException.class, () -> {
-            appRepositoryService.createAppDefinitionQuery().deploymentIds(new HashSet<>()).list();
-        });
+        assertThatThrownBy(() -> appRepositoryService.createAppDefinitionQuery().deploymentIds(new HashSet<>()).list())
+            .isInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
@@ -176,9 +176,8 @@ public class CaseDefinitionQueryTest extends FlowableAppTestCase {
 
     @Test
     public void testQueryByEmptyAppDefinitionIds() {
-        assertThrows(FlowableIllegalArgumentException.class, () -> {
-            appRepositoryService.createAppDefinitionQuery().appDefinitionIds(new HashSet<>()).list();
-        });
+        assertThatThrownBy(() -> appRepositoryService.createAppDefinitionQuery().appDefinitionIds(new HashSet<>()).list())
+            .isInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
@@ -401,24 +400,16 @@ public class CaseDefinitionQueryTest extends FlowableAppTestCase {
         assertThat(appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionKey().asc().list()).hasSize(4);
         assertThat(appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionKey().asc().count()).isEqualTo(4);
         List<AppDefinition> appDefinitions = appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionKey().asc().list();
-        for (int i = 0; i < appDefinitions.size(); i++) {
-            if (i > 0) {
-                assertThat(appDefinitions.get(i).getKey()).isEqualTo("testApp");
-            } else {
-                assertThat(appDefinitions.get(i).getKey()).isEqualTo("fullInfoApp");
-            }
-        }
+        assertThat(appDefinitions)
+            .extracting(AppDefinition::getKey)
+            .containsExactly("fullInfoApp", "testApp", "testApp", "testApp");
 
         assertThat(appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionKey().desc().list()).hasSize(4);
         assertThat(appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionKey().desc().count()).isEqualTo(4);
         appDefinitions = appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionKey().desc().list();
-        for (int i = 0; i < appDefinitions.size(); i++) {
-            if (i <= 2) {
-                assertThat(appDefinitions.get(i).getKey()).isEqualTo("testApp");
-            } else {
-                assertThat(appDefinitions.get(i).getKey()).isEqualTo("fullInfoApp");
-            }
-        }
+        assertThat(appDefinitions)
+            .extracting(AppDefinition::getKey)
+            .containsExactly("testApp", "testApp", "testApp", "fullInfoApp");
     }
 
     @Test
@@ -453,16 +444,17 @@ public class CaseDefinitionQueryTest extends FlowableAppTestCase {
         assertThat(appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionVersion().desc().count()).isEqualTo(4);
 
         List<AppDefinition> appDefinitions = appRepositoryService.createAppDefinitionQuery().orderByAppDefinitionVersion().desc().list();
-        assertThat(appDefinitions.get(0).getVersion()).isEqualTo(3);
-        assertThat(appDefinitions.get(1).getVersion()).isEqualTo(2);
-        assertThat(appDefinitions.get(2).getVersion()).isEqualTo(1);
-        assertThat(appDefinitions.get(3).getVersion()).isEqualTo(1);
+        assertThat(appDefinitions)
+            .extracting(AppDefinition::getVersion)
+            .containsExactly(3, 2, 1, 1);
 
         appDefinitions = appRepositoryService.createAppDefinitionQuery().latestVersion().orderByAppDefinitionVersion().asc().list();
-        assertThat(appDefinitions.get(0).getVersion()).isEqualTo(1);
-        assertThat(appDefinitions.get(0).getKey()).isEqualTo("fullInfoApp");
-        assertThat(appDefinitions.get(1).getVersion()).isEqualTo(3);
-        assertThat(appDefinitions.get(1).getKey()).isEqualTo("testApp");
+        assertThat(appDefinitions)
+            .extracting(AppDefinition::getKey, AppDefinition::getVersion)
+            .containsExactly(
+                tuple("fullInfoApp", 1),
+                tuple("testApp", 3)
+            );
     }
 
     private List<String> getAppDefinitionIds(String deploymentId) {

--- a/modules/flowable-app-engine/src/test/java/org/flowable/app/engine/test/repository/CustomAppModelTest.java
+++ b/modules/flowable-app-engine/src/test/java/org/flowable/app/engine/test/repository/CustomAppModelTest.java
@@ -40,8 +40,9 @@ public class CustomAppModelTest extends FlowableAppTestCase {
             AppDefinition appDefinition = appRepositoryService.createAppDefinitionQuery().appDefinitionKey("extraInfoApp").singleResult();
             
             AppModel appModel = appRepositoryService.getAppModel(appDefinition.getId());
-            assertThat(appModel).isNotNull();
-            assertThat(appModel instanceof CustomAppModel).isTrue();
+            assertThat(appModel)
+                .isNotNull()
+                .isInstanceOf(CustomAppModel.class);
             
             CustomAppModel customAppModel = (CustomAppModel) appModel;
             assertThat(customAppModel.getKey()).isEqualTo("extraInfoApp");

--- a/modules/flowable-app-engine/src/test/java/org/flowable/app/engine/test/repository/CustomAppModelTest.java
+++ b/modules/flowable-app-engine/src/test/java/org/flowable/app/engine/test/repository/CustomAppModelTest.java
@@ -12,9 +12,7 @@
  */
 package org.flowable.app.engine.test.repository;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.app.api.repository.AppDefinition;
 import org.flowable.app.api.repository.AppDeployment;
@@ -37,18 +35,18 @@ public class CustomAppModelTest extends FlowableAppTestCase {
         try {
             deploymentId = appRepositoryService.createDeployment().addClasspathResource("org/flowable/app/engine/test/extraInfoApp.app").deploy().getId();
             AppDeployment appDeployment = appRepositoryService.createDeploymentQuery().singleResult();
-            assertNotNull(appDeployment);
+            assertThat(appDeployment).isNotNull();
             
             AppDefinition appDefinition = appRepositoryService.createAppDefinitionQuery().appDefinitionKey("extraInfoApp").singleResult();
             
             AppModel appModel = appRepositoryService.getAppModel(appDefinition.getId());
-            assertNotNull(appModel);
-            assertTrue(appModel instanceof CustomAppModel);
+            assertThat(appModel).isNotNull();
+            assertThat(appModel instanceof CustomAppModel).isTrue();
             
             CustomAppModel customAppModel = (CustomAppModel) appModel;
-            assertEquals("extraInfoApp", customAppModel.getKey());
-            assertEquals("Extra info app", customAppModel.getName());
-            assertEquals("test", customAppModel.getExtraProperty());
+            assertThat(customAppModel.getKey()).isEqualTo("extraInfoApp");
+            assertThat(customAppModel.getName()).isEqualTo("Extra info app");
+            assertThat(customAppModel.getExtraProperty()).isEqualTo("test");
             
         } finally {
             appEngineConfiguration.setAppResourceConverter(defaultAppResourceConverter);
@@ -62,13 +60,13 @@ public class CustomAppModelTest extends FlowableAppTestCase {
         try {
             deploymentId = appRepositoryService.createDeployment().addClasspathResource("org/flowable/app/engine/test/extraInfoApp.app").deploy().getId();
             AppDeployment appDeployment = appRepositoryService.createDeploymentQuery().singleResult();
-            assertNotNull(appDeployment);
+            assertThat(appDeployment).isNotNull();
 
             AppDefinition appDefinition = appRepositoryService.createAppDefinitionQuery().appDefinitionKey("extraInfoApp").singleResult();
-            assertNotNull(appDefinition);
+            assertThat(appDefinition).isNotNull();
 
             AppModel appModel = appRepositoryService.getAppModel(appDefinition.getId());
-            assertNotNull(appModel);
+            assertThat(appModel).isNotNull();
 
         } finally {
             if (deploymentId != null) {

--- a/modules/flowable-app-engine/src/test/java/org/flowable/app/engine/test/repository/DeploymentQueryTest.java
+++ b/modules/flowable-app-engine/src/test/java/org/flowable/app/engine/test/repository/DeploymentQueryTest.java
@@ -59,7 +59,7 @@ public class DeploymentQueryTest extends FlowableAppTestCase {
 
         assertThat(appRepositoryService.createDeploymentQuery().list())
             .extracting(AppDeployment::getId)
-            .containsExactly(deploymentId1, deploymentId2);
+            .containsExactlyInAnyOrder(deploymentId1, deploymentId2);
     }
     
     @Test

--- a/modules/flowable-app-engine/src/test/java/org/flowable/app/engine/test/repository/DeploymentQueryTest.java
+++ b/modules/flowable-app-engine/src/test/java/org/flowable/app/engine/test/repository/DeploymentQueryTest.java
@@ -56,18 +56,10 @@ public class DeploymentQueryTest extends FlowableAppTestCase {
     public void testQueryNoParams() {
         assertThat(appRepositoryService.createDeploymentQuery().list()).hasSize(2);
         assertThat(appRepositoryService.createDeploymentQuery().count()).isEqualTo(2);
-        
-        boolean deployment1Found = false;
-        boolean deployment2Found = false;
-        for (AppDeployment cmmnDeployment : appRepositoryService.createDeploymentQuery().list()) {
-            if (deploymentId1.equals(cmmnDeployment.getId())) {
-                deployment1Found = true;
-            } else if (deploymentId2.equals(cmmnDeployment.getId())) {
-                deployment2Found = true;
-            }
-        }
-        assertThat(deployment1Found).isTrue();
-        assertThat(deployment2Found).isTrue();
+
+        assertThat(appRepositoryService.createDeploymentQuery().list())
+            .extracting(AppDeployment::getId)
+            .containsExactly(deploymentId1, deploymentId2);
     }
     
     @Test

--- a/modules/flowable-app-engine/src/test/java/org/flowable/app/engine/test/repository/DeploymentQueryTest.java
+++ b/modules/flowable-app-engine/src/test/java/org/flowable/app/engine/test/repository/DeploymentQueryTest.java
@@ -12,10 +12,7 @@
  */
 package org.flowable.app.engine.test.repository;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
@@ -57,8 +54,8 @@ public class DeploymentQueryTest extends FlowableAppTestCase {
     
     @Test
     public void testQueryNoParams() {
-        assertEquals(2, appRepositoryService.createDeploymentQuery().list().size());
-        assertEquals(2, appRepositoryService.createDeploymentQuery().count());
+        assertThat(appRepositoryService.createDeploymentQuery().list()).hasSize(2);
+        assertThat(appRepositoryService.createDeploymentQuery().count()).isEqualTo(2);
         
         boolean deployment1Found = false;
         boolean deployment2Found = false;
@@ -69,103 +66,104 @@ public class DeploymentQueryTest extends FlowableAppTestCase {
                 deployment2Found = true;
             }
         }
-        assertTrue(deployment1Found);
-        assertTrue(deployment2Found);
+        assertThat(deployment1Found).isTrue();
+        assertThat(deployment2Found).isTrue();
     }
     
     @Test
     public void testQueryByDeploymentId() {
-        assertNotNull(appRepositoryService.createDeploymentQuery().deploymentId(deploymentId1).singleResult());
-        assertEquals(deploymentId1, appRepositoryService.createDeploymentQuery().deploymentId(deploymentId1).singleResult().getId());
-        assertEquals(1, appRepositoryService.createDeploymentQuery().deploymentId(deploymentId1).list().size());
-        assertEquals(1, appRepositoryService.createDeploymentQuery().deploymentId(deploymentId1).count());
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentId(deploymentId1).singleResult()).isNotNull();
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentId(deploymentId1).singleResult().getId()).isEqualTo(deploymentId1);
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentId(deploymentId1).list()).hasSize(1);
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentId(deploymentId1).count()).isEqualTo(1);
         
-        assertNotNull(appRepositoryService.createDeploymentQuery().deploymentId(deploymentId2).singleResult());
-        assertEquals(1, appRepositoryService.createDeploymentQuery().deploymentId(deploymentId2).list().size());
-        assertEquals(1, appRepositoryService.createDeploymentQuery().deploymentId(deploymentId2).count());
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentId(deploymentId2).singleResult()).isNotNull();
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentId(deploymentId2).list()).hasSize(1);
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentId(deploymentId2).count()).isEqualTo(1);
     }
     
     @Test
     public void testQueryByInvalidDeploymentId() {
-        assertNull(appRepositoryService.createDeploymentQuery().deploymentId("invalid").singleResult());
-        assertEquals(0, appRepositoryService.createDeploymentQuery().deploymentId("invalid").list().size());
-        assertEquals(0, appRepositoryService.createDeploymentQuery().deploymentId("invalid").count());
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentId("invalid").singleResult()).isNull();
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentId("invalid").list()).hasSize(0);
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentId("invalid").count()).isEqualTo(0);
     }
     
     @Test
     public void testQueryByDeploymentName() {
-        assertNotNull(appRepositoryService.createDeploymentQuery().deploymentName("testName").singleResult());
-        assertEquals(deploymentId2, appRepositoryService.createDeploymentQuery().deploymentName("testName").singleResult().getId());
-        assertEquals(1, appRepositoryService.createDeploymentQuery().deploymentName("testName").list().size());
-        assertEquals(1, appRepositoryService.createDeploymentQuery().deploymentName("testName").count());
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentName("testName").singleResult()).isNotNull();
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentName("testName").singleResult().getId()).isEqualTo(deploymentId2);
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentName("testName").list()).hasSize(1);
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentName("testName").count()).isEqualTo(1);
     }
     
     @Test
     public void testQueryByInvalidDeploymentName() {
-        assertNull(appRepositoryService.createDeploymentQuery().deploymentName("invalid").singleResult());
-        assertEquals(0, appRepositoryService.createDeploymentQuery().deploymentName("invalid").list().size());
-        assertEquals(0, appRepositoryService.createDeploymentQuery().deploymentName("invalid").count());
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentName("invalid").singleResult()).isNull();
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentName("invalid").list()).hasSize(0);
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentName("invalid").count()).isEqualTo(0);
     }
     
     @Test
     public void testQueryByDeploymentNameLike() {
-        assertNotNull(appRepositoryService.createDeploymentQuery().deploymentNameLike("test%").singleResult());
-        assertEquals(deploymentId2, appRepositoryService.createDeploymentQuery().deploymentNameLike("test%").singleResult().getId());
-        assertEquals(1, appRepositoryService.createDeploymentQuery().deploymentNameLike("test%").list().size());
-        assertEquals(1, appRepositoryService.createDeploymentQuery().deploymentNameLike("test%").count());
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentNameLike("test%").singleResult()).isNotNull();
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentNameLike("test%").singleResult().getId()).isEqualTo(deploymentId2);
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentNameLike("test%").list()).hasSize(1);
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentNameLike("test%").count()).isEqualTo(1);
         
-        assertNull(appRepositoryService.createDeploymentQuery().deploymentNameLike("inval%").singleResult());
-        assertEquals(0, appRepositoryService.createDeploymentQuery().deploymentNameLike("inval%").list().size());
-        assertEquals(0, appRepositoryService.createDeploymentQuery().deploymentNameLike("inval%").count());
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentNameLike("inval%").singleResult()).isNull();
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentNameLike("inval%").list()).hasSize(0);
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentNameLike("inval%").count()).isEqualTo(0);
     }
     
     @Test
     public void testQueryByDeploymentCategory() {
-        assertNotNull(appRepositoryService.createDeploymentQuery().deploymentCategory("testCategory").singleResult());
-        assertEquals(deploymentId2, appRepositoryService.createDeploymentQuery().deploymentCategory("testCategory").singleResult().getId());
-        assertEquals(1, appRepositoryService.createDeploymentQuery().deploymentCategory("testCategory").list().size());
-        assertEquals(1, appRepositoryService.createDeploymentQuery().deploymentCategory("testCategory").count());
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentCategory("testCategory").singleResult()).isNotNull();
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentCategory("testCategory").singleResult().getId()).isEqualTo(deploymentId2);
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentCategory("testCategory").list()).hasSize(1);
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentCategory("testCategory").count()).isEqualTo(1);
     }
     
     @Test
     public void testQueryByInvalidDeploymentCategory() {
-        assertNull(appRepositoryService.createDeploymentQuery().deploymentCategory("invalid").singleResult());
-        assertEquals(0, appRepositoryService.createDeploymentQuery().deploymentCategory("invalid").list().size());
-        assertEquals(0, appRepositoryService.createDeploymentQuery().deploymentCategory("invalid").count());
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentCategory("invalid").singleResult()).isNull();
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentCategory("invalid").list()).hasSize(0);
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentCategory("invalid").count()).isEqualTo(0);
     }
     
     @Test
     public void testQueryByDeploymentCategoryNotEquals() {
-        assertNotNull(appRepositoryService.createDeploymentQuery().deploymentCategoryNotEquals("testCategory").singleResult());
-        assertEquals(deploymentId1, appRepositoryService.createDeploymentQuery().deploymentCategoryNotEquals("testCategory").singleResult().getId());
-        assertEquals(1, appRepositoryService.createDeploymentQuery().deploymentCategoryNotEquals("testCategory").list().size());
-        assertEquals(1, appRepositoryService.createDeploymentQuery().deploymentCategoryNotEquals("testCategory").count());
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentCategoryNotEquals("testCategory").singleResult()).isNotNull();
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentCategoryNotEquals("testCategory").singleResult().getId()).isEqualTo(deploymentId1);
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentCategoryNotEquals("testCategory").list()).hasSize(1);
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentCategoryNotEquals("testCategory").count()).isEqualTo(1);
     }
     
     @Test
     public void testQueryByDeploymentNameAndCategory() {
-        assertNotNull(appRepositoryService.createDeploymentQuery().deploymentName("testName").deploymentCategory("testCategory").singleResult());
-        assertEquals(deploymentId2, appRepositoryService.createDeploymentQuery().deploymentName("testName").deploymentCategory("testCategory").singleResult().getId());
-        assertEquals(1, appRepositoryService.createDeploymentQuery().deploymentName("testName").deploymentCategory("testCategory").list().size());
-        assertEquals(1, appRepositoryService.createDeploymentQuery().deploymentName("testName").deploymentCategory("testCategory").count());
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentName("testName").deploymentCategory("testCategory").singleResult()).isNotNull();
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentName("testName").deploymentCategory("testCategory").singleResult().getId())
+            .isEqualTo(deploymentId2);
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentName("testName").deploymentCategory("testCategory").list()).hasSize(1);
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentName("testName").deploymentCategory("testCategory").count()).isEqualTo(1);
     }
     
     @Test
     public void testOrdering() {
-        assertEquals(2, appRepositoryService.createDeploymentQuery().orderByDeploymentId().asc().list().size());
-        assertEquals(2, appRepositoryService.createDeploymentQuery().orderByDeploymentId().asc().count());
-        assertEquals(2, appRepositoryService.createDeploymentQuery().orderByDeploymentId().desc().list().size());
-        assertEquals(2, appRepositoryService.createDeploymentQuery().orderByDeploymentId().desc().count());
+        assertThat(appRepositoryService.createDeploymentQuery().orderByDeploymentId().asc().list()).hasSize(2);
+        assertThat(appRepositoryService.createDeploymentQuery().orderByDeploymentId().asc().count()).isEqualTo(2);
+        assertThat(appRepositoryService.createDeploymentQuery().orderByDeploymentId().desc().list()).hasSize(2);
+        assertThat(appRepositoryService.createDeploymentQuery().orderByDeploymentId().desc().count()).isEqualTo(2);
         
-        assertEquals(2, appRepositoryService.createDeploymentQuery().orderByDeploymenTime().asc().list().size());
-        assertEquals(2, appRepositoryService.createDeploymentQuery().orderByDeploymenTime().asc().count());
-        assertEquals(2, appRepositoryService.createDeploymentQuery().orderByDeploymenTime().desc().list().size());
-        assertEquals(2, appRepositoryService.createDeploymentQuery().orderByDeploymenTime().desc().count());
+        assertThat(appRepositoryService.createDeploymentQuery().orderByDeploymenTime().asc().list()).hasSize(2);
+        assertThat(appRepositoryService.createDeploymentQuery().orderByDeploymenTime().asc().count()).isEqualTo(2);
+        assertThat(appRepositoryService.createDeploymentQuery().orderByDeploymenTime().desc().list()).hasSize(2);
+        assertThat(appRepositoryService.createDeploymentQuery().orderByDeploymenTime().desc().count()).isEqualTo(2);
         
-        assertEquals(2, appRepositoryService.createDeploymentQuery().orderByDeploymentName().asc().list().size());
-        assertEquals(2, appRepositoryService.createDeploymentQuery().orderByDeploymentName().asc().count());
-        assertEquals(2, appRepositoryService.createDeploymentQuery().orderByDeploymentName().desc().list().size());
-        assertEquals(2, appRepositoryService.createDeploymentQuery().orderByDeploymentName().desc().count());
+        assertThat(appRepositoryService.createDeploymentQuery().orderByDeploymentName().asc().list()).hasSize(2);
+        assertThat(appRepositoryService.createDeploymentQuery().orderByDeploymentName().asc().count()).isEqualTo(2);
+        assertThat(appRepositoryService.createDeploymentQuery().orderByDeploymentName().desc().list()).hasSize(2);
+        assertThat(appRepositoryService.createDeploymentQuery().orderByDeploymentName().desc().count()).isEqualTo(2);
     }
 
 }

--- a/modules/flowable-app-engine/src/test/java/org/flowable/app/engine/test/repository/DeploymentTest.java
+++ b/modules/flowable-app-engine/src/test/java/org/flowable/app/engine/test/repository/DeploymentTest.java
@@ -14,9 +14,6 @@ package org.flowable.app.engine.test.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 import java.io.InputStream;
 import java.util.Arrays;
@@ -40,7 +37,7 @@ public class DeploymentTest extends FlowableAppTestCase {
     /**
      * Simplest test possible: deploy the simple-case.cmmn (from the cmmn-converter module) and see if 
      * - a deployment exists
-     * - a resouce exists
+     * - a resource exists
      * - a case definition was created 
      * - that case definition is in the cache
      * - case definition properties set
@@ -49,42 +46,42 @@ public class DeploymentTest extends FlowableAppTestCase {
     @AppDeployment
     public void testAppDefinitionDeployed() throws Exception {
         org.flowable.app.api.repository.AppDeployment appDeployment = appRepositoryService.createDeploymentQuery().singleResult();
-        assertNotNull(appDeployment);
+        assertThat(appDeployment).isNotNull();
         
         List<String> resourceNames = appRepositoryService.getDeploymentResourceNames(appDeployment.getId());
-        assertEquals(1, resourceNames.size());
-        assertEquals("org/flowable/app/engine/test/repository/DeploymentTest.testAppDefinitionDeployed.app", resourceNames.get(0));
+        assertThat(resourceNames.size()).isEqualTo(1);
+        assertThat(resourceNames.get(0)).isEqualTo("org/flowable/app/engine/test/repository/DeploymentTest.testAppDefinitionDeployed.app");
         
         InputStream inputStream = appRepositoryService.getResourceAsStream(appDeployment.getId(), resourceNames.get(0));
-        assertNotNull(inputStream);
+        assertThat(inputStream).isNotNull();
         inputStream.close();
         
         DeploymentCache<AppDefinitionCacheEntry> appDefinitionCache = appEngineConfiguration.getAppDefinitionCache();
-        assertEquals(1, ((DefaultDeploymentCache<AppDefinitionCacheEntry>) appDefinitionCache).getAll().size());
+        assertThat(((DefaultDeploymentCache<AppDefinitionCacheEntry>) appDefinitionCache).getAll().size()).isEqualTo(1);
         
         AppDefinitionCacheEntry cachedAppDefinition = ((DefaultDeploymentCache<AppDefinitionCacheEntry>) appDefinitionCache).getAll().iterator().next();
-        assertNotNull(cachedAppDefinition.getAppModel());
-        assertNotNull(cachedAppDefinition.getAppDefinition());
+        assertThat(cachedAppDefinition.getAppModel()).isNotNull();
+        assertThat(cachedAppDefinition.getAppDefinition()).isNotNull();
         
         AppDefinition appDefinition = cachedAppDefinition.getAppDefinition();
-        assertNotNull(appDefinition.getId());
-        assertNotNull(appDefinition.getDeploymentId());
-        assertNotNull(appDefinition.getKey());
-        assertNotNull(appDefinition.getResourceName());
-        assertTrue(appDefinition.getVersion() > 0);
+        assertThat(appDefinition.getId()).isNotNull();
+        assertThat(appDefinition.getDeploymentId()).isNotNull();
+        assertThat(appDefinition.getKey()).isNotNull();
+        assertThat(appDefinition.getResourceName()).isNotNull();
+        assertThat(appDefinition.getVersion() > 0).isTrue();
         
         appDefinition = appRepositoryService.createAppDefinitionQuery().deploymentId(appDeployment.getId()).singleResult();
-        assertNotNull(appDefinition.getId());
-        assertNotNull(appDefinition.getDeploymentId());
-        assertNotNull(appDefinition.getKey());
-        assertNotNull(appDefinition.getResourceName());
-        assertEquals(1, appDefinition.getVersion());
+        assertThat(appDefinition.getId()).isNotNull();
+        assertThat(appDefinition.getDeploymentId()).isNotNull();
+        assertThat(appDefinition.getKey()).isNotNull();
+        assertThat(appDefinition.getResourceName()).isNotNull();
+        assertThat(appDefinition.getVersion()).isEqualTo(1);
         
         AppModel appModel = appRepositoryService.getAppModel(appDefinition.getId());
-        assertNotNull(appModel);
+        assertThat(appModel).isNotNull();
         
-        assertEquals("testApp", appModel.getKey());
-        assertEquals("Test app", appModel.getName());
+        assertThat(appModel.getKey()).isEqualTo("testApp");
+        assertThat(appModel.getName()).isEqualTo("Test app");
     }
     
     @Test
@@ -92,10 +89,10 @@ public class DeploymentTest extends FlowableAppTestCase {
         appRepositoryService.createDeployment().addZipInputStream(new ZipInputStream(this.getClass().getClassLoader().getResourceAsStream(
                         "org/flowable/app/engine/test/vacationRequest.zip"))).deploy();
         org.flowable.app.api.repository.AppDeployment appDeployment = appRepositoryService.createDeploymentQuery().singleResult();
-        assertNotNull(appDeployment);
+        assertThat(appDeployment).isNotNull();
         
         List<String> resourceNames = appRepositoryService.getDeploymentResourceNames(appDeployment.getId());
-        assertEquals(4, resourceNames.size());
+        assertThat(resourceNames.size()).isEqualTo(4);
         
         boolean vacationRequestAppFound = false;
         for (String resourceName : resourceNames) {
@@ -104,38 +101,38 @@ public class DeploymentTest extends FlowableAppTestCase {
                 break;
             }
         }
-        assertTrue(vacationRequestAppFound);
+        assertThat(vacationRequestAppFound).isTrue();
         
         InputStream inputStream = appRepositoryService.getResourceAsStream(appDeployment.getId(), "vacationRequestApp.app");
-        assertNotNull(inputStream);
+        assertThat(inputStream).isNotNull();
         inputStream.close();
         
         DeploymentCache<AppDefinitionCacheEntry> appDefinitionCache = appEngineConfiguration.getAppDefinitionCache();
-        assertEquals(1, ((DefaultDeploymentCache<AppDefinitionCacheEntry>) appDefinitionCache).getAll().size());
+        assertThat(((DefaultDeploymentCache<AppDefinitionCacheEntry>) appDefinitionCache).getAll().size()).isEqualTo(1);
         
         AppDefinitionCacheEntry cachedAppDefinition = ((DefaultDeploymentCache<AppDefinitionCacheEntry>) appDefinitionCache).getAll().iterator().next();
-        assertNotNull(cachedAppDefinition.getAppModel());
-        assertNotNull(cachedAppDefinition.getAppDefinition());
+        assertThat(cachedAppDefinition.getAppModel()).isNotNull();
+        assertThat(cachedAppDefinition.getAppDefinition()).isNotNull();
         
         AppDefinition appDefinition = cachedAppDefinition.getAppDefinition();
-        assertNotNull(appDefinition.getId());
-        assertNotNull(appDefinition.getDeploymentId());
-        assertNotNull(appDefinition.getKey());
-        assertNotNull(appDefinition.getResourceName());
-        assertTrue(appDefinition.getVersion() > 0);
+        assertThat(appDefinition.getId()).isNotNull();
+        assertThat(appDefinition.getDeploymentId()).isNotNull();
+        assertThat(appDefinition.getKey()).isNotNull();
+        assertThat(appDefinition.getResourceName()).isNotNull();
+        assertThat(appDefinition.getVersion() > 0).isTrue();
         
         appDefinition = appRepositoryService.createAppDefinitionQuery().deploymentId(appDeployment.getId()).singleResult();
-        assertNotNull(appDefinition.getId());
-        assertNotNull(appDefinition.getDeploymentId());
-        assertNotNull(appDefinition.getKey());
-        assertNotNull(appDefinition.getResourceName());
-        assertEquals(1, appDefinition.getVersion());
+        assertThat(appDefinition.getId()).isNotNull();
+        assertThat(appDefinition.getDeploymentId()).isNotNull();
+        assertThat(appDefinition.getKey()).isNotNull();
+        assertThat(appDefinition.getResourceName()).isNotNull();
+        assertThat(appDefinition.getVersion()).isEqualTo(1);
         
         AppModel appModel = appRepositoryService.getAppModel(appDefinition.getId());
-        assertNotNull(appModel);
+        assertThat(appModel).isNotNull();
         
-        assertEquals("vacationRequestApp", appModel.getKey());
-        assertEquals("Vacation request app", appModel.getName());
+        assertThat(appModel.getKey()).isEqualTo("vacationRequestApp");
+        assertThat(appModel.getName()).isEqualTo("Vacation request app");
         
         appRepositoryService.deleteDeployment(appDeployment.getId(), true);
     }

--- a/modules/flowable-app-engine/src/test/java/org/flowable/app/engine/test/repository/DeploymentTest.java
+++ b/modules/flowable-app-engine/src/test/java/org/flowable/app/engine/test/repository/DeploymentTest.java
@@ -49,15 +49,14 @@ public class DeploymentTest extends FlowableAppTestCase {
         assertThat(appDeployment).isNotNull();
         
         List<String> resourceNames = appRepositoryService.getDeploymentResourceNames(appDeployment.getId());
-        assertThat(resourceNames.size()).isEqualTo(1);
-        assertThat(resourceNames.get(0)).isEqualTo("org/flowable/app/engine/test/repository/DeploymentTest.testAppDefinitionDeployed.app");
+        assertThat(resourceNames).containsOnly("org/flowable/app/engine/test/repository/DeploymentTest.testAppDefinitionDeployed.app");
         
         InputStream inputStream = appRepositoryService.getResourceAsStream(appDeployment.getId(), resourceNames.get(0));
         assertThat(inputStream).isNotNull();
         inputStream.close();
         
         DeploymentCache<AppDefinitionCacheEntry> appDefinitionCache = appEngineConfiguration.getAppDefinitionCache();
-        assertThat(((DefaultDeploymentCache<AppDefinitionCacheEntry>) appDefinitionCache).getAll().size()).isEqualTo(1);
+        assertThat(((DefaultDeploymentCache<AppDefinitionCacheEntry>) appDefinitionCache).getAll()).hasSize(1);
         
         AppDefinitionCacheEntry cachedAppDefinition = ((DefaultDeploymentCache<AppDefinitionCacheEntry>) appDefinitionCache).getAll().iterator().next();
         assertThat(cachedAppDefinition.getAppModel()).isNotNull();
@@ -68,7 +67,7 @@ public class DeploymentTest extends FlowableAppTestCase {
         assertThat(appDefinition.getDeploymentId()).isNotNull();
         assertThat(appDefinition.getKey()).isNotNull();
         assertThat(appDefinition.getResourceName()).isNotNull();
-        assertThat(appDefinition.getVersion() > 0).isTrue();
+        assertThat(appDefinition.getVersion()).isPositive();
         
         appDefinition = appRepositoryService.createAppDefinitionQuery().deploymentId(appDeployment.getId()).singleResult();
         assertThat(appDefinition.getId()).isNotNull();
@@ -92,23 +91,16 @@ public class DeploymentTest extends FlowableAppTestCase {
         assertThat(appDeployment).isNotNull();
         
         List<String> resourceNames = appRepositoryService.getDeploymentResourceNames(appDeployment.getId());
-        assertThat(resourceNames.size()).isEqualTo(4);
-        
-        boolean vacationRequestAppFound = false;
-        for (String resourceName : resourceNames) {
-            if ("vacationRequestApp.app".equals(resourceName)) {
-                vacationRequestAppFound = true;
-                break;
-            }
-        }
-        assertThat(vacationRequestAppFound).isTrue();
+        assertThat(resourceNames).hasSize(4);
+
+        assertThat(resourceNames).contains("vacationRequestApp.app");
         
         InputStream inputStream = appRepositoryService.getResourceAsStream(appDeployment.getId(), "vacationRequestApp.app");
         assertThat(inputStream).isNotNull();
         inputStream.close();
         
         DeploymentCache<AppDefinitionCacheEntry> appDefinitionCache = appEngineConfiguration.getAppDefinitionCache();
-        assertThat(((DefaultDeploymentCache<AppDefinitionCacheEntry>) appDefinitionCache).getAll().size()).isEqualTo(1);
+        assertThat(((DefaultDeploymentCache<AppDefinitionCacheEntry>) appDefinitionCache).getAll()).hasSize(1);
         
         AppDefinitionCacheEntry cachedAppDefinition = ((DefaultDeploymentCache<AppDefinitionCacheEntry>) appDefinitionCache).getAll().iterator().next();
         assertThat(cachedAppDefinition.getAppModel()).isNotNull();
@@ -119,7 +111,7 @@ public class DeploymentTest extends FlowableAppTestCase {
         assertThat(appDefinition.getDeploymentId()).isNotNull();
         assertThat(appDefinition.getKey()).isNotNull();
         assertThat(appDefinition.getResourceName()).isNotNull();
-        assertThat(appDefinition.getVersion() > 0).isTrue();
+        assertThat(appDefinition.getVersion()).isPositive();
         
         appDefinition = appRepositoryService.createAppDefinitionQuery().deploymentId(appDeployment.getId()).singleResult();
         assertThat(appDefinition.getId()).isNotNull();

--- a/modules/flowable-event-registry-spring/src/test/java/org/flowable/eventregistry/spring/test/autodeployment/DefaultAutoDeploymentStrategyTest.java
+++ b/modules/flowable-event-registry-spring/src/test/java/org/flowable/eventregistry/spring/test/autodeployment/DefaultAutoDeploymentStrategyTest.java
@@ -13,9 +13,7 @@
 
 package org.flowable.eventregistry.spring.test.autodeployment;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.never;
@@ -41,14 +39,14 @@ public class DefaultAutoDeploymentStrategyTest extends AbstractAutoDeploymentStr
     public void before() throws Exception {
         super.before();
         classUnderTest = new DefaultAutoDeploymentStrategy();
-        assertNotNull(classUnderTest);
+        assertThat(classUnderTest).isNotNull();
     }
 
     @Test
     public void testHandlesMode() {
-        assertTrue(classUnderTest.handlesMode(DefaultAutoDeploymentStrategy.DEPLOYMENT_MODE));
-        assertFalse(classUnderTest.handlesMode("other-mode"));
-        assertFalse(classUnderTest.handlesMode(null));
+        assertThat(classUnderTest.handlesMode(DefaultAutoDeploymentStrategy.DEPLOYMENT_MODE)).isTrue();
+        assertThat(classUnderTest.handlesMode("other-mode")).isFalse();
+        assertThat(classUnderTest.handlesMode(null)).isFalse();
     }
 
     @Test

--- a/modules/flowable-event-registry-spring/src/test/java/org/flowable/eventregistry/spring/test/autodeployment/ResourceParentFolderAutoDeploymentStrategyTest.java
+++ b/modules/flowable-event-registry-spring/src/test/java/org/flowable/eventregistry/spring/test/autodeployment/ResourceParentFolderAutoDeploymentStrategyTest.java
@@ -13,9 +13,7 @@
 
 package org.flowable.eventregistry.spring.test.autodeployment;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.never;
@@ -54,7 +52,7 @@ public class ResourceParentFolderAutoDeploymentStrategyTest extends AbstractAuto
     public void before() throws Exception {
         super.before();
         classUnderTest = new ResourceParentFolderAutoDeploymentStrategy();
-        assertNotNull(classUnderTest);
+        assertThat(classUnderTest).isNotNull();
 
         when(parentFile1Mock.getName()).thenReturn(parentFilename1);
         when(parentFile1Mock.isDirectory()).thenReturn(true);
@@ -64,9 +62,9 @@ public class ResourceParentFolderAutoDeploymentStrategyTest extends AbstractAuto
 
     @Test
     public void testHandlesMode() {
-        assertTrue(classUnderTest.handlesMode(ResourceParentFolderAutoDeploymentStrategy.DEPLOYMENT_MODE));
-        assertFalse(classUnderTest.handlesMode("other-mode"));
-        assertFalse(classUnderTest.handlesMode(null));
+        assertThat(classUnderTest.handlesMode(ResourceParentFolderAutoDeploymentStrategy.DEPLOYMENT_MODE)).isTrue();
+        assertThat(classUnderTest.handlesMode("other-mode")).isFalse();
+        assertThat(classUnderTest.handlesMode(null)).isFalse();
     }
 
     @Test

--- a/modules/flowable-event-registry-spring/src/test/java/org/flowable/eventregistry/spring/test/autodeployment/SingleResourceAutoDeploymentStrategyTest.java
+++ b/modules/flowable-event-registry-spring/src/test/java/org/flowable/eventregistry/spring/test/autodeployment/SingleResourceAutoDeploymentStrategyTest.java
@@ -13,9 +13,7 @@
 
 package org.flowable.eventregistry.spring.test.autodeployment;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.never;
@@ -41,14 +39,14 @@ public class SingleResourceAutoDeploymentStrategyTest extends AbstractAutoDeploy
     public void before() throws Exception {
         super.before();
         classUnderTest = new SingleResourceAutoDeploymentStrategy();
-        assertNotNull(classUnderTest);
+        assertThat(classUnderTest).isNotNull();
     }
 
     @Test
     public void testHandlesMode() {
-        assertTrue(classUnderTest.handlesMode(SingleResourceAutoDeploymentStrategy.DEPLOYMENT_MODE));
-        assertFalse(classUnderTest.handlesMode("other-mode"));
-        assertFalse(classUnderTest.handlesMode(null));
+        assertThat(classUnderTest.handlesMode(SingleResourceAutoDeploymentStrategy.DEPLOYMENT_MODE)).isTrue();
+        assertThat(classUnderTest.handlesMode("other-mode")).isFalse();
+        assertThat(classUnderTest.handlesMode(null)).isFalse();
     }
 
     @Test

--- a/modules/flowable-event-registry-spring/src/test/java/org/flowable/eventregistry/spring/test/autodeployment/SpringAutoDeployTest.java
+++ b/modules/flowable-event-registry-spring/src/test/java/org/flowable/eventregistry/spring/test/autodeployment/SpringAutoDeployTest.java
@@ -150,7 +150,7 @@ public class SpringAutoDeployTest {
         String filePath = "org/flowable/eventregistry/spring/test/autodeployment/simpleEvent.event";
         String originalEventFileContent = IoUtil.readFileAsString(filePath);
         String updatedEventFileContent = originalEventFileContent.replace("My event", "My event test");
-        assertThat(updatedEventFileContent.length() > originalEventFileContent.length()).isTrue();
+        assertThat(updatedEventFileContent.length()).isGreaterThan(originalEventFileContent.length());
         IoUtil.writeStringToFile(updatedEventFileContent, filePath);
 
         // Classic produced/consumer problem here:

--- a/modules/flowable-event-registry-spring/src/test/java/org/flowable/eventregistry/spring/test/autodeployment/SpringAutoDeployTest.java
+++ b/modules/flowable-event-registry-spring/src/test/java/org/flowable/eventregistry/spring/test/autodeployment/SpringAutoDeployTest.java
@@ -14,8 +14,6 @@
 package org.flowable.eventregistry.spring.test.autodeployment;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Driver;
 import java.util.HashMap;
@@ -125,34 +123,34 @@ public class SpringAutoDeployTest {
         expectedEventDefinitionKeys.add("myEvent");
         expectedEventDefinitionKeys.add("myEvent2");
 
-        assertEquals(expectedEventDefinitionKeys, eventDefinitionKeys);
+        assertThat(eventDefinitionKeys).isEqualTo(expectedEventDefinitionKeys);
     }
 
     @Test
     public void testNoRedeploymentForSpringContainerRestart() throws Exception {
         createAppContextWithoutDeploymentMode();
         EventDeploymentQuery deploymentQuery = repositoryService.createDeploymentQuery();
-        assertEquals(1, deploymentQuery.count());
+        assertThat(deploymentQuery.count()).isOne();
         EventDefinitionQuery eventDefinitionQuery = repositoryService.createEventDefinitionQuery();
-        assertEquals(2, eventDefinitionQuery.count());
+        assertThat(eventDefinitionQuery.count()).isEqualTo(2);
 
         // Creating a new app context with same resources doesn't lead to more deployments
         createAppContextWithoutDeploymentMode();
-        assertEquals(1, deploymentQuery.count());
-        assertEquals(2, eventDefinitionQuery.count());
+        assertThat(deploymentQuery.count()).isOne();
+        assertThat(eventDefinitionQuery.count()).isEqualTo(2);
     }
 
     // Updating the event file should lead to a new deployment when restarting the Spring container
     @Test
     public void testResourceRedeploymentAfterEventDefinitionChange() throws Exception {
         createAppContextWithoutDeploymentMode();
-        assertEquals(1, repositoryService.createDeploymentQuery().count());
+        assertThat(repositoryService.createDeploymentQuery().count()).isOne();
         applicationContext.close();
 
         String filePath = "org/flowable/eventregistry/spring/test/autodeployment/simpleEvent.event";
         String originalEventFileContent = IoUtil.readFileAsString(filePath);
         String updatedEventFileContent = originalEventFileContent.replace("My event", "My event test");
-        assertTrue(updatedEventFileContent.length() > originalEventFileContent.length());
+        assertThat(updatedEventFileContent.length() > originalEventFileContent.length()).isTrue();
         IoUtil.writeStringToFile(updatedEventFileContent, filePath);
 
         // Classic produced/consumer problem here:
@@ -169,16 +167,16 @@ public class SpringAutoDeployTest {
 
         // Assertions come AFTER the file write! Otherwise the event file is
         // messed up if the assertions fail.
-        assertEquals(2, repositoryService.createDeploymentQuery().count());
-        assertEquals(4, repositoryService.createEventDefinitionQuery().count());
+        assertThat(repositoryService.createDeploymentQuery().count()).isEqualTo(2);
+        assertThat(repositoryService.createEventDefinitionQuery().count()).isEqualTo(4);
     }
 
     @Test
     public void testAutoDeployWithDeploymentModeDefault() {
         createAppContextWithDefaultDeploymentMode();
-        assertEquals(1, repositoryService.createDeploymentQuery().count());
-        assertEquals(2, repositoryService.createEventDefinitionQuery().count());
-        assertEquals(1, repositoryService.createChannelDefinitionQuery().count());
+        assertThat(repositoryService.createDeploymentQuery().count()).isOne();
+        assertThat(repositoryService.createEventDefinitionQuery().count()).isEqualTo(2);
+        assertThat(repositoryService.createChannelDefinitionQuery().count()).isOne();
     }
 
     @Test
@@ -192,15 +190,15 @@ public class SpringAutoDeployTest {
         assertThat(repositoryService.createEventDefinitionQuery().list())
             .extracting(EventDefinition::getKey)
             .containsExactlyInAnyOrder("myEvent", "myEvent2");
-        assertThat(repositoryService.createDeploymentQuery().count()).isEqualTo(1);
+        assertThat(repositoryService.createDeploymentQuery().count()).isOne();
     }
 
     @Test
     public void testAutoDeployWithDeploymentModeSingleResource() {
         createAppContextWithSingleResourceDeploymentMode();
-        assertEquals(3, repositoryService.createDeploymentQuery().count());
-        assertEquals(2, repositoryService.createEventDefinitionQuery().count());
-        assertEquals(1, repositoryService.createChannelDefinitionQuery().count());
+        assertThat(repositoryService.createDeploymentQuery().count()).isEqualTo(3);
+        assertThat(repositoryService.createEventDefinitionQuery().count()).isEqualTo(2);
+        assertThat(repositoryService.createChannelDefinitionQuery().count()).isOne();
     }
 
     @Test
@@ -220,8 +218,8 @@ public class SpringAutoDeployTest {
     @Test
     public void testAutoDeployWithDeploymentModeResourceParentFolder() {
         createAppContextWithResourceParentFolderDeploymentMode();
-        assertEquals(2, repositoryService.createDeploymentQuery().count());
-        assertEquals(3, repositoryService.createEventDefinitionQuery().count());
+        assertThat(repositoryService.createDeploymentQuery().count()).isEqualTo(2);
+        assertThat(repositoryService.createEventDefinitionQuery().count()).isEqualTo(3);
     }
 
     @Test

--- a/modules/flowable-form-engine/pom.xml
+++ b/modules/flowable-form-engine/pom.xml
@@ -115,11 +115,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.junit.vintage</groupId>
-			<artifactId>junit-vintage-engine</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
 			<scope>test</scope>

--- a/modules/flowable-form-engine/src/test/java/org/flowable/form/engine/test/DeploymentQueryTest.java
+++ b/modules/flowable-form-engine/src/test/java/org/flowable/form/engine/test/DeploymentQueryTest.java
@@ -12,9 +12,7 @@
  */
 package org.flowable.form.engine.test;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -77,93 +75,93 @@ public class DeploymentQueryTest extends AbstractFlowableFormTest {
     
     @Test
     public void testQueryById() {
-        assertNotNull(repositoryService.createDeploymentQuery().deploymentId(deploymentId1).singleResult());
-        assertEquals(1, repositoryService.createDeploymentQuery().deploymentId(deploymentId1).list().size());
-        assertEquals(1, repositoryService.createDeploymentQuery().deploymentId(deploymentId1).count());
+        assertThat(repositoryService.createDeploymentQuery().deploymentId(deploymentId1).singleResult()).isNotNull();
+        assertThat(repositoryService.createDeploymentQuery().deploymentId(deploymentId1).list().size()).isOne();
+        assertThat(repositoryService.createDeploymentQuery().deploymentId(deploymentId1).count()).isOne();
         
-        assertNull(repositoryService.createDeploymentQuery().deploymentId("invalid").singleResult());
-        assertEquals(0, repositoryService.createDeploymentQuery().deploymentId("invalid").list().size());
-        assertEquals(0, repositoryService.createDeploymentQuery().deploymentId("invalid").count());
+        assertThat(repositoryService.createDeploymentQuery().deploymentId("invalid").singleResult()).isNull();
+        assertThat(repositoryService.createDeploymentQuery().deploymentId("invalid").list().size()).isZero();
+        assertThat(repositoryService.createDeploymentQuery().deploymentId("invalid").count()).isZero();
     }
     
     @Test
     public void testQueryByName() {
-        assertNotNull(repositoryService.createDeploymentQuery().deploymentName("test2.form").singleResult());
-        assertEquals(1, repositoryService.createDeploymentQuery().deploymentName("test2.form").list().size());
-        assertEquals(1, repositoryService.createDeploymentQuery().deploymentName("test2.form").count());
+        assertThat(repositoryService.createDeploymentQuery().deploymentName("test2.form").singleResult()).isNotNull();
+        assertThat(repositoryService.createDeploymentQuery().deploymentName("test2.form").list().size()).isOne();
+        assertThat(repositoryService.createDeploymentQuery().deploymentName("test2.form").count()).isOne();
         
-        assertNull(repositoryService.createDeploymentQuery().deploymentName("invalid").singleResult());
-        assertEquals(0, repositoryService.createDeploymentQuery().deploymentName("invalid").list().size());
-        assertEquals(0, repositoryService.createDeploymentQuery().deploymentName("invalid").count());
+        assertThat(repositoryService.createDeploymentQuery().deploymentName("invalid").singleResult()).isNull();
+        assertThat(repositoryService.createDeploymentQuery().deploymentName("invalid").list().size()).isZero();
+        assertThat(repositoryService.createDeploymentQuery().deploymentName("invalid").count()).isZero();
     }
     
     @Test
     public void testQueryByNameLike() {
-        assertEquals(3, repositoryService.createDeploymentQuery().deploymentNameLike("test%").list().size());
-        assertEquals(3, repositoryService.createDeploymentQuery().deploymentNameLike("test%").count());
+        assertThat(repositoryService.createDeploymentQuery().deploymentNameLike("test%").list()).hasSize(3);
+        assertThat(repositoryService.createDeploymentQuery().deploymentNameLike("test%").count()).isEqualTo(3);
         
-        assertNull(repositoryService.createDeploymentQuery().deploymentNameLike("inva%").singleResult());
-        assertEquals(0, repositoryService.createDeploymentQuery().deploymentNameLike("inva").list().size());
-        assertEquals(0, repositoryService.createDeploymentQuery().deploymentNameLike("inva").count());
+        assertThat(repositoryService.createDeploymentQuery().deploymentNameLike("inva%").singleResult()).isNull();
+        assertThat(repositoryService.createDeploymentQuery().deploymentNameLike("inva").list().size()).isZero();
+        assertThat(repositoryService.createDeploymentQuery().deploymentNameLike("inva").count()).isZero();
     }
     
     @Test
     public void testQueryByCategory() {
-        assertNotNull(repositoryService.createDeploymentQuery().deploymentCategory("testCategoryC").singleResult());
-        assertEquals(1, repositoryService.createDeploymentQuery().deploymentCategory("testCategoryC").list().size());
-        assertEquals(1, repositoryService.createDeploymentQuery().deploymentCategory("testCategoryC").count());
+        assertThat(repositoryService.createDeploymentQuery().deploymentCategory("testCategoryC").singleResult()).isNotNull();
+        assertThat(repositoryService.createDeploymentQuery().deploymentCategory("testCategoryC").list().size()).isOne();
+        assertThat(repositoryService.createDeploymentQuery().deploymentCategory("testCategoryC").count()).isOne();
         
-        assertNull(repositoryService.createDeploymentQuery().deploymentCategory("inva%").singleResult());
-        assertEquals(0, repositoryService.createDeploymentQuery().deploymentCategory("inva%").list().size());
-        assertEquals(0, repositoryService.createDeploymentQuery().deploymentCategory("inva%").count());
+        assertThat(repositoryService.createDeploymentQuery().deploymentCategory("inva%").singleResult()).isNull();
+        assertThat(repositoryService.createDeploymentQuery().deploymentCategory("inva%").list().size()).isZero();
+        assertThat(repositoryService.createDeploymentQuery().deploymentCategory("inva%").count()).isZero();
     }
     
     @Test
     public void testQueryByCategoryNotEquals() {
-        assertEquals(2, repositoryService.createDeploymentQuery().deploymentCategoryNotEquals("testCategoryC").list().size());
-        assertEquals(2, repositoryService.createDeploymentQuery().deploymentCategoryNotEquals("testCategoryC").count());
+        assertThat(repositoryService.createDeploymentQuery().deploymentCategoryNotEquals("testCategoryC").list()).hasSize(2);
+        assertThat(repositoryService.createDeploymentQuery().deploymentCategoryNotEquals("testCategoryC").count()).isEqualTo(2);
         
-        assertEquals(3, repositoryService.createDeploymentQuery().deploymentCategoryNotEquals("invalid").list().size());
-        assertEquals(3, repositoryService.createDeploymentQuery().deploymentCategoryNotEquals("invalid").count());
+        assertThat(repositoryService.createDeploymentQuery().deploymentCategoryNotEquals("invalid").list()).hasSize(3);
+        assertThat(repositoryService.createDeploymentQuery().deploymentCategoryNotEquals("invalid").count()).isEqualTo(3);
     }
     
     @Test
     public void testQueryByTenantId() {
-        assertEquals(2, repositoryService.createDeploymentQuery().deploymentTenantId("tenantA").list().size());
-        assertEquals(2, repositoryService.createDeploymentQuery().deploymentTenantId("tenantA").count());
+        assertThat(repositoryService.createDeploymentQuery().deploymentTenantId("tenantA").list()).hasSize(2);
+        assertThat(repositoryService.createDeploymentQuery().deploymentTenantId("tenantA").count()).isEqualTo(2);
         
-        assertEquals(0, repositoryService.createDeploymentQuery().deploymentTenantId("invalid").list().size());
-        assertEquals(0, repositoryService.createDeploymentQuery().deploymentTenantId("invalid").count());
+        assertThat(repositoryService.createDeploymentQuery().deploymentTenantId("invalid").list().size()).isZero();
+        assertThat(repositoryService.createDeploymentQuery().deploymentTenantId("invalid").count()).isZero();
     }
     
     @Test
     public void testQueryByTenantIdLike() {
-        assertEquals(3, repositoryService.createDeploymentQuery().deploymentTenantIdLike("tenant%").list().size());
-        assertEquals(3, repositoryService.createDeploymentQuery().deploymentTenantIdLike("tenant%").count());
+        assertThat(repositoryService.createDeploymentQuery().deploymentTenantIdLike("tenant%").list()).hasSize(3);
+        assertThat(repositoryService.createDeploymentQuery().deploymentTenantIdLike("tenant%").count()).isEqualTo(3);
         
-        assertEquals(0, repositoryService.createDeploymentQuery().deploymentTenantIdLike("invalid").list().size());
-        assertEquals(0, repositoryService.createDeploymentQuery().deploymentTenantIdLike("invalid").count());
+        assertThat(repositoryService.createDeploymentQuery().deploymentTenantIdLike("invalid").list().size()).isZero();
+        assertThat(repositoryService.createDeploymentQuery().deploymentTenantIdLike("invalid").count()).isZero();
     }
     
     @Test
     public void testQueryByDecisionTableKey() {
-        assertEquals(1, repositoryService.createDeploymentQuery().formDefinitionKey("form2").list().size());
-        assertEquals(1, repositoryService.createDeploymentQuery().formDefinitionKey("form2").count());
+        assertThat(repositoryService.createDeploymentQuery().formDefinitionKey("form2").list().size()).isOne();
+        assertThat(repositoryService.createDeploymentQuery().formDefinitionKey("form2").count()).isOne();
         
-        assertEquals(0, repositoryService.createDeploymentQuery().formDefinitionKey("invalid").list().size());
-        assertEquals(0, repositoryService.createDeploymentQuery().formDefinitionKey("invalid").count());
+        assertThat(repositoryService.createDeploymentQuery().formDefinitionKey("invalid").list().size()).isZero();
+        assertThat(repositoryService.createDeploymentQuery().formDefinitionKey("invalid").count()).isZero();
     }
     
     @Test
     public void testQueryByDecisionTableKeyLike() {
-        assertEquals(3, repositoryService.createDeploymentQuery().formDefinitionKeyLike("form%").list().size());
-        assertEquals(3, repositoryService.createDeploymentQuery().formDefinitionKeyLike("form%").count());
-        assertEquals(1, repositoryService.createDeploymentQuery().formDefinitionKeyLike("form%").listPage(0, 1).size());
-        assertEquals(2, repositoryService.createDeploymentQuery().formDefinitionKeyLike("form%").listPage(0, 2).size());
-        assertEquals(2, repositoryService.createDeploymentQuery().formDefinitionKeyLike("form%").listPage(1, 2).size());
+        assertThat(repositoryService.createDeploymentQuery().formDefinitionKeyLike("form%").list()).hasSize(3);
+        assertThat(repositoryService.createDeploymentQuery().formDefinitionKeyLike("form%").count()).isEqualTo(3);
+        assertThat(repositoryService.createDeploymentQuery().formDefinitionKeyLike("form%").listPage(0, 1).size()).isOne();
+        assertThat(repositoryService.createDeploymentQuery().formDefinitionKeyLike("form%").listPage(0, 2).size()).isEqualTo(2);
+        assertThat(repositoryService.createDeploymentQuery().formDefinitionKeyLike("form%").listPage(1, 2).size()).isEqualTo(2);
         
-        assertEquals(0, repositoryService.createDeploymentQuery().formDefinitionKeyLike("inva%").list().size());
-        assertEquals(0, repositoryService.createDeploymentQuery().formDefinitionKeyLike("inva%").count());
+        assertThat(repositoryService.createDeploymentQuery().formDefinitionKeyLike("inva%").list().size()).isZero();
+        assertThat(repositoryService.createDeploymentQuery().formDefinitionKeyLike("inva%").count()).isZero();
     }
     
 }

--- a/modules/flowable-form-engine/src/test/java/org/flowable/form/engine/test/DeploymentQueryTest.java
+++ b/modules/flowable-form-engine/src/test/java/org/flowable/form/engine/test/DeploymentQueryTest.java
@@ -76,22 +76,22 @@ public class DeploymentQueryTest extends AbstractFlowableFormTest {
     @Test
     public void testQueryById() {
         assertThat(repositoryService.createDeploymentQuery().deploymentId(deploymentId1).singleResult()).isNotNull();
-        assertThat(repositoryService.createDeploymentQuery().deploymentId(deploymentId1).list().size()).isOne();
+        assertThat(repositoryService.createDeploymentQuery().deploymentId(deploymentId1).list()).hasSize(1);
         assertThat(repositoryService.createDeploymentQuery().deploymentId(deploymentId1).count()).isOne();
         
         assertThat(repositoryService.createDeploymentQuery().deploymentId("invalid").singleResult()).isNull();
-        assertThat(repositoryService.createDeploymentQuery().deploymentId("invalid").list().size()).isZero();
+        assertThat(repositoryService.createDeploymentQuery().deploymentId("invalid").list()).hasSize(0);
         assertThat(repositoryService.createDeploymentQuery().deploymentId("invalid").count()).isZero();
     }
     
     @Test
     public void testQueryByName() {
         assertThat(repositoryService.createDeploymentQuery().deploymentName("test2.form").singleResult()).isNotNull();
-        assertThat(repositoryService.createDeploymentQuery().deploymentName("test2.form").list().size()).isOne();
+        assertThat(repositoryService.createDeploymentQuery().deploymentName("test2.form").list()).hasSize(1);
         assertThat(repositoryService.createDeploymentQuery().deploymentName("test2.form").count()).isOne();
         
         assertThat(repositoryService.createDeploymentQuery().deploymentName("invalid").singleResult()).isNull();
-        assertThat(repositoryService.createDeploymentQuery().deploymentName("invalid").list().size()).isZero();
+        assertThat(repositoryService.createDeploymentQuery().deploymentName("invalid").list()).hasSize(0);
         assertThat(repositoryService.createDeploymentQuery().deploymentName("invalid").count()).isZero();
     }
     
@@ -101,18 +101,18 @@ public class DeploymentQueryTest extends AbstractFlowableFormTest {
         assertThat(repositoryService.createDeploymentQuery().deploymentNameLike("test%").count()).isEqualTo(3);
         
         assertThat(repositoryService.createDeploymentQuery().deploymentNameLike("inva%").singleResult()).isNull();
-        assertThat(repositoryService.createDeploymentQuery().deploymentNameLike("inva").list().size()).isZero();
+        assertThat(repositoryService.createDeploymentQuery().deploymentNameLike("inva").list()).hasSize(0);
         assertThat(repositoryService.createDeploymentQuery().deploymentNameLike("inva").count()).isZero();
     }
     
     @Test
     public void testQueryByCategory() {
         assertThat(repositoryService.createDeploymentQuery().deploymentCategory("testCategoryC").singleResult()).isNotNull();
-        assertThat(repositoryService.createDeploymentQuery().deploymentCategory("testCategoryC").list().size()).isOne();
+        assertThat(repositoryService.createDeploymentQuery().deploymentCategory("testCategoryC").list()).hasSize(1);
         assertThat(repositoryService.createDeploymentQuery().deploymentCategory("testCategoryC").count()).isOne();
         
         assertThat(repositoryService.createDeploymentQuery().deploymentCategory("inva%").singleResult()).isNull();
-        assertThat(repositoryService.createDeploymentQuery().deploymentCategory("inva%").list().size()).isZero();
+        assertThat(repositoryService.createDeploymentQuery().deploymentCategory("inva%").list()).hasSize(0);
         assertThat(repositoryService.createDeploymentQuery().deploymentCategory("inva%").count()).isZero();
     }
     
@@ -130,7 +130,7 @@ public class DeploymentQueryTest extends AbstractFlowableFormTest {
         assertThat(repositoryService.createDeploymentQuery().deploymentTenantId("tenantA").list()).hasSize(2);
         assertThat(repositoryService.createDeploymentQuery().deploymentTenantId("tenantA").count()).isEqualTo(2);
         
-        assertThat(repositoryService.createDeploymentQuery().deploymentTenantId("invalid").list().size()).isZero();
+        assertThat(repositoryService.createDeploymentQuery().deploymentTenantId("invalid").list()).hasSize(0);
         assertThat(repositoryService.createDeploymentQuery().deploymentTenantId("invalid").count()).isZero();
     }
     
@@ -139,16 +139,16 @@ public class DeploymentQueryTest extends AbstractFlowableFormTest {
         assertThat(repositoryService.createDeploymentQuery().deploymentTenantIdLike("tenant%").list()).hasSize(3);
         assertThat(repositoryService.createDeploymentQuery().deploymentTenantIdLike("tenant%").count()).isEqualTo(3);
         
-        assertThat(repositoryService.createDeploymentQuery().deploymentTenantIdLike("invalid").list().size()).isZero();
+        assertThat(repositoryService.createDeploymentQuery().deploymentTenantIdLike("invalid").list()).hasSize(0);
         assertThat(repositoryService.createDeploymentQuery().deploymentTenantIdLike("invalid").count()).isZero();
     }
     
     @Test
     public void testQueryByDecisionTableKey() {
-        assertThat(repositoryService.createDeploymentQuery().formDefinitionKey("form2").list().size()).isOne();
+        assertThat(repositoryService.createDeploymentQuery().formDefinitionKey("form2").list()).hasSize(1);
         assertThat(repositoryService.createDeploymentQuery().formDefinitionKey("form2").count()).isOne();
         
-        assertThat(repositoryService.createDeploymentQuery().formDefinitionKey("invalid").list().size()).isZero();
+        assertThat(repositoryService.createDeploymentQuery().formDefinitionKey("invalid").list()).hasSize(0);
         assertThat(repositoryService.createDeploymentQuery().formDefinitionKey("invalid").count()).isZero();
     }
     
@@ -156,11 +156,11 @@ public class DeploymentQueryTest extends AbstractFlowableFormTest {
     public void testQueryByDecisionTableKeyLike() {
         assertThat(repositoryService.createDeploymentQuery().formDefinitionKeyLike("form%").list()).hasSize(3);
         assertThat(repositoryService.createDeploymentQuery().formDefinitionKeyLike("form%").count()).isEqualTo(3);
-        assertThat(repositoryService.createDeploymentQuery().formDefinitionKeyLike("form%").listPage(0, 1).size()).isOne();
-        assertThat(repositoryService.createDeploymentQuery().formDefinitionKeyLike("form%").listPage(0, 2).size()).isEqualTo(2);
-        assertThat(repositoryService.createDeploymentQuery().formDefinitionKeyLike("form%").listPage(1, 2).size()).isEqualTo(2);
+        assertThat(repositoryService.createDeploymentQuery().formDefinitionKeyLike("form%").listPage(0, 1)).hasSize(1);
+        assertThat(repositoryService.createDeploymentQuery().formDefinitionKeyLike("form%").listPage(0, 2)).hasSize(2);
+        assertThat(repositoryService.createDeploymentQuery().formDefinitionKeyLike("form%").listPage(1, 2)).hasSize(2);
         
-        assertThat(repositoryService.createDeploymentQuery().formDefinitionKeyLike("inva%").list().size()).isZero();
+        assertThat(repositoryService.createDeploymentQuery().formDefinitionKeyLike("inva%").list()).hasSize(0);
         assertThat(repositoryService.createDeploymentQuery().formDefinitionKeyLike("inva%").count()).isZero();
     }
     

--- a/modules/flowable-form-engine/src/test/java/org/flowable/form/engine/test/DeploymentTest.java
+++ b/modules/flowable-form-engine/src/test/java/org/flowable/form/engine/test/DeploymentTest.java
@@ -12,8 +12,7 @@
  */
 package org.flowable.form.engine.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
@@ -32,8 +31,8 @@ public class DeploymentTest extends AbstractFlowableFormTest {
                 .latestVersion()
                 .formDefinitionKey("form1")
                 .singleResult();
-        assertNotNull(formDefinition);
-        assertEquals("form1", formDefinition.getKey());
+        assertThat(formDefinition).isNotNull();
+        assertThat(formDefinition.getKey()).isEqualTo("form1");
     }
 
     @Test
@@ -43,15 +42,15 @@ public class DeploymentTest extends AbstractFlowableFormTest {
                 .latestVersion()
                 .formDefinitionKey("form1")
                 .singleResult();
-        assertNotNull(formDefinition);
-        assertEquals("form1", formDefinition.getKey());
-        assertEquals(1, formDefinition.getVersion());
+        assertThat(formDefinition).isNotNull();
+        assertThat(formDefinition.getKey()).isEqualTo("form1");
+        assertThat(formDefinition.getVersion()).isOne();
 
         FormInfo formInfo = repositoryService.getFormModelByKey("form1");
         SimpleFormModel formModel = (SimpleFormModel) formInfo.getFormModel();
-        assertEquals(1, formModel.getFields().size());
-        assertEquals("input1", formModel.getFields().get(0).getId());
-        assertEquals("Input1", formModel.getFields().get(0).getName());
+        assertThat(formModel.getFields().size()).isOne();
+        assertThat(formModel.getFields().get(0).getId()).isEqualTo("input1");
+        assertThat(formModel.getFields().get(0).getName()).isEqualTo("Input1");
 
         FormDeployment redeployment = repositoryService.createDeployment()
                 .addClasspathResource("org/flowable/form/engine/test/deployment/simple2.form")
@@ -61,15 +60,15 @@ public class DeploymentTest extends AbstractFlowableFormTest {
                 .latestVersion()
                 .formDefinitionKey("form1")
                 .singleResult();
-        assertNotNull(formDefinition);
-        assertEquals("form1", formDefinition.getKey());
-        assertEquals(2, formDefinition.getVersion());
+        assertThat(formDefinition).isNotNull();
+        assertThat(formDefinition.getKey()).isEqualTo("form1");
+        assertThat(formDefinition.getVersion()).isEqualTo(2);
 
         formInfo = repositoryService.getFormModelByKey("form1");
         formModel = (SimpleFormModel) formInfo.getFormModel();
-        assertEquals(1, formModel.getFields().size());
-        assertEquals("input2", formModel.getFields().get(0).getId());
-        assertEquals("Input2", formModel.getFields().get(0).getName());
+        assertThat(formModel.getFields().size()).isOne();
+        assertThat(formModel.getFields().get(0).getId()).isEqualTo("input2");
+        assertThat(formModel.getFields().get(0).getName()).isEqualTo("Input2");
 
         repositoryService.deleteDeployment(redeployment.getId());
     }
@@ -79,10 +78,10 @@ public class DeploymentTest extends AbstractFlowableFormTest {
             "org/flowable/form/engine/test/deployment/form_with_dates.form" })
     public void deploy2Forms() {
         List<FormDefinition> formDefinitions = repositoryService.createFormDefinitionQuery().orderByFormName().asc().list();
-        assertEquals(2, formDefinitions.size());
+        assertThat(formDefinitions.size()).isEqualTo(2);
 
-        assertEquals("My date form", formDefinitions.get(0).getName());
-        assertEquals("My first form", formDefinitions.get(1).getName());
+        assertThat(formDefinitions.get(0).getName()).isEqualTo("My date form");
+        assertThat(formDefinitions.get(1).getName()).isEqualTo("My first form");
     }
     
     @Test
@@ -98,23 +97,23 @@ public class DeploymentTest extends AbstractFlowableFormTest {
         
         try {
             FormDefinition definition = repositoryService.createFormDefinitionQuery().deploymentId(deployment.getId()).singleResult();
-            assertNotNull(definition);
-            assertEquals("form1", definition.getKey());
-            assertEquals(1, definition.getVersion());
+            assertThat(definition).isNotNull();
+            assertThat(definition.getKey()).isEqualTo("form1");
+            assertThat(definition.getVersion()).isOne();
             
             FormDefinition newDefinition = repositoryService.createFormDefinitionQuery().deploymentId(newDeployment.getId()).singleResult();
-            assertNotNull(newDefinition);
-            assertEquals("form1", newDefinition.getKey());
-            assertEquals(2, newDefinition.getVersion());
+            assertThat(newDefinition).isNotNull();
+            assertThat(newDefinition.getKey()).isEqualTo("form1");
+            assertThat(newDefinition.getVersion()).isEqualTo(2);
             
             FormInfo formInfo = repositoryService.getFormModelByKeyAndParentDeploymentId("form1", "someDeploymentId");
-            assertEquals("form1", formInfo.getKey());
-            assertEquals(1, formInfo.getVersion());
+            assertThat(formInfo.getKey()).isEqualTo("form1");
+            assertThat(formInfo.getVersion()).isOne();
             
             formEngineConfiguration.setAlwaysLookupLatestDefinitionVersion(true);
             formInfo = repositoryService.getFormModelByKeyAndParentDeploymentId("form1", "someDeploymentId");
-            assertEquals("form1", formInfo.getKey());
-            assertEquals(2, formInfo.getVersion());
+            assertThat(formInfo.getKey()).isEqualTo("form1");
+            assertThat(formInfo.getVersion()).isEqualTo(2);
         
         } finally {
             formEngineConfiguration.setAlwaysLookupLatestDefinitionVersion(false);

--- a/modules/flowable-form-engine/src/test/java/org/flowable/form/engine/test/DeploymentTest.java
+++ b/modules/flowable-form-engine/src/test/java/org/flowable/form/engine/test/DeploymentTest.java
@@ -13,12 +13,14 @@
 package org.flowable.form.engine.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import java.util.List;
 
 import org.flowable.form.api.FormDefinition;
 import org.flowable.form.api.FormDeployment;
 import org.flowable.form.api.FormInfo;
+import org.flowable.form.model.FormField;
 import org.flowable.form.model.SimpleFormModel;
 import org.junit.jupiter.api.Test;
 
@@ -48,9 +50,10 @@ public class DeploymentTest extends AbstractFlowableFormTest {
 
         FormInfo formInfo = repositoryService.getFormModelByKey("form1");
         SimpleFormModel formModel = (SimpleFormModel) formInfo.getFormModel();
-        assertThat(formModel.getFields().size()).isOne();
-        assertThat(formModel.getFields().get(0).getId()).isEqualTo("input1");
-        assertThat(formModel.getFields().get(0).getName()).isEqualTo("Input1");
+        assertThat(formModel.getFields()).hasSize(1);
+        assertThat(formModel.getFields())
+            .extracting(FormField::getId, FormField::getName)
+            .containsExactly(tuple("input1", "Input1"));
 
         FormDeployment redeployment = repositoryService.createDeployment()
                 .addClasspathResource("org/flowable/form/engine/test/deployment/simple2.form")
@@ -66,9 +69,10 @@ public class DeploymentTest extends AbstractFlowableFormTest {
 
         formInfo = repositoryService.getFormModelByKey("form1");
         formModel = (SimpleFormModel) formInfo.getFormModel();
-        assertThat(formModel.getFields().size()).isOne();
-        assertThat(formModel.getFields().get(0).getId()).isEqualTo("input2");
-        assertThat(formModel.getFields().get(0).getName()).isEqualTo("Input2");
+        assertThat(formModel.getFields()).hasSize(1);
+        assertThat(formModel.getFields())
+            .extracting(FormField::getId, FormField::getName)
+            .containsExactly(tuple("input2", "Input2"));
 
         repositoryService.deleteDeployment(redeployment.getId());
     }
@@ -78,10 +82,11 @@ public class DeploymentTest extends AbstractFlowableFormTest {
             "org/flowable/form/engine/test/deployment/form_with_dates.form" })
     public void deploy2Forms() {
         List<FormDefinition> formDefinitions = repositoryService.createFormDefinitionQuery().orderByFormName().asc().list();
-        assertThat(formDefinitions.size()).isEqualTo(2);
+        assertThat(formDefinitions).hasSize(2);
 
-        assertThat(formDefinitions.get(0).getName()).isEqualTo("My date form");
-        assertThat(formDefinitions.get(1).getName()).isEqualTo("My first form");
+        assertThat(formDefinitions)
+            .extracting(FormDefinition::getName)
+            .containsExactly("My date form", "My first form");
     }
     
     @Test

--- a/modules/flowable-form-engine/src/test/java/org/flowable/form/engine/test/ForceCloseMybatisConnectionPoolTest.java
+++ b/modules/flowable-form-engine/src/test/java/org/flowable/form/engine/test/ForceCloseMybatisConnectionPoolTest.java
@@ -40,7 +40,7 @@ public class ForceCloseMybatisConnectionPoolTest {
 
         PooledDataSource pooledDataSource = (PooledDataSource) standaloneInMemFormEngineConfiguration.getDataSource();
         PoolState state = pooledDataSource.getPoolState();
-        assertThat(state.getIdleConnectionCount()).isGreaterThan(0);
+        assertThat(state.getIdleConnectionCount()).isPositive();
 
         // then
         // if the  engine is closed
@@ -64,14 +64,14 @@ public class ForceCloseMybatisConnectionPoolTest {
 
         PooledDataSource pooledDataSource = (PooledDataSource) standaloneInMemFormEngineConfiguration.getDataSource();
         PoolState state = pooledDataSource.getPoolState();
-        assertThat(state.getIdleConnectionCount()).isGreaterThan(0);
+        assertThat(state.getIdleConnectionCount()).isPositive();
 
         // then
         // if the  engine is closed
         formEngine.close();
 
         // the idle connections are not closed
-        assertThat(state.getIdleConnectionCount()).isGreaterThan(0);
+        assertThat(state.getIdleConnectionCount()).isPositive();
 
         pooledDataSource.forceCloseAll();
         assertThat(state.getIdleConnectionCount()).isZero();

--- a/modules/flowable-form-engine/src/test/java/org/flowable/form/engine/test/ForceCloseMybatisConnectionPoolTest.java
+++ b/modules/flowable-form-engine/src/test/java/org/flowable/form/engine/test/ForceCloseMybatisConnectionPoolTest.java
@@ -12,8 +12,7 @@
  */
 package org.flowable.form.engine.test;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.ibatis.datasource.pooled.PoolState;
 import org.apache.ibatis.datasource.pooled.PooledDataSource;
@@ -41,14 +40,14 @@ public class ForceCloseMybatisConnectionPoolTest {
 
         PooledDataSource pooledDataSource = (PooledDataSource) standaloneInMemFormEngineConfiguration.getDataSource();
         PoolState state = pooledDataSource.getPoolState();
-        assertTrue(state.getIdleConnectionCount() > 0);
+        assertThat(state.getIdleConnectionCount()).isGreaterThan(0);
 
         // then
         // if the  engine is closed
         formEngine.close();
 
         // the idle connections are closed
-        assertEquals(0, state.getIdleConnectionCount());
+        assertThat(state.getIdleConnectionCount()).isZero();
 
     }
 
@@ -65,17 +64,17 @@ public class ForceCloseMybatisConnectionPoolTest {
 
         PooledDataSource pooledDataSource = (PooledDataSource) standaloneInMemFormEngineConfiguration.getDataSource();
         PoolState state = pooledDataSource.getPoolState();
-        assertTrue(state.getIdleConnectionCount() > 0);
+        assertThat(state.getIdleConnectionCount()).isGreaterThan(0);
 
         // then
         // if the  engine is closed
         formEngine.close();
 
         // the idle connections are not closed
-        assertTrue(state.getIdleConnectionCount() > 0);
+        assertThat(state.getIdleConnectionCount()).isGreaterThan(0);
 
         pooledDataSource.forceCloseAll();
-        assertEquals(0, state.getIdleConnectionCount());
+        assertThat(state.getIdleConnectionCount()).isZero();
     }
 
 }

--- a/modules/flowable-form-engine/src/test/java/org/flowable/form/engine/test/FormInstanceTest.java
+++ b/modules/flowable-form-engine/src/test/java/org/flowable/form/engine/test/FormInstanceTest.java
@@ -14,6 +14,7 @@ package org.flowable.form.engine.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.api.Assertions.tuple;
 
 import java.text.SimpleDateFormat;
 import java.util.HashMap;
@@ -59,9 +60,10 @@ public class FormInstanceTest extends AbstractFlowableFormTest {
         SimpleFormModel formModel = (SimpleFormModel) formInstanceModel.getFormModel();
         assertThat(formModel.getFields().size()).isOne();
         FormField formField = formModel.getFields().get(0);
-        assertThat(formField.getId()).isEqualTo("input1");
-        assertThat(formField.getValue()).isEqualTo("test");
-        
+        assertThat(formModel.getFields())
+            .extracting(FormField::getId, FormField::getValue)
+            .containsExactly(tuple("input1", "test"));
+
         assertThat(formService.createFormInstanceQuery().id(formInstance.getId()).count()).isOne();
         formService.deleteFormInstance(formInstance.getId());
         assertThat(formService.createFormInstanceQuery().id(formInstance.getId()).count()).isZero();

--- a/modules/flowable-form-engine/src/test/java/org/flowable/form/engine/test/FormInstanceTest.java
+++ b/modules/flowable-form-engine/src/test/java/org/flowable/form/engine/test/FormInstanceTest.java
@@ -14,9 +14,6 @@ package org.flowable.form.engine.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 
 import java.text.SimpleDateFormat;
 import java.util.HashMap;
@@ -51,23 +48,23 @@ public class FormInstanceTest extends AbstractFlowableFormTest {
             );
 
         FormInstance formInstance = formService.createFormInstance(formValues, formInfo, null, null, null, null, "default");
-        assertEquals(formInfo.getId(), formInstance.getFormDefinitionId());
+        assertThat(formInstance.getFormDefinitionId()).isEqualTo(formInfo.getId());
         JsonNode formNode = formEngineConfiguration.getObjectMapper().readTree(formInstance.getFormValueBytes());
-        assertEquals("test", formNode.get("values").get("input1").asText());
-        assertEquals("default", formNode.get("flowable_form_outcome").asText());
+        assertThat(formNode.get("values").get("input1").asText()).isEqualTo("test");
+        assertThat(formNode.get("flowable_form_outcome").asText()).isEqualTo("default");
 
         FormInstanceInfo formInstanceModel = formService.getFormInstanceModelById(formInstance.getId(), null);
-        assertEquals("form1", formInstanceModel.getKey());
+        assertThat(formInstanceModel.getKey()).isEqualTo("form1");
         
         SimpleFormModel formModel = (SimpleFormModel) formInstanceModel.getFormModel();
-        assertEquals(1, formModel.getFields().size());
+        assertThat(formModel.getFields().size()).isOne();
         FormField formField = formModel.getFields().get(0);
-        assertEquals("input1", formField.getId());
-        assertEquals("test", formField.getValue());
+        assertThat(formField.getId()).isEqualTo("input1");
+        assertThat(formField.getValue()).isEqualTo("test");
         
-        assertEquals(1, formService.createFormInstanceQuery().id(formInstance.getId()).count());
+        assertThat(formService.createFormInstanceQuery().id(formInstance.getId()).count()).isOne();
         formService.deleteFormInstance(formInstance.getId());
-        assertEquals(0, formService.createFormInstanceQuery().id(formInstance.getId()).count());
+        assertThat(formService.createFormInstanceQuery().id(formInstance.getId()).count()).isZero();
     }
     
     @Test
@@ -85,26 +82,26 @@ public class FormInstanceTest extends AbstractFlowableFormTest {
             );
 
         FormInstance formInstance = formService.createFormInstance(valuesMap, formInfo, "aTaskId", null, null, "flowable", "default");
-        assertEquals(formInfo.getId(), formInstance.getFormDefinitionId());
+        assertThat(formInstance.getFormDefinitionId()).isEqualTo(formInfo.getId());
         JsonNode formNode = formEngineConfiguration.getObjectMapper().readTree(formInstance.getFormValueBytes());
-        assertEquals("test", formNode.get("values").get("input1").asText());
-        assertEquals("default", formNode.get("flowable_form_outcome").asText());
+        assertThat(formNode.get("values").get("input1").asText()).isEqualTo("test");
+        assertThat(formNode.get("flowable_form_outcome").asText()).isEqualTo("default");
 
         FormInstanceInfo formInstanceModel = formService.getFormInstanceModelByKey("form1", "aTaskId", null, null, "flowable", false);
-        assertEquals("form1", formInstanceModel.getKey());
+        assertThat(formInstanceModel.getKey()).isEqualTo("form1");
         
         SimpleFormModel formModel = (SimpleFormModel) formInstanceModel.getFormModel();
-        assertEquals(1, formModel.getFields().size());
+        assertThat(formModel.getFields().size()).isOne();
         FormField formField = formModel.getFields().get(0);
-        assertEquals("input1", formField.getId());
-        assertEquals("test", formField.getValue());
+        assertThat(formField.getId()).isEqualTo("input1");
+        assertThat(formField.getValue()).isEqualTo("test");
         
         formInstance = formService.createFormInstanceQuery().formDefinitionId(formInfo.getId()).tenantId("flowable").singleResult();
-        assertNotNull(formInstance);
-        assertEquals("flowable", formInstance.getTenantId());
+        assertThat(formInstance).isNotNull();
+        assertThat(formInstance.getTenantId()).isEqualTo("flowable");
         
         formService.deleteFormInstance(formInstance.getId());
-        assertEquals(0, formService.createFormInstanceQuery().formDefinitionId(formInfo.getId()).tenantId("flowable").count());
+        assertThat(formService.createFormInstanceQuery().formDefinitionId(formInfo.getId()).tenantId("flowable").count()).isZero();
     }
     
     @Test
@@ -115,7 +112,7 @@ public class FormInstanceTest extends AbstractFlowableFormTest {
         Map<String, Object> valuesMap = new HashMap<>();
         valuesMap.put("input1", "test");
         Map<String, Object> formValues = formService.getVariablesFromFormSubmission(formInfo, valuesMap, "default");
-        assertEquals("test", formValues.get("input1"));
+        assertThat(formValues.get("input1")).isEqualTo("test");
         assertThat(formValues)
             .containsOnly(
                 entry("input1", "test"),
@@ -123,26 +120,26 @@ public class FormInstanceTest extends AbstractFlowableFormTest {
             );
 
         FormInstance formInstance = formService.createFormInstance(formValues, formInfo, "aTaskId", null, null, "flowable", "default");
-        assertEquals(formInfo.getId(), formInstance.getFormDefinitionId());
+        assertThat(formInstance.getFormDefinitionId()).isEqualTo(formInfo.getId());
         JsonNode formNode = formEngineConfiguration.getObjectMapper().readTree(formInstance.getFormValueBytes());
-        assertEquals("test", formNode.get("values").get("input1").asText());
-        assertEquals("default", formNode.get("flowable_form_outcome").asText());
+        assertThat(formNode.get("values").get("input1").asText()).isEqualTo("test");
+        assertThat(formNode.get("flowable_form_outcome").asText()).isEqualTo("default");
 
         FormInstanceInfo formInstanceModel = formService.getFormInstanceModelByKey("form1", "aTaskId", null, null, "flowable", true);
-        assertEquals("form1", formInstanceModel.getKey());
+        assertThat(formInstanceModel.getKey()).isEqualTo("form1");
         
         SimpleFormModel formModel = (SimpleFormModel) formInstanceModel.getFormModel();
-        assertEquals(1, formModel.getFields().size());
+        assertThat(formModel.getFields().size()).isOne();
         FormField formField = formModel.getFields().get(0);
-        assertEquals("input1", formField.getId());
-        assertEquals("test", formField.getValue());
+        assertThat(formField.getId()).isEqualTo("input1");
+        assertThat(formField.getValue()).isEqualTo("test");
         
         formInstance = formService.createFormInstanceQuery().formDefinitionId(formInfo.getId()).tenantId("flowable").singleResult();
-        assertNotNull(formInstance);
-        assertEquals("flowable", formInstance.getTenantId());
+        assertThat(formInstance).isNotNull();
+        assertThat(formInstance.getTenantId()).isEqualTo("flowable");
         
         formService.deleteFormInstance(formInstance.getId());
-        assertEquals(0, formService.createFormInstanceQuery().formDefinitionId(formInfo.getId()).tenantId("flowable").count());
+        assertThat(formService.createFormInstanceQuery().formDefinitionId(formInfo.getId()).tenantId("flowable").count()).isZero();
     }
     
     @Test
@@ -164,26 +161,26 @@ public class FormInstanceTest extends AbstractFlowableFormTest {
                 );
     
             FormInstance formInstance = formService.createFormInstance(formValues, formInfo, "aTaskId", null, null, "flowable", "default");
-            assertEquals(formInfo.getId(), formInstance.getFormDefinitionId());
+            assertThat(formInstance.getFormDefinitionId()).isEqualTo(formInfo.getId());
             JsonNode formNode = formEngineConfiguration.getObjectMapper().readTree(formInstance.getFormValueBytes());
-            assertEquals("test", formNode.get("values").get("input1").asText());
-            assertEquals("default", formNode.get("flowable_form_outcome").asText());
+            assertThat(formNode.get("values").get("input1").asText()).isEqualTo("test");
+            assertThat(formNode.get("flowable_form_outcome").asText()).isEqualTo("default");
     
             FormInstanceInfo formInstanceModel = formService.getFormInstanceModelByKey("form1", "aTaskId", null, null, "flowable", false);
-            assertEquals("form1", formInstanceModel.getKey());
+            assertThat(formInstanceModel.getKey()).isEqualTo("form1");
             
             SimpleFormModel formModel = (SimpleFormModel) formInstanceModel.getFormModel();
-            assertEquals(1, formModel.getFields().size());
+            assertThat(formModel.getFields().size()).isOne();
             FormField formField = formModel.getFields().get(0);
-            assertEquals("input1", formField.getId());
-            assertEquals("test", formField.getValue());
+            assertThat(formField.getId()).isEqualTo("input1");
+            assertThat(formField.getValue()).isEqualTo("test");
             
             formInstance = formService.createFormInstanceQuery().formDefinitionId(formInfo.getId()).tenantId("flowable").singleResult();
-            assertNotNull(formInstance);
-            assertEquals("flowable", formInstance.getTenantId());
+            assertThat(formInstance).isNotNull();
+            assertThat(formInstance.getTenantId()).isEqualTo("flowable");
             
             formService.deleteFormInstance(formInstance.getId());
-            assertEquals(0, formService.createFormInstanceQuery().formDefinitionId(formInfo.getId()).tenantId("flowable").count());
+            assertThat(formService.createFormInstanceQuery().formDefinitionId(formInfo.getId()).tenantId("flowable").count()).isZero();
             
         } finally {
             formEngineConfiguration.setFallbackToDefaultTenant(false);
@@ -213,19 +210,19 @@ public class FormInstanceTest extends AbstractFlowableFormTest {
             );
 
         FormInstance formInstance = formService.createFormInstance(formValues, formInfo, null, null, null, null, "date");
-        assertEquals(formInfo.getId(), formInstance.getFormDefinitionId());
+        assertThat(formInstance.getFormDefinitionId()).isEqualTo(formInfo.getId());
         JsonNode formNode = formEngineConfiguration.getObjectMapper().readTree(formInstance.getFormValueBytes());
         JsonNode valuesNode = formNode.get("values");
-        assertEquals(4, valuesNode.size());
-        assertEquals("test", valuesNode.get("input1").asText());
-        assertEquals("2016-01-01", valuesNode.get("date1").asText());
-        assertEquals("2017-01-01", valuesNode.get("date2").asText());
-        assertEquals("2018-01-01", valuesNode.get("date3").asText());
-        assertEquals("date", formNode.get("flowable_form_outcome").asText());
+        assertThat(valuesNode.size()).isEqualTo(4);
+        assertThat(valuesNode.get("input1").asText()).isEqualTo("test");
+        assertThat(valuesNode.get("date1").asText()).isEqualTo("2016-01-01");
+        assertThat(valuesNode.get("date2").asText()).isEqualTo("2017-01-01");
+        assertThat(valuesNode.get("date3").asText()).isEqualTo("2018-01-01");
+        assertThat(formNode.get("flowable_form_outcome").asText()).isEqualTo("date");
         
-        assertEquals(1, formService.createFormInstanceQuery().id(formInstance.getId()).count());
+        assertThat(formService.createFormInstanceQuery().id(formInstance.getId()).count()).isOne();
         formService.deleteFormInstancesByFormDefinition(formInstance.getFormDefinitionId());
-        assertEquals(0, formService.createFormInstanceQuery().id(formInstance.getId()).count());
+        assertThat(formService.createFormInstanceQuery().id(formInstance.getId()).count()).isZero();
     }
 
     @Test
@@ -245,18 +242,18 @@ public class FormInstanceTest extends AbstractFlowableFormTest {
             );
 
         FormInstance formInstance = formService.saveFormInstance(formValues, formInfo, taskId, "someId", "testDefId", null, "default");
-        assertEquals(formInfo.getId(), formInstance.getFormDefinitionId());
+        assertThat(formInstance.getFormDefinitionId()).isEqualTo(formInfo.getId());
         JsonNode formNode = formEngineConfiguration.getObjectMapper().readTree(formInstance.getFormValueBytes());
-        assertEquals("test", formNode.get("values").get("input1").asText());
-        assertEquals("default", formNode.get("flowable_form_outcome").asText());
+        assertThat(formNode.get("values").get("input1").asText()).isEqualTo("test");
+        assertThat(formNode.get("flowable_form_outcome").asText()).isEqualTo("default");
 
         FormInstanceInfo formInstanceModel = formService.getFormInstanceModelById(formInstance.getId(), null);
-        assertEquals("form1", formInstanceModel.getKey());
+        assertThat(formInstanceModel.getKey()).isEqualTo("form1");
         SimpleFormModel formModel = (SimpleFormModel) formInstanceModel.getFormModel();
-        assertEquals(1, formModel.getFields().size());
+        assertThat(formModel.getFields().size()).isOne();
         FormField formField = formModel.getFields().get(0);
-        assertEquals("input1", formField.getId());
-        assertEquals("test", formField.getValue());
+        assertThat(formField.getId()).isEqualTo("input1");
+        assertThat(formField.getValue()).isEqualTo("test");
 
         valuesMap = new HashMap<>();
         valuesMap.put("input1", "updatedValue");
@@ -268,25 +265,25 @@ public class FormInstanceTest extends AbstractFlowableFormTest {
             );
 
         formInstance = formService.saveFormInstance(formValues, formInfo, taskId, "someId", "testDefId", null, "updatedOutcome");
-        assertEquals(formInfo.getId(), formInstance.getFormDefinitionId());
+        assertThat(formInstance.getFormDefinitionId()).isEqualTo(formInfo.getId());
         formNode = formEngineConfiguration.getObjectMapper().readTree(formInstance.getFormValueBytes());
-        assertEquals("updatedValue", formNode.get("values").get("input1").asText());
-        assertEquals("updatedOutcome", formNode.get("flowable_form_outcome").asText());
+        assertThat(formNode.get("values").get("input1").asText()).isEqualTo("updatedValue");
+        assertThat(formNode.get("flowable_form_outcome").asText()).isEqualTo("updatedOutcome");
 
         formInstanceModel = formService.getFormInstanceModelById(formInstance.getId(), null);
-        assertEquals("form1", formInstanceModel.getKey());
-        assertEquals("User", formInstanceModel.getSubmittedBy());
+        assertThat(formInstanceModel.getKey()).isEqualTo("form1");
+        assertThat(formInstanceModel.getSubmittedBy()).isEqualTo("User");
         formModel = (SimpleFormModel) formInstanceModel.getFormModel();
-        assertEquals(1, formModel.getFields().size());
+        assertThat(formModel.getFields().size()).isOne();
         formField = formModel.getFields().get(0);
-        assertEquals("input1", formField.getId());
-        assertEquals("updatedValue", formField.getValue());
+        assertThat(formField.getId()).isEqualTo("input1");
+        assertThat(formField.getValue()).isEqualTo("updatedValue");
 
-        assertEquals(1, formService.createFormInstanceQuery().formDefinitionId(formInfo.getId()).count());
+        assertThat(formService.createFormInstanceQuery().formDefinitionId(formInfo.getId()).count()).isOne();
         
-        assertEquals(1, formService.createFormInstanceQuery().id(formInstance.getId()).count());
+        assertThat(formService.createFormInstanceQuery().id(formInstance.getId()).count()).isOne();
         formService.deleteFormInstancesByProcessDefinition("testDefId");
-        assertEquals(0, formService.createFormInstanceQuery().id(formInstance.getId()).count());
+        assertThat(formService.createFormInstanceQuery().id(formInstance.getId()).count()).isZero();
     }
     
     @Test
@@ -309,50 +306,50 @@ public class FormInstanceTest extends AbstractFlowableFormTest {
 
         // test setting hyperlink from variable
         FormInstance formInstance = formService.createFormInstanceWithScopeId(formValues, formInfo, "123456", "someId", "cmmn", "testDefId", null, "default");
-        assertEquals(formInfo.getId(), formInstance.getFormDefinitionId());
+        assertThat(formInstance.getFormDefinitionId()).isEqualTo(formInfo.getId());
         JsonNode formNode = formEngineConfiguration.getObjectMapper().readTree(formInstance.getFormValueBytes());
-        assertEquals("http://notmylink.com", formNode.get("values").get("plainLink").asText());
+        assertThat(formNode.get("values").get("plainLink").asText()).isEqualTo("http://notmylink.com");
         // no variable provided for expressionLink and anotherPlainLink
-        assertNull(formNode.get("values").get("expressionLink"));
-        assertNull(formNode.get("values").get("anotherPlainLink"));
+        assertThat(formNode.get("values").get("expressionLink")).isNull();
+        assertThat(formNode.get("values").get("anotherPlainLink")).isNull();
 
         // test hyperlink expression parsing in GetFormInstanceModelCmd
         FormInstanceInfo formInstanceModel = formService.getFormInstanceModelById(formInstance.getId(), variables);
-        assertEquals("hyperlink", formInstanceModel.getKey());
+        assertThat(formInstanceModel.getKey()).isEqualTo("hyperlink");
 
         SimpleFormModel formModel = (SimpleFormModel) formInstanceModel.getFormModel();
-        assertEquals(3, formModel.getFields().size());
+        assertThat(formModel.getFields().size()).isEqualTo(3);
         FormField plainLinkField = formModel.getFields().get(0);
-        assertEquals("plainLink", plainLinkField.getId());
-        assertEquals("http://notmylink.com", plainLinkField.getValue());
+        assertThat(plainLinkField.getId()).isEqualTo("plainLink");
+        assertThat(plainLinkField.getValue()).isEqualTo("http://notmylink.com");
 
         FormField expressionLinkField = formModel.getFields().get(1);
-        assertEquals("expressionLink", expressionLinkField.getId());
-        assertEquals("http://www.flowable.org/downloads.html", expressionLinkField.getValue());
+        assertThat(expressionLinkField.getId()).isEqualTo("expressionLink");
+        assertThat(expressionLinkField.getValue()).isEqualTo("http://www.flowable.org/downloads.html");
 
         FormField anotherPlainLinkField = formModel.getFields().get(2);
-        assertEquals("anotherPlainLink", anotherPlainLinkField.getId());
-        assertEquals("http://blog.flowable.org", anotherPlainLinkField.getValue());
+        assertThat(anotherPlainLinkField.getId()).isEqualTo("anotherPlainLink");
+        assertThat(anotherPlainLinkField.getValue()).isEqualTo("http://blog.flowable.org");
 
         // test hyperlink expression parsing in GetFormModelWithVariablesCmd
         FormInfo formInfoWithVars = formService.getFormModelWithVariablesById(formInfo.getId(), null, variables);
         SimpleFormModel model = (SimpleFormModel) formInfoWithVars.getFormModel();
-        assertEquals(3, model.getFields().size());
+        assertThat(model.getFields().size()).isEqualTo(3);
         plainLinkField = model.getFields().get(0);
-        assertEquals("plainLink", plainLinkField.getId());
-        assertEquals("http://notmylink.com", plainLinkField.getValue());
+        assertThat(plainLinkField.getId()).isEqualTo("plainLink");
+        assertThat(plainLinkField.getValue()).isEqualTo("http://notmylink.com");
 
         expressionLinkField = model.getFields().get(1);
-        assertEquals("expressionLink", expressionLinkField.getId());
-        assertEquals("http://www.flowable.org/downloads.html", expressionLinkField.getValue());
+        assertThat(expressionLinkField.getId()).isEqualTo("expressionLink");
+        assertThat(expressionLinkField.getValue()).isEqualTo("http://www.flowable.org/downloads.html");
 
         anotherPlainLinkField = model.getFields().get(2);
-        assertEquals("anotherPlainLink", anotherPlainLinkField.getId());
-        assertEquals("http://blog.flowable.org", anotherPlainLinkField.getValue());
+        assertThat(anotherPlainLinkField.getId()).isEqualTo("anotherPlainLink");
+        assertThat(anotherPlainLinkField.getValue()).isEqualTo("http://blog.flowable.org");
         
-        assertEquals(1, formService.createFormInstanceQuery().id(formInstance.getId()).count());
+        assertThat(formService.createFormInstanceQuery().id(formInstance.getId()).count()).isOne();
         formService.deleteFormInstancesByScopeDefinition("testDefId");
-        assertEquals(0, formService.createFormInstanceQuery().id(formInstance.getId()).count());
+        assertThat(formService.createFormInstanceQuery().id(formInstance.getId()).count()).isZero();
     }
 
 }

--- a/modules/flowable-form-engine/src/test/java/org/flowable/form/engine/test/FormModelTest.java
+++ b/modules/flowable-form-engine/src/test/java/org/flowable/form/engine/test/FormModelTest.java
@@ -13,7 +13,7 @@
 package org.flowable.form.engine.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -23,7 +23,6 @@ import org.flowable.common.engine.impl.DefaultTenantProvider;
 import org.flowable.form.api.FormInfo;
 import org.flowable.form.model.FormField;
 import org.flowable.form.model.SimpleFormModel;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class FormModelTest extends AbstractFlowableFormTest {
@@ -59,16 +58,14 @@ public class FormModelTest extends AbstractFlowableFormTest {
     @Test
     @FormDeploymentAnnotation(resources = "org/flowable/form/engine/test/deployment/simple.form", tenantId="flowable")
     public void getSimpleFormModelInAnotherTenantWithVariables() throws Exception {
-        assertThrows(FlowableObjectNotFoundException.class, () -> {
-            repositoryService.getFormModelByKey("form1", "someTenant", false).getId();
-        });
+        assertThatThrownBy(() -> repositoryService.getFormModelByKey("form1", "someTenant", false).getId())
+            .isInstanceOf(FlowableObjectNotFoundException.class);
 
         Map<String, Object> variables = new HashMap<>();
         variables.put("input1", "test");
 
-        assertThrows(FlowableObjectNotFoundException.class, () -> {
-            formService.getFormModelWithVariablesByKey("form1", null, variables, "someTenant", false);
-        });
+        assertThatThrownBy(() -> formService.getFormModelWithVariablesByKey("form1", null, variables, "someTenant", false))
+            .isInstanceOf(FlowableObjectNotFoundException.class);
     }
     
     @Test
@@ -112,17 +109,15 @@ public class FormModelTest extends AbstractFlowableFormTest {
         DefaultTenantProvider originalDefaultTenantProvider = formEngineConfiguration.getDefaultTenantProvider();
         formEngineConfiguration.setDefaultTenantValue("defaultFlowable");
         try {
-            assertThrows(FlowableObjectNotFoundException.class, () -> {
-                repositoryService.getFormModelByKey("form1", "someTenant", true).getId();
-            });
-    
+            assertThatThrownBy(() -> repositoryService.getFormModelByKey("form1", "someTenant", true).getId())
+                .isInstanceOf(FlowableObjectNotFoundException.class);
+
             Map<String, Object> variables = new HashMap<>();
             variables.put("input1", "test");
 
-            assertThrows(FlowableObjectNotFoundException.class, () -> {
-                formService.getFormModelWithVariablesByKey("form1", null, variables, "someTenant", true);
-            });
-            
+            assertThatThrownBy(() -> formService.getFormModelWithVariablesByKey("form1", null, variables, "someTenant", true))
+                .isInstanceOf(FlowableObjectNotFoundException.class);
+
         } finally {
             formEngineConfiguration.setDefaultTenantProvider(originalDefaultTenantProvider);
         }
@@ -158,16 +153,14 @@ public class FormModelTest extends AbstractFlowableFormTest {
         formEngineConfiguration.setFallbackToDefaultTenant(true);
         formEngineConfiguration.setDefaultTenantValue("defaultFlowable");
         try {
-            assertThrows(FlowableObjectNotFoundException.class, () -> {
-                repositoryService.getFormModelByKey("form1", "someTenant", false).getId();
-            });
-    
+            assertThatThrownBy(() -> repositoryService.getFormModelByKey("form1", "someTenant", false).getId())
+                .isInstanceOf(FlowableObjectNotFoundException.class);
+
             Map<String, Object> variables = new HashMap<>();
             variables.put("input1", "test");
 
-            assertThrows(FlowableObjectNotFoundException.class, () -> {
-                formService.getFormModelWithVariablesByKey("form1", null, variables, "someTenant", false);
-            });
+            assertThatThrownBy(() -> formService.getFormModelWithVariablesByKey("form1", null, variables, "someTenant", false))
+                .isInstanceOf(FlowableObjectNotFoundException.class);
             
         } finally {
             formEngineConfiguration.setFallbackToDefaultTenant(false);
@@ -177,7 +170,7 @@ public class FormModelTest extends AbstractFlowableFormTest {
     
     protected void assertFormModel(FormInfo formInfo) {
         SimpleFormModel formModel = (SimpleFormModel) formInfo.getFormModel();
-        assertThat(formModel.getFields().size()).isOne();
+        assertThat(formModel.getFields()).hasSize(1);
         FormField formField = formModel.getFields().get(0);
         assertThat(formField.getId()).isEqualTo("input1");
         assertThat(formField.getValue()).isEqualTo("test");

--- a/modules/flowable-form-engine/src/test/java/org/flowable/form/engine/test/FormModelTest.java
+++ b/modules/flowable-form-engine/src/test/java/org/flowable/form/engine/test/FormModelTest.java
@@ -12,8 +12,8 @@
  */
 package org.flowable.form.engine.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -23,6 +23,7 @@ import org.flowable.common.engine.impl.DefaultTenantProvider;
 import org.flowable.form.api.FormInfo;
 import org.flowable.form.model.FormField;
 import org.flowable.form.model.SimpleFormModel;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class FormModelTest extends AbstractFlowableFormTest {
@@ -37,7 +38,7 @@ public class FormModelTest extends AbstractFlowableFormTest {
 
         FormInfo formInfo = formService.getFormModelWithVariablesById(formDefinitionId, null, variables, null, false);
 
-        assertEquals(formDefinitionId, formInfo.getId());
+        assertThat(formInfo.getId()).isEqualTo(formDefinitionId);
         assertFormModel(formInfo);
     }
     
@@ -51,31 +52,23 @@ public class FormModelTest extends AbstractFlowableFormTest {
 
         FormInfo formInfo = formService.getFormModelWithVariablesByKey("form1", null, variables, "flowable", false);
 
-        assertEquals(formDefinitionId, formInfo.getId());
+        assertThat(formInfo.getId()).isEqualTo(formDefinitionId);
         assertFormModel(formInfo);
     }
     
     @Test
     @FormDeploymentAnnotation(resources = "org/flowable/form/engine/test/deployment/simple.form", tenantId="flowable")
     public void getSimpleFormModelInAnotherTenantWithVariables() throws Exception {
-        try {
+        assertThrows(FlowableObjectNotFoundException.class, () -> {
             repositoryService.getFormModelByKey("form1", "someTenant", false).getId();
-            fail("expected exception");
-            
-        } catch (FlowableObjectNotFoundException e) {
-            // expected
-        }
+        });
 
         Map<String, Object> variables = new HashMap<>();
         variables.put("input1", "test");
 
-        try {
+        assertThrows(FlowableObjectNotFoundException.class, () -> {
             formService.getFormModelWithVariablesByKey("form1", null, variables, "someTenant", false);
-            fail("expected exception");
-            
-        } catch (FlowableObjectNotFoundException e) {
-            // expected
-        }
+        });
     }
     
     @Test
@@ -88,7 +81,7 @@ public class FormModelTest extends AbstractFlowableFormTest {
 
         FormInfo formInfo = formService.getFormModelWithVariablesByKey("form1", null, variables, "flowable", true);
 
-        assertEquals(formDefinitionId, formInfo.getId());
+        assertThat(formInfo.getId()).isEqualTo(formDefinitionId);
         assertFormModel(formInfo);
     }
     
@@ -105,7 +98,7 @@ public class FormModelTest extends AbstractFlowableFormTest {
     
             FormInfo formInfo = formService.getFormModelWithVariablesByKey("form1", null, variables, "flowable", true);
     
-            assertEquals(formDefinitionId, formInfo.getId());
+            assertThat(formInfo.getId()).isEqualTo(formDefinitionId);
             assertFormModel(formInfo);
             
         } finally {
@@ -119,24 +112,16 @@ public class FormModelTest extends AbstractFlowableFormTest {
         DefaultTenantProvider originalDefaultTenantProvider = formEngineConfiguration.getDefaultTenantProvider();
         formEngineConfiguration.setDefaultTenantValue("defaultFlowable");
         try {
-            try {
+            assertThrows(FlowableObjectNotFoundException.class, () -> {
                 repositoryService.getFormModelByKey("form1", "someTenant", true).getId();
-                fail("expected exception");
-                
-            } catch (FlowableObjectNotFoundException e) {
-                // expected
-            }
+            });
     
             Map<String, Object> variables = new HashMap<>();
             variables.put("input1", "test");
-    
-            try {
+
+            assertThrows(FlowableObjectNotFoundException.class, () -> {
                 formService.getFormModelWithVariablesByKey("form1", null, variables, "someTenant", true);
-                fail("expected exception");
-                
-            } catch (FlowableObjectNotFoundException e) {
-                // expected
-            }
+            });
             
         } finally {
             formEngineConfiguration.setDefaultTenantProvider(originalDefaultTenantProvider);
@@ -157,7 +142,7 @@ public class FormModelTest extends AbstractFlowableFormTest {
     
             FormInfo formInfo = formService.getFormModelWithVariablesByKey("form1", null, variables, "flowable", false);
     
-            assertEquals(formDefinitionId, formInfo.getId());
+            assertThat(formInfo.getId()).isEqualTo(formDefinitionId);
             assertFormModel(formInfo);
             
         } finally {
@@ -173,24 +158,16 @@ public class FormModelTest extends AbstractFlowableFormTest {
         formEngineConfiguration.setFallbackToDefaultTenant(true);
         formEngineConfiguration.setDefaultTenantValue("defaultFlowable");
         try {
-            try {
+            assertThrows(FlowableObjectNotFoundException.class, () -> {
                 repositoryService.getFormModelByKey("form1", "someTenant", false).getId();
-                fail("expected exception");
-                
-            } catch (FlowableObjectNotFoundException e) {
-                // expected
-            }
+            });
     
             Map<String, Object> variables = new HashMap<>();
             variables.put("input1", "test");
-    
-            try {
+
+            assertThrows(FlowableObjectNotFoundException.class, () -> {
                 formService.getFormModelWithVariablesByKey("form1", null, variables, "someTenant", false);
-                fail("expected exception");
-                
-            } catch (FlowableObjectNotFoundException e) {
-                // expected
-            }
+            });
             
         } finally {
             formEngineConfiguration.setFallbackToDefaultTenant(false);
@@ -200,10 +177,10 @@ public class FormModelTest extends AbstractFlowableFormTest {
     
     protected void assertFormModel(FormInfo formInfo) {
         SimpleFormModel formModel = (SimpleFormModel) formInfo.getFormModel();
-        assertEquals(1, formModel.getFields().size());
+        assertThat(formModel.getFields().size()).isOne();
         FormField formField = formModel.getFields().get(0);
-        assertEquals("input1", formField.getId());
-        assertEquals("test", formField.getValue());
+        assertThat(formField.getId()).isEqualTo("input1");
+        assertThat(formField.getValue()).isEqualTo("test");
     }
 
 }

--- a/modules/flowable-form-engine/src/test/java/org/flowable/form/engine/test/OptionFormFieldTest.java
+++ b/modules/flowable-form-engine/src/test/java/org/flowable/form/engine/test/OptionFormFieldTest.java
@@ -12,9 +12,8 @@
  */
 package org.flowable.form.engine.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -43,8 +42,8 @@ public class OptionFormFieldTest extends AbstractFlowableFormTest {
         SimpleFormModel formModel = (SimpleFormModel) formInfo.getFormModel();
         
         OptionFormField optionFormField = (OptionFormField) formModel.getFields().get(0);
-        assertEquals("${optionsVariable}", optionFormField.getOptionsExpression());
-        assertNull(optionFormField.getOptions());
+        assertThat(optionFormField.getOptionsExpression()).isEqualTo("${optionsVariable}");
+        assertThat(optionFormField.getOptions()).isNull();
         
         String expectedJson = "[{\"id\":\"opt0\",\"name\":\"Opt0\"},{\"id\":\"opt1\",\"name\":\"Opt1\"},{\"id\":\"opt2\",\"name\":\"Opt2\"}]";
         List<Option> expectedOptions = new ArrayList<>();
@@ -81,7 +80,7 @@ public class OptionFormFieldTest extends AbstractFlowableFormTest {
         SimpleFormModel formInstanceModel = (SimpleFormModel) formInstanceInfo.getFormModel(); 
         optionFormField = (OptionFormField) formInstanceModel.getFields().get(0);
         assertOptions(optionFormField);
-        assertEquals("Opt2", optionFormField.getValue());
+        assertThat(optionFormField.getValue()).isEqualTo("Opt2");
         
         
         // test form instance from json variable
@@ -98,7 +97,7 @@ public class OptionFormFieldTest extends AbstractFlowableFormTest {
         
         optionFormField = (OptionFormField) formInstanceModel.getFields().get(0);
         assertOptions(optionFormField);
-        assertEquals("Opt2", optionFormField.getValue());
+        assertThat(optionFormField.getValue()).isEqualTo("Opt2");
 
         // test expression failure on model
         variables.clear();
@@ -135,8 +134,8 @@ public class OptionFormFieldTest extends AbstractFlowableFormTest {
         List<Option> actualOptions = optionFormField.getOptions();
         for (int i = 0; i < actualOptions.size(); i++) {
             Option option = actualOptions.get(i);
-            assertEquals(option.getId(), "opt" + i);    
-            assertEquals(option.getName(), "Opt" + i);
+            assertThat("opt" + i).isEqualTo(option.getId());
+            assertThat("Opt" + i).isEqualTo(option.getName());
         }
     }
 

--- a/modules/flowable-form-engine/src/test/java/org/flowable/form/engine/test/OptionFormFieldTest.java
+++ b/modules/flowable-form-engine/src/test/java/org/flowable/form/engine/test/OptionFormFieldTest.java
@@ -13,7 +13,7 @@
 package org.flowable.form.engine.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -101,11 +101,9 @@ public class OptionFormFieldTest extends AbstractFlowableFormTest {
 
         // test expression failure on model
         variables.clear();
-        try {
-            formModel = getOptionsFormModelWithVariablesByKey(variables);
-            fail("Expression failure should result in a FlowableException");
-        } catch (FlowableException e) {
-        }
+
+        assertThatThrownBy(() -> getOptionsFormModelWithVariablesByKey(variables))
+            .isInstanceOf(FlowableException.class);
 
         // test expression failure on instance
         variables.clear();

--- a/modules/flowable-form-spring/src/test/java/org/flowable/spring/test/autodeployment/DefaultAutoDeploymentStrategyTest.java
+++ b/modules/flowable-form-spring/src/test/java/org/flowable/spring/test/autodeployment/DefaultAutoDeploymentStrategyTest.java
@@ -13,9 +13,7 @@
 
 package org.flowable.spring.test.autodeployment;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.never;
@@ -44,14 +42,14 @@ public class DefaultAutoDeploymentStrategyTest extends AbstractAutoDeploymentStr
     public void before() throws Exception {
         super.before();
         classUnderTest = new DefaultAutoDeploymentStrategy();
-        assertNotNull(classUnderTest);
+        assertThat(classUnderTest).isNotNull();
     }
 
     @Test
     public void testHandlesMode() {
-        assertTrue(classUnderTest.handlesMode(DefaultAutoDeploymentStrategy.DEPLOYMENT_MODE));
-        assertFalse(classUnderTest.handlesMode("other-mode"));
-        assertFalse(classUnderTest.handlesMode(null));
+        assertThat(classUnderTest.handlesMode(DefaultAutoDeploymentStrategy.DEPLOYMENT_MODE)).isTrue();
+        assertThat(classUnderTest.handlesMode("other-mode")).isFalse();
+        assertThat(classUnderTest.handlesMode(null)).isFalse();
     }
 
     @Test

--- a/modules/flowable-form-spring/src/test/java/org/flowable/spring/test/autodeployment/ResourceParentFolderAutoDeploymentStrategyTest.java
+++ b/modules/flowable-form-spring/src/test/java/org/flowable/spring/test/autodeployment/ResourceParentFolderAutoDeploymentStrategyTest.java
@@ -13,9 +13,7 @@
 
 package org.flowable.spring.test.autodeployment;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.never;
@@ -57,7 +55,7 @@ public class ResourceParentFolderAutoDeploymentStrategyTest extends AbstractAuto
     public void before() throws Exception {
         super.before();
         classUnderTest = new ResourceParentFolderAutoDeploymentStrategy();
-        assertNotNull(classUnderTest);
+        assertThat(classUnderTest).isNotNull();
 
         when(parentFile1Mock.getName()).thenReturn(parentFilename1);
         when(parentFile1Mock.isDirectory()).thenReturn(true);
@@ -67,9 +65,9 @@ public class ResourceParentFolderAutoDeploymentStrategyTest extends AbstractAuto
 
     @Test
     public void testHandlesMode() {
-        assertTrue(classUnderTest.handlesMode(ResourceParentFolderAutoDeploymentStrategy.DEPLOYMENT_MODE));
-        assertFalse(classUnderTest.handlesMode("other-mode"));
-        assertFalse(classUnderTest.handlesMode(null));
+        assertThat(classUnderTest.handlesMode(ResourceParentFolderAutoDeploymentStrategy.DEPLOYMENT_MODE)).isTrue();
+        assertThat(classUnderTest.handlesMode("other-mode")).isFalse();
+        assertThat(classUnderTest.handlesMode(null)).isFalse();
     }
 
     @Test

--- a/modules/flowable-form-spring/src/test/java/org/flowable/spring/test/autodeployment/SingleResourceAutoDeploymentStrategyTest.java
+++ b/modules/flowable-form-spring/src/test/java/org/flowable/spring/test/autodeployment/SingleResourceAutoDeploymentStrategyTest.java
@@ -13,9 +13,7 @@
 
 package org.flowable.spring.test.autodeployment;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.never;
@@ -44,14 +42,14 @@ public class SingleResourceAutoDeploymentStrategyTest extends AbstractAutoDeploy
     public void before() throws Exception {
         super.before();
         classUnderTest = new SingleResourceAutoDeploymentStrategy();
-        assertNotNull(classUnderTest);
+        assertThat(classUnderTest).isNotNull();
     }
 
     @Test
     public void testHandlesMode() {
-        assertTrue(classUnderTest.handlesMode(SingleResourceAutoDeploymentStrategy.DEPLOYMENT_MODE));
-        assertFalse(classUnderTest.handlesMode("other-mode"));
-        assertFalse(classUnderTest.handlesMode(null));
+        assertThat(classUnderTest.handlesMode(SingleResourceAutoDeploymentStrategy.DEPLOYMENT_MODE)).isTrue();
+        assertThat(classUnderTest.handlesMode("other-mode")).isFalse();
+        assertThat(classUnderTest.handlesMode(null)).isFalse();
     }
 
     @Test

--- a/modules/flowable-form-spring/src/test/java/org/flowable/spring/test/autodeployment/SpringAutoDeployTest.java
+++ b/modules/flowable-form-spring/src/test/java/org/flowable/spring/test/autodeployment/SpringAutoDeployTest.java
@@ -15,8 +15,6 @@ package org.flowable.spring.test.autodeployment;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Driver;
 import java.util.HashMap;
@@ -134,34 +132,34 @@ public class SpringAutoDeployTest {
         expectedFormDefinitionKeys.add("form1");
         expectedFormDefinitionKeys.add("form2");
 
-        assertEquals(expectedFormDefinitionKeys, formDefinitionKeys);
+        assertThat(formDefinitionKeys).isEqualTo(expectedFormDefinitionKeys);
     }
 
     @Test
     public void testNoRedeploymentForSpringContainerRestart() throws Exception {
         createAppContextWithoutDeploymentMode();
         FormDeploymentQuery deploymentQuery = repositoryService.createDeploymentQuery();
-        assertEquals(1, deploymentQuery.count());
+        assertThat(deploymentQuery.count()).isOne();
         FormDefinitionQuery formDefinitionQuery = repositoryService.createFormDefinitionQuery();
-        assertEquals(2, formDefinitionQuery.count());
+        assertThat(formDefinitionQuery.count()).isEqualTo(2);
 
         // Creating a new app context with same resources doesn't lead to more deployments
         createAppContextWithoutDeploymentMode();
-        assertEquals(1, deploymentQuery.count());
-        assertEquals(2, formDefinitionQuery.count());
+        assertThat(deploymentQuery.count()).isOne();
+        assertThat(formDefinitionQuery.count()).isEqualTo(2);
     }
 
     // Updating the form file should lead to a new deployment when restarting the Spring container
     @Test
     public void testResourceRedeploymentAfterFormDefinitionChange() throws Exception {
         createAppContextWithoutDeploymentMode();
-        assertEquals(1, repositoryService.createDeploymentQuery().count());
+        assertThat(repositoryService.createDeploymentQuery().count()).isOne();
         applicationContext.close();
 
         String filePath = "org/flowable/spring/test/autodeployment/simple.form";
         String originalFormFileContent = IoUtil.readFileAsString(filePath);
         String updatedFormFileContent = originalFormFileContent.replace("My first form", "My first forms");
-        assertTrue(updatedFormFileContent.length() > originalFormFileContent.length());
+        assertThat(updatedFormFileContent.length() > originalFormFileContent.length()).isTrue();
         IoUtil.writeStringToFile(updatedFormFileContent, filePath);
 
         // Classic produced/consumer problem here:
@@ -178,15 +176,15 @@ public class SpringAutoDeployTest {
 
         // Assertions come AFTER the file write! Otherwise the form file is
         // messed up if the assertions fail.
-        assertEquals(2, repositoryService.createDeploymentQuery().count());
-        assertEquals(4, repositoryService.createFormDefinitionQuery().count());
+        assertThat(repositoryService.createDeploymentQuery().count()).isEqualTo(2);
+        assertThat(repositoryService.createFormDefinitionQuery().count()).isEqualTo(4);
     }
 
     @Test
     public void testAutoDeployWithDeploymentModeDefault() {
         createAppContextWithDefaultDeploymentMode();
-        assertEquals(1, repositoryService.createDeploymentQuery().count());
-        assertEquals(2, repositoryService.createFormDefinitionQuery().count());
+        assertThat(repositoryService.createDeploymentQuery().count()).isOne();
+        assertThat(repositoryService.createFormDefinitionQuery().count()).isEqualTo(2);
     }
 
     @Test
@@ -206,7 +204,7 @@ public class SpringAutoDeployTest {
         assertThat(repositoryService.createFormDefinitionQuery().list())
             .extracting(FormDefinition::getKey)
             .isEmpty();
-        assertThat(repositoryService.createDeploymentQuery().count()).isEqualTo(0);
+        assertThat(repositoryService.createDeploymentQuery().count()).isZero();
     }
 
     @Test
@@ -220,14 +218,14 @@ public class SpringAutoDeployTest {
         assertThat(repositoryService.createFormDefinitionQuery().list())
             .extracting(FormDefinition::getKey)
             .isEmpty();
-        assertThat(repositoryService.createDeploymentQuery().count()).isEqualTo(0);
+        assertThat(repositoryService.createDeploymentQuery().count()).isZero();
     }
 
     @Test
     public void testAutoDeployWithDeploymentModeSingleResource() {
         createAppContextWithSingleResourceDeploymentMode();
-        assertEquals(2, repositoryService.createDeploymentQuery().count());
-        assertEquals(2, repositoryService.createFormDefinitionQuery().count());
+        assertThat(repositoryService.createDeploymentQuery().count()).isEqualTo(2);
+        assertThat(repositoryService.createFormDefinitionQuery().count()).isEqualTo(2);
     }
 
     @Test
@@ -267,8 +265,8 @@ public class SpringAutoDeployTest {
     @Test
     public void testAutoDeployWithDeploymentModeResourceParentFolder() {
         createAppContextWithResourceParenFolderDeploymentMode();
-        assertEquals(2, repositoryService.createDeploymentQuery().count());
-        assertEquals(3, repositoryService.createFormDefinitionQuery().count());
+        assertThat(repositoryService.createDeploymentQuery().count()).isEqualTo(2);
+        assertThat(repositoryService.createFormDefinitionQuery().count()).isEqualTo(3);
     }
 
     @Test
@@ -289,7 +287,7 @@ public class SpringAutoDeployTest {
         assertThat(repositoryService.createFormDefinitionQuery().list())
             .extracting(FormDefinition::getKey)
             .isEmpty();
-        assertThat(repositoryService.createDeploymentQuery().count()).isEqualTo(0);
+        assertThat(repositoryService.createDeploymentQuery().count()).isZero();
     }
 
     @Test


### PR DESCRIPTION
I noticed in some recent pushes some files with a mix of assertion styles.   It appeared that the Assertj Fluent style was the newer preferred format so I started updating the mixed files and then expanded to the entire package level.   

If this is acceptable I will continue to make similar changes in other packages time permitting.
