### PR TITLE
ServiceTask with expression triggerable

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/ServiceTaskExpressionActivityBehavior.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/ServiceTaskExpressionActivityBehavior.java
@@ -51,6 +51,7 @@ public class ServiceTaskExpressionActivityBehavior extends TaskActivityBehavior 
     protected String resultVariable;
     protected List<MapExceptionEntry> mapExceptions;
     protected boolean useLocalScopeForResultVariable;
+	private boolean triggerable;
 
     public ServiceTaskExpressionActivityBehavior(ServiceTask serviceTask, Expression expression, Expression skipExpression) {
 
@@ -60,6 +61,7 @@ public class ServiceTaskExpressionActivityBehavior extends TaskActivityBehavior 
         this.resultVariable = serviceTask.getResultVariableName();
         this.mapExceptions = serviceTask.getMapExceptions();
         this.useLocalScopeForResultVariable = serviceTask.isUseLocalScopeForResultVariable();
+        this.triggerable = serviceTask.isTriggerable();
     }
 
     @Override
@@ -93,8 +95,9 @@ public class ServiceTaskExpressionActivityBehavior extends TaskActivityBehavior 
                     }
                 }
             }
-
-            leave(execution);
+            if (!this.triggerable) {
+            	leave(execution);
+            }
             
         } catch (Exception exc) {
 
@@ -119,4 +122,10 @@ public class ServiceTaskExpressionActivityBehavior extends TaskActivityBehavior 
             }
         }
     }
+
+	@Override
+	public void trigger(DelegateExecution execution, String signalName, Object signalData) {
+		leave(execution);
+	}
+    
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/ServiceTaskExpressionActivityBehavior.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/ServiceTaskExpressionActivityBehavior.java
@@ -51,7 +51,7 @@ public class ServiceTaskExpressionActivityBehavior extends TaskActivityBehavior 
     protected String resultVariable;
     protected List<MapExceptionEntry> mapExceptions;
     protected boolean useLocalScopeForResultVariable;
-	private boolean triggerable;
+    protected boolean triggerable;
 
     public ServiceTaskExpressionActivityBehavior(ServiceTask serviceTask, Expression expression, Expression skipExpression) {
 
@@ -96,9 +96,9 @@ public class ServiceTaskExpressionActivityBehavior extends TaskActivityBehavior 
                 }
             }
             if (!this.triggerable) {
-            	leave(execution);
+                leave(execution);
             }
-            
+
         } catch (Exception exc) {
 
             Throwable cause = exc;
@@ -123,9 +123,9 @@ public class ServiceTaskExpressionActivityBehavior extends TaskActivityBehavior 
         }
     }
 
-	@Override
-	public void trigger(DelegateExecution execution, String signalName, Object signalData) {
-		leave(execution);
-	}
-    
+    @Override
+    public void trigger(DelegateExecution execution, String signalName, Object signalData) {
+        super.trigger(execution, signalName, signalData);
+    }
+
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/servicetask/TriggerableServiceTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/servicetask/TriggerableServiceTaskTest.java
@@ -67,11 +67,11 @@ public class TriggerableServiceTaskTest extends PluggableFlowableTestCase {
         assertNotNull(execution);
         assertEquals(3, runtimeService.getVariable(processId, "count"));
     }
-    
+
     @Test
     @Deployment
     public void testExpression() {
-    	DummyTestBean testBean = new DummyTestBean();
+        DummyTestBean testBean = new DummyTestBean();
         Map<String, Object> varMap = new HashMap<>();
         varMap.put("bean", testBean);
 
@@ -81,7 +81,7 @@ public class TriggerableServiceTaskTest extends PluggableFlowableTestCase {
         assertNotNull(execution);
         assertTrue((boolean) runtimeService.getVariable(processId, "executed"));
 
-        Map<String,Object> processVariables = new HashMap<>();
+        Map<String, Object> processVariables = new HashMap<>();
         processVariables.put("count", 1);
         runtimeService.trigger(execution.getId(), processVariables, null);
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/servicetask/TriggerableServiceTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/servicetask/TriggerableServiceTaskTest.java
@@ -67,6 +67,28 @@ public class TriggerableServiceTaskTest extends PluggableFlowableTestCase {
         assertNotNull(execution);
         assertEquals(3, runtimeService.getVariable(processId, "count"));
     }
+    
+    @Test
+    @Deployment
+    public void testExpression() {
+    	DummyTestBean testBean = new DummyTestBean();
+        Map<String, Object> varMap = new HashMap<>();
+        varMap.put("bean", testBean);
+
+        String processId = runtimeService.startProcessInstanceByKey("process", varMap).getProcessInstanceId();
+
+        Execution execution = runtimeService.createExecutionQuery().processInstanceId(processId).activityId("service1").singleResult();
+        assertNotNull(execution);
+        assertTrue((boolean) runtimeService.getVariable(processId, "executed"));
+
+        Map<String,Object> processVariables = new HashMap<>();
+        processVariables.put("count", 1);
+        runtimeService.trigger(execution.getId(), processVariables, null);
+
+        execution = runtimeService.createExecutionQuery().processInstanceId(processId).activityId("usertask1").singleResult();
+        assertNotNull(execution);
+        assertEquals(1, runtimeService.getVariable(processId, "count"));
+    }
 
     @Test
     @Deployment

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/servicetask/TriggerableServiceTaskTest.testExpression.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/servicetask/TriggerableServiceTaskTest.testExpression.bpmn20.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions 
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:flowable="http://flowable.org/bpmn"
+  targetNamespace="Examples">
+
+  <process id="process">
+  
+    <startEvent id="theStart" />
+    <sequenceFlow sourceRef="theStart" targetRef="service1" />
+    
+    <serviceTask id="service1" flowable:expression="${bean.test(execution)}" flowable:triggerable="true"/>
+    <sequenceFlow sourceRef="service1" targetRef="usertask1" />
+
+    <userTask id="usertask1" name="Task A"/>
+    <sequenceFlow sourceRef="usertask1" targetRef="theEnd" />
+
+    <endEvent id="theEnd" />
+    
+  </process>
+
+</definitions>


### PR DESCRIPTION
A ServiceTask with an expression should also be triggerable:

The org.flowable.engine.impl.bpmn.behavior.ServiceTaskExpressionActivityBehavior
class would just not call leave when triggerable is true (in execute()) and leaves in trigger().

https://forum.flowable.org/t/how-to-use-triggerable/3016

#### Check List:
* Unit tests: YES 
* Documentation: YES


