### PR TITLE
Use assertj fluent style in flowable-cmmn-converter module

### DIFF
--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/CaseCustomExtensionElementXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/CaseCustomExtensionElementXmlConverterTest.java
@@ -13,6 +13,7 @@
 package org.flowable.test.cmmn.converter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import java.util.List;
 
@@ -51,11 +52,11 @@ public class CaseCustomExtensionElementXmlConverterTest extends AbstractConverte
         List<ExtensionElement> customElements = primaryCase.getExtensionElements().get("customElement");
         assertThat(customElements).hasSize(1);
 
-        ExtensionElement customElement = customElements.get(0);
-        assertThat(customElement.getElementText()).isEqualTo("Element text");
-        assertThat(customElement.getNamespacePrefix()).isEqualTo("flowable");
-        assertThat(customElement.getNamespace()).isEqualTo("http://flowable.org/cmmn");
-        assertThat(customElement.getAttributeValue(null, "attribute")).isEqualTo("Value");
+        assertThat(customElements)
+            .extracting(ExtensionElement::getElementText, ExtensionElement::getNamespacePrefix, ExtensionElement::getNamespace)
+            .containsExactly(tuple("Element text", "flowable", "http://flowable.org/cmmn"));
+
+        assertThat(customElements.get(0).getAttributeValue(null, "attribute")).isEqualTo("Value");
     }
 
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/CaseCustomExtensionElementXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/CaseCustomExtensionElementXmlConverterTest.java
@@ -53,8 +53,8 @@ public class CaseCustomExtensionElementXmlConverterTest extends AbstractConverte
         assertThat(customElements).hasSize(1);
 
         assertThat(customElements)
-            .extracting(ExtensionElement::getElementText, ExtensionElement::getNamespacePrefix, ExtensionElement::getNamespace)
-            .containsExactly(tuple("Element text", "flowable", "http://flowable.org/cmmn"));
+                .extracting(ExtensionElement::getElementText, ExtensionElement::getNamespacePrefix, ExtensionElement::getNamespace)
+                .containsExactly(tuple("Element text", "flowable", "http://flowable.org/cmmn"));
 
         assertThat(customElements.get(0).getAttributeValue(null, "attribute")).isEqualTo("Value");
     }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/CasePageTaskCmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/CasePageTaskCmmnXmlConverterTest.java
@@ -12,9 +12,8 @@
  */
 package org.flowable.test.cmmn.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import java.util.List;
 
@@ -49,64 +48,66 @@ public class CasePageTaskCmmnXmlConverterTest extends AbstractConverterTest {
     }
     
     public void validateModel(CmmnModel cmmnModel) {
-        assertNotNull(cmmnModel);
-        assertEquals(1, cmmnModel.getCases().size());
+        assertThat(cmmnModel).isNotNull();
         
         // Case
-        Case caze = cmmnModel.getCases().get(0);
-        assertEquals("casePageCase", caze.getId());
+        assertThat(cmmnModel.getCases())
+            .isNotNull()
+            .hasSize(1)
+            .extracting(Case::getId)
+            .containsExactly("casePageCase");
         
-        Stage planModel = caze.getPlanModel();
+        Stage planModel = cmmnModel.getCases().get(0).getPlanModel();
         
         // Plan items definitions
         List<PlanItemDefinition> planItemDefinitions = planModel.getPlanItemDefinitions();
-        assertEquals(2, planItemDefinitions.size());
-        assertEquals(2, planModel.findPlanItemDefinitionsOfType(CasePageTask.class, false).size());
+        assertThat(planItemDefinitions).hasSize(2);
+        assertThat(planModel.findPlanItemDefinitionsOfType(CasePageTask.class, false)).hasSize(2);
         
         // Plan items
         List<PlanItem> planItems = planModel.getPlanItems();
-        assertEquals(2, planItems.size());
+        assertThat(planItems).hasSize(2);
         
         PlanItem planItemTaskA = cmmnModel.findPlanItem("planItemTaskA");
         PlanItemDefinition planItemDefinition = planItemTaskA.getPlanItemDefinition();
-        assertEquals(0, planItemTaskA.getEntryCriteria().size());
-        assertTrue(planItemDefinition instanceof CasePageTask);
+        assertThat(planItemTaskA.getEntryCriteria()).isEmpty();
+        assertThat(planItemDefinition).isInstanceOf(CasePageTask.class);
 
         CasePageTask taskA = (CasePageTask) planItemDefinition;
-        assertEquals(CasePageTask.TYPE, taskA.getType());
-        assertEquals("A", taskA.getName());
-        assertEquals("testKey", taskA.getFormKey());
-        assertEquals("Label 1", taskA.getLabel());
-        assertEquals("Icon 1", taskA.getIcon());
-        assertEquals("johndoe", taskA.getAssignee());
-        assertEquals("janedoe", taskA.getOwner());
-        assertEquals(2, taskA.getCandidateUsers().size());
-        assertEquals("johndoe", taskA.getCandidateUsers().get(0));
-        assertEquals("janedoe", taskA.getCandidateUsers().get(1));
-        assertEquals(2, taskA.getCandidateGroups().size());
-        assertEquals("sales", taskA.getCandidateGroups().get(0));
-        assertEquals("management", taskA.getCandidateGroups().get(1));
-        assertNotNull(planItemTaskA.getItemControl());
-        assertNotNull(planItemTaskA.getItemControl().getParentCompletionRule());
-        assertEquals(ParentCompletionRule.IGNORE, planItemTaskA.getItemControl().getParentCompletionRule().getType());
+        assertThat(taskA.getType()).isEqualTo(CasePageTask.TYPE);
+        assertThat(taskA.getName()).isEqualTo("A");
+        assertThat(taskA.getFormKey()).isEqualTo("testKey");
+        assertThat(taskA.getLabel()).isEqualTo("Label 1");
+        assertThat(taskA.getIcon()).isEqualTo("Icon 1");
+        assertThat(taskA.getAssignee()).isEqualTo("johndoe");
+        assertThat(taskA.getOwner()).isEqualTo("janedoe");
+        assertThat(taskA.getCandidateUsers()).hasSize(2);
+        assertThat(taskA.getCandidateUsers().get(0)).isEqualTo("johndoe");
+        assertThat(taskA.getCandidateUsers().get(1)).isEqualTo("janedoe");
+        assertThat(taskA.getCandidateGroups()).hasSize(2);
+        assertThat(taskA.getCandidateGroups().get(0)).isEqualTo("sales");
+        assertThat(taskA.getCandidateGroups().get(1)).isEqualTo("management");
+        assertThat(planItemTaskA.getItemControl()).isNotNull();
+        assertThat(planItemTaskA.getItemControl().getParentCompletionRule()).isNotNull();
+        assertThat(planItemTaskA.getItemControl().getParentCompletionRule().getType()).isEqualTo(ParentCompletionRule.IGNORE);
 
         PlanItem planItemTaskB = cmmnModel.findPlanItem("planItemTaskB");
         planItemDefinition = planItemTaskB.getPlanItemDefinition();
-        assertEquals(1, planItemTaskB.getEntryCriteria().size());
-        assertTrue(planItemDefinition instanceof CasePageTask);
+        assertThat(planItemTaskB.getEntryCriteria()).hasSize(1);
+        assertThat(planItemDefinition).isInstanceOf(CasePageTask.class);
         CasePageTask taskB = (CasePageTask) planItemDefinition;
-        assertEquals(CasePageTask.TYPE, taskB.getType());
-        assertEquals("B", taskB.getName());
-        assertNotNull(planItemTaskB.getItemControl());
-        assertNotNull(planItemTaskB.getItemControl().getParentCompletionRule());
-        assertEquals(ParentCompletionRule.IGNORE, planItemTaskB.getItemControl().getParentCompletionRule().getType());
+        assertThat(taskB.getType()).isEqualTo(CasePageTask.TYPE);
+        assertThat(taskB.getName()).isEqualTo("B");
+        assertThat(planItemTaskB.getItemControl()).isNotNull();
+        assertThat(planItemTaskB.getItemControl().getParentCompletionRule()).isNotNull();
+        assertThat(planItemTaskB.getItemControl().getParentCompletionRule().getType()).isEqualTo(ParentCompletionRule.IGNORE);
         
-        assertEquals(1, taskB.getExtensionElements().size());
+        assertThat(taskB.getExtensionElements()).hasSize(1);
         List<ExtensionElement> extensionElements = taskB.getExtensionElements().get("index");
-        assertEquals(1, extensionElements.size());
-        ExtensionElement extensionElement = extensionElements.get(0);
-        assertEquals("index", extensionElement.getName());
-        assertEquals("0", extensionElement.getElementText());
+        assertThat(extensionElements).hasSize(1);
+        assertThat(extensionElements)
+            .extracting(ExtensionElement::getName, ExtensionElement::getElementText)
+            .containsExactly(tuple("index", "0"));
     }
 
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/CasePageTaskCmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/CasePageTaskCmmnXmlConverterTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,9 +31,9 @@ import org.junit.Test;
  * @author Tijs Rademakers
  */
 public class CasePageTaskCmmnXmlConverterTest extends AbstractConverterTest {
-    
+
     private static final String CMMN_RESOURCE = "org/flowable/test/cmmn/converter/case-page-task.cmmn";
-    
+
     @Test
     public void convertXMLToModel() throws Exception {
         CmmnModel cmmnModel = readXMLFile(CMMN_RESOURCE);
@@ -46,28 +46,26 @@ public class CasePageTaskCmmnXmlConverterTest extends AbstractConverterTest {
         CmmnModel parsedModel = exportAndReadXMLFile(cmmnModel);
         validateModel(parsedModel);
     }
-    
+
     public void validateModel(CmmnModel cmmnModel) {
         assertThat(cmmnModel).isNotNull();
-        
+
         // Case
         assertThat(cmmnModel.getCases())
-            .isNotNull()
-            .hasSize(1)
-            .extracting(Case::getId)
-            .containsExactly("casePageCase");
-        
+                .extracting(Case::getId)
+                .containsExactly("casePageCase");
+
         Stage planModel = cmmnModel.getCases().get(0).getPlanModel();
-        
+
         // Plan items definitions
         List<PlanItemDefinition> planItemDefinitions = planModel.getPlanItemDefinitions();
         assertThat(planItemDefinitions).hasSize(2);
         assertThat(planModel.findPlanItemDefinitionsOfType(CasePageTask.class, false)).hasSize(2);
-        
+
         // Plan items
         List<PlanItem> planItems = planModel.getPlanItems();
         assertThat(planItems).hasSize(2);
-        
+
         PlanItem planItemTaskA = cmmnModel.findPlanItem("planItemTaskA");
         PlanItemDefinition planItemDefinition = planItemTaskA.getPlanItemDefinition();
         assertThat(planItemTaskA.getEntryCriteria()).isEmpty();
@@ -81,12 +79,8 @@ public class CasePageTaskCmmnXmlConverterTest extends AbstractConverterTest {
         assertThat(taskA.getIcon()).isEqualTo("Icon 1");
         assertThat(taskA.getAssignee()).isEqualTo("johndoe");
         assertThat(taskA.getOwner()).isEqualTo("janedoe");
-        assertThat(taskA.getCandidateUsers()).hasSize(2);
-        assertThat(taskA.getCandidateUsers().get(0)).isEqualTo("johndoe");
-        assertThat(taskA.getCandidateUsers().get(1)).isEqualTo("janedoe");
-        assertThat(taskA.getCandidateGroups()).hasSize(2);
-        assertThat(taskA.getCandidateGroups().get(0)).isEqualTo("sales");
-        assertThat(taskA.getCandidateGroups().get(1)).isEqualTo("management");
+        assertThat(taskA.getCandidateUsers()).containsExactly("johndoe", "janedoe");
+        assertThat(taskA.getCandidateGroups()).containsExactly("sales", "management");
         assertThat(planItemTaskA.getItemControl()).isNotNull();
         assertThat(planItemTaskA.getItemControl().getParentCompletionRule()).isNotNull();
         assertThat(planItemTaskA.getItemControl().getParentCompletionRule().getType()).isEqualTo(ParentCompletionRule.IGNORE);
@@ -101,13 +95,13 @@ public class CasePageTaskCmmnXmlConverterTest extends AbstractConverterTest {
         assertThat(planItemTaskB.getItemControl()).isNotNull();
         assertThat(planItemTaskB.getItemControl().getParentCompletionRule()).isNotNull();
         assertThat(planItemTaskB.getItemControl().getParentCompletionRule().getType()).isEqualTo(ParentCompletionRule.IGNORE);
-        
+
         assertThat(taskB.getExtensionElements()).hasSize(1);
         List<ExtensionElement> extensionElements = taskB.getExtensionElements().get("index");
         assertThat(extensionElements).hasSize(1);
         assertThat(extensionElements)
-            .extracting(ExtensionElement::getName, ExtensionElement::getElementText)
-            .containsExactly(tuple("index", "0"));
+                .extracting(ExtensionElement::getName, ExtensionElement::getElementText)
+                .containsExactly(tuple("index", "0"));
     }
 
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/CaseStartEventXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/CaseStartEventXmlConverterTest.java
@@ -12,7 +12,7 @@
  */
 package org.flowable.test.cmmn.converter;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.cmmn.model.CmmnModel;
 import org.junit.Test;
@@ -38,7 +38,7 @@ public class CaseStartEventXmlConverterTest extends AbstractConverterTest {
     }
     
     public void validateModel(CmmnModel cmmnModel) {
-        assertEquals("myEvent", cmmnModel.getPrimaryCase().getStartEventType());
+        assertThat(cmmnModel.getPrimaryCase().getStartEventType()).isEqualTo("myEvent");
     }
 
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/CaseTaskCmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/CaseTaskCmmnXmlConverterTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,9 +28,9 @@ import org.junit.Test;
  * @author martin.grofcik
  */
 public class CaseTaskCmmnXmlConverterTest extends AbstractConverterTest {
-    
+
     private static final String CMMN_RESOURCE = "org/flowable/test/cmmn/converter/case-task.cmmn";
-    
+
     @Test
     public void convertXMLToModel() throws Exception {
         CmmnModel cmmnModel = readXMLFile(CMMN_RESOURCE);
@@ -43,36 +43,32 @@ public class CaseTaskCmmnXmlConverterTest extends AbstractConverterTest {
         CmmnModel parsedModel = exportAndReadXMLFile(cmmnModel);
         validateModel(parsedModel);
     }
-    
+
     public void validateModel(CmmnModel cmmnModel) {
         assertThat(cmmnModel).isNotNull();
 
         // Case
         assertThat(cmmnModel.getCases())
-            .isNotNull()
-            .hasSize(1)
-            .extracting(Case::getId)
-            .containsExactly("myCase");
+                .extracting(Case::getId)
+                .containsExactly("myCase");
 
         // Plan model
         Stage planModel = cmmnModel.getCases().get(0).getPlanModel();
         assertThat(planModel)
-            .extracting(Stage::getId, Stage::getName)
-            .containsExactly("myPlanModel", "My CasePlanModel");
-        
+                .extracting(Stage::getId, Stage::getName)
+                .containsExactly("myPlanModel", "My CasePlanModel");
+
         PlanItem planItemTask1 = cmmnModel.findPlanItem("planItem1");
         PlanItemDefinition planItemDefinition = planItemTask1.getPlanItemDefinition();
         assertThat(planItemDefinition).isInstanceOf(CaseTask.class);
         CaseTask task1 = (CaseTask) planItemDefinition;
         assertThat(task1.getCaseRefExpression()).isEqualTo("caseDefinitionKey");
-        
+
         assertThat(task1.getFallbackToDefaultTenant()).isTrue();
 
         assertThat(task1.getInParameters())
-            .isNotNull()
-            .hasSize(1)
-            .extracting(IOParameter::getSource, IOParameter::getTarget)
-            .containsExactly(tuple("testSource", "testTarget"));
+                .extracting(IOParameter::getSource, IOParameter::getTarget)
+                .containsExactly(tuple("testSource", "testTarget"));
     }
 
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/CaseTaskCmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/CaseTaskCmmnXmlConverterTest.java
@@ -13,9 +13,7 @@
 package org.flowable.test.cmmn.converter;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.tuple;
 
 import org.flowable.cmmn.model.Case;
 import org.flowable.cmmn.model.CaseTask;
@@ -47,34 +45,34 @@ public class CaseTaskCmmnXmlConverterTest extends AbstractConverterTest {
     }
     
     public void validateModel(CmmnModel cmmnModel) {
-        assertNotNull(cmmnModel);
-        assertEquals(1, cmmnModel.getCases().size());
-        
+        assertThat(cmmnModel).isNotNull();
+
         // Case
-        Case caze = cmmnModel.getCases().get(0);
-        assertEquals("myCase", caze.getId());
-        
+        assertThat(cmmnModel.getCases())
+            .isNotNull()
+            .hasSize(1)
+            .extracting(Case::getId)
+            .containsExactly("myCase");
+
         // Plan model
-        Stage planModel = caze.getPlanModel();
-        assertNotNull(planModel);
-        assertEquals("myPlanModel", planModel.getId());
-        assertEquals("My CasePlanModel", planModel.getName());
+        Stage planModel = cmmnModel.getCases().get(0).getPlanModel();
+        assertThat(planModel)
+            .extracting(Stage::getId, Stage::getName)
+            .containsExactly("myPlanModel", "My CasePlanModel");
         
         PlanItem planItemTask1 = cmmnModel.findPlanItem("planItem1");
         PlanItemDefinition planItemDefinition = planItemTask1.getPlanItemDefinition();
-        assertTrue(planItemDefinition instanceof CaseTask);
+        assertThat(planItemDefinition).isInstanceOf(CaseTask.class);
         CaseTask task1 = (CaseTask) planItemDefinition;
-        assertEquals("caseDefinitionKey", task1.getCaseRefExpression());
+        assertThat(task1.getCaseRefExpression()).isEqualTo("caseDefinitionKey");
         
-        assertTrue(task1.getFallbackToDefaultTenant());
+        assertThat(task1.getFallbackToDefaultTenant()).isTrue();
 
         assertThat(task1.getInParameters())
-                .isNotNull()
-                .hasSize(1);
-        IOParameter inParameter = task1.getInParameters().get(0);
-        assertThat(inParameter).isNotNull();
-        assertThat(inParameter.getSource()).isEqualTo("testSource");
-        assertThat(inParameter.getTarget()).isEqualTo("testTarget");
+            .isNotNull()
+            .hasSize(1)
+            .extracting(IOParameter::getSource, IOParameter::getTarget)
+            .containsExactly(tuple("testSource", "testTarget"));
     }
 
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/CmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/CmmnXmlConverterTest.java
@@ -92,11 +92,10 @@ public class CmmnXmlConverterTest extends AbstractConverterTest {
         for (Sentry sentry : planModel.getSentries()) {
             List<SentryOnPart> onParts = sentry.getOnParts();
             if (onParts != null && !onParts.isEmpty()) {
-                assertThat(onParts).hasSize(1);
-                assertThat(onParts.get(0).getId()).isNotNull();
-                assertThat(onParts.get(0).getSourceRef()).isNotNull();
-                assertThat(onParts.get(0).getSource()).isNotNull();
-                assertThat(onParts.get(0).getStandardEvent()).isNotNull();
+                assertThat(onParts)
+                    .hasSize(1)
+                    .extracting(SentryOnPart::getId, SentryOnPart::getSourceRef, SentryOnPart::getSource, SentryOnPart::getStandardEvent)
+                    .doesNotContainNull();
             } else {
                 assertThat(sentry.getSentryIfPart().getCondition()).isEqualTo("${true}");
                 assertThat(sentry.getName()).isEqualTo("criterion name");

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/CmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/CmmnXmlConverterTest.java
@@ -49,7 +49,7 @@ public class CmmnXmlConverterTest extends AbstractConverterTest {
 
     /**
      * Test simple case model, with 4 consequent elements: taskA -> milestone 1 -> taskB -> milestone 2.
-     *
+     * <p>
      * The converters should check following model class instances:
      * - 1 case
      * - 1 stage (the plan model)
@@ -76,16 +76,14 @@ public class CmmnXmlConverterTest extends AbstractConverterTest {
 
         // Case
         assertThat(cmmnModel.getCases())
-            .hasSize(1)
-            .extracting(Case::getId)
-            .containsExactly("myCase");
+                .extracting(Case::getId)
+                .containsExactly("myCase");
 
         // Plan model
         Stage planModel = cmmnModel.getCases().get(0).getPlanModel();
         assertThat(cmmnModel.getCases())
-            .isNotNull()
-            .extracting(cases -> cases.getPlanModel().getId(), cases -> cases.getPlanModel().getName(), cases -> cases.getPlanModel().getFormKey())
-            .containsExactly(tuple("myPlanModel", "My CasePlanModel", "casePlanForm"));
+                .extracting(cases -> cases.getPlanModel().getId(), cases -> cases.getPlanModel().getName(), cases -> cases.getPlanModel().getFormKey())
+                .containsExactly(tuple("myPlanModel", "My CasePlanModel", "casePlanForm"));
 
         // Sentries
         assertThat(planModel.getSentries()).hasSize(4);
@@ -93,9 +91,9 @@ public class CmmnXmlConverterTest extends AbstractConverterTest {
             List<SentryOnPart> onParts = sentry.getOnParts();
             if (onParts != null && !onParts.isEmpty()) {
                 assertThat(onParts)
-                    .hasSize(1)
-                    .extracting(SentryOnPart::getId, SentryOnPart::getSourceRef, SentryOnPart::getSource, SentryOnPart::getStandardEvent)
-                    .doesNotContainNull();
+                        .hasSize(1)
+                        .extracting(SentryOnPart::getId, SentryOnPart::getSourceRef, SentryOnPart::getSource, SentryOnPart::getStandardEvent)
+                        .doesNotContainNull();
             } else {
                 assertThat(sentry.getSentryIfPart().getCondition()).isEqualTo("${true}");
                 assertThat(sentry.getName()).isEqualTo("criterion name");
@@ -131,10 +129,10 @@ public class CmmnXmlConverterTest extends AbstractConverterTest {
 
             if (!planItem.getId().equals("planItemTaskA")) {
                 assertThat(planItem.getEntryCriteria())
-                    .isNotNull()
-                    .hasSize(1)
-                    .extracting(Criterion::getSentry)
-                    .isNotNull(); // Verify if sentry reference is resolved
+                        .isNotNull()
+                        .hasSize(1)
+                        .extracting(Criterion::getSentry)
+                        .isNotNull(); // Verify if sentry reference is resolved
             }
 
             if (planItem.getPlanItemDefinition() instanceof Task) {
@@ -187,29 +185,29 @@ public class CmmnXmlConverterTest extends AbstractConverterTest {
         Stage nestedNestedStage = null;
         for (PlanItem planItem : nestedStage.getPlanItems()) {
             assertThat(planItem.getPlanItemDefinition()).isNotNull();
-            if (planItem.getPlanItemDefinition()  instanceof Stage) {
+            if (planItem.getPlanItemDefinition() instanceof Stage) {
                 nestedNestedStage = (Stage) planItem.getPlanItemDefinition();
             }
         }
         assertThat(nestedNestedStage).isNotNull();
         assertThat(nestedNestedStage.getName()).isEqualTo("Nested Stage 2");
         assertThat(nestedNestedStage.getPlanItems())
-            .hasSize(1)
-            .extracting(planItem -> planItem.getPlanItemDefinition().getId())
-            .containsExactly("rootTask");
+                .extracting(planItem -> planItem.getPlanItemDefinition().getId())
+                .containsExactly("rootTask");
     }
 
     @Test
     public void testCaseLifecycleListener() throws Exception {
         CmmnModel cmmnModel = cmmnXmlConverter.convertToCmmnModel(getInputStreamProvider("case-lifecycle-listeners.cmmn"));
         cmmnModel = exportAndReadXMLFile(cmmnModel);
-        
+
         assertThat(cmmnModel.getCases()).hasSize(1);
         Case aCase = cmmnModel.getCases().get(0);
         assertThat(aCase.getLifecycleListeners())
-            .hasSize(1)
-            .extracting(FlowableListener::getSourceState, FlowableListener::getTargetState, FlowableListener::getImplementationType, FlowableListener::getImplementation)
-            .containsExactly(tuple("active", "completed", ImplementationType.IMPLEMENTATION_TYPE_EXPRESSION, "${caseInstance.setVariable('stageThree', false)}"));
+                .extracting(FlowableListener::getSourceState, FlowableListener::getTargetState, FlowableListener::getImplementationType,
+                        FlowableListener::getImplementation)
+                .containsExactly(
+                        tuple("active", "completed", ImplementationType.IMPLEMENTATION_TYPE_EXPRESSION, "${caseInstance.setVariable('stageThree', false)}"));
     }
 
     @Test

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/CompletionNeutralConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/CompletionNeutralConverterTest.java
@@ -38,12 +38,12 @@ public class CompletionNeutralConverterTest extends AbstractConverterTest {
             Stage planModel = cmmnModel.getPrimaryCase().getPlanModel();
             List<PlanItem> planItems = planModel.getPlanItems();
             assertThat(planItems)
-                .hasSize(4)
-                .extracting(
-                    planItem -> planItem.getItemControl(),
-                    planItem -> planItem.getItemControl().getCompletionNeutralRule(),
-                    planItem -> planItem.getItemControl().getCompletionNeutralRule().getCondition())
-                .doesNotContainNull();
+                    .hasSize(4)
+                    .extracting(
+                            planItem -> planItem.getItemControl(),
+                            planItem -> planItem.getItemControl().getCompletionNeutralRule(),
+                            planItem -> planItem.getItemControl().getCompletionNeutralRule().getCondition())
+                    .doesNotContainNull();
             planItems.forEach(planItem -> {
                 assertThat(planItem.getItemControl().getCompletionNeutralRule().getCondition()).isEqualTo("${" + planItem.getId() + "}");
             });
@@ -52,19 +52,18 @@ public class CompletionNeutralConverterTest extends AbstractConverterTest {
             List<PlanItem> planItems1 = stageOne.getPlanItems();
 
             assertThat(planItems1)
-                .hasSize(1)
-                .extracting(
-                    planItem -> planItem.getItemControl(),
-                    planItem -> planItem.getItemControl().getCompletionNeutralRule())
-                .doesNotContainNull();
+                    .hasSize(1)
+                    .extracting(
+                            planItem -> planItem.getItemControl(),
+                            planItem -> planItem.getItemControl().getCompletionNeutralRule())
+                    .doesNotContainNull();
             PlanItem planItem = planItems1.get(0);
             assertThat(planItem.getItemControl().getCompletionNeutralRule().getCondition()).isNull();
 
             List<ExtensionElement> extensionElements = planItem.getExtensionElements().get("planItemTest");
             assertThat(extensionElements)
-                .hasSize(1)
-                .extracting(ExtensionElement::getName, ExtensionElement::getElementText)
-                .containsExactly(tuple("planItemTest", "hello"));
+                    .extracting(ExtensionElement::getName, ExtensionElement::getElementText)
+                    .containsExactly(tuple("planItemTest", "hello"));
         };
 
         validateModel(cmmnResource, modelValidator);
@@ -84,13 +83,12 @@ public class CompletionNeutralConverterTest extends AbstractConverterTest {
                 assertThat(definition.getDefaultControl().getCompletionNeutralRule().getCondition()).isNotNull();
                 assertThat(definition.getDefaultControl().getCompletionNeutralRule().getCondition()).isEqualTo("${" + definition.getId() + "}");
             });
-            
+
             PlanItemDefinition planItemDef = cmmnModel.findPlanItemDefinition("taskTwo");
             List<ExtensionElement> extensionElements = planItemDef.getExtensionElements().get("taskTest");
             assertThat(extensionElements)
-                .hasSize(1)
-                .extracting(ExtensionElement::getName, ExtensionElement::getElementText)
-                .containsExactly(tuple("taskTest", "hello"));
+                    .extracting(ExtensionElement::getName, ExtensionElement::getElementText)
+                    .containsExactly(tuple("taskTest", "hello"));
         };
 
         validateModel(cmmnResource, modelValidator);

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/CompletionNeutralConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/CompletionNeutralConverterTest.java
@@ -37,20 +37,27 @@ public class CompletionNeutralConverterTest extends AbstractConverterTest {
             assertThat(cmmnModel).isNotNull();
             Stage planModel = cmmnModel.getPrimaryCase().getPlanModel();
             List<PlanItem> planItems = planModel.getPlanItems();
-            assertThat(planItems).hasSize(4);
+            assertThat(planItems)
+                .hasSize(4)
+                .extracting(
+                    planItem -> planItem.getItemControl(),
+                    planItem -> planItem.getItemControl().getCompletionNeutralRule(),
+                    planItem -> planItem.getItemControl().getCompletionNeutralRule().getCondition())
+                .doesNotContainNull();
             planItems.forEach(planItem -> {
-                assertThat(planItem.getItemControl()).isNotNull();
-                assertThat(planItem.getItemControl().getCompletionNeutralRule()).isNotNull();
-                assertThat(planItem.getItemControl().getCompletionNeutralRule().getCondition()).isNotNull();
                 assertThat(planItem.getItemControl().getCompletionNeutralRule().getCondition()).isEqualTo("${" + planItem.getId() + "}");
             });
 
             Stage stageOne = (Stage) cmmnModel.getPrimaryCase().getPlanModel().findPlanItemDefinitionInStageOrDownwards("stageOne");
             List<PlanItem> planItems1 = stageOne.getPlanItems();
-            assertThat(planItems1).hasSize(1);
+
+            assertThat(planItems1)
+                .hasSize(1)
+                .extracting(
+                    planItem -> planItem.getItemControl(),
+                    planItem -> planItem.getItemControl().getCompletionNeutralRule())
+                .doesNotContainNull();
             PlanItem planItem = planItems1.get(0);
-            assertThat(planItem.getItemControl()).isNotNull();
-            assertThat(planItem.getItemControl().getCompletionNeutralRule()).isNotNull();
             assertThat(planItem.getItemControl().getCompletionNeutralRule().getCondition()).isNull();
 
             List<ExtensionElement> extensionElements = planItem.getExtensionElements().get("planItemTest");

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/CompletionNeutralConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/CompletionNeutralConverterTest.java
@@ -12,9 +12,8 @@
  */
 package org.flowable.test.cmmn.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import java.util.List;
 import java.util.function.Consumer;
@@ -35,31 +34,30 @@ public class CompletionNeutralConverterTest extends AbstractConverterTest {
     public void completionNeutralDefinedAtPlanItem() throws Exception {
         String cmmnResource = "org/flowable/test/cmmn/converter/completionNeutralAtPlanItem.cmmn";
         Consumer<CmmnModel> modelValidator = cmmnModel -> {
-            assertNotNull(cmmnModel);
+            assertThat(cmmnModel).isNotNull();
             Stage planModel = cmmnModel.getPrimaryCase().getPlanModel();
             List<PlanItem> planItems = planModel.getPlanItems();
-            assertEquals(4, planItems.size());
+            assertThat(planItems).hasSize(4);
             planItems.forEach(planItem -> {
-                assertNotNull(planItem.getItemControl());
-                assertNotNull(planItem.getItemControl().getCompletionNeutralRule());
-                assertNotNull(planItem.getItemControl().getCompletionNeutralRule().getCondition());
-                assertEquals("${" + planItem.getId() + "}", planItem.getItemControl().getCompletionNeutralRule().getCondition());
+                assertThat(planItem.getItemControl()).isNotNull();
+                assertThat(planItem.getItemControl().getCompletionNeutralRule()).isNotNull();
+                assertThat(planItem.getItemControl().getCompletionNeutralRule().getCondition()).isNotNull();
+                assertThat(planItem.getItemControl().getCompletionNeutralRule().getCondition()).isEqualTo("${" + planItem.getId() + "}");
             });
 
             Stage stageOne = (Stage) cmmnModel.getPrimaryCase().getPlanModel().findPlanItemDefinitionInStageOrDownwards("stageOne");
             List<PlanItem> planItems1 = stageOne.getPlanItems();
-            assertEquals(1, planItems1.size());
+            assertThat(planItems1).hasSize(1);
             PlanItem planItem = planItems1.get(0);
-            assertNotNull(planItem.getItemControl());
-            assertNotNull(planItem.getItemControl().getCompletionNeutralRule());
-            assertNull(planItem.getItemControl().getCompletionNeutralRule().getCondition());
-            
-            assertEquals(1, planItem.getExtensionElements().size());
+            assertThat(planItem.getItemControl()).isNotNull();
+            assertThat(planItem.getItemControl().getCompletionNeutralRule()).isNotNull();
+            assertThat(planItem.getItemControl().getCompletionNeutralRule().getCondition()).isNull();
+
             List<ExtensionElement> extensionElements = planItem.getExtensionElements().get("planItemTest");
-            assertEquals(1, extensionElements.size());
-            ExtensionElement extensionElement = extensionElements.get(0);
-            assertEquals("planItemTest", extensionElement.getName());
-            assertEquals("hello", extensionElement.getElementText());
+            assertThat(extensionElements)
+                .hasSize(1)
+                .extracting(ExtensionElement::getName, ExtensionElement::getElementText)
+                .containsExactly(tuple("planItemTest", "hello"));
         };
 
         validateModel(cmmnResource, modelValidator);
@@ -69,24 +67,23 @@ public class CompletionNeutralConverterTest extends AbstractConverterTest {
     public void completionNeutralDefinedAtPlanItemDefinition() throws Exception {
         String cmmnResource = "org/flowable/test/cmmn/converter/completionNeutralAtPlanItemDefinition.cmmn";
         Consumer<CmmnModel> modelValidator = cmmnModel -> {
-            assertNotNull(cmmnModel);
+            assertThat(cmmnModel).isNotNull();
             Stage planModel = cmmnModel.getPrimaryCase().getPlanModel();
             List<PlanItemDefinition> planItemDefinitions = planModel.getPlanItemDefinitions();
-            assertEquals(4, planItemDefinitions.size());
+            assertThat(planItemDefinitions).hasSize(4);
             planItemDefinitions.forEach(definition -> {
-                assertNotNull(definition.getDefaultControl());
-                assertNotNull(definition.getDefaultControl().getCompletionNeutralRule());
-                assertNotNull(definition.getDefaultControl().getCompletionNeutralRule().getCondition());
-                assertEquals("${" + definition.getId() + "}", definition.getDefaultControl().getCompletionNeutralRule().getCondition());
+                assertThat(definition.getDefaultControl()).isNotNull();
+                assertThat(definition.getDefaultControl().getCompletionNeutralRule()).isNotNull();
+                assertThat(definition.getDefaultControl().getCompletionNeutralRule().getCondition()).isNotNull();
+                assertThat(definition.getDefaultControl().getCompletionNeutralRule().getCondition()).isEqualTo("${" + definition.getId() + "}");
             });
             
             PlanItemDefinition planItemDef = cmmnModel.findPlanItemDefinition("taskTwo");
-            assertEquals(1, planItemDef.getExtensionElements().size());
             List<ExtensionElement> extensionElements = planItemDef.getExtensionElements().get("taskTest");
-            assertEquals(1, extensionElements.size());
-            ExtensionElement extensionElement = extensionElements.get(0);
-            assertEquals("taskTest", extensionElement.getName());
-            assertEquals("hello", extensionElement.getElementText());
+            assertThat(extensionElements)
+                .hasSize(1)
+                .extracting(ExtensionElement::getName, ExtensionElement::getElementText)
+                .containsExactly(tuple("taskTest", "hello"));
         };
 
         validateModel(cmmnResource, modelValidator);

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/EventListenerWithEventTypeXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/EventListenerWithEventTypeXmlConverterTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,9 +28,9 @@ import org.junit.Test;
  * @author Joram Barrez
  */
 public class EventListenerWithEventTypeXmlConverterTest extends AbstractConverterTest {
-    
+
     private static final String CMMN_RESOURCE = "org/flowable/test/cmmn/converter/event-listener-with-event-type.cmmn";
-    
+
     @Test
     public void convertXMLToModel() throws Exception {
         CmmnModel cmmnModel = readXMLFile(CMMN_RESOURCE);
@@ -43,7 +43,7 @@ public class EventListenerWithEventTypeXmlConverterTest extends AbstractConverte
         CmmnModel parsedModel = exportAndReadXMLFile(cmmnModel);
         validateModel(parsedModel);
     }
-    
+
     public void validateModel(CmmnModel cmmnModel) {
         PlanItemDefinition planItemDefinition = cmmnModel.findPlanItemDefinition("eventListener");
         assertThat(planItemDefinition).isInstanceOf(GenericEventListener.class);
@@ -53,10 +53,9 @@ public class EventListenerWithEventTypeXmlConverterTest extends AbstractConverte
 
         List<ExtensionElement> correlationParameters = genericEventListener.getExtensionElements().getOrDefault("eventCorrelationParameter", new ArrayList<>());
         assertThat(correlationParameters)
-            .hasSize(1)
-            .extracting(extensionElement -> extensionElement.getAttributeValue(null, "name"),
-                extensionElement -> extensionElement.getAttributeValue(null, "value"))
-            .containsExactly(tuple("customerId", "${customerIdVar}"));
+                .extracting(extensionElement -> extensionElement.getAttributeValue(null, "name"),
+                        extensionElement -> extensionElement.getAttributeValue(null, "value"))
+                .containsExactly(tuple("customerId", "${customerIdVar}"));
     }
 
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/EventListenerWithEventTypeXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/EventListenerWithEventTypeXmlConverterTest.java
@@ -13,7 +13,7 @@
 package org.flowable.test.cmmn.converter;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.tuple;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -52,10 +52,11 @@ public class EventListenerWithEventTypeXmlConverterTest extends AbstractConverte
         assertThat(genericEventListener.getEventType()).isEqualTo("myEvent");
 
         List<ExtensionElement> correlationParameters = genericEventListener.getExtensionElements().getOrDefault("eventCorrelationParameter", new ArrayList<>());
-        assertEquals(1, correlationParameters.size());
-        ExtensionElement extensionElement = correlationParameters.get(0);
-        assertEquals("customerId", extensionElement.getAttributeValue(null, "name"));
-        assertEquals("${customerIdVar}", extensionElement.getAttributeValue(null, "value"));
+        assertThat(correlationParameters)
+            .hasSize(1)
+            .extracting(extensionElement -> extensionElement.getAttributeValue(null, "name"),
+                extensionElement -> extensionElement.getAttributeValue(null, "value"))
+            .containsExactly(tuple("customerId", "${customerIdVar}"));
     }
 
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/ExitCriteriaBlockingExpressionCmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/ExitCriteriaBlockingExpressionCmmnXmlConverterTest.java
@@ -67,25 +67,25 @@ public class ExitCriteriaBlockingExpressionCmmnXmlConverterTest extends Abstract
         assertThat(planItemTaskB).isNotNull();
         assertThat(planItemTaskB.getDefinitionRef()).isEqualTo("taskDefinition");
         assertThat(planItemTaskB.getExitCriteria())
-            .extracting(Criterion::getId, Criterion::getSentryRef)
-            .containsOnly(
-                tuple("exitCriterion_1", "sentry")
-            );
+                .extracting(Criterion::getId, Criterion::getSentryRef)
+                .containsOnly(
+                        tuple("exitCriterion_1", "sentry")
+                );
 
         assertThat(planModel.getSentries())
-            .extracting(Sentry::getId)
-            .containsOnly("sentry");
+                .extracting(Sentry::getId)
+                .containsOnly("sentry");
         assertThat(planModel.getSentries().get(0).getOnParts())
-            .extracting(SentryOnPart::getId, SentryOnPart::getSourceRef, SentryOnPart::getStandardEvent)
-            .containsOnly(
-                tuple("onPart_1", "taskA", "complete")
-            );
+                .extracting(SentryOnPart::getId, SentryOnPart::getSourceRef, SentryOnPart::getStandardEvent)
+                .containsOnly(
+                        tuple("onPart_1", "taskA", "complete")
+                );
 
         assertThat(cmmnModel.getAssociations())
-            .extracting(Association::getId, Association::getSourceRef, Association::getTargetRef, Association::getTransitionEvent)
-            .containsOnly(
-                tuple("association_1", "taskA", "exitCriterion_1", "complete")
-            );
+                .extracting(Association::getId, Association::getSourceRef, Association::getTargetRef, Association::getTransitionEvent)
+                .containsOnly(
+                        tuple("association_1", "taskA", "exitCriterion_1", "complete")
+                );
     }
 
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/ExitCriteriaBlockingExpressionCmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/ExitCriteriaBlockingExpressionCmmnXmlConverterTest.java
@@ -63,30 +63,29 @@ public class ExitCriteriaBlockingExpressionCmmnXmlConverterTest extends Abstract
         assertThat(planItemTaskA).isNotNull();
         assertThat(planItemTaskA.getDefinitionRef()).isEqualTo("taskDefinition");
 
-
         PlanItem planItemTaskB = cmmnModel.findPlanItem("taskB");
         assertThat(planItemTaskB).isNotNull();
         assertThat(planItemTaskB.getDefinitionRef()).isEqualTo("taskDefinition");
         assertThat(planItemTaskB.getExitCriteria())
-                .extracting(Criterion::getId, Criterion::getSentryRef)
-                .containsOnly(
-                        tuple("exitCriterion_1", "sentry")
-                );
+            .extracting(Criterion::getId, Criterion::getSentryRef)
+            .containsOnly(
+                tuple("exitCriterion_1", "sentry")
+            );
 
         assertThat(planModel.getSentries())
-                .extracting(Sentry::getId)
-                .containsOnly("sentry");
+            .extracting(Sentry::getId)
+            .containsOnly("sentry");
         assertThat(planModel.getSentries().get(0).getOnParts())
-                .extracting(SentryOnPart::getId, SentryOnPart::getSourceRef, SentryOnPart::getStandardEvent)
-                .containsOnly(
-                        tuple("onPart_1", "taskA", "complete")
-                );
+            .extracting(SentryOnPart::getId, SentryOnPart::getSourceRef, SentryOnPart::getStandardEvent)
+            .containsOnly(
+                tuple("onPart_1", "taskA", "complete")
+            );
 
         assertThat(cmmnModel.getAssociations())
-                .extracting(Association::getId, Association::getSourceRef, Association::getTargetRef, Association::getTransitionEvent)
-                .containsOnly(
-                        tuple("association_1", "taskA", "exitCriterion_1", "complete")
-                );
+            .extracting(Association::getId, Association::getSourceRef, Association::getTargetRef, Association::getTransitionEvent)
+            .containsOnly(
+                tuple("association_1", "taskA", "exitCriterion_1", "complete")
+            );
     }
 
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/ExitCriteriaNonBlockingCmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/ExitCriteriaNonBlockingCmmnXmlConverterTest.java
@@ -62,22 +62,21 @@ public class ExitCriteriaNonBlockingCmmnXmlConverterTest extends AbstractConvert
         assertThat(planItemTaskA).isNotNull();
         assertThat(planItemTaskA.getDefinitionRef()).isEqualTo("taskDefinition");
 
-
         PlanItem planItemTaskB = cmmnModel.findPlanItem("taskB");
         assertThat(planItemTaskB).isNotNull();
         assertThat(planItemTaskB.getDefinitionRef()).isEqualTo("taskDefinition");
         assertThat(planItemTaskB.getExitCriteria())
-                .extracting(Criterion::getId, Criterion::getSentryRef)
-                .isEmpty();
+            .extracting(Criterion::getId, Criterion::getSentryRef)
+            .isEmpty();
 
         assertThat(planModel.getSentries())
-                .extracting(Sentry::getId)
-                .containsOnly("sentry");
+            .extracting(Sentry::getId)
+            .containsOnly("sentry");
         assertThat(planModel.getSentries().get(0).getOnParts())
-                .extracting(SentryOnPart::getId, SentryOnPart::getSourceRef, SentryOnPart::getStandardEvent)
-                .containsOnly(
-                        tuple("onPart_1", "taskA", "complete")
-                );
+            .extracting(SentryOnPart::getId, SentryOnPart::getSourceRef, SentryOnPart::getStandardEvent)
+            .containsOnly(
+                tuple("onPart_1", "taskA", "complete")
+            );
 
         assertThat(cmmnModel.getAssociations()).isEmpty();
     }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/ExitSentryExtendedAttributesConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/ExitSentryExtendedAttributesConverterTest.java
@@ -12,14 +12,13 @@
  */
 package org.flowable.test.cmmn.converter;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.flowable.cmmn.model.Criterion.EXIT_EVENT_TYPE_COMPLETE;
 import static org.flowable.cmmn.model.Criterion.EXIT_EVENT_TYPE_EXIT;
 import static org.flowable.cmmn.model.Criterion.EXIT_EVENT_TYPE_FORCE_COMPLETE;
 import static org.flowable.cmmn.model.Criterion.EXIT_TYPE_ACTIVE_AND_ENABLED_INSTANCES;
 import static org.flowable.cmmn.model.Criterion.EXIT_TYPE_ACTIVE_INSTANCES;
 import static org.flowable.cmmn.model.Criterion.EXIT_TYPE_DEFAULT;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 import org.flowable.cmmn.model.CmmnModel;
 import org.junit.Test;
@@ -42,7 +41,7 @@ public class ExitSentryExtendedAttributesConverterTest extends AbstractConverter
     }
 
     public void validateModel(CmmnModel cmmnModel) {
-        assertNotNull(cmmnModel);
+        assertThat(cmmnModel).isNotNull();
 
         assertCriterionExitEventType(cmmnModel, "exitCriterion1", null);
         assertCriterionExitEventType(cmmnModel, "exitCriterion2", EXIT_EVENT_TYPE_EXIT);
@@ -61,12 +60,12 @@ public class ExitSentryExtendedAttributesConverterTest extends AbstractConverter
     }
 
     protected void assertCriterionExitEventType(CmmnModel cmmnModel, String criterionId, String expectedExitEventType) {
-        assertNotNull(cmmnModel.getCriterion(criterionId));
-        assertEquals(expectedExitEventType, cmmnModel.getCriterion(criterionId).getExitEventType());
+        assertThat(cmmnModel.getCriterion(criterionId)).isNotNull();
+        assertThat(cmmnModel.getCriterion(criterionId).getExitEventType()).isEqualTo(expectedExitEventType);
     }
 
     protected void assertCriterionExitType(CmmnModel cmmnModel, String criterionId, String expectedExitType) {
-        assertNotNull(cmmnModel.getCriterion(criterionId));
-        assertEquals(expectedExitType, cmmnModel.getCriterion(criterionId).getExitType());
+        assertThat(cmmnModel.getCriterion(criterionId)).isNotNull();
+        assertThat(cmmnModel.getCriterion(criterionId).getExitType()).isEqualTo(expectedExitType);
     }
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/GenericEventListenerCmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/GenericEventListenerCmmnXmlConverterTest.java
@@ -12,8 +12,8 @@
  */
 package org.flowable.test.cmmn.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import java.util.List;
 
@@ -43,17 +43,15 @@ public class GenericEventListenerCmmnXmlConverterTest extends AbstractConverterT
     }
 
     public void validateModel(CmmnModel cmmnModel) {
-        assertNotNull(cmmnModel);
+        assertThat(cmmnModel).isNotNull();
 
         List<HumanTask> humanTasks = cmmnModel.getPrimaryCase().getPlanModel().findPlanItemDefinitionsOfType(HumanTask.class, true);
-        assertEquals(2, humanTasks.size());
+        assertThat(humanTasks).hasSize(2);
 
         List<GenericEventListener> genericEventListeners = cmmnModel.getPrimaryCase().getPlanModel().findPlanItemDefinitionsOfType(GenericEventListener.class, true);
-        assertEquals(1, genericEventListeners.size());
-
-        GenericEventListener genericEventListener = genericEventListeners.get(0);
-        assertEquals("myGenericEventListener", genericEventListener.getName());
-        assertEquals("genericActionListener",genericEventListener.getId());
-        assertEquals("GenericEventListener documentation", genericEventListener.getDocumentation());
+        assertThat(genericEventListeners)
+            .hasSize(1)
+            .extracting(GenericEventListener::getName, GenericEventListener::getId, GenericEventListener::getDocumentation)
+            .containsExactly(tuple("myGenericEventListener", "genericActionListener", "GenericEventListener documentation"));
     }
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/GenericEventListenerCmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/GenericEventListenerCmmnXmlConverterTest.java
@@ -48,10 +48,10 @@ public class GenericEventListenerCmmnXmlConverterTest extends AbstractConverterT
         List<HumanTask> humanTasks = cmmnModel.getPrimaryCase().getPlanModel().findPlanItemDefinitionsOfType(HumanTask.class, true);
         assertThat(humanTasks).hasSize(2);
 
-        List<GenericEventListener> genericEventListeners = cmmnModel.getPrimaryCase().getPlanModel().findPlanItemDefinitionsOfType(GenericEventListener.class, true);
+        List<GenericEventListener> genericEventListeners = cmmnModel.getPrimaryCase().getPlanModel()
+                .findPlanItemDefinitionsOfType(GenericEventListener.class, true);
         assertThat(genericEventListeners)
-            .hasSize(1)
-            .extracting(GenericEventListener::getName, GenericEventListener::getId, GenericEventListener::getDocumentation)
-            .containsExactly(tuple("myGenericEventListener", "genericActionListener", "GenericEventListener documentation"));
+                .extracting(GenericEventListener::getName, GenericEventListener::getId, GenericEventListener::getDocumentation)
+                .containsExactly(tuple("myGenericEventListener", "genericActionListener", "GenericEventListener documentation"));
     }
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/JavaTaskCmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/JavaTaskCmmnXmlConverterTest.java
@@ -54,17 +54,15 @@ public class JavaTaskCmmnXmlConverterTest extends AbstractConverterTest {
 
         // Case
         assertThat(cmmnModel.getCases())
-            .hasSize(1)
-            .extracting(Case::getId, Case::getInitiatorVariableName)
-            .containsExactly(tuple("javaCase", "test"));
+                .extracting(Case::getId, Case::getInitiatorVariableName)
+                .containsExactly(tuple("javaCase", "test"));
 
         // Plan model
         Stage planModel = cmmnModel.getCases().get(0).getPlanModel();
         assertThat(planModel).isNotNull();
         assertThat(cmmnModel.getCases())
-            .isNotNull()
-            .extracting(caze -> caze.getPlanModel().getId(), caze -> caze.getPlanModel().getName())
-            .containsExactly(tuple("myPlanModel", "My CasePlanModel"));
+                .extracting(caze -> caze.getPlanModel().getId(), caze -> caze.getPlanModel().getName())
+                .containsExactly(tuple("myPlanModel", "My CasePlanModel"));
 
         // Plan items definitions
         List<PlanItemDefinition> planItemDefinitions = planModel.getPlanItemDefinitions();
@@ -100,16 +98,14 @@ public class JavaTaskCmmnXmlConverterTest extends AbstractConverterTest {
         assertThat(taskB.isExclusive()).isTrue();
 
         assertThat(taskB.getFieldExtensions())
-            .hasSize(4)
-            .extracting(FieldExtension::getFieldName, FieldExtension::getStringValue, FieldExtension::getExpression)
-            .containsExactly(tuple("fieldA", "test", null), tuple("fieldB", null, "test"), tuple("fieldC", "test", null), tuple("fieldD", null, "test"));
+                .extracting(FieldExtension::getFieldName, FieldExtension::getStringValue, FieldExtension::getExpression)
+                .containsExactly(tuple("fieldA", "test", null), tuple("fieldB", null, "test"), tuple("fieldC", "test", null), tuple("fieldD", null, "test"));
 
         assertThat(taskB.getExtensionElements()).hasSize(1);
         List<ExtensionElement> extensionElements = taskB.getExtensionElements().get("taskTest");
         assertThat(extensionElements)
-            .hasSize(1)
-            .extracting(ExtensionElement::getName, ExtensionElement::getElementText)
-            .containsExactly(tuple("taskTest", "hello"));
+                .extracting(ExtensionElement::getName, ExtensionElement::getElementText)
+                .containsExactly(tuple("taskTest", "hello"));
     }
 
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/MilestoneCmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/MilestoneCmmnXmlConverterTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,8 +12,8 @@
  */
 package org.flowable.test.cmmn.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import java.util.List;
 
@@ -26,9 +26,9 @@ import org.junit.Test;
  * @author Tijs Rademakers
  */
 public class MilestoneCmmnXmlConverterTest extends AbstractConverterTest {
-    
+
     private static final String CMMN_RESOURCE = "org/flowable/test/cmmn/converter/milestone.cmmn";
-    
+
     @Test
     public void convertXMLToModel() throws Exception {
         CmmnModel cmmnModel = readXMLFile(CMMN_RESOURCE);
@@ -41,31 +41,25 @@ public class MilestoneCmmnXmlConverterTest extends AbstractConverterTest {
         CmmnModel parsedModel = exportAndReadXMLFile(cmmnModel);
         validateModel(parsedModel);
     }
-    
+
     public void validateModel(CmmnModel cmmnModel) {
         Stage planModel = cmmnModel.getPrimaryCase().getPlanModel();
         List<Milestone> milestones = planModel.findPlanItemDefinitionsOfType(Milestone.class, false);
-        
-        assertEquals(1, milestones.size());
-        Milestone milestone = milestones.get(0);
-        
-        assertEquals("Milestone 1", milestone.getName());
-        assertEquals(Integer.valueOf(5), milestone.getDisplayOrder());
-        assertEquals("false", milestone.getIncludeInStageOverview());
-        
+        assertThat(milestones)
+            .hasSize(1)
+            .extracting(Milestone::getName, Milestone::getDisplayOrder, Milestone::getIncludeInStageOverview)
+            .containsExactly(tuple("Milestone 1", 5, "false"));
+
         Stage nestedStage = planModel.findPlanItemDefinitionsOfType(Stage.class, false).get(0);
-        assertNotNull(nestedStage);
-        assertEquals("Nested Stage", nestedStage.getName());
-        
-        assertEquals(1, nestedStage.getPlanItems().size());
+        assertThat(nestedStage).isNotNull();
+        assertThat(nestedStage.getName()).isEqualTo("Nested Stage");
+
+        assertThat(nestedStage.getPlanItems()).hasSize(1);
         milestones = nestedStage.findPlanItemDefinitionsOfType(Milestone.class, false);
-        
-        assertEquals(1, milestones.size());
-        milestone = milestones.get(0);
-        
-        assertEquals("Milestone 2", milestone.getName());
-        assertEquals(Integer.valueOf(3), milestone.getDisplayOrder());
-        assertEquals("true", milestone.getIncludeInStageOverview());
+        assertThat(milestones)
+            .hasSize(1)
+            .extracting(Milestone::getName, Milestone::getDisplayOrder, Milestone::getIncludeInStageOverview)
+            .containsExactly(tuple("Milestone 2", 3, "true"));
     }
 
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/MilestoneCmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/MilestoneCmmnXmlConverterTest.java
@@ -46,9 +46,8 @@ public class MilestoneCmmnXmlConverterTest extends AbstractConverterTest {
         Stage planModel = cmmnModel.getPrimaryCase().getPlanModel();
         List<Milestone> milestones = planModel.findPlanItemDefinitionsOfType(Milestone.class, false);
         assertThat(milestones)
-            .hasSize(1)
-            .extracting(Milestone::getName, Milestone::getDisplayOrder, Milestone::getIncludeInStageOverview)
-            .containsExactly(tuple("Milestone 1", 5, "false"));
+                .extracting(Milestone::getName, Milestone::getDisplayOrder, Milestone::getIncludeInStageOverview)
+                .containsExactly(tuple("Milestone 1", 5, "false"));
 
         Stage nestedStage = planModel.findPlanItemDefinitionsOfType(Stage.class, false).get(0);
         assertThat(nestedStage).isNotNull();
@@ -57,9 +56,8 @@ public class MilestoneCmmnXmlConverterTest extends AbstractConverterTest {
         assertThat(nestedStage.getPlanItems()).hasSize(1);
         milestones = nestedStage.findPlanItemDefinitionsOfType(Milestone.class, false);
         assertThat(milestones)
-            .hasSize(1)
-            .extracting(Milestone::getName, Milestone::getDisplayOrder, Milestone::getIncludeInStageOverview)
-            .containsExactly(tuple("Milestone 2", 3, "true"));
+                .extracting(Milestone::getName, Milestone::getDisplayOrder, Milestone::getIncludeInStageOverview)
+                .containsExactly(tuple("Milestone 2", 3, "true"));
     }
 
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/NestedStagesCmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/NestedStagesCmmnXmlConverterTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,8 +12,7 @@
  */
 package org.flowable.test.cmmn.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.cmmn.model.CmmnModel;
 import org.flowable.cmmn.model.PlanItem;
@@ -24,9 +23,9 @@ import org.junit.Test;
  * @author Tijs Rademakers
  */
 public class NestedStagesCmmnXmlConverterTest extends AbstractConverterTest {
-    
+
     private static final String CMMN_RESOURCE = "org/flowable/test/cmmn/converter/nested-stages.cmmn";
-    
+
     @Test
     public void convertXMLToModel() throws Exception {
         CmmnModel cmmnModel = readXMLFile(CMMN_RESOURCE);
@@ -39,34 +38,34 @@ public class NestedStagesCmmnXmlConverterTest extends AbstractConverterTest {
         CmmnModel parsedModel = exportAndReadXMLFile(cmmnModel);
         validateModel(parsedModel);
     }
-    
+
     public void validateModel(CmmnModel cmmnModel) {
         Stage planModel = cmmnModel.getPrimaryCase().getPlanModel();
-        assertEquals(2, planModel.getPlanItems().size());
-        
+        assertThat(planModel.getPlanItems()).hasSize(2);
+
         Stage nestedStage = null;
         for (PlanItem planItem : planModel.getPlanItems()) {
-            assertNotNull(planItem.getPlanItemDefinition());
+            assertThat(planItem.getPlanItemDefinition()).isNotNull();
             if (planItem.getPlanItemDefinition() instanceof Stage) {
                 nestedStage = (Stage) planItem.getPlanItemDefinition();
             }
         }
-        assertNotNull(nestedStage);
-        assertEquals("Nested Stage", nestedStage.getName());
-        
-        // Nested stage has 3 plan items, and one of them refereces the rootTook from the plan model
-        assertEquals(3, nestedStage.getPlanItems().size());
+        assertThat(nestedStage).isNotNull();
+        assertThat(nestedStage.getName()).isEqualTo("Nested Stage");
+
+        // Nested stage has 3 plan items, and one of them refereces the rootTask from the plan model
+        assertThat(nestedStage.getPlanItems()).hasSize(3);
         Stage nestedNestedStage = null;
         for (PlanItem planItem : nestedStage.getPlanItems()) {
-            assertNotNull(planItem.getPlanItemDefinition());
-            if (planItem.getPlanItemDefinition()  instanceof Stage) {
+            assertThat(planItem.getPlanItemDefinition()).isNotNull();
+            if (planItem.getPlanItemDefinition() instanceof Stage) {
                 nestedNestedStage = (Stage) planItem.getPlanItemDefinition();
             }
         }
-        assertNotNull(nestedNestedStage);
-        assertEquals("Nested Stage 2", nestedNestedStage.getName());
-        assertEquals(1, nestedNestedStage.getPlanItems().size());
-        assertEquals("rootTask", nestedNestedStage.getPlanItems().get(0).getPlanItemDefinition().getId());
+        assertThat(nestedNestedStage).isNotNull();
+        assertThat(nestedNestedStage.getName()).isEqualTo("Nested Stage 2");
+        assertThat(nestedNestedStage.getPlanItems()).hasSize(1);
+        assertThat(nestedNestedStage.getPlanItems().get(0).getPlanItemDefinition().getId()).isEqualTo("rootTask");
     }
 
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/ParentCompletionConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/ParentCompletionConverterTest.java
@@ -43,12 +43,12 @@ public class ParentCompletionConverterTest extends AbstractConverterTest {
         assertThat(cmmnModel).isNotNull();
         Stage planModel = cmmnModel.getPrimaryCase().getPlanModel();
         List<PlanItem> planItems = planModel.getPlanItems();
-        assertThat(planItems).hasSize(4);
-        planItems.forEach(planItem -> {
-            assertThat(planItem.getItemControl()).isNotNull();
-            assertThat(planItem.getItemControl().getParentCompletionRule()).isNotNull();
-            assertThat(planItem.getItemControl().getParentCompletionRule().getType()).isNotNull();
-        });
+        assertThat(planItems)
+            .hasSize(4)
+            .extracting(planItem -> planItem.getItemControl(),
+                planItem -> planItem.getItemControl().getParentCompletionRule(),
+                planItem -> planItem.getItemControl().getParentCompletionRule().getType())
+            .doesNotContainNull();
 
         assertThat(planItems)
             .extracting(planItem -> planItem.getItemControl().getParentCompletionRule().getType())

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/ParentCompletionConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/ParentCompletionConverterTest.java
@@ -23,9 +23,9 @@ import org.flowable.cmmn.model.Stage;
 import org.junit.Test;
 
 public class ParentCompletionConverterTest extends AbstractConverterTest {
-    
+
     private static final String CMMN_RESOURCE = "org/flowable/test/cmmn/converter/parentCompletionRuleAtPlanItem.cmmn";
-    
+
     @Test
     public void convertXMLToModel() throws Exception {
         CmmnModel cmmnModel = readXMLFile(CMMN_RESOURCE);
@@ -38,21 +38,21 @@ public class ParentCompletionConverterTest extends AbstractConverterTest {
         CmmnModel parsedModel = exportAndReadXMLFile(cmmnModel);
         validateModel(parsedModel);
     }
-    
+
     public void validateModel(CmmnModel cmmnModel) {
         assertThat(cmmnModel).isNotNull();
         Stage planModel = cmmnModel.getPrimaryCase().getPlanModel();
         List<PlanItem> planItems = planModel.getPlanItems();
         assertThat(planItems)
-            .hasSize(4)
-            .extracting(planItem -> planItem.getItemControl(),
-                planItem -> planItem.getItemControl().getParentCompletionRule(),
-                planItem -> planItem.getItemControl().getParentCompletionRule().getType())
-            .doesNotContainNull();
+                .extracting(planItem -> planItem.getItemControl(),
+                        planItem -> planItem.getItemControl().getParentCompletionRule(),
+                        planItem -> planItem.getItemControl().getParentCompletionRule().getType())
+                .doesNotContainNull();
 
         assertThat(planItems)
-            .extracting(planItem -> planItem.getItemControl().getParentCompletionRule().getType())
-            .containsExactly(ParentCompletionRule.IGNORE, ParentCompletionRule.DEFAULT, ParentCompletionRule.IGNORE_IF_AVAILABLE, ParentCompletionRule.IGNORE_IF_AVAILABLE_OR_ENABLED);
+                .extracting(planItem -> planItem.getItemControl().getParentCompletionRule().getType())
+                .containsExactly(ParentCompletionRule.IGNORE, ParentCompletionRule.DEFAULT, ParentCompletionRule.IGNORE_IF_AVAILABLE,
+                        ParentCompletionRule.IGNORE_IF_AVAILABLE_OR_ENABLED);
 
         Stage stageOne = (Stage) cmmnModel.getPrimaryCase().getPlanModel().findPlanItemDefinitionInStageOrDownwards("stageOne");
         List<PlanItem> planItems1 = stageOne.getPlanItems();

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/ParentCompletionConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/ParentCompletionConverterTest.java
@@ -12,8 +12,7 @@
  */
 package org.flowable.test.cmmn.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
@@ -41,28 +40,27 @@ public class ParentCompletionConverterTest extends AbstractConverterTest {
     }
     
     public void validateModel(CmmnModel cmmnModel) {
-        assertNotNull(cmmnModel);
+        assertThat(cmmnModel).isNotNull();
         Stage planModel = cmmnModel.getPrimaryCase().getPlanModel();
         List<PlanItem> planItems = planModel.getPlanItems();
-        assertEquals(4, planItems.size());
+        assertThat(planItems).hasSize(4);
         planItems.forEach(planItem -> {
-            assertNotNull(planItem.getItemControl());
-            assertNotNull(planItem.getItemControl().getParentCompletionRule());
-            assertNotNull(planItem.getItemControl().getParentCompletionRule().getType());
+            assertThat(planItem.getItemControl()).isNotNull();
+            assertThat(planItem.getItemControl().getParentCompletionRule()).isNotNull();
+            assertThat(planItem.getItemControl().getParentCompletionRule().getType()).isNotNull();
         });
-        
-        assertEquals(ParentCompletionRule.IGNORE, planItems.get(0).getItemControl().getParentCompletionRule().getType());
-        assertEquals(ParentCompletionRule.DEFAULT, planItems.get(1).getItemControl().getParentCompletionRule().getType());
-        assertEquals(ParentCompletionRule.IGNORE_IF_AVAILABLE, planItems.get(2).getItemControl().getParentCompletionRule().getType());
-        assertEquals(ParentCompletionRule.IGNORE_IF_AVAILABLE_OR_ENABLED, planItems.get(3).getItemControl().getParentCompletionRule().getType());
+
+        assertThat(planItems)
+            .extracting(planItem -> planItem.getItemControl().getParentCompletionRule().getType())
+            .containsExactly(ParentCompletionRule.IGNORE, ParentCompletionRule.DEFAULT, ParentCompletionRule.IGNORE_IF_AVAILABLE, ParentCompletionRule.IGNORE_IF_AVAILABLE_OR_ENABLED);
 
         Stage stageOne = (Stage) cmmnModel.getPrimaryCase().getPlanModel().findPlanItemDefinitionInStageOrDownwards("stageOne");
         List<PlanItem> planItems1 = stageOne.getPlanItems();
-        assertEquals(1, planItems1.size());
+        assertThat(planItems1).hasSize(1);
         PlanItem planItem = planItems1.get(0);
-        assertNotNull(planItem.getItemControl());
-        assertNotNull(planItem.getItemControl().getParentCompletionRule());
-        assertEquals(ParentCompletionRule.IGNORE_AFTER_FIRST_COMPLETION, planItem.getItemControl().getParentCompletionRule().getType());
+        assertThat(planItem.getItemControl()).isNotNull();
+        assertThat(planItem.getItemControl().getParentCompletionRule()).isNotNull();
+        assertThat(planItem.getItemControl().getParentCompletionRule().getType()).isEqualTo(ParentCompletionRule.IGNORE_AFTER_FIRST_COMPLETION);
     }
 
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/ProcessTask2CmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/ProcessTask2CmmnXmlConverterTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,7 +13,6 @@
 package org.flowable.test.cmmn.converter;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
 
 import org.flowable.cmmn.model.Case;
 import org.flowable.cmmn.model.CmmnModel;
@@ -28,9 +27,9 @@ import org.junit.Test;
  * @author Tijs Rademakers
  */
 public class ProcessTask2CmmnXmlConverterTest extends AbstractConverterTest {
-    
+
     private static final String CMMN_RESOURCE = "org/flowable/test/cmmn/converter/process-task2.cmmn";
-    
+
     @Test
     public void convertXMLToModel() throws Exception {
         CmmnModel cmmnModel = readXMLFile(CMMN_RESOURCE);
@@ -43,32 +42,30 @@ public class ProcessTask2CmmnXmlConverterTest extends AbstractConverterTest {
         CmmnModel parsedModel = exportAndReadXMLFile(cmmnModel);
         validateModel(parsedModel);
     }
-    
+
     public void validateModel(CmmnModel cmmnModel) {
         assertThat(cmmnModel).isNotNull();
-        
+
         // Case
         assertThat(cmmnModel.getCases())
-            .hasSize(1)
-            .extracting(Case::getId)
-            .containsExactly("processTaskModel");
-        
+                .extracting(Case::getId)
+                .containsExactly("processTaskModel");
+
         // Plan model
         Stage planModel = cmmnModel.getCases().get(0).getPlanModel();
         assertThat(planModel)
-            .isNotNull()
-            .extracting(Stage::getId, Stage::getName)
-            .containsExactly("onecaseplanmodel1", "Case plan model");
+                .extracting(Stage::getId, Stage::getName)
+                .containsExactly("onecaseplanmodel1", "Case plan model");
 
         PlanItem planItemTask1 = cmmnModel.findPlanItem("planItem2");
         PlanItemDefinition planItemDefinition = planItemTask1.getPlanItemDefinition();
         assertThat(planItemDefinition).isInstanceOf(ProcessTask.class);
         ProcessTask task1 = (ProcessTask) planItemDefinition;
         assertThat(task1.getProcessRefExpression()).isEqualTo("myTestProcess");
-        
+
         assertThat(task1.getInParameters()).isEmpty();
         assertThat(task1.getOutParameters()).isEmpty();
-        
+
         PlanItemDefinition taskDefinition = cmmnModel.findPlanItemDefinition("onehumantask1");
         assertThat(taskDefinition).isInstanceOf(HumanTask.class);
         HumanTask humanTask = (HumanTask) taskDefinition;

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/ProcessTask2CmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/ProcessTask2CmmnXmlConverterTest.java
@@ -12,9 +12,8 @@
  */
 package org.flowable.test.cmmn.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import org.flowable.cmmn.model.Case;
 import org.flowable.cmmn.model.CmmnModel;
@@ -46,39 +45,41 @@ public class ProcessTask2CmmnXmlConverterTest extends AbstractConverterTest {
     }
     
     public void validateModel(CmmnModel cmmnModel) {
-        assertNotNull(cmmnModel);
-        assertEquals(1, cmmnModel.getCases().size());
+        assertThat(cmmnModel).isNotNull();
         
         // Case
-        Case caze = cmmnModel.getCases().get(0);
-        assertEquals("processTaskModel", caze.getId());
+        assertThat(cmmnModel.getCases())
+            .hasSize(1)
+            .extracting(Case::getId)
+            .containsExactly("processTaskModel");
         
         // Plan model
-        Stage planModel = caze.getPlanModel();
-        assertNotNull(planModel);
-        assertEquals("onecaseplanmodel1", planModel.getId());
-        assertEquals("Case plan model", planModel.getName());
-        
+        Stage planModel = cmmnModel.getCases().get(0).getPlanModel();
+        assertThat(planModel)
+            .isNotNull()
+            .extracting(Stage::getId, Stage::getName)
+            .containsExactly("onecaseplanmodel1", "Case plan model");
+
         PlanItem planItemTask1 = cmmnModel.findPlanItem("planItem2");
         PlanItemDefinition planItemDefinition = planItemTask1.getPlanItemDefinition();
-        assertTrue(planItemDefinition instanceof ProcessTask);
+        assertThat(planItemDefinition).isInstanceOf(ProcessTask.class);
         ProcessTask task1 = (ProcessTask) planItemDefinition;
-        assertEquals("myTestProcess", task1.getProcessRefExpression());
+        assertThat(task1.getProcessRefExpression()).isEqualTo("myTestProcess");
         
-        assertEquals(0, task1.getInParameters().size());
-        assertEquals(0, task1.getOutParameters().size());
+        assertThat(task1.getInParameters()).isEmpty();
+        assertThat(task1.getOutParameters()).isEmpty();
         
         PlanItemDefinition taskDefinition = cmmnModel.findPlanItemDefinition("onehumantask1");
-        assertTrue(taskDefinition instanceof HumanTask);
+        assertThat(taskDefinition).isInstanceOf(HumanTask.class);
         HumanTask humanTask = (HumanTask) taskDefinition;
-        assertEquals("Human task", humanTask.getName());
-        assertEquals("admin", humanTask.getAssignee());
-        assertEquals("admin", humanTask.getOwner());
-        assertEquals("aHumanTaskForm", humanTask.getFormKey());
-        assertEquals("50", humanTask.getPriority());
-        assertEquals("2019-01-01", humanTask.getDueDate());
-        assertEquals("testCategory", humanTask.getCategory());
-        assertEquals("validateFormFieldsValue", humanTask.getValidateFormFields());
+        assertThat(humanTask.getName()).isEqualTo("Human task");
+        assertThat(humanTask.getAssignee()).isEqualTo("admin");
+        assertThat(humanTask.getOwner()).isEqualTo("admin");
+        assertThat(humanTask.getFormKey()).isEqualTo("aHumanTaskForm");
+        assertThat(humanTask.getPriority()).isEqualTo("50");
+        assertThat(humanTask.getDueDate()).isEqualTo("2019-01-01");
+        assertThat(humanTask.getCategory()).isEqualTo("testCategory");
+        assertThat(humanTask.getValidateFormFields()).isEqualTo("validateFormFieldsValue");
     }
 
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/ProcessTaskCmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/ProcessTaskCmmnXmlConverterTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,9 +28,9 @@ import org.junit.Test;
  * @author Tijs Rademakers
  */
 public class ProcessTaskCmmnXmlConverterTest extends AbstractConverterTest {
-    
+
     private static final String CMMN_RESOURCE = "org/flowable/test/cmmn/converter/process-task.cmmn";
-    
+
     @Test
     public void convertXMLToModel() throws Exception {
         CmmnModel cmmnModel = readXMLFile(CMMN_RESOURCE);
@@ -43,21 +43,21 @@ public class ProcessTaskCmmnXmlConverterTest extends AbstractConverterTest {
         CmmnModel parsedModel = exportAndReadXMLFile(cmmnModel);
         validateModel(parsedModel);
     }
-    
+
     public void validateModel(CmmnModel cmmnModel) {
         assertThat(cmmnModel).isNotNull();
         assertThat(cmmnModel.getCases()).hasSize(1);
-        
+
         // Case
         Case caze = cmmnModel.getCases().get(0);
         assertThat(caze.getId()).isEqualTo("myCase");
-        
+
         // Plan model
         Stage planModel = caze.getPlanModel();
         assertThat(planModel).isNotNull();
         assertThat(planModel.getId()).isEqualTo("myPlanModel");
         assertThat(planModel.getName()).isEqualTo("My CasePlanModel");
-        
+
         PlanItem planItemTask1 = cmmnModel.findPlanItem("planItem1");
         PlanItemDefinition planItemDefinition = planItemTask1.getPlanItemDefinition();
         assertThat(planItemDefinition).isInstanceOf(ProcessTask.class);
@@ -65,14 +65,12 @@ public class ProcessTaskCmmnXmlConverterTest extends AbstractConverterTest {
         assertThat(task1.getProcessRefExpression()).isEqualTo("${processDefinitionKey}");
 
         assertThat(task1.getInParameters())
-            .hasSize(1)
-            .extracting(IOParameter::getSource, IOParameter::getTarget)
-            .containsExactly(tuple("num2", "num"));
+                .extracting(IOParameter::getSource, IOParameter::getTarget)
+                .containsExactly(tuple("num2", "num"));
 
         assertThat(task1.getOutParameters())
-            .hasSize(1)
-            .extracting(IOParameter::getSource, IOParameter::getTarget)
-            .containsExactly(tuple("num", "num3"));
+                .extracting(IOParameter::getSource, IOParameter::getTarget)
+                .containsExactly(tuple("num", "num3"));
 
         assertThat(task1.getFallbackToDefaultTenant()).isTrue();
     }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/ProcessTaskCmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/ProcessTaskCmmnXmlConverterTest.java
@@ -12,9 +12,8 @@
  */
 package org.flowable.test.cmmn.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import org.flowable.cmmn.model.Case;
 import org.flowable.cmmn.model.CmmnModel;
@@ -46,36 +45,36 @@ public class ProcessTaskCmmnXmlConverterTest extends AbstractConverterTest {
     }
     
     public void validateModel(CmmnModel cmmnModel) {
-        assertNotNull(cmmnModel);
-        assertEquals(1, cmmnModel.getCases().size());
+        assertThat(cmmnModel).isNotNull();
+        assertThat(cmmnModel.getCases()).hasSize(1);
         
         // Case
         Case caze = cmmnModel.getCases().get(0);
-        assertEquals("myCase", caze.getId());
+        assertThat(caze.getId()).isEqualTo("myCase");
         
         // Plan model
         Stage planModel = caze.getPlanModel();
-        assertNotNull(planModel);
-        assertEquals("myPlanModel", planModel.getId());
-        assertEquals("My CasePlanModel", planModel.getName());
+        assertThat(planModel).isNotNull();
+        assertThat(planModel.getId()).isEqualTo("myPlanModel");
+        assertThat(planModel.getName()).isEqualTo("My CasePlanModel");
         
         PlanItem planItemTask1 = cmmnModel.findPlanItem("planItem1");
         PlanItemDefinition planItemDefinition = planItemTask1.getPlanItemDefinition();
-        assertTrue(planItemDefinition instanceof ProcessTask);
+        assertThat(planItemDefinition).isInstanceOf(ProcessTask.class);
         ProcessTask task1 = (ProcessTask) planItemDefinition;
-        assertEquals("${processDefinitionKey}", task1.getProcessRefExpression());
-        
-        assertEquals(1, task1.getInParameters().size());
-        IOParameter parameter = task1.getInParameters().get(0);
-        assertEquals("num2", parameter.getSource());
-        assertEquals("num", parameter.getTarget());
-        
-        assertEquals(1, task1.getOutParameters().size());
-        parameter = task1.getOutParameters().get(0);
-        assertEquals("num", parameter.getSource());
-        assertEquals("num3", parameter.getTarget());
+        assertThat(task1.getProcessRefExpression()).isEqualTo("${processDefinitionKey}");
 
-        assertTrue(task1.getFallbackToDefaultTenant());
+        assertThat(task1.getInParameters())
+            .hasSize(1)
+            .extracting(IOParameter::getSource, IOParameter::getTarget)
+            .containsExactly(tuple("num2", "num"));
+
+        assertThat(task1.getOutParameters())
+            .hasSize(1)
+            .extracting(IOParameter::getSource, IOParameter::getTarget)
+            .containsExactly(tuple("num", "num3"));
+
+        assertThat(task1.getFallbackToDefaultTenant()).isTrue();
     }
 
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/RepetitionRuleExtendedAttributesConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/RepetitionRuleExtendedAttributesConverterTest.java
@@ -12,9 +12,8 @@
  */
 package org.flowable.test.cmmn.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.List;
 import java.util.Map;
@@ -49,9 +48,9 @@ public class RepetitionRuleExtendedAttributesConverterTest extends AbstractConve
     }
 
     public void validateModel(CmmnModel cmmnModel) {
-        assertNotNull(cmmnModel);
-        assertNotNull(cmmnModel.getCases());
-        assertEquals(1, cmmnModel.getCases().size());
+        assertThat(cmmnModel).isNotNull();
+        assertThat(cmmnModel.getCases()).isNotNull();
+        assertThat(cmmnModel.getCases()).hasSize(1);
 
         Map<String, CaseElement> caseElements = cmmnModel.getCases().get(0).getAllCaseElements();
 
@@ -86,11 +85,11 @@ public class RepetitionRuleExtendedAttributesConverterTest extends AbstractConve
         }
 
         RepetitionRule repetitionRule = ((PlanItem) planItems.get(0)).getItemControl().getRepetitionRule();
-        assertNotNull("no repetition rule found for plan item with name '" + planItemName + "'", repetitionRule);
+        assertThat(repetitionRule).as("no repetition rule found for plan item with name '" + planItemName + "'").isNotNull();
 
-        assertEquals(collectionVariableName, repetitionRule.getCollectionVariableName());
-        assertEquals(elementVariableName, repetitionRule.getElementVariableName());
-        assertEquals(elementIndexVariableName, repetitionRule.getElementIndexVariableName());
-        assertEquals(maxInstanceCount, repetitionRule.getMaxInstanceCount());
+        assertThat(repetitionRule.getCollectionVariableName()).isEqualTo(collectionVariableName);
+        assertThat(repetitionRule.getElementVariableName()).isEqualTo(elementVariableName);
+        assertThat(repetitionRule.getElementIndexVariableName()).isEqualTo(elementIndexVariableName);
+        assertThat(repetitionRule.getMaxInstanceCount()).isEqualTo(maxInstanceCount);
     }
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/ScriptServiceTaskCmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/ScriptServiceTaskCmmnXmlConverterTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -52,16 +52,14 @@ public class ScriptServiceTaskCmmnXmlConverterTest extends AbstractConverterTest
 
         // Case
         assertThat(cmmnModel.getCases())
-            .hasSize(1)
-            .extracting(Case::getId, Case::getInitiatorVariableName)
-            .containsExactly(tuple("scriptCase", "test"));
+                .extracting(Case::getId, Case::getInitiatorVariableName)
+                .containsExactly(tuple("scriptCase", "test"));
 
         // Plan model
         Stage planModel = cmmnModel.getCases().get(0).getPlanModel();
         assertThat(planModel)
-            .isNotNull()
-            .extracting(Stage::getId, Stage::getName)
-            .containsExactly("myScriptPlanModel", "My Script CasePlanModel");
+                .extracting(Stage::getId, Stage::getName)
+                .containsExactly("myScriptPlanModel", "My Script CasePlanModel");
 
         // Plan items definitions
         List<PlanItemDefinition> planItemDefinitions = planModel.getPlanItemDefinitions();
@@ -86,9 +84,8 @@ public class ScriptServiceTaskCmmnXmlConverterTest extends AbstractConverterTest
         assertThat(scriptTask.isAsync()).isFalse();
 
         assertThat(scriptTask.getFieldExtensions())
-            .hasSize(1)
-            .extracting(FieldExtension::getFieldName, FieldExtension::getStringValue)
-            .containsExactly(tuple("script", "var a = 5;"));
+                .extracting(FieldExtension::getFieldName, FieldExtension::getStringValue)
+                .containsExactly(tuple("script", "var a = 5;"));
     }
 
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/ScriptServiceTaskCmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/ScriptServiceTaskCmmnXmlConverterTest.java
@@ -12,10 +12,8 @@
  */
 package org.flowable.test.cmmn.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import java.util.List;
 
@@ -50,45 +48,47 @@ public class ScriptServiceTaskCmmnXmlConverterTest extends AbstractConverterTest
     }
 
     public void validateModel(CmmnModel cmmnModel) {
-        assertNotNull(cmmnModel);
-        assertEquals(1, cmmnModel.getCases().size());
+        assertThat(cmmnModel).isNotNull();
 
         // Case
-        Case caze = cmmnModel.getCases().get(0);
-        assertEquals("scriptCase", caze.getId());
-        assertEquals("test", caze.getInitiatorVariableName());
+        assertThat(cmmnModel.getCases())
+            .hasSize(1)
+            .extracting(Case::getId, Case::getInitiatorVariableName)
+            .containsExactly(tuple("scriptCase", "test"));
 
         // Plan model
-        Stage planModel = caze.getPlanModel();
-        assertNotNull(planModel);
-        assertEquals("myScriptPlanModel", planModel.getId());
-        assertEquals("My Script CasePlanModel", planModel.getName());
+        Stage planModel = cmmnModel.getCases().get(0).getPlanModel();
+        assertThat(planModel)
+            .isNotNull()
+            .extracting(Stage::getId, Stage::getName)
+            .containsExactly("myScriptPlanModel", "My Script CasePlanModel");
 
         // Plan items definitions
         List<PlanItemDefinition> planItemDefinitions = planModel.getPlanItemDefinitions();
-        assertEquals(1, planItemDefinitions.size());
-        assertEquals(1, planModel.findPlanItemDefinitionsOfType(Task.class, false).size());
+        assertThat(planItemDefinitions).hasSize(1);
+        assertThat(planModel.findPlanItemDefinitionsOfType(Task.class, false)).hasSize(1);
 
         // Plan items
         List<PlanItem> planItems = planModel.getPlanItems();
-        assertEquals(1, planItems.size());
+        assertThat(planItems).hasSize(1);
 
         PlanItem planItemTaskA = cmmnModel.findPlanItem("planItemTaskA");
         PlanItemDefinition planItemDefinition = planItemTaskA.getPlanItemDefinition();
-        assertEquals(0, planItemTaskA.getEntryCriteria().size());
-        assertTrue(planItemDefinition instanceof ScriptServiceTask);
+
+        assertThat(planItemTaskA.getEntryCriteria()).isEmpty();
+        assertThat(planItemDefinition).isInstanceOf(ScriptServiceTask.class);
         ScriptServiceTask scriptTask = (ScriptServiceTask) planItemDefinition;
-        assertEquals(ScriptServiceTask.SCRIPT_TASK, scriptTask.getType());
-        assertEquals("javascript", scriptTask.getScriptFormat());
-        assertEquals("scriptResult", scriptTask.getResultVariableName());
-        assertFalse(scriptTask.isAutoStoreVariables());
-        assertTrue(scriptTask.isBlocking());
-        assertFalse(scriptTask.isAsync());
-        
-        assertEquals(1, scriptTask.getFieldExtensions().size());
-        FieldExtension fieldExtension = scriptTask.getFieldExtensions().get(0);
-        assertEquals("script", fieldExtension.getFieldName());
-        assertEquals("var a = 5;", fieldExtension.getStringValue());
+        assertThat(scriptTask.getType()).isEqualTo(ScriptServiceTask.SCRIPT_TASK);
+        assertThat(scriptTask.getScriptFormat()).isEqualTo("javascript");
+        assertThat(scriptTask.getResultVariableName()).isEqualTo("scriptResult");
+        assertThat(scriptTask.isAutoStoreVariables()).isFalse();
+        assertThat(scriptTask.isBlocking()).isTrue();
+        assertThat(scriptTask.isAsync()).isFalse();
+
+        assertThat(scriptTask.getFieldExtensions())
+            .hasSize(1)
+            .extracting(FieldExtension::getFieldName, FieldExtension::getStringValue)
+            .containsExactly(tuple("script", "var a = 5;"));
     }
 
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/SignalEventListenerCmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/SignalEventListenerCmmnXmlConverterTest.java
@@ -45,10 +45,10 @@ public class SignalEventListenerCmmnXmlConverterTest extends AbstractConverterTe
         List<HumanTask> humanTasks = cmmnModel.getPrimaryCase().getPlanModel().findPlanItemDefinitionsOfType(HumanTask.class, true);
         assertThat(humanTasks).hasSize(2);
 
-        List<SignalEventListener> signalEventListeners = cmmnModel.getPrimaryCase().getPlanModel().findPlanItemDefinitionsOfType(SignalEventListener.class, true);
+        List<SignalEventListener> signalEventListeners = cmmnModel.getPrimaryCase().getPlanModel()
+                .findPlanItemDefinitionsOfType(SignalEventListener.class, true);
         assertThat(signalEventListeners)
-            .hasSize(1)
-            .extracting(SignalEventListener::getName, SignalEventListener::getId, SignalEventListener::getSignalRef)
-            .containsExactly(tuple("mySignalEventListener", "signalActionListener", "testSignal"));
+                .extracting(SignalEventListener::getName, SignalEventListener::getId, SignalEventListener::getSignalRef)
+                .containsExactly(tuple("mySignalEventListener", "signalActionListener", "testSignal"));
     }
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/SignalEventListenerCmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/SignalEventListenerCmmnXmlConverterTest.java
@@ -12,8 +12,8 @@
  */
 package org.flowable.test.cmmn.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import java.util.List;
 
@@ -40,17 +40,15 @@ public class SignalEventListenerCmmnXmlConverterTest extends AbstractConverterTe
     }
 
     public void validateModel(CmmnModel cmmnModel) {
-        assertNotNull(cmmnModel);
+        assertThat(cmmnModel).isNotNull();
 
         List<HumanTask> humanTasks = cmmnModel.getPrimaryCase().getPlanModel().findPlanItemDefinitionsOfType(HumanTask.class, true);
-        assertEquals(2, humanTasks.size());
+        assertThat(humanTasks).hasSize(2);
 
         List<SignalEventListener> signalEventListeners = cmmnModel.getPrimaryCase().getPlanModel().findPlanItemDefinitionsOfType(SignalEventListener.class, true);
-        assertEquals(1, signalEventListeners.size());
-
-        SignalEventListener signalEventListener = signalEventListeners.get(0);
-        assertEquals("mySignalEventListener", signalEventListener.getName());
-        assertEquals("signalActionListener",signalEventListener.getId());
-        assertEquals("testSignal",signalEventListener.getSignalRef());
+        assertThat(signalEventListeners)
+            .hasSize(1)
+            .extracting(SignalEventListener::getName, SignalEventListener::getId, SignalEventListener::getSignalRef)
+            .containsExactly(tuple("mySignalEventListener", "signalActionListener", "testSignal"));
     }
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/SimpleCmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/SimpleCmmnXmlConverterTest.java
@@ -74,11 +74,10 @@ public class SimpleCmmnXmlConverterTest extends AbstractConverterTest {
         assertThat(planModel.getSentries()).hasSize(3);
         for (Sentry sentry : planModel.getSentries()) {
             List<SentryOnPart> onParts = sentry.getOnParts();
-            assertThat(onParts).hasSize(1);
-            assertThat(onParts.get(0).getId()).isNotNull();
-            assertThat(onParts.get(0).getSourceRef()).isNotNull();
-            assertThat(onParts.get(0).getSource()).isNotNull();
-            assertThat(onParts.get(0).getStandardEvent()).isNotNull();
+            assertThat(onParts)
+                .hasSize(1)
+                .extracting(SentryOnPart::getId, SentryOnPart::getSourceRef, SentryOnPart::getSource, SentryOnPart::getStandardEvent)
+                .doesNotContainNull();
         }
 
         // Plan items definitions
@@ -97,9 +96,9 @@ public class SimpleCmmnXmlConverterTest extends AbstractConverterTest {
         int nrOfTasks = 0;
         int nrOfMileStones = 0;
         for (PlanItem planItem : planItems) {
-            assertThat(planItem.getId()).isNotNull();
-            assertThat(planItem.getDefinitionRef()).isNotNull();
-            assertThat(planItem.getPlanItemDefinition()).isNotNull(); // Verify plan item definition ref is resolved
+            assertThat(planItem)
+                .extracting(PlanItem::getId, PlanItem::getDefinitionRef, PlanItem::getPlanItemDefinition) // Verify plan item definition ref is resolved
+                .doesNotContainNull();
 
             PlanItemDefinition planItemDefinition = planItem.getPlanItemDefinition();
             if (planItemDefinition instanceof Milestone) {

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/SimpleCmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/SimpleCmmnXmlConverterTest.java
@@ -12,10 +12,7 @@
  */
 package org.flowable.test.cmmn.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
@@ -51,58 +48,58 @@ public class SimpleCmmnXmlConverterTest extends AbstractConverterTest {
     }
 
     public void validateModel(CmmnModel cmmnModel) {
-        assertNotNull(cmmnModel);
-        assertEquals(1, cmmnModel.getCases().size());
+        assertThat(cmmnModel).isNotNull();
+        assertThat(cmmnModel.getCases()).hasSize(1);
 
         // Case
         Case caze = cmmnModel.getCases().get(0);
-        assertEquals("myCase", caze.getId());
-        assertEquals("test", caze.getInitiatorVariableName());
-        assertEquals(2, caze.getCandidateStarterUsers().size());
-        assertTrue(caze.getCandidateStarterUsers().contains("test"));
-        assertTrue(caze.getCandidateStarterUsers().contains("test2"));
-        assertEquals(2, caze.getCandidateStarterGroups().size());
-        assertTrue(caze.getCandidateStarterGroups().contains("group"));
-        assertTrue(caze.getCandidateStarterGroups().contains("group2"));
+        assertThat(caze.getId()).isEqualTo("myCase");
+        assertThat(caze.getInitiatorVariableName()).isEqualTo("test");
+        assertThat(caze.getCandidateStarterUsers()).hasSize(2);
+        assertThat(caze.getCandidateStarterUsers().contains("test")).isTrue();
+        assertThat(caze.getCandidateStarterUsers().contains("test2")).isTrue();
+        assertThat(caze.getCandidateStarterGroups()).hasSize(2);
+        assertThat(caze.getCandidateStarterGroups().contains("group")).isTrue();
+        assertThat(caze.getCandidateStarterGroups().contains("group2")).isTrue();
 
         // Plan model
         Stage planModel = caze.getPlanModel();
-        assertNotNull(planModel);
-        assertEquals("myPlanModel", planModel.getId());
-        assertEquals("My CasePlanModel", planModel.getName());
-        assertEquals("formKey", planModel.getFormKey());
-        assertEquals("validateFormFieldsValue", planModel.getValidateFormFields());
+        assertThat(planModel).isNotNull();
+        assertThat(planModel.getId()).isEqualTo("myPlanModel");
+        assertThat(planModel.getName()).isEqualTo("My CasePlanModel");
+        assertThat(planModel.getFormKey()).isEqualTo("formKey");
+        assertThat(planModel.getValidateFormFields()).isEqualTo("validateFormFieldsValue");
 
         // Sentries
-        assertEquals(3, planModel.getSentries().size());
+        assertThat(planModel.getSentries()).hasSize(3);
         for (Sentry sentry : planModel.getSentries()) {
             List<SentryOnPart> onParts = sentry.getOnParts();
-            assertEquals(1, onParts.size());
-            assertNotNull(onParts.get(0).getId());
-            assertNotNull(onParts.get(0).getSourceRef());
-            assertNotNull(onParts.get(0).getSource());
-            assertNotNull(onParts.get(0).getStandardEvent());
+            assertThat(onParts).hasSize(1);
+            assertThat(onParts.get(0).getId()).isNotNull();
+            assertThat(onParts.get(0).getSourceRef()).isNotNull();
+            assertThat(onParts.get(0).getSource()).isNotNull();
+            assertThat(onParts.get(0).getStandardEvent()).isNotNull();
         }
 
         // Plan items definitions
         List<PlanItemDefinition> planItemDefinitions = planModel.getPlanItemDefinitions();
-        assertEquals(4, planItemDefinitions.size());
-        assertEquals(2, planModel.findPlanItemDefinitionsOfType(Task.class, false).size());
-        assertEquals(2, planModel.findPlanItemDefinitionsOfType(Milestone.class, false).size());
+        assertThat(planItemDefinitions).hasSize(4);
+        assertThat(planModel.findPlanItemDefinitionsOfType(Task.class, false)).hasSize(2);
+        assertThat(planModel.findPlanItemDefinitionsOfType(Milestone.class, false)).hasSize(2);
         for (PlanItemDefinition planItemDefinition : planItemDefinitions) {
-            assertNotNull(planItemDefinition.getId());
-            assertNotNull(planItemDefinition.getName());
+            assertThat(planItemDefinition.getId()).isNotNull();
+            assertThat(planItemDefinition.getName()).isNotNull();
         }
 
         // Plan items
         List<PlanItem> planItems = planModel.getPlanItems();
-        assertEquals(4, planItems.size());
+        assertThat(planItems).hasSize(4);
         int nrOfTasks = 0;
         int nrOfMileStones = 0;
         for (PlanItem planItem : planItems) {
-            assertNotNull(planItem.getId());
-            assertNotNull(planItem.getDefinitionRef());
-            assertNotNull(planItem.getPlanItemDefinition()); // Verify plan item definition ref is resolved
+            assertThat(planItem.getId()).isNotNull();
+            assertThat(planItem.getDefinitionRef()).isNotNull();
+            assertThat(planItem.getPlanItemDefinition()).isNotNull(); // Verify plan item definition ref is resolved
 
             PlanItemDefinition planItemDefinition = planItem.getPlanItemDefinition();
             if (planItemDefinition instanceof Milestone) {
@@ -112,22 +109,22 @@ public class SimpleCmmnXmlConverterTest extends AbstractConverterTest {
             }
 
             if (!planItem.getId().equals("planItemTaskA")) {
-                assertNotNull(planItem.getEntryCriteria());
-                assertEquals(1, planItem.getEntryCriteria().size());
-                assertNotNull(planItem.getEntryCriteria().get(0).getSentry()); // Verify if sentry reference is resolved
+                assertThat(planItem.getEntryCriteria()).isNotNull();
+                assertThat(planItem.getEntryCriteria()).hasSize(1);
+                assertThat(planItem.getEntryCriteria().get(0).getSentry()).isNotNull(); // Verify if sentry reference is resolved
             }
 
             if (planItem.getPlanItemDefinition() instanceof Task) {
                 if (planItem.getId().equals("planItemTaskB")) {
-                    assertFalse(((Task) planItem.getPlanItemDefinition()).isBlocking());
+                    assertThat(((Task) planItem.getPlanItemDefinition()).isBlocking()).isFalse();
                 } else {
-                    assertTrue(((Task) planItem.getPlanItemDefinition()).isBlocking());
+                    assertThat(((Task) planItem.getPlanItemDefinition()).isBlocking()).isTrue();
                 }
             }
         }
 
-        assertEquals(2, nrOfMileStones);
-        assertEquals(2, nrOfTasks);
+        assertThat(nrOfMileStones).isEqualTo(2);
+        assertThat(nrOfTasks).isEqualTo(2);
     }
 
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/SimpleDiCmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/SimpleDiCmmnXmlConverterTest.java
@@ -57,42 +57,42 @@ public class SimpleDiCmmnXmlConverterTest extends AbstractConverterTest {
         
         GraphicInfo graphicInfo = cmmnModel.getGraphicInfo("myPlanModel");
         assertThat(graphicInfo).isNotNull();
-        assertThat(graphicInfo.getX()).isCloseTo(1.0, offset(0.1));
-        assertThat(graphicInfo.getY()).isCloseTo(19.0, offset(0.1));
-        assertThat(graphicInfo.getWidth()).isCloseTo(400.0, offset(0.1));
-        assertThat(graphicInfo.getHeight()).isCloseTo(300.0, offset(0.1));
+        assertThat(graphicInfo.getX()).isEqualTo(1.0);
+        assertThat(graphicInfo.getY()).isEqualTo(19.0);
+        assertThat(graphicInfo.getWidth()).isEqualTo(400.0);
+        assertThat(graphicInfo.getHeight()).isEqualTo(300.0);
         
         graphicInfo = cmmnModel.getGraphicInfo("planItem1");
         assertThat(graphicInfo).isNotNull();
-        assertThat(graphicInfo.getX()).isCloseTo(70.0, offset(0.1));
-        assertThat(graphicInfo.getY()).isCloseTo(65.0, offset(0.1));
-        assertThat(graphicInfo.getWidth()).isCloseTo(80.0, offset(0.1));
-        assertThat(graphicInfo.getHeight()).isCloseTo(60.0, offset(0.1));
+        assertThat(graphicInfo.getX()).isEqualTo(70.0);
+        assertThat(graphicInfo.getY()).isEqualTo(65.0);
+        assertThat(graphicInfo.getWidth()).isEqualTo(80.0);
+        assertThat(graphicInfo.getHeight()).isEqualTo(60.0);
         
         graphicInfo = cmmnModel.getGraphicInfo("planItem2");
         assertThat(graphicInfo).isNotNull();
-        assertThat(graphicInfo.getX()).isCloseTo(250.0, offset(0.1));
-        assertThat(graphicInfo.getY()).isCloseTo(100.0, offset(0.1));
-        assertThat(graphicInfo.getWidth()).isCloseTo(80.0, offset(0.1));
-        assertThat(graphicInfo.getHeight()).isCloseTo(60.0, offset(0.1));
+        assertThat(graphicInfo.getX()).isEqualTo(250.0);
+        assertThat(graphicInfo.getY()).isEqualTo(100.0);
+        assertThat(graphicInfo.getWidth()).isEqualTo(80.0);
+        assertThat(graphicInfo.getHeight()).isEqualTo(60.0);
         
         graphicInfo = cmmnModel.getGraphicInfo("criterion1");
         assertThat(graphicInfo).isNotNull();
-        assertThat(graphicInfo.getX()).isCloseTo(268.0, offset(0.1));
-        assertThat(graphicInfo.getY()).isCloseTo(216.0, offset(0.1));
-        assertThat(graphicInfo.getWidth()).isCloseTo(20.0, offset(0.1));
-        assertThat(graphicInfo.getHeight()).isCloseTo(28.0, offset(0.1));
+        assertThat(graphicInfo.getX()).isEqualTo(268.0);
+        assertThat(graphicInfo.getY()).isEqualTo(216.0);
+        assertThat(graphicInfo.getWidth()).isEqualTo(20.0);
+        assertThat(graphicInfo.getHeight()).isEqualTo(28.0);
         
         List<GraphicInfo> waypoints = cmmnModel.getFlowLocationGraphicInfo("CMMNEdge_onPart1");
         assertThat(waypoints).hasSize(4);
-        assertThat(waypoints.get(0).getX()).isCloseTo(170.0, offset(0.1));
-        assertThat(waypoints.get(0).getY()).isCloseTo(95.0, offset(0.1));
-        assertThat(waypoints.get(1).getX()).isCloseTo(220.0, offset(0.1));
-        assertThat(waypoints.get(1).getY()).isCloseTo(95.0, offset(0.1));
-        assertThat(waypoints.get(2).getX()).isCloseTo(220.0, offset(0.1));
-        assertThat(waypoints.get(2).getY()).isCloseTo(130.0, offset(0.1));
-        assertThat(waypoints.get(3).getX()).isCloseTo(250.0, offset(0.1));
-        assertThat(waypoints.get(3).getY()).isCloseTo(130.0, offset(0.1));
+        assertThat(waypoints.get(0).getX()).isEqualTo(170.0);
+        assertThat(waypoints.get(0).getY()).isEqualTo(95.0);
+        assertThat(waypoints.get(1).getX()).isEqualTo(220.0);
+        assertThat(waypoints.get(1).getY()).isEqualTo(95.0);
+        assertThat(waypoints.get(2).getX()).isEqualTo(220.0);
+        assertThat(waypoints.get(2).getY()).isEqualTo(130.0);
+        assertThat(waypoints.get(3).getX()).isEqualTo(250.0);
+        assertThat(waypoints.get(3).getY()).isEqualTo(130.0);
     }
 
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/SimpleDiCmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/SimpleDiCmmnXmlConverterTest.java
@@ -12,8 +12,8 @@
  */
 package org.flowable.test.cmmn.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Offset.offset;
 
 import java.util.List;
 
@@ -45,54 +45,54 @@ public class SimpleDiCmmnXmlConverterTest extends AbstractConverterTest {
     
     public void validateModel(CmmnModel cmmnModel) {
         Stage planModel = cmmnModel.getPrimaryCase().getPlanModel();
-        assertEquals(2, planModel.getPlanItems().size());
+        assertThat(planModel.getPlanItems()).hasSize(2);
         
         PlanItem planItem = cmmnModel.findPlanItem("planItem1");
-        assertNotNull(planItem);
-        assertEquals("task1", planItem.getDefinitionRef());
+        assertThat(planItem).isNotNull();
+        assertThat(planItem.getDefinitionRef()).isEqualTo("task1");
         
         planItem = cmmnModel.findPlanItem("planItem2");
-        assertNotNull(planItem);
-        assertEquals("task2", planItem.getDefinitionRef());
+        assertThat(planItem).isNotNull();
+        assertThat(planItem.getDefinitionRef()).isEqualTo("task2");
         
         GraphicInfo graphicInfo = cmmnModel.getGraphicInfo("myPlanModel");
-        assertNotNull(graphicInfo);
-        assertEquals(1.0, graphicInfo.getX(), 0.1);
-        assertEquals(19.0, graphicInfo.getY(), 0.1);
-        assertEquals(400.0, graphicInfo.getWidth(), 0.1);
-        assertEquals(300.0, graphicInfo.getHeight(), 0.1);
+        assertThat(graphicInfo).isNotNull();
+        assertThat(graphicInfo.getX()).isCloseTo(1.0, offset(0.1));
+        assertThat(graphicInfo.getY()).isCloseTo(19.0, offset(0.1));
+        assertThat(graphicInfo.getWidth()).isCloseTo(400.0, offset(0.1));
+        assertThat(graphicInfo.getHeight()).isCloseTo(300.0, offset(0.1));
         
         graphicInfo = cmmnModel.getGraphicInfo("planItem1");
-        assertNotNull(graphicInfo);
-        assertEquals(70.0, graphicInfo.getX(), 0.1);
-        assertEquals(65.0, graphicInfo.getY(), 0.1);
-        assertEquals(80.0, graphicInfo.getWidth(), 0.1);
-        assertEquals(60.0, graphicInfo.getHeight(), 0.1);
+        assertThat(graphicInfo).isNotNull();
+        assertThat(graphicInfo.getX()).isCloseTo(70.0, offset(0.1));
+        assertThat(graphicInfo.getY()).isCloseTo(65.0, offset(0.1));
+        assertThat(graphicInfo.getWidth()).isCloseTo(80.0, offset(0.1));
+        assertThat(graphicInfo.getHeight()).isCloseTo(60.0, offset(0.1));
         
         graphicInfo = cmmnModel.getGraphicInfo("planItem2");
-        assertNotNull(graphicInfo);
-        assertEquals(250.0, graphicInfo.getX(), 0.1);
-        assertEquals(100.0, graphicInfo.getY(), 0.1);
-        assertEquals(80.0, graphicInfo.getWidth(), 0.1);
-        assertEquals(60.0, graphicInfo.getHeight(), 0.1);
+        assertThat(graphicInfo).isNotNull();
+        assertThat(graphicInfo.getX()).isCloseTo(250.0, offset(0.1));
+        assertThat(graphicInfo.getY()).isCloseTo(100.0, offset(0.1));
+        assertThat(graphicInfo.getWidth()).isCloseTo(80.0, offset(0.1));
+        assertThat(graphicInfo.getHeight()).isCloseTo(60.0, offset(0.1));
         
         graphicInfo = cmmnModel.getGraphicInfo("criterion1");
-        assertNotNull(graphicInfo);
-        assertEquals(268.0, graphicInfo.getX(), 0.1);
-        assertEquals(216.0, graphicInfo.getY(), 0.1);
-        assertEquals(20.0, graphicInfo.getWidth(), 0.1);
-        assertEquals(28.0, graphicInfo.getHeight(), 0.1);
+        assertThat(graphicInfo).isNotNull();
+        assertThat(graphicInfo.getX()).isCloseTo(268.0, offset(0.1));
+        assertThat(graphicInfo.getY()).isCloseTo(216.0, offset(0.1));
+        assertThat(graphicInfo.getWidth()).isCloseTo(20.0, offset(0.1));
+        assertThat(graphicInfo.getHeight()).isCloseTo(28.0, offset(0.1));
         
         List<GraphicInfo> waypoints = cmmnModel.getFlowLocationGraphicInfo("CMMNEdge_onPart1");
-        assertEquals(4, waypoints.size());
-        assertEquals(170.0, waypoints.get(0).getX(), 0.1);
-        assertEquals(95.0, waypoints.get(0).getY(), 0.1);
-        assertEquals(220.0, waypoints.get(1).getX(), 0.1);
-        assertEquals(95.0, waypoints.get(1).getY(), 0.1);
-        assertEquals(220.0, waypoints.get(2).getX(), 0.1);
-        assertEquals(130.0, waypoints.get(2).getY(), 0.1);
-        assertEquals(250.0, waypoints.get(3).getX(), 0.1);
-        assertEquals(130.0, waypoints.get(3).getY(), 0.1);
+        assertThat(waypoints).hasSize(4);
+        assertThat(waypoints.get(0).getX()).isCloseTo(170.0, offset(0.1));
+        assertThat(waypoints.get(0).getY()).isCloseTo(95.0, offset(0.1));
+        assertThat(waypoints.get(1).getX()).isCloseTo(220.0, offset(0.1));
+        assertThat(waypoints.get(1).getY()).isCloseTo(95.0, offset(0.1));
+        assertThat(waypoints.get(2).getX()).isCloseTo(220.0, offset(0.1));
+        assertThat(waypoints.get(2).getY()).isCloseTo(130.0, offset(0.1));
+        assertThat(waypoints.get(3).getX()).isCloseTo(250.0, offset(0.1));
+        assertThat(waypoints.get(3).getY()).isCloseTo(130.0, offset(0.1));
     }
 
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/SimpleExtensionElementsCmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/SimpleExtensionElementsCmmnXmlConverterTest.java
@@ -12,8 +12,8 @@
  */
 package org.flowable.test.cmmn.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import java.util.List;
 
@@ -48,54 +48,54 @@ public class SimpleExtensionElementsCmmnXmlConverterTest extends AbstractConvert
     }
 
     public void validateModel(CmmnModel cmmnModel) {
-        assertNotNull(cmmnModel);
-        assertEquals(1, cmmnModel.getCases().size());
+        assertThat(cmmnModel).isNotNull();
+        assertThat(cmmnModel.getCases()).hasSize(1);
 
         // Case
         Case caze = cmmnModel.getCases().get(0);
-        assertEquals("myCase", caze.getId());
+        assertThat(caze.getId()).isEqualTo("myCase");
 
         // Plan model
         Stage planModel = caze.getPlanModel();
-        assertNotNull(planModel);
-        assertEquals("myPlanModel", planModel.getId());
-        assertEquals("My CasePlanModel", planModel.getName());
-        assertEquals("formKey", planModel.getFormKey());
-        assertEquals("formFieldValidationValue", planModel.getValidateFormFields());
+        assertThat(planModel).isNotNull();
+        assertThat(planModel.getId()).isEqualTo("myPlanModel");
+        assertThat(planModel.getName()).isEqualTo("My CasePlanModel");
+        assertThat(planModel.getFormKey()).isEqualTo("formKey");
+        assertThat(planModel.getValidateFormFields()).isEqualTo("formFieldValidationValue");
 
         Task task = (Task) planModel.findPlanItemDefinitionInStageOrUpwards("taskA");
-        assertEquals(1, task.getExtensionElements().size());
+        assertThat(task.getExtensionElements()).hasSize(1);
         List<ExtensionElement> extensionElements = task.getExtensionElements().get("taskTest");
-        assertEquals(1, extensionElements.size());
-        ExtensionElement extensionElement = extensionElements.get(0);
-        assertEquals("taskTest", extensionElement.getName());
-        assertEquals("hello", extensionElement.getElementText());
+        assertThat(extensionElements)
+            .hasSize(1)
+            .extracting(ExtensionElement::getName, ExtensionElement::getElementText)
+            .containsExactly(tuple("taskTest", "hello"));
         
         Milestone milestone = (Milestone) planModel.findPlanItemDefinitionInStageOrUpwards("mileStoneOne");
-        assertEquals(1, milestone.getExtensionElements().size());
+        assertThat(milestone.getExtensionElements()).hasSize(1);
         extensionElements = milestone.getExtensionElements().get("milestoneTest");
-        assertEquals(1, extensionElements.size());
-        extensionElement = extensionElements.get(0);
-        assertEquals("milestoneTest", extensionElement.getName());
-        assertEquals("hello2", extensionElement.getElementText());
+        assertThat(extensionElements)
+            .hasSize(1)
+            .extracting(ExtensionElement::getName, ExtensionElement::getElementText)
+            .containsExactly(tuple("milestoneTest", "hello2"));
         
         PlanItem planItem = planModel.findPlanItemInPlanFragmentOrDownwards("planItemTaskA");
-        assertEquals(1, planItem.getExtensionElements().size());
+        assertThat(planItem.getExtensionElements()).hasSize(1);
         extensionElements = planItem.getExtensionElements().get("test");
-        assertEquals(1, extensionElements.size());
-        extensionElement = extensionElements.get(0);
-        assertEquals("test", extensionElement.getName());
-        assertEquals("test", extensionElement.getElementText());
+        assertThat(extensionElements)
+            .hasSize(1)
+            .extracting(ExtensionElement::getName, ExtensionElement::getElementText)
+            .containsExactly(tuple("test", "test"));
 
         List<Sentry> sentries = planModel.getSentries();
-        assertEquals(3, sentries.size());
+        assertThat(sentries).hasSize(3);
         Sentry sentry = sentries.get(0);
-        assertEquals(1, sentry.getExtensionElements().size());
+        assertThat(sentry.getExtensionElements()).hasSize(1);
         extensionElements = sentry.getExtensionElements().get("test2");
-        assertEquals(1, extensionElements.size());
-        extensionElement = extensionElements.get(0);
-        assertEquals("test2", extensionElement.getName());
-        assertEquals("test2", extensionElement.getElementText());
+        assertThat(extensionElements)
+            .hasSize(1)
+            .extracting(ExtensionElement::getName, ExtensionElement::getElementText)
+            .containsExactly(tuple("test2", "test2"));
     }
 
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/SimpleExtensionElementsCmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/SimpleExtensionElementsCmmnXmlConverterTest.java
@@ -67,25 +67,22 @@ public class SimpleExtensionElementsCmmnXmlConverterTest extends AbstractConvert
         assertThat(task.getExtensionElements()).hasSize(1);
         List<ExtensionElement> extensionElements = task.getExtensionElements().get("taskTest");
         assertThat(extensionElements)
-            .hasSize(1)
-            .extracting(ExtensionElement::getName, ExtensionElement::getElementText)
-            .containsExactly(tuple("taskTest", "hello"));
-        
+                .extracting(ExtensionElement::getName, ExtensionElement::getElementText)
+                .containsExactly(tuple("taskTest", "hello"));
+
         Milestone milestone = (Milestone) planModel.findPlanItemDefinitionInStageOrUpwards("mileStoneOne");
         assertThat(milestone.getExtensionElements()).hasSize(1);
         extensionElements = milestone.getExtensionElements().get("milestoneTest");
         assertThat(extensionElements)
-            .hasSize(1)
-            .extracting(ExtensionElement::getName, ExtensionElement::getElementText)
-            .containsExactly(tuple("milestoneTest", "hello2"));
-        
+                .extracting(ExtensionElement::getName, ExtensionElement::getElementText)
+                .containsExactly(tuple("milestoneTest", "hello2"));
+
         PlanItem planItem = planModel.findPlanItemInPlanFragmentOrDownwards("planItemTaskA");
         assertThat(planItem.getExtensionElements()).hasSize(1);
         extensionElements = planItem.getExtensionElements().get("test");
         assertThat(extensionElements)
-            .hasSize(1)
-            .extracting(ExtensionElement::getName, ExtensionElement::getElementText)
-            .containsExactly(tuple("test", "test"));
+                .extracting(ExtensionElement::getName, ExtensionElement::getElementText)
+                .containsExactly(tuple("test", "test"));
 
         List<Sentry> sentries = planModel.getSentries();
         assertThat(sentries).hasSize(3);
@@ -93,9 +90,8 @@ public class SimpleExtensionElementsCmmnXmlConverterTest extends AbstractConvert
         assertThat(sentry.getExtensionElements()).hasSize(1);
         extensionElements = sentry.getExtensionElements().get("test2");
         assertThat(extensionElements)
-            .hasSize(1)
-            .extracting(ExtensionElement::getName, ExtensionElement::getElementText)
-            .containsExactly(tuple("test2", "test2"));
+                .extracting(ExtensionElement::getName, ExtensionElement::getElementText)
+                .containsExactly(tuple("test2", "test2"));
     }
 
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/TimerEventListenerCmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/TimerEventListenerCmmnXmlConverterTest.java
@@ -12,8 +12,8 @@
  */
 package org.flowable.test.cmmn.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import java.util.List;
 
@@ -34,18 +34,17 @@ public class TimerEventListenerCmmnXmlConverterTest extends AbstractConverterTes
     @Test
     public void testConvertXmlToCmmnModel() throws Exception {
         CmmnModel cmmnModel = readXMLFile("org/flowable/test/cmmn/converter/timer-event-listener.cmmn");
-        assertNotNull(cmmnModel);
+        assertThat(cmmnModel).isNotNull();
         
         List<HumanTask> humanTasks = cmmnModel.getPrimaryCase().getPlanModel().findPlanItemDefinitionsOfType(HumanTask.class, true);
-        assertEquals(2, humanTasks.size());
+        assertThat(humanTasks).hasSize(2);
         
         List<TimerEventListener> timerEventListeners =  cmmnModel.getPrimaryCase().getPlanModel().findPlanItemDefinitionsOfType(TimerEventListener.class, true);
-        assertEquals(1, timerEventListeners.size());
-        
-        TimerEventListener timerEventListener = timerEventListeners.get(0);
-        assertEquals("PT6H", timerEventListener.getTimerExpression());
-        assertEquals("A", timerEventListener.getTimerStartTriggerPlanItem().getName());
-        assertEquals(PlanItemTransition.COMPLETE, timerEventListener.getTimerStartTriggerStandardEvent());
+        assertThat(timerEventListeners)
+            .hasSize(1)
+            .extracting(TimerEventListener::getTimerExpression, TimerEventListener::getTimerStartTriggerStandardEvent)
+            .containsExactly(tuple("PT6H", PlanItemTransition.COMPLETE));
+        assertThat(timerEventListeners.get(0).getTimerStartTriggerPlanItem().getName()).isEqualTo("A");
     }
 
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/TimerEventListenerCmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/TimerEventListenerCmmnXmlConverterTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,7 +27,7 @@ import org.junit.Test;
  * @author Joram Barrez
  */
 public class TimerEventListenerCmmnXmlConverterTest extends AbstractConverterTest {
-    
+
     /**
      * @throws Exception
      */
@@ -35,15 +35,14 @@ public class TimerEventListenerCmmnXmlConverterTest extends AbstractConverterTes
     public void testConvertXmlToCmmnModel() throws Exception {
         CmmnModel cmmnModel = readXMLFile("org/flowable/test/cmmn/converter/timer-event-listener.cmmn");
         assertThat(cmmnModel).isNotNull();
-        
+
         List<HumanTask> humanTasks = cmmnModel.getPrimaryCase().getPlanModel().findPlanItemDefinitionsOfType(HumanTask.class, true);
         assertThat(humanTasks).hasSize(2);
-        
-        List<TimerEventListener> timerEventListeners =  cmmnModel.getPrimaryCase().getPlanModel().findPlanItemDefinitionsOfType(TimerEventListener.class, true);
+
+        List<TimerEventListener> timerEventListeners = cmmnModel.getPrimaryCase().getPlanModel().findPlanItemDefinitionsOfType(TimerEventListener.class, true);
         assertThat(timerEventListeners)
-            .hasSize(1)
-            .extracting(TimerEventListener::getTimerExpression, TimerEventListener::getTimerStartTriggerStandardEvent)
-            .containsExactly(tuple("PT6H", PlanItemTransition.COMPLETE));
+                .extracting(TimerEventListener::getTimerExpression, TimerEventListener::getTimerStartTriggerStandardEvent)
+                .containsExactly(tuple("PT6H", PlanItemTransition.COMPLETE));
         assertThat(timerEventListeners.get(0).getTimerStartTriggerPlanItem().getName()).isEqualTo("A");
     }
 

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/UserEventListenerCmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/UserEventListenerCmmnXmlConverterTest.java
@@ -12,8 +12,7 @@
  */
 package org.flowable.test.cmmn.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
@@ -43,17 +42,17 @@ public class UserEventListenerCmmnXmlConverterTest extends AbstractConverterTest
     }
 
     public void validateModel(CmmnModel cmmnModel) {
-        assertNotNull(cmmnModel);
+        assertThat(cmmnModel).isNotNull();
 
         List<HumanTask> humanTasks = cmmnModel.getPrimaryCase().getPlanModel().findPlanItemDefinitionsOfType(HumanTask.class, true);
-        assertEquals(2, humanTasks.size());
+        assertThat(humanTasks).hasSize(2);
 
         List<UserEventListener> userEventListeners = cmmnModel.getPrimaryCase().getPlanModel().findPlanItemDefinitionsOfType(UserEventListener.class, true);
-        assertEquals(1, userEventListeners.size());
+        assertThat(userEventListeners).hasSize(1);
 
         UserEventListener userEventListener = userEventListeners.get(0);
-        assertEquals("myUserEventListener", userEventListener.getName());
-        assertEquals("userActionListener",userEventListener.getId());
-        assertEquals("UserEventListener documentation",userEventListener.getDocumentation());
+        assertThat(userEventListener.getName()).isEqualTo("myUserEventListener");
+        assertThat(userEventListener.getId()).isEqualTo("userActionListener");
+        assertThat(userEventListener.getDocumentation()).isEqualTo("UserEventListener documentation");
     }
 }


### PR DESCRIPTION
Another iteration of moving to Assertj Fluent style.

@filiphr I tried to use `.extracting` more often in this PR.
