### PR TITLE
Use assertj fluent style in flowable-cmmn-engine (part 3)

### DIFF
--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/history/HistoricCaseInstanceQueryImplTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/history/HistoricCaseInstanceQueryImplTest.java
@@ -12,9 +12,7 @@
  */
 package org.flowable.cmmn.test.history;
 
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNot.not;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Calendar;
 import java.util.Collections;
@@ -40,14 +38,15 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
 
     @Before
     public void createCase() {
-        deplId = cmmnRepositoryService.createDeployment().
-            addClasspathResource("org/flowable/cmmn/test/runtime/CaseTaskTest.testBasicBlocking.cmmn").
-            addClasspathResource("org/flowable/cmmn/test/runtime/oneTaskCase.cmmn").
-            deploy().getId();
-        
-        cmmnRuntimeService.createCaseInstanceBuilder().
-                caseDefinitionKey("myCase").
-                start();
+        deplId = cmmnRepositoryService.createDeployment()
+                .addClasspathResource("org/flowable/cmmn/test/runtime/CaseTaskTest.testBasicBlocking.cmmn")
+                .addClasspathResource("org/flowable/cmmn/test/runtime/oneTaskCase.cmmn")
+                .deploy()
+                .getId();
+
+        cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("myCase")
+                .start();
     }
 
     @After
@@ -57,17 +56,36 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
 
     @Test
     public void getCaseInstanceByCaseDefinitionKey() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            start();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .start();
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionKey("oneTaskCase").count(), is(1L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionKey("oneTaskCase").list().get(0).getId(), is(caseInstance.getId()));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionKey("oneTaskCase").singleResult().getId(), is(caseInstance.getId()));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionKey("oneTaskCase").count()).isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionKey("oneTaskCase").list().get(0).getId()).isEqualTo(caseInstance.getId());
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionKey("oneTaskCase").singleResult().getId())
+                .isEqualTo(caseInstance.getId());
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().or().caseDefinitionKey("oneTaskCase").caseInstanceId("Undefined").endOr().count(), is(1L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().or().caseDefinitionKey("oneTaskCase").caseInstanceId("Undefined").endOr().list().get(0).getId(), is(caseInstance.getId()));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().or().caseDefinitionKey("oneTaskCase").caseInstanceId("Undefined").endOr().singleResult().getId(), is(caseInstance.getId()));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .caseDefinitionKey("oneTaskCase")
+                .caseInstanceId("Undefined")
+                .endOr()
+                .count())
+                .isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .caseDefinitionKey("oneTaskCase")
+                .caseInstanceId("Undefined")
+                .endOr()
+                .list().get(0).getId())
+                .isEqualTo(caseInstance.getId());
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .caseDefinitionKey("oneTaskCase")
+                .caseInstanceId("Undefined")
+                .endOr()
+                .singleResult().getId())
+                .isEqualTo(caseInstance.getId());
     }
 
     @Test
@@ -87,272 +105,322 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .name("nameTask3")
                 .start();
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceNameLikeIgnoreCase("taskName%").count(), is(2L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceNameLikeIgnoreCase("%TASK3").count(), is(1L));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceNameLikeIgnoreCase("taskName%").count()).isEqualTo(2L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceNameLikeIgnoreCase("%TASK3").count()).isEqualTo(1L);
     }
 
     public void getCaseInstanceByCaseDefinitionKeyIncludingVariables() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-                caseDefinitionKey("oneTaskCase").
-                start();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .start();
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionKey("oneTaskCase").includeCaseVariables().count(), is(1L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionKey("oneTaskCase").includeCaseVariables().list().get(0).getId(), is(caseInstance.getId()));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionKey("oneTaskCase").includeCaseVariables().singleResult().getId(), is(caseInstance.getId()));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionKey("oneTaskCase").includeCaseVariables().count()).isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionKey("oneTaskCase").includeCaseVariables().list().get(0).getId())
+                .isEqualTo(caseInstance.getId());
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionKey("oneTaskCase").includeCaseVariables().singleResult().getId())
+                .isEqualTo(caseInstance.getId());
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().or().caseDefinitionKey("oneTaskCase").caseInstanceId("Undefined").endOr().includeCaseVariables().count(), is(1L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().or().caseDefinitionKey("oneTaskCase").caseInstanceId("Undefined").endOr().includeCaseVariables().list().get(0).getId(), is(caseInstance.getId()));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().or().caseDefinitionKey("oneTaskCase").caseInstanceId("Undefined").endOr().includeCaseVariables().singleResult().getId(), is(caseInstance.getId()));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .caseDefinitionKey("oneTaskCase")
+                .caseInstanceId("Undefined")
+                .endOr()
+                .includeCaseVariables().count())
+                .isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .caseDefinitionKey("oneTaskCase")
+                .caseInstanceId("Undefined")
+                .endOr()
+                .includeCaseVariables().list().get(0).getId())
+                .isEqualTo(caseInstance.getId());
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .caseDefinitionKey("oneTaskCase")
+                .caseInstanceId("Undefined")
+                .endOr()
+                .includeCaseVariables().singleResult().getId())
+                .isEqualTo(caseInstance.getId());
     }
 
     @Test
     public void getCaseInstanceByCaseDefinitionKeys() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            start();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .start();
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionKeys(Collections.singleton("oneTaskCase")).count(), is(1L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionKeys(Collections.singleton("oneTaskCase")).list().get(0).getId(), is(caseInstance.getId()));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionKeys(Collections.singleton("oneTaskCase")).singleResult().getId(), is(caseInstance.getId()));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionKeys(Collections.singleton("oneTaskCase")).count()).isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionKeys(Collections.singleton("oneTaskCase")).list().get(0).getId())
+                .isEqualTo(caseInstance.getId());
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionKeys(Collections.singleton("oneTaskCase")).singleResult().getId())
+                .isEqualTo(caseInstance.getId());
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().or().
-            caseInstanceId("undefined").
-            caseDefinitionKeys(Collections.singleton("oneTaskCase")).
-            endOr().
-            count(), is(1L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().or().
-            caseInstanceId("undefined").
-            caseDefinitionKeys(Collections.singleton("oneTaskCase"))
-            .endOr()
-            .list().get(0).getId(), is(caseInstance.getId()));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().or().
-            caseInstanceId("undefined").
-            caseDefinitionKeys(Collections.singleton("oneTaskCase")).
-            endOr().singleResult().getId(), is(caseInstance.getId()));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .caseInstanceId("undefined")
+                .caseDefinitionKeys(Collections.singleton("oneTaskCase"))
+                .endOr()
+                .count())
+                .isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .caseInstanceId("undefined")
+                .caseDefinitionKeys(Collections.singleton("oneTaskCase"))
+                .endOr()
+                .list().get(0).getId())
+                .isEqualTo(caseInstance.getId());
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .caseInstanceId("undefined")
+                .caseDefinitionKeys(Collections.singleton("oneTaskCase"))
+                .endOr()
+                .singleResult().getId())
+                .isEqualTo(caseInstance.getId());
     }
 
     @Test
     public void getCaseInstanceByCaseDefinitionCategory() {
-        cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            start();
+        cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .start();
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionCategory("http://flowable.org/cmmn").count(), is(2L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionCategory("http://flowable.org/cmmn").list().size(), is(2));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionCategory("http://flowable.org/cmmn").count()).isEqualTo(2L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionCategory("http://flowable.org/cmmn").list()).hasSize(2);
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            or().
-                caseDefinitionCategory("http://flowable.org/cmmn").
-                caseInstanceId("undefined").
-            endOr().
-            count(), is(2L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            or().
-                caseDefinitionCategory("http://flowable.org/cmmn").
-                caseInstanceId("undefined").
-            endOr().
-            list().size(), is(2));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .caseDefinitionCategory("http://flowable.org/cmmn")
+                .caseInstanceId("undefined")
+                .endOr()
+                .count())
+                .isEqualTo(2L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .caseDefinitionCategory("http://flowable.org/cmmn")
+                .caseInstanceId("undefined")
+                .endOr()
+                .list())
+                .hasSize(2);
     }
 
     @Test
     public void getCaseInstanceByCaseDefinitionName() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            start();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .start();
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionName("oneTaskCaseName").count(), is(1L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionName("oneTaskCaseName").list().get(0).getId(), is(caseInstance.getId()));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionName("oneTaskCaseName").singleResult().getId(), is(caseInstance.getId()));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionName("oneTaskCaseName").count()).isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionName("oneTaskCaseName").list().get(0).getId())
+                .isEqualTo(caseInstance.getId());
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionName("oneTaskCaseName").singleResult().getId())
+                .isEqualTo(caseInstance.getId());
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            or().
-                caseDefinitionName("oneTaskCaseName").
-                caseInstanceId("undefined").
-            endOr().
-            count(), is(1L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            or().
-                caseDefinitionName("oneTaskCaseName").
-                caseInstanceId("undefined").
-            endOr().
-            list().get(0).getId(), is(caseInstance.getId()));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            or().
-                caseDefinitionName("oneTaskCaseName").
-                caseInstanceId("undefined").
-            endOr().
-            singleResult().getId(), is(caseInstance.getId()));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .caseDefinitionName("oneTaskCaseName")
+                .caseInstanceId("undefined")
+                .endOr()
+                .count())
+                .isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .caseDefinitionName("oneTaskCaseName")
+                .caseInstanceId("undefined")
+                .endOr()
+                .list().get(0).getId())
+                .isEqualTo(caseInstance.getId());
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .caseDefinitionName("oneTaskCaseName")
+                .caseInstanceId("undefined")
+                .endOr()
+                .singleResult().getId())
+                .isEqualTo(caseInstance.getId());
     }
 
     @Test
     public void getCaseInstanceByCaseDefinitionId() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            start();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .start();
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionId(caseInstance.getCaseDefinitionId()).count(), is(1L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionId(caseInstance.getCaseDefinitionId()).list().get(0).getId(), is(caseInstance.getId()));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionId(caseInstance.getCaseDefinitionId()).singleResult().getId(), is(caseInstance.getId()));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionId(caseInstance.getCaseDefinitionId()).count()).isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionId(caseInstance.getCaseDefinitionId()).list().get(0).getId())
+                .isEqualTo(caseInstance.getId());
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionId(caseInstance.getCaseDefinitionId()).singleResult().getId())
+                .isEqualTo(caseInstance.getId());
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            or().
-                caseDefinitionId(caseInstance.getCaseDefinitionId()).
-                caseInstanceId("undefinedId").
-            endOr().
-            count(), is(1L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            or().
-                caseDefinitionId(caseInstance.getCaseDefinitionId()).
-                caseInstanceId("undefinedId").
-            endOr().
-            list().get(0).getId(), is(caseInstance.getId()));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            or().
-                caseDefinitionId(caseInstance.getCaseDefinitionId()).
-                caseInstanceId("undefinedId").
-            endOr().
-            singleResult().getId(), is(caseInstance.getId()));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .caseDefinitionId(caseInstance.getCaseDefinitionId())
+                .caseInstanceId("undefinedId")
+                .endOr()
+                .count())
+                .isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .caseDefinitionId(caseInstance.getCaseDefinitionId())
+                .caseInstanceId("undefinedId")
+                .endOr().list().get(0).getId())
+                .isEqualTo(caseInstance.getId());
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .caseDefinitionId(caseInstance.getCaseDefinitionId())
+                .caseInstanceId("undefinedId")
+                .endOr()
+                .singleResult().getId())
+                .isEqualTo(caseInstance.getId());
     }
 
     @Test
     public void getCaseInstanceByCaseDefinitionVersion() {
-        cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            start();
+        cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .start();
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionVersion(1).count(), is(2L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionVersion(1).list().size(), is(2));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionVersion(1).count()).isEqualTo(2L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionVersion(1).list()).hasSize(2);
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            or().
-                caseDefinitionVersion(1).
-                caseInstanceId("undefinedId").
-            endOr().
-            count(), is(2L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            or().
-                caseDefinitionVersion(1).
-                caseInstanceId("undefinedId").
-            endOr().
-            list().size(), is(2));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .caseDefinitionVersion(1)
+                .caseInstanceId("undefinedId")
+                .endOr()
+                .count())
+                .isEqualTo(2L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .caseDefinitionVersion(1)
+                .caseInstanceId("undefinedId")
+                .endOr()
+                .list())
+                .hasSize(2);
     }
 
     @Test
     public void getCaseInstanceByCaseId() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            start();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .start();
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count(), is(1L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceId(caseInstance.getId()).list().get(0).getId(),
-            is(caseInstance.getId()));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult().getId(),
-            is(caseInstance.getId()));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceId(caseInstance.getId()).list().get(0).getId())
+                .isEqualTo(caseInstance.getId());
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult().getId())
+                .isEqualTo(caseInstance.getId());
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            or().
-                caseInstanceId(caseInstance.getId()).
-                caseDefinitionName("undefinedId").
-            endOr().
-            count(), is(1L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            or().
-                caseInstanceId(caseInstance.getId()).
-                caseDefinitionName("undefinedId").
-            endOr().
-            list().get(0).getId(), is(caseInstance.getId()));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            or().
-                caseInstanceId(caseInstance.getId()).
-                caseDefinitionId("undefined").
-            endOr().
-            singleResult().getId(), is(caseInstance.getId()));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .caseInstanceId(caseInstance.getId())
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .count())
+                .isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .caseInstanceId(caseInstance.getId())
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .list().get(0).getId())
+                .isEqualTo(caseInstance.getId());
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .caseInstanceId(caseInstance.getId())
+                .caseDefinitionId("undefined")
+                .endOr()
+                .singleResult().getId())
+                .isEqualTo(caseInstance.getId());
     }
 
     @Test
     public void getCaseInstanceByBusinessKey() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            businessKey("businessKey").
-            start();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .businessKey("businessKey")
+                .start();
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceBusinessKey("businessKey").count(), is(1L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceBusinessKey("businessKey").list().get(0).getId(),
-            is(caseInstance.getId()));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceBusinessKey("businessKey").singleResult().getId(),
-            is(caseInstance.getId()));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceBusinessKey("businessKey").count()).isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceBusinessKey("businessKey").list().get(0).getId())
+                .isEqualTo(caseInstance.getId());
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceBusinessKey("businessKey").singleResult().getId())
+                .isEqualTo(caseInstance.getId());
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            or().
-                caseInstanceBusinessKey("businessKey").
-                caseDefinitionName("undefinedId").
-            endOr().
-            count(), is(1L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            or().
-                caseInstanceBusinessKey("businessKey").
-                caseDefinitionName("undefinedId").
-            endOr().
-            list().get(0).getId(), is(caseInstance.getId()));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            or().
-                caseInstanceBusinessKey("businessKey").
-                caseDefinitionId("undefined").
-            endOr().
-            singleResult().getId(), is(caseInstance.getId()));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .caseInstanceBusinessKey("businessKey")
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .count())
+                .isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .caseInstanceBusinessKey("businessKey")
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .list().get(0).getId())
+                .isEqualTo(caseInstance.getId());
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .caseInstanceBusinessKey("businessKey")
+                .caseDefinitionId("undefined")
+                .endOr()
+                .singleResult().getId())
+                .isEqualTo(caseInstance.getId());
     }
 
     @Test
     public void getCaseInstanceByStartedBefore() {
-        cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            start();
-        
+        cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .start();
+
         Calendar todayCal = new GregorianCalendar();
         Calendar dateCal = new GregorianCalendar(todayCal.get(Calendar.YEAR) + 1, todayCal.get(Calendar.MONTH), todayCal.get(Calendar.DAY_OF_YEAR));
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().startedBefore(dateCal.getTime()).count(), is(2L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().startedBefore(dateCal.getTime()).list().size(),
-            is(2));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().startedBefore(dateCal.getTime()).count()).isEqualTo(2L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().startedBefore(dateCal.getTime()).list()).hasSize(2);
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            or().
-                startedBefore(dateCal.getTime()).
-                caseDefinitionName("undefinedId").
-            endOr().
-            count(), is(2L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            or().
-                startedBefore(dateCal.getTime()).
-                caseDefinitionName("undefinedId").
-            endOr().
-            list().size(), is(2));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .startedBefore(dateCal.getTime())
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .count())
+                .isEqualTo(2L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .startedBefore(dateCal.getTime())
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .list())
+                .hasSize(2);
     }
 
     @Test
     public void getCaseInstanceByStartedAfter() {
-        cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            start();
+        cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .start();
 
         Calendar todayCal = new GregorianCalendar();
         Calendar dateCal = new GregorianCalendar(todayCal.get(Calendar.YEAR) - 1, todayCal.get(Calendar.MONTH), todayCal.get(Calendar.DAY_OF_YEAR));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().startedAfter(dateCal.getTime()).count(), is(2L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().startedAfter(dateCal.getTime()).list().size(),
-            is(2));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().startedAfter(dateCal.getTime()).count()).isEqualTo(2L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().startedAfter(dateCal.getTime()).list()).hasSize(2);
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            or().
-                startedAfter(dateCal.getTime()).
-                caseDefinitionName("undefinedId").
-            endOr().
-            count(), is(2L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            or().
-                startedAfter(dateCal.getTime()).
-                caseDefinitionName("undefinedId").
-            endOr().
-            list().size(), is(2));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .startedAfter(dateCal.getTime())
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .count())
+                .isEqualTo(2L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .startedAfter(dateCal.getTime())
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .list())
+                .hasSize(2);
     }
 
     @Test
@@ -360,34 +428,35 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
         String authenticatedUserId = Authentication.getAuthenticatedUserId();
         try {
             Authentication.setAuthenticatedUserId("kermit");
-            CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-                caseDefinitionKey("oneTaskCase").
-                start();
+            CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                    .caseDefinitionKey("oneTaskCase")
+                    .start();
 
-            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().startedBy("kermit").count(), is(1L));
-            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().startedBy("kermit").list().get(0).getId(),
-                is(caseInstance.getId()));
-            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().startedBy("kermit").singleResult().getId(),
-                is(caseInstance.getId()));
+            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().startedBy("kermit").count()).isEqualTo(1L);
+            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().startedBy("kermit").list().get(0).getId()).isEqualTo(caseInstance.getId());
+            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().startedBy("kermit").singleResult().getId()).isEqualTo(caseInstance.getId());
 
-            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-                or().
-                startedBy("kermit").
-                caseDefinitionName("undefinedId").
-                endOr().
-                count(), is(1L));
-            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-                or().
-                startedBy("kermit").
-                caseDefinitionName("undefinedId").
-                endOr().
-                list().get(0).getId(), is(caseInstance.getId()));
-            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-                or().
-                startedBy("kermit").
-                caseDefinitionId("undefined").
-                endOr().
-                singleResult().getId(), is(caseInstance.getId()));
+            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                    .or()
+                    .startedBy("kermit")
+                    .caseDefinitionName("undefinedId")
+                    .endOr()
+                    .count())
+                    .isEqualTo(1L);
+            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                    .or()
+                    .startedBy("kermit")
+                    .caseDefinitionName("undefinedId")
+                    .endOr()
+                    .list().get(0).getId())
+                    .isEqualTo(caseInstance.getId());
+            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                    .or()
+                    .startedBy("kermit")
+                    .caseDefinitionId("undefined")
+                    .endOr()
+                    .singleResult().getId())
+                    .isEqualTo(caseInstance.getId());
         } finally {
             Authentication.setAuthenticatedUserId(authenticatedUserId);
         }
@@ -395,188 +464,203 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
 
     @Test
     public void getCaseInstanceByCallBackId() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            callbackId("callBackId").
-            start();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .callbackId("callBackId")
+                .start();
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceCallbackId("callBackId").count(), is(1L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceCallbackId("callBackId").list().get(0).getId(),
-            is(caseInstance.getId()));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceCallbackId("callBackId").singleResult().getId(),
-            is(caseInstance.getId()));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceCallbackId("callBackId").count()).isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceCallbackId("callBackId").list().get(0).getId())
+                .isEqualTo(caseInstance.getId());
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceCallbackId("callBackId").singleResult().getId())
+                .isEqualTo(caseInstance.getId());
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            or().
-            caseInstanceCallbackId("callBackId").
-            caseDefinitionName("undefinedId").
-            endOr().
-            count(), is(1L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            or().
-            caseInstanceCallbackId("callBackId").
-            caseDefinitionName("undefinedId").
-            endOr().
-            list().get(0).getId(), is(caseInstance.getId()));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            or().
-            caseInstanceCallbackId("callBackId").
-            caseDefinitionId("undefined").
-            endOr().
-            singleResult().getId(), is(caseInstance.getId()));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .caseInstanceCallbackId("callBackId")
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .count())
+                .isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .caseInstanceCallbackId("callBackId")
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .list().get(0).getId())
+                .isEqualTo(caseInstance.getId());
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .caseInstanceCallbackId("callBackId")
+                .caseDefinitionId("undefined")
+                .endOr()
+                .singleResult().getId())
+                .isEqualTo(caseInstance.getId());
     }
 
     @Test
     public void getCaseInstanceByCallBackType() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            callbackType("callBackType").
-            start();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .callbackType("callBackType")
+                .start();
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceCallbackType("callBackType").count(), is(1L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceCallbackType("callBackType").list().get(0).getId(),
-            is(caseInstance.getId()));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceCallbackType("callBackType").singleResult().getId(),
-            is(caseInstance.getId()));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceCallbackType("callBackType").count()).isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceCallbackType("callBackType").list().get(0).getId())
+                .isEqualTo(caseInstance.getId());
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceCallbackType("callBackType").singleResult().getId())
+                .isEqualTo(caseInstance.getId());
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            or().
-            caseInstanceCallbackType("callBackType").
-            caseDefinitionName("undefinedId").
-            endOr().
-            count(), is(1L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            or().
-            caseInstanceCallbackType("callBackType").
-            caseDefinitionName("undefinedId").
-            endOr().
-            list().get(0).getId(), is(caseInstance.getId()));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            or().
-            caseInstanceCallbackType("callBackType").
-            caseDefinitionId("undefined").
-            endOr().
-            singleResult().getId(), is(caseInstance.getId()));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .caseInstanceCallbackType("callBackType")
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .count())
+                .isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .caseInstanceCallbackType("callBackType")
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .list().get(0).getId())
+                .isEqualTo(caseInstance.getId());
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .caseInstanceCallbackType("callBackType")
+                .caseDefinitionId("undefined")
+                .endOr()
+                .singleResult().getId())
+                .isEqualTo(caseInstance.getId());
     }
 
     @Test
     public void getCaseInstanceByReferenceId() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("oneTaskCase")
-            .referenceId("testReferenceId")
-            .start();
+                .caseDefinitionKey("oneTaskCase")
+                .referenceId("testReferenceId")
+                .start();
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceReferenceId("testReferenceId").count(), is(1L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceReferenceId("testReferenceId").list().get(0).getId(),
-            is(caseInstance.getId()));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceReferenceId("testReferenceId").singleResult().getId(),
-            is(caseInstance.getId()));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceReferenceId("testReferenceId").count()).isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceReferenceId("testReferenceId").list().get(0).getId())
+                .isEqualTo(caseInstance.getId());
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceReferenceId("testReferenceId").singleResult().getId())
+                .isEqualTo(caseInstance.getId());
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            or().
-            caseInstanceReferenceId("testReferenceId").
-            caseDefinitionName("undefined").
-            endOr().
-            count(), is(1L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            or().
-            caseInstanceReferenceId("testReferenceId").
-            caseDefinitionName("undefined").
-            endOr().
-            list().get(0).getId(), is(caseInstance.getId()));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            or().
-            caseInstanceReferenceId("testReferenceId").
-            caseDefinitionId("undefined").
-            endOr().
-            singleResult().getId(), is(caseInstance.getId()));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .caseInstanceReferenceId("testReferenceId")
+                .caseDefinitionName("undefined")
+                .endOr()
+                .count())
+                .isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .caseInstanceReferenceId("testReferenceId")
+                .caseDefinitionName("undefined")
+                .endOr()
+                .list().get(0).getId())
+                .isEqualTo(caseInstance.getId());
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .caseInstanceReferenceId("testReferenceId")
+                .caseDefinitionId("undefined")
+                .endOr()
+                .singleResult().getId())
+                .isEqualTo(caseInstance.getId());
     }
 
     @Test
     public void getCaseInstanceByReferenceType() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("oneTaskCase")
-            .referenceType("testReferenceType")
-            .start();
+                .caseDefinitionKey("oneTaskCase")
+                .referenceType("testReferenceType")
+                .start();
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceReferenceType("testReferenceType").count(), is(1L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceReferenceType("testReferenceType").list().get(0).getId(),
-            is(caseInstance.getId()));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceReferenceType("testReferenceType").singleResult().getId(),
-            is(caseInstance.getId()));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceReferenceType("testReferenceType").count()).isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceReferenceType("testReferenceType").list().get(0).getId())
+                .isEqualTo(caseInstance.getId());
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceReferenceType("testReferenceType").singleResult().getId())
+                .isEqualTo(caseInstance.getId());
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            or().
-            caseInstanceReferenceType("testReferenceType").
-            caseDefinitionName("undefinedId").
-            endOr().
-            count(), is(1L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            or().
-            caseInstanceReferenceType("testReferenceType").
-            caseDefinitionName("undefinedId").
-            endOr().
-            list().get(0).getId(), is(caseInstance.getId()));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            or().
-            caseInstanceReferenceType("testReferenceType").
-            caseDefinitionId("undefined").
-            endOr().
-            singleResult().getId(), is(caseInstance.getId()));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .caseInstanceReferenceType("testReferenceType")
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .count())
+                .isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .caseInstanceReferenceType("testReferenceType")
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .list().get(0).getId())
+                .isEqualTo(caseInstance.getId());
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .caseInstanceReferenceType("testReferenceType")
+                .caseDefinitionId("undefined")
+                .endOr()
+                .singleResult().getId())
+                .isEqualTo(caseInstance.getId());
     }
 
     @Test
     public void getCaseInstanceByReferenceIdAndType() {
         for (int i = 0; i < 5; i++) {
             CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-                .caseDefinitionKey("oneTaskCase")
-                .referenceId("testReferenceId")
-                .referenceType("testReferenceType")
-                .start();
+                    .caseDefinitionKey("oneTaskCase")
+                    .referenceId("testReferenceId")
+                    .referenceType("testReferenceType")
+                    .start();
         }
 
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceReferenceId("testReferenceId")
-            .caseInstanceReferenceType("testReferenceType").count(), is(5L));
+                .caseInstanceReferenceType("testReferenceType").count()).isEqualTo(5L);
     }
 
     @Test
     public void getCaseInstanceByTenantId() {
-        String tempDeploymentId = cmmnRepositoryService.createDeployment().
-            addClasspathResource("org/flowable/cmmn/test/runtime/CaseTaskTest.testBasicBlocking.cmmn").
-            addClasspathResource("org/flowable/cmmn/test/runtime/oneTaskCase.cmmn").
-            tenantId("tenantId").
-            deploy()
-            .getId();
+        String tempDeploymentId = cmmnRepositoryService.createDeployment()
+                .addClasspathResource("org/flowable/cmmn/test/runtime/CaseTaskTest.testBasicBlocking.cmmn")
+                .addClasspathResource("org/flowable/cmmn/test/runtime/oneTaskCase.cmmn")
+                .tenantId("tenantId")
+                .deploy()
+                .getId();
         try {
-            CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-                caseDefinitionKey("oneTaskCase").
-                tenantId("tenantId").
-                start();
+            CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                    .caseDefinitionKey("oneTaskCase")
+                    .tenantId("tenantId")
+                    .start();
 
-            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceTenantId("tenantId").count(), is(1L));
-            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceTenantId("tenantId").list().get(0).getId(),
-                is(caseInstance.getId()));
-            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceTenantId("tenantId").singleResult().getId(),
-                is(caseInstance.getId()));
+            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceTenantId("tenantId").count()).isEqualTo(1L);
+            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceTenantId("tenantId").list().get(0).getId())
+                    .isEqualTo(caseInstance.getId());
+            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceTenantId("tenantId").singleResult().getId())
+                    .isEqualTo(caseInstance.getId());
 
-            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-                or().
-                caseInstanceTenantId("tenantId").
-                caseDefinitionName("undefinedId").
-                endOr().
-                count(), is(1L));
-            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-                or().
-                caseInstanceTenantId("tenantId").
-                caseDefinitionName("undefinedId").
-                endOr().
-                list().get(0).getId(), is(caseInstance.getId()));
-            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-                or().
-                caseInstanceTenantId("tenantId").
-                caseDefinitionId("undefined").
-                endOr().
-                singleResult().getId(), is(caseInstance.getId()));
+            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                    .or()
+                    .caseInstanceTenantId("tenantId")
+                    .caseDefinitionName("undefinedId")
+                    .endOr()
+                    .count())
+                    .isEqualTo(1L);
+            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                    .or()
+                    .caseInstanceTenantId("tenantId")
+                    .caseDefinitionName("undefinedId")
+                    .endOr()
+                    .list().get(0).getId())
+                    .isEqualTo(caseInstance.getId());
+            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                    .or()
+                    .caseInstanceTenantId("tenantId")
+                    .caseDefinitionId("undefined")
+                    .endOr()
+                    .singleResult().getId())
+                    .isEqualTo(caseInstance.getId());
         } finally {
             cmmnRepositoryService.deleteDeployment(tempDeploymentId, true);
         }
@@ -584,42 +668,45 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
 
     @Test
     public void getCaseInstanceWithoutTenantId() {
-        String tempDeploymentId = cmmnRepositoryService.createDeployment().
-            addClasspathResource("org/flowable/cmmn/test/runtime/CaseTaskTest.testBasicBlocking.cmmn").
-            addClasspathResource("org/flowable/cmmn/test/runtime/oneTaskCase.cmmn").
-            tenantId("tenantId").
-            deploy()
-            .getId();
+        String tempDeploymentId = cmmnRepositoryService.createDeployment()
+                .addClasspathResource("org/flowable/cmmn/test/runtime/CaseTaskTest.testBasicBlocking.cmmn")
+                .addClasspathResource("org/flowable/cmmn/test/runtime/oneTaskCase.cmmn")
+                .tenantId("tenantId")
+                .deploy()
+                .getId();
         try {
-            CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-                caseDefinitionKey("oneTaskCase").
-                tenantId("tenantId").
-                start();
+            CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                    .caseDefinitionKey("oneTaskCase")
+                    .tenantId("tenantId")
+                    .start();
 
-            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceWithoutTenantId().count(), is(1L));
-            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceWithoutTenantId().list().get(0).getId(),
-                is(not(caseInstance.getId())));
-            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceWithoutTenantId().singleResult().getId(),
-                is(not(caseInstance.getId())));
+            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceWithoutTenantId().count()).isEqualTo(1L);
+            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceWithoutTenantId().list().get(0).getId())
+                    .isNotEqualTo(caseInstance.getId());
+            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceWithoutTenantId().singleResult().getId())
+                    .isNotEqualTo(caseInstance.getId());
 
-            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-                or().
-                caseInstanceWithoutTenantId().
-                caseDefinitionName("undefinedId").
-                endOr().
-                count(), is(1L));
-            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-                or().
-                caseInstanceWithoutTenantId().
-                caseDefinitionName("undefinedId").
-                endOr().
-                list().get(0).getId(), is(not(caseInstance.getId())));
-            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-                or().
-                caseInstanceWithoutTenantId().
-                caseDefinitionId("undefined").
-                endOr().
-                singleResult().getId(), is(not(caseInstance.getId())));
+            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                    .or()
+                    .caseInstanceWithoutTenantId()
+                    .caseDefinitionName("undefinedId")
+                    .endOr()
+                    .count())
+                    .isEqualTo(1L);
+            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                    .or()
+                    .caseInstanceWithoutTenantId()
+                    .caseDefinitionName("undefinedId")
+                    .endOr()
+                    .list().get(0).getId())
+                    .isNotEqualTo(caseInstance.getId());
+            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                    .or()
+                    .caseInstanceWithoutTenantId()
+                    .caseDefinitionId("undefined")
+                    .endOr()
+                    .singleResult().getId())
+                    .isNotEqualTo(caseInstance.getId());
         } finally {
             cmmnRepositoryService.deleteDeployment(tempDeploymentId, true);
         }
@@ -627,187 +714,202 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
 
     @Test
     public void getCaseInstanceByInvolvedUser() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            start();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .start();
         cmmnRuntimeService.addUserIdentityLink(caseInstance.getId(), "kermit", IdentityLinkType.PARTICIPANT);
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("kermit").count(), is(1L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("kermit").list().get(0).getId(),
-            is(caseInstance.getId()));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("kermit").singleResult().getId(),
-            is(caseInstance.getId()));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("kermit").count()).isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("kermit").list().get(0).getId())
+                .isEqualTo(caseInstance.getId());
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("kermit").singleResult().getId())
+                .isEqualTo(caseInstance.getId());
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            or().
-                involvedUser("kermit").
-                caseDefinitionName("undefinedId").
-            endOr().
-            count(), is(1L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            or().
-            involvedUser("kermit").
-            caseDefinitionName("undefinedId").
-            endOr().
-            list().get(0).getId(), is(caseInstance.getId()));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            or().
-            involvedUser("kermit").
-            caseDefinitionId("undefined").
-            endOr().
-            singleResult().getId(), is(caseInstance.getId()));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .involvedUser("kermit")
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .count())
+                .isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .involvedUser("kermit")
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .list().get(0).getId())
+                .isEqualTo(caseInstance.getId());
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .involvedUser("kermit")
+                .caseDefinitionId("undefined")
+                .endOr()
+                .singleResult().getId())
+                .isEqualTo(caseInstance.getId());
     }
 
     @Test
     public void getCaseInstanceByInvolvedGroup() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            start();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .start();
         cmmnRuntimeService.addGroupIdentityLink(caseInstance.getId(), "testGroup", IdentityLinkType.PARTICIPANT);
         cmmnRuntimeService.addGroupIdentityLink(caseInstance.getId(), "testGroup2", IdentityLinkType.PARTICIPANT);
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Collections.singleton("testGroup")).count(), is(1L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId(),
-            is(caseInstance.getId()));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Collections.singleton("testGroup")).singleResult().getId(),
-            is(caseInstance.getId()));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Collections.singleton("testGroup")).count()).isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId())
+                .isEqualTo(caseInstance.getId());
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Collections.singleton("testGroup")).singleResult().getId())
+                .isEqualTo(caseInstance.getId());
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            or().
-                involvedGroups(Collections.singleton("testGroup")).
-                caseDefinitionName("undefinedId").
-            endOr().
-            count(), is(1L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            or().
-            involvedGroups(Collections.singleton("testGroup")).
-            caseDefinitionName("undefinedId").
-            endOr().
-            list().get(0).getId(), is(caseInstance.getId()));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            or().
-            involvedGroups(Collections.singleton("testGroup")).
-            caseDefinitionId("undefined").
-            endOr().
-            singleResult().getId(), is(caseInstance.getId()));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .involvedGroups(Collections.singleton("testGroup"))
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .count())
+                .isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .involvedGroups(Collections.singleton("testGroup"))
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .list().get(0).getId())
+                .isEqualTo(caseInstance.getId());
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .involvedGroups(Collections.singleton("testGroup"))
+                .caseDefinitionId("undefined")
+                .endOr()
+                .singleResult().getId())
+                .isEqualTo(caseInstance.getId());
     }
 
     @Test
     public void getCaseInstanceByInvolvedGroupOrUser() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            start();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .start();
         cmmnRuntimeService.addGroupIdentityLink(caseInstance.getId(), "testGroup", IdentityLinkType.PARTICIPANT);
         cmmnRuntimeService.addGroupIdentityLink(caseInstance.getId(), "testGroup2", IdentityLinkType.PARTICIPANT);
         cmmnRuntimeService.addUserIdentityLink(caseInstance.getId(), "kermit", IdentityLinkType.CANDIDATE);
-        CaseInstance caseInstance2 = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            start();
+        CaseInstance caseInstance2 = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .start();
         cmmnRuntimeService.addGroupIdentityLink(caseInstance2.getId(), "testGroup2", IdentityLinkType.PARTICIPANT);
-        CaseInstance caseInstance3 = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            start();
+        CaseInstance caseInstance3 = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .start();
         cmmnRuntimeService.addUserIdentityLink(caseInstance3.getId(), "kermit", IdentityLinkType.PARTICIPANT);
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet())).involvedUser("kermit").count(), is(1L));
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet()))
-                .involvedUser("kermit").list().get(0).getId(),
-            is(caseInstance.getId()));
+                .involvedUser("kermit").count())
+                .isEqualTo(1L);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet()))
-                .involvedUser("kermit").singleResult().getId(),
-            is(caseInstance.getId()));
+                .involvedUser("kermit").list().get(0).getId())
+                .isEqualTo(caseInstance.getId());
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet()))
+                .involvedUser("kermit").singleResult().getId())
+                .isEqualTo(caseInstance.getId());
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            or().
-                involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet())).
-                caseDefinitionName("undefinedId").
-            endOr().
-            count(), is(2L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            or().
-            involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet())).
-            caseDefinitionName("undefinedId").
-            endOr().
-            list().size(), is(2));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet()))
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .count())
+                .isEqualTo(2L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet()))
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .list())
+                .hasSize(2);
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            or().
-                involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet())).
-                involvedUser("kermit").
-                caseDefinitionName("undefinedId").
-            endOr().
-            count(), is(3L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            or().
-            involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet())).
-            involvedUser("kermit").
-            caseDefinitionName("undefinedId").
-            endOr().
-            list().size(), is(3));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet()))
+                .involvedUser("kermit")
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .count())
+                .isEqualTo(3L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet()))
+                .involvedUser("kermit")
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .list())
+                .hasSize(3);
     }
 
     @Test
     public void getCaseInstanceByVariable() {
-        cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            variable("queryVariable", "queryVariableValue").
-            start();
-        CaseInstance caseInstance2 = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            variable("queryVariable", "queryVariableValue").
-            variable("queryVariable2", "queryVariableValue2").
-            start();
-        cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            variable("queryVariable", "queryVariableValue").
-            variable("queryVariable3", "queryVariableValue3").
-            start();
+        cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .variable("queryVariable", "queryVariableValue")
+                .start();
+        CaseInstance caseInstance2 = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .variable("queryVariable", "queryVariableValue")
+                .variable("queryVariable2", "queryVariableValue2")
+                .start();
+        cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .variable("queryVariable", "queryVariableValue")
+                .variable("queryVariable3", "queryVariableValue3")
+                .start();
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            variableValueEquals("queryVariable", "queryVariableValue").
-            variableValueEquals("queryVariable2","queryVariableValue2").
-            count(), is(1L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            variableValueEquals("queryVariable", "queryVariableValue").
-            variableValueEquals("queryVariable2", "queryVariableValue2")
-            .list().get(0).getId(),
-            is(caseInstance2.getId()));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-                variableValueEquals("queryVariable", "queryVariableValue").
-                variableValueEquals("queryVariable2", "queryVariableValue2").
-                singleResult().getId(),
-            is(caseInstance2.getId()));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .variableValueEquals("queryVariable", "queryVariableValue")
+                .variableValueEquals("queryVariable2", "queryVariableValue2")
+                .count())
+                .isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .variableValueEquals("queryVariable", "queryVariableValue")
+                .variableValueEquals("queryVariable2", "queryVariableValue2")
+                .list().get(0).getId())
+                .isEqualTo(caseInstance2.getId());
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .variableValueEquals("queryVariable", "queryVariableValue")
+                .variableValueEquals("queryVariable2", "queryVariableValue2")
+                .singleResult().getId())
+                .isEqualTo(caseInstance2.getId());
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            or().
-            variableValueEquals("queryVariable", "queryVariableValue").
-            variableValueEquals("queryVariable2", "queryVariableValue2").
-            caseDefinitionName("undefinedId").
-            endOr().
-            count(), is(3L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().
-            or().
-            variableValueEquals("queryVariable", "queryVariableValue").
-            variableValueEquals("queryVariable2", "queryVariableValue2").
-            caseDefinitionName("undefinedId").
-            endOr().
-            list().size(), is(3));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .variableValueEquals("queryVariable", "queryVariableValue")
+                .variableValueEquals("queryVariable2", "queryVariableValue2")
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .count())
+                .isEqualTo(3L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
+                .or()
+                .variableValueEquals("queryVariable", "queryVariableValue")
+                .variableValueEquals("queryVariable2", "queryVariableValue2")
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .list())
+                .hasSize(3);
     }
 
     @Test
     public void getCaseInstanceByIdWithoutTenant() {
-        CaseInstance caseInstance1 = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            name("testCaseInstance1").
-            start();
-        CaseInstance caseInstance2 = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            name("testCaseInstance2").
-            start();
+        CaseInstance caseInstance1 = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .name("testCaseInstance1")
+                .start();
+        CaseInstance caseInstance2 = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .name("testCaseInstance2")
+                .start();
 
         try {
-            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceId(caseInstance1.getId()).caseInstanceWithoutTenantId().count(),
-                is(1L));
+            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceId(caseInstance1.getId()).caseInstanceWithoutTenantId().count())
+                    .isEqualTo(1L);
         } finally {
             cmmnRuntimeService.terminateCaseInstance(caseInstance2.getId());
             cmmnHistoryService.deleteHistoricCaseInstance(caseInstance2.getId());
@@ -815,8 +917,6 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
             cmmnHistoryService.deleteHistoricCaseInstance(caseInstance1.getId());
         }
 
-
     }
-
 
 }


### PR DESCRIPTION
This is a single file as I had to touch the majority of lines in
the file to move from old style `AssertThat` to the newer style.
In addition the formatting within the file was inconsistent causing
more changes.

