### PR TITLE
Use assertj fluent style in flowable-cmmn-engine (part 4)

### DIFF
--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/history/CmmnHistoryServiceDisableTaskLogTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/history/CmmnHistoryServiceDisableTaskLogTest.java
@@ -41,7 +41,7 @@ public class CmmnHistoryServiceDisableTaskLogTest extends CustomCmmnConfiguratio
     @After
     public void deleteTasks() {
         if (task != null) {
-            assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).count()).isEqualTo(0);
+            assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).count()).isEqualTo(0L);
             cmmnHistoryService.deleteHistoricTaskInstance(task.getId());
             cmmnTaskService.deleteTask(task.getId());
         }
@@ -49,9 +49,13 @@ public class CmmnHistoryServiceDisableTaskLogTest extends CustomCmmnConfiguratio
 
     @Test
     public void createTaskEvent() {
-        task = cmmnTaskService.createTaskBuilder().
-            assignee("testAssignee").
-            create();
+        task = cmmnTaskService.createTaskBuilder()
+                .assignee("testAssignee")
+                .create();
+        assertThat(task).isNotNull();
+        assertThat(task.getId()).isNotNull();
+        assertThat(task.getName()).isNull();
+        assertThat(task.getAssignee()).isEqualTo("testAssignee");
     }
 
     @Test
@@ -59,19 +63,23 @@ public class CmmnHistoryServiceDisableTaskLogTest extends CustomCmmnConfiguratio
         String previousUserId = Authentication.getAuthenticatedUserId();
         Authentication.setAuthenticatedUserId("testUser");
         try {
-            task = cmmnTaskService.createTaskBuilder().
-                assignee("testAssignee").
-                create();
+            task = cmmnTaskService.createTaskBuilder()
+                    .assignee("testAssignee")
+                    .create();
         } finally {
             Authentication.setAuthenticatedUserId(previousUserId);
         }
+        assertThat(task).isNotNull();
+        assertThat(task.getId()).isNotNull();
+        assertThat(task.getName()).isNull();
+        assertThat(task.getAssignee()).isEqualTo("testAssignee");
     }
 
     @Test
     public void createUserTaskLogEntry() {
-        task = cmmnTaskService.createTaskBuilder().
-            assignee("testAssignee").
-            create();
+        task = cmmnTaskService.createTaskBuilder()
+                .assignee("testAssignee")
+                .create();
         cmmnHistoryService.createHistoricTaskLogEntryBuilder().taskId(task.getId()).create();
     }
 

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/history/CmmnHistoryServiceTaskLogTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/history/CmmnHistoryServiceTaskLogTest.java
@@ -13,9 +13,7 @@
 package org.flowable.cmmn.test.history;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.tuple;
 
 import java.util.Calendar;
 import java.util.Date;
@@ -33,7 +31,6 @@ import org.flowable.task.api.Task;
 import org.flowable.task.api.history.HistoricTaskLogEntry;
 import org.flowable.task.api.history.HistoricTaskLogEntryBuilder;
 import org.flowable.task.api.history.HistoricTaskLogEntryQuery;
-import org.hamcrest.MatcherAssert;
 import org.junit.After;
 import org.junit.Test;
 
@@ -63,26 +60,25 @@ public class CmmnHistoryServiceTaskLogTest extends CustomCmmnConfigurationFlowab
 
     protected void deleteTaskWithLogEntries(String taskId) {
         cmmnHistoryService.deleteHistoricTaskInstance(taskId);
-        cmmnTaskService.deleteTask(taskId,true);
+        cmmnTaskService.deleteTask(taskId, true);
     }
 
     @Test
     public void createTaskEvent() {
-        task = cmmnTaskService.createTaskBuilder().
-            assignee("testAssignee").
-            create();
+        task = cmmnTaskService.createTaskBuilder()
+                .assignee("testAssignee")
+                .create();
 
         List<HistoricTaskLogEntry> taskLogsByTaskInstanceId = cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
-        assertThat(taskLogsByTaskInstanceId).size().isEqualTo(1);
-
-        assertThat(taskLogsByTaskInstanceId.get(0)).
-            extracting(HistoricTaskLogEntry::getTaskId).isEqualTo(task.getId());
-        assertThat(taskLogsByTaskInstanceId.get(0)).
-            extracting(HistoricTaskLogEntry::getType).isEqualTo("USER_TASK_CREATED");
-        assertThat(taskLogsByTaskInstanceId.get(0)).
-            extracting(HistoricTaskLogEntry::getTimeStamp).isNotNull();
-        assertThat(taskLogsByTaskInstanceId.get(0)).
-            extracting(HistoricTaskLogEntry::getUserId).isNull();
+        assertThat(taskLogsByTaskInstanceId)
+                .extracting(HistoricTaskLogEntry::getTaskId, HistoricTaskLogEntry::getType)
+                .containsExactly(tuple(task.getId(), "USER_TASK_CREATED"));
+        assertThat(taskLogsByTaskInstanceId)
+                .extracting(HistoricTaskLogEntry::getTimeStamp)
+                .isNotNull();
+        assertThat(taskLogsByTaskInstanceId)
+                .extracting(HistoricTaskLogEntry::getUserId)
+                .containsOnlyNulls();
     }
 
     @Test
@@ -90,15 +86,14 @@ public class CmmnHistoryServiceTaskLogTest extends CustomCmmnConfigurationFlowab
         String previousUserId = Authentication.getAuthenticatedUserId();
         Authentication.setAuthenticatedUserId("testUser");
         try {
-            task = cmmnTaskService.createTaskBuilder().
-                assignee("testAssignee").
-                create();
+            task = cmmnTaskService.createTaskBuilder()
+                    .assignee("testAssignee")
+                    .create();
 
             List<HistoricTaskLogEntry> taskLogsByTaskInstanceId = cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
-            assertThat(taskLogsByTaskInstanceId).size().isEqualTo(1);
-
-            assertThat(taskLogsByTaskInstanceId.get(0)).
-                extracting(HistoricTaskLogEntry::getUserId).isEqualTo("testUser");
+            assertThat(taskLogsByTaskInstanceId)
+                    .extracting(HistoricTaskLogEntry::getUserId)
+                    .containsExactly("testUser");
         } finally {
             Authentication.setAuthenticatedUserId(previousUserId);
         }
@@ -122,8 +117,8 @@ public class CmmnHistoryServiceTaskLogTest extends CustomCmmnConfigurationFlowab
         try {
             List<HistoricTaskLogEntry> taskLogsByTaskInstanceId = cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(null).list();
 
-            assertThat(taskLogsByTaskInstanceId).size().isEqualTo(3L);
-            
+            assertThat(taskLogsByTaskInstanceId).hasSize(3);
+
         } finally {
             deleteTaskWithLogEntries(taskC.getId());
             deleteTaskWithLogEntries(taskB.getId());
@@ -133,119 +128,146 @@ public class CmmnHistoryServiceTaskLogTest extends CustomCmmnConfigurationFlowab
 
     @Test
     public void deleteTaskEventLogEntry() {
-        task = cmmnTaskService.createTaskBuilder().
-            assignee("testAssignee").
-            create();
+        task = cmmnTaskService.createTaskBuilder()
+                .assignee("testAssignee")
+                .create();
         List<HistoricTaskLogEntry> taskLogsByTaskInstanceId = cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
-        assertThat(
-            taskLogsByTaskInstanceId
-        ).size().isEqualTo(1);
+        assertThat(taskLogsByTaskInstanceId).hasSize(1);
 
         cmmnHistoryService.deleteHistoricTaskLogEntry(taskLogsByTaskInstanceId.get(0).getLogNumber());
 
         taskLogsByTaskInstanceId = cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
-        assertThat(
-            taskLogsByTaskInstanceId
-        ).isEmpty();
+        assertThat(taskLogsByTaskInstanceId).isEmpty();
     }
 
     @Test
     public void deleteNonExistingTaskEventLogEntry() {
         task = cmmnTaskService.createTaskBuilder().create();
-        
+
         // non existing log entry delete should be successful
         cmmnHistoryService.deleteHistoricTaskLogEntry(9999);
 
-        assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list().size()).isEqualTo(1);
+        assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list()).hasSize(1);
     }
 
     @Test
     public void taskAssigneeEvent() {
-        task = cmmnTaskService.createTaskBuilder().
-            assignee("initialAssignee").
-            create();
+        task = cmmnTaskService.createTaskBuilder()
+                .assignee("initialAssignee")
+                .create();
 
         cmmnTaskService.setAssignee(task.getId(), "newAssignee");
         List<HistoricTaskLogEntry> taskLogEntries = cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
 
-        assertThat(taskLogEntries).size().isEqualTo(2);
-        assertThat(taskLogEntries.get(1)).
-            extracting(assigneeTaskLogEntry -> assigneeTaskLogEntry.getData()).
-            isEqualTo("{\"newAssigneeId\":\"newAssignee\",\"previousAssigneeId\":\"initialAssignee\"}");
-        assertThat(taskLogEntries.get(1)).extracting(HistoricTaskLogEntry::getTimeStamp).isNotNull();
-        assertThat(taskLogEntries.get(1)).extracting(HistoricTaskLogEntry::getTaskId).isEqualTo(task.getId());
-        assertThat(taskLogEntries.get(1)).extracting(HistoricTaskLogEntry::getUserId).isNull();
-        assertThat(taskLogEntries.get(1)).extracting(HistoricTaskLogEntry::getType).isEqualTo("USER_TASK_ASSIGNEE_CHANGED");
+        assertThat(taskLogEntries).hasSize(2);
+        assertThat(taskLogEntries.get(1))
+                .extracting(HistoricTaskLogEntry::getData)
+                .isEqualToComparingOnlyGivenFields("{\"newAssigneeId\":\"newAssignee\",\"previousAssigneeId\":\"initialAssignee\"}");
+        assertThat(taskLogEntries.get(1))
+                .extracting(HistoricTaskLogEntry::getTimeStamp)
+                .isNotNull();
+        assertThat(taskLogEntries.get(1))
+                .extracting(HistoricTaskLogEntry::getTaskId)
+                .isEqualTo(task.getId());
+        assertThat(taskLogEntries.get(1))
+                .extracting(HistoricTaskLogEntry::getUserId)
+                .isNull();
+        assertThat(taskLogEntries.get(1))
+                .extracting(HistoricTaskLogEntry::getType)
+                .isEqualTo("USER_TASK_ASSIGNEE_CHANGED");
     }
 
     @Test
     public void changeAssigneeTaskEventAsAuthenticatedUser() {
         assertThatAuthenticatedUserIsSet(
-            taskId -> cmmnTaskService.setAssignee(taskId, "newAssignee")
+                taskId -> cmmnTaskService.setAssignee(taskId, "newAssignee")
         );
     }
 
     @Test
     public void taskOwnerEvent() {
-        task = cmmnTaskService.createTaskBuilder().
-            assignee("initialAssignee").
-            create();
+        task = cmmnTaskService.createTaskBuilder()
+                .assignee("initialAssignee")
+                .create();
 
         cmmnTaskService.setOwner(task.getId(), "newOwner");
         List<HistoricTaskLogEntry> taskLogEntries = cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
 
-        assertThat(taskLogEntries).size().isEqualTo(2);
-        assertThat(taskLogEntries.get(1).getData()).
-            contains("\"previousOwnerId\":null").
-            contains("\"newOwnerId\":\"newOwner\"");
-        assertThat(taskLogEntries.get(1)).extracting(HistoricTaskLogEntry::getTimeStamp).isNotNull();
-        assertThat(taskLogEntries.get(1)).extracting(HistoricTaskLogEntry::getTaskId).isEqualTo(task.getId());
-        assertThat(taskLogEntries.get(1)).extracting(HistoricTaskLogEntry::getUserId).isNull();
-        assertThat(taskLogEntries.get(1)).extracting(HistoricTaskLogEntry::getType).isEqualTo("USER_TASK_OWNER_CHANGED");
+        assertThat(taskLogEntries).hasSize(2);
+        assertThat(taskLogEntries.get(1))
+                .extracting(HistoricTaskLogEntry::getData)
+                .isEqualToComparingOnlyGivenFields("{\"previousOwnerId\":null\", \"newOwnerId\":\"newOwner\"}");
+        assertThat(taskLogEntries.get(1))
+                .extracting(HistoricTaskLogEntry::getTimeStamp)
+                .isNotNull();
+        assertThat(taskLogEntries.get(1))
+                .extracting(HistoricTaskLogEntry::getTaskId)
+                .isEqualTo(task.getId());
+        assertThat(taskLogEntries.get(1))
+                .extracting(HistoricTaskLogEntry::getUserId)
+                .isNull();
+        assertThat(taskLogEntries.get(1))
+                .extracting(HistoricTaskLogEntry::getType)
+                .isEqualTo("USER_TASK_OWNER_CHANGED");
     }
 
     @Test
     public void changeOwnerTaskEventAsAuthenticatedUser() {
         assertThatAuthenticatedUserIsSet(
-            taskId -> cmmnTaskService.setOwner(taskId, "newOwner")
+                taskId -> cmmnTaskService.setOwner(taskId, "newOwner")
         );
     }
 
     @Test
     public void claimTaskEvent() {
-        task = cmmnTaskService.createTaskBuilder().
-            create();
+        task = cmmnTaskService.createTaskBuilder().create();
 
         cmmnTaskService.claim(task.getId(), "testUser");
 
         List<HistoricTaskLogEntry> taskLogEntries = cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
-        assertThat(taskLogEntries).size().isEqualTo(2);
-        assertThat(taskLogEntries.get(1).getData()).
-            contains("\"newAssigneeId\":\"testUser\"").
-            contains("\"previousAssigneeId\":null");
-        assertThat(taskLogEntries.get(1)).extracting(HistoricTaskLogEntry::getTimeStamp).isNotNull();
-        assertThat(taskLogEntries.get(1)).extracting(HistoricTaskLogEntry::getTaskId).isEqualTo(task.getId());
-        assertThat(taskLogEntries.get(1)).extracting(HistoricTaskLogEntry::getUserId).isNull();
-        assertThat(taskLogEntries.get(1)).extracting(HistoricTaskLogEntry::getType).isEqualTo("USER_TASK_ASSIGNEE_CHANGED");
+        assertThat(taskLogEntries).hasSize(2);
+        assertThat(taskLogEntries.get(1))
+                .extracting(HistoricTaskLogEntry::getData)
+                .isEqualToComparingOnlyGivenFields("{\"newAssigneeId\":\"testUser\", \"previousAssigneeId\":null\"}");
+        assertThat(taskLogEntries.get(1))
+                .extracting(HistoricTaskLogEntry::getTimeStamp)
+                .isNotNull();
+        assertThat(taskLogEntries.get(1))
+                .extracting(HistoricTaskLogEntry::getTaskId)
+                .isEqualTo(task.getId());
+        assertThat(taskLogEntries.get(1))
+                .extracting(HistoricTaskLogEntry::getUserId)
+                .isNull();
+        assertThat(taskLogEntries.get(1))
+                .extracting(HistoricTaskLogEntry::getType)
+                .isEqualTo("USER_TASK_ASSIGNEE_CHANGED");
     }
 
     @Test
     public void unClaimTaskEvent() {
-        task = cmmnTaskService.createTaskBuilder().
-            assignee("initialAssignee").
-            create();
+        task = cmmnTaskService.createTaskBuilder()
+                .assignee("initialAssignee")
+                .create();
 
         cmmnTaskService.unclaim(task.getId());
 
         List<HistoricTaskLogEntry> taskLogEntries = cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
-        assertThat(taskLogEntries).size().isEqualTo(2);
-        assertThat(taskLogEntries.get(1).getData()).
-            contains("\"newAssigneeId\":null").
-            contains("\"previousAssigneeId\":\"initialAssignee\"");
-        assertThat(taskLogEntries.get(1)).extracting(HistoricTaskLogEntry::getTimeStamp).isNotNull();
-        assertThat(taskLogEntries.get(1)).extracting(HistoricTaskLogEntry::getTaskId).isEqualTo(task.getId());
-        assertThat(taskLogEntries.get(1)).extracting(HistoricTaskLogEntry::getUserId).isNull();
-        assertThat(taskLogEntries.get(1)).extracting(HistoricTaskLogEntry::getType).isEqualTo("USER_TASK_ASSIGNEE_CHANGED");
+        assertThat(taskLogEntries).hasSize(2);
+        assertThat(taskLogEntries.get(1))
+                .extracting(HistoricTaskLogEntry::getData)
+                .isEqualToComparingOnlyGivenFields("{\"newAssigneeId\":null\", \"previousAssigneeId\":\"initialAssignee\"}");
+        assertThat(taskLogEntries.get(1))
+                .extracting(HistoricTaskLogEntry::getTimeStamp)
+                .isNotNull();
+        assertThat(taskLogEntries.get(1))
+                .extracting(HistoricTaskLogEntry::getTaskId)
+                .isEqualTo(task.getId());
+        assertThat(taskLogEntries.get(1))
+                .extracting(HistoricTaskLogEntry::getUserId)
+                .isNull();
+        assertThat(taskLogEntries.get(1))
+                .extracting(HistoricTaskLogEntry::getType)
+                .isEqualTo("USER_TASK_ASSIGNEE_CHANGED");
     }
 
     @Test
@@ -255,37 +277,45 @@ public class CmmnHistoryServiceTaskLogTest extends CustomCmmnConfigurationFlowab
         cmmnTaskService.setPriority(task.getId(), Integer.MAX_VALUE);
         List<HistoricTaskLogEntry> taskLogEntries = cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
 
-        assertThat(taskLogEntries).size().isEqualTo(2);
-        assertThat(taskLogEntries.get(1).getData()).
-            contains("\"newPriority\":2147483647").
-            contains("\"previousPriority\":50");
-        assertThat(taskLogEntries.get(1)).extracting(HistoricTaskLogEntry::getTimeStamp).isNotNull();
-        assertThat(taskLogEntries.get(1)).extracting(HistoricTaskLogEntry::getTaskId).isEqualTo(task.getId());
-        assertThat(taskLogEntries.get(1)).extracting(HistoricTaskLogEntry::getUserId).isNull();
-        assertThat(taskLogEntries.get(1)).extracting(HistoricTaskLogEntry::getType).isEqualTo("USER_TASK_PRIORITY_CHANGED");
+        assertThat(taskLogEntries).hasSize(2);
+        assertThat(taskLogEntries.get(1))
+                .extracting(HistoricTaskLogEntry::getData)
+                .isEqualToComparingOnlyGivenFields("{\"newPriority\":2147483647, \"previousPriority\":50}");
+        assertThat(taskLogEntries.get(1))
+                .extracting(HistoricTaskLogEntry::getTimeStamp)
+                .isNotNull();
+        assertThat(taskLogEntries.get(1))
+                .extracting(HistoricTaskLogEntry::getTaskId)
+                .isEqualTo(task.getId());
+        assertThat(taskLogEntries.get(1))
+                .extracting(HistoricTaskLogEntry::getUserId)
+                .isNull();
+        assertThat(taskLogEntries.get(1))
+                .extracting(HistoricTaskLogEntry::getType)
+                .isEqualTo("USER_TASK_PRIORITY_CHANGED");
     }
 
     @Test
     public void changePriorityEventAsAuthenticatedUser() {
         assertThatAuthenticatedUserIsSet(
-            taskId ->  cmmnTaskService.setPriority(taskId, Integer.MAX_VALUE)
+                taskId -> cmmnTaskService.setPriority(taskId, Integer.MAX_VALUE)
         );
     }
 
     protected void assertThatAuthenticatedUserIsSet(Consumer<String> functionToAssert) {
         String previousUserId = Authentication.getAuthenticatedUserId();
-        task = cmmnTaskService.createTaskBuilder().
-            assignee("testAssignee").
-            create();
+        task = cmmnTaskService.createTaskBuilder()
+                .assignee("testAssignee")
+                .create();
         Authentication.setAuthenticatedUserId("testUser");
         try {
             functionToAssert.accept(task.getId());
 
             List<HistoricTaskLogEntry> taskLogsByTaskInstanceId = cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
-            assertThat(taskLogsByTaskInstanceId).size().isEqualTo(2);
-
-            assertThat(taskLogsByTaskInstanceId.get(1)).
-                extracting(HistoricTaskLogEntry::getUserId).isEqualTo("testUser");
+            assertThat(taskLogsByTaskInstanceId).hasSize(2);
+            assertThat(taskLogsByTaskInstanceId.get(1))
+                    .extracting(HistoricTaskLogEntry::getUserId)
+                    .isEqualTo("testUser");
         } finally {
             Authentication.setAuthenticatedUserId(previousUserId);
         }
@@ -298,14 +328,22 @@ public class CmmnHistoryServiceTaskLogTest extends CustomCmmnConfigurationFlowab
         cmmnTaskService.setDueDate(task.getId(), new Date());
         List<HistoricTaskLogEntry> taskLogEntries = cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
 
-        assertThat(taskLogEntries).size().isEqualTo(2);
-        assertThat(taskLogEntries.get(1).getData()).
-            contains("\"newDueDate\":").
-            contains("\"previousDueDate\":null");
-        assertThat(taskLogEntries.get(1)).extracting(HistoricTaskLogEntry::getTimeStamp).isNotNull();
-        assertThat(taskLogEntries.get(1)).extracting(HistoricTaskLogEntry::getTaskId).isEqualTo(task.getId());
-        assertThat(taskLogEntries.get(1)).extracting(HistoricTaskLogEntry::getUserId).isNull();
-        assertThat(taskLogEntries.get(1)).extracting(HistoricTaskLogEntry::getType).isEqualTo("USER_TASK_DUEDATE_CHANGED");
+        assertThat(taskLogEntries).hasSize(2);
+        assertThat(taskLogEntries.get(1))
+                .extracting(HistoricTaskLogEntry::getData)
+                .isEqualToComparingOnlyGivenFields("{\"newDueDate\":null, \"previousDueDate\":null}");
+        assertThat(taskLogEntries.get(1))
+                .extracting(HistoricTaskLogEntry::getTimeStamp)
+                .isNotNull();
+        assertThat(taskLogEntries.get(1))
+                .extracting(HistoricTaskLogEntry::getTaskId)
+                .isEqualTo(task.getId());
+        assertThat(taskLogEntries.get(1))
+                .extracting(HistoricTaskLogEntry::getUserId)
+                .isNull();
+        assertThat(taskLogEntries.get(1))
+                .extracting(HistoricTaskLogEntry::getType)
+                .isEqualTo("USER_TASK_DUEDATE_CHANGED");
     }
 
     @Test
@@ -319,13 +357,13 @@ public class CmmnHistoryServiceTaskLogTest extends CustomCmmnConfigurationFlowab
         cmmnTaskService.saveTask(task);
 
         List<HistoricTaskLogEntry> taskLogEntries = cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
-        assertThat(taskLogEntries).as("Only User task created log entry is expected").size().isEqualTo(1);
+        assertThat(taskLogEntries).as("Only User task created log entry is expected").hasSize(1);
     }
 
     @Test
     public void changeDueDateEventAsAuthenticatedUser() {
         assertThatAuthenticatedUserIsSet(
-            taskId ->  cmmnTaskService.setDueDate(taskId, new Date())
+                taskId -> cmmnTaskService.setDueDate(taskId, new Date())
         );
     }
 
@@ -341,14 +379,23 @@ public class CmmnHistoryServiceTaskLogTest extends CustomCmmnConfigurationFlowab
 
         List<HistoricTaskLogEntry> logEntries = cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
 
-        MatcherAssert.assertThat(logEntries.size(), is(2));
+        assertThat(logEntries).hasSize(2);
         HistoricTaskLogEntry historicTaskLogEntry = logEntries.get(1);
         assertThat(historicTaskLogEntry.getLogNumber()).isNotNull();
-        assertThat(historicTaskLogEntry.getUserId()).isEqualTo("testUser");
-        assertThat(historicTaskLogEntry.getTaskId()).isEqualTo(task.getId());
-        assertThat(historicTaskLogEntry.getType()).isEqualTo("customType");
-        assertThat(historicTaskLogEntry.getTimeStamp()).isEqualTo(getInsertDate());
-        assertThat(historicTaskLogEntry.getData()).isEqualTo("testData");
+        assertThat(historicTaskLogEntry)
+                .extracting(
+                        HistoricTaskLogEntry::getUserId,
+                        HistoricTaskLogEntry::getTaskId,
+                        HistoricTaskLogEntry::getType,
+                        HistoricTaskLogEntry::getTimeStamp,
+                        HistoricTaskLogEntry::getData)
+                .containsExactly(
+                        "testUser",
+                        task.getId(),
+                        "customType",
+                        getInsertDate(),
+                        "testData"
+                );
         cmmnHistoryService.deleteHistoricTaskLogEntry(logEntries.get(0).getLogNumber());
     }
 
@@ -360,14 +407,15 @@ public class CmmnHistoryServiceTaskLogTest extends CustomCmmnConfigurationFlowab
         historicTaskLogEntryBuilder.create();
         List<HistoricTaskLogEntry> logEntries = cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
 
-        MatcherAssert.assertThat(logEntries.size(), is(2));
+        assertThat(logEntries).hasSize(2);
         HistoricTaskLogEntry historicTaskLogEntry = logEntries.get(1);
-        assertThat(historicTaskLogEntry.getLogNumber()).isNotNull();
-        assertThat(historicTaskLogEntry.getUserId()).isNull();
+        assertThat(historicTaskLogEntry)
+                .extracting(HistoricTaskLogEntry::getLogNumber, HistoricTaskLogEntry::getTimeStamp)
+                .doesNotContainNull();
+        assertThat(historicTaskLogEntry)
+                .extracting(HistoricTaskLogEntry::getUserId, HistoricTaskLogEntry::getType, HistoricTaskLogEntry::getData)
+                .containsNull();
         assertThat(historicTaskLogEntry.getTaskId()).isEqualTo(task.getId());
-        assertThat(historicTaskLogEntry.getType()).isNull();
-        assertThat(historicTaskLogEntry.getTimeStamp()).isNotNull();
-        assertThat(historicTaskLogEntry.getData()).isNull();
     }
 
     @Test
@@ -382,51 +430,47 @@ public class CmmnHistoryServiceTaskLogTest extends CustomCmmnConfigurationFlowab
 
         List<HistoricTaskLogEntry> logEntries = cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
 
-        MatcherAssert.assertThat(logEntries.size(), is(2));
+        assertThat(logEntries).hasSize(2);
         HistoricTaskLogEntry historicTaskLogEntry = logEntries.get(1);
-        assertThat(historicTaskLogEntry.getLogNumber()).isNotNull();
-        assertThat(historicTaskLogEntry.getTimeStamp()).isNotNull();
+        assertThat(historicTaskLogEntry)
+                .extracting(HistoricTaskLogEntry::getLogNumber, HistoricTaskLogEntry::getTimeStamp)
+                .doesNotContainNull();
     }
 
     @Test
     public void logCaseTaskEvents() {
         deployOneHumanTaskCaseModel();
         CaseInstance oneTaskCase = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("oneTaskCase").start();
-        assertNotNull(oneTaskCase);
+        assertThat(oneTaskCase).isNotNull();
 
         Task task = cmmnTaskService.createTaskQuery().caseInstanceId(oneTaskCase.getId()).singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         try {
             cmmnTaskService.setAssignee(task.getId(), "newAssignee");
             cmmnTaskService.setOwner(task.getId(), "newOwner");
             cmmnTaskService.complete(task.getId());
 
             List<HistoricTaskLogEntry> logEntries = cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
-            assertThat(logEntries).size().isEqualTo(4);
-            assertThat(logEntries.get(0)).
-                extracting(taskLogEntry -> taskLogEntry.getType()).isEqualTo("USER_TASK_CREATED")
-            ;
-            assertThat(logEntries.get(0)).
-                extracting(taskLogEntry -> taskLogEntry.getScopeType()).isEqualTo(ScopeTypes.CMMN)
-            ;
-            assertThat(logEntries.get(0)).
-                extracting(taskLogEntry -> taskLogEntry.getScopeId()).isEqualTo(oneTaskCase.getId())
-            ;
-            assertThat(logEntries.get(0)).
-                extracting(taskLogEntry -> taskLogEntry.getSubScopeId()).isEqualTo(task.getSubScopeId())
-            ;
-            assertThat(logEntries.get(0)).
-                extracting(taskLogEntry -> taskLogEntry.getScopeDefinitionId()).isEqualTo(oneTaskCase.getCaseDefinitionId())
-            ;
-            assertThat(logEntries.get(1)).
-                extracting(taskLogEntry -> taskLogEntry.getType()).isEqualTo("USER_TASK_ASSIGNEE_CHANGED")
-            ;
-            assertThat(logEntries.get(2)).
-                extracting(taskLogEntry -> taskLogEntry.getType()).isEqualTo("USER_TASK_OWNER_CHANGED")
-            ;
-            assertThat(logEntries.get(3)).
-                extracting(taskLogEntry -> taskLogEntry.getType()).isEqualTo("USER_TASK_COMPLETED")
-            ;
+
+            assertThat(logEntries.get(0))
+                    .extracting(
+                            HistoricTaskLogEntry::getType,
+                            HistoricTaskLogEntry::getScopeType,
+                            HistoricTaskLogEntry::getScopeId,
+                            HistoricTaskLogEntry::getSubScopeId,
+                            HistoricTaskLogEntry::getScopeDefinitionId
+                    )
+                    .containsExactly(
+                            "USER_TASK_CREATED",
+                            ScopeTypes.CMMN,
+                            oneTaskCase.getId(),
+                            task.getSubScopeId(),
+                            oneTaskCase.getCaseDefinitionId()
+                    );
+
+            assertThat(logEntries)
+                    .extracting(HistoricTaskLogEntry::getType)
+                    .containsExactly("USER_TASK_CREATED", "USER_TASK_ASSIGNEE_CHANGED", "USER_TASK_OWNER_CHANGED", "USER_TASK_COMPLETED");
         } finally {
             deleteTaskWithLogEntries(task.getId());
         }
@@ -436,23 +480,23 @@ public class CmmnHistoryServiceTaskLogTest extends CustomCmmnConfigurationFlowab
     public void logAddCandidateUser() {
         deployOneHumanTaskCaseModel();
         CaseInstance oneTaskCase = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("oneTaskCase").start();
-        assertNotNull(oneTaskCase);
+        assertThat(oneTaskCase).isNotNull();
         Task task = cmmnTaskService.createTaskQuery().caseInstanceId(oneTaskCase.getId()).singleResult();
 
         try {
-            assertNotNull(oneTaskCase);
-            assertNotNull(task);
+            assertThat(oneTaskCase).isNotNull();
+            assertThat(task).isNotNull();
 
             cmmnTaskService.addUserIdentityLink(task.getId(), "newCandidateUser", IdentityLinkType.CANDIDATE);
 
             List<HistoricTaskLogEntry> logEntries = cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
-            assertThat(logEntries).size().isEqualTo(2);
-            assertThat(logEntries.get(1)).
-                extracting(HistoricTaskLogEntry::getType).isEqualTo("USER_TASK_IDENTITY_LINK_ADDED");
-            assertThat(logEntries.get(1).getData()).contains(
-                "\"type\":\"candidate\"",
-                "\"userId\":\"newCandidateUser\""
-            );
+            assertThat(logEntries).hasSize(2);
+            assertThat(logEntries.get(1))
+                    .extracting(HistoricTaskLogEntry::getType)
+                    .isEqualTo("USER_TASK_IDENTITY_LINK_ADDED");
+            assertThat(logEntries.get(1))
+                    .extracting(HistoricTaskLogEntry::getData)
+                    .isEqualToComparingOnlyGivenFields("{\"type\":\"candidate\", \"userId\":\"newCandidateUser\"}");
         } finally {
             cmmnTaskService.complete(task.getId());
             deleteTaskWithLogEntries(task.getId());
@@ -463,21 +507,20 @@ public class CmmnHistoryServiceTaskLogTest extends CustomCmmnConfigurationFlowab
     public void logAddCandidateGroup() {
         deployOneHumanTaskCaseModel();
         CaseInstance oneTaskCase = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("oneTaskCase").start();
-        assertNotNull(oneTaskCase);
+        assertThat(oneTaskCase).isNotNull();
         Task task = cmmnTaskService.createTaskQuery().caseInstanceId(oneTaskCase.getId()).singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         try {
-
             cmmnTaskService.addGroupIdentityLink(task.getId(), "newCandidateGroup", IdentityLinkType.CANDIDATE);
 
             List<HistoricTaskLogEntry> logEntries = cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
-            assertThat(logEntries).size().isEqualTo(2);
-            assertThat(logEntries.get(1)).
-                extracting(HistoricTaskLogEntry::getType).isEqualTo("USER_TASK_IDENTITY_LINK_ADDED");
-            assertThat(logEntries.get(1).getData()).contains(
-                "\"type\":\"candidate\"",
-                "\"groupId\":\"newCandidateGroup\""
-            );
+            assertThat(logEntries).hasSize(2);
+            assertThat(logEntries.get(1))
+                    .extracting(HistoricTaskLogEntry::getType)
+                    .isEqualTo("USER_TASK_IDENTITY_LINK_ADDED");
+            assertThat(logEntries.get(1))
+                    .extracting(HistoricTaskLogEntry::getData)
+                    .isEqualToComparingOnlyGivenFields("{\"type\":\"candidate\", \"userId\":\"newCandidateGroup\"}");
         } finally {
             cmmnTaskService.complete(task.getId());
             deleteTaskWithLogEntries(task.getId());
@@ -488,23 +531,22 @@ public class CmmnHistoryServiceTaskLogTest extends CustomCmmnConfigurationFlowab
     public void logDeleteCandidateGroup() {
         deployOneHumanTaskCaseModel();
         CaseInstance oneTaskCase = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("oneTaskCase").start();
-        assertNotNull(oneTaskCase);
+        assertThat(oneTaskCase).isNotNull();
         Task task = cmmnTaskService.createTaskQuery().caseInstanceId(oneTaskCase.getId()).singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
 
         cmmnTaskService.addGroupIdentityLink(task.getId(), "newCandidateGroup", IdentityLinkType.CANDIDATE);
         try {
-
             cmmnTaskService.deleteGroupIdentityLink(task.getId(), "newCandidateGroup", IdentityLinkType.CANDIDATE);
 
             List<HistoricTaskLogEntry> logEntries = cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
-            assertThat(logEntries).size().isEqualTo(3);
-            assertThat(logEntries.get(2)).
-                extracting(HistoricTaskLogEntry::getType).isEqualTo("USER_TASK_IDENTITY_LINK_REMOVED");
-            assertThat(logEntries.get(2).getData()).contains(
-                "\"type\":\"candidate\"",
-                "\"groupId\":\"newCandidateGroup\""
-            );
+            assertThat(logEntries).hasSize(3);
+            assertThat(logEntries.get(2))
+                    .extracting(HistoricTaskLogEntry::getType)
+                    .isEqualTo("USER_TASK_IDENTITY_LINK_REMOVED");
+            assertThat(logEntries.get(2))
+                    .extracting(HistoricTaskLogEntry::getData)
+                    .isEqualToComparingOnlyGivenFields("{\"type\":\"candidate\", \"userId\":\"newCandidateGroup\"}");
         } finally {
             cmmnTaskService.complete(task.getId());
             deleteTaskWithLogEntries(task.getId());
@@ -515,21 +557,21 @@ public class CmmnHistoryServiceTaskLogTest extends CustomCmmnConfigurationFlowab
     public void logDeleteCandidateUser() {
         deployOneHumanTaskCaseModel();
         CaseInstance oneTaskCase = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("oneTaskCase").start();
-        assertNotNull(oneTaskCase);
+        assertThat(oneTaskCase).isNotNull();
         Task task = cmmnTaskService.createTaskQuery().caseInstanceId(oneTaskCase.getId()).singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         cmmnTaskService.addUserIdentityLink(task.getId(), "newCandidateUser", IdentityLinkType.CANDIDATE);
 
         try {
             cmmnTaskService.deleteUserIdentityLink(task.getId(), "newCandidateUser", IdentityLinkType.CANDIDATE);
             List<HistoricTaskLogEntry> logEntries = cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
-            assertThat(logEntries).size().isEqualTo(3);
-            assertThat(logEntries.get(2)).
-                extracting(HistoricTaskLogEntry::getType).isEqualTo("USER_TASK_IDENTITY_LINK_REMOVED");
-            assertThat(logEntries.get(2).getData()).contains(
-                "\"type\":\"candidate\"",
-                "\"userId\":\"newCandidateUser\""
-            );
+            assertThat(logEntries).hasSize(3);
+            assertThat(logEntries.get(2))
+                    .extracting(HistoricTaskLogEntry::getType)
+                    .isEqualTo("USER_TASK_IDENTITY_LINK_REMOVED");
+            assertThat(logEntries.get(2))
+                    .extracting(HistoricTaskLogEntry::getData)
+                    .isEqualToComparingOnlyGivenFields("{\"type\":\"candidate\", \"userId\":\"newCandidateUser\"}");
         } finally {
             cmmnTaskService.complete(task.getId());
             deleteTaskWithLogEntries(task.getId());
@@ -538,19 +580,17 @@ public class CmmnHistoryServiceTaskLogTest extends CustomCmmnConfigurationFlowab
 
     @Test
     public void queryForTaskLogEntriesByTaskId() {
-        task = cmmnTaskService.createTaskBuilder().
-            assignee("testAssignee").
-            create();
+        task = cmmnTaskService.createTaskBuilder()
+                .assignee("testAssignee")
+                .create();
         Task anotherTask = cmmnTaskService.createTaskBuilder().create();
 
         try {
             List<HistoricTaskLogEntry> logEntries = cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
-            assertThat(logEntries.size()).isEqualTo(1);
-            assertThat(logEntries.get(0)).extracting(HistoricTaskLogEntry::getTaskId).isEqualTo(task.getId());
-
-            assertThat(
-                cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).count()
-            ).isEqualTo(1l);
+            assertThat(logEntries)
+                    .extracting(HistoricTaskLogEntry::getTaskId)
+                    .containsExactly(task.getId());
+            assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).count()).isEqualTo(1l);
         } finally {
             deleteTaskWithLogEntries(anotherTask.getId());
         }
@@ -559,15 +599,15 @@ public class CmmnHistoryServiceTaskLogTest extends CustomCmmnConfigurationFlowab
     @Test
     public void queryForTaskLogEntriesByUserId() {
         assertThatTaskLogIsFetched(
-            cmmnHistoryService.createHistoricTaskLogEntryBuilder().userId("testUser"),
-            cmmnHistoryService.createHistoricTaskLogEntryQuery().userId("testUser")
+                cmmnHistoryService.createHistoricTaskLogEntryBuilder().userId("testUser"),
+                cmmnHistoryService.createHistoricTaskLogEntryQuery().userId("testUser")
         );
     }
 
     protected void assertThatTaskLogIsFetched(HistoricTaskLogEntryBuilder historicTaskLogEntryBuilder, HistoricTaskLogEntryQuery historicTaskLogEntryQuery) {
-        task = cmmnTaskService.createTaskBuilder().
-            assignee("testAssignee").
-            create();
+        task = cmmnTaskService.createTaskBuilder()
+                .assignee("testAssignee")
+                .create();
         Task anotherTask = cmmnTaskService.createTaskBuilder().create();
         historicTaskLogEntryBuilder.taskId(task.getId()).create();
         historicTaskLogEntryBuilder.taskId(task.getId()).create();
@@ -575,15 +615,15 @@ public class CmmnHistoryServiceTaskLogTest extends CustomCmmnConfigurationFlowab
 
         try {
             List<HistoricTaskLogEntry> logEntries = historicTaskLogEntryQuery.list();
-            assertThat(logEntries.size()).isEqualTo(3);
+            assertThat(logEntries).hasSize(3);
             assertThat(logEntries).extracting(HistoricTaskLogEntry::getTaskId).containsExactly(task.getId(), task.getId(), task.getId());
 
             assertThat(historicTaskLogEntryQuery.count()).isEqualTo(3);
 
             List<HistoricTaskLogEntry> pagedLogEntries = historicTaskLogEntryQuery.listPage(1, 1);
-            assertThat(pagedLogEntries.size()).isEqualTo(1);
+            assertThat(pagedLogEntries).hasSize(1);
             assertThat(pagedLogEntries.get(0)).isEqualToComparingFieldByField(logEntries.get(1));
-            
+
         } finally {
             deleteTaskWithLogEntries(anotherTask.getId());
             cmmnTaskService.deleteTask(anotherTask.getId());
@@ -593,56 +633,56 @@ public class CmmnHistoryServiceTaskLogTest extends CustomCmmnConfigurationFlowab
     @Test
     public void queryForTaskLogEntriesByType() {
         assertThatTaskLogIsFetched(
-            cmmnHistoryService.createHistoricTaskLogEntryBuilder().type("testType"),
-            cmmnHistoryService.createHistoricTaskLogEntryQuery().type("testType")
+                cmmnHistoryService.createHistoricTaskLogEntryBuilder().type("testType"),
+                cmmnHistoryService.createHistoricTaskLogEntryQuery().type("testType")
         );
     }
 
     @Test
     public void queryForTaskLogEntriesByProcessInstanceId() {
         assertThatTaskLogIsFetched(
-            cmmnHistoryService.createHistoricTaskLogEntryBuilder().processInstanceId("testProcess"),
-            cmmnHistoryService.createHistoricTaskLogEntryQuery().processInstanceId("testProcess")
+                cmmnHistoryService.createHistoricTaskLogEntryBuilder().processInstanceId("testProcess"),
+                cmmnHistoryService.createHistoricTaskLogEntryQuery().processInstanceId("testProcess")
         );
     }
 
     @Test
     public void queryForTaskLogEntriesByScopeId() {
         assertThatTaskLogIsFetched(
-            cmmnHistoryService.createHistoricTaskLogEntryBuilder().scopeId("testScopeId"),
-            cmmnHistoryService.createHistoricTaskLogEntryQuery().scopeId("testScopeId")
+                cmmnHistoryService.createHistoricTaskLogEntryBuilder().scopeId("testScopeId"),
+                cmmnHistoryService.createHistoricTaskLogEntryQuery().scopeId("testScopeId")
         );
     }
 
     @Test
     public void queryForTaskLogEntriesBySubScopeId() {
         assertThatTaskLogIsFetched(
-            cmmnHistoryService.createHistoricTaskLogEntryBuilder().subScopeId("testSubScopeId"),
-            cmmnHistoryService.createHistoricTaskLogEntryQuery().subScopeId("testSubScopeId")
+                cmmnHistoryService.createHistoricTaskLogEntryBuilder().subScopeId("testSubScopeId"),
+                cmmnHistoryService.createHistoricTaskLogEntryQuery().subScopeId("testSubScopeId")
         );
     }
 
     @Test
     public void queryForTaskLogEntriesByScopeType() {
         assertThatTaskLogIsFetched(
-            cmmnHistoryService.createHistoricTaskLogEntryBuilder().scopeType("testScopeType"),
-            cmmnHistoryService.createHistoricTaskLogEntryQuery().scopeType("testScopeType")
+                cmmnHistoryService.createHistoricTaskLogEntryBuilder().scopeType("testScopeType"),
+                cmmnHistoryService.createHistoricTaskLogEntryQuery().scopeType("testScopeType")
         );
     }
 
     @Test
     public void queryForTaskLogEntriesByFromTimeStamp() {
         assertThatTaskLogIsFetched(
-            cmmnHistoryService.createHistoricTaskLogEntryBuilder().timeStamp(getInsertDate()),
-            cmmnHistoryService.createHistoricTaskLogEntryQuery().from(getCompareBeforeDate())
+                cmmnHistoryService.createHistoricTaskLogEntryBuilder().timeStamp(getInsertDate()),
+                cmmnHistoryService.createHistoricTaskLogEntryQuery().from(getCompareBeforeDate())
         );
     }
 
     @Test
     public void queryForTaskLogEntriesByFromIncludedTimeStamp() {
         assertThatTaskLogIsFetched(
-            cmmnHistoryService.createHistoricTaskLogEntryBuilder().timeStamp(getInsertDate()),
-            cmmnHistoryService.createHistoricTaskLogEntryQuery().from(getInsertDate())
+                cmmnHistoryService.createHistoricTaskLogEntryBuilder().timeStamp(getInsertDate()),
+                cmmnHistoryService.createHistoricTaskLogEntryQuery().from(getInsertDate())
         );
     }
 
@@ -650,27 +690,33 @@ public class CmmnHistoryServiceTaskLogTest extends CustomCmmnConfigurationFlowab
     public void queryForTaskLogEntriesByToIncludedTimeStamp() {
         HistoricTaskLogEntryBuilder historicTaskLogEntryBuilder = cmmnHistoryService.createHistoricTaskLogEntryBuilder().timeStamp(getInsertDate());
         HistoricTaskLogEntryQuery historicTaskLogEntryQuery = cmmnHistoryService.createHistoricTaskLogEntryQuery().to(getCompareAfterDate());
-        
-        task = cmmnTaskService.createTaskBuilder().
-            assignee("testAssignee").
-            create();
+
+        task = cmmnTaskService.createTaskBuilder()
+                .assignee("testAssignee")
+                .create();
         Task anotherTask = cmmnTaskService.createTaskBuilder().create();
         historicTaskLogEntryBuilder.taskId(task.getId()).create();
         historicTaskLogEntryBuilder.taskId(task.getId()).create();
         historicTaskLogEntryBuilder.taskId(task.getId()).create();
-    
+
         try {
             List<HistoricTaskLogEntry> logEntries = historicTaskLogEntryQuery.list();
-            assertThat(logEntries.size()).isEqualTo(5);
-            assertThat(logEntries).extracting(HistoricTaskLogEntry::getTaskId).containsExactly(task.getId(), anotherTask.getId(), 
-                            task.getId(), task.getId(), task.getId());
-    
+            assertThat(logEntries)
+                    .extracting(HistoricTaskLogEntry::getTaskId)
+                    .containsExactly(
+                            task.getId(),
+                            anotherTask.getId(),
+                            task.getId(),
+                            task.getId(),
+                            task.getId()
+                    );
+
             assertThat(historicTaskLogEntryQuery.count()).isEqualTo(5);
-    
+
             List<HistoricTaskLogEntry> pagedLogEntries = historicTaskLogEntryQuery.listPage(1, 1);
-            assertThat(pagedLogEntries.size()).isEqualTo(1);
+            assertThat(pagedLogEntries).hasSize(1);
             assertThat(pagedLogEntries.get(0)).isEqualToComparingFieldByField(logEntries.get(1));
-            
+
         } finally {
             deleteTaskWithLogEntries(anotherTask.getId());
             cmmnTaskService.deleteTask(anotherTask.getId());
@@ -680,40 +726,40 @@ public class CmmnHistoryServiceTaskLogTest extends CustomCmmnConfigurationFlowab
     @Test
     public void queryForTaskLogEntriesByFromToTimeStamp() {
         assertThatTaskLogIsFetched(
-            cmmnHistoryService.createHistoricTaskLogEntryBuilder().timeStamp(getInsertDate()),
-            cmmnHistoryService.createHistoricTaskLogEntryQuery().from(getCompareBeforeDate()).to(getCompareAfterDate())
+                cmmnHistoryService.createHistoricTaskLogEntryBuilder().timeStamp(getInsertDate()),
+                cmmnHistoryService.createHistoricTaskLogEntryQuery().from(getCompareBeforeDate()).to(getCompareAfterDate())
         );
     }
 
     @Test
     public void queryForTaskLogEntriesByTenantId() {
         assertThatTaskLogIsFetched(
-            cmmnHistoryService.createHistoricTaskLogEntryBuilder().timeStamp(getInsertDate()),
-            cmmnHistoryService.createHistoricTaskLogEntryQuery().from(getCompareBeforeDate()).to(getCompareAfterDate())
+                cmmnHistoryService.createHistoricTaskLogEntryBuilder().timeStamp(getInsertDate()),
+                cmmnHistoryService.createHistoricTaskLogEntryQuery().from(getCompareBeforeDate()).to(getCompareAfterDate())
         );
     }
 
     @Test
     public void queryForTaskLogEntriesByProcessDefinitionId() {
         assertThatTaskLogIsFetched(
-            cmmnHistoryService.createHistoricTaskLogEntryBuilder().processDefinitionId("testProcessDefinitionId"),
-            cmmnHistoryService.createHistoricTaskLogEntryQuery().processDefinitionId("testProcessDefinitionId")
+                cmmnHistoryService.createHistoricTaskLogEntryBuilder().processDefinitionId("testProcessDefinitionId"),
+                cmmnHistoryService.createHistoricTaskLogEntryQuery().processDefinitionId("testProcessDefinitionId")
         );
     }
 
     @Test
     public void queryForTaskLogEntriesByScopeDefinitionId() {
         assertThatTaskLogIsFetched(
-            cmmnHistoryService.createHistoricTaskLogEntryBuilder().scopeDefinitionId("testScopeDefinitionId"),
-            cmmnHistoryService.createHistoricTaskLogEntryQuery().scopeDefinitionId("testScopeDefinitionId")
+                cmmnHistoryService.createHistoricTaskLogEntryBuilder().scopeDefinitionId("testScopeDefinitionId"),
+                cmmnHistoryService.createHistoricTaskLogEntryQuery().scopeDefinitionId("testScopeDefinitionId")
         );
     }
 
     @Test
     public void queryForTaskLogEntriesByLogNumber() {
-        task = cmmnTaskService.createTaskBuilder().
-            assignee("testAssignee").
-            create();
+        task = cmmnTaskService.createTaskBuilder()
+                .assignee("testAssignee")
+                .create();
         Task anotherTask = cmmnTaskService.createTaskBuilder().create();
         HistoricTaskLogEntryBuilder historicTaskLogEntryBuilder = cmmnHistoryService.createHistoricTaskLogEntryBuilder();
         historicTaskLogEntryBuilder.taskId(task.getId()).create();
@@ -723,20 +769,21 @@ public class CmmnHistoryServiceTaskLogTest extends CustomCmmnConfigurationFlowab
         List<HistoricTaskLogEntry> allLogEntries = cmmnHistoryService.createHistoricTaskLogEntryQuery().list();
 
         try {
-            HistoricTaskLogEntryQuery historicTaskLogEntryQuery = cmmnHistoryService.createHistoricTaskLogEntryQuery().
-                fromLogNumber(allLogEntries.get(1).getLogNumber()).
-                toLogNumber(allLogEntries.get(allLogEntries.size() - 2).getLogNumber());
-            
+            HistoricTaskLogEntryQuery historicTaskLogEntryQuery = cmmnHistoryService.createHistoricTaskLogEntryQuery()
+                    .fromLogNumber(allLogEntries.get(1).getLogNumber())
+                    .toLogNumber(allLogEntries.get(allLogEntries.size() - 2).getLogNumber());
+
             List<HistoricTaskLogEntry> logEntries = historicTaskLogEntryQuery.list();
-            assertThat(logEntries.size()).isEqualTo(3);
-            assertThat(logEntries).extracting(HistoricTaskLogEntry::getTaskId).containsExactly(anotherTask.getId(), task.getId(), task.getId());
+            assertThat(logEntries)
+                    .extracting(HistoricTaskLogEntry::getTaskId)
+                    .containsExactly(anotherTask.getId(), task.getId(), task.getId());
 
             assertThat(historicTaskLogEntryQuery.count()).isEqualTo(3l);
 
             List<HistoricTaskLogEntry> pagedLogEntries = historicTaskLogEntryQuery.listPage(1, 1);
-            assertThat(pagedLogEntries.size()).isEqualTo(1);
+            assertThat(pagedLogEntries).hasSize(1);
             assertThat(pagedLogEntries.get(0)).isEqualToComparingFieldByField(logEntries.get(1));
-            
+
         } finally {
             deleteTaskWithLogEntries(anotherTask.getId());
             cmmnTaskService.deleteTask(anotherTask.getId(), true);
@@ -751,15 +798,17 @@ public class CmmnHistoryServiceTaskLogTest extends CustomCmmnConfigurationFlowab
         historicTaskLogEntryBuilder.taskId("3").create();
 
         try {
-            assertEquals(3,
-                cmmnHistoryService.createNativeHistoricTaskLogEntryQuery().sql("SELECT * FROM ACT_HI_TSK_LOG").list().size());
-            assertEquals(3,
-                cmmnHistoryService.createNativeHistoricTaskLogEntryQuery().sql("SELECT count(*) FROM ACT_HI_TSK_LOG").count());
+            assertThat(cmmnHistoryService.createNativeHistoricTaskLogEntryQuery().sql("SELECT * FROM ACT_HI_TSK_LOG").list())
+                    .hasSize(3);
+            assertThat(cmmnHistoryService.createNativeHistoricTaskLogEntryQuery().sql("SELECT count(*) FROM ACT_HI_TSK_LOG").count())
+                    .isEqualTo(3);
 
-            assertEquals(1, cmmnHistoryService.createNativeHistoricTaskLogEntryQuery().parameter("taskId", "1").
-                sql("SELECT * FROM ACT_HI_TSK_LOG WHERE TASK_ID_ = #{taskId}").list().size());
-            assertEquals(1, cmmnHistoryService.createNativeHistoricTaskLogEntryQuery().parameter("taskId", "1").
-                sql("SELECT count(*) FROM ACT_HI_TSK_LOG WHERE TASK_ID_ = #{taskId}").count());
+            assertThat(cmmnHistoryService.createNativeHistoricTaskLogEntryQuery().parameter("taskId", "1")
+                    .sql("SELECT * FROM ACT_HI_TSK_LOG WHERE TASK_ID_ = #{taskId}").list())
+                    .hasSize(1);
+            assertThat(cmmnHistoryService.createNativeHistoricTaskLogEntryQuery().parameter("taskId", "1")
+                    .sql("SELECT count(*) FROM ACT_HI_TSK_LOG WHERE TASK_ID_ = #{taskId}").count())
+                    .isEqualTo(1);
         } finally {
             deleteTaskWithLogEntries("1");
             deleteTaskWithLogEntries("2");
@@ -772,33 +821,36 @@ public class CmmnHistoryServiceTaskLogTest extends CustomCmmnConfigurationFlowab
         CaseInstance caseInstance = null;
         try {
             cmmnRepositoryService.createDeployment()
-                .addClasspathResource("org/flowable/cmmn/test/history/CmmnHistoryServiceTaskLogTest.testTaskLogEntriesDeletedOnDeploymentDelete.cmmn").deploy();
+                    .addClasspathResource("org/flowable/cmmn/test/history/CmmnHistoryServiceTaskLogTest.testTaskLogEntriesDeletedOnDeploymentDelete.cmmn")
+                    .deploy();
             caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("myCase").start();
             Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
             cmmnTaskService.complete(task.getId());
 
-            assertEquals(6, cmmnHistoryService.createHistoricTaskLogEntryQuery().caseInstanceId(caseInstance.getId()).count());
-            assertEquals(6, cmmnHistoryService.createHistoricTaskLogEntryQuery().caseDefinitionId(caseInstance.getCaseDefinitionId()).count());
+            assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(6);
+            assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().caseDefinitionId(caseInstance.getCaseDefinitionId()).count()).isEqualTo(6);
 
         } finally {
             cmmnRepositoryService.deleteDeployment(cmmnRepositoryService.createCaseDefinitionQuery()
-                .caseDefinitionId(caseInstance.getCaseDefinitionId()).singleResult().getDeploymentId(), true);
+                    .caseDefinitionId(caseInstance.getCaseDefinitionId()).singleResult().getDeploymentId(), true);
 
-            assertEquals(0, cmmnHistoryService.createHistoricTaskLogEntryQuery().caseInstanceId(caseInstance.getId()).count());
-            assertEquals(0, cmmnHistoryService.createHistoricTaskLogEntryQuery().caseDefinitionId(caseInstance.getCaseDefinitionId()).count());
+            assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().caseInstanceId(caseInstance.getId()).count())
+                    .isEqualTo(0);
+            assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().caseDefinitionId(caseInstance.getCaseDefinitionId()).count())
+                    .isEqualTo(0);
         }
     }
-    
+
     protected Date getInsertDate() {
         Calendar cal = new GregorianCalendar(2020, 3, 10);
         return cal.getTime();
     }
-    
+
     protected Date getCompareBeforeDate() {
         Calendar cal = new GregorianCalendar(2020, 3, 9);
         return cal.getTime();
     }
-    
+
     protected Date getCompareAfterDate() {
         Calendar cal = new GregorianCalendar(2020, 3, 11);
         return cal.getTime();

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/history/HistoricCaseInstanceInvolvementTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/history/HistoricCaseInstanceInvolvementTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,10 +13,8 @@
 
 package org.flowable.cmmn.test.history;
 
-import static java.util.Collections.emptyList;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Collections;
 import java.util.stream.Collectors;
@@ -28,27 +26,22 @@ import org.flowable.common.engine.api.FlowableIllegalArgumentException;
 import org.flowable.identitylink.api.IdentityLinkType;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 /**
  * @author martin.grofcik
  */
 public class HistoricCaseInstanceInvolvementTest extends FlowableCmmnTestCase {
 
-    @Rule
-    public ExpectedException expectException = ExpectedException.none();
-
     protected String deploymentId;
 
     @Before
     public void createCaseInstance() {
         deploymentId = cmmnEngine.getCmmnRepositoryService().createDeployment().addClasspathResource("org/flowable/cmmn/test/runtime/oneTaskCase.cmmn")
-            .deploy().getId();
-        cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            start();
+                .deploy().getId();
+        cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .start();
     }
 
     @After
@@ -58,142 +51,138 @@ public class HistoricCaseInstanceInvolvementTest extends FlowableCmmnTestCase {
 
     @Test
     public void getCaseInstanceWithInvolvedUser() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            start();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .start();
         cmmnRuntimeService.addUserIdentityLink(caseInstance.getId(), "kermit", IdentityLinkType.PARTICIPANT);
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("kermit").count(), is(1L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("kermit").list().get(0).getId(), is(caseInstance.getId()));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("kermit").singleResult().getId(), is(caseInstance.getId()));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("kermit").count()).isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("kermit").list().get(0).getId()).isEqualTo(caseInstance.getId());
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("kermit").singleResult().getId()).isEqualTo(caseInstance.getId());
     }
 
     @Test
     public void getCaseInstanceWithTwoInvolvedUser() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            start();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .start();
         cmmnRuntimeService.addUserIdentityLink(caseInstance.getId(), "kermit", IdentityLinkType.PARTICIPANT);
         cmmnRuntimeService.addUserIdentityLink(caseInstance.getId(), "gonzo", IdentityLinkType.PARTICIPANT);
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("kermit").count(), is(1L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("kermit").list().get(0).getId(), is(caseInstance.getId()));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("kermit").singleResult().getId(), is(caseInstance.getId()));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("kermit").count()).isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("kermit").list().get(0).getId()).isEqualTo(caseInstance.getId());
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("kermit").singleResult().getId()).isEqualTo(caseInstance.getId());
     }
 
     @Test
     public void getCaseInstanceWithTwoInvolvedUserEmptyQuery() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            start();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .start();
         cmmnRuntimeService.addUserIdentityLink(caseInstance.getId(), "kermit", IdentityLinkType.PARTICIPANT);
         cmmnRuntimeService.addUserIdentityLink(caseInstance.getId(), "gonzo", IdentityLinkType.PARTICIPANT);
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("").count(), is(0L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("").list(), is(emptyList()));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("").singleResult(), is(nullValue()));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("").count()).isEqualTo(0L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("").list()).isEmpty();
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("").singleResult()).isNull();
     }
 
     @Test
     public void getCaseInstanceWithNonExistingInvolvedUser() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            start();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .start();
         cmmnRuntimeService.addUserIdentityLink(caseInstance.getId(), "kermit", IdentityLinkType.PARTICIPANT);
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("gonzo").count(), is(0L));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("gonzo").count()).isEqualTo(0L);
     }
 
     @Test
     public void getCaseInstanceWithNullInvolvedUser() {
-        this.expectException.expect(FlowableIllegalArgumentException.class);
-        this.expectException.expectMessage("involvedUser is null");
-
-        cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser(null);
+        assertThatThrownBy(() -> cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser(null))
+                .isInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage("involvedUser is null");
     }
 
     @Test
     public void getCaseInstanceWithNullInvolvedGroups() {
-        this.expectException.expect(FlowableIllegalArgumentException.class);
-        this.expectException.expectMessage("involvedGroups are null");
-
-        cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(null);
+        assertThatThrownBy(() -> cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(null))
+                .isInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage("involvedGroups are null");
     }
 
     @Test
     public void getCaseInstanceWithEmptyInvolvedGroups() {
-        this.expectException.expect(FlowableIllegalArgumentException.class);
-        this.expectException.expectMessage("involvedGroups are empty");
-
-        cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Collections.emptySet());
+        assertThatThrownBy(() -> cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Collections.emptySet()))
+                .isInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage("involvedGroups are empty");
     }
 
     @Test
     public void getCaseInstanceWithNonNullInvolvedUser() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            start();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .start();
         cmmnRuntimeService.addUserIdentityLink(caseInstance.getId(), "kermit", IdentityLinkType.PARTICIPANT);
 
-        this.expectException.expect(FlowableIllegalArgumentException.class);
-        this.expectException.expectMessage("involvedUser is null");
-
-        cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser(null).count();
+        assertThatThrownBy(() -> cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser(null).count())
+                .isInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage("involvedUser is null");
     }
 
     @Test
     public void getCaseInstanceWithInvolvedGroups() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            start();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .start();
         cmmnRuntimeService.addGroupIdentityLink(caseInstance.getId(), "testGroup", IdentityLinkType.PARTICIPANT);
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Collections.singleton("testGroup")).count(), is(1L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId(), is(caseInstance.getId()));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Collections.singleton("testGroup")).singleResult().getId(), is(caseInstance.getId()));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Collections.singleton("testGroup")).count()).isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId())
+                .isEqualTo(caseInstance.getId());
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Collections.singleton("testGroup")).singleResult().getId())
+                .isEqualTo(caseInstance.getId());
     }
 
     @Test
     public void getCaseInstanceWithEmptyGroupId() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            start();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .start();
         cmmnRuntimeService.addGroupIdentityLink(caseInstance.getId(), "testGroup", IdentityLinkType.PARTICIPANT);
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Collections.singleton("")).count(), is(0L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Collections.singleton("")).list(), is(emptyList()));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Collections.singleton("")).singleResult(), is(nullValue()));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Collections.singleton("")).count()).isEqualTo(0L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Collections.singleton("")).list()).isEmpty();
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Collections.singleton("")).singleResult()).isNull();
     }
 
     @Test
     public void getCaseInstanceWithNonExistingGroupId() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            start();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .start();
         cmmnRuntimeService.addGroupIdentityLink(caseInstance.getId(), "testGroup", IdentityLinkType.PARTICIPANT);
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Collections.singleton("NonExisting")).count(), is(0L));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Collections.singleton("NonExisting")).list(), is(emptyList()));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Collections.singleton("NonExisting")).singleResult(), is(nullValue()));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Collections.singleton("NonExisting")).count()).isEqualTo(0L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Collections.singleton("NonExisting")).list()).isEmpty();
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Collections.singleton("NonExisting")).singleResult()).isNull();
     }
 
     @Test
     public void getCaseInstanceWithTwoInvolvedGroups() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            start();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .start();
         cmmnRuntimeService.addGroupIdentityLink(caseInstance.getId(), "testGroup", IdentityLinkType.PARTICIPANT);
         cmmnRuntimeService.addGroupIdentityLink(caseInstance.getId(), "testGroup2", IdentityLinkType.PARTICIPANT);
 
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(
-            Stream.of("testGroup", "testGroup2", "testGroup3").collect(Collectors.toSet())
-        ).count(), is(1L));
+                Stream.of("testGroup", "testGroup2", "testGroup3").collect(Collectors.toSet())).count())
+                .isEqualTo(1L);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(
-            Stream.of("testGroup", "testGroup2", "testGroup3").collect(Collectors.toSet())
-        ).list().get(0).getId(), is(caseInstance.getId()));
+                Stream.of("testGroup", "testGroup2", "testGroup3").collect(Collectors.toSet())).list().get(0).getId()).isEqualTo(caseInstance.getId());
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(
-            Stream.of("testGroup", "testGroup2", "testGroup3").collect(Collectors.toSet())
-        ).singleResult().getId(), is(caseInstance.getId()));
+                Stream.of("testGroup", "testGroup2", "testGroup3").collect(Collectors.toSet())).singleResult().getId()).isEqualTo(caseInstance.getId());
     }
 
 }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/history/HistoricDataEngineDeleteTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/history/HistoricDataEngineDeleteTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,7 +12,7 @@
  */
 package org.flowable.cmmn.test.history;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -39,16 +39,16 @@ import org.junit.jupiter.api.Test;
 public class HistoricDataEngineDeleteTest {
 
     @Test
-    @CmmnDeployment(resources="org/flowable/cmmn/test/human-task-milestone-model.cmmn")
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/human-task-milestone-model.cmmn")
     public void testHistoryCleanupTimerJob(CmmnEngineConfiguration cmmnEngineConfiguration, CmmnRuntimeService cmmnRuntimeService,
-                    CmmnHistoryService cmmnHistoryService, CmmnTaskService cmmnTaskService, CmmnManagementService cmmnManagementService) {
-        
+            CmmnHistoryService cmmnHistoryService, CmmnTaskService cmmnTaskService, CmmnManagementService cmmnManagementService) {
+
         try {
             Clock clock = cmmnEngineConfiguration.getClock();
             Calendar cal = clock.getCurrentCalendar();
             cal.add(Calendar.DAY_OF_YEAR, -400);
             clock.setCurrentCalendar(cal);
-            
+
             List<String> caseInstanceIds = new ArrayList<>();
             for (int i = 0; i < 20; i++) {
                 CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("oneTaskCase").start();
@@ -56,46 +56,50 @@ public class HistoricDataEngineDeleteTest {
                 cmmnRuntimeService.setVariable(caseInstance.getId(), "testVar", "testValue" + (i + 1));
                 cmmnRuntimeService.setVariable(caseInstance.getId(), "numVar", (i + 1));
             }
-            
+
             if (cmmnEngineConfiguration.getHistoryLevel() != HistoryLevel.NONE) {
-                
-                assertEquals(20, cmmnHistoryService.createHistoricCaseInstanceQuery().count());
-                
+
+                assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().count()).isEqualTo(20);
+
                 for (int i = 0; i < 10; i++) {
                     Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstanceIds.get(i)).singleResult();
                     cmmnTaskService.setVariableLocal(task.getId(), "taskVar", "taskValue" + (i + 1));
                     cmmnTaskService.complete(task.getId());
                 }
-                
-                assertEquals(1, cmmnManagementService.createTimerJobQuery().handlerType(CmmnHistoryCleanupJobHandler.TYPE).count());
-                
-                Job executableJob = cmmnManagementService.moveTimerToExecutableJob(cmmnManagementService.createTimerJobQuery().handlerType(CmmnHistoryCleanupJobHandler.TYPE).singleResult().getId());
+
+                assertThat(cmmnManagementService.createTimerJobQuery().handlerType(CmmnHistoryCleanupJobHandler.TYPE).count()).isEqualTo(1);
+
+                Job executableJob = cmmnManagementService.moveTimerToExecutableJob(
+                        cmmnManagementService.createTimerJobQuery().handlerType(CmmnHistoryCleanupJobHandler.TYPE).singleResult().getId());
                 cmmnManagementService.executeJob(executableJob.getId());
-                
-                assertEquals(1, cmmnManagementService.createTimerJobQuery().handlerType(CmmnHistoryCleanupJobHandler.TYPE).count());
-                
-                assertEquals(10, cmmnHistoryService.createHistoricCaseInstanceQuery().count());
-                assertEquals(20, cmmnHistoryService.createHistoricPlanItemInstanceQuery().count());
-                assertEquals(10, cmmnHistoryService.createHistoricTaskInstanceQuery().count());
-                
+
+                assertThat(cmmnManagementService.createTimerJobQuery().handlerType(CmmnHistoryCleanupJobHandler.TYPE).count()).isEqualTo(1);
+
+                assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().count()).isEqualTo(10);
+                assertThat(cmmnHistoryService.createHistoricPlanItemInstanceQuery().count()).isEqualTo(20);
+                assertThat(cmmnHistoryService.createHistoricTaskInstanceQuery().count()).isEqualTo(10);
+
                 for (int i = 0; i < 20; i++) {
                     if (i < 10) {
-                        assertEquals(0, cmmnHistoryService.getHistoricIdentityLinksForCaseInstance(caseInstanceIds.get(i)).size());
-                        assertEquals(0, cmmnHistoryService.createHistoricTaskLogEntryQuery().caseInstanceId(caseInstanceIds.get(i)).count());
-                        assertEquals(0, cmmnHistoryService.createHistoricVariableInstanceQuery().caseInstanceId(caseInstanceIds.get(i)).count());
-                        assertEquals(0, cmmnHistoryService.createHistoricMilestoneInstanceQuery().milestoneInstanceCaseInstanceId(caseInstanceIds.get(i)).count());
-                        
+                        assertThat(cmmnHistoryService.getHistoricIdentityLinksForCaseInstance(caseInstanceIds.get(i))).isEmpty();
+                        assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().caseInstanceId(caseInstanceIds.get(i)).count()).isEqualTo(0);
+                        assertThat(cmmnHistoryService.createHistoricVariableInstanceQuery().caseInstanceId(caseInstanceIds.get(i)).count()).isEqualTo(0);
+                        assertThat(cmmnHistoryService.createHistoricMilestoneInstanceQuery().milestoneInstanceCaseInstanceId(caseInstanceIds.get(i)).count())
+                                .isEqualTo(0);
+
                     } else {
-                        assertEquals(1, cmmnHistoryService.getHistoricIdentityLinksForCaseInstance(caseInstanceIds.get(i)).size());
-                        assertEquals(1, cmmnHistoryService.createHistoricTaskLogEntryQuery().caseInstanceId(caseInstanceIds.get(i)).count());
-                        assertEquals(2, cmmnHistoryService.createHistoricVariableInstanceQuery().caseInstanceId(caseInstanceIds.get(i)).count());
-                        assertEquals(1, cmmnHistoryService.createHistoricMilestoneInstanceQuery().milestoneInstanceCaseInstanceId(caseInstanceIds.get(i)).count());
+                        assertThat(cmmnHistoryService.getHistoricIdentityLinksForCaseInstance(caseInstanceIds.get(i))).hasSize(1);
+                        assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().caseInstanceId(caseInstanceIds.get(i)).count()).isEqualTo(1);
+                        assertThat(cmmnHistoryService.createHistoricVariableInstanceQuery().caseInstanceId(caseInstanceIds.get(i)).count()).isEqualTo(2);
+                        assertThat(cmmnHistoryService.createHistoricMilestoneInstanceQuery().milestoneInstanceCaseInstanceId(caseInstanceIds.get(i)).count())
+                                .isEqualTo(1);
                     }
                 }
-                
-                cmmnManagementService.deleteTimerJob(cmmnManagementService.createTimerJobQuery().handlerType(CmmnHistoryCleanupJobHandler.TYPE).singleResult().getId());
+
+                cmmnManagementService
+                        .deleteTimerJob(cmmnManagementService.createTimerJobQuery().handlerType(CmmnHistoryCleanupJobHandler.TYPE).singleResult().getId());
             }
-        
+
         } finally {
             cmmnEngineConfiguration.resetClock();
         }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/history/HistoricPlanItemInstanceQueryTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/history/HistoricPlanItemInstanceQueryTest.java
@@ -13,8 +13,6 @@
 package org.flowable.cmmn.test.history;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -39,13 +37,13 @@ public class HistoricPlanItemInstanceQueryTest extends FlowableCmmnTestCase {
     @Before
     public void deployCaseDefinition() {
         this.deploymentId = cmmnRepositoryService.createDeployment()
-            .addClasspathResource("org/flowable/cmmn/test/history/HistoricPlanItemInstanceQueryTest.testQuery.cmmn")
-            .deploy()
-            .getId();
+                .addClasspathResource("org/flowable/cmmn/test/history/HistoricPlanItemInstanceQueryTest.testQuery.cmmn")
+                .deploy()
+                .getId();
         caseDefinitionId = cmmnRepositoryService.createCaseDefinitionQuery()
-            .deploymentId(deploymentId)
-            .singleResult()
-            .getId();
+                .deploymentId(deploymentId)
+                .singleResult()
+                .getId();
     }
 
     @After
@@ -56,14 +54,14 @@ public class HistoricPlanItemInstanceQueryTest extends FlowableCmmnTestCase {
     @Test
     public void testByCaseDefinitionId() {
         startInstances(5);
-        assertEquals(20, cmmnHistoryService.createHistoricPlanItemInstanceQuery().list().size());
+        assertThat(cmmnHistoryService.createHistoricPlanItemInstanceQuery().list()).hasSize(20);
     }
 
     @Test
     public void testByCaseInstanceId() {
         List<String> caseInstanceIds = startInstances(3);
         for (String caseInstanceId : caseInstanceIds) {
-            assertEquals(4, cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceCaseInstanceId(caseInstanceId).list().size());
+            assertThat(cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceCaseInstanceId(caseInstanceId).list()).hasSize(4);
         }
     }
 
@@ -71,11 +69,11 @@ public class HistoricPlanItemInstanceQueryTest extends FlowableCmmnTestCase {
     public void testByStageInstanceId() {
         startInstances(1);
         HistoricPlanItemInstance planItemInstance = cmmnHistoryService.createHistoricPlanItemInstanceQuery()
-            .planItemInstanceDefinitionType(PlanItemDefinitionType.STAGE)
-            .planItemInstanceName("Stage one")
-            .singleResult();
-        assertNotNull(planItemInstance);
-        assertEquals(2, cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceStageInstanceId(planItemInstance.getId()).count());
+                .planItemInstanceDefinitionType(PlanItemDefinitionType.STAGE)
+                .planItemInstanceName("Stage one")
+                .singleResult();
+        assertThat(planItemInstance).isNotNull();
+        assertThat(cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceStageInstanceId(planItemInstance.getId()).count()).isEqualTo(2);
     }
 
     @Test
@@ -83,61 +81,66 @@ public class HistoricPlanItemInstanceQueryTest extends FlowableCmmnTestCase {
         startInstances(1);
         List<HistoricPlanItemInstance> planItemInstances = cmmnHistoryService.createHistoricPlanItemInstanceQuery().list();
         for (HistoricPlanItemInstance planItemInstance : planItemInstances) {
-            assertEquals(1L, cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceId(planItemInstance.getId()).count());
+            assertThat(cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceId(planItemInstance.getId()).count()).isEqualTo(1L);
         }
     }
 
     @Test
     public void testByElementId() {
         startInstances(4);
-        assertEquals(4, cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceElementId("planItem3").list().size());
+        assertThat(cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceElementId("planItem3").list()).hasSize(4);
     }
 
     @Test
     public void testByName() {
         startInstances(9);
-        assertEquals(9, cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceName("B").list().size());
+        assertThat(cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceName("B").list()).hasSize(9);
     }
 
     @Test
     public void testByState() {
         startInstances(1);
-        assertEquals(2, cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceState(PlanItemInstanceState.ACTIVE).list().size());
-        assertEquals(1, cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceState(PlanItemInstanceState.AVAILABLE).list().size());
-        assertEquals(1, cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceState(PlanItemInstanceState.ENABLED).list().size());
+        assertThat(cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceState(PlanItemInstanceState.ACTIVE).list()).hasSize(2);
+        assertThat(cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceState(PlanItemInstanceState.AVAILABLE).list()).hasSize(1);
+        assertThat(cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceState(PlanItemInstanceState.ENABLED).list()).hasSize(1);
     }
 
     @Test
     public void testByPlanItemDefinitionType() {
         startInstances(3);
-        assertEquals(6, cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceDefinitionType(PlanItemDefinitionType.HUMAN_TASK).list().size());
-        assertEquals(6, cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceDefinitionType(PlanItemDefinitionType.STAGE).list().size());
+        assertThat(cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceDefinitionType(PlanItemDefinitionType.HUMAN_TASK).list().size())
+                .isEqualTo(6);
+        assertThat(cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceDefinitionType(PlanItemDefinitionType.STAGE).list().size())
+                .isEqualTo(6);
     }
 
     @Test
     public void testByPlanItemDefinitionTypes() {
         startInstances(2);
-        assertEquals(8, cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceDefinitionTypes(Arrays.asList(PlanItemDefinitionType.STAGE, PlanItemDefinitionType.HUMAN_TASK)).list().size());
+        assertThat(cmmnHistoryService.createHistoricPlanItemInstanceQuery()
+                .planItemInstanceDefinitionTypes(Arrays.asList(PlanItemDefinitionType.STAGE, PlanItemDefinitionType.HUMAN_TASK)).list()).hasSize(8);
     }
 
     @Test
     public void testByStateAndType() {
         startInstances(3);
-        assertEquals(3, cmmnHistoryService.createHistoricPlanItemInstanceQuery()
-            .planItemInstanceState(PlanItemInstanceState.ACTIVE)
-            .planItemInstanceDefinitionType(PlanItemDefinitionType.HUMAN_TASK)
-            .list().size());
+        assertThat(cmmnHistoryService.createHistoricPlanItemInstanceQuery()
+                .planItemInstanceState(PlanItemInstanceState.ACTIVE)
+                .planItemInstanceDefinitionType(PlanItemDefinitionType.HUMAN_TASK)
+                .list())
+                .hasSize(3);
 
-        assertEquals(3, cmmnHistoryService.createHistoricPlanItemInstanceQuery()
-            .planItemInstanceState(PlanItemInstanceState.ENABLED)
-            .planItemInstanceDefinitionType(PlanItemDefinitionType.HUMAN_TASK)
-            .list().size());
+        assertThat(cmmnHistoryService.createHistoricPlanItemInstanceQuery()
+                .planItemInstanceState(PlanItemInstanceState.ENABLED)
+                .planItemInstanceDefinitionType(PlanItemDefinitionType.HUMAN_TASK)
+                .list())
+                .hasSize(3);
     }
 
     @Test
     public void testOrderBy() {
         startInstances(4);
-        
+
         assertThat(cmmnHistoryService.createHistoricPlanItemInstanceQuery().orderByName().asc().list()).hasSize(16);
         assertThat(cmmnHistoryService.createHistoricPlanItemInstanceQuery().orderByName().desc().list()).hasSize(16);
 

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/history/HistoryDataDeleteTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/history/HistoryDataDeleteTest.java
@@ -12,7 +12,7 @@
  */
 package org.flowable.cmmn.test.history;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -33,38 +33,38 @@ import org.junit.Test;
 public class HistoryDataDeleteTest extends FlowableCmmnTestCase {
 
     @Test
-    @CmmnDeployment(resources="org/flowable/cmmn/test/one-human-task-model.cmmn")
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/one-human-task-model.cmmn")
     public void testDeleteSingleHistoricCaseInstance() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("oneTaskCase").start();
         cmmnRuntimeService.setVariable(caseInstance.getId(), "testVar", "testValue");
         cmmnRuntimeService.setVariable(caseInstance.getId(), "numVar", 43);
-        
+
         if (cmmnEngineConfiguration.getHistoryLevel() != HistoryLevel.NONE) {
-            assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count());
-            
+            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
+
             Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
             cmmnTaskService.setVariableLocal(task.getId(), "taskVar", "taskValue");
             cmmnTaskService.complete(task.getId());
-                
+
             HistoricCaseInstanceQuery query = cmmnHistoryService.createHistoricCaseInstanceQuery();
             Calendar cal = new GregorianCalendar();
             cal.set(Calendar.YEAR, cal.get(Calendar.YEAR) + 1);
             query.finishedBefore(cal.getTime());
-                    
+
             query.deleteWithRelatedData();
-            
-            assertEquals(0, cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count());
-            assertEquals(0, cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceCaseInstanceId(caseInstance.getId()).count());
-            assertEquals(0, cmmnHistoryService.createHistoricTaskInstanceQuery().caseInstanceId(caseInstance.getId()).count());
-            assertEquals(0, cmmnHistoryService.getHistoricIdentityLinksForCaseInstance(caseInstance.getId()).size());
-            assertEquals(0, cmmnHistoryService.getHistoricEntityLinkChildrenForCaseInstance(caseInstance.getId()).size());
-            assertEquals(0, cmmnHistoryService.createHistoricTaskLogEntryQuery().caseInstanceId(caseInstance.getId()).count());
-            assertEquals(0, cmmnHistoryService.createHistoricVariableInstanceQuery().caseInstanceId(caseInstance.getId()).count());
+
+            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+            assertThat(cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceCaseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+            assertThat(cmmnHistoryService.createHistoricTaskInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+            assertThat(cmmnHistoryService.getHistoricIdentityLinksForCaseInstance(caseInstance.getId())).isEmpty();
+            assertThat(cmmnHistoryService.getHistoricEntityLinkChildrenForCaseInstance(caseInstance.getId())).isEmpty();
+            assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+            assertThat(cmmnHistoryService.createHistoricVariableInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
         }
     }
-    
+
     @Test
-    @CmmnDeployment(resources="org/flowable/cmmn/test/human-task-milestone-model.cmmn")
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/human-task-milestone-model.cmmn")
     public void testDeleteHistoricInstances() {
         List<String> caseInstanceIds = new ArrayList<>();
         for (int i = 0; i < 20; i++) {
@@ -73,39 +73,41 @@ public class HistoryDataDeleteTest extends FlowableCmmnTestCase {
             cmmnRuntimeService.setVariable(caseInstance.getId(), "testVar", "testValue" + (i + 1));
             cmmnRuntimeService.setVariable(caseInstance.getId(), "numVar", (i + 1));
         }
-        
+
         if (cmmnEngineConfiguration.getHistoryLevel() != HistoryLevel.NONE) {
-            
-            assertEquals(20, cmmnHistoryService.createHistoricCaseInstanceQuery().count());
-            
+
+            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().count()).isEqualTo(20);
+
             for (int i = 0; i < 10; i++) {
                 Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstanceIds.get(i)).singleResult();
                 cmmnTaskService.setVariableLocal(task.getId(), "taskVar", "taskValue" + (i + 1));
                 cmmnTaskService.complete(task.getId());
             }
-                    
+
             HistoricCaseInstanceQuery query = cmmnHistoryService.createHistoricCaseInstanceQuery();
             Calendar cal = new GregorianCalendar();
             cal.set(Calendar.YEAR, cal.get(Calendar.YEAR) + 1);
             query.finishedBefore(cal.getTime());
             query.deleteWithRelatedData();
-            
-            assertEquals(10, cmmnHistoryService.createHistoricCaseInstanceQuery().count());
-            assertEquals(20, cmmnHistoryService.createHistoricPlanItemInstanceQuery().count());
-            assertEquals(10, cmmnHistoryService.createHistoricTaskInstanceQuery().count());
-            
+
+            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().count()).isEqualTo(10);
+            assertThat(cmmnHistoryService.createHistoricPlanItemInstanceQuery().count()).isEqualTo(20);
+            assertThat(cmmnHistoryService.createHistoricTaskInstanceQuery().count()).isEqualTo(10);
+
             for (int i = 0; i < 20; i++) {
                 if (i < 10) {
-                    assertEquals(0, cmmnHistoryService.getHistoricIdentityLinksForCaseInstance(caseInstanceIds.get(i)).size());
-                    assertEquals(0, cmmnHistoryService.createHistoricTaskLogEntryQuery().caseInstanceId(caseInstanceIds.get(i)).count());
-                    assertEquals(0, cmmnHistoryService.createHistoricVariableInstanceQuery().caseInstanceId(caseInstanceIds.get(i)).count());
-                    assertEquals(0, cmmnHistoryService.createHistoricMilestoneInstanceQuery().milestoneInstanceCaseInstanceId(caseInstanceIds.get(i)).count());
-                    
+                    assertThat(cmmnHistoryService.getHistoricIdentityLinksForCaseInstance(caseInstanceIds.get(i))).isEmpty();
+                    assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().caseInstanceId(caseInstanceIds.get(i)).count()).isEqualTo(0);
+                    assertThat(cmmnHistoryService.createHistoricVariableInstanceQuery().caseInstanceId(caseInstanceIds.get(i)).count()).isEqualTo(0);
+                    assertThat(cmmnHistoryService.createHistoricMilestoneInstanceQuery().milestoneInstanceCaseInstanceId(caseInstanceIds.get(i)).count())
+                            .isEqualTo(0);
+
                 } else {
-                    assertEquals(1, cmmnHistoryService.getHistoricIdentityLinksForCaseInstance(caseInstanceIds.get(i)).size());
-                    assertEquals(1, cmmnHistoryService.createHistoricTaskLogEntryQuery().caseInstanceId(caseInstanceIds.get(i)).count());
-                    assertEquals(2, cmmnHistoryService.createHistoricVariableInstanceQuery().caseInstanceId(caseInstanceIds.get(i)).count());
-                    assertEquals(1, cmmnHistoryService.createHistoricMilestoneInstanceQuery().milestoneInstanceCaseInstanceId(caseInstanceIds.get(i)).count());
+                    assertThat(cmmnHistoryService.getHistoricIdentityLinksForCaseInstance(caseInstanceIds.get(i))).hasSize(1);
+                    assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().caseInstanceId(caseInstanceIds.get(i)).count()).isEqualTo(1);
+                    assertThat(cmmnHistoryService.createHistoricVariableInstanceQuery().caseInstanceId(caseInstanceIds.get(i)).count()).isEqualTo(2);
+                    assertThat(cmmnHistoryService.createHistoricMilestoneInstanceQuery().milestoneInstanceCaseInstanceId(caseInstanceIds.get(i)).count())
+                            .isEqualTo(1);
                 }
             }
         }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/history/HistoryServiceTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/history/HistoryServiceTest.java
@@ -14,8 +14,6 @@ package org.flowable.cmmn.test.history;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -44,75 +42,75 @@ public class HistoryServiceTest extends FlowableCmmnTestCase {
     @CmmnDeployment
     public void testStartSimplePassthroughCase() {
         cmmnRuntimeService.createCaseInstanceBuilder()
-                        .caseDefinitionKey("myCase")
-                        .variable("var1", "test")
-                        .variable("var2", 10)
-                        .start();
-        
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueEquals("var1", "test").count());
-        assertEquals(0, cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueEquals("var1", "test2").count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueEqualsIgnoreCase("var1", "TEST").count());
-        assertEquals(0, cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueEqualsIgnoreCase("var1", "TEST2").count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueLike("var1", "te%").count());
-        assertEquals(0, cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueLike("var1", "te2%").count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueLikeIgnoreCase("var1", "TE%").count());
-        assertEquals(0, cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueLikeIgnoreCase("var1", "TE2%").count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueGreaterThan("var2", 5).count());
-        assertEquals(0, cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueGreaterThan("var2", 11).count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueLessThan("var2", 11).count());
-        assertEquals(0, cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueLessThan("var2", 8).count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().variableExists("var1").count());
-        assertEquals(0, cmmnHistoryService.createHistoricCaseInstanceQuery().variableExists("var3").count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().variableNotExists("var3").count());
-        assertEquals(0, cmmnHistoryService.createHistoricCaseInstanceQuery().variableNotExists("var1").count());
-        
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
+                .caseDefinitionKey("myCase")
+                .variable("var1", "test")
+                .variable("var2", 10)
+                .start();
+
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueEquals("var1", "test").count()).isEqualTo(1);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueEquals("var1", "test2").count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueEqualsIgnoreCase("var1", "TEST").count()).isEqualTo(1);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueEqualsIgnoreCase("var1", "TEST2").count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueLike("var1", "te%").count()).isEqualTo(1);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueLike("var1", "te2%").count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueLikeIgnoreCase("var1", "TE%").count()).isEqualTo(1);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueLikeIgnoreCase("var1", "TE2%").count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueGreaterThan("var2", 5).count()).isEqualTo(1);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueGreaterThan("var2", 11).count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueLessThan("var2", 11).count()).isEqualTo(1);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueLessThan("var2", 8).count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableExists("var1").count()).isEqualTo(1);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableExists("var3").count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableNotExists("var3").count()).isEqualTo(1);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableNotExists("var1").count()).isEqualTo(0);
+
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
     }
 
     @Test
     @CmmnDeployment
     public void testStartSimplePassthroughCaseWithBlockingTask() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-                        .caseDefinitionKey("myCase")
-                        .variable("startVar", "test")
-                        .variable("changeVar", 10)
-                        .start();
-        
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueEquals("startVar", "test").count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueEquals("changeVar", 10).count());
-        
+                .caseDefinitionKey("myCase")
+                .variable("startVar", "test")
+                .variable("changeVar", 10)
+                .start();
+
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueEquals("startVar", "test").count()).isEqualTo(1);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueEquals("changeVar", 10).count()).isEqualTo(1);
+
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .singleResult();
-        assertNotNull(planItemInstance);
-        assertEquals("Task A", planItemInstance.getName());
-        
+        assertThat(planItemInstance).isNotNull();
+        assertThat(planItemInstance.getName()).isEqualTo("Task A");
+
         Map<String, Object> varMap = new HashMap<>();
         varMap.put("newVar", "test");
         varMap.put("changeVar", 11);
         cmmnRuntimeService.setVariables(caseInstance.getId(), varMap);
-        
+
         Map<String, Object> localVarMap = new HashMap<>();
         localVarMap.put("localVar", "test");
         localVarMap.put("localNumberVar", 2);
         cmmnRuntimeService.setLocalVariables(planItemInstance.getId(), localVarMap);
-        
+
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
-        
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueEquals("startVar", "test").count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueEquals("changeVar", 11).count());
-        assertEquals(0, cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueEquals("changeVar", 10).count());
-        
+
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueEquals("startVar", "test").count()).isEqualTo(1);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueEquals("changeVar", 11).count()).isEqualTo(1);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueEquals("changeVar", 10).count()).isEqualTo(0);
+
         planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .singleResult();
-        assertNotNull(planItemInstance);
-        assertEquals("Task B", planItemInstance.getName());
+        assertThat(planItemInstance).isNotNull();
+        assertThat(planItemInstance.getName()).isEqualTo("Task B");
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
-        
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
+
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
     }
 
     @Test
@@ -123,231 +121,232 @@ public class HistoryServiceTest extends FlowableCmmnTestCase {
         cmmnEngineConfiguration.getClock().setCurrentTime(fixTime);
 
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("allStates")
-            .start();
+                .caseDefinitionKey("allStates")
+                .start();
 
         List<PlanItemInstance> runtimePlanItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).list();
         assertThat(runtimePlanItemInstances)
-            .extracting(PlanItemInstance::getPlanItemDefinitionId, PlanItemInstance::getState)
-            .as("planItemDefinitionId, state")
-            .containsExactlyInAnyOrder(
-                tuple("eventListenerAvailable", PlanItemInstanceState.AVAILABLE),
-                tuple("eventListenerUnavailable", PlanItemInstanceState.UNAVAILABLE),
-                tuple("serviceTaskAvailableEnabled", PlanItemInstanceState.ENABLED),
-                tuple("serviceTaskAvailableAsyncActive", PlanItemInstanceState.ASYNC_ACTIVE)
-            );
+                .extracting(PlanItemInstance::getPlanItemDefinitionId, PlanItemInstance::getState)
+                .as("planItemDefinitionId, state")
+                .containsExactlyInAnyOrder(
+                        tuple("eventListenerAvailable", PlanItemInstanceState.AVAILABLE),
+                        tuple("eventListenerUnavailable", PlanItemInstanceState.UNAVAILABLE),
+                        tuple("serviceTaskAvailableEnabled", PlanItemInstanceState.ENABLED),
+                        tuple("serviceTaskAvailableAsyncActive", PlanItemInstanceState.ASYNC_ACTIVE)
+                );
 
         Map<String, PlanItemInstance> runtimePlanItemInstancesByDefinitionId = runtimePlanItemInstances.stream()
-            .collect(Collectors.toMap(PlanItemInstance::getPlanItemDefinitionId, Function.identity()));
+                .collect(Collectors.toMap(PlanItemInstance::getPlanItemDefinitionId, Function.identity()));
 
         PlanItemInstance eventListenerAvailable = runtimePlanItemInstancesByDefinitionId.get("eventListenerAvailable");
 
         assertThat(eventListenerAvailable).extracting(
-            PlanItemInstance::getCompletedTime,
-            PlanItemInstance::getEndedTime,
-            PlanItemInstance::getOccurredTime,
-            PlanItemInstance::getTerminatedTime,
-            PlanItemInstance::getExitTime,
-            PlanItemInstance::getLastEnabledTime,
-            PlanItemInstance::getLastDisabledTime,
-            PlanItemInstance::getLastStartedTime,
-            PlanItemInstance::getLastSuspendedTime
+                PlanItemInstance::getCompletedTime,
+                PlanItemInstance::getEndedTime,
+                PlanItemInstance::getOccurredTime,
+                PlanItemInstance::getTerminatedTime,
+                PlanItemInstance::getExitTime,
+                PlanItemInstance::getLastEnabledTime,
+                PlanItemInstance::getLastDisabledTime,
+                PlanItemInstance::getLastStartedTime,
+                PlanItemInstance::getLastSuspendedTime
         ).containsOnlyNulls();
 
         assertThat(eventListenerAvailable).extracting(
-            PlanItemInstance::getCreateTime,
-            PlanItemInstance::getLastAvailableTime
+                PlanItemInstance::getCreateTime,
+                PlanItemInstance::getLastAvailableTime
         ).containsOnly(fixTime);
 
         PlanItemInstance eventListenerUnavailable = runtimePlanItemInstancesByDefinitionId.get("eventListenerUnavailable");
 
         assertThat(eventListenerUnavailable).extracting(
-            PlanItemInstance::getCompletedTime,
-            PlanItemInstance::getEndedTime,
-            PlanItemInstance::getOccurredTime,
-            PlanItemInstance::getTerminatedTime,
-            PlanItemInstance::getExitTime,
-            PlanItemInstance::getLastEnabledTime,
-            PlanItemInstance::getLastAvailableTime,
-            PlanItemInstance::getLastDisabledTime,
-            PlanItemInstance::getLastStartedTime,
-            PlanItemInstance::getLastSuspendedTime
+                PlanItemInstance::getCompletedTime,
+                PlanItemInstance::getEndedTime,
+                PlanItemInstance::getOccurredTime,
+                PlanItemInstance::getTerminatedTime,
+                PlanItemInstance::getExitTime,
+                PlanItemInstance::getLastEnabledTime,
+                PlanItemInstance::getLastAvailableTime,
+                PlanItemInstance::getLastDisabledTime,
+                PlanItemInstance::getLastStartedTime,
+                PlanItemInstance::getLastSuspendedTime
         ).containsOnlyNulls();
 
         assertThat(eventListenerUnavailable).extracting(
-            PlanItemInstance::getCreateTime
+                PlanItemInstance::getCreateTime
         ).isEqualTo(fixTime);
 
         PlanItemInstance serviceTaskAvailableEnabled = runtimePlanItemInstancesByDefinitionId.get("serviceTaskAvailableEnabled");
 
         assertThat(serviceTaskAvailableEnabled).extracting(
-            PlanItemInstance::getCompletedTime,
-            PlanItemInstance::getEndedTime,
-            PlanItemInstance::getOccurredTime,
-            PlanItemInstance::getTerminatedTime,
-            PlanItemInstance::getExitTime,
-            PlanItemInstance::getLastDisabledTime,
-            PlanItemInstance::getLastStartedTime,
-            PlanItemInstance::getLastSuspendedTime
+                PlanItemInstance::getCompletedTime,
+                PlanItemInstance::getEndedTime,
+                PlanItemInstance::getOccurredTime,
+                PlanItemInstance::getTerminatedTime,
+                PlanItemInstance::getExitTime,
+                PlanItemInstance::getLastDisabledTime,
+                PlanItemInstance::getLastStartedTime,
+                PlanItemInstance::getLastSuspendedTime
         ).containsOnlyNulls();
 
         assertThat(serviceTaskAvailableEnabled).extracting(
-            PlanItemInstance::getCreateTime,
-            PlanItemInstance::getLastEnabledTime,
-            PlanItemInstance::getLastAvailableTime
+                PlanItemInstance::getCreateTime,
+                PlanItemInstance::getLastEnabledTime,
+                PlanItemInstance::getLastAvailableTime
         ).containsOnly(fixTime);
 
         PlanItemInstance serviceTaskAvailableAsyncActive = runtimePlanItemInstancesByDefinitionId.get("serviceTaskAvailableAsyncActive");
 
         assertThat(serviceTaskAvailableAsyncActive).extracting(
-            PlanItemInstance::getCompletedTime,
-            PlanItemInstance::getEndedTime,
-            PlanItemInstance::getOccurredTime,
-            PlanItemInstance::getTerminatedTime,
-            PlanItemInstance::getExitTime,
-            PlanItemInstance::getLastEnabledTime,
-            PlanItemInstance::getLastDisabledTime,
-            PlanItemInstance::getLastSuspendedTime
+                PlanItemInstance::getCompletedTime,
+                PlanItemInstance::getEndedTime,
+                PlanItemInstance::getOccurredTime,
+                PlanItemInstance::getTerminatedTime,
+                PlanItemInstance::getExitTime,
+                PlanItemInstance::getLastEnabledTime,
+                PlanItemInstance::getLastDisabledTime,
+                PlanItemInstance::getLastSuspendedTime
         ).containsOnlyNulls();
 
         assertThat(serviceTaskAvailableAsyncActive).extracting(
-            PlanItemInstance::getCreateTime,
-            PlanItemInstance::getLastAvailableTime,
-            PlanItemInstance::getLastStartedTime
+                PlanItemInstance::getCreateTime,
+                PlanItemInstance::getLastAvailableTime,
+                PlanItemInstance::getLastStartedTime
         ).containsOnly(fixTime);
 
         List<HistoricPlanItemInstance> historicPlanItemInstances = cmmnHistoryService.createHistoricPlanItemInstanceQuery()
-            .planItemInstanceCaseInstanceId(caseInstance.getId())
-            .list();
+                .planItemInstanceCaseInstanceId(caseInstance.getId())
+                .list();
 
         assertThat(historicPlanItemInstances)
-            .extracting(HistoricPlanItemInstance::getPlanItemDefinitionId, HistoricPlanItemInstance::getState)
-            .containsExactlyInAnyOrder(
-                tuple("serviceTaskAvailableActiveCompleted", PlanItemInstanceState.COMPLETED),
-                tuple("stageAvailableActiveTerminated", PlanItemInstanceState.TERMINATED),
-                tuple("humanTaskAvailableActiveTerminatedAndWaitingForRepetition", PlanItemInstanceState.TERMINATED),
-                tuple("eventListenerAvailable", PlanItemInstanceState.AVAILABLE),
-                tuple("eventListenerUnavailable", PlanItemInstanceState.UNAVAILABLE),
-                tuple("serviceTaskAvailableEnabled", PlanItemInstanceState.ENABLED),
-                tuple("serviceTaskAvailableAsyncActive", PlanItemInstanceState.ASYNC_ACTIVE)
-            );
+                .extracting(HistoricPlanItemInstance::getPlanItemDefinitionId, HistoricPlanItemInstance::getState)
+                .containsExactlyInAnyOrder(
+                        tuple("serviceTaskAvailableActiveCompleted", PlanItemInstanceState.COMPLETED),
+                        tuple("stageAvailableActiveTerminated", PlanItemInstanceState.TERMINATED),
+                        tuple("humanTaskAvailableActiveTerminatedAndWaitingForRepetition", PlanItemInstanceState.TERMINATED),
+                        tuple("eventListenerAvailable", PlanItemInstanceState.AVAILABLE),
+                        tuple("eventListenerUnavailable", PlanItemInstanceState.UNAVAILABLE),
+                        tuple("serviceTaskAvailableEnabled", PlanItemInstanceState.ENABLED),
+                        tuple("serviceTaskAvailableAsyncActive", PlanItemInstanceState.ASYNC_ACTIVE)
+                );
 
         Map<String, HistoricPlanItemInstance> historicPlanItemInstancesByDefinitionId = historicPlanItemInstances.stream()
-            .collect(Collectors.toMap(HistoricPlanItemInstance::getPlanItemDefinitionId, Function.identity()));
+                .collect(Collectors.toMap(HistoricPlanItemInstance::getPlanItemDefinitionId, Function.identity()));
 
         HistoricPlanItemInstance historicEventListenerAvailable = historicPlanItemInstancesByDefinitionId.get("eventListenerAvailable");
 
         assertThat(historicEventListenerAvailable).extracting(
-            HistoricPlanItemInstance::getCompletedTime,
-            HistoricPlanItemInstance::getEndedTime,
-            HistoricPlanItemInstance::getOccurredTime,
-            HistoricPlanItemInstance::getTerminatedTime,
-            HistoricPlanItemInstance::getExitTime,
-            HistoricPlanItemInstance::getLastEnabledTime,
-            HistoricPlanItemInstance::getLastDisabledTime,
-            HistoricPlanItemInstance::getLastStartedTime,
-            HistoricPlanItemInstance::getLastSuspendedTime
+                HistoricPlanItemInstance::getCompletedTime,
+                HistoricPlanItemInstance::getEndedTime,
+                HistoricPlanItemInstance::getOccurredTime,
+                HistoricPlanItemInstance::getTerminatedTime,
+                HistoricPlanItemInstance::getExitTime,
+                HistoricPlanItemInstance::getLastEnabledTime,
+                HistoricPlanItemInstance::getLastDisabledTime,
+                HistoricPlanItemInstance::getLastStartedTime,
+                HistoricPlanItemInstance::getLastSuspendedTime
         ).containsOnlyNulls();
 
         assertThat(historicEventListenerAvailable).extracting(
-            HistoricPlanItemInstance::getCreateTime,
-            HistoricPlanItemInstance::getLastAvailableTime
+                HistoricPlanItemInstance::getCreateTime,
+                HistoricPlanItemInstance::getLastAvailableTime
         ).containsOnly(fixTime);
 
         HistoricPlanItemInstance historicEventListenerUnavailable = historicPlanItemInstancesByDefinitionId.get("eventListenerUnavailable");
 
         assertThat(historicEventListenerUnavailable).extracting(
-            HistoricPlanItemInstance::getCompletedTime,
-            HistoricPlanItemInstance::getEndedTime,
-            HistoricPlanItemInstance::getOccurredTime,
-            HistoricPlanItemInstance::getTerminatedTime,
-            HistoricPlanItemInstance::getExitTime,
-            HistoricPlanItemInstance::getLastEnabledTime,
-            HistoricPlanItemInstance::getLastAvailableTime,
-            HistoricPlanItemInstance::getLastDisabledTime,
-            HistoricPlanItemInstance::getLastStartedTime,
-            HistoricPlanItemInstance::getLastSuspendedTime
+                HistoricPlanItemInstance::getCompletedTime,
+                HistoricPlanItemInstance::getEndedTime,
+                HistoricPlanItemInstance::getOccurredTime,
+                HistoricPlanItemInstance::getTerminatedTime,
+                HistoricPlanItemInstance::getExitTime,
+                HistoricPlanItemInstance::getLastEnabledTime,
+                HistoricPlanItemInstance::getLastAvailableTime,
+                HistoricPlanItemInstance::getLastDisabledTime,
+                HistoricPlanItemInstance::getLastStartedTime,
+                HistoricPlanItemInstance::getLastSuspendedTime
         ).containsOnlyNulls();
 
         assertThat(historicEventListenerUnavailable).extracting(
-            HistoricPlanItemInstance::getCreateTime
+                HistoricPlanItemInstance::getCreateTime
         ).isEqualTo(fixTime);
 
         HistoricPlanItemInstance historicServiceTaskAvailableEnabled = historicPlanItemInstancesByDefinitionId.get("serviceTaskAvailableEnabled");
 
         assertThat(historicServiceTaskAvailableEnabled).extracting(
-            HistoricPlanItemInstance::getCompletedTime,
-            HistoricPlanItemInstance::getEndedTime,
-            HistoricPlanItemInstance::getOccurredTime,
-            HistoricPlanItemInstance::getTerminatedTime,
-            HistoricPlanItemInstance::getExitTime,
-            HistoricPlanItemInstance::getLastDisabledTime,
-            HistoricPlanItemInstance::getLastStartedTime,
-            HistoricPlanItemInstance::getLastSuspendedTime
+                HistoricPlanItemInstance::getCompletedTime,
+                HistoricPlanItemInstance::getEndedTime,
+                HistoricPlanItemInstance::getOccurredTime,
+                HistoricPlanItemInstance::getTerminatedTime,
+                HistoricPlanItemInstance::getExitTime,
+                HistoricPlanItemInstance::getLastDisabledTime,
+                HistoricPlanItemInstance::getLastStartedTime,
+                HistoricPlanItemInstance::getLastSuspendedTime
         ).containsOnlyNulls();
 
         assertThat(historicServiceTaskAvailableEnabled).extracting(
-            HistoricPlanItemInstance::getCreateTime,
-            HistoricPlanItemInstance::getLastEnabledTime,
-            HistoricPlanItemInstance::getLastAvailableTime
+                HistoricPlanItemInstance::getCreateTime,
+                HistoricPlanItemInstance::getLastEnabledTime,
+                HistoricPlanItemInstance::getLastAvailableTime
         ).containsOnly(fixTime);
 
-        HistoricPlanItemInstance historicServiceTaskAvailableActiveCompleted = historicPlanItemInstancesByDefinitionId.get("serviceTaskAvailableActiveCompleted");
+        HistoricPlanItemInstance historicServiceTaskAvailableActiveCompleted = historicPlanItemInstancesByDefinitionId
+                .get("serviceTaskAvailableActiveCompleted");
 
         assertThat(historicServiceTaskAvailableActiveCompleted).extracting(
-            HistoricPlanItemInstance::getOccurredTime,
-            HistoricPlanItemInstance::getTerminatedTime,
-            HistoricPlanItemInstance::getExitTime,
-            HistoricPlanItemInstance::getLastEnabledTime,
-            HistoricPlanItemInstance::getLastDisabledTime,
-            HistoricPlanItemInstance::getLastSuspendedTime
+                HistoricPlanItemInstance::getOccurredTime,
+                HistoricPlanItemInstance::getTerminatedTime,
+                HistoricPlanItemInstance::getExitTime,
+                HistoricPlanItemInstance::getLastEnabledTime,
+                HistoricPlanItemInstance::getLastDisabledTime,
+                HistoricPlanItemInstance::getLastSuspendedTime
         ).containsOnlyNulls();
 
         assertThat(historicServiceTaskAvailableActiveCompleted).extracting(
-            HistoricPlanItemInstance::getCreateTime,
-            HistoricPlanItemInstance::getCompletedTime,
-            HistoricPlanItemInstance::getEndedTime,
-            HistoricPlanItemInstance::getLastAvailableTime,
-            HistoricPlanItemInstance::getLastStartedTime
+                HistoricPlanItemInstance::getCreateTime,
+                HistoricPlanItemInstance::getCompletedTime,
+                HistoricPlanItemInstance::getEndedTime,
+                HistoricPlanItemInstance::getLastAvailableTime,
+                HistoricPlanItemInstance::getLastStartedTime
         ).containsOnly(fixTime);
 
         HistoricPlanItemInstance historicStageAvailableActiveTerminated = historicPlanItemInstancesByDefinitionId.get("stageAvailableActiveTerminated");
 
         assertThat(historicStageAvailableActiveTerminated).extracting(
-            HistoricPlanItemInstance::getCompletedTime,
-            HistoricPlanItemInstance::getOccurredTime,
-            HistoricPlanItemInstance::getTerminatedTime,
-            HistoricPlanItemInstance::getLastEnabledTime,
-            HistoricPlanItemInstance::getLastDisabledTime,
-            HistoricPlanItemInstance::getLastSuspendedTime
+                HistoricPlanItemInstance::getCompletedTime,
+                HistoricPlanItemInstance::getOccurredTime,
+                HistoricPlanItemInstance::getTerminatedTime,
+                HistoricPlanItemInstance::getLastEnabledTime,
+                HistoricPlanItemInstance::getLastDisabledTime,
+                HistoricPlanItemInstance::getLastSuspendedTime
         ).containsOnlyNulls();
 
         assertThat(historicStageAvailableActiveTerminated).extracting(
-            HistoricPlanItemInstance::getCreateTime,
-            HistoricPlanItemInstance::getEndedTime,
-            HistoricPlanItemInstance::getExitTime,
-            HistoricPlanItemInstance::getLastAvailableTime,
-            HistoricPlanItemInstance::getLastStartedTime
+                HistoricPlanItemInstance::getCreateTime,
+                HistoricPlanItemInstance::getEndedTime,
+                HistoricPlanItemInstance::getExitTime,
+                HistoricPlanItemInstance::getLastAvailableTime,
+                HistoricPlanItemInstance::getLastStartedTime
         ).containsOnly(fixTime);
 
         HistoricPlanItemInstance historicHumanTaskAvailableActiveTerminatedAndWaitingForRepetition = historicPlanItemInstancesByDefinitionId
-            .get("humanTaskAvailableActiveTerminatedAndWaitingForRepetition");
+                .get("humanTaskAvailableActiveTerminatedAndWaitingForRepetition");
 
         assertThat(historicHumanTaskAvailableActiveTerminatedAndWaitingForRepetition).extracting(
-            HistoricPlanItemInstance::getCompletedTime,
-            HistoricPlanItemInstance::getOccurredTime,
-            HistoricPlanItemInstance::getTerminatedTime,
-            HistoricPlanItemInstance::getLastEnabledTime,
-            HistoricPlanItemInstance::getLastDisabledTime,
-            HistoricPlanItemInstance::getLastSuspendedTime
+                HistoricPlanItemInstance::getCompletedTime,
+                HistoricPlanItemInstance::getOccurredTime,
+                HistoricPlanItemInstance::getTerminatedTime,
+                HistoricPlanItemInstance::getLastEnabledTime,
+                HistoricPlanItemInstance::getLastDisabledTime,
+                HistoricPlanItemInstance::getLastSuspendedTime
         ).containsOnlyNulls();
 
         assertThat(historicHumanTaskAvailableActiveTerminatedAndWaitingForRepetition).extracting(
-            HistoricPlanItemInstance::getCreateTime,
-            HistoricPlanItemInstance::getEndedTime,
-            HistoricPlanItemInstance::getExitTime,
-            HistoricPlanItemInstance::getLastAvailableTime,
-            HistoricPlanItemInstance::getLastStartedTime
+                HistoricPlanItemInstance::getCreateTime,
+                HistoricPlanItemInstance::getEndedTime,
+                HistoricPlanItemInstance::getExitTime,
+                HistoricPlanItemInstance::getLastAvailableTime,
+                HistoricPlanItemInstance::getLastStartedTime
         ).containsOnly(fixTime);
     }
 }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/history/PlanItemInstanceHistoryServiceTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/history/PlanItemInstanceHistoryServiceTest.java
@@ -12,11 +12,7 @@
  */
 package org.flowable.cmmn.test.history;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Calendar;
 import java.util.Collections;
@@ -46,33 +42,32 @@ import org.junit.Test;
 public class PlanItemInstanceHistoryServiceTest extends FlowableCmmnTestCase {
 
     private static Consumer<HistoricPlanItemInstance> assertCreateTimeHistoricPlanItemInstance = h -> {
-        assertNotNull(h.getCreateTime());
-        assertTrue(h.getCreateTime().getTime() >= 0L);
-//        if (!PlanItemInstanceState.WAITING_FOR_REPETITION.equalsIgnoreCase(h.getState())) {
-//            assertNotNull(h.getLastAvailableTime());
-//        }
+        assertThat(h.getCreateTime()).isNotNull();
+        assertThat(h.getCreateTime().getTime()).isGreaterThanOrEqualTo(0L);
+        //        if (!PlanItemInstanceState.WAITING_FOR_REPETITION.equalsIgnoreCase(h.getState())) {
+        //            assertThat(h.getLastAvailableTime()).isNotNull();
+        //        }
     };
 
     private static Consumer<HistoricPlanItemInstance> assertStartedTimeHistoricPlanItemInstance = h -> {
-        assertNotNull(h.getLastStartedTime());
-        assertTrue(h.getLastStartedTime().getTime() >= h.getCreateTime().getTime());
+        assertThat(h.getLastStartedTime()).isNotNull();
+        assertThat(h.getLastStartedTime().getTime()).isGreaterThanOrEqualTo(h.getCreateTime().getTime());
     };
 
     private static Consumer<HistoricPlanItemInstance> assertEndedTimeHistoricPlanItemInstance = h -> {
-        assertNotNull(h.getEndedTime());
-        assertTrue(h.getEndedTime().getTime() >= h.getLastStartedTime().getTime());
+        assertThat(h.getEndedTime()).isNotNull();
+        assertThat(h.getEndedTime().getTime()).isGreaterThanOrEqualTo(h.getLastStartedTime().getTime());
     };
 
     private static Consumer<HistoricPlanItemInstance> assertEndStateHistoricPlanItemInstance = h -> {
-        assertNotNull(h.getState());
-        assertTrue(PlanItemInstanceState.END_STATES.contains(h.getState()));
+        assertThat(h.getState()).isNotNull();
+        assertThat(PlanItemInstanceState.END_STATES).contains(h.getState());
     };
 
     private static Consumer<HistoricPlanItemInstance> assertStartedStateHistoricPlanItemInstance = h -> {
-        assertNotNull(h.getState());
-        assertTrue(PlanItemInstanceState.ACTIVE.contains(h.getState()) ||
-                PlanItemInstanceState.ENABLED.contains(h.getState()) ||
-                PlanItemInstanceState.ASYNC_ACTIVE.contains(h.getState()));
+        assertThat(h.getState()).isNotNull();
+        assertThat(h.getState())
+                .isIn(PlanItemInstanceState.ACTIVE, PlanItemInstanceState.ENABLED, PlanItemInstanceState.ASYNC_ACTIVE);
     };
 
     @Test
@@ -82,19 +77,25 @@ public class PlanItemInstanceHistoryServiceTest extends FlowableCmmnTestCase {
 
         //one Task, one Stage, one Milestone
         List<PlanItemInstance> currentPlanItems = cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).list();
-        assertNotNull(currentPlanItems);
-        assertEquals(3, currentPlanItems.size());
-        assertTrue(currentPlanItems.stream().map(PlanItemInstance::getPlanItemDefinitionType).anyMatch(PlanItemDefinitionType.STAGE::equalsIgnoreCase));
-        assertTrue(currentPlanItems.stream().map(PlanItemInstance::getPlanItemDefinitionType).anyMatch(PlanItemDefinitionType.MILESTONE::equalsIgnoreCase));
-        assertTrue(currentPlanItems.stream().map(PlanItemInstance::getPlanItemDefinitionType).anyMatch("task"::equalsIgnoreCase));
+        assertThat(currentPlanItems).isNotNull();
+        assertThat(currentPlanItems).hasSize(3);
+        assertThat(currentPlanItems.stream().map(PlanItemInstance::getPlanItemDefinitionType).anyMatch(PlanItemDefinitionType.STAGE::equalsIgnoreCase))
+                .isTrue();
+        assertThat(currentPlanItems.stream().map(PlanItemInstance::getPlanItemDefinitionType).anyMatch(PlanItemDefinitionType.MILESTONE::equalsIgnoreCase))
+                .isTrue();
+        assertThat(currentPlanItems.stream().map(PlanItemInstance::getPlanItemDefinitionType).anyMatch("task"::equalsIgnoreCase)).isTrue();
 
         //Milestone are just another planItem too, so it will appear in the planItemInstance History
-        List<HistoricPlanItemInstance> historicPlanItems = cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceCaseInstanceId(caseInstance.getId()).list();
-        assertNotNull(historicPlanItems);
-        assertEquals(3, historicPlanItems.size());
-        assertTrue(historicPlanItems.stream().map(HistoricPlanItemInstance::getPlanItemDefinitionType).anyMatch(PlanItemDefinitionType.STAGE::equalsIgnoreCase));
-        assertTrue(historicPlanItems.stream().map(HistoricPlanItemInstance::getPlanItemDefinitionType).anyMatch(PlanItemDefinitionType.MILESTONE::equalsIgnoreCase));
-        assertTrue(historicPlanItems.stream().anyMatch(h -> "task".equalsIgnoreCase(h.getPlanItemDefinitionType()) && "planItemTaskA".equalsIgnoreCase(h.getElementId())));
+        List<HistoricPlanItemInstance> historicPlanItems = cmmnHistoryService.createHistoricPlanItemInstanceQuery()
+                .planItemInstanceCaseInstanceId(caseInstance.getId()).list();
+        assertThat(historicPlanItems).isNotNull();
+        assertThat(historicPlanItems).hasSize(3);
+        assertThat(historicPlanItems.stream().map(HistoricPlanItemInstance::getPlanItemDefinitionType).anyMatch(PlanItemDefinitionType.STAGE::equalsIgnoreCase))
+                .isTrue();
+        assertThat(historicPlanItems.stream().map(HistoricPlanItemInstance::getPlanItemDefinitionType)
+                .anyMatch(PlanItemDefinitionType.MILESTONE::equalsIgnoreCase)).isTrue();
+        assertThat(historicPlanItems.stream()
+                .anyMatch(h -> "task".equalsIgnoreCase(h.getPlanItemDefinitionType()) && "planItemTaskA".equalsIgnoreCase(h.getElementId()))).isTrue();
 
         //Check Start timeStamp within the second of its original creation
         historicPlanItems.forEach(assertCreateTimeHistoricPlanItemInstance);
@@ -102,49 +103,57 @@ public class PlanItemInstanceHistoryServiceTest extends FlowableCmmnTestCase {
 
         //Check activation timestamp... for those "live" instances not in "Waiting" state (i.e. AVAILABLE)
         List<String> nonWaitingPlanInstanceIds = getIdsOfNonWaitingPlanItemInstances(currentPlanItems);
-        assertFalse(nonWaitingPlanInstanceIds.isEmpty());
-        List<HistoricPlanItemInstance> filteredHistoricPlanItemInstances = historicPlanItems.stream().filter(h -> nonWaitingPlanInstanceIds.contains(h.getId())).collect(Collectors.toList());
-        assertFalse(filteredHistoricPlanItemInstances.isEmpty());
+        assertThat(nonWaitingPlanInstanceIds).isNotEmpty();
+        List<HistoricPlanItemInstance> filteredHistoricPlanItemInstances = historicPlanItems.stream().filter(h -> nonWaitingPlanInstanceIds.contains(h.getId()))
+                .collect(Collectors.toList());
+        assertThat(filteredHistoricPlanItemInstances).isNotEmpty();
         filteredHistoricPlanItemInstances.forEach(assertCreateTimeHistoricPlanItemInstance
                 .andThen(assertStartedTimeHistoricPlanItemInstance)
                 .andThen(assertStartedTimeHistoricPlanItemInstance)
                 .andThen(assertStartedStateHistoricPlanItemInstance));
 
         //No planItemInstance has "ended" yet, so no historicPlanItemInstance should have endTime timestamp
-        historicPlanItems.forEach(h -> assertNull(h.getEndedTime()));
+        historicPlanItems.forEach(h -> assertThat(h.getEndedTime()).isNull());
 
         //Milestone history is only filled when the milestone occurs
-        List<HistoricMilestoneInstance> historicMilestones = cmmnHistoryService.createHistoricMilestoneInstanceQuery().milestoneInstanceCaseInstanceId(caseInstance.getId()).list();
-        assertNotNull(historicMilestones);
-        assertTrue(historicMilestones.isEmpty());
+        List<HistoricMilestoneInstance> historicMilestones = cmmnHistoryService.createHistoricMilestoneInstanceQuery()
+                .milestoneInstanceCaseInstanceId(caseInstance.getId()).list();
+        assertThat(historicMilestones).isNotNull();
+        assertThat(historicMilestones).isEmpty();
 
         //////////////////////////////////////////////////////////////////
         //Trigger the task to reach the milestone and activate the stage//
         assertCaseInstanceNotEnded(caseInstance);
         PlanItemInstance task = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceElementId("planItemTaskA").singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         cmmnRuntimeService.triggerPlanItemInstance(task.getId());
         assertCaseInstanceNotEnded(caseInstance);
 
         //Now there are 2 plan items in a non-final state, a Stage and its containing task (only 1 new planItem)
         currentPlanItems = cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).list();
-        assertNotNull(currentPlanItems);
-        assertEquals(2, currentPlanItems.size());
-        assertTrue(currentPlanItems.stream().map(PlanItemInstance::getPlanItemDefinitionType).anyMatch(PlanItemDefinitionType.STAGE::equalsIgnoreCase));
-        assertTrue(currentPlanItems.stream().anyMatch(p -> "task".equalsIgnoreCase(p.getPlanItemDefinitionType()) && "planItemTaskB".equalsIgnoreCase(p.getElementId())));
+        assertThat(currentPlanItems).isNotNull();
+        assertThat(currentPlanItems).hasSize(2);
+        assertThat(currentPlanItems.stream().map(PlanItemInstance::getPlanItemDefinitionType).anyMatch(PlanItemDefinitionType.STAGE::equalsIgnoreCase))
+                .isTrue();
+        assertThat(currentPlanItems.stream()
+                .anyMatch(p -> "task".equalsIgnoreCase(p.getPlanItemDefinitionType()) && "planItemTaskB".equalsIgnoreCase(p.getElementId()))).isTrue();
 
         historicPlanItems = cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceCaseInstanceId(caseInstance.getId()).list();
-        assertNotNull(historicPlanItems);
-        assertEquals(4, historicPlanItems.size());
-        assertEquals(1L, cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceId(historicPlanItems.get(0).getId()).planItemInstanceWithoutTenantId().list().size());
-        assertEquals(1, cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceId(historicPlanItems.get(0).getId()).planItemInstanceWithoutTenantId().count());
+        assertThat(historicPlanItems).isNotNull();
+        assertThat(historicPlanItems).hasSize(4);
+        assertThat(
+                cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceId(historicPlanItems.get(0).getId()).planItemInstanceWithoutTenantId()
+                        .list()).hasSize(1);
+        assertThat(
+                cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceId(historicPlanItems.get(0).getId()).planItemInstanceWithoutTenantId()
+                        .count()).isEqualTo(1);
 
         //Check start timestamps of newly added timeStamp within the second of its original creation
         checkHistoryCreateTimestamp(currentPlanItems, historicPlanItems, 1000L);
 
         //Check activationTime if applies and the endTime for not "live" instances
         List<String> livePlanItemInstanceIds = currentPlanItems.stream().map(PlanItemInstance::getId).collect(Collectors.toList());
-        assertFalse(livePlanItemInstanceIds.isEmpty());
+        assertThat(livePlanItemInstanceIds).isNotEmpty();
         filteredHistoricPlanItemInstances = historicPlanItems.stream().filter(h -> !livePlanItemInstanceIds.contains(h.getId())).collect(Collectors.toList());
         filteredHistoricPlanItemInstances.forEach(assertCreateTimeHistoricPlanItemInstance
                 .andThen(assertStartedTimeHistoricPlanItemInstance)
@@ -153,21 +162,21 @@ public class PlanItemInstanceHistoryServiceTest extends FlowableCmmnTestCase {
 
         //Milestone appears now in the MilestoneHistory
         historicMilestones = cmmnHistoryService.createHistoricMilestoneInstanceQuery().milestoneInstanceCaseInstanceId(caseInstance.getId()).list();
-        assertNotNull(historicMilestones);
-        assertEquals(1, historicMilestones.size());
+        assertThat(historicMilestones).isNotNull();
+        assertThat(historicMilestones).hasSize(1);
 
         //////////////////////////////////////////////////
         //Trigger the last planItem to complete the Case//
         assertCaseInstanceNotEnded(caseInstance);
         task = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceElementId("planItemTaskB").singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         cmmnRuntimeService.triggerPlanItemInstance(task.getId());
         assertCaseInstanceEnded(caseInstance);
 
         //History remains
         historicPlanItems = cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceCaseInstanceId(caseInstance.getId()).list();
-        assertNotNull(historicPlanItems);
-        assertEquals(4, historicPlanItems.size());
+        assertThat(historicPlanItems).isNotNull();
+        assertThat(historicPlanItems).hasSize(4);
         historicPlanItems.forEach(assertCreateTimeHistoricPlanItemInstance
                 .andThen(assertStartedTimeHistoricPlanItemInstance)
                 .andThen(assertEndedTimeHistoricPlanItemInstance)
@@ -175,8 +184,8 @@ public class PlanItemInstanceHistoryServiceTest extends FlowableCmmnTestCase {
         );
 
         historicMilestones = cmmnHistoryService.createHistoricMilestoneInstanceQuery().milestoneInstanceCaseInstanceId(caseInstance.getId()).list();
-        assertNotNull(historicMilestones);
-        assertEquals(1, historicMilestones.size());
+        assertThat(historicMilestones).isNotNull();
+        assertThat(historicMilestones).hasSize(1);
     }
 
     @Test
@@ -193,12 +202,13 @@ public class PlanItemInstanceHistoryServiceTest extends FlowableCmmnTestCase {
 
         //Basic case setup check
         List<HistoricPlanItemInstance> historicPlanItemInstances = cmmnHistoryService.createHistoricPlanItemInstanceQuery().list();
-        assertEquals(2, historicPlanItemInstances.size());
-        assertEquals(1, historicPlanItemInstances.stream().filter(h -> PlanItemDefinitionType.STAGE.equals(h.getPlanItemDefinitionType())).count());
-        assertEquals(1, historicPlanItemInstances.stream().filter(h -> PlanItemDefinitionType.HUMAN_TASK.equals(h.getPlanItemDefinitionType())).count());
+        assertThat(historicPlanItemInstances).hasSize(2);
+        assertThat(historicPlanItemInstances.stream().filter(h -> PlanItemDefinitionType.STAGE.equals(h.getPlanItemDefinitionType())).count()).isEqualTo(1);
+        assertThat(historicPlanItemInstances.stream().filter(h -> PlanItemDefinitionType.HUMAN_TASK.equals(h.getPlanItemDefinitionType())).count())
+                .isEqualTo(1);
 
         //Check by different criteria
-        assertEquals(2, cmmnHistoryService.createHistoricPlanItemInstanceQuery()
+        assertThat(cmmnHistoryService.createHistoricPlanItemInstanceQuery()
                 .planItemInstanceCaseInstanceId(caseInstance.getId())
                 .createdBefore(afterCaseInstance)
                 .createdAfter(beforeCaseInstance)
@@ -207,7 +217,7 @@ public class PlanItemInstanceHistoryServiceTest extends FlowableCmmnTestCase {
                 .lastStartedBefore(afterCaseInstance)
                 .lastStartedAfter(beforeCaseInstance)
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
-                .count());
+                .count()).isEqualTo(2);
 
         Calendar beforeCompleteCalendar = cmmnEngineConfiguration.getClock().getCurrentCalendar();
         beforeCompleteCalendar.add(Calendar.HOUR, -1);
@@ -222,18 +232,33 @@ public class PlanItemInstanceHistoryServiceTest extends FlowableCmmnTestCase {
                 .completedBefore(afterComplete)
                 .completedAfter(beforeComplete)
                 .list();
-        assertEquals(2, historicPlanItemInstances.size());
+        assertThat(historicPlanItemInstances).hasSize(2);
+        assertThat(historicPlanItemInstances)
+                .extracting(HistoricPlanItemInstance::getExitTime)
+                .containsOnlyNulls();
+        assertThat(historicPlanItemInstances)
+                .extracting(HistoricPlanItemInstance::getTerminatedTime)
+                .containsOnlyNulls();
+        assertThat(historicPlanItemInstances)
+                .extracting(HistoricPlanItemInstance::getOccurredTime)
+                .containsOnlyNulls();
+        assertThat(historicPlanItemInstances)
+                .extracting(HistoricPlanItemInstance::getLastDisabledTime)
+                .containsOnlyNulls();
+        assertThat(historicPlanItemInstances)
+                .extracting(HistoricPlanItemInstance::getLastEnabledTime)
+                .containsOnlyNulls();
+        assertThat(historicPlanItemInstances)
+                .extracting(HistoricPlanItemInstance::getLastSuspendedTime)
+                .containsOnlyNulls();
+        assertThat(historicPlanItemInstances)
+                .extracting(HistoricPlanItemInstance::getCreateTime)
+                .isNotNull();
+
         historicPlanItemInstances.forEach(h -> {
-            assertNull(h.getExitTime());
-            assertNull(h.getTerminatedTime());
-            assertNull(h.getOccurredTime());
-            assertNull(h.getLastDisabledTime());
-            assertNull(h.getLastEnabledTime());
-            assertNull(h.getLastSuspendedTime());
-            assertNotNull(h.getCreateTime());
-            assertTrue(h.getCreateTime().getTime() <= h.getLastAvailableTime().getTime());
-            assertTrue(h.getLastAvailableTime().getTime() <= h.getCompletedTime().getTime());
-            assertTrue(h.getCompletedTime().getTime() <= h.getEndedTime().getTime());
+            assertThat(h.getCreateTime().getTime()).isLessThanOrEqualTo(h.getLastAvailableTime().getTime());
+            assertThat(h.getLastAvailableTime().getTime()).isLessThanOrEqualTo(h.getCompletedTime().getTime());
+            assertThat(h.getCompletedTime().getTime()).isLessThanOrEqualTo(h.getEndedTime().getTime());
         });
 
         assertCaseInstanceEnded(caseInstance);
@@ -245,35 +270,36 @@ public class PlanItemInstanceHistoryServiceTest extends FlowableCmmnTestCase {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testEntryAndExitPropagate").start();
 
         List<PlanItemInstance> currentPlanItems = cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).list();
-        assertNotNull(currentPlanItems);
-        assertEquals(3, currentPlanItems.size());
-        assertEquals(1, currentPlanItems.stream()
+        assertThat(currentPlanItems).isNotNull();
+        assertThat(currentPlanItems).hasSize(3);
+        assertThat(currentPlanItems.stream()
                 .filter(p -> PlanItemDefinitionType.STAGE.equalsIgnoreCase(p.getPlanItemDefinitionType()))
                 .filter(p -> PlanItemInstanceState.AVAILABLE.equalsIgnoreCase(p.getState()))
-                .count());
-        assertEquals(2, currentPlanItems.stream()
+                .count()).isEqualTo(1);
+        assertThat(currentPlanItems.stream()
                 .filter(p -> PlanItemDefinitionType.USER_EVENT_LISTENER.equalsIgnoreCase(p.getPlanItemDefinitionType()))
                 .filter(p -> PlanItemInstanceState.AVAILABLE.equalsIgnoreCase(p.getState()))
-                .count());
+                .count()).isEqualTo(2);
 
-        List<HistoricPlanItemInstance> historicPlanItems = cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceCaseInstanceId(caseInstance.getId()).list();
-        assertNotNull(historicPlanItems);
-        assertEquals(3, historicPlanItems.size());
+        List<HistoricPlanItemInstance> historicPlanItems = cmmnHistoryService.createHistoricPlanItemInstanceQuery()
+                .planItemInstanceCaseInstanceId(caseInstance.getId()).list();
+        assertThat(historicPlanItems).isNotNull();
+        assertThat(historicPlanItems).hasSize(3);
         checkHistoryCreateTimestamp(currentPlanItems, historicPlanItems, 1000L);
-        assertEquals(1, historicPlanItems.stream().filter(h -> PlanItemDefinitionType.STAGE.equalsIgnoreCase(h.getPlanItemDefinitionType()))
+        assertThat(historicPlanItems.stream().filter(h -> PlanItemDefinitionType.STAGE.equalsIgnoreCase(h.getPlanItemDefinitionType()))
                 .filter(h -> PlanItemInstanceState.AVAILABLE.equalsIgnoreCase(h.getState()))
                 .filter(h -> h.getLastAvailableTime() != null && h.getCreateTime().getTime() <= h.getLastAvailableTime().getTime())
-                .count());
+                .count()).isEqualTo(1);
 
         //QUERY FOR STAGES
         historicPlanItems = cmmnHistoryService.createHistoricPlanItemInstanceQuery()
                 .planItemInstanceDefinitionType(PlanItemDefinitionType.STAGE)
                 .planItemInstanceState(PlanItemInstanceState.AVAILABLE)
                 .list();
-        assertEquals(1, historicPlanItems.size());
+        assertThat(historicPlanItems).hasSize(1);
         historicPlanItems.forEach(h -> {
-            assertNotNull(h.getLastAvailableTime());
-            assertTrue(h.getCreateTime().getTime() <= h.getLastAvailableTime().getTime());
+            assertThat(h.getLastAvailableTime()).isNotNull();
+            assertThat(h.getCreateTime().getTime()).isLessThanOrEqualTo(h.getLastAvailableTime().getTime());
         });
 
         //QUERY FOR USER_EVENT_LISTENERS
@@ -281,10 +307,10 @@ public class PlanItemInstanceHistoryServiceTest extends FlowableCmmnTestCase {
                 .planItemInstanceDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER)
                 .planItemInstanceState(PlanItemInstanceState.AVAILABLE)
                 .list();
-        assertEquals(2, historicPlanItems.size());
+        assertThat(historicPlanItems).hasSize(2);
         historicPlanItems.forEach(h -> {
-            assertNotNull(h.getLastAvailableTime());
-            assertTrue(h.getCreateTime().getTime() <= h.getLastAvailableTime().getTime());
+            assertThat(h.getLastAvailableTime()).isNotNull();
+            assertThat(h.getCreateTime().getTime()).isLessThanOrEqualTo(h.getLastAvailableTime().getTime());
         });
 
         //Fulfill stages entryCriteria - keep date marks for query criteria
@@ -299,13 +325,13 @@ public class PlanItemInstanceHistoryServiceTest extends FlowableCmmnTestCase {
 
         //A userEventListeners is removed and two human task are instanced
         currentPlanItems = cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).list();
-        assertNotNull(currentPlanItems);
-        assertEquals(4, currentPlanItems.size());
+        assertThat(currentPlanItems).isNotNull();
+        assertThat(currentPlanItems).hasSize(4);
 
         //Two more planItemInstances in the history
         historicPlanItems = cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceCaseInstanceId(caseInstance.getId()).list();
-        assertNotNull(historicPlanItems);
-        assertEquals(5, historicPlanItems.size());
+        assertThat(historicPlanItems).isNotNull();
+        assertThat(historicPlanItems).hasSize(5);
         checkHistoryCreateTimestamp(currentPlanItems, historicPlanItems, 1000L);
 
         //Both stages should be active now
@@ -313,11 +339,11 @@ public class PlanItemInstanceHistoryServiceTest extends FlowableCmmnTestCase {
                 .planItemInstanceDefinitionType(PlanItemDefinitionType.STAGE)
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .list();
-        assertEquals(1, historicPlanItems.size());
+        assertThat(historicPlanItems).hasSize(1);
         historicPlanItems.forEach(h -> {
-            assertNotNull(h.getLastStartedTime());
-            assertTrue(h.getCreateTime().getTime() <= h.getLastAvailableTime().getTime());
-            assertTrue(h.getLastAvailableTime().getTime() <= h.getLastStartedTime().getTime());
+            assertThat(h.getLastStartedTime()).isNotNull();
+            assertThat(h.getCreateTime().getTime()).isLessThanOrEqualTo(h.getLastAvailableTime().getTime());
+            assertThat(h.getLastAvailableTime().getTime()).isLessThanOrEqualTo(h.getLastStartedTime().getTime());
         });
 
         //3 new Human Tasks
@@ -325,34 +351,36 @@ public class PlanItemInstanceHistoryServiceTest extends FlowableCmmnTestCase {
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .planItemInstanceDefinitionType(PlanItemDefinitionType.HUMAN_TASK)
                 .list();
-        assertEquals(2, historicPlanItems.size());
+        assertThat(historicPlanItems).hasSize(2);
         historicPlanItems.forEach(h -> {
             //These are already started/active, but before that should also have available timestamp
-            assertEquals(PlanItemInstanceState.ACTIVE, h.getState());
-            assertNotNull(h.getLastAvailableTime());
-            assertNotNull(h.getLastStartedTime());
-            assertTrue(h.getCreateTime().getTime() <= h.getLastAvailableTime().getTime());
-            assertTrue(h.getLastAvailableTime().getTime() <= h.getLastStartedTime().getTime());
+            assertThat(h.getState()).isEqualTo(PlanItemInstanceState.ACTIVE);
+            assertThat(h.getLastAvailableTime()).isNotNull();
+            assertThat(h.getLastStartedTime()).isNotNull();
+            assertThat(h.getCreateTime().getTime()).isLessThanOrEqualTo(h.getLastAvailableTime().getTime());
+            assertThat(h.getLastAvailableTime().getTime()).isLessThanOrEqualTo(h.getLastStartedTime().getTime());
         });
 
         //There should be 3 eventListeners the history, two of them "occurred" and one should still be available
-        assertEquals(2, cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER).count());
-        assertEquals(1, cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER).planItemInstanceState(PlanItemInstanceState.AVAILABLE).count());
+        assertThat(cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER).count())
+                .isEqualTo(2);
+        assertThat(cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER)
+                .planItemInstanceState(PlanItemInstanceState.AVAILABLE).count()).isEqualTo(1);
         historicPlanItems = cmmnHistoryService.createHistoricPlanItemInstanceQuery()
                 .planItemInstanceDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER)
                 .occurredAfter(occurredAfter)
                 .occurredBefore(occurredBefore)
                 .list();
-        assertEquals(1, historicPlanItems.size());
+        assertThat(historicPlanItems).hasSize(1);
         historicPlanItems.forEach(h -> {
             //These are "completed" planItemInstance with occurred timestamp and ended timestamp
-            assertEquals(PlanItemInstanceState.COMPLETED, h.getState());
-            assertNotNull(h.getLastAvailableTime());
-            assertNotNull(h.getOccurredTime());
-            assertNotNull(h.getEndedTime());
-            assertTrue(h.getCreateTime().getTime() <= h.getLastAvailableTime().getTime());
-            assertTrue(h.getLastAvailableTime().getTime() <= h.getOccurredTime().getTime());
-            assertTrue(h.getOccurredTime().getTime() <= h.getEndedTime().getTime());
+            assertThat(h.getState()).isEqualTo(PlanItemInstanceState.COMPLETED);
+            assertThat(h.getLastAvailableTime()).isNotNull();
+            assertThat(h.getOccurredTime()).isNotNull();
+            assertThat(h.getEndedTime()).isNotNull();
+            assertThat(h.getCreateTime().getTime()).isLessThanOrEqualTo(h.getLastAvailableTime().getTime());
+            assertThat(h.getLastAvailableTime().getTime()).isLessThanOrEqualTo(h.getOccurredTime().getTime());
+            assertThat(h.getOccurredTime().getTime()).isLessThanOrEqualTo(h.getEndedTime().getTime());
         });
 
         //Complete one of the Tasks on stageOne
@@ -365,23 +393,24 @@ public class PlanItemInstanceHistoryServiceTest extends FlowableCmmnTestCase {
         Date completedBefore = cmmnEngineConfiguration.getClock().getCurrentTime();
 
         //one completed task, fetched with completeTime queryCriteria
-        HistoricPlanItemInstance historicPlanItem = cmmnHistoryService.createHistoricPlanItemInstanceQuery().completedBefore(completedBefore).completedAfter(completedAfter).singleResult();
-        assertNotNull(historicPlanItem);
-        assertEquals("planItemTaskA", historicPlanItem.getElementId());
-        assertEquals(PlanItemInstanceState.COMPLETED, historicPlanItem.getState());
-        assertNotNull(historicPlanItem.getLastAvailableTime());
-        assertNotNull(historicPlanItem.getCompletedTime());
-        assertNotNull(historicPlanItem.getEndedTime());
-        assertTrue(historicPlanItem.getCreateTime().getTime() <= historicPlanItem.getLastAvailableTime().getTime());
-        assertTrue(historicPlanItem.getLastAvailableTime().getTime() <= historicPlanItem.getCompletedTime().getTime());
-        assertTrue(historicPlanItem.getCompletedTime().getTime() <= historicPlanItem.getEndedTime().getTime());
+        HistoricPlanItemInstance historicPlanItem = cmmnHistoryService.createHistoricPlanItemInstanceQuery().completedBefore(completedBefore)
+                .completedAfter(completedAfter).singleResult();
+        assertThat(historicPlanItem).isNotNull();
+        assertThat(historicPlanItem.getElementId()).isEqualTo("planItemTaskA");
+        assertThat(historicPlanItem.getState()).isEqualTo(PlanItemInstanceState.COMPLETED);
+        assertThat(historicPlanItem.getLastAvailableTime()).isNotNull();
+        assertThat(historicPlanItem.getCompletedTime()).isNotNull();
+        assertThat(historicPlanItem.getEndedTime()).isNotNull();
+        assertThat(historicPlanItem.getCreateTime().getTime()).isLessThanOrEqualTo(historicPlanItem.getLastAvailableTime().getTime());
+        assertThat(historicPlanItem.getLastAvailableTime().getTime()).isLessThanOrEqualTo(historicPlanItem.getCompletedTime().getTime());
+        assertThat(historicPlanItem.getCompletedTime().getTime()).isLessThanOrEqualTo(historicPlanItem.getEndedTime().getTime());
 
         // one task still active
         historicPlanItems = cmmnHistoryService.createHistoricPlanItemInstanceQuery()
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .planItemInstanceDefinitionType(PlanItemDefinitionType.HUMAN_TASK)
                 .list();
-        assertEquals(1, historicPlanItems.size());
+        assertThat(historicPlanItems).hasSize(1);
 
         //Trigger exit criteria of stage one
         Date endedAfter = cmmnEngineConfiguration.getClock().getCurrentTime();
@@ -397,18 +426,18 @@ public class PlanItemInstanceHistoryServiceTest extends FlowableCmmnTestCase {
                 .exitAfter(endedAfter)
                 .list();
         //The stage and the remaining containing task
-        assertEquals(2, historicPlanItems.size());
-        assertTrue(historicPlanItems.stream().anyMatch(h -> PlanItemDefinitionType.STAGE.equalsIgnoreCase(h.getPlanItemDefinitionType())));
-        assertTrue(historicPlanItems.stream().anyMatch(h -> PlanItemDefinitionType.HUMAN_TASK.equalsIgnoreCase(h.getPlanItemDefinitionType())));
+        assertThat(historicPlanItems).hasSize(2);
+        assertThat(historicPlanItems.stream().anyMatch(h -> PlanItemDefinitionType.STAGE.equalsIgnoreCase(h.getPlanItemDefinitionType()))).isTrue();
+        assertThat(historicPlanItems.stream().anyMatch(h -> PlanItemDefinitionType.HUMAN_TASK.equalsIgnoreCase(h.getPlanItemDefinitionType()))).isTrue();
 
         historicPlanItems.forEach(h -> {
-            assertEquals(PlanItemInstanceState.TERMINATED, h.getState());
-            assertNotNull(h.getLastAvailableTime());
-            assertNotNull(h.getExitTime());
-            assertNotNull(h.getEndedTime());
-            assertTrue(h.getCreateTime().getTime() <= h.getLastAvailableTime().getTime());
-            assertTrue(h.getLastAvailableTime().getTime() <= h.getExitTime().getTime());
-            assertTrue(h.getExitTime().getTime() <= h.getEndedTime().getTime());
+            assertThat(h.getState()).isEqualTo(PlanItemInstanceState.TERMINATED);
+            assertThat(h.getLastAvailableTime()).isNotNull();
+            assertThat(h.getExitTime()).isNotNull();
+            assertThat(h.getEndedTime()).isNotNull();
+            assertThat(h.getCreateTime().getTime()).isLessThanOrEqualTo(h.getLastAvailableTime().getTime());
+            assertThat(h.getLastAvailableTime().getTime()).isLessThanOrEqualTo(h.getExitTime().getTime());
+            assertThat(h.getExitTime().getTime()).isLessThanOrEqualTo(h.getEndedTime().getTime());
         });
 
         assertCaseInstanceEnded(caseInstance);
@@ -425,33 +454,37 @@ public class PlanItemInstanceHistoryServiceTest extends FlowableCmmnTestCase {
                 .start();
 
         for (int i = 1; i <= totalRepetitions; i++) {
-            PlanItemInstance repeatingTaskPlanItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceElementId("repeatingTaskPlanItem").singleResult();
-            assertNotNull(repeatingTaskPlanItemInstance);
-            assertEquals(PlanItemInstanceState.ACTIVE, repeatingTaskPlanItemInstance.getState());
+            PlanItemInstance repeatingTaskPlanItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceElementId("repeatingTaskPlanItem")
+                    .singleResult();
+            assertThat(repeatingTaskPlanItemInstance).isNotNull();
+            assertThat(repeatingTaskPlanItemInstance.getState()).isEqualTo(PlanItemInstanceState.ACTIVE);
 
             //History Before task execution
             List<HistoricPlanItemInstance> historyBefore = cmmnHistoryService.createHistoricPlanItemInstanceQuery().list();
-            Map<String, List<HistoricPlanItemInstance>> historyBeforeByState = historyBefore.stream().collect(Collectors.groupingBy(HistoricPlanItemInstance::getState));
-            assertEquals(1, historyBeforeByState.get(PlanItemInstanceState.ACTIVE).size());
-            assertEquals(i - 1, historyBeforeByState.getOrDefault(PlanItemInstanceState.COMPLETED, Collections.EMPTY_LIST).size());
+            Map<String, List<HistoricPlanItemInstance>> historyBeforeByState = historyBefore.stream()
+                    .collect(Collectors.groupingBy(HistoricPlanItemInstance::getState));
+            assertThat(historyBeforeByState.get(PlanItemInstanceState.ACTIVE)).hasSize(1);
+            assertThat(historyBeforeByState.getOrDefault(PlanItemInstanceState.COMPLETED, Collections.EMPTY_LIST)).hasSize(i - 1);
 
             //Sanity check Active planItemInstance
-            assertEquals(repeatingTaskPlanItemInstance.getId(), historyBeforeByState.get(PlanItemInstanceState.ACTIVE).get(0).getId());
+            assertThat(historyBeforeByState.get(PlanItemInstanceState.ACTIVE).get(0).getId()).isEqualTo(repeatingTaskPlanItemInstance.getId());
             //Sanity check repetition counter
-            HistoricVariableInstance historicRepetitionCounter = cmmnHistoryService.createHistoricVariableInstanceQuery().planItemInstanceId(repeatingTaskPlanItemInstance.getId()).singleResult();
-            assertNotNull(historicRepetitionCounter);
-            assertEquals(i, historicRepetitionCounter.getValue());
+            HistoricVariableInstance historicRepetitionCounter = cmmnHistoryService.createHistoricVariableInstanceQuery()
+                    .planItemInstanceId(repeatingTaskPlanItemInstance.getId()).singleResult();
+            assertThat(historicRepetitionCounter).isNotNull();
+            assertThat(historicRepetitionCounter.getValue()).isEqualTo(i);
 
             //Execute the repetition
             Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).subScopeId(repeatingTaskPlanItemInstance.getId()).singleResult();
-            assertNotNull(task);
+            assertThat(task).isNotNull();
             cmmnTaskService.complete(task.getId());
 
             //History Before task execution
             List<HistoricPlanItemInstance> historyAfter = cmmnHistoryService.createHistoricPlanItemInstanceQuery().list();
-            Map<String, List<HistoricPlanItemInstance>> historyAfterByState = historyAfter.stream().collect(Collectors.groupingBy(HistoricPlanItemInstance::getState));
-            assertEquals(i == totalRepetitions ? 0 : 1, historyAfterByState.getOrDefault(PlanItemInstanceState.ACTIVE, Collections.EMPTY_LIST).size());
-            assertEquals(i, historyAfterByState.getOrDefault(PlanItemInstanceState.COMPLETED, Collections.EMPTY_LIST).size());
+            Map<String, List<HistoricPlanItemInstance>> historyAfterByState = historyAfter.stream()
+                    .collect(Collectors.groupingBy(HistoricPlanItemInstance::getState));
+            assertThat(historyAfterByState.getOrDefault(PlanItemInstanceState.ACTIVE, Collections.EMPTY_LIST)).hasSize(i == totalRepetitions ? 0 : 1);
+            assertThat(historyAfterByState.getOrDefault(PlanItemInstanceState.COMPLETED, Collections.EMPTY_LIST)).hasSize(i);
         }
 
         //Check history in sequence
@@ -471,9 +504,9 @@ public class PlanItemInstanceHistoryServiceTest extends FlowableCmmnTestCase {
                     .andThen(assertEndedTimeHistoricPlanItemInstance)
                     .andThen(assertEndStateHistoricPlanItemInstance)
                     .accept(h);
-            assertTrue(previousCreateTime <= h.getCreateTime().getTime());
-            assertTrue(previousActivateTime <= h.getLastStartedTime().getTime());
-            assertTrue(previousEndTime <= h.getEndedTime().getTime());
+            assertThat(previousCreateTime).isLessThanOrEqualTo(h.getCreateTime().getTime());
+            assertThat(previousActivateTime).isLessThanOrEqualTo(h.getLastStartedTime().getTime());
+            assertThat(previousEndTime).isLessThanOrEqualTo(h.getEndedTime().getTime());
             previousCreateTime = h.getCreateTime().getTime();
             previousActivateTime = h.getLastStartedTime().getTime();
             previousEndTime = h.getEndedTime().getTime();
@@ -489,16 +522,17 @@ public class PlanItemInstanceHistoryServiceTest extends FlowableCmmnTestCase {
                 .collect(Collectors.toList());
     }
 
-    private void checkHistoryCreateTimestamp(final List<PlanItemInstance> currentPlanItems, final List<HistoricPlanItemInstance> historicPlanItemInstances, long threshold) {
+    private void checkHistoryCreateTimestamp(final List<PlanItemInstance> currentPlanItems, final List<HistoricPlanItemInstance> historicPlanItemInstances,
+            long threshold) {
         currentPlanItems.forEach(p -> {
             Optional<Long> createTimestamp = historicPlanItemInstances.stream()
                     .filter(h -> h.getId().equals(p.getId()))
                     .findFirst()
                     .map(HistoricPlanItemInstance::getCreateTime)
                     .map(Date::getTime);
-            assertTrue(createTimestamp.isPresent());
+            assertThat(createTimestamp.isPresent()).isTrue();
             long delta = createTimestamp.orElse(Long.MAX_VALUE) - p.getCreateTime().getTime();
-            assertTrue(delta <= threshold);
+            assertThat(delta).isLessThanOrEqualTo(threshold);
         });
     }
 }


### PR DESCRIPTION
Breaking the changes into groups to make review easier.

This finishes off the `org.flowable.cmmn.test.history` package.

