### PR TITLE
Use assertj fluent style in flowable-cmmn-engine (part 5)

### DIFF
--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/CompletionNeutralTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/CompletionNeutralTest.java
@@ -12,6 +12,10 @@
  */
 package org.flowable.cmmn.test.itemcontrol;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
 import org.flowable.cmmn.api.runtime.CaseInstance;
 import org.flowable.cmmn.api.runtime.PlanItemDefinitionType;
 import org.flowable.cmmn.api.runtime.PlanItemInstance;
@@ -21,12 +25,6 @@ import org.flowable.cmmn.engine.test.FlowableCmmnTestCase;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
-
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 
 /**
  * @author Joram Barrez
@@ -40,39 +38,39 @@ public class CompletionNeutralTest extends FlowableCmmnTestCase {
     @CmmnDeployment
     public void testSimpleStageCompletion() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey(name.getMethodName()).start();
-        assertNotNull(caseInstance);
+        assertThat(caseInstance).isNotNull();
 
         //Check case setup
-        assertEquals(4, cmmnRuntimeService.createPlanItemInstanceQuery().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(4);
 
         PlanItemInstance taskA = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("taskA").singleResult();
-        assertNotNull(taskA);
-        assertEquals(PlanItemInstanceState.ACTIVE, taskA.getState());
+        assertThat(taskA).isNotNull();
+        assertThat(taskA.getState()).isEqualTo(PlanItemInstanceState.ACTIVE);
 
         PlanItemInstance stageOne = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("stageOne").singleResult();
-        assertNotNull(stageOne);
-        assertEquals(PlanItemInstanceState.ACTIVE, stageOne.getState());
+        assertThat(stageOne).isNotNull();
+        assertThat(stageOne.getState()).isEqualTo(PlanItemInstanceState.ACTIVE);
 
         PlanItemInstance taskB = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("taskB").singleResult();
-        assertNotNull(taskB);
-        assertEquals(PlanItemInstanceState.AVAILABLE, taskB.getState());
+        assertThat(taskB).isNotNull();
+        assertThat(taskB.getState()).isEqualTo(PlanItemInstanceState.AVAILABLE);
 
         PlanItemInstance taskC = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("taskC").singleResult();
-        assertNotNull(taskC);
-        assertEquals(PlanItemInstanceState.ACTIVE, taskC.getState());
+        assertThat(taskC).isNotNull();
+        assertThat(taskC.getState()).isEqualTo(PlanItemInstanceState.ACTIVE);
 
         //Trigger the test
         assertCaseInstanceNotEnded(caseInstance);
         cmmnRuntimeService.triggerPlanItemInstance(taskC.getId());
 
         taskA = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("taskA").singleResult();
-        assertNotNull(taskA);
+        assertThat(taskA).isNotNull();
         stageOne = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("stageOne").singleResult();
-        assertNull(stageOne);
+        assertThat(stageOne).isNull();
         taskB = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("taskB").singleResult();
-        assertNull(taskB);
+        assertThat(taskB).isNull();
         taskC = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("taskC").singleResult();
-        assertNull(taskC);
+        assertThat(taskC).isNull();
 
         assertCaseInstanceNotEnded(caseInstance);
 
@@ -84,39 +82,40 @@ public class CompletionNeutralTest extends FlowableCmmnTestCase {
     @CmmnDeployment
     public void testStagedEventListenerBypassed() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey(name.getMethodName()).start();
-        assertNotNull(caseInstance);
+        assertThat(caseInstance).isNotNull();
 
         //Check case setup
-        assertEquals(4, cmmnRuntimeService.createPlanItemInstanceQuery().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(4);
 
         PlanItemInstance taskA = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("taskA").singleResult();
-        assertNotNull(taskA);
-        assertEquals(PlanItemInstanceState.ACTIVE, taskA.getState());
+        assertThat(taskA).isNotNull();
+        assertThat(taskA.getState()).isEqualTo(PlanItemInstanceState.ACTIVE);
 
         PlanItemInstance stageOne = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("stageOne").singleResult();
-        assertNotNull(stageOne);
-        assertEquals(PlanItemInstanceState.ACTIVE, stageOne.getState());
+        assertThat(stageOne).isNotNull();
+        assertThat(stageOne.getState()).isEqualTo(PlanItemInstanceState.ACTIVE);
 
         PlanItemInstance taskB = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("taskB").singleResult();
-        assertNotNull(taskB);
-        assertEquals(PlanItemInstanceState.ACTIVE, taskB.getState());
+        assertThat(taskB).isNotNull();
+        assertThat(taskB.getState()).isEqualTo(PlanItemInstanceState.ACTIVE);
 
-        PlanItemInstance listener = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER).singleResult();
-        assertNotNull(listener);
-        assertEquals(PlanItemInstanceState.AVAILABLE, listener.getState());
+        PlanItemInstance listener = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER)
+                .singleResult();
+        assertThat(listener).isNotNull();
+        assertThat(listener.getState()).isEqualTo(PlanItemInstanceState.AVAILABLE);
 
         //Trigger the test
         cmmnRuntimeService.triggerPlanItemInstance(taskB.getId());
         assertCaseInstanceNotEnded(caseInstance);
 
         taskA = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("taskA").singleResult();
-        assertNotNull(taskA);
+        assertThat(taskA).isNotNull();
         stageOne = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("stageOne").singleResult();
-        assertNull(stageOne);
+        assertThat(stageOne).isNull();
         taskB = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("taskB").singleResult();
-        assertNull(taskB);
+        assertThat(taskB).isNull();
         listener = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER).singleResult();
-        assertNull(listener);
+        assertThat(listener).isNull();
 
         //End the case
         cmmnRuntimeService.triggerPlanItemInstance(taskA.getId());
@@ -127,33 +126,34 @@ public class CompletionNeutralTest extends FlowableCmmnTestCase {
     @CmmnDeployment
     public void testEventListenerBypassed() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey(name.getMethodName()).start();
-        assertNotNull(caseInstance);
+        assertThat(caseInstance).isNotNull();
 
         //Check case setup
-        assertEquals(3, cmmnRuntimeService.createPlanItemInstanceQuery().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(3);
 
         PlanItemInstance taskA = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("taskA").singleResult();
-        assertNotNull(taskA);
-        assertEquals(PlanItemInstanceState.ACTIVE, taskA.getState());
+        assertThat(taskA).isNotNull();
+        assertThat(taskA.getState()).isEqualTo(PlanItemInstanceState.ACTIVE);
 
         PlanItemInstance taskB = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("taskB").singleResult();
-        assertNotNull(taskB);
-        assertEquals(PlanItemInstanceState.ACTIVE, taskB.getState());
+        assertThat(taskB).isNotNull();
+        assertThat(taskB.getState()).isEqualTo(PlanItemInstanceState.ACTIVE);
 
-        PlanItemInstance listener = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER).singleResult();
-        assertNotNull(listener);
-        assertEquals(PlanItemInstanceState.AVAILABLE, listener.getState());
+        PlanItemInstance listener = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER)
+                .singleResult();
+        assertThat(listener).isNotNull();
+        assertThat(listener.getState()).isEqualTo(PlanItemInstanceState.AVAILABLE);
 
         //Trigger the test
         cmmnRuntimeService.triggerPlanItemInstance(taskB.getId());
         assertCaseInstanceNotEnded(caseInstance);
 
         taskA = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("taskA").singleResult();
-        assertNotNull(taskA);
+        assertThat(taskA).isNotNull();
         taskB = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("taskB").singleResult();
-        assertNull(taskB);
+        assertThat(taskB).isNull();
         listener = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER).singleResult();
-        assertNull(listener);
+        assertThat(listener).isNull();
 
         //End the case
         cmmnRuntimeService.triggerPlanItemInstance(taskA.getId());
@@ -164,41 +164,41 @@ public class CompletionNeutralTest extends FlowableCmmnTestCase {
     @CmmnDeployment
     public void testEmbeddedStage() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey(name.getMethodName()).start();
-        assertNotNull(caseInstance);
+        assertThat(caseInstance).isNotNull();
 
         //Check case setup
-        assertEquals(6, cmmnRuntimeService.createPlanItemInstanceQuery().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(6);
 
         PlanItemInstance taskA = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("taskA").singleResult();
-        assertNotNull(taskA);
-        assertEquals(PlanItemInstanceState.ACTIVE, taskA.getState());
+        assertThat(taskA).isNotNull();
+        assertThat(taskA.getState()).isEqualTo(PlanItemInstanceState.ACTIVE);
 
         PlanItemInstance stageOne = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("stageOne").singleResult();
-        assertNotNull(stageOne);
-        assertEquals(PlanItemInstanceState.ACTIVE, stageOne.getState());
+        assertThat(stageOne).isNotNull();
+        assertThat(stageOne.getState()).isEqualTo(PlanItemInstanceState.ACTIVE);
 
         PlanItemInstance taskB = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("taskB").singleResult();
-        assertNotNull(taskB);
-        assertEquals(PlanItemInstanceState.AVAILABLE, taskB.getState());
+        assertThat(taskB).isNotNull();
+        assertThat(taskB.getState()).isEqualTo(PlanItemInstanceState.AVAILABLE);
 
         PlanItemInstance stageTwo = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("completionNeutralStage").singleResult();
-        assertNotNull(stageTwo);
-        assertEquals(PlanItemInstanceState.ACTIVE, stageTwo.getState());
+        assertThat(stageTwo).isNotNull();
+        assertThat(stageTwo.getState()).isEqualTo(PlanItemInstanceState.ACTIVE);
 
         PlanItemInstance taskC = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("taskC").singleResult();
-        assertNotNull(taskC);
-        assertEquals(PlanItemInstanceState.AVAILABLE, taskC.getState());
+        assertThat(taskC).isNotNull();
+        assertThat(taskC.getState()).isEqualTo(PlanItemInstanceState.AVAILABLE);
 
         PlanItemInstance taskD = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("taskD").singleResult();
-        assertNotNull(taskD);
-        assertEquals(PlanItemInstanceState.ACTIVE, taskD.getState());
+        assertThat(taskD).isNotNull();
+        assertThat(taskD.getState()).isEqualTo(PlanItemInstanceState.ACTIVE);
 
         //Trigger the test
         cmmnRuntimeService.triggerPlanItemInstance(taskD.getId());
         assertCaseInstanceNotEnded(caseInstance);
-        assertEquals(1, cmmnRuntimeService.createPlanItemInstanceQuery().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(1);
         taskA = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("taskA").singleResult();
-        assertNotNull(taskA);
+        assertThat(taskA).isNotNull();
         cmmnRuntimeService.triggerPlanItemInstance(taskA.getId());
         assertCaseInstanceEnded(caseInstance);
     }
@@ -207,44 +207,44 @@ public class CompletionNeutralTest extends FlowableCmmnTestCase {
     @CmmnDeployment
     public void testRequiredPrecedence() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey(name.getMethodName()).start();
-        assertNotNull(caseInstance);
+        assertThat(caseInstance).isNotNull();
 
         //Check case setup
-        assertEquals(4, cmmnRuntimeService.createPlanItemInstanceQuery().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(4);
 
         PlanItemInstance taskA = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("taskA").singleResult();
-        assertNotNull(taskA);
-        assertEquals(PlanItemInstanceState.ACTIVE, taskA.getState());
+        assertThat(taskA).isNotNull();
+        assertThat(taskA.getState()).isEqualTo(PlanItemInstanceState.ACTIVE);
 
         PlanItemInstance stageOne = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("stageOne").singleResult();
-        assertNotNull(stageOne);
-        assertEquals(PlanItemInstanceState.ACTIVE, stageOne.getState());
+        assertThat(stageOne).isNotNull();
+        assertThat(stageOne.getState()).isEqualTo(PlanItemInstanceState.ACTIVE);
 
         PlanItemInstance taskB = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("taskB").singleResult();
-        assertNotNull(taskB);
-        assertEquals(PlanItemInstanceState.AVAILABLE, taskB.getState());
+        assertThat(taskB).isNotNull();
+        assertThat(taskB.getState()).isEqualTo(PlanItemInstanceState.AVAILABLE);
 
         PlanItemInstance taskC = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("taskC").singleResult();
-        assertNotNull(taskC);
-        assertEquals(PlanItemInstanceState.ACTIVE, taskC.getState());
+        assertThat(taskC).isNotNull();
+        assertThat(taskC.getState()).isEqualTo(PlanItemInstanceState.ACTIVE);
 
         //Trigger the test
         cmmnRuntimeService.triggerPlanItemInstance(taskC.getId());
         assertCaseInstanceNotEnded(caseInstance);
-        assertEquals(3, cmmnRuntimeService.createPlanItemInstanceQuery().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(3);
 
         taskA = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("taskA").singleResult();
-        assertNotNull(taskA);
+        assertThat(taskA).isNotNull();
         stageOne = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("stageOne").singleResult();
-        assertNotNull(stageOne);
+        assertThat(stageOne).isNotNull();
         taskB = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("taskB").singleResult();
-        assertNotNull(taskB);
+        assertThat(taskB).isNotNull();
         taskC = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("taskC").singleResult();
-        assertNull(taskC);
+        assertThat(taskC).isNull();
 
         cmmnRuntimeService.triggerPlanItemInstance(taskA.getId());
         assertCaseInstanceNotEnded(caseInstance);
-        assertEquals(2, cmmnRuntimeService.createPlanItemInstanceQuery().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(2);
         cmmnRuntimeService.triggerPlanItemInstance(taskB.getId());
         assertCaseInstanceEnded(caseInstance);
     }
@@ -253,24 +253,25 @@ public class CompletionNeutralTest extends FlowableCmmnTestCase {
     @CmmnDeployment
     public void testRequiredPrecedenceDeepNest() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey(name.getMethodName()).start();
-        assertNotNull(caseInstance);
+        assertThat(caseInstance).isNotNull();
 
         List<PlanItemInstance> list = cmmnRuntimeService.createPlanItemInstanceQuery().list();
 
         //Check case setup
-        assertEquals(5, cmmnRuntimeService.createPlanItemInstanceQuery().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(5);
 
         PlanItemInstance taskA = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("taskA").singleResult();
-        assertNotNull(taskA);
-        assertEquals(PlanItemInstanceState.ACTIVE, taskA.getState());
+        assertThat(taskA).isNotNull();
+        assertThat(taskA.getState()).isEqualTo(PlanItemInstanceState.ACTIVE);
 
         PlanItemInstance stageOne = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("stageOne").singleResult();
-        assertNotNull(stageOne);
-        assertEquals(PlanItemInstanceState.AVAILABLE, stageOne.getState());
+        assertThat(stageOne).isNotNull();
+        assertThat(stageOne.getState()).isEqualTo(PlanItemInstanceState.AVAILABLE);
 
-        List<PlanItemInstance> listeners = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER).list();
-        assertEquals(3, listeners.size());
-        listeners.forEach(l -> assertEquals(PlanItemInstanceState.AVAILABLE,l.getState()));
+        List<PlanItemInstance> listeners = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER)
+                .list();
+        assertThat(listeners).hasSize(3);
+        listeners.forEach(l -> assertThat(l.getState()).isEqualTo(PlanItemInstanceState.AVAILABLE));
 
         //Trigger the test
         //Triggering Listener One will Activate StageOne which will complete as nothing ties it
@@ -279,11 +280,11 @@ public class CompletionNeutralTest extends FlowableCmmnTestCase {
                 .planItemDefinitionId("userEventOne").singleResult();
         cmmnRuntimeService.triggerPlanItemInstance(userEventOne.getId());
         stageOne = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("stageOne").singleResult();
-        assertNull(stageOne);
+        assertThat(stageOne).isNull();
 
         // The listeners should all be removed
         listeners = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER).list();
-        assertEquals(0, listeners.size());
+        assertThat(listeners).isEmpty();
         assertCaseInstanceNotEnded(caseInstance);
 
         //The only thing keeping the case from ending is TaskA even with a deep nested required task, because its not AVAILABLE yet
@@ -295,22 +296,23 @@ public class CompletionNeutralTest extends FlowableCmmnTestCase {
     @CmmnDeployment
     public void testRequiredPrecedenceDeepNest2() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey(name.getMethodName()).start();
-        assertNotNull(caseInstance);
+        assertThat(caseInstance).isNotNull();
 
         //Check case setup
-        assertEquals(5, cmmnRuntimeService.createPlanItemInstanceQuery().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(5);
 
         PlanItemInstance taskA = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("taskA").singleResult();
-        assertNotNull(taskA);
-        assertEquals(PlanItemInstanceState.ACTIVE, taskA.getState());
+        assertThat(taskA).isNotNull();
+        assertThat(taskA.getState()).isEqualTo(PlanItemInstanceState.ACTIVE);
 
         PlanItemInstance stageOne = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("stageOne").singleResult();
-        assertNotNull(stageOne);
-        assertEquals(PlanItemInstanceState.AVAILABLE, stageOne.getState());
+        assertThat(stageOne).isNotNull();
+        assertThat(stageOne.getState()).isEqualTo(PlanItemInstanceState.AVAILABLE);
 
-        List<PlanItemInstance> listeners = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER).list();
-        assertEquals(3, listeners.size());
-        listeners.forEach(l -> assertEquals(PlanItemInstanceState.AVAILABLE,l.getState()));
+        List<PlanItemInstance> listeners = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER)
+                .list();
+        assertThat(listeners).hasSize(3);
+        listeners.forEach(l -> assertThat(l.getState()).isEqualTo(PlanItemInstanceState.AVAILABLE));
 
         //Trigger the test
         //This time a task inside StageOne is required, thus it will not complete once activated
@@ -320,21 +322,21 @@ public class CompletionNeutralTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.triggerPlanItemInstance(userEvent.getId());
         assertCaseInstanceNotEnded(caseInstance);
 
-        assertEquals(6, cmmnRuntimeService.createPlanItemInstanceQuery().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(6);
         listeners = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER).list();
-        assertEquals(2, listeners.size());
+        assertThat(listeners).hasSize(2);
         taskA = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("taskA").singleResult();
-        assertNotNull(taskA);
-        assertEquals(PlanItemInstanceState.ACTIVE, taskA.getState());
+        assertThat(taskA).isNotNull();
+        assertThat(taskA.getState()).isEqualTo(PlanItemInstanceState.ACTIVE);
         stageOne = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("stageOne").singleResult();
-        assertNotNull(stageOne);
-        assertEquals(PlanItemInstanceState.ACTIVE, stageOne.getState());
+        assertThat(stageOne).isNotNull();
+        assertThat(stageOne.getState()).isEqualTo(PlanItemInstanceState.ACTIVE);
         PlanItemInstance stageTwo = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("stageTwo").singleResult();
-        assertNotNull(stageTwo);
-        assertEquals(PlanItemInstanceState.AVAILABLE, stageTwo.getState());
+        assertThat(stageTwo).isNotNull();
+        assertThat(stageTwo.getState()).isEqualTo(PlanItemInstanceState.AVAILABLE);
         PlanItemInstance taskB = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("taskB").singleResult();
-        assertNotNull(taskB);
-        assertEquals(PlanItemInstanceState.AVAILABLE, taskB.getState());
+        assertThat(taskB).isNotNull();
+        assertThat(taskB.getState()).isEqualTo(PlanItemInstanceState.AVAILABLE);
 
         //Completing taskB and then taskA should end the case
         //Order is important since required taskC nested in StageTwo is not yet available
@@ -354,23 +356,23 @@ public class CompletionNeutralTest extends FlowableCmmnTestCase {
     @CmmnDeployment
     public void testRequiredPrecedenceDeepNest3() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey(name.getMethodName()).start();
-        assertNotNull(caseInstance);
+        assertThat(caseInstance).isNotNull();
 
         //Check case setup
-        assertEquals(5, cmmnRuntimeService.createPlanItemInstanceQuery().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(5);
 
         PlanItemInstance taskA = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("taskA").singleResult();
-        assertNotNull(taskA);
-        assertEquals(PlanItemInstanceState.ACTIVE, taskA.getState());
+        assertThat(taskA).isNotNull();
+        assertThat(taskA.getState()).isEqualTo(PlanItemInstanceState.ACTIVE);
 
         PlanItemInstance stageOne = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("stageOne").singleResult();
-        assertNotNull(stageOne);
-        assertEquals(PlanItemInstanceState.AVAILABLE, stageOne.getState());
+        assertThat(stageOne).isNotNull();
+        assertThat(stageOne.getState()).isEqualTo(PlanItemInstanceState.AVAILABLE);
 
-        List<PlanItemInstance> listeners = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER).list();
-        assertEquals(3, listeners.size());
-        listeners.forEach(l -> assertEquals(PlanItemInstanceState.AVAILABLE,l.getState()));
-
+        List<PlanItemInstance> listeners = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER)
+                .list();
+        assertThat(listeners).hasSize(3);
+        listeners.forEach(l -> assertThat(l.getState()).isEqualTo(PlanItemInstanceState.AVAILABLE));
 
         //Trigger the test
         //This time a task inside StageOne is required, thus it will not complete once activated
@@ -380,21 +382,21 @@ public class CompletionNeutralTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.triggerPlanItemInstance(userEvent.getId());
         assertCaseInstanceNotEnded(caseInstance);
 
-        assertEquals(6, cmmnRuntimeService.createPlanItemInstanceQuery().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(6);
         listeners = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER).list();
-        assertEquals(2, listeners.size());
+        assertThat(listeners).hasSize(2);
         taskA = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("taskA").singleResult();
-        assertNotNull(taskA);
-        assertEquals(PlanItemInstanceState.ACTIVE, taskA.getState());
+        assertThat(taskA).isNotNull();
+        assertThat(taskA.getState()).isEqualTo(PlanItemInstanceState.ACTIVE);
         stageOne = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("stageOne").singleResult();
-        assertNotNull(stageOne);
-        assertEquals(PlanItemInstanceState.ACTIVE, stageOne.getState());
+        assertThat(stageOne).isNotNull();
+        assertThat(stageOne.getState()).isEqualTo(PlanItemInstanceState.ACTIVE);
         PlanItemInstance stageTwo = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("stageTwo").singleResult();
-        assertNotNull(stageTwo);
-        assertEquals(PlanItemInstanceState.AVAILABLE, stageTwo.getState());
+        assertThat(stageTwo).isNotNull();
+        assertThat(stageTwo.getState()).isEqualTo(PlanItemInstanceState.AVAILABLE);
         PlanItemInstance taskB = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("taskB").singleResult();
-        assertNotNull(taskB);
-        assertEquals(PlanItemInstanceState.AVAILABLE, taskB.getState());
+        assertThat(taskB).isNotNull();
+        assertThat(taskB.getState()).isEqualTo(PlanItemInstanceState.AVAILABLE);
 
         //This time we complete taskA first, making stageTwo Active,
         //making available the required taskC
@@ -407,18 +409,18 @@ public class CompletionNeutralTest extends FlowableCmmnTestCase {
         assertCaseInstanceNotEnded(caseInstance);
 
         List<PlanItemInstance> list = cmmnRuntimeService.createPlanItemInstanceQuery().list();
-        assertEquals(4, cmmnRuntimeService.createPlanItemInstanceQuery().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(4);
         listeners = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER).list();
-        assertEquals(1, listeners.size());
+        assertThat(listeners).hasSize(1);
         stageOne = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("stageOne").singleResult();
-        assertNotNull(stageOne);
-        assertEquals(PlanItemInstanceState.ACTIVE, stageOne.getState());
+        assertThat(stageOne).isNotNull();
+        assertThat(stageOne.getState()).isEqualTo(PlanItemInstanceState.ACTIVE);
         stageTwo = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("stageTwo").singleResult();
-        assertNotNull(stageTwo);
-        assertEquals(PlanItemInstanceState.ACTIVE, stageTwo.getState());
+        assertThat(stageTwo).isNotNull();
+        assertThat(stageTwo.getState()).isEqualTo(PlanItemInstanceState.ACTIVE);
         PlanItemInstance taskC = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("taskC").singleResult();
-        assertNotNull(taskC);
-        assertEquals(PlanItemInstanceState.AVAILABLE, taskC.getState());
+        assertThat(taskC).isNotNull();
+        assertThat(taskC.getState()).isEqualTo(PlanItemInstanceState.AVAILABLE);
 
         //Now we need to activate TaskC and complete it to end the case
         userEvent = cmmnRuntimeService.createPlanItemInstanceQuery()

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/CrossBoundaryActivationWithExitEventTypeCombinationTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/CrossBoundaryActivationWithExitEventTypeCombinationTest.java
@@ -12,12 +12,12 @@
  */
 package org.flowable.cmmn.test.itemcontrol;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.ACTIVE;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.AVAILABLE;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.ENABLED;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.UNAVAILABLE;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.WAITING_FOR_REPETITION;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 
@@ -25,7 +25,6 @@ import org.flowable.cmmn.api.runtime.CaseInstance;
 import org.flowable.cmmn.api.runtime.PlanItemInstance;
 import org.flowable.cmmn.engine.test.CmmnDeployment;
 import org.flowable.cmmn.engine.test.FlowableCmmnTestCase;
-import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -43,7 +42,7 @@ public class CrossBoundaryActivationWithExitEventTypeCombinationTest extends Flo
             .start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(6, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(6);
 
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", AVAILABLE);
@@ -57,7 +56,7 @@ public class CrossBoundaryActivationWithExitEventTypeCombinationTest extends Flo
         cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "complete stage", AVAILABLE));
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
 
         assertPlanItemInstanceState(planItemInstances, "Stage B", ACTIVE, WAITING_FOR_REPETITION);
         assertPlanItemInstanceState(planItemInstances, "Decision", ACTIVE);
@@ -69,7 +68,7 @@ public class CrossBoundaryActivationWithExitEventTypeCombinationTest extends Flo
             .trigger();
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(6, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(6);
 
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", WAITING_FOR_REPETITION);
@@ -84,7 +83,7 @@ public class CrossBoundaryActivationWithExitEventTypeCombinationTest extends Flo
         cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "complete stage", AVAILABLE));
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
 
         assertPlanItemInstanceState(planItemInstances, "Stage B", ACTIVE, WAITING_FOR_REPETITION);
         assertPlanItemInstanceState(planItemInstances, "Decision", ACTIVE);
@@ -96,7 +95,7 @@ public class CrossBoundaryActivationWithExitEventTypeCombinationTest extends Flo
             .trigger();
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(6, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(6);
 
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", WAITING_FOR_REPETITION);
@@ -110,7 +109,7 @@ public class CrossBoundaryActivationWithExitEventTypeCombinationTest extends Flo
         cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "complete stage", AVAILABLE));
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
 
         assertPlanItemInstanceState(planItemInstances, "Stage B", ACTIVE, WAITING_FOR_REPETITION);
         assertPlanItemInstanceState(planItemInstances, "Decision", ACTIVE);
@@ -122,7 +121,7 @@ public class CrossBoundaryActivationWithExitEventTypeCombinationTest extends Flo
             .trigger();
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
 
         assertPlanItemInstanceState(planItemInstances, "Stage B", ACTIVE, WAITING_FOR_REPETITION);
         assertPlanItemInstanceState(planItemInstances, "Follow-up", ACTIVE);
@@ -130,10 +129,10 @@ public class CrossBoundaryActivationWithExitEventTypeCombinationTest extends Flo
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Follow-up", ACTIVE));
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(0, planItemInstances.size());
+        assertThat(planItemInstances).isEmpty();
 
         assertCaseInstanceEnded(caseInstance);
-        Assert.assertEquals(0L, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count());
-        Assert.assertEquals(0L, cmmnRuntimeService.createCaseInstanceQuery().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0L);
     }
 }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/DynamicPlanItemNameWithRepetitionBasedOnJsonArrayTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/DynamicPlanItemNameWithRepetitionBasedOnJsonArrayTest.java
@@ -12,9 +12,9 @@
  */
 package org.flowable.cmmn.test.itemcontrol;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.ACTIVE;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.AVAILABLE;
-import static org.junit.Assert.assertEquals;
 
 import java.util.List;
 
@@ -45,13 +45,13 @@ public class DynamicPlanItemNameWithRepetitionBasedOnJsonArrayTest extends Flowa
         arrayNode.addObject().put("name", "C").put("foo", "c");
 
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("dynamicPlanItemNameTestOnJsonArray")
-            .variable("myCollection", arrayNode)
-            .variable("foo", "FooValue")
-            .start();
+                .caseDefinitionKey("dynamicPlanItemNameTestOnJsonArray")
+                .variable("myCollection", arrayNode)
+                .variable("foo", "FooValue")
+                .start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task (A / 0 - FooValue)", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task (B / 1 - FooValue)", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task (C / 2 - FooValue)", ACTIVE);
@@ -68,13 +68,13 @@ public class DynamicPlanItemNameWithRepetitionBasedOnJsonArrayTest extends Flowa
         arrayNode.addObject().put("name", "C").put("bar", "c");
 
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("dynamicPlanItemNameTestOnJsonArray")
-            .variable("myCollection", arrayNode)
-            .variable("foo", "FooValue")
-            .start();
+                .caseDefinitionKey("dynamicPlanItemNameTestOnJsonArray")
+                .variable("myCollection", arrayNode)
+                .variable("foo", "FooValue")
+                .start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task (A / 0 - FooValue)", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task (B / 1 - FooValue)", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task (C / 2 - FooValue)", ACTIVE);
@@ -91,12 +91,12 @@ public class DynamicPlanItemNameWithRepetitionBasedOnJsonArrayTest extends Flowa
         arrayNode.addObject().put("name", "C").put("bar", "c");
 
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("dynamicPlanItemNameTestOnJsonArray")
-            .variable("foo", "FooValue")
-            .start();
+                .caseDefinitionKey("dynamicPlanItemNameTestOnJsonArray")
+                .variable("foo", "FooValue")
+                .start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(1, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(1);
 
         // as we don't have the collection yet available, the name must use the expression as fallback without any exception, as the item / itemIndex local
         // variables are not available on the available plan item instance
@@ -106,7 +106,7 @@ public class DynamicPlanItemNameWithRepetitionBasedOnJsonArrayTest extends Flowa
         cmmnRuntimeService.setVariable(caseInstance.getId(), "myCollection", arrayNode);
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
 
         assertPlanItemInstanceState(planItemInstances, "Task (A / 0 - FooValue)", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task (B / 1 - FooValue)", ACTIVE);

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/DynamicPlanItemNameWithRepetitionTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/DynamicPlanItemNameWithRepetitionTest.java
@@ -12,8 +12,8 @@
  */
 package org.flowable.cmmn.test.itemcontrol;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.ACTIVE;
-import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
 import java.util.List;
@@ -36,13 +36,13 @@ public class DynamicPlanItemNameWithRepetitionTest extends FlowableCmmnTestCase 
     public void testDynamicNameWithRepetitionCollectionAndCaseVariable() {
         List<String> myCollection = Arrays.asList("A", "B", "C");
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("dynamicPlanItemNameTest")
-            .variable("myCollection", myCollection)
-            .variable("foo", "FooValue")
-            .start();
+                .caseDefinitionKey("dynamicPlanItemNameTest")
+                .variable("myCollection", myCollection)
+                .variable("foo", "FooValue")
+                .start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task (A / 0 - FooValue)", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task (B / 1 - FooValue)", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task (C / 2 - FooValue)", ACTIVE);

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/ManualActivationRuleTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/ManualActivationRuleTest.java
@@ -12,9 +12,8 @@
  */
 package org.flowable.cmmn.test.itemcontrol;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 
@@ -42,15 +41,15 @@ public class ManualActivationRuleTest extends FlowableCmmnTestCase {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testManualActivatedHumanTask").start();
         
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult();
-        assertEquals(PlanItemInstanceState.ENABLED, planItemInstance.getState());
-        assertEquals(0, cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count());
+        assertThat(planItemInstance.getState()).isEqualTo(PlanItemInstanceState.ENABLED);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
         
         cmmnRuntimeService.startPlanItemInstance(planItemInstance.getId());
         planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult();
-        assertEquals(PlanItemInstanceState.ACTIVE, planItemInstance.getState());
+        assertThat(planItemInstance.getState()).isEqualTo(PlanItemInstanceState.ACTIVE);
         
         Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
-        assertEquals("The Task", task.getName());
+        assertThat(task.getName()).isEqualTo("The Task");
         
         cmmnTaskService.complete(task.getId());
         assertCaseInstanceEnded(caseInstance);
@@ -62,8 +61,8 @@ public class ManualActivationRuleTest extends FlowableCmmnTestCase {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testDisableSingleHumanTask").start();
         
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult();
-        assertEquals(PlanItemInstanceState.ENABLED, planItemInstance.getState());
-        assertEquals(0, cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count());
+        assertThat(planItemInstance.getState()).isEqualTo(PlanItemInstanceState.ENABLED);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
         
         // Disabling the single plan item will terminate the case
         cmmnRuntimeService.disablePlanItemInstance(planItemInstance.getId());
@@ -76,55 +75,57 @@ public class ManualActivationRuleTest extends FlowableCmmnTestCase {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testDisableHumanTask").start();
         
         List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).list();
+        assertThat(planItemInstances)
+                .extracting(PlanItemInstance::getState)
+                .contains(PlanItemInstanceState.ENABLED);
         for (PlanItemInstance planItemInstance : planItemInstances) {
-            assertEquals(PlanItemInstanceState.ENABLED, planItemInstance.getState());
+            assertThat(planItemInstance.getState()).isEqualTo(PlanItemInstanceState.ENABLED);
         }
-        assertEquals(0, cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count());
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
         
         PlanItemInstance planItemInstance = planItemInstances.get(0);
         cmmnRuntimeService.disablePlanItemInstance(planItemInstance.getId());
-        assertEquals(1, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateEnabled().count());
-        assertEquals(1, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateDisabled().count());
-        assertEquals(0, cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateEnabled().count()).isEqualTo(1);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateDisabled().count()).isEqualTo(1);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
 
         cmmnRuntimeService.enablePlanItemInstance(planItemInstance.getId());
-        assertEquals(2, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateEnabled().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateEnabled().count()).isEqualTo(2);
     }
     
     @Test
     @CmmnDeployment
     public void testManualActivationWithSentries() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testManualActivationWithSentries").start();
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateEnabled().count());
-        assertEquals(1, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateAvailable().count());
-        assertEquals(1, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateActive().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateEnabled().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateAvailable().count()).isEqualTo(1);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateActive().count()).isEqualTo(1);
         
         cmmnRuntimeService.setVariables(caseInstance.getId(), CollectionUtil.singletonMap("variable", "startStage"));
-        assertEquals(1, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateEnabled().count());
-        assertEquals(1, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateActive().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateEnabled().count()).isEqualTo(1);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateActive().count()).isEqualTo(1);
         cmmnRuntimeService.startPlanItemInstance(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateEnabled().singleResult().getId());
         
-        assertEquals(4, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateActive().count());
-        assertEquals(1, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateAvailable().count());
-        assertEquals(3, cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateActive().count()).isEqualTo(4);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateAvailable().count()).isEqualTo(1);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(3);
         
         // Completing C should enable the nested stage
         Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).taskName("C").singleResult();
         cmmnTaskService.complete(task.getId());
         
-        assertEquals(1, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateEnabled().count());
-        assertEquals(3, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateActive().count());
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateAvailable().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateEnabled().count()).isEqualTo(1);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateActive().count()).isEqualTo(3);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateAvailable().count()).isEqualTo(0);
         
         // Enabling the nested stage activates task D
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateEnabled().singleResult();
         cmmnRuntimeService.startPlanItemInstance(planItemInstance.getId());
         
         List<Task> tasks = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).orderByTaskName().asc().list();
-        assertEquals(3, tasks.size());
-        assertEquals("A", tasks.get(0).getName());
-        assertEquals("B", tasks.get(1).getName());
-        assertEquals("D", tasks.get(2).getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("A", "B", "D");
         
         // Completing all the tasks ends the case instance
         for (Task t : cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).list()) {
@@ -137,19 +138,19 @@ public class ManualActivationRuleTest extends FlowableCmmnTestCase {
     @CmmnDeployment
     public void testExitEnabledPlanItem() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testExitEnabledPlanItem").start();
-        assertEquals(1, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateEnabled().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateEnabled().count()).isEqualTo(1);
         
         List<Task> tasks = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).orderByTaskName().asc().list();
-        assertEquals(2, tasks.size());
-        assertEquals("A", tasks.get(0).getName());
-        assertEquals("C", tasks.get(1).getName());
-        
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("A", "C");
+
         // Completing task A will exit the enabled stage
         cmmnTaskService.complete(tasks.get(0).getId());
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateEnabled().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateEnabled().count()).isEqualTo(0);
         
         Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
-        assertEquals("C", task.getName());
+        assertThat(task.getName()).isEqualTo("C");
         
         cmmnTaskService.complete(task.getId());
         assertCaseInstanceEnded(caseInstance);
@@ -163,20 +164,20 @@ public class ManualActivationRuleTest extends FlowableCmmnTestCase {
                 .caseDefinitionKey("testManuallyActivatedServiceTask")
                 .variable("manual", true)
                 .start();
-        assertEquals(1, cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count());
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
         
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateEnabled().planItemDefinitionType(PlanItemDefinitionType.SERVICE_TASK).singleResult();
-        assertNotNull(planItemInstance);
+        assertThat(planItemInstance).isNotNull();
         cmmnRuntimeService.startPlanItemInstance(planItemInstance.getId());
-        assertEquals("test", cmmnRuntimeService.getVariable(caseInstance.getId(), "variable"));
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "variable")).isEqualTo("test");
         
         // Manual Activation disabled
         caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
                 .caseDefinitionKey("testManuallyActivatedServiceTask")
                 .variable("manual", false)
                 .start();
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateEnabled().count());
-        assertEquals("test", cmmnRuntimeService.getVariable(caseInstance.getId(), "variable"));
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateEnabled().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "variable")).isEqualTo("test");
     }
     
     @Test
@@ -187,27 +188,28 @@ public class ManualActivationRuleTest extends FlowableCmmnTestCase {
                 .variable("stopRepeat", false)
                 .start();
         
-        assertEquals(1, cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count());
-        assertEquals(1, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateEnabled().count());
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateEnabled().count()).isEqualTo(1);
         cmmnRuntimeService.startPlanItemInstance(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateEnabled().singleResult().getId());
         
         // This can go on forever (but testing 100 here), as it's repeated without stop
         for (int i = 0; i < 100; i++) {
             
             List<Task> tasks = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).orderByTaskName().asc().list();
-            assertEquals(2, tasks.size());
-            assertEquals("Non-repeated task", tasks.get(0).getName());
-            assertEquals("Repeated task", tasks.get(1).getName());
-            
+            assertThat(tasks)
+                    .extracting(Task::getName)
+                    .containsExactly("Non-repeated task", "Repeated task");
+
             // Completing the repeated task should again lead to an enabled task
             cmmnTaskService.complete(tasks.get(1).getId());
-            assertEquals(1, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateEnabled().count());
+            assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateEnabled().count())
+                    .isEqualTo(1);
             cmmnRuntimeService.startPlanItemInstance(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateEnabled().singleResult().getId());
         }
         
-        assertEquals(2, cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count());
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(2);
         cmmnRuntimeService.setVariables(caseInstance.getId(), CollectionUtil.singletonMap("stopRepeat", true));
-        assertEquals(1, cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count());
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
     }
     
     @Test
@@ -215,17 +217,14 @@ public class ManualActivationRuleTest extends FlowableCmmnTestCase {
     public void testInvalidDisable() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testInvalidDisable").start();
         
-        assertEquals(1, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateEnabled().count());
-        assertEquals(1, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateActive().count());
-        assertEquals(1, cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count());
-        
-        try {
-            PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateActive().singleResult();
-            cmmnRuntimeService.disablePlanItemInstance(planItemInstance.getId());
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-            assertEquals("Can only disable a plan item instance which is in state ENABLED", e.getMessage());
-        }
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateEnabled().count()).isEqualTo(1);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateActive().count()).isEqualTo(1);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
+
+        PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateActive().singleResult();
+        assertThatThrownBy(() -> cmmnRuntimeService.disablePlanItemInstance(planItemInstance.getId()))
+                .isInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage("Can only disable a plan item instance which is in state ENABLED");
     }
     
     @Test
@@ -233,17 +232,14 @@ public class ManualActivationRuleTest extends FlowableCmmnTestCase {
     public void testInvalidEnable() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testInvalidEnable").start();
         
-        assertEquals(1, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateEnabled().count());
-        assertEquals(1, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateActive().count());
-        assertEquals(1, cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count());
-        
-        try {
-            PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateActive().singleResult();
-            cmmnRuntimeService.enablePlanItemInstance(planItemInstance.getId());
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-            assertEquals("Can only enable a plan item instance which is in state AVAILABLE or DISABLED", e.getMessage());
-        }
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateEnabled().count()).isEqualTo(1);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateActive().count()).isEqualTo(1);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
+
+        PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateActive().singleResult();
+        assertThatThrownBy(() -> cmmnRuntimeService.enablePlanItemInstance(planItemInstance.getId()))
+                .isInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage("Can only enable a plan item instance which is in state AVAILABLE or DISABLED");
     }
     
     @Test
@@ -251,17 +247,14 @@ public class ManualActivationRuleTest extends FlowableCmmnTestCase {
     public void testInvalidStart() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testInvalidStart").start();
         
-        assertEquals(1, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateEnabled().count());
-        assertEquals(1, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateActive().count());
-        assertEquals(1, cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count());
-        
-        try {
-            PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateActive().singleResult();
-            cmmnRuntimeService.startPlanItemInstance(planItemInstance.getId());
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-            assertEquals("Can only enable a plan item instance which is in state ENABLED", e.getMessage());
-        }
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateEnabled().count()).isEqualTo(1);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateActive().count()).isEqualTo(1);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
+
+        PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateActive().singleResult();
+        assertThatThrownBy(() -> cmmnRuntimeService.startPlanItemInstance(planItemInstance.getId()))
+                .isInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage("Can only enable a plan item instance which is in state ENABLED");
     }
 
     // Test specifically made for testing a plan item instance caching issue
@@ -274,11 +267,11 @@ public class ManualActivationRuleTest extends FlowableCmmnTestCase {
             .start();
 
         Task taskA = cmmnTaskService.createTaskQuery().singleResult();
-        assertEquals("A", taskA.getName());
+        assertThat(taskA.getName()).isEqualTo("A");
         cmmnTaskService.complete(taskA.getId());
 
         final PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceState(PlanItemInstanceState.ENABLED).singleResult();
-        assertEquals("B", planItemInstance.getName());
+        assertThat(planItemInstance.getName()).isEqualTo("B");
 
         cmmnEngineConfiguration.getCommandExecutor().execute(new Command<Void>() {
             @Override
@@ -287,7 +280,7 @@ public class ManualActivationRuleTest extends FlowableCmmnTestCase {
                 // Fetch the plan item instance before the next command (already putting it in the cache)
                 // to trigger the caching issue (when eagerly fetching plan items the old state was being overwritten)
                 PlanItemInstance p = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceId(planItemInstance.getId()).singleResult();
-                assertNotNull(p);
+                assertThat(p).isNotNull();
 
                 cmmnRuntimeService.startPlanItemInstance(planItemInstance.getId());
 
@@ -296,16 +289,16 @@ public class ManualActivationRuleTest extends FlowableCmmnTestCase {
         });
 
         Task taskB = cmmnTaskService.createTaskQuery().singleResult();
-        assertEquals("B", taskB.getName());
+        assertThat(taskB.getName()).isEqualTo("B");
         PlanItemInstance planItemInstanceAfterCommand = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceId(planItemInstance.getId()).singleResult();
-        assertEquals(PlanItemInstanceState.ACTIVE, planItemInstanceAfterCommand.getState());
+        assertThat(planItemInstanceAfterCommand.getState()).isEqualTo(PlanItemInstanceState.ACTIVE);
 
         cmmnTaskService.complete(taskB.getId());
         Task taskC = cmmnTaskService.createTaskQuery().singleResult();
-        assertEquals("C", taskC.getName());
+        assertThat(taskC.getName()).isEqualTo("C");
 
         cmmnTaskService.complete(taskC.getId());
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
     }
 
     @Test
@@ -315,11 +308,11 @@ public class ManualActivationRuleTest extends FlowableCmmnTestCase {
         cmmnTaskService.complete(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).taskName("A").singleResult().getId());
         assertCaseInstanceNotEnded(caseInstance);
 
-        assertEquals(0, cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).taskName("B").count());
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).taskName("B").count()).isEqualTo(0);
 
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceState(PlanItemInstanceState.ENABLED).singleResult();
         cmmnRuntimeService.startPlanItemInstance(planItemInstance.getId());
-        assertEquals(1, cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).taskName("B").count());
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).taskName("B").count()).isEqualTo(1);
 
         // 1 instance is required, the others aren't
         cmmnTaskService.complete(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).taskName("B").singleResult().getId());

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/OrphanEventListenerRemovalCombinedWithRepetitionTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/OrphanEventListenerRemovalCombinedWithRepetitionTest.java
@@ -12,10 +12,10 @@
  */
 package org.flowable.cmmn.test.itemcontrol;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.ACTIVE;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.AVAILABLE;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.WAITING_FOR_REPETITION;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 
@@ -23,7 +23,6 @@ import org.flowable.cmmn.api.runtime.CaseInstance;
 import org.flowable.cmmn.api.runtime.PlanItemInstance;
 import org.flowable.cmmn.engine.test.CmmnDeployment;
 import org.flowable.cmmn.engine.test.FlowableCmmnTestCase;
-import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -37,11 +36,11 @@ public class OrphanEventListenerRemovalCombinedWithRepetitionTest extends Flowab
     @CmmnDeployment(resources = "org/flowable/cmmn/test/itemcontrol/OrphanEventListenerRemovalCombinedWithRepetitionTest.testRemovalOfOrphanedEventListeners.cmmn")
     public void testRemovalOfOrphanedEventListenersWithOuterStart() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("nestedRepetitionPlanItemsWithOrphanedEventListeners")
-            .start();
+                .caseDefinitionKey("nestedRepetitionPlanItemsWithOrphanedEventListeners")
+                .start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(5, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(5);
 
         assertPlanItemInstanceState(planItemInstances, "Stage A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "start Task A 1", AVAILABLE);
@@ -53,7 +52,7 @@ public class OrphanEventListenerRemovalCombinedWithRepetitionTest extends Flowab
         cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "start Stage A", AVAILABLE));
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(5, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(5);
 
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", AVAILABLE);
@@ -65,7 +64,7 @@ public class OrphanEventListenerRemovalCombinedWithRepetitionTest extends Flowab
         cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "kill Stage A", AVAILABLE));
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(2, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(2);
 
         assertPlanItemInstanceState(planItemInstances, "start Task A 1", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "start Task A 2", AVAILABLE);
@@ -73,12 +72,12 @@ public class OrphanEventListenerRemovalCombinedWithRepetitionTest extends Flowab
         // starting Task A through both event listeners must also start the stages again
         cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "start Task A 1", AVAILABLE));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(1, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(1);
         assertPlanItemInstanceState(planItemInstances, "start Task A 2", AVAILABLE);
         cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "start Task A 2", AVAILABLE));
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
 
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", ACTIVE);
@@ -88,19 +87,19 @@ public class OrphanEventListenerRemovalCombinedWithRepetitionTest extends Flowab
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE));
 
         assertCaseInstanceEnded(caseInstance);
-        Assert.assertEquals(0L, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count());
-        Assert.assertEquals(0L, cmmnRuntimeService.createCaseInstanceQuery().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0L);
     }
 
     @Test
     @CmmnDeployment(resources = "org/flowable/cmmn/test/itemcontrol/OrphanEventListenerRemovalCombinedWithRepetitionTest.testRemovalOfOrphanedEventListeners.cmmn")
     public void testRemovalOfOrphanedEventListenersWithInnerStart() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("nestedRepetitionPlanItemsWithOrphanedEventListeners")
-            .start();
+                .caseDefinitionKey("nestedRepetitionPlanItemsWithOrphanedEventListeners")
+                .start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(5, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(5);
 
         assertPlanItemInstanceState(planItemInstances, "Stage A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "start Task A 1", AVAILABLE);
@@ -113,7 +112,7 @@ public class OrphanEventListenerRemovalCombinedWithRepetitionTest extends Flowab
         cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "start Task A 2", AVAILABLE));
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(5, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(5);
 
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", ACTIVE);
@@ -124,19 +123,19 @@ public class OrphanEventListenerRemovalCombinedWithRepetitionTest extends Flowab
         cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "kill Stage A", AVAILABLE));
 
         assertCaseInstanceEnded(caseInstance);
-        Assert.assertEquals(0L, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count());
-        Assert.assertEquals(0L, cmmnRuntimeService.createCaseInstanceQuery().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0L);
     }
 
     @Test
     @CmmnDeployment(resources = "org/flowable/cmmn/test/itemcontrol/OrphanEventListenerRemovalCombinedWithRepetitionTwoTest.testRemovalOfOrphanedEventListeners.cmmn")
     public void testRemovalOfOrphanedEventListenersWithOuterStartAndInnerExitEventListener() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("nestedRepetitionPlanItemsWithOrphanedEventListenersTwo")
-            .start();
+                .caseDefinitionKey("nestedRepetitionPlanItemsWithOrphanedEventListenersTwo")
+                .start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(6, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(6);
 
         assertPlanItemInstanceState(planItemInstances, "Stage A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "start Task A 1", AVAILABLE);
@@ -149,7 +148,7 @@ public class OrphanEventListenerRemovalCombinedWithRepetitionTest extends Flowab
         cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "start Stage A", AVAILABLE));
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(6, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(6);
 
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", AVAILABLE);
@@ -162,7 +161,7 @@ public class OrphanEventListenerRemovalCombinedWithRepetitionTest extends Flowab
         cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "kill Stage A", AVAILABLE));
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
 
         assertPlanItemInstanceState(planItemInstances, "start Task A 1", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "start Task A 2", AVAILABLE);
@@ -171,12 +170,12 @@ public class OrphanEventListenerRemovalCombinedWithRepetitionTest extends Flowab
         // starting Task A through both event listeners must also start the stages again
         cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "start Task A 1", AVAILABLE));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(2, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(2);
         assertPlanItemInstanceState(planItemInstances, "start Task A 2", AVAILABLE);
         cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "start Task A 2", AVAILABLE));
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(5, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(5);
 
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", ACTIVE);
@@ -187,7 +186,7 @@ public class OrphanEventListenerRemovalCombinedWithRepetitionTest extends Flowab
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE));
 
         assertCaseInstanceEnded(caseInstance);
-        Assert.assertEquals(0L, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count());
-        Assert.assertEquals(0L, cmmnRuntimeService.createCaseInstanceQuery().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0L);
     }
 }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/PlanItemRepetitionManualActivationMaxCountTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/PlanItemRepetitionManualActivationMaxCountTest.java
@@ -12,11 +12,11 @@
  */
 package org.flowable.cmmn.test.itemcontrol;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.ACTIVE;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.AVAILABLE;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.ENABLED;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.WAITING_FOR_REPETITION;
-import static org.junit.Assert.assertEquals;
 
 import java.util.List;
 
@@ -39,7 +39,7 @@ public class PlanItemRepetitionManualActivationMaxCountTest extends FlowableCmmn
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("repetitionMaxInstanceCountTestTwo").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -48,7 +48,7 @@ public class PlanItemRepetitionManualActivationMaxCountTest extends FlowableCmmn
         cmmnRuntimeService.setVariable(caseInstance.getId(), "enableTaskA", true);
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Task A", ENABLED, WAITING_FOR_REPETITION);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -60,7 +60,7 @@ public class PlanItemRepetitionManualActivationMaxCountTest extends FlowableCmmn
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("repetitionMaxInstanceCountTestTwo").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -69,7 +69,7 @@ public class PlanItemRepetitionManualActivationMaxCountTest extends FlowableCmmn
         cmmnRuntimeService.setVariable(caseInstance.getId(), "enableTaskA", true);
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Task A", ENABLED, WAITING_FOR_REPETITION);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -77,16 +77,15 @@ public class PlanItemRepetitionManualActivationMaxCountTest extends FlowableCmmn
         // start and then complete Task A
         cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ENABLED));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE, WAITING_FOR_REPETITION);
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE));
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Task A", ENABLED, WAITING_FOR_REPETITION);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
-
 
         // disable Task A again by setting its enable flag to false
         cmmnRuntimeService.setVariable(caseInstance.getId(), "enableTaskA", false);
@@ -94,12 +93,12 @@ public class PlanItemRepetitionManualActivationMaxCountTest extends FlowableCmmn
         // start and then complete Task A
         cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ENABLED));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE, WAITING_FOR_REPETITION);
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE));
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task A", WAITING_FOR_REPETITION);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -111,7 +110,7 @@ public class PlanItemRepetitionManualActivationMaxCountTest extends FlowableCmmn
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("repetitionMaxInstanceCountTestTwo").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -120,7 +119,7 @@ public class PlanItemRepetitionManualActivationMaxCountTest extends FlowableCmmn
         cmmnRuntimeService.setVariable(caseInstance.getId(), "enableTaskB", true);
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Task A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ENABLED, WAITING_FOR_REPETITION);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -132,7 +131,7 @@ public class PlanItemRepetitionManualActivationMaxCountTest extends FlowableCmmn
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("repetitionMaxInstanceCountTestTwo").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -141,7 +140,7 @@ public class PlanItemRepetitionManualActivationMaxCountTest extends FlowableCmmn
         cmmnRuntimeService.setVariable(caseInstance.getId(), "enableTaskC", true);
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(7, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(7);
         assertPlanItemInstanceState(planItemInstances, "Task A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", ENABLED, ENABLED, ENABLED, ENABLED, WAITING_FOR_REPETITION);

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/PlanItemRepetitionMaxCountTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/PlanItemRepetitionMaxCountTest.java
@@ -12,10 +12,10 @@
  */
 package org.flowable.cmmn.test.itemcontrol;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.ACTIVE;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.AVAILABLE;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.WAITING_FOR_REPETITION;
-import static org.junit.Assert.assertEquals;
 
 import java.util.List;
 
@@ -38,7 +38,7 @@ public class PlanItemRepetitionMaxCountTest extends FlowableCmmnTestCase {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("repetitionMaxInstanceCountTestOne").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -47,7 +47,7 @@ public class PlanItemRepetitionMaxCountTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.setVariable(caseInstance.getId(), "enableTaskA", true);
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE, WAITING_FOR_REPETITION);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -59,7 +59,7 @@ public class PlanItemRepetitionMaxCountTest extends FlowableCmmnTestCase {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("repetitionMaxInstanceCountTestOne").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -68,7 +68,7 @@ public class PlanItemRepetitionMaxCountTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.setVariable(caseInstance.getId(), "enableTaskA", true);
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE, WAITING_FOR_REPETITION);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -77,7 +77,7 @@ public class PlanItemRepetitionMaxCountTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE));
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE, WAITING_FOR_REPETITION);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -89,7 +89,7 @@ public class PlanItemRepetitionMaxCountTest extends FlowableCmmnTestCase {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("repetitionMaxInstanceCountTestOne").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -98,7 +98,7 @@ public class PlanItemRepetitionMaxCountTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.setVariable(caseInstance.getId(), "enableTaskB", true);
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Task A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE, WAITING_FOR_REPETITION);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -110,7 +110,7 @@ public class PlanItemRepetitionMaxCountTest extends FlowableCmmnTestCase {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("repetitionMaxInstanceCountTestOne").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -119,7 +119,7 @@ public class PlanItemRepetitionMaxCountTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.setVariable(caseInstance.getId(), "enableTaskC", true);
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(7, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(7);
         assertPlanItemInstanceState(planItemInstances, "Task A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", ACTIVE, ACTIVE, ACTIVE, ACTIVE, WAITING_FOR_REPETITION);

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/PlanItemRepetitionMaxInstanceCountWithNumberTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/PlanItemRepetitionMaxInstanceCountWithNumberTest.java
@@ -12,11 +12,11 @@
  */
 package org.flowable.cmmn.test.itemcontrol;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.ACTIVE;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.AVAILABLE;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.ENABLED;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.WAITING_FOR_REPETITION;
-import static org.junit.Assert.assertEquals;
 
 import java.util.List;
 
@@ -39,7 +39,7 @@ public class PlanItemRepetitionMaxInstanceCountWithNumberTest extends FlowableCm
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("maxInstanceCountNumberTest").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(5, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(5);
         assertPlanItemInstanceState(planItemInstances, "Task A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ENABLED);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -50,8 +50,9 @@ public class PlanItemRepetitionMaxInstanceCountWithNumberTest extends FlowableCm
         cmmnRuntimeService.setVariable(caseInstance.getId(), "enableTaskA", true);
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(15, planItemInstances.size());
-        assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE, ACTIVE, ACTIVE, ACTIVE, ACTIVE, ACTIVE, ACTIVE, ACTIVE, ACTIVE, ACTIVE, WAITING_FOR_REPETITION);
+        assertThat(planItemInstances).hasSize(15);
+        assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE, ACTIVE, ACTIVE, ACTIVE, ACTIVE, ACTIVE, ACTIVE, ACTIVE, ACTIVE, ACTIVE,
+                WAITING_FOR_REPETITION);
         assertPlanItemInstanceState(planItemInstances, "Task B", ENABLED);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task D", ENABLED);
@@ -64,7 +65,7 @@ public class PlanItemRepetitionMaxInstanceCountWithNumberTest extends FlowableCm
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("maxInstanceCountNumberTest").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(5, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(5);
         assertPlanItemInstanceState(planItemInstances, "Task A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ENABLED);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -75,7 +76,7 @@ public class PlanItemRepetitionMaxInstanceCountWithNumberTest extends FlowableCm
         startAndCompleteTaskMultipleTimes(caseInstance.getId(), "Task B", 4);
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(8, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(8);
 
         assertPlanItemInstanceState(planItemInstances, "Task A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ENABLED);
@@ -90,7 +91,7 @@ public class PlanItemRepetitionMaxInstanceCountWithNumberTest extends FlowableCm
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("maxInstanceCountNumberTest").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(5, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(5);
         assertPlanItemInstanceState(planItemInstances, "Task A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ENABLED);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -104,7 +105,7 @@ public class PlanItemRepetitionMaxInstanceCountWithNumberTest extends FlowableCm
         startAndCompleteTaskMultipleTimes(caseInstance.getId(), "Task D", 6);
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
 
         assertPlanItemInstanceState(planItemInstances, "Task A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ENABLED);
@@ -119,18 +120,17 @@ public class PlanItemRepetitionMaxInstanceCountWithNumberTest extends FlowableCm
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("maxInstanceCountNumberTest").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(5, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(5);
         assertPlanItemInstanceState(planItemInstances, "Task A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ENABLED);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task D", ENABLED);
         assertPlanItemInstanceState(planItemInstances, "Task E", AVAILABLE);
 
-
         // manually trigger Task E by completing Task D three times, but as E is not yet enabled, it must not yet be active
         startAndCompleteTaskMultipleTimes(caseInstance.getId(), "Task D", 3);
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(5, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(5);
         assertPlanItemInstanceState(planItemInstances, "Task A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ENABLED);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -141,7 +141,7 @@ public class PlanItemRepetitionMaxInstanceCountWithNumberTest extends FlowableCm
         cmmnRuntimeService.setVariable(caseInstance.getId(), "enableTaskE", true);
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
 
         assertPlanItemInstanceState(planItemInstances, "Task A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ENABLED);

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/PlanItemRepetitionOnPartMaxCountTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/PlanItemRepetitionOnPartMaxCountTest.java
@@ -12,11 +12,11 @@
  */
 package org.flowable.cmmn.test.itemcontrol;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.ACTIVE;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.AVAILABLE;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.ENABLED;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.WAITING_FOR_REPETITION;
-import static org.junit.Assert.assertEquals;
 
 import java.util.List;
 
@@ -39,7 +39,7 @@ public class PlanItemRepetitionOnPartMaxCountTest extends FlowableCmmnTestCase {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("repetitionMaxInstanceCountWithOnPart").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(9, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(9);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", ACTIVE);
@@ -52,27 +52,27 @@ public class PlanItemRepetitionOnPartMaxCountTest extends FlowableCmmnTestCase {
         // complete Task A which should enable Task B
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task A"));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ENABLED, WAITING_FOR_REPETITION);
 
         // completing Task A again must not start another instance of B
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task A"));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ENABLED, WAITING_FOR_REPETITION);
 
         // completing Task B will make sure we can start another one when completing Task A again
         cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task B", ENABLED));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task B", ACTIVE));
 
         // complete Task A which should enable Task B
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task A"));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ENABLED, WAITING_FOR_REPETITION);
     }
@@ -83,7 +83,7 @@ public class PlanItemRepetitionOnPartMaxCountTest extends FlowableCmmnTestCase {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("repetitionMaxInstanceCountWithOnPart").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(9, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(9);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", ACTIVE);
@@ -96,14 +96,14 @@ public class PlanItemRepetitionOnPartMaxCountTest extends FlowableCmmnTestCase {
         // complete Task C which should start Task D
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task C"));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Task C", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task D", ACTIVE, WAITING_FOR_REPETITION);
 
         // completing Task C again must not start another instance of D
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task C"));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Task C", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task D", ACTIVE, WAITING_FOR_REPETITION);
 
@@ -113,7 +113,7 @@ public class PlanItemRepetitionOnPartMaxCountTest extends FlowableCmmnTestCase {
         // complete Task C which should start Task D
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task C"));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Task C", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task D", ACTIVE, WAITING_FOR_REPETITION);
     }
@@ -124,7 +124,7 @@ public class PlanItemRepetitionOnPartMaxCountTest extends FlowableCmmnTestCase {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("repetitionMaxInstanceCountWithOnPart").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(9, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(9);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", ACTIVE);
@@ -137,34 +137,34 @@ public class PlanItemRepetitionOnPartMaxCountTest extends FlowableCmmnTestCase {
         // complete Task E which should not yet do anything as we didn't set yet the enabled flag
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task E"));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(9, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(9);
         assertPlanItemInstanceState(planItemInstances, "Task E", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task F", AVAILABLE);
 
         // enable Task F by setting its condition to true
         cmmnRuntimeService.setVariable(caseInstance.getId(), "enableTaskF", true);
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Task E", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task F", ENABLED, WAITING_FOR_REPETITION);
 
         // completing Task E again must not start another instance of F
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task E"));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Task E", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task F", ENABLED, WAITING_FOR_REPETITION);
 
         // completing Task F will make sure we can start another one when completing Task E again
         cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task F", ENABLED));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task F", ACTIVE));
 
         // complete Task E which should enable Task F again
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task E"));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Task E", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task F", ENABLED, WAITING_FOR_REPETITION);
     }
@@ -175,7 +175,7 @@ public class PlanItemRepetitionOnPartMaxCountTest extends FlowableCmmnTestCase {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("repetitionMaxInstanceCountWithOnPart").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(9, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(9);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", ACTIVE);
@@ -188,21 +188,21 @@ public class PlanItemRepetitionOnPartMaxCountTest extends FlowableCmmnTestCase {
         // complete Task G should not yet enable Task G as its condition is not yet true
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task G"));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(9, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(9);
         assertPlanItemInstanceState(planItemInstances, "Task G", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task H", AVAILABLE);
 
         // enable Task H by setting its condition to true
         cmmnRuntimeService.setVariable(caseInstance.getId(), "enableTaskH", true);
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Task G", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task H", ACTIVE, WAITING_FOR_REPETITION);
 
         // completing Task G again must not start another instance of H
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task G"));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Task G", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task H", ACTIVE, WAITING_FOR_REPETITION);
 
@@ -212,7 +212,7 @@ public class PlanItemRepetitionOnPartMaxCountTest extends FlowableCmmnTestCase {
         // complete Task G which should start Task H
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task G"));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Task G", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task H", ACTIVE, WAITING_FOR_REPETITION);
     }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/PlanItemRepetitionOnPartMaxCountUnlimitedTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/PlanItemRepetitionOnPartMaxCountUnlimitedTest.java
@@ -12,11 +12,11 @@
  */
 package org.flowable.cmmn.test.itemcontrol;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.ACTIVE;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.AVAILABLE;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.ENABLED;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.WAITING_FOR_REPETITION;
-import static org.junit.Assert.assertEquals;
 
 import java.util.List;
 
@@ -39,7 +39,7 @@ public class PlanItemRepetitionOnPartMaxCountUnlimitedTest extends FlowableCmmnT
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("repetitionMaxInstanceCountUnlimitedWithOnPart").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(9, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(9);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", ACTIVE);
@@ -52,14 +52,14 @@ public class PlanItemRepetitionOnPartMaxCountUnlimitedTest extends FlowableCmmnT
         // complete Task A which should enable Task B
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task A"));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ENABLED, WAITING_FOR_REPETITION);
 
         // completing Task A again must start another instance of B
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task A"));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(11, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(11);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ENABLED, ENABLED, WAITING_FOR_REPETITION);
     }
@@ -70,7 +70,7 @@ public class PlanItemRepetitionOnPartMaxCountUnlimitedTest extends FlowableCmmnT
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("repetitionMaxInstanceCountUnlimitedWithOnPart").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(9, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(9);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", ACTIVE);
@@ -83,14 +83,14 @@ public class PlanItemRepetitionOnPartMaxCountUnlimitedTest extends FlowableCmmnT
         // complete Task C which should start Task D
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task C"));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Task C", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task D", ACTIVE, WAITING_FOR_REPETITION);
 
         // completing Task C again must start another instance of D
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task C"));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(11, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(11);
         assertPlanItemInstanceState(planItemInstances, "Task C", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task D", ACTIVE, ACTIVE, WAITING_FOR_REPETITION);
     }
@@ -101,7 +101,7 @@ public class PlanItemRepetitionOnPartMaxCountUnlimitedTest extends FlowableCmmnT
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("repetitionMaxInstanceCountUnlimitedWithOnPart").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(9, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(9);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", ACTIVE);
@@ -114,21 +114,21 @@ public class PlanItemRepetitionOnPartMaxCountUnlimitedTest extends FlowableCmmnT
         // complete Task E which should not yet do anything as we didn't set yet the enabled flag
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task E"));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(9, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(9);
         assertPlanItemInstanceState(planItemInstances, "Task E", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task F", AVAILABLE);
 
         // enable Task F by setting its condition to true
         cmmnRuntimeService.setVariable(caseInstance.getId(), "enableTaskF", true);
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Task E", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task F", ENABLED, WAITING_FOR_REPETITION);
 
         // completing Task E again must start another instance of F
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task E"));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(11, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(11);
         assertPlanItemInstanceState(planItemInstances, "Task E", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task F", ENABLED, ENABLED, WAITING_FOR_REPETITION);
     }
@@ -139,7 +139,7 @@ public class PlanItemRepetitionOnPartMaxCountUnlimitedTest extends FlowableCmmnT
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("repetitionMaxInstanceCountUnlimitedWithOnPart").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(9, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(9);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", ACTIVE);
@@ -152,21 +152,21 @@ public class PlanItemRepetitionOnPartMaxCountUnlimitedTest extends FlowableCmmnT
         // complete Task G should not yet enable Task G as its condition is not yet true
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task G"));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(9, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(9);
         assertPlanItemInstanceState(planItemInstances, "Task G", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task H", AVAILABLE);
 
         // enable Task H by setting its condition to true
         cmmnRuntimeService.setVariable(caseInstance.getId(), "enableTaskH", true);
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Task G", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task H", ACTIVE, WAITING_FOR_REPETITION);
 
         // completing Task G again must start another instance of H
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task G"));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(11, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(11);
         assertPlanItemInstanceState(planItemInstances, "Task G", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task H", ACTIVE, ACTIVE, WAITING_FOR_REPETITION);
     }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/PlanItemRepetitionWithCollectionVariableAndConditionDynamicNameTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/PlanItemRepetitionWithCollectionVariableAndConditionDynamicNameTest.java
@@ -12,9 +12,9 @@
  */
 package org.flowable.cmmn.test.itemcontrol;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.ACTIVE;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.AVAILABLE;
-import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
 import java.util.List;
@@ -38,7 +38,7 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionDynamicNameTest
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("repetitionWithCollectionVariableTestThree").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B (na - na)", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C (na - na)", AVAILABLE);
@@ -47,12 +47,12 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionDynamicNameTest
 
         // complete Task A by providing the collection used for repetition
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE))
-            .variable("taskOutputList", taskOutputList)
-            .trigger();
+                .variable("taskOutputList", taskOutputList)
+                .trigger();
 
         // as we didn't enable Task B yet, no instances must have been created
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B (na - na)", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C (na - na)", AVAILABLE);
@@ -62,7 +62,7 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionDynamicNameTest
 
         // now we need to have 4 instances of Task B with adequate local variables
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(7, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(7);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B (na - na)", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task B (A - 0)", ACTIVE);
@@ -72,13 +72,13 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionDynamicNameTest
         assertPlanItemInstanceState(planItemInstances, "Task C (na - na)", AVAILABLE);
 
         // now let's complete all Tasks B -> nothing must happen additionally
-        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances,"Task B (A - 0)", ACTIVE));
-        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances,"Task B (B - 1)", ACTIVE));
-        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances,"Task B (C - 2)", ACTIVE));
-        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances,"Task B (D - 3)", ACTIVE));
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task B (A - 0)", ACTIVE));
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task B (B - 1)", ACTIVE));
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task B (C - 2)", ACTIVE));
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task B (D - 3)", ACTIVE));
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B (na - na)", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C (na - na)", AVAILABLE);
@@ -90,7 +90,7 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionDynamicNameTest
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("repetitionWithCollectionVariableTestThree").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B (na - na)", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C (na - na)", AVAILABLE);
@@ -98,7 +98,7 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionDynamicNameTest
         // enable the condition on Task B upfront -> nothing yet to happen
         cmmnRuntimeService.setVariable(caseInstance.getId(), "enableTaskB", true);
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B (na - na)", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C (na - na)", AVAILABLE);
@@ -107,12 +107,12 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionDynamicNameTest
 
         // complete Task A by providing the collection used for repetition
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE))
-            .variable("taskOutputList", taskOutputList)
-            .trigger();
+                .variable("taskOutputList", taskOutputList)
+                .trigger();
 
         // now we need to have 4 instances of Task B with adequate local variables
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(7, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(7);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B (na - na)", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task B (A - 0)", ACTIVE);
@@ -122,13 +122,13 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionDynamicNameTest
         assertPlanItemInstanceState(planItemInstances, "Task C (na - na)", AVAILABLE);
 
         // now let's complete all Tasks B -> nothing must happen additionally
-        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances,"Task B (A - 0)", ACTIVE));
-        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances,"Task B (B - 1)", ACTIVE));
-        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances,"Task B (C - 2)", ACTIVE));
-        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances,"Task B (D - 3)", ACTIVE));
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task B (A - 0)", ACTIVE));
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task B (B - 1)", ACTIVE));
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task B (C - 2)", ACTIVE));
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task B (D - 3)", ACTIVE));
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B (na - na)", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C (na - na)", AVAILABLE);
@@ -140,7 +140,7 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionDynamicNameTest
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("repetitionWithCollectionVariableTestThree").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B (na - na)", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C (na - na)", AVAILABLE);
@@ -152,12 +152,12 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionDynamicNameTest
 
         // complete Task A by providing the collection used for repetition
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE))
-            .variable("taskOutputList", taskOutputList)
-            .trigger();
+                .variable("taskOutputList", taskOutputList)
+                .trigger();
 
         // now we need to have 4 instances of Task B with adequate local variables
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(7, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(7);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B (na - na)", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task B (A - 0)", ACTIVE);
@@ -167,20 +167,20 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionDynamicNameTest
         assertPlanItemInstanceState(planItemInstances, "Task C (na - na)", AVAILABLE);
 
         // complete all active tasks
-        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances,"Task B (A - 0)", ACTIVE));
-        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances,"Task B (B - 1)", ACTIVE));
-        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances,"Task B (C - 2)", ACTIVE));
-        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances,"Task B (D - 3)", ACTIVE));
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task B (A - 0)", ACTIVE));
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task B (B - 1)", ACTIVE));
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task B (C - 2)", ACTIVE));
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task B (D - 3)", ACTIVE));
 
         taskOutputList = Arrays.asList("E", "F");
 
         // complete Task A again by providing a different collection used for repetition
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE))
-            .variable("taskOutputList", taskOutputList)
-            .trigger();
+                .variable("taskOutputList", taskOutputList)
+                .trigger();
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(5, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(5);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B (na - na)", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task B (E - 0)", ACTIVE);
@@ -188,11 +188,11 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionDynamicNameTest
         assertPlanItemInstanceState(planItemInstances, "Task C (na - na)", AVAILABLE);
 
         // now let's complete all Tasks B -> nothing must happen additionally
-        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances,"Task B (E - 0)", ACTIVE));
-        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances,"Task B (F - 1)", ACTIVE));
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task B (E - 0)", ACTIVE));
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task B (F - 1)", ACTIVE));
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B (na - na)", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C (na - na)", AVAILABLE);
@@ -204,7 +204,7 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionDynamicNameTest
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("repetitionWithCollectionVariableTestThree").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B (na - na)", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C (na - na)", AVAILABLE);
@@ -216,12 +216,12 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionDynamicNameTest
 
         // complete Task A by providing the collection used for repetition
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE))
-            .variable("taskOutputList", taskOutputList)
-            .trigger();
+                .variable("taskOutputList", taskOutputList)
+                .trigger();
 
         // now we need to have 4 instances of Task B with adequate local variables
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(7, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(7);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B (na - na)", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task B (A - 0)", ACTIVE);
@@ -231,18 +231,18 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionDynamicNameTest
         assertPlanItemInstanceState(planItemInstances, "Task C (na - na)", AVAILABLE);
 
         // only complete two active Task B
-        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances,"Task B (A - 0)", ACTIVE));
-        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances,"Task B (B - 1)", ACTIVE));
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task B (A - 0)", ACTIVE));
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task B (B - 1)", ACTIVE));
 
         taskOutputList = Arrays.asList("E", "F");
 
         // complete Task A again by providing a different collection used for repetition
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE))
-            .variable("taskOutputList", taskOutputList)
-            .trigger();
+                .variable("taskOutputList", taskOutputList)
+                .trigger();
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(7, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(7);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B (na - na)", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task B (C - 2)", ACTIVE);
@@ -252,13 +252,13 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionDynamicNameTest
         assertPlanItemInstanceState(planItemInstances, "Task C (na - na)", AVAILABLE);
 
         // now let's complete all Tasks B -> nothing must happen additionally
-        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances,"Task B (C - 2)", ACTIVE));
-        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances,"Task B (D - 3)", ACTIVE));
-        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances,"Task B (E - 0)", ACTIVE));
-        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances,"Task B (F - 1)", ACTIVE));
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task B (C - 2)", ACTIVE));
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task B (D - 3)", ACTIVE));
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task B (E - 0)", ACTIVE));
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task B (F - 1)", ACTIVE));
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B (na - na)", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C (na - na)", AVAILABLE);
@@ -270,7 +270,7 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionDynamicNameTest
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("repetitionWithCollectionVariableTestThree").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B (na - na)", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C (na - na)", AVAILABLE);
@@ -278,7 +278,7 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionDynamicNameTest
         // enable task C upfront (nothing must happen yet)
         cmmnRuntimeService.setVariable(caseInstance.getId(), "enableTaskC", true);
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B (na - na)", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C (na - na)", AVAILABLE);
@@ -290,7 +290,7 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionDynamicNameTest
 
         // now we need to have 4 instances of Task C with adequate local variables
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(6, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(6);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B (na - na)", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C (A - 0)", ACTIVE);
@@ -301,7 +301,7 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionDynamicNameTest
         // if we change the collection variable, nothing else must happen
         cmmnRuntimeService.setVariable(caseInstance.getId(), "myCollection", Arrays.asList("foo"));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(6, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(6);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B (na - na)", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C (A - 0)", ACTIVE);
@@ -312,7 +312,7 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionDynamicNameTest
         // even if we remove the variable completely, nothing else must happen
         cmmnRuntimeService.removeVariable(caseInstance.getId(), "myCollection");
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(6, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(6);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B (na - na)", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C (A - 0)", ACTIVE);
@@ -321,13 +321,13 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionDynamicNameTest
         assertPlanItemInstanceState(planItemInstances, "Task C (D - 3)", ACTIVE);
 
         // now let's complete all Tasks C -> nothing must happen additionally
-        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances,"Task C (A - 0)", ACTIVE));
-        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances,"Task C (B - 1)", ACTIVE));
-        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances,"Task C (C - 2)", ACTIVE));
-        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances,"Task C (D - 3)", ACTIVE));
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task C (A - 0)", ACTIVE));
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task C (B - 1)", ACTIVE));
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task C (C - 2)", ACTIVE));
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task C (D - 3)", ACTIVE));
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(2, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(2);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B (na - na)", AVAILABLE);
         assertNoPlanItemInstance(planItemInstances, "Task C");
@@ -339,7 +339,7 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionDynamicNameTest
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("repetitionWithCollectionVariableTestThree").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B (na - na)", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C (na - na)", AVAILABLE);
@@ -350,7 +350,7 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionDynamicNameTest
         cmmnRuntimeService.setVariable(caseInstance.getId(), "myCollection", myCollection);
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B (na - na)", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C (na - na)", AVAILABLE);
@@ -360,7 +360,7 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionDynamicNameTest
 
         // now we need to have 4 instances of Task C with adequate local variables
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(6, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(6);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B (na - na)", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C (A - 0)", ACTIVE);
@@ -371,7 +371,7 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionDynamicNameTest
         // if we change the collection variable, nothing else must happen
         cmmnRuntimeService.setVariable(caseInstance.getId(), "myCollection", Arrays.asList("foo"));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(6, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(6);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B (na - na)", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C (A - 0)", ACTIVE);
@@ -382,7 +382,7 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionDynamicNameTest
         // even if we remove the variable completely, nothing else must happen
         cmmnRuntimeService.removeVariable(caseInstance.getId(), "myCollection");
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(6, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(6);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B (na - na)", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C (A - 0)", ACTIVE);
@@ -391,13 +391,13 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionDynamicNameTest
         assertPlanItemInstanceState(planItemInstances, "Task C (D - 3)", ACTIVE);
 
         // now let's complete all Tasks C -> nothing must happen additionally
-        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances,"Task C (A - 0)", ACTIVE));
-        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances,"Task C (B - 1)", ACTIVE));
-        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances,"Task C (C - 2)", ACTIVE));
-        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances,"Task C (D - 3)", ACTIVE));
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task C (A - 0)", ACTIVE));
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task C (B - 1)", ACTIVE));
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task C (C - 2)", ACTIVE));
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task C (D - 3)", ACTIVE));
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(2, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(2);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B (na - na)", AVAILABLE);
         assertNoPlanItemInstance(planItemInstances, "Task C (na - na)");

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/PlanItemRepetitionWithCollectionVariableAndConditionTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/PlanItemRepetitionWithCollectionVariableAndConditionTest.java
@@ -12,9 +12,9 @@
  */
 package org.flowable.cmmn.test.itemcontrol;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.ACTIVE;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.AVAILABLE;
-import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
 import java.util.List;
@@ -38,7 +38,7 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionTest extends Fl
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("repetitionWithCollectionVariableTestTwo").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -47,12 +47,12 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionTest extends Fl
 
         // complete Task A by providing the collection used for repetition
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE))
-            .variable("taskOutputList", taskOutputList)
-            .trigger();
+                .variable("taskOutputList", taskOutputList)
+                .trigger();
 
         // as we didn't enable Task B yet, no instances must have been created
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -62,7 +62,7 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionTest extends Fl
 
         // now we need to have 4 instances of Task B with adequate local variables
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(7, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(7);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE, ACTIVE, ACTIVE, ACTIVE, AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -71,19 +71,19 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionTest extends Fl
 
         // now let's complete all Tasks B -> nothing must happen additionally
         List<PlanItemInstance> tasks = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .planItemInstanceName("Task B")
-            .planItemInstanceStateActive()
-            .orderByCreateTime().asc()
-            .list();
+                .caseInstanceId(caseInstance.getId())
+                .planItemInstanceName("Task B")
+                .planItemInstanceStateActive()
+                .orderByCreateTime().asc()
+                .list();
 
-        assertEquals(4, tasks.size());
+        assertThat(tasks).hasSize(4);
         for (PlanItemInstance task : tasks) {
             cmmnRuntimeService.triggerPlanItemInstance(task.getId());
         }
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -95,7 +95,7 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionTest extends Fl
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("repetitionWithCollectionVariableTestTwo").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -103,7 +103,7 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionTest extends Fl
         // enable the condition on Task B upfront -> nothing yet to happen
         cmmnRuntimeService.setVariable(caseInstance.getId(), "enableTaskB", true);
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -112,12 +112,12 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionTest extends Fl
 
         // complete Task A by providing the collection used for repetition
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE))
-            .variable("taskOutputList", taskOutputList)
-            .trigger();
+                .variable("taskOutputList", taskOutputList)
+                .trigger();
 
         // now we need to have 4 instances of Task B with adequate local variables
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(7, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(7);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE, ACTIVE, ACTIVE, ACTIVE, AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -126,19 +126,19 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionTest extends Fl
 
         // now let's complete all Tasks B -> nothing must happen additionally
         List<PlanItemInstance> tasks = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .planItemInstanceName("Task B")
-            .planItemInstanceStateActive()
-            .orderByCreateTime().asc()
-            .list();
+                .caseInstanceId(caseInstance.getId())
+                .planItemInstanceName("Task B")
+                .planItemInstanceStateActive()
+                .orderByCreateTime().asc()
+                .list();
 
-        assertEquals(4, tasks.size());
+        assertThat(tasks).hasSize(4);
         for (PlanItemInstance task : tasks) {
             cmmnRuntimeService.triggerPlanItemInstance(task.getId());
         }
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -150,7 +150,7 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionTest extends Fl
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("repetitionWithCollectionVariableTestTwo").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -162,12 +162,12 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionTest extends Fl
 
         // complete Task A by providing the collection used for repetition
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE))
-            .variable("taskOutputList", taskOutputList)
-            .trigger();
+                .variable("taskOutputList", taskOutputList)
+                .trigger();
 
         // now we need to have 4 instances of Task B with adequate local variables
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(7, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(7);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE, ACTIVE, ACTIVE, ACTIVE, AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -177,17 +177,17 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionTest extends Fl
         // complete all active tasks
         completeAllPlanItems(caseInstance.getId(), "Task B", 4);
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
 
         taskOutputList = Arrays.asList("E", "F");
 
         // complete Task A again by providing a different collection used for repetition
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE))
-            .variable("taskOutputList", taskOutputList)
-            .trigger();
+                .variable("taskOutputList", taskOutputList)
+                .trigger();
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(5, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(5);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE, ACTIVE, AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -198,7 +198,7 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionTest extends Fl
         completeAllPlanItems(caseInstance.getId(), "Task B", 2);
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -210,7 +210,7 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionTest extends Fl
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("repetitionWithCollectionVariableTestTwo").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -222,12 +222,12 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionTest extends Fl
 
         // complete Task A by providing the collection used for repetition
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE))
-            .variable("taskOutputList", taskOutputList)
-            .trigger();
+                .variable("taskOutputList", taskOutputList)
+                .trigger();
 
         // now we need to have 4 instances of Task B with adequate local variables
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(7, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(7);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE, ACTIVE, ACTIVE, ACTIVE, AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -237,17 +237,17 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionTest extends Fl
         // only complete two active Task B
         completePlanItemsWithItemValues(caseInstance.getId(), "Task B", 4, "A", "B");
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(5, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(5);
 
         taskOutputList = Arrays.asList("E", "F");
 
         // complete Task A again by providing a different collection used for repetition
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE))
-            .variable("taskOutputList", taskOutputList)
-            .trigger();
+                .variable("taskOutputList", taskOutputList)
+                .trigger();
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(7, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(7);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE, ACTIVE, ACTIVE, ACTIVE, AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -258,7 +258,7 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionTest extends Fl
         completeAllPlanItems(caseInstance.getId(), "Task B", 4);
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -270,7 +270,7 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionTest extends Fl
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("repetitionWithCollectionVariableTestTwo").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -278,7 +278,7 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionTest extends Fl
         // enable task C upfront (nothing must happen yet)
         cmmnRuntimeService.setVariable(caseInstance.getId(), "enableTaskC", true);
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -290,7 +290,7 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionTest extends Fl
 
         // now we need to have 4 instances of Task C with adequate local variables
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(6, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(6);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", ACTIVE, ACTIVE, ACTIVE, ACTIVE);
@@ -300,7 +300,7 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionTest extends Fl
         // if we change the collection variable, nothing else must happen
         cmmnRuntimeService.setVariable(caseInstance.getId(), "myCollection", Arrays.asList("foo"));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(6, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(6);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", ACTIVE, ACTIVE, ACTIVE, ACTIVE);
@@ -308,26 +308,26 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionTest extends Fl
         // even if we remove the variable completely, nothing else must happen
         cmmnRuntimeService.removeVariable(caseInstance.getId(), "myCollection");
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(6, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(6);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", ACTIVE, ACTIVE, ACTIVE, ACTIVE);
 
         // now let's complete all Tasks C -> nothing must happen additionally
         List<PlanItemInstance> tasks = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .planItemInstanceName("Task C")
-            .planItemInstanceStateActive()
-            .orderByCreateTime().asc()
-            .list();
+                .caseInstanceId(caseInstance.getId())
+                .planItemInstanceName("Task C")
+                .planItemInstanceStateActive()
+                .orderByCreateTime().asc()
+                .list();
 
-        assertEquals(4, tasks.size());
+        assertThat(tasks).hasSize(4);
         for (PlanItemInstance task : tasks) {
             cmmnRuntimeService.triggerPlanItemInstance(task.getId());
         }
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(2, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(2);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertNoPlanItemInstance(planItemInstances, "Task C");
@@ -339,7 +339,7 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionTest extends Fl
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("repetitionWithCollectionVariableTestTwo").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -350,7 +350,7 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionTest extends Fl
         cmmnRuntimeService.setVariable(caseInstance.getId(), "myCollection", myCollection);
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -360,7 +360,7 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionTest extends Fl
 
         // now we need to have 4 instances of Task C with adequate local variables
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(6, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(6);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", ACTIVE, ACTIVE, ACTIVE, ACTIVE);
@@ -370,7 +370,7 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionTest extends Fl
         // if we change the collection variable, nothing else must happen
         cmmnRuntimeService.setVariable(caseInstance.getId(), "myCollection", Arrays.asList("foo"));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(6, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(6);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", ACTIVE, ACTIVE, ACTIVE, ACTIVE);
@@ -378,26 +378,26 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionTest extends Fl
         // even if we remove the variable completely, nothing else must happen
         cmmnRuntimeService.removeVariable(caseInstance.getId(), "myCollection");
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(6, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(6);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", ACTIVE, ACTIVE, ACTIVE, ACTIVE);
 
         // now let's complete all Tasks C -> nothing must happen additionally
         List<PlanItemInstance> tasks = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .planItemInstanceName("Task C")
-            .planItemInstanceStateActive()
-            .orderByCreateTime().asc()
-            .list();
+                .caseInstanceId(caseInstance.getId())
+                .planItemInstanceName("Task C")
+                .planItemInstanceStateActive()
+                .orderByCreateTime().asc()
+                .list();
 
-        assertEquals(4, tasks.size());
+        assertThat(tasks).hasSize(4);
         for (PlanItemInstance task : tasks) {
             cmmnRuntimeService.triggerPlanItemInstance(task.getId());
         }
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(2, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(2);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertNoPlanItemInstance(planItemInstances, "Task C");

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/PlanItemRepetitionWithCollectionVariableTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/PlanItemRepetitionWithCollectionVariableTest.java
@@ -12,9 +12,9 @@
  */
 package org.flowable.cmmn.test.itemcontrol;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.ACTIVE;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.AVAILABLE;
-import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
 import java.util.List;
@@ -38,7 +38,7 @@ public class PlanItemRepetitionWithCollectionVariableTest extends FlowableCmmnTe
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("repetitionWithCollectionVariableTestOne").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -47,12 +47,12 @@ public class PlanItemRepetitionWithCollectionVariableTest extends FlowableCmmnTe
 
         // complete Task A by providing the collection used for repetition
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE))
-            .variable("taskOutputList", taskOutputList)
-            .trigger();
+                .variable("taskOutputList", taskOutputList)
+                .trigger();
 
         // now we need to have 4 instances of Task B with adequate local variables
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(7, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(7);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE, ACTIVE, ACTIVE, ACTIVE, AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -61,19 +61,19 @@ public class PlanItemRepetitionWithCollectionVariableTest extends FlowableCmmnTe
 
         // now let's complete all Tasks B -> nothing must happen additionally
         List<PlanItemInstance> tasks = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .planItemInstanceName("Task B")
-            .planItemInstanceStateActive()
-            .orderByCreateTime().asc()
-            .list();
+                .caseInstanceId(caseInstance.getId())
+                .planItemInstanceName("Task B")
+                .planItemInstanceStateActive()
+                .orderByCreateTime().asc()
+                .list();
 
-        assertEquals(4, tasks.size());
+        assertThat(tasks).hasSize(4);
         for (PlanItemInstance task : tasks) {
             cmmnRuntimeService.triggerPlanItemInstance(task.getId());
         }
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -85,7 +85,7 @@ public class PlanItemRepetitionWithCollectionVariableTest extends FlowableCmmnTe
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("repetitionWithCollectionVariableTestOne").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -94,12 +94,12 @@ public class PlanItemRepetitionWithCollectionVariableTest extends FlowableCmmnTe
 
         // complete Task A by providing the collection used for repetition
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE))
-            .variable("taskOutputList", taskOutputList)
-            .trigger();
+                .variable("taskOutputList", taskOutputList)
+                .trigger();
 
         // now we need to have 4 instances of Task B with adequate local variables
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(7, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(7);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE, ACTIVE, ACTIVE, ACTIVE, AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -109,17 +109,17 @@ public class PlanItemRepetitionWithCollectionVariableTest extends FlowableCmmnTe
         // complete all active tasks
         completeAllPlanItems(caseInstance.getId(), "Task B", 4);
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
 
         taskOutputList = Arrays.asList("E", "F");
 
         // complete Task A again by providing a different collection used for repetition
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE))
-            .variable("taskOutputList", taskOutputList)
-            .trigger();
+                .variable("taskOutputList", taskOutputList)
+                .trigger();
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(5, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(5);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE, ACTIVE, AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -130,7 +130,7 @@ public class PlanItemRepetitionWithCollectionVariableTest extends FlowableCmmnTe
         completeAllPlanItems(caseInstance.getId(), "Task B", 2);
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -142,7 +142,7 @@ public class PlanItemRepetitionWithCollectionVariableTest extends FlowableCmmnTe
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("repetitionWithCollectionVariableTestOne").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -151,12 +151,12 @@ public class PlanItemRepetitionWithCollectionVariableTest extends FlowableCmmnTe
 
         // complete Task A by providing the collection used for repetition
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE))
-            .variable("taskOutputList", taskOutputList)
-            .trigger();
+                .variable("taskOutputList", taskOutputList)
+                .trigger();
 
         // now we need to have 4 instances of Task B with adequate local variables
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(7, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(7);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE, ACTIVE, ACTIVE, ACTIVE, AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -166,17 +166,17 @@ public class PlanItemRepetitionWithCollectionVariableTest extends FlowableCmmnTe
         // only complete two active Task B
         completePlanItemsWithItemValues(caseInstance.getId(), "Task B", 4, "A", "B");
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(5, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(5);
 
         taskOutputList = Arrays.asList("E", "F");
 
         // complete Task A again by providing a different collection used for repetition
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE))
-            .variable("taskOutputList", taskOutputList)
-            .trigger();
+                .variable("taskOutputList", taskOutputList)
+                .trigger();
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(7, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(7);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE, ACTIVE, ACTIVE, ACTIVE, AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -187,7 +187,7 @@ public class PlanItemRepetitionWithCollectionVariableTest extends FlowableCmmnTe
         completeAllPlanItems(caseInstance.getId(), "Task B", 4);
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -199,7 +199,7 @@ public class PlanItemRepetitionWithCollectionVariableTest extends FlowableCmmnTe
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("repetitionWithCollectionVariableTestOne").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -211,7 +211,7 @@ public class PlanItemRepetitionWithCollectionVariableTest extends FlowableCmmnTe
 
         // now we need to have 4 instances of Task C with adequate local variables
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(6, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(6);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", ACTIVE, ACTIVE, ACTIVE, ACTIVE);
@@ -221,7 +221,7 @@ public class PlanItemRepetitionWithCollectionVariableTest extends FlowableCmmnTe
         // if we change the collection variable, nothing else must happen
         cmmnRuntimeService.setVariable(caseInstance.getId(), "myCollection", Arrays.asList("foo"));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(6, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(6);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", ACTIVE, ACTIVE, ACTIVE, ACTIVE);
@@ -229,26 +229,26 @@ public class PlanItemRepetitionWithCollectionVariableTest extends FlowableCmmnTe
         // even if we remove the variable completely, nothing else must happen
         cmmnRuntimeService.removeVariable(caseInstance.getId(), "myCollection");
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(6, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(6);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", ACTIVE, ACTIVE, ACTIVE, ACTIVE);
 
         // now let's complete all Tasks C -> nothing must happen additionally
         List<PlanItemInstance> tasks = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .planItemInstanceName("Task C")
-            .planItemInstanceStateActive()
-            .orderByCreateTime().asc()
-            .list();
+                .caseInstanceId(caseInstance.getId())
+                .planItemInstanceName("Task C")
+                .planItemInstanceStateActive()
+                .orderByCreateTime().asc()
+                .list();
 
-        assertEquals(4, tasks.size());
+        assertThat(tasks).hasSize(4);
         for (PlanItemInstance task : tasks) {
             cmmnRuntimeService.triggerPlanItemInstance(task.getId());
         }
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(2, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(2);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertNoPlanItemInstance(planItemInstances, "Task C");

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/StageRepetitionMaxCountTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/StageRepetitionMaxCountTest.java
@@ -12,10 +12,10 @@
  */
 package org.flowable.cmmn.test.itemcontrol;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.ACTIVE;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.AVAILABLE;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.WAITING_FOR_REPETITION;
-import static org.junit.Assert.assertEquals;
 
 import java.util.List;
 
@@ -38,26 +38,26 @@ public class StageRepetitionMaxCountTest extends FlowableCmmnTestCase {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("stageWithRepetitionAndMaxInstanceCount").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(2, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(2);
         assertPlanItemInstanceState(planItemInstances, "Stage A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", AVAILABLE);
 
         // start Stage A which should start Task A as well
         cmmnRuntimeService.setVariable(caseInstance.getId(), "enableStageA", true);
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE, WAITING_FOR_REPETITION);
         assertPlanItemInstanceState(planItemInstances, "Stage B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
 
         // complete Task A which terminates Stage A and starts Stage B
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE))
-            .variable("enableStageA", false)
-            .variable("enableStageB", true)
-            .trigger();
+                .variable("enableStageA", false)
+                .variable("enableStageB", true)
+                .trigger();
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Stage A", WAITING_FOR_REPETITION);
         assertPlanItemInstanceState(planItemInstances, "Stage B", ACTIVE, WAITING_FOR_REPETITION);
         assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE);
@@ -66,7 +66,7 @@ public class StageRepetitionMaxCountTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task B", ACTIVE));
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE, WAITING_FOR_REPETITION);
         assertPlanItemInstanceState(planItemInstances, "Stage B", WAITING_FOR_REPETITION);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
@@ -78,7 +78,7 @@ public class StageRepetitionMaxCountTest extends FlowableCmmnTestCase {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("stageWithRepetitionAndMaxInstanceCount").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(2, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(2);
         assertPlanItemInstanceState(planItemInstances, "Stage A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", AVAILABLE);
 
@@ -86,7 +86,7 @@ public class StageRepetitionMaxCountTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.setVariable(caseInstance.getId(), "enableStageA", true);
         cmmnRuntimeService.setVariable(caseInstance.getId(), "enableStageB", true);
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE, WAITING_FOR_REPETITION);
         assertPlanItemInstanceState(planItemInstances, "Stage B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
@@ -96,7 +96,7 @@ public class StageRepetitionMaxCountTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE));
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Stage A", WAITING_FOR_REPETITION);
         assertPlanItemInstanceState(planItemInstances, "Stage B", ACTIVE, WAITING_FOR_REPETITION);
         assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE);
@@ -105,7 +105,7 @@ public class StageRepetitionMaxCountTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task B", ACTIVE));
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE, WAITING_FOR_REPETITION);
         assertPlanItemInstanceState(planItemInstances, "Stage B", WAITING_FOR_REPETITION);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);


### PR DESCRIPTION
Breaking the changes into groups to make review easier.

This is all the code in the `org.flowable.cmmn.test.itemcontrol` package.

