### PR TITLE
Use assertj fluent style in flowable-cmmn-engine (part 6)

### DIFF
--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/listener/AvailableConditionTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/listener/AvailableConditionTest.java
@@ -41,7 +41,7 @@ public class AvailableConditionTest extends FlowableCmmnTestCase {
         assertThat(eventListenerPlanItemInstance.getState()).isEqualTo(PlanItemInstanceState.UNAVAILABLE);
 
         // The event listener query should not return them as they are unavailable
-        assertThat(cmmnRuntimeService.createUserEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).list()).hasSize(0);
+        assertThat(cmmnRuntimeService.createUserEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).list()).isEmpty();
         assertThat(cmmnRuntimeService.createUserEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).stateUnavailable().list()).hasSize(1);
 
         // After case instance start human task A should be active, human taskA B should be enabled
@@ -113,7 +113,7 @@ public class AvailableConditionTest extends FlowableCmmnTestCase {
     public void testAvailableConditionDismisses() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testAvailableCondition").start();
 
-        // The plan item instance for the event listener should have been created in the unavailabe state, as the condition is not true.
+        // The plan item instance for the event listener should have been created in the unavailable state, as the condition is not true.
         PlanItemInstance eventListenerPlanItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
             .planItemDefinitionType(PlanItemDefinitionType.GENERIC_EVENT_LISTENER).singleResult();
         assertThat(eventListenerPlanItemInstance.getState()).isEqualTo(PlanItemInstanceState.UNAVAILABLE);

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/listener/PlanItemInstanceLifecycleListenerTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/listener/PlanItemInstanceLifecycleListenerTest.java
@@ -12,8 +12,7 @@
  */
 package org.flowable.cmmn.test.listener;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.Map;
@@ -62,7 +61,7 @@ public class PlanItemInstanceLifecycleListenerTest extends FlowableCmmnTestCase 
         cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testLifeCycleListener").start();
 
         List<TestLifeCycleEvent> events = testLifeCycleListener.getEvents();
-        assertEquals(7, events.size());
+        assertThat(events).hasSize(7);
 
         assertEvent(events.get(0), "Stage one", null, PlanItemInstanceState.AVAILABLE);
         assertEvent(events.get(1), "Stage two", null, PlanItemInstanceState.AVAILABLE);
@@ -82,7 +81,7 @@ public class PlanItemInstanceLifecycleListenerTest extends FlowableCmmnTestCase 
         cmmnRuntimeService.disablePlanItemInstance(planItemInstanceB.getId());
 
         events = testLifeCycleListener.getEvents();
-        assertEquals(1, events.size());
+        assertThat(events).hasSize(1);
         assertEvent(events.get(0), "B", PlanItemInstanceState.ENABLED, PlanItemInstanceState.DISABLED);
 
         testLifeCycleListener.clear();
@@ -91,7 +90,7 @@ public class PlanItemInstanceLifecycleListenerTest extends FlowableCmmnTestCase 
         cmmnRuntimeService.enablePlanItemInstance(planItemInstanceB.getId());
 
         events = testLifeCycleListener.getEvents();
-        assertEquals(1, events.size());
+        assertThat(events).hasSize(1);
         assertEvent(events.get(0), "B", PlanItemInstanceState.DISABLED, PlanItemInstanceState.ENABLED);
 
         testLifeCycleListener.clear();
@@ -101,7 +100,7 @@ public class PlanItemInstanceLifecycleListenerTest extends FlowableCmmnTestCase 
         cmmnRuntimeService.startPlanItemInstance(planItemInstanceB.getId());
 
         events = testLifeCycleListener.getEvents();
-        assertEquals(1, events.size());
+        assertThat(events).hasSize(1);
         assertEvent(events.get(0), "B", PlanItemInstanceState.ENABLED, PlanItemInstanceState.ACTIVE);
 
         testLifeCycleListener.clear();
@@ -112,7 +111,7 @@ public class PlanItemInstanceLifecycleListenerTest extends FlowableCmmnTestCase 
         }
 
         events = testLifeCycleListener.getEvents();
-        assertEquals(10, events.size());
+        assertThat(events).hasSize(10);
 
         assertEvent(events.get(0), "A", PlanItemInstanceState.ACTIVE, PlanItemInstanceState.COMPLETED);
         assertEvent(events.get(1), "B", PlanItemInstanceState.ACTIVE, PlanItemInstanceState.COMPLETED);
@@ -137,7 +136,7 @@ public class PlanItemInstanceLifecycleListenerTest extends FlowableCmmnTestCase 
         cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testLifeCycleListener").start();
 
         List<TestLifeCycleEvent> events = testLifeCycleListener.getEvents();
-        assertEquals(4, events.size());
+        assertThat(events).hasSize(4);
 
         assertEvent(events.get(0), "A", null, PlanItemInstanceState.AVAILABLE);
         assertEvent(events.get(1), "B", null, PlanItemInstanceState.AVAILABLE);
@@ -152,7 +151,7 @@ public class PlanItemInstanceLifecycleListenerTest extends FlowableCmmnTestCase 
         cmmnRuntimeService.disablePlanItemInstance(planItemInstanceB.getId());
 
         events = testLifeCycleListener.getEvents();
-        assertEquals(1, events.size());
+        assertThat(events).hasSize(1);
         assertEvent(events.get(0), "B", PlanItemInstanceState.ENABLED, PlanItemInstanceState.DISABLED);
 
         testLifeCycleListener.clear();
@@ -161,7 +160,7 @@ public class PlanItemInstanceLifecycleListenerTest extends FlowableCmmnTestCase 
         cmmnRuntimeService.enablePlanItemInstance(planItemInstanceB.getId());
 
         events = testLifeCycleListener.getEvents();
-        assertEquals(1, events.size());
+        assertThat(events).hasSize(1);
         assertEvent(events.get(0), "B", PlanItemInstanceState.DISABLED, PlanItemInstanceState.ENABLED);
 
         testLifeCycleListener.clear();
@@ -171,7 +170,7 @@ public class PlanItemInstanceLifecycleListenerTest extends FlowableCmmnTestCase 
         cmmnRuntimeService.startPlanItemInstance(planItemInstanceB.getId());
 
         events = testLifeCycleListener.getEvents();
-        assertEquals(1, events.size());
+        assertThat(events).hasSize(1);
         assertEvent(events.get(0), "B", PlanItemInstanceState.ENABLED, PlanItemInstanceState.ACTIVE);
 
         testLifeCycleListener.clear();
@@ -182,7 +181,7 @@ public class PlanItemInstanceLifecycleListenerTest extends FlowableCmmnTestCase 
         }
 
         events = testLifeCycleListener.getEvents();
-        assertEquals(4, events.size());
+        assertThat(events).hasSize(4);
 
         assertEvent(events.get(0), "A", PlanItemInstanceState.ACTIVE, PlanItemInstanceState.COMPLETED);
         assertEvent(events.get(1), "B", PlanItemInstanceState.ACTIVE, PlanItemInstanceState.COMPLETED);
@@ -198,7 +197,7 @@ public class PlanItemInstanceLifecycleListenerTest extends FlowableCmmnTestCase 
         cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testLifeCycleListener").start();
 
         List<TestLifeCycleEvent> events = testLifeCycleListener.getEvents();
-        assertEquals(3, events.size());
+        assertThat(events).hasSize(3);
 
         assertEvent(events.get(0), "Stage one", PlanItemInstanceState.AVAILABLE, PlanItemInstanceState.ACTIVE);
         assertEvent(events.get(1), "A", PlanItemInstanceState.AVAILABLE, PlanItemInstanceState.ACTIVE);
@@ -211,20 +210,20 @@ public class PlanItemInstanceLifecycleListenerTest extends FlowableCmmnTestCase 
         cmmnRuntimeService.disablePlanItemInstance(planItemInstanceB.getId());
 
         events = testLifeCycleListener.getEvents();
-        assertEquals(0, events.size());
+        assertThat(events).isEmpty();
 
         // Enable B
         cmmnRuntimeService.enablePlanItemInstance(planItemInstanceB.getId());
 
         events = testLifeCycleListener.getEvents();
-        assertEquals(0, events.size());
+        assertThat(events).isEmpty();
 
         // Start B
         planItemInstanceB = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceName("B").singleResult();
         cmmnRuntimeService.startPlanItemInstance(planItemInstanceB.getId());
 
         events = testLifeCycleListener.getEvents();
-        assertEquals(0, events.size());
+        assertThat(events).isEmpty();
 
         testLifeCycleListener.clear();
 
@@ -234,7 +233,7 @@ public class PlanItemInstanceLifecycleListenerTest extends FlowableCmmnTestCase 
         }
 
         events = testLifeCycleListener.getEvents();
-        assertEquals(3, events.size());
+        assertThat(events).hasSize(3);
 
         assertEvent(events.get(0), "Stage two", PlanItemInstanceState.AVAILABLE, PlanItemInstanceState.ACTIVE);
         assertEvent(events.get(1), "M1", PlanItemInstanceState.AVAILABLE, PlanItemInstanceState.ACTIVE);
@@ -249,7 +248,7 @@ public class PlanItemInstanceLifecycleListenerTest extends FlowableCmmnTestCase 
         cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testLifeCycleListener").start();
 
         List<TestLifeCycleEvent> events = testLifeCycleListener.getEvents();
-        assertEquals(2, events.size());
+        assertThat(events).hasSize(2);
 
         assertEvent(events.get(0), "Stage one", PlanItemInstanceState.AVAILABLE, PlanItemInstanceState.ACTIVE);
         assertEvent(events.get(1), "A", PlanItemInstanceState.AVAILABLE, PlanItemInstanceState.ACTIVE);
@@ -261,20 +260,20 @@ public class PlanItemInstanceLifecycleListenerTest extends FlowableCmmnTestCase 
         cmmnRuntimeService.disablePlanItemInstance(planItemInstanceB.getId());
 
         events = testLifeCycleListener.getEvents();
-        assertEquals(0, events.size());
+        assertThat(events).isEmpty();
 
         // Enable B
         cmmnRuntimeService.enablePlanItemInstance(planItemInstanceB.getId());
 
         events = testLifeCycleListener.getEvents();
-        assertEquals(0, events.size());
+        assertThat(events).isEmpty();
 
         // Start B
         planItemInstanceB = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceName("B").singleResult();
         cmmnRuntimeService.startPlanItemInstance(planItemInstanceB.getId());
 
         events = testLifeCycleListener.getEvents();
-        assertEquals(1, events.size());
+        assertThat(events).hasSize(1);
         assertEvent(events.get(0), "B", PlanItemInstanceState.ENABLED, PlanItemInstanceState.ACTIVE);
 
         testLifeCycleListener.clear();
@@ -285,7 +284,7 @@ public class PlanItemInstanceLifecycleListenerTest extends FlowableCmmnTestCase 
         }
 
         events = testLifeCycleListener.getEvents();
-        assertEquals(3, events.size());
+        assertThat(events).hasSize(3);
 
         assertEvent(events.get(0), "Stage two", PlanItemInstanceState.AVAILABLE, PlanItemInstanceState.ACTIVE);
         assertEvent(events.get(1), "M1", PlanItemInstanceState.AVAILABLE, PlanItemInstanceState.ACTIVE);
@@ -298,13 +297,13 @@ public class PlanItemInstanceLifecycleListenerTest extends FlowableCmmnTestCase 
     }
 
     private void assertEvent(TestLifeCycleEvent event, String name, String oldState, String newState) {
-        assertEquals(name, event.getPlanItemInstance().getName());
+        assertThat(event.getPlanItemInstance().getName()).isEqualTo(name);
         if (oldState == null) {
-            assertNull(event.getOldState());
+            assertThat(event.getOldState()).isNull();
         } else {
-            assertEquals(oldState, event.getOldState());
+            assertThat(event.getOldState()).isEqualTo(oldState);
         }
-        assertEquals(newState, event.getNewState());
+        assertThat(event.getNewState()).isEqualTo(newState);
     }
 
 }


### PR DESCRIPTION
Breaking the changes into groups to make review easier.

This is all the code in the `org.flowable.cmmn.test.listener` package.

