### PR TITLE
Use LinkedHashMap for deterministic order

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/dynamic/MoveExecutionEntityContainer.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/dynamic/MoveExecutionEntityContainer.java
@@ -14,6 +14,7 @@ package org.flowable.engine.impl.dynamic;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -41,7 +42,7 @@ public class MoveExecutionEntityContainer {
     protected ExecutionEntity superExecution;
     protected String newAssigneeId;
     protected Map<String, ExecutionEntity> continueParentExecutionMap = new HashMap<>();
-    protected Map<String, FlowElementMoveEntry> moveToFlowElementMap = new HashMap<>();
+    protected Map<String, FlowElementMoveEntry> moveToFlowElementMap = new LinkedHashMap<>();
 
     public MoveExecutionEntityContainer(List<ExecutionEntity> executions, List<String> moveToActivityIds) {
         this.executions = executions;


### PR DESCRIPTION
The test in `org.flowable.engine.test.api.runtime.changestate.ChangeStateForGatewaysTest#testSetCurrentActivityToMultipleActivitiesForParallelGateway` can fail due to a different iteration order of HashMap. The test failure is presented as follows.
`org.junit.ComparisonFailure: expected:<task1> but was:<task2>` when executing `assertEquals("task1", ((FlowableActivityEvent) event).getActivityId());`

The root cause of this failure lies in the following stack trace:
java.util.HashMap$Values.iterator(HashMap.java:968)
java.util.AbstractCollection.toArray(AbstractCollection.java:137)
java.util.ArrayList.<init>(ArrayList.java:178)
org.flowable.engine.impl.dynamic.MoveExecutionEntityContainer.getMoveToFlowElements(MoveExecutionEntityContainer.java:180)
The specification about HashMap says that "this class makes no guarantees as to the order of the map; in particular, it does not guarantee that the order will remain constant over time". The documentation is here for your reference: https://docs.oracle.com/javase/8/docs/api/java/util/HashMap.html

The initialization location of the HashMap is in `MoveExecutionEntityContainer.java:44`, where `protected Map<String, FlowElementMoveEntry> moveToFlowElementMap = new HashMap<>();` is executed.

The fix is to use LinkedHashMap instead of HashMap so that the non-deterministic behaviour is eliminated completely. In this way, the code will become more stable and it passes the test successfully.




#### Check List:
* Unit tests: YES
* Documentation: NO
