### PR TITLE
Use assertj fluent style in flowable-cmmn-engine (part 8)

### DIFF
--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/AutoCompleteEvaluationTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/AutoCompleteEvaluationTest.java
@@ -12,9 +12,9 @@
  */
 package org.flowable.cmmn.test.runtime;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.ACTIVE;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.ENABLED;
-import static org.junit.Assert.assertEquals;
 
 import java.util.List;
 
@@ -36,13 +36,13 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
     @CmmnDeployment(resources = "org/flowable/cmmn/test/runtime/AutoCompleteEvaluationTest.testAutoCompleteCondition.cmmn")
     public void testEnableStageAutoCompleteConditionOnStart() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("autoCompleteTest")
-            .variable("enableStageAutoComplete", true)
-            .start();
+                .caseDefinitionKey("autoCompleteTest")
+                .variable("enableStageAutoComplete", true)
+                .start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ENABLED);
         assertPlanItemInstanceState(planItemInstances, "Task B", ENABLED);
@@ -54,29 +54,29 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(1, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(1);
         assertPlanItemInstanceState(planItemInstances, "Task C", ENABLED);
 
         // start and complete Task C -> will complete the case
         cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task C"));
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task C"));
 
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().count());
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
     @Test
     @CmmnDeployment(resources = "org/flowable/cmmn/test/runtime/AutoCompleteEvaluationTest.testAutoCompleteCondition.cmmn")
     public void testEnableStageAutoCompleteConditionOnStartSecondPath() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("autoCompleteTest")
-            .variable("enableStageAutoComplete", true)
-            .start();
+                .caseDefinitionKey("autoCompleteTest")
+                .variable("enableStageAutoComplete", true)
+                .start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ENABLED);
         assertPlanItemInstanceState(planItemInstances, "Task B", ENABLED);
@@ -90,7 +90,7 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE);
@@ -101,7 +101,7 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ENABLED);
@@ -112,30 +112,30 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(1, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(1);
         assertPlanItemInstanceState(planItemInstances, "Task C", ENABLED);
 
         // start and complete Task C -> will complete the case
         cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task C"));
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task C"));
 
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().count());
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
     @Test
     @CmmnDeployment(resources = "org/flowable/cmmn/test/runtime/AutoCompleteEvaluationTest.testAutoCompleteCondition.cmmn")
     public void testEnablePlanModelAutoCompleteConditionOnStart() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("autoCompleteTest")
-            .variable("enableStageAutoComplete", true)
-            .variable("enablePlanModelAutoComplete", true)
-            .start();
+                .caseDefinitionKey("autoCompleteTest")
+                .variable("enableStageAutoComplete", true)
+                .variable("enablePlanModelAutoComplete", true)
+                .start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ENABLED);
         assertPlanItemInstanceState(planItemInstances, "Task B", ENABLED);
@@ -145,23 +145,23 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task B"));
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task B"));
 
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().count());
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
     @Test
     @CmmnDeployment(resources = "org/flowable/cmmn/test/runtime/AutoCompleteEvaluationTest.testAutoCompleteCondition.cmmn")
     public void testEnablePlanModelAutoCompleteConditionOnStartSecondPath() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("autoCompleteTest")
-            .variable("enableStageAutoComplete", true)
-            .variable("enablePlanModelAutoComplete", true)
-            .start();
+                .caseDefinitionKey("autoCompleteTest")
+                .variable("enableStageAutoComplete", true)
+                .variable("enablePlanModelAutoComplete", true)
+                .start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ENABLED);
         assertPlanItemInstanceState(planItemInstances, "Task B", ENABLED);
@@ -175,7 +175,7 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE);
@@ -186,7 +186,7 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ENABLED);
@@ -200,28 +200,27 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(1, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(1);
         assertPlanItemInstanceState(planItemInstances, "Task C", ACTIVE);
 
         // complete Task C -> will complete the case
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task C"));
 
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().count());
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
-
 
     @Test
     @CmmnDeployment(resources = "org/flowable/cmmn/test/runtime/AutoCompleteEvaluationTest.testAutoCompleteCondition.cmmn")
     public void testEnableStageAutoCompleteConditionDynamic() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("autoCompleteTest")
-            .start();
+                .caseDefinitionKey("autoCompleteTest")
+                .start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ENABLED);
         assertPlanItemInstanceState(planItemInstances, "Task B", ENABLED);
@@ -233,7 +232,7 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ENABLED);
         assertPlanItemInstanceState(planItemInstances, "Task B", ENABLED);
@@ -244,28 +243,28 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(1, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(1);
         assertPlanItemInstanceState(planItemInstances, "Task C", ENABLED);
 
         // start and complete Task C -> will complete the case
         cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task C"));
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task C"));
 
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().count());
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
     @Test
     @CmmnDeployment(resources = "org/flowable/cmmn/test/runtime/AutoCompleteEvaluationTest.testAutoCompleteCondition.cmmn")
     public void testEnableStageAutoCompleteConditionDynamicSecondPath() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("autoCompleteTest")
-            .start();
+                .caseDefinitionKey("autoCompleteTest")
+                .start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ENABLED);
         assertPlanItemInstanceState(planItemInstances, "Task B", ENABLED);
@@ -279,7 +278,7 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE);
@@ -290,7 +289,7 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ENABLED);
@@ -301,29 +300,29 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(1, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(1);
         assertPlanItemInstanceState(planItemInstances, "Task C", ENABLED);
 
         // start and complete Task C -> will complete the case
         cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task C"));
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task C"));
 
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().count());
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
     @Test
     @CmmnDeployment(resources = "org/flowable/cmmn/test/runtime/AutoCompleteEvaluationTest.testAutoCompleteCondition.cmmn")
     public void testEnablePlanModelAutoCompleteConditionDynamic() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("autoCompleteTest")
-            .variable("enableStageAutoComplete", true)
-            .start();
+                .caseDefinitionKey("autoCompleteTest")
+                .variable("enableStageAutoComplete", true)
+                .start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ENABLED);
         assertPlanItemInstanceState(planItemInstances, "Task B", ENABLED);
@@ -335,28 +334,28 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(1, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(1);
         assertPlanItemInstanceState(planItemInstances, "Task C", ENABLED);
 
         // set the auto-complete flag on the case plan model which should directly complete the case
         cmmnRuntimeService.setVariable(caseInstance.getId(), "enablePlanModelAutoComplete", true);
 
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().count());
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
     @Test
     @CmmnDeployment(resources = "org/flowable/cmmn/test/runtime/AutoCompleteEvaluationTest.testAutoCompleteCondition.cmmn")
     public void testEnablePlanModelAutoCompleteConditionDynamicSecondPath() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("autoCompleteTest")
-            .variable("enableStageAutoComplete", true)
-            .start();
+                .caseDefinitionKey("autoCompleteTest")
+                .variable("enableStageAutoComplete", true)
+                .start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ENABLED);
         assertPlanItemInstanceState(planItemInstances, "Task B", ENABLED);
@@ -370,7 +369,7 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE);
@@ -381,7 +380,7 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ENABLED);
@@ -395,7 +394,7 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(1, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(1);
         assertPlanItemInstanceState(planItemInstances, "Task C", ACTIVE);
 
         // set the auto-complete flag on the case plan model which should directly complete the case
@@ -404,9 +403,9 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
         // complete Task C -> will complete the case
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task C"));
 
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().count());
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
     @Test
@@ -414,11 +413,11 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
     public void testStageNotCompletedUntilChildrenStable() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("myCase").start();
         Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
-        assertEquals("mandatory task 1", task.getName());
+        assertThat(task.getName()).isEqualTo("mandatory task 1");
 
         cmmnTaskService.complete(task.getId());
         task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
-        assertEquals("mandatory task 3", task.getName());
+        assertThat(task.getName()).isEqualTo("mandatory task 3");
 
         cmmnTaskService.complete(task.getId());
         assertCaseInstanceEnded(caseInstance);

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CacheTaskTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CacheTaskTest.java
@@ -14,8 +14,6 @@ package org.flowable.cmmn.test.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 import java.util.Map;
 
@@ -32,71 +30,73 @@ import org.junit.Test;
  * @author Joram Barrez
  */
 public class CacheTaskTest extends FlowableCmmnTestCase {
-    
+
     @Test
     @CmmnDeployment
     public void testCaseCache() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-                        .caseDefinitionKey("myCase")
-                        .start();
-        
-        HistoricPlanItemInstance planItemInstance = cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceCaseInstanceId(caseInstance.getId()).singleResult();
-        
-        assertNotNull(ServiceCacheTask.caseInstanceId);
-        assertEquals(caseInstance.getId(), ServiceCacheTask.caseInstanceId);
-        assertNotNull(ServiceCacheTask.historicCaseInstanceId);
-        assertEquals(caseInstance.getId(), ServiceCacheTask.historicCaseInstanceId);
-        assertNotNull(ServiceCacheTask.planItemInstanceId);
-        assertEquals(planItemInstance.getId(), ServiceCacheTask.planItemInstanceId);
-        assertNotNull(ServiceCacheTask.historicPlanItemInstanceId);
-        assertEquals(planItemInstance.getId(), ServiceCacheTask.historicPlanItemInstanceId);
+                .caseDefinitionKey("myCase")
+                .start();
+
+        HistoricPlanItemInstance planItemInstance = cmmnHistoryService.createHistoricPlanItemInstanceQuery()
+                .planItemInstanceCaseInstanceId(caseInstance.getId()).singleResult();
+
+        assertThat(ServiceCacheTask.caseInstanceId).isNotNull();
+        assertThat(ServiceCacheTask.caseInstanceId).isEqualTo(caseInstance.getId());
+        assertThat(ServiceCacheTask.historicCaseInstanceId).isNotNull();
+        assertThat(ServiceCacheTask.historicCaseInstanceId).isEqualTo(caseInstance.getId());
+        assertThat(ServiceCacheTask.planItemInstanceId).isNotNull();
+        assertThat(ServiceCacheTask.planItemInstanceId).isEqualTo(planItemInstance.getId());
+        assertThat(ServiceCacheTask.historicPlanItemInstanceId).isNotNull();
+        assertThat(ServiceCacheTask.historicPlanItemInstanceId).isEqualTo(planItemInstance.getId());
     }
-    
+
     @Test
     @CmmnDeployment
     public void testTaskListenerCache() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-                        .caseDefinitionKey("myCase")
-                        .start();
+                .caseDefinitionKey("myCase")
+                .start();
         Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
 
-        assertNotNull(CacheTaskListener.taskId);
-        assertEquals(task.getId(), CacheTaskListener.taskId);
-        assertNotNull(CacheTaskListener.historicTaskId);
-        assertEquals(task.getId(), CacheTaskListener.historicTaskId);
+        assertThat(CacheTaskListener.taskId).isNotNull();
+        assertThat(CacheTaskListener.taskId).isEqualTo(task.getId());
+        assertThat(CacheTaskListener.historicTaskId).isNotNull();
+        assertThat(CacheTaskListener.historicTaskId).isEqualTo(task.getId());
     }
-    
+
     @Test
     @CmmnDeployment
     public void testMilestoneListenerCache() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-                        .caseDefinitionKey("myCase")
-                        .start();
-        HistoricMilestoneInstance milestoneInstance = cmmnHistoryService.createHistoricMilestoneInstanceQuery().milestoneInstanceCaseInstanceId(caseInstance.getId()).singleResult();
-        assertNotNull(milestoneInstance);
+                .caseDefinitionKey("myCase")
+                .start();
+        HistoricMilestoneInstance milestoneInstance = cmmnHistoryService.createHistoricMilestoneInstanceQuery()
+                .milestoneInstanceCaseInstanceId(caseInstance.getId()).singleResult();
+        assertThat(milestoneInstance).isNotNull();
 
-        assertNotNull(CacheMilestoneListener.milestoneInstanceId);
-        assertEquals(milestoneInstance.getId(), CacheMilestoneListener.milestoneInstanceId);
-        assertNotNull(CacheMilestoneListener.historicMilestoneInstanceId);
-        assertEquals(milestoneInstance.getId(), CacheMilestoneListener.historicMilestoneInstanceId);
+        assertThat(CacheMilestoneListener.milestoneInstanceId).isNotNull();
+        assertThat(CacheMilestoneListener.milestoneInstanceId).isEqualTo(milestoneInstance.getId());
+        assertThat(CacheMilestoneListener.historicMilestoneInstanceId).isNotNull();
+        assertThat(CacheMilestoneListener.historicMilestoneInstanceId).isEqualTo(milestoneInstance.getId());
     }
 
     @Test
     @CmmnDeployment
     public void testCaseInstanceQueryWithIncludeVariables() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("testCaseInstanceQueryWithIncludeVariables")
-            .variable("myVar1", "Hello")
-            .variable("myVar2", "World")
-            .variable("myVar3", 123)
-            .start();
+                .caseDefinitionKey("testCaseInstanceQueryWithIncludeVariables")
+                .variable("myVar1", "Hello")
+                .variable("myVar2", "World")
+                .variable("myVar3", 123)
+                .start();
 
         Map.Entry[] entries = {
-            entry("myVar1", "Hello"),
-            entry("myVar2", "World"),
-            entry("myVar3", 123),
-            entry("varFromTheServiceTask", "valueFromTheServiceTask")
+                entry("myVar1", "Hello"),
+                entry("myVar2", "World"),
+                entry("myVar3", 123),
+                entry("varFromTheServiceTask", "valueFromTheServiceTask")
         };
 
         assertThat(caseInstance.getCaseVariables()).containsOnly(entries);

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CaseCompletableReEvaluationTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CaseCompletableReEvaluationTest.java
@@ -12,11 +12,11 @@
  */
 package org.flowable.cmmn.test.runtime;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.ACTIVE;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.AVAILABLE;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.ENABLED;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.UNAVAILABLE;
-import static org.junit.Assert.assertEquals;
 
 import java.util.List;
 
@@ -40,7 +40,7 @@ public class CaseCompletableReEvaluationTest extends FlowableCmmnTestCase {
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(2, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(2);
         assertPlanItemInstanceState(planItemInstances, "Complete case if completable", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ENABLED);
 
@@ -49,15 +49,15 @@ public class CaseCompletableReEvaluationTest extends FlowableCmmnTestCase {
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(2, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(2);
         assertPlanItemInstanceState(planItemInstances, "Complete case if completable", UNAVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
 
         // complete task A which will complete the case
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task A"));
 
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().count());
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CaseInstanceInvolvementTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CaseInstanceInvolvementTest.java
@@ -13,10 +13,7 @@
 
 package org.flowable.cmmn.test.runtime;
 
-import static java.util.Collections.emptyList;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
 import java.util.stream.Collectors;
@@ -47,9 +44,9 @@ public class CaseInstanceInvolvementTest extends FlowableCmmnTestCase {
             start();
         cmmnRuntimeService.addUserIdentityLink(caseInstance.getId(), "kermit", IdentityLinkType.PARTICIPANT);
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("kermit").count(), is(1L));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("kermit").list().get(0).getId(), is(caseInstance.getId()));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("kermit").singleResult().getId(), is(caseInstance.getId()));
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("kermit").count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("kermit").list().get(0).getId()).isEqualTo(caseInstance.getId());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("kermit").singleResult().getId()).isEqualTo(caseInstance.getId());
     }
 
     @Test
@@ -61,9 +58,9 @@ public class CaseInstanceInvolvementTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.addUserIdentityLink(caseInstance.getId(), "kermit", IdentityLinkType.PARTICIPANT);
         cmmnRuntimeService.addUserIdentityLink(caseInstance.getId(), "gonzo", IdentityLinkType.PARTICIPANT);
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("kermit").count(), is(1L));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("kermit").list().get(0).getId(), is(caseInstance.getId()));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("kermit").singleResult().getId(), is(caseInstance.getId()));
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("kermit").count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("kermit").list().get(0).getId()).isEqualTo(caseInstance.getId());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("kermit").singleResult().getId()).isEqualTo(caseInstance.getId());
     }
 
     @Test
@@ -75,9 +72,9 @@ public class CaseInstanceInvolvementTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.addUserIdentityLink(caseInstance.getId(), "kermit", IdentityLinkType.PARTICIPANT);
         cmmnRuntimeService.addUserIdentityLink(caseInstance.getId(), "gonzo", IdentityLinkType.PARTICIPANT);
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("").count(), is(0L));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("").list(), is(emptyList()));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("").singleResult(), is(nullValue()));
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("").count()).isEqualTo(0L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("").list()).isEmpty();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("").singleResult()).isNull();
     }
 
     @Test
@@ -88,7 +85,7 @@ public class CaseInstanceInvolvementTest extends FlowableCmmnTestCase {
             start();
         cmmnRuntimeService.addUserIdentityLink(caseInstance.getId(), "kermit", IdentityLinkType.PARTICIPANT);
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("gonzo").count(), is(0L));
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("gonzo").count()).isEqualTo(0L);
     }
 
     @Test
@@ -137,9 +134,11 @@ public class CaseInstanceInvolvementTest extends FlowableCmmnTestCase {
             start();
         cmmnRuntimeService.addGroupIdentityLink(caseInstance.getId(), "testGroup", IdentityLinkType.PARTICIPANT);
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroups(Collections.singleton("testGroup")).count(), is(1L));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId(), is(caseInstance.getId()));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroups(Collections.singleton("testGroup")).singleResult().getId(), is(caseInstance.getId()));
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroups(Collections.singleton("testGroup")).count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId())
+                .isEqualTo(caseInstance.getId());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroups(Collections.singleton("testGroup")).singleResult().getId())
+                .isEqualTo(caseInstance.getId());
     }
 
     @Test
@@ -150,9 +149,9 @@ public class CaseInstanceInvolvementTest extends FlowableCmmnTestCase {
             start();
         cmmnRuntimeService.addGroupIdentityLink(caseInstance.getId(), "testGroup", IdentityLinkType.PARTICIPANT);
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroups(Collections.singleton("")).count(), is(0L));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroups(Collections.singleton("")).list(), is(emptyList()));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroups(Collections.singleton("")).singleResult(), is(nullValue()));
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroups(Collections.singleton("")).count()).isEqualTo(0L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroups(Collections.singleton("")).list()).isEmpty();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroups(Collections.singleton("")).singleResult()).isNull();
     }
 
     @Test
@@ -165,14 +164,14 @@ public class CaseInstanceInvolvementTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.addGroupIdentityLink(caseInstance.getId(), "testGroup2", IdentityLinkType.PARTICIPANT);
 
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroups(
-            Stream.of("testGroup", "testGroup2", "testGroup3").collect(Collectors.toSet())
-        ).count(), is(1L));
+                Stream.of("testGroup", "testGroup2", "testGroup3").collect(Collectors.toSet())
+        ).count()).isEqualTo(1L);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroups(
-            Stream.of("testGroup", "testGroup2", "testGroup3").collect(Collectors.toSet())
-        ).list().get(0).getId(), is(caseInstance.getId()));
+                Stream.of("testGroup", "testGroup2", "testGroup3").collect(Collectors.toSet())
+        ).list().get(0).getId()).isEqualTo(caseInstance.getId());
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroups(
-            Stream.of("testGroup", "testGroup2", "testGroup3").collect(Collectors.toSet())
-        ).singleResult().getId(), is(caseInstance.getId()));
+                Stream.of("testGroup", "testGroup2", "testGroup3").collect(Collectors.toSet())
+        ).singleResult().getId()).isEqualTo(caseInstance.getId());
     }
 
 }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CaseInstanceQueryImplTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CaseInstanceQueryImplTest.java
@@ -12,9 +12,7 @@
  */
 package org.flowable.cmmn.test.runtime;
 
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNot.not;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -49,15 +47,15 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
 
     @Before
     public void createCase() {
-        deplId = cmmnRepositoryService.createDeployment().
-            addClasspathResource("org/flowable/cmmn/test/runtime/CaseTaskTest.testBasicBlocking.cmmn").
-            addClasspathResource("org/flowable/cmmn/test/runtime/oneTaskCase.cmmn").
-            deploy()
-            .getId();
-        
-        cmmnRuntimeService.createCaseInstanceBuilder().
-                caseDefinitionKey("myCase").
-                start();
+        deplId = cmmnRepositoryService.createDeployment()
+                .addClasspathResource("org/flowable/cmmn/test/runtime/CaseTaskTest.testBasicBlocking.cmmn")
+                .addClasspathResource("org/flowable/cmmn/test/runtime/oneTaskCase.cmmn")
+                .deploy()
+                .getId();
+
+        cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("myCase")
+                .start();
     }
 
     @After
@@ -67,269 +65,275 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
 
     @Test
     public void getCaseInstanceByCaseDefinitionKey() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            start();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .start();
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionKey("oneTaskCase").count(), is(1L));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionKey("oneTaskCase").list().get(0).getId(), is(caseInstance.getId()));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionKey("oneTaskCase").singleResult().getId(), is(caseInstance.getId()));
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionKey("oneTaskCase").count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionKey("oneTaskCase").list().get(0).getId()).isEqualTo(caseInstance.getId());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionKey("oneTaskCase").singleResult().getId()).isEqualTo(caseInstance.getId());
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().or().caseDefinitionKey("oneTaskCase").caseInstanceId("Undefined").endOr().count(), is(1L));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().or().caseDefinitionKey("oneTaskCase").caseInstanceId("Undefined").endOr().list().get(0).getId(), is(caseInstance.getId()));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().or().caseDefinitionKey("oneTaskCase").caseInstanceId("Undefined").endOr().singleResult().getId(), is(caseInstance.getId()));
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().or().caseDefinitionKey("oneTaskCase").caseInstanceId("Undefined").endOr().count())
+                .isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().or().caseDefinitionKey("oneTaskCase").caseInstanceId("Undefined").endOr().list().get(0).getId())
+                .isEqualTo(caseInstance.getId());
+        assertThat(
+                cmmnRuntimeService.createCaseInstanceQuery().or().caseDefinitionKey("oneTaskCase").caseInstanceId("Undefined").endOr().singleResult().getId())
+                .isEqualTo(caseInstance.getId());
     }
 
     @Test
     public void getCaseInstanceByCaseDefinitionKeys() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            start();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .start();
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionKeys(Collections.singleton("oneTaskCase")).count(), is(1L));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionKeys(Collections.singleton("oneTaskCase")).list().get(0).getId(), is(caseInstance.getId()));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionKeys(Collections.singleton("oneTaskCase")).singleResult().getId(), is(caseInstance.getId()));
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionKeys(Collections.singleton("oneTaskCase")).count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionKeys(Collections.singleton("oneTaskCase")).list().get(0).getId())
+                .isEqualTo(caseInstance.getId());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionKeys(Collections.singleton("oneTaskCase")).singleResult().getId())
+                .isEqualTo(caseInstance.getId());
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().or().
-            caseInstanceId("undefined").
-            caseDefinitionKeys(Collections.singleton("oneTaskCase")).
-            endOr().
-            count(), is(1L));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().or().
-            caseInstanceId("undefined").
-            caseDefinitionKeys(Collections.singleton("oneTaskCase"))
-            .endOr()
-            .list().get(0).getId(), is(caseInstance.getId()));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().or().
-            caseInstanceId("undefined").
-            caseDefinitionKeys(Collections.singleton("oneTaskCase")).
-            endOr().singleResult().getId(), is(caseInstance.getId()));
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .caseInstanceId("undefined")
+                .caseDefinitionKeys(Collections.singleton("oneTaskCase"))
+                .endOr()
+                .count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .caseInstanceId("undefined")
+                .caseDefinitionKeys(Collections.singleton("oneTaskCase"))
+                .endOr()
+                .list().get(0).getId()).isEqualTo(caseInstance.getId());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().or()
+                .caseInstanceId("undefined")
+                .caseDefinitionKeys(Collections.singleton("oneTaskCase"))
+                .endOr().singleResult().getId()).isEqualTo(caseInstance.getId());
     }
 
     @Test
     public void getCaseInstanceByCaseDefinitionCategory() {
-        cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            start();
+        cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .start();
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionCategory("http://flowable.org/cmmn").count(), is(2L));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionCategory("http://flowable.org/cmmn").list().size(), is(2));
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionCategory("http://flowable.org/cmmn").count()).isEqualTo(2L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionCategory("http://flowable.org/cmmn").list()).hasSize(2);
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            or().
-                caseDefinitionCategory("http://flowable.org/cmmn").
-                caseInstanceId("undefined").
-            endOr().
-            count(), is(2L));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            or().
-                caseDefinitionCategory("http://flowable.org/cmmn").
-                caseInstanceId("undefined").
-            endOr().
-            list().size(), is(2));
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .caseDefinitionCategory("http://flowable.org/cmmn")
+                .caseInstanceId("undefined")
+                .endOr()
+                .count()).isEqualTo(2L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .caseDefinitionCategory("http://flowable.org/cmmn")
+                .caseInstanceId("undefined")
+                .endOr()
+                .list()).hasSize(2);
     }
 
     @Test
     public void getCaseInstanceByCaseDefinitionName() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            start();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .start();
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionName("oneTaskCaseName").count(), is(1L));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionName("oneTaskCaseName").list().get(0).getId(), is(caseInstance.getId()));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionName("oneTaskCaseName").singleResult().getId(), is(caseInstance.getId()));
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionName("oneTaskCaseName").count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionName("oneTaskCaseName").list().get(0).getId()).isEqualTo(caseInstance.getId());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionName("oneTaskCaseName").singleResult().getId()).isEqualTo(caseInstance.getId());
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            or().
-                caseDefinitionName("oneTaskCaseName").
-                caseInstanceId("undefined").
-            endOr().
-            count(), is(1L));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            or().
-                caseDefinitionName("oneTaskCaseName").
-                caseInstanceId("undefined").
-            endOr().
-            list().get(0).getId(), is(caseInstance.getId()));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            or().
-                caseDefinitionName("oneTaskCaseName").
-                caseInstanceId("undefined").
-            endOr().
-            singleResult().getId(), is(caseInstance.getId()));
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .caseDefinitionName("oneTaskCaseName")
+                .caseInstanceId("undefined")
+                .endOr()
+                .count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .caseDefinitionName("oneTaskCaseName")
+                .caseInstanceId("undefined")
+                .endOr()
+                .list().get(0).getId()).isEqualTo(caseInstance.getId());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .caseDefinitionName("oneTaskCaseName")
+                .caseInstanceId("undefined")
+                .endOr()
+                .singleResult().getId()).isEqualTo(caseInstance.getId());
     }
 
     @Test
     public void getCaseInstanceByCaseDefinitionId() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            start();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .start();
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionId(caseInstance.getCaseDefinitionId()).count(), is(1L));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionId(caseInstance.getCaseDefinitionId()).caseInstanceId(caseInstance.getId()).count(), is(1L));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionId(caseInstance.getCaseDefinitionId()).list().get(0).getId(), is(caseInstance.getId()));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionId(caseInstance.getCaseDefinitionId()).singleResult().getId(), is(caseInstance.getId()));
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionId(caseInstance.getCaseDefinitionId()).count()).isEqualTo(1L);
+        assertThat(
+                cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionId(caseInstance.getCaseDefinitionId()).caseInstanceId(caseInstance.getId()).count())
+                .isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionId(caseInstance.getCaseDefinitionId()).list().get(0).getId())
+                .isEqualTo(caseInstance.getId());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionId(caseInstance.getCaseDefinitionId()).singleResult().getId())
+                .isEqualTo(caseInstance.getId());
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            or().
-                caseDefinitionId(caseInstance.getCaseDefinitionId()).
-                caseInstanceId("undefinedId").
-            endOr().
-            count(), is(1L));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            or().
-                caseDefinitionId(caseInstance.getCaseDefinitionId()).
-                caseInstanceId("undefinedId").
-            endOr().
-            list().get(0).getId(), is(caseInstance.getId()));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            or().
-                caseDefinitionId(caseInstance.getCaseDefinitionId()).
-                caseInstanceId("undefinedId").
-            endOr().
-            singleResult().getId(), is(caseInstance.getId()));
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .caseDefinitionId(caseInstance.getCaseDefinitionId())
+                .caseInstanceId("undefinedId")
+                .endOr()
+                .count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .caseDefinitionId(caseInstance.getCaseDefinitionId())
+                .caseInstanceId("undefinedId")
+                .endOr()
+                .list().get(0).getId()).isEqualTo(caseInstance.getId());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .caseDefinitionId(caseInstance.getCaseDefinitionId())
+                .caseInstanceId("undefinedId")
+                .endOr()
+                .singleResult().getId()).isEqualTo(caseInstance.getId());
     }
 
     @Test
     public void getCaseInstanceByCaseDefinitionVersion() {
-        cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            start();
+        cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .start();
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionVersion(1).count(), is(2L));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionVersion(1).list().size(), is(2));
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionVersion(1).count()).isEqualTo(2L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionVersion(1).list()).hasSize(2);
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            or().
-                caseDefinitionVersion(1).
-                caseInstanceId("undefinedId").
-            endOr().
-            count(), is(2L));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            or().
-                caseDefinitionVersion(1).
-                caseInstanceId("undefinedId").
-            endOr().
-            list().size(), is(2));
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .caseDefinitionVersion(1)
+                .caseInstanceId("undefinedId")
+                .endOr()
+                .count()).isEqualTo(2L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .caseDefinitionVersion(1)
+                .caseInstanceId("undefinedId")
+                .endOr()
+                .list()).hasSize(2);
     }
 
     @Test
     public void getCaseInstanceByCaseId() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            start();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .start();
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count(), is(1L));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).list().get(0).getId(),
-            is(caseInstance.getId()));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult().getId(),
-            is(caseInstance.getId()));
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).list().get(0).getId()).isEqualTo(caseInstance.getId());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult().getId()).isEqualTo(caseInstance.getId());
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            or().
-                caseInstanceId(caseInstance.getId()).
-                caseDefinitionName("undefinedId").
-            endOr().
-            count(), is(1L));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            or().
-                caseInstanceId(caseInstance.getId()).
-                caseDefinitionName("undefinedId").
-            endOr().
-            list().get(0).getId(), is(caseInstance.getId()));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            or().
-                caseInstanceId(caseInstance.getId()).
-                caseDefinitionId("undefined").
-            endOr().
-            singleResult().getId(), is(caseInstance.getId()));
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .caseInstanceId(caseInstance.getId())
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .caseInstanceId(caseInstance.getId())
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .list().get(0).getId()).isEqualTo(caseInstance.getId());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .caseInstanceId(caseInstance.getId())
+                .caseDefinitionId("undefined")
+                .endOr()
+                .singleResult().getId()).isEqualTo(caseInstance.getId());
     }
 
     @Test
     public void getCaseInstanceByBusinessKey() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            businessKey("businessKey").
-            start();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .businessKey("businessKey")
+                .start();
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceBusinessKey("businessKey").count(), is(1L));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceBusinessKey("businessKey").list().get(0).getId(),
-            is(caseInstance.getId()));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceBusinessKey("businessKey").singleResult().getId(),
-            is(caseInstance.getId()));
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceBusinessKey("businessKey").count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceBusinessKey("businessKey").list().get(0).getId()).isEqualTo(caseInstance.getId());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceBusinessKey("businessKey").singleResult().getId()).isEqualTo(caseInstance.getId());
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            or().
-                caseInstanceBusinessKey("businessKey").
-                caseDefinitionName("undefinedId").
-            endOr().
-            count(), is(1L));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            or().
-                caseInstanceBusinessKey("businessKey").
-                caseDefinitionName("undefinedId").
-            endOr().
-            list().get(0).getId(), is(caseInstance.getId()));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            or().
-                caseInstanceBusinessKey("businessKey").
-                caseDefinitionId("undefined").
-            endOr().
-            singleResult().getId(), is(caseInstance.getId()));
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .caseInstanceBusinessKey("businessKey")
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .caseInstanceBusinessKey("businessKey")
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .list().get(0).getId()).isEqualTo(caseInstance.getId());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .caseInstanceBusinessKey("businessKey")
+                .caseDefinitionId("undefined")
+                .endOr()
+                .singleResult().getId()).isEqualTo(caseInstance.getId());
     }
 
     @Test
     public void getCaseInstanceByStartedBefore() {
-        cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            start();
-        
+        cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .start();
+
         Calendar todayCal = new GregorianCalendar();
         Calendar dateCal = new GregorianCalendar(todayCal.get(Calendar.YEAR) + 1, todayCal.get(Calendar.MONTH), todayCal.get(Calendar.DAY_OF_YEAR));
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceStartedBefore(dateCal.getTime()).count(), is(2L));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceStartedBefore(dateCal.getTime()).list().size(),
-            is(2));
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceStartedBefore(dateCal.getTime()).count()).isEqualTo(2L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceStartedBefore(dateCal.getTime()).list()).hasSize(2);
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            or().
-            caseInstanceStartedBefore(dateCal.getTime()).
-            caseDefinitionName("undefinedId").
-            endOr().
-            count(), is(2L));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            or().
-            caseInstanceStartedBefore(dateCal.getTime()).
-            caseDefinitionName("undefinedId").
-            endOr().
-            list().size(), is(2));
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .caseInstanceStartedBefore(dateCal.getTime())
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .count()).isEqualTo(2L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .caseInstanceStartedBefore(dateCal.getTime())
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .list()).hasSize(2);
     }
 
     @Test
     public void getCaseInstanceByStartedAfter() {
-        cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            start();
-        
+        cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .start();
+
         Calendar todayCal = new GregorianCalendar();
         Calendar dateCal = new GregorianCalendar(todayCal.get(Calendar.YEAR) - 1, todayCal.get(Calendar.MONTH), todayCal.get(Calendar.DAY_OF_YEAR));
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceStartedAfter(dateCal.getTime()).count(), is(2L));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceStartedAfter(dateCal.getTime()).list().size(),
-            is(2));
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceStartedAfter(dateCal.getTime()).count()).isEqualTo(2L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceStartedAfter(dateCal.getTime()).list()).hasSize(2);
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            or().
-                caseInstanceStartedAfter(dateCal.getTime()).
-                caseDefinitionName("undefinedId").
-            endOr().
-            count(), is(2L));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            or().
-                caseInstanceStartedAfter(dateCal.getTime()).
-                caseDefinitionName("undefinedId").
-            endOr().
-            list().size(), is(2));
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .caseInstanceStartedAfter(dateCal.getTime())
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .count()).isEqualTo(2L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .caseInstanceStartedAfter(dateCal.getTime())
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .list()).hasSize(2);
     }
 
     @Test
@@ -337,34 +341,32 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
         String authenticatedUserId = Authentication.getAuthenticatedUserId();
         try {
             Authentication.setAuthenticatedUserId("kermit");
-            CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-                caseDefinitionKey("oneTaskCase").
-                start();
+            CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                    .caseDefinitionKey("oneTaskCase")
+                    .start();
 
-            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceStartedBy("kermit").count(), is(1L));
-            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceStartedBy("kermit").list().get(0).getId(),
-                is(caseInstance.getId()));
-            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceStartedBy("kermit").singleResult().getId(),
-                is(caseInstance.getId()));
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceStartedBy("kermit").count()).isEqualTo(1L);
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceStartedBy("kermit").list().get(0).getId()).isEqualTo(caseInstance.getId());
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceStartedBy("kermit").singleResult().getId()).isEqualTo(caseInstance.getId());
 
-            assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-                or().
-                caseInstanceStartedBy("kermit").
-                caseDefinitionName("undefinedId").
-                endOr().
-                count(), is(1L));
-            assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-                or().
-                caseInstanceStartedBy("kermit").
-                caseDefinitionName("undefinedId").
-                endOr().
-                list().get(0).getId(), is(caseInstance.getId()));
-            assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-                or().
-                caseInstanceStartedBy("kermit").
-                caseDefinitionId("undefined").
-                endOr().
-                singleResult().getId(), is(caseInstance.getId()));
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                    .or()
+                    .caseInstanceStartedBy("kermit")
+                    .caseDefinitionName("undefinedId")
+                    .endOr()
+                    .count()).isEqualTo(1L);
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                    .or()
+                    .caseInstanceStartedBy("kermit")
+                    .caseDefinitionName("undefinedId")
+                    .endOr()
+                    .list().get(0).getId()).isEqualTo(caseInstance.getId());
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                    .or()
+                    .caseInstanceStartedBy("kermit")
+                    .caseDefinitionId("undefined")
+                    .endOr()
+                    .singleResult().getId()).isEqualTo(caseInstance.getId());
         } finally {
             Authentication.setAuthenticatedUserId(authenticatedUserId);
         }
@@ -372,188 +374,183 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
 
     @Test
     public void getCaseInstanceByCallBackId() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            callbackId("callBackId").
-            start();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .callbackId("callBackId")
+                .start();
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceCallbackId("callBackId").count(), is(1L));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceCallbackId("callBackId").list().get(0).getId(),
-            is(caseInstance.getId()));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceCallbackId("callBackId").singleResult().getId(),
-            is(caseInstance.getId()));
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceCallbackId("callBackId").count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceCallbackId("callBackId").list().get(0).getId()).isEqualTo(caseInstance.getId());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceCallbackId("callBackId").singleResult().getId()).isEqualTo(caseInstance.getId());
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            or().
-            caseInstanceCallbackId("callBackId").
-            caseDefinitionName("undefinedId").
-            endOr().
-            count(), is(1L));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            or().
-            caseInstanceCallbackId("callBackId").
-            caseDefinitionName("undefinedId").
-            endOr().
-            list().get(0).getId(), is(caseInstance.getId()));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            or().
-            caseInstanceCallbackId("callBackId").
-            caseDefinitionId("undefined").
-            endOr().
-            singleResult().getId(), is(caseInstance.getId()));
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .caseInstanceCallbackId("callBackId")
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .caseInstanceCallbackId("callBackId")
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .list().get(0).getId()).isEqualTo(caseInstance.getId());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .caseInstanceCallbackId("callBackId")
+                .caseDefinitionId("undefined")
+                .endOr()
+                .singleResult().getId()).isEqualTo(caseInstance.getId());
     }
 
     @Test
     public void getCaseInstanceByCallBackType() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            callbackType("callBackType").
-            start();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .callbackType("callBackType")
+                .start();
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceCallbackType("callBackType").count(), is(1L));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceCallbackType("callBackType").list().get(0).getId(),
-            is(caseInstance.getId()));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceCallbackType("callBackType").singleResult().getId(),
-            is(caseInstance.getId()));
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceCallbackType("callBackType").count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceCallbackType("callBackType").list().get(0).getId()).isEqualTo(caseInstance.getId());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceCallbackType("callBackType").singleResult().getId())
+                .isEqualTo(caseInstance.getId());
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            or().
-            caseInstanceCallbackType("callBackType").
-            caseDefinitionName("undefinedId").
-            endOr().
-            count(), is(1L));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            or().
-            caseInstanceCallbackType("callBackType").
-            caseDefinitionName("undefinedId").
-            endOr().
-            list().get(0).getId(), is(caseInstance.getId()));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            or().
-            caseInstanceCallbackType("callBackType").
-            caseDefinitionId("undefined").
-            endOr().
-            singleResult().getId(), is(caseInstance.getId()));
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .caseInstanceCallbackType("callBackType")
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .caseInstanceCallbackType("callBackType")
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .list().get(0).getId()).isEqualTo(caseInstance.getId());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .caseInstanceCallbackType("callBackType")
+                .caseDefinitionId("undefined")
+                .endOr()
+                .singleResult().getId()).isEqualTo(caseInstance.getId());
     }
 
     @Test
     public void getCaseInstanceByReferenceId() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("oneTaskCase")
-            .referenceId("testReferenceId")
-            .start();
+                .caseDefinitionKey("oneTaskCase")
+                .referenceId("testReferenceId")
+                .start();
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceReferenceId("testReferenceId").count(), is(1L));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceReferenceId("testReferenceId").list().get(0).getId(),
-            is(caseInstance.getId()));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceReferenceId("testReferenceId").singleResult().getId(),
-            is(caseInstance.getId()));
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceReferenceId("testReferenceId").count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceReferenceId("testReferenceId").list().get(0).getId())
+                .isEqualTo(caseInstance.getId());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceReferenceId("testReferenceId").singleResult().getId())
+                .isEqualTo(caseInstance.getId());
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            or().
-            caseInstanceReferenceId("testReferenceId").
-            caseDefinitionName("undefinedId").
-            endOr().
-            count(), is(1L));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            or().
-            caseInstanceReferenceId("testReferenceId").
-            caseDefinitionName("undefinedId").
-            endOr().
-            list().get(0).getId(), is(caseInstance.getId()));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            or().
-            caseInstanceReferenceId("testReferenceId").
-            caseDefinitionId("undefined").
-            endOr().
-            singleResult().getId(), is(caseInstance.getId()));
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .caseInstanceReferenceId("testReferenceId")
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .caseInstanceReferenceId("testReferenceId")
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .list().get(0).getId()).isEqualTo(caseInstance.getId());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .caseInstanceReferenceId("testReferenceId")
+                .caseDefinitionId("undefined")
+                .endOr()
+                .singleResult().getId()).isEqualTo(caseInstance.getId());
     }
 
     @Test
     public void getCaseInstanceByReferenceType() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("oneTaskCase")
-            .referenceType("testReferenceType")
-            .start();
+                .caseDefinitionKey("oneTaskCase")
+                .referenceType("testReferenceType")
+                .start();
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceReferenceType("testReferenceType").count(), is(1L));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceReferenceType("testReferenceType").list().get(0).getId(),
-            is(caseInstance.getId()));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceReferenceType("testReferenceType").singleResult().getId(),
-            is(caseInstance.getId()));
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceReferenceType("testReferenceType").count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceReferenceType("testReferenceType").list().get(0).getId())
+                .isEqualTo(caseInstance.getId());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceReferenceType("testReferenceType").singleResult().getId())
+                .isEqualTo(caseInstance.getId());
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            or().
-            caseInstanceReferenceType("testReferenceType").
-            caseDefinitionName("undefinedId").
-            endOr().
-            count(), is(1L));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            or().
-            caseInstanceReferenceType("testReferenceType").
-            caseDefinitionName("undefinedId").
-            endOr().
-            list().get(0).getId(), is(caseInstance.getId()));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            or().
-            caseInstanceReferenceType("testReferenceType").
-            caseDefinitionId("undefined").
-            endOr().
-            singleResult().getId(), is(caseInstance.getId()));
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .caseInstanceReferenceType("testReferenceType")
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .caseInstanceReferenceType("testReferenceType")
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .list().get(0).getId()).isEqualTo(caseInstance.getId());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .caseInstanceReferenceType("testReferenceType")
+                .caseDefinitionId("undefined")
+                .endOr()
+                .singleResult().getId()).isEqualTo(caseInstance.getId());
     }
 
     @Test
     public void getCaseInstanceByReferenceIdAndType() {
         for (int i = 0; i < 4; i++) {
             cmmnRuntimeService.createCaseInstanceBuilder()
-                .caseDefinitionKey("oneTaskCase")
-                .referenceId("testReferenceId")
-                .referenceType("testReferenceType")
-                .start();
+                    .caseDefinitionKey("oneTaskCase")
+                    .referenceId("testReferenceId")
+                    .referenceType("testReferenceType")
+                    .start();
         }
 
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceReferenceId("testReferenceId")
-            .caseInstanceReferenceType("testReferenceType").count(), is(4L));
+                .caseInstanceReferenceType("testReferenceType").count()).isEqualTo(4L);
     }
 
     @Test
     public void getCaseInstanceByTenantId() {
-        String tempDeploymentId = cmmnRepositoryService.createDeployment().
-            addClasspathResource("org/flowable/cmmn/test/runtime/CaseTaskTest.testBasicBlocking.cmmn").
-            addClasspathResource("org/flowable/cmmn/test/runtime/oneTaskCase.cmmn").
-            tenantId("tenantId").
-            deploy()
-            .getId();
+        String tempDeploymentId = cmmnRepositoryService.createDeployment()
+                .addClasspathResource("org/flowable/cmmn/test/runtime/CaseTaskTest.testBasicBlocking.cmmn")
+                .addClasspathResource("org/flowable/cmmn/test/runtime/oneTaskCase.cmmn")
+                .tenantId("tenantId")
+                .deploy()
+                .getId();
         try {
-            CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-                caseDefinitionKey("oneTaskCase").
-                tenantId("tenantId").
-                start();
+            CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                    .caseDefinitionKey("oneTaskCase")
+                    .tenantId("tenantId")
+                    .start();
 
-            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId("tenantId").count(), is(1L));
-            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId("tenantId").list().get(0).getId(),
-                is(caseInstance.getId()));
-            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId("tenantId").singleResult().getId(),
-                is(caseInstance.getId()));
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId("tenantId").count()).isEqualTo(1L);
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId("tenantId").list().get(0).getId()).isEqualTo(caseInstance.getId());
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId("tenantId").singleResult().getId()).isEqualTo(caseInstance.getId());
 
-            assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-                or().
-                caseInstanceTenantId("tenantId").
-                caseDefinitionName("undefinedId").
-                endOr().
-                count(), is(1L));
-            assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-                or().
-                caseInstanceTenantId("tenantId").
-                caseDefinitionName("undefinedId").
-                endOr().
-                list().get(0).getId(), is(caseInstance.getId()));
-            assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-                or().
-                caseInstanceTenantId("tenantId").
-                caseDefinitionId("undefined").
-                endOr().
-                singleResult().getId(), is(caseInstance.getId()));
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                    .or()
+                    .caseInstanceTenantId("tenantId")
+                    .caseDefinitionName("undefinedId")
+                    .endOr()
+                    .count()).isEqualTo(1L);
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                    .or()
+                    .caseInstanceTenantId("tenantId")
+                    .caseDefinitionName("undefinedId")
+                    .endOr()
+                    .list().get(0).getId()).isEqualTo(caseInstance.getId());
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                    .or()
+                    .caseInstanceTenantId("tenantId")
+                    .caseDefinitionId("undefined")
+                    .endOr()
+                    .singleResult().getId()).isEqualTo(caseInstance.getId());
         } finally {
             cmmnRepositoryService.deleteDeployment(tempDeploymentId, true);
         }
@@ -561,42 +558,40 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
 
     @Test
     public void getCaseInstanceByTenantIdLike() {
-        String tempDeploymentId = cmmnRepositoryService.createDeployment().
-            addClasspathResource("org/flowable/cmmn/test/runtime/CaseTaskTest.testBasicBlocking.cmmn").
-            addClasspathResource("org/flowable/cmmn/test/runtime/oneTaskCase.cmmn").
-            tenantId("tenantId").
-            deploy()
-            .getId();
+        String tempDeploymentId = cmmnRepositoryService.createDeployment()
+                .addClasspathResource("org/flowable/cmmn/test/runtime/CaseTaskTest.testBasicBlocking.cmmn")
+                .addClasspathResource("org/flowable/cmmn/test/runtime/oneTaskCase.cmmn")
+                .tenantId("tenantId")
+                .deploy()
+                .getId();
         try {
-            CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-                caseDefinitionKey("oneTaskCase").
-                tenantId("tenantId").
-                start();
+            CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                    .caseDefinitionKey("oneTaskCase")
+                    .tenantId("tenantId")
+                    .start();
 
-            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantIdLike("ten%").count(), is(1L));
-            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantIdLike("ten%").list().get(0).getId(),
-                is(caseInstance.getId()));
-            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantIdLike("ten%").singleResult().getId(),
-                is(caseInstance.getId()));
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantIdLike("ten%").count()).isEqualTo(1L);
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantIdLike("ten%").list().get(0).getId()).isEqualTo(caseInstance.getId());
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantIdLike("ten%").singleResult().getId()).isEqualTo(caseInstance.getId());
 
-            assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-                or().
-                caseInstanceTenantIdLike("ten%").
-                caseDefinitionName("undefinedId").
-                endOr().
-                count(), is(1L));
-            assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-                or().
-                caseInstanceTenantIdLike("ten%").
-                caseDefinitionName("undefinedId").
-                endOr().
-                list().get(0).getId(), is(caseInstance.getId()));
-            assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-                or().
-                caseInstanceTenantIdLike("ten%").
-                caseDefinitionId("undefined").
-                endOr().
-                singleResult().getId(), is(caseInstance.getId()));
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                    .or()
+                    .caseInstanceTenantIdLike("ten%")
+                    .caseDefinitionName("undefinedId")
+                    .endOr()
+                    .count()).isEqualTo(1L);
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                    .or()
+                    .caseInstanceTenantIdLike("ten%")
+                    .caseDefinitionName("undefinedId")
+                    .endOr()
+                    .list().get(0).getId()).isEqualTo(caseInstance.getId());
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                    .or()
+                    .caseInstanceTenantIdLike("ten%")
+                    .caseDefinitionId("undefined")
+                    .endOr()
+                    .singleResult().getId()).isEqualTo(caseInstance.getId());
         } finally {
             cmmnRepositoryService.deleteDeployment(tempDeploymentId, true);
         }
@@ -604,42 +599,40 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
 
     @Test
     public void getCaseInstanceWithoutTenantId() {
-        String tempDeploymentId = cmmnRepositoryService.createDeployment().
-            addClasspathResource("org/flowable/cmmn/test/runtime/CaseTaskTest.testBasicBlocking.cmmn").
-            addClasspathResource("org/flowable/cmmn/test/runtime/oneTaskCase.cmmn").
-            tenantId("tenantId").
-            deploy()
-            .getId();
+        String tempDeploymentId = cmmnRepositoryService.createDeployment()
+                .addClasspathResource("org/flowable/cmmn/test/runtime/CaseTaskTest.testBasicBlocking.cmmn")
+                .addClasspathResource("org/flowable/cmmn/test/runtime/oneTaskCase.cmmn")
+                .tenantId("tenantId")
+                .deploy()
+                .getId();
         try {
-            CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-                caseDefinitionKey("oneTaskCase").
-                tenantId("tenantId").
-                start();
+            CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                    .caseDefinitionKey("oneTaskCase")
+                    .tenantId("tenantId")
+                    .start();
 
-            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceWithoutTenantId().count(), is(1L));
-            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceWithoutTenantId().list().get(0).getId(),
-                is(not(caseInstance.getId())));
-            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceWithoutTenantId().singleResult().getId(),
-                is(not(caseInstance.getId())));
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceWithoutTenantId().count()).isEqualTo(1L);
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceWithoutTenantId().list().get(0).getId()).isNotEqualTo(caseInstance.getId());
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceWithoutTenantId().singleResult().getId()).isNotEqualTo(caseInstance.getId());
 
-            assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-                or().
-                caseInstanceWithoutTenantId().
-                caseDefinitionName("undefinedId").
-                endOr().
-                count(), is(1L));
-            assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-                or().
-                caseInstanceWithoutTenantId().
-                caseDefinitionName("undefinedId").
-                endOr().
-                list().get(0).getId(), is(not(caseInstance.getId())));
-            assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-                or().
-                caseInstanceWithoutTenantId().
-                caseDefinitionId("undefined").
-                endOr().
-                singleResult().getId(), is(not(caseInstance.getId())));
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                    .or()
+                    .caseInstanceWithoutTenantId()
+                    .caseDefinitionName("undefinedId")
+                    .endOr()
+                    .count()).isEqualTo(1L);
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                    .or()
+                    .caseInstanceWithoutTenantId()
+                    .caseDefinitionName("undefinedId")
+                    .endOr()
+                    .list().get(0).getId()).isNotEqualTo(caseInstance.getId());
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                    .or()
+                    .caseInstanceWithoutTenantId()
+                    .caseDefinitionId("undefined")
+                    .endOr()
+                    .singleResult().getId()).isNotEqualTo(caseInstance.getId());
         } finally {
             cmmnRepositoryService.deleteDeployment(tempDeploymentId, true);
         }
@@ -647,186 +640,181 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
 
     @Test
     public void getCaseInstanceByInvolvedUser() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            start();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .start();
         cmmnRuntimeService.addUserIdentityLink(caseInstance.getId(), "kermit", IdentityLinkType.PARTICIPANT);
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("kermit").count(), is(1L));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("kermit").list().get(0).getId(),
-            is(caseInstance.getId()));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("kermit").singleResult().getId(),
-            is(caseInstance.getId()));
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("kermit").count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("kermit").list().get(0).getId()).isEqualTo(caseInstance.getId());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("kermit").singleResult().getId()).isEqualTo(caseInstance.getId());
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            or().
-                involvedUser("kermit").
-                caseDefinitionName("undefinedId").
-            endOr().
-            count(), is(1L));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            or().
-            involvedUser("kermit").
-            caseDefinitionName("undefinedId").
-            endOr().
-            list().get(0).getId(), is(caseInstance.getId()));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            or().
-            involvedUser("kermit").
-            caseDefinitionId("undefined").
-            endOr().
-            singleResult().getId(), is(caseInstance.getId()));
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .involvedUser("kermit")
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .involvedUser("kermit")
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .list().get(0).getId()).isEqualTo(caseInstance.getId());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .involvedUser("kermit")
+                .caseDefinitionId("undefined")
+                .endOr()
+                .singleResult().getId()).isEqualTo(caseInstance.getId());
     }
 
     @Test
     public void getCaseInstanceByInvolvedGroup() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            start();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .start();
         cmmnRuntimeService.addGroupIdentityLink(caseInstance.getId(), "testGroup", IdentityLinkType.PARTICIPANT);
         cmmnRuntimeService.addGroupIdentityLink(caseInstance.getId(), "testGroup2", IdentityLinkType.PARTICIPANT);
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroups(Collections.singleton("testGroup")).count(), is(1L));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId(),
-            is(caseInstance.getId()));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroups(Collections.singleton("testGroup")).singleResult().getId(),
-            is(caseInstance.getId()));
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroups(Collections.singleton("testGroup")).count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId())
+                .isEqualTo(caseInstance.getId());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroups(Collections.singleton("testGroup")).singleResult().getId())
+                .isEqualTo(caseInstance.getId());
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            or().
-                involvedGroups(Collections.singleton("testGroup")).
-                caseDefinitionName("undefinedId").
-            endOr().
-            count(), is(1L));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            or().
-            involvedGroups(Collections.singleton("testGroup")).
-            caseDefinitionName("undefinedId").
-            endOr().
-            list().get(0).getId(), is(caseInstance.getId()));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            or().
-            involvedGroups(Collections.singleton("testGroup")).
-            caseDefinitionId("undefined").
-            endOr().
-            singleResult().getId(), is(caseInstance.getId()));
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .involvedGroups(Collections.singleton("testGroup"))
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .involvedGroups(Collections.singleton("testGroup"))
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .list().get(0).getId()).isEqualTo(caseInstance.getId());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .involvedGroups(Collections.singleton("testGroup"))
+                .caseDefinitionId("undefined")
+                .endOr()
+                .singleResult().getId()).isEqualTo(caseInstance.getId());
     }
 
     @Test
     public void getCaseInstanceByInvolvedGroupOrUser() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            start();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .start();
         cmmnRuntimeService.addGroupIdentityLink(caseInstance.getId(), "testGroup", IdentityLinkType.PARTICIPANT);
         cmmnRuntimeService.addGroupIdentityLink(caseInstance.getId(), "testGroup2", IdentityLinkType.PARTICIPANT);
         cmmnRuntimeService.addUserIdentityLink(caseInstance.getId(), "kermit", IdentityLinkType.CANDIDATE);
-        CaseInstance caseInstance2 = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            start();
+        CaseInstance caseInstance2 = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .start();
         cmmnRuntimeService.addGroupIdentityLink(caseInstance2.getId(), "testGroup2", IdentityLinkType.PARTICIPANT);
-        CaseInstance caseInstance3 = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            start();
+        CaseInstance caseInstance3 = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .start();
         cmmnRuntimeService.addUserIdentityLink(caseInstance3.getId(), "kermit", IdentityLinkType.PARTICIPANT);
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet())).involvedUser("kermit").count(), is(1L));
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet()))
-                .involvedUser("kermit").list().get(0).getId(),
-            is(caseInstance.getId()));
+                .involvedUser("kermit").count()).isEqualTo(1L);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet()))
-                .involvedUser("kermit").singleResult().getId(),
-            is(caseInstance.getId()));
+                .involvedUser("kermit").list().get(0).getId()).isEqualTo(caseInstance.getId());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet()))
+                .involvedUser("kermit").singleResult().getId()).isEqualTo(caseInstance.getId());
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            or().
-                involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet())).
-                caseDefinitionName("undefinedId").
-            endOr().
-            count(), is(2L));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            or().
-            involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet())).
-            caseDefinitionName("undefinedId").
-            endOr().
-            list().size(), is(2));
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet()))
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .count()).isEqualTo(2L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet()))
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .list()).hasSize(2);
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            or().
-                involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet())).
-                involvedUser("kermit").
-                caseDefinitionName("undefinedId").
-            endOr().
-            count(), is(3L));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            or().
-            involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet())).
-            involvedUser("kermit").
-            caseDefinitionName("undefinedId").
-            endOr().
-            list().size(), is(3));
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet()))
+                .involvedUser("kermit")
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .count()).isEqualTo(3L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet()))
+                .involvedUser("kermit")
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .list()).hasSize(3);
     }
 
     @Test
     public void getCaseInstanceByVariable() {
-        cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            variable("queryVariable", "queryVariableValue").
-            start();
-        CaseInstance caseInstance2 = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            variable("queryVariable", "queryVariableValue").
-            variable("queryVariable2", "queryVariableValue2").
-            start();
-        cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            variable("queryVariable", "queryVariableValue").
-            variable("queryVariable3", "queryVariableValue3").
-            start();
+        cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .variable("queryVariable", "queryVariableValue")
+                .start();
+        CaseInstance caseInstance2 = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .variable("queryVariable", "queryVariableValue")
+                .variable("queryVariable2", "queryVariableValue2")
+                .start();
+        cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .variable("queryVariable", "queryVariableValue")
+                .variable("queryVariable3", "queryVariableValue3")
+                .start();
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            variableValueEquals("queryVariable", "queryVariableValue").
-            variableValueEquals("queryVariable2","queryVariableValue2").
-            count(), is(1L));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            variableValueEquals("queryVariable", "queryVariableValue").
-            variableValueEquals("queryVariable2", "queryVariableValue2")
-            .list().get(0).getId(),
-            is(caseInstance2.getId()));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-                variableValueEquals("queryVariable", "queryVariableValue").
-                variableValueEquals("queryVariable2", "queryVariableValue2").
-                singleResult().getId(),
-            is(caseInstance2.getId()));
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .variableValueEquals("queryVariable", "queryVariableValue")
+                .variableValueEquals("queryVariable2", "queryVariableValue2")
+                .count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .variableValueEquals("queryVariable", "queryVariableValue")
+                .variableValueEquals("queryVariable2", "queryVariableValue2")
+                .list().get(0).getId()).isEqualTo(caseInstance2.getId());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .variableValueEquals("queryVariable", "queryVariableValue")
+                .variableValueEquals("queryVariable2", "queryVariableValue2")
+                .singleResult().getId()).isEqualTo(caseInstance2.getId());
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            or().
-            variableValueEquals("queryVariable", "queryVariableValue").
-            variableValueEquals("queryVariable2", "queryVariableValue2").
-            caseDefinitionName("undefinedId").
-            endOr().
-            count(), is(3L));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().
-            or().
-            variableValueEquals("queryVariable", "queryVariableValue").
-            variableValueEquals("queryVariable2", "queryVariableValue2").
-            caseDefinitionName("undefinedId").
-            endOr().
-            list().size(), is(3));
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .variableValueEquals("queryVariable", "queryVariableValue")
+                .variableValueEquals("queryVariable2", "queryVariableValue2")
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .count()).isEqualTo(3L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery()
+                .or()
+                .variableValueEquals("queryVariable", "queryVariableValue")
+                .variableValueEquals("queryVariable2", "queryVariableValue2")
+                .caseDefinitionName("undefinedId")
+                .endOr()
+                .list()).hasSize(3);
     }
 
     @Test
     public void getCaseInstanceByIdWithoutTenant() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            name("caseInstance1").
-            start();
-        cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            name("caseInstance2").
-            start();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .name("caseInstance1")
+                .start();
+        cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .name("caseInstance2")
+                .start();
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).caseInstanceWithoutTenantId().count(), is(1L));
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).caseInstanceWithoutTenantId().list().size(), is(1));
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).caseInstanceWithoutTenantId().count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).caseInstanceWithoutTenantId().list()).hasSize(1);
     }
 
     @Test
@@ -845,17 +833,17 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
         vars.put("instantVar", instant1);
         vars.put("instantVar2", instant2);
         CaseInstance caseInstance2 = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("oneTaskCase")
-            .variables(vars)
-            .start();
+                .caseDefinitionKey("oneTaskCase")
+                .variables(vars)
+                .start();
 
         Instant nextYear = instant1.plus(365, ChronoUnit.DAYS);
         vars = new HashMap<>();
         vars.put("instantVar", nextYear);
         CaseInstance caseInstance3 = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("oneTaskCase")
-            .variables(vars)
-            .start();
+                .caseDefinitionKey("oneTaskCase")
+                .variables(vars)
+                .start();
 
         Instant nextMonth = instant1.plus(30, ChronoUnit.DAYS);
 
@@ -905,11 +893,11 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
         // Test LESS_THAN
         caseInstances = cmmnRuntimeService.createCaseInstanceQuery().variableValueLessThan("instantVar", nextYear).list();
         Assertions.assertThat(caseInstances)
-            .extracting(CaseInstance::getId)
-            .containsExactlyInAnyOrder(
-                caseInstance1.getId(),
-                caseInstance2.getId()
-            );
+                .extracting(CaseInstance::getId)
+                .containsExactlyInAnyOrder(
+                        caseInstance1.getId(),
+                        caseInstance2.getId()
+                );
 
         Assertions.assertThat(cmmnRuntimeService.createCaseInstanceQuery().variableValueLessThan("instantVar", instant1).count()).isEqualTo(0);
         Assertions.assertThat(cmmnRuntimeService.createCaseInstanceQuery().variableValueLessThan("instantVar", twoYearsLater).count()).isEqualTo(3);
@@ -927,11 +915,11 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
 
         caseInstances = cmmnRuntimeService.createCaseInstanceQuery().variableValueEquals(instant1).list();
         Assertions.assertThat(caseInstances)
-            .extracting(CaseInstance::getId)
-            .containsExactlyInAnyOrder(
-                caseInstance1.getId(),
-                caseInstance2.getId()
-            );
+                .extracting(CaseInstance::getId)
+                .containsExactlyInAnyOrder(
+                        caseInstance1.getId(),
+                        caseInstance2.getId()
+                );
 
         caseInstance = cmmnRuntimeService.createCaseInstanceQuery().variableValueEquals(twoYearsLater).singleResult();
         Assertions.assertThat(caseInstance).isNull();
@@ -953,17 +941,17 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
         vars.put("localDateVar", localDate);
         vars.put("localDateVar2", localDate2);
         CaseInstance caseInstance2 = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("oneTaskCase")
-            .variables(vars)
-            .start();
+                .caseDefinitionKey("oneTaskCase")
+                .variables(vars)
+                .start();
 
         LocalDate nextYear = localDate.plusYears(1);
         vars = new HashMap<>();
         vars.put("localDateVar", nextYear);
         CaseInstance caseInstance3 = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("oneTaskCase")
-            .variables(vars)
-            .start();
+                .caseDefinitionKey("oneTaskCase")
+                .variables(vars)
+                .start();
 
         LocalDate nextMonth = localDate.plusMonths(1);
 
@@ -1013,11 +1001,11 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
         // Test LESS_THAN
         caseInstances = cmmnRuntimeService.createCaseInstanceQuery().variableValueLessThan("localDateVar", nextYear).list();
         Assertions.assertThat(caseInstances)
-            .extracting(CaseInstance::getId)
-            .containsExactlyInAnyOrder(
-                caseInstance1.getId(),
-                caseInstance2.getId()
-            );
+                .extracting(CaseInstance::getId)
+                .containsExactlyInAnyOrder(
+                        caseInstance1.getId(),
+                        caseInstance2.getId()
+                );
 
         Assertions.assertThat(cmmnRuntimeService.createCaseInstanceQuery().variableValueLessThan("localDateVar", localDate).count()).isEqualTo(0);
         Assertions.assertThat(cmmnRuntimeService.createCaseInstanceQuery().variableValueLessThan("localDateVar", twoYearsLater).count()).isEqualTo(3);
@@ -1035,11 +1023,11 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
 
         caseInstances = cmmnRuntimeService.createCaseInstanceQuery().variableValueEquals(localDate).list();
         Assertions.assertThat(caseInstances)
-            .extracting(CaseInstance::getId)
-            .containsExactlyInAnyOrder(
-                caseInstance1.getId(),
-                caseInstance2.getId()
-            );
+                .extracting(CaseInstance::getId)
+                .containsExactlyInAnyOrder(
+                        caseInstance1.getId(),
+                        caseInstance2.getId()
+                );
 
         caseInstance = cmmnRuntimeService.createCaseInstanceQuery().variableValueEquals(twoYearsLater).singleResult();
         Assertions.assertThat(caseInstance).isNull();
@@ -1061,17 +1049,17 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
         vars.put("localDateTimeVar", localDateTime);
         vars.put("localDateTimeVar2", localDateTime2);
         CaseInstance caseInstance2 = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("oneTaskCase")
-            .variables(vars)
-            .start();
+                .caseDefinitionKey("oneTaskCase")
+                .variables(vars)
+                .start();
 
         LocalDateTime nextYear = localDateTime.plusYears(1);
         vars = new HashMap<>();
         vars.put("localDateTimeVar", nextYear);
         CaseInstance caseInstance3 = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("oneTaskCase")
-            .variables(vars)
-            .start();
+                .caseDefinitionKey("oneTaskCase")
+                .variables(vars)
+                .start();
 
         LocalDateTime nextMonth = localDateTime.plusMonths(1);
 
@@ -1085,7 +1073,8 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
         Assertions.assertThat(caseInstances).hasSize(2);
 
         // Query on two localDateTime variables, should result in single value
-        query = cmmnRuntimeService.createCaseInstanceQuery().variableValueEquals("localDateTimeVar", localDateTime).variableValueEquals("localDateTimeVar2", localDateTime2);
+        query = cmmnRuntimeService.createCaseInstanceQuery().variableValueEquals("localDateTimeVar", localDateTime)
+                .variableValueEquals("localDateTimeVar2", localDateTime2);
         CaseInstance caseInstance = query.singleResult();
         Assertions.assertThat(caseInstance).isNotNull();
         Assertions.assertThat(caseInstance.getId()).isEqualTo(caseInstance2.getId());
@@ -1116,16 +1105,17 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
         Assertions.assertThat(caseInstance).isNotNull();
         Assertions.assertThat(caseInstance.getId()).isEqualTo(caseInstance3.getId());
 
-        Assertions.assertThat(cmmnRuntimeService.createCaseInstanceQuery().variableValueGreaterThanOrEqual("localDateTimeVar", oneYearAgo).count()).isEqualTo(3);
+        Assertions.assertThat(cmmnRuntimeService.createCaseInstanceQuery().variableValueGreaterThanOrEqual("localDateTimeVar", oneYearAgo).count())
+                .isEqualTo(3);
 
         // Test LESS_THAN
         caseInstances = cmmnRuntimeService.createCaseInstanceQuery().variableValueLessThan("localDateTimeVar", nextYear).list();
         Assertions.assertThat(caseInstances)
-            .extracting(CaseInstance::getId)
-            .containsExactlyInAnyOrder(
-                caseInstance1.getId(),
-                caseInstance2.getId()
-            );
+                .extracting(CaseInstance::getId)
+                .containsExactlyInAnyOrder(
+                        caseInstance1.getId(),
+                        caseInstance2.getId()
+                );
 
         Assertions.assertThat(cmmnRuntimeService.createCaseInstanceQuery().variableValueLessThan("localDateTimeVar", localDateTime).count()).isEqualTo(0);
         Assertions.assertThat(cmmnRuntimeService.createCaseInstanceQuery().variableValueLessThan("localDateTimeVar", twoYearsLater).count()).isEqualTo(3);
@@ -1143,11 +1133,11 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
 
         caseInstances = cmmnRuntimeService.createCaseInstanceQuery().variableValueEquals(localDateTime).list();
         Assertions.assertThat(caseInstances)
-            .extracting(CaseInstance::getId)
-            .containsExactlyInAnyOrder(
-                caseInstance1.getId(),
-                caseInstance2.getId()
-            );
+                .extracting(CaseInstance::getId)
+                .containsExactlyInAnyOrder(
+                        caseInstance1.getId(),
+                        caseInstance2.getId()
+                );
 
         caseInstance = cmmnRuntimeService.createCaseInstanceQuery().variableValueEquals(twoYearsLater).singleResult();
         Assertions.assertThat(caseInstance).isNull();

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CaseInstanceUpdateBusinessKeyTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CaseInstanceUpdateBusinessKeyTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.cmmn.test.runtime;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.flowable.cmmn.api.delegate.DelegatePlanItemInstance;
 import org.flowable.cmmn.api.history.HistoricCaseInstance;
 import org.flowable.cmmn.api.listener.PlanItemInstanceLifecycleListener;
@@ -26,17 +28,15 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-
 public class CaseInstanceUpdateBusinessKeyTest extends FlowableCmmnTestCase {
 
     private String deplId;
 
     @Before
     public void createCase() {
-        org.flowable.cmmn.api.repository.CmmnDeployment deployment = cmmnRepositoryService.createDeployment().
-            addClasspathResource("org/flowable/cmmn/test/runtime/CaseInstanceUpdateBusinessKeyTest.testUpdateExistingCaseBusinessKey.cmmn").
-            deploy();
+        org.flowable.cmmn.api.repository.CmmnDeployment deployment = cmmnRepositoryService.createDeployment()
+                .addClasspathResource("org/flowable/cmmn/test/runtime/CaseInstanceUpdateBusinessKeyTest.testUpdateExistingCaseBusinessKey.cmmn")
+                .deploy();
 
         deplId = deployment.getId();
     }
@@ -50,14 +50,14 @@ public class CaseInstanceUpdateBusinessKeyTest extends FlowableCmmnTestCase {
     @CmmnDeployment
     public void testCaseInstanceUpdateBusinessKey() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("businessKeyCase").start();
-        assertEquals("bzKey", caseInstance.getBusinessKey());
+        assertThat(caseInstance.getBusinessKey()).isEqualTo("bzKey");
 
         Task task = cmmnTaskService.createTaskQuery().singleResult();
         cmmnTaskService.complete(task.getId());
 
         if (cmmnEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.ACTIVITY)) {
             HistoricCaseInstance historicCaseInstance = cmmnHistoryService.createHistoricCaseInstanceQuery().singleResult();
-            assertEquals("bzKey", historicCaseInstance.getBusinessKey());
+            assertThat(historicCaseInstance.getBusinessKey()).isEqualTo("bzKey");
         }
     }
 
@@ -67,23 +67,23 @@ public class CaseInstanceUpdateBusinessKeyTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("businessKeyCase").businessKey("bzKey").start();
 
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceQuery().singleResult();
-        assertEquals("bzKey", caseInstance.getBusinessKey());
+        assertThat(caseInstance.getBusinessKey()).isEqualTo("bzKey");
 
         if (cmmnEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.ACTIVITY)) {
             HistoricCaseInstance historicCaseInstance = cmmnHistoryService.createHistoricCaseInstanceQuery().singleResult();
-            assertEquals("bzKey", historicCaseInstance.getBusinessKey());
+            assertThat(historicCaseInstance.getBusinessKey()).isEqualTo("bzKey");
         }
 
         cmmnRuntimeService.updateBusinessKey(caseInstance.getId(), "newKey");
 
         caseInstance = cmmnRuntimeService.createCaseInstanceQuery().singleResult();
-        assertEquals("newKey", caseInstance.getBusinessKey());
+        assertThat(caseInstance.getBusinessKey()).isEqualTo("newKey");
 
         Task task = cmmnTaskService.createTaskQuery().singleResult();
         cmmnTaskService.complete(task.getId());
         if (cmmnEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.ACTIVITY)) {
             HistoricCaseInstance historicCaseInstance2 = cmmnHistoryService.createHistoricCaseInstanceQuery().singleResult();
-            assertEquals("newKey", historicCaseInstance2.getBusinessKey());
+            assertThat(historicCaseInstance2.getBusinessKey()).isEqualTo("newKey");
         }
     }
 

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CasePageTaskTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CasePageTaskTest.java
@@ -12,10 +12,7 @@
  */
 package org.flowable.cmmn.test.runtime;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -34,7 +31,7 @@ import org.flowable.identitylink.api.history.HistoricIdentityLink;
 import org.junit.Test;
 
 public class CasePageTaskTest extends FlowableCmmnTestCase {
-    
+
     @Test
     @CmmnDeployment
     public void testInStage() {
@@ -47,209 +44,215 @@ public class CasePageTaskTest extends FlowableCmmnTestCase {
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .orderByName().asc()
                 .list();
-        assertEquals(4, planItemInstances.size());
-        String[] expectedNames = new String[] { "Case Page Task One", "Stage One", "Task One", "Task Two"};
-        for (int i=0; i<planItemInstances.size(); i++) {
-            assertEquals(expectedNames[i], planItemInstances.get(i).getName());
-        }
-       
+
+        String[] expectedNames = new String[] { "Case Page Task One", "Stage One", "Task One", "Task Two" };
+        assertThat(planItemInstances)
+                .extracting(PlanItemInstance::getName)
+                .containsExactly(expectedNames);
+
         // Finishing task 2 should complete the stage
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(3).getId());
-       
+
         planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-                        .caseInstanceId(caseInstance.getId())
-                        .planItemInstanceState(PlanItemInstanceState.ACTIVE)
-                        .orderByName().asc()
-                        .list();
-        
-        assertEquals(1, planItemInstances.size());
+                .caseInstanceId(caseInstance.getId())
+                .planItemInstanceState(PlanItemInstanceState.ACTIVE)
+                .orderByName().asc()
+                .list();
+
+        assertThat(planItemInstances).hasSize(1);
         expectedNames = new String[] { "Task One" };
-        for (int i=0; i<planItemInstances.size(); i++) {
-            assertEquals(expectedNames[i], planItemInstances.get(i).getName());
-        }
-       
+        assertThat(planItemInstances)
+                .extracting(PlanItemInstance::getName)
+                .containsExactly(expectedNames);
+
         PlanItemInstance pagePlanItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
-                        .caseInstanceId(caseInstance.getId())
-                        .planItemDefinitionId("casePageTask1")
-                        .planItemInstanceFormKey("myFormKeyValue")
-                        .includeEnded()
-                        .singleResult();
-        assertNotNull(pagePlanItemInstance);
+                .caseInstanceId(caseInstance.getId())
+                .planItemDefinitionId("casePageTask1")
+                .planItemInstanceFormKey("myFormKeyValue")
+                .includeEnded()
+                .singleResult();
+        assertThat(pagePlanItemInstance).isNotNull();
 
         // page tasks go into terminated state, if their parent stage gets completed, regardless its previous state
-        assertEquals(PlanItemInstanceState.TERMINATED, pagePlanItemInstance.getState());
-        assertEquals("myFormKeyValue", pagePlanItemInstance.getFormKey());
-        assertEquals("myFormKeyValue", pagePlanItemInstance.getExtraValue());
-        
+        assertThat(pagePlanItemInstance.getState()).isEqualTo(PlanItemInstanceState.TERMINATED);
+        assertThat(pagePlanItemInstance.getFormKey()).isEqualTo("myFormKeyValue");
+        assertThat(pagePlanItemInstance.getExtraValue()).isEqualTo("myFormKeyValue");
+
         pagePlanItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
-                        .caseInstanceId(caseInstance.getId())
-                        .planItemInstanceFormKey("myFormKeyValue")
-                        .includeEnded()
-                        .singleResult();
-        assertNotNull(pagePlanItemInstance);
-       
+                .caseInstanceId(caseInstance.getId())
+                .planItemInstanceFormKey("myFormKeyValue")
+                .includeEnded()
+                .singleResult();
+        assertThat(pagePlanItemInstance).isNotNull();
+
         // Finish case instance
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(0).getId());
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().count());
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
-        
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
+
         HistoricPlanItemInstance historicPlanItemInstance = cmmnHistoryService.createHistoricPlanItemInstanceQuery()
                 .planItemInstanceCaseInstanceId(caseInstance.getId())
                 .planItemInstanceFormKey("myFormKeyValue")
                 .singleResult();
-        assertNotNull(historicPlanItemInstance);
-        assertEquals("myFormKeyValue", historicPlanItemInstance.getFormKey());
-        assertEquals("myFormKeyValue", historicPlanItemInstance.getExtraValue());
+        assertThat(historicPlanItemInstance).isNotNull();
+        assertThat(historicPlanItemInstance.getFormKey()).isEqualTo("myFormKeyValue");
+        assertThat(historicPlanItemInstance.getExtraValue()).isEqualTo("myFormKeyValue");
     }
 
     @Test
     @CmmnDeployment
     public void testTerminateStage() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("myCase").start();
-        UserEventListenerInstance userEventListener = cmmnRuntimeService.createUserEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult();
+        UserEventListenerInstance userEventListener = cmmnRuntimeService.createUserEventListenerInstanceQuery().caseInstanceId(caseInstance.getId())
+                .singleResult();
         cmmnRuntimeService.completeUserEventListenerInstance(userEventListener.getId());
-        
+
         List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-               .caseInstanceId(caseInstance.getId())
-               .planItemInstanceState(PlanItemInstanceState.ACTIVE)
-               .orderByName().asc()
-               .list();
-       
-        assertEquals(1, planItemInstances.size());
-        assertEquals("Task One", planItemInstances.get(0).getName());
-       
+                .caseInstanceId(caseInstance.getId())
+                .planItemInstanceState(PlanItemInstanceState.ACTIVE)
+                .orderByName().asc()
+                .list();
+
+        assertThat(planItemInstances)
+                .extracting(PlanItemInstance::getName)
+                .containsExactly("Task One");
+
         PlanItemInstance pagePlanItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
-                        .caseInstanceId(caseInstance.getId())
-                        .planItemDefinitionId("casePageTask1")
-                        .includeEnded()
-                        .singleResult();
-        assertNotNull(pagePlanItemInstance);
-        assertEquals(PlanItemInstanceState.TERMINATED, pagePlanItemInstance.getState());
-       
+                .caseInstanceId(caseInstance.getId())
+                .planItemDefinitionId("casePageTask1")
+                .includeEnded()
+                .singleResult();
+        assertThat(pagePlanItemInstance).isNotNull();
+        assertThat(pagePlanItemInstance.getState()).isEqualTo(PlanItemInstanceState.TERMINATED);
+
         // Finish case instance
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(0).getId());
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().count());
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
-    
+
     @Test
     @CmmnDeployment
     public void testIdentityLinks() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
                 .caseDefinitionKey("myCase")
                 .start();
-        
+
         PlanItemInstance pagePlanItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
-                        .caseInstanceId(caseInstance.getId())
-                        .planItemDefinitionId("casePageTask1")
-                        .singleResult();
-        assertNotNull(pagePlanItemInstance);
-        
+                .caseInstanceId(caseInstance.getId())
+                .planItemDefinitionId("casePageTask1")
+                .singleResult();
+        assertThat(pagePlanItemInstance).isNotNull();
+
         List<IdentityLink> identityLinks = cmmnRuntimeService.getIdentityLinksForPlanItemInstance(pagePlanItemInstance.getId());
-        assertEquals(5, identityLinks.size());
-        
-        List<IdentityLink> assigneeLink = identityLinks.stream().filter(identityLink -> identityLink.getType().equals(IdentityLinkType.ASSIGNEE)).collect(Collectors.toList());
-        assertEquals(1, assigneeLink.size());
-        assertEquals("johndoe", assigneeLink.get(0).getUserId());
-        
-        List<IdentityLink> ownerLink = identityLinks.stream().filter(identityLink -> identityLink.getType().equals(IdentityLinkType.OWNER)).collect(Collectors.toList());
-        assertEquals(1, ownerLink.size());
-        assertEquals("janedoe", ownerLink.get(0).getUserId());
-        
-        List<IdentityLink> candidateUserLinks = identityLinks.stream().filter(identityLink -> identityLink.getType().equals(IdentityLinkType.CANDIDATE) && 
-                        identityLink.getUserId() != null).collect(Collectors.toList());
-        assertEquals(2, candidateUserLinks.size());
-        List<String> linkValues = new ArrayList<>();
-        for (IdentityLink candidateLink : candidateUserLinks) {
-            linkValues.add(candidateLink.getUserId());
-        }
-        assertTrue(linkValues.contains("johndoe"));
-        assertTrue(linkValues.contains("janedoe"));
-        
+        assertThat(identityLinks).hasSize(5);
+
+        List<IdentityLink> assigneeLink = identityLinks.stream().filter(identityLink -> identityLink.getType().equals(IdentityLinkType.ASSIGNEE))
+                .collect(Collectors.toList());
+        assertThat(assigneeLink)
+                .extracting(IdentityLink::getUserId)
+                .containsExactly("johndoe");
+
+        List<IdentityLink> ownerLink = identityLinks.stream().filter(identityLink -> identityLink.getType().equals(IdentityLinkType.OWNER))
+                .collect(Collectors.toList());
+        assertThat(ownerLink)
+                .extracting(IdentityLink::getUserId)
+                .containsExactly("janedoe");
+
+        List<IdentityLink> candidateUserLinks = identityLinks.stream().filter(identityLink -> identityLink.getType().equals(IdentityLinkType.CANDIDATE) &&
+                identityLink.getUserId() != null).collect(Collectors.toList());
+        assertThat(candidateUserLinks)
+                .extracting(IdentityLink::getUserId)
+                .containsExactlyInAnyOrder("johndoe", "janedoe");
+
         List<IdentityLink> groupLink = identityLinks.stream().filter(identityLink -> identityLink.getType().equals(IdentityLinkType.CANDIDATE) &&
-                        identityLink.getGroupId() != null).collect(Collectors.toList());
-        assertEquals(1, groupLink.size());
-        assertEquals("sales", groupLink.get(0).getGroupId());
-        
+                identityLink.getGroupId() != null).collect(Collectors.toList());
+        assertThat(groupLink)
+                .extracting(IdentityLink::getGroupId)
+                .containsExactly("sales");
+
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().involvedUser("johndoe").singleResult();
-        assertEquals("Case Page Task One", planItemInstance.getName());
-        
+        assertThat(planItemInstance.getName()).isEqualTo("Case Page Task One");
+
         planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().involvedUser("janedoe").singleResult();
-        assertEquals("Case Page Task One", planItemInstance.getName());
-        
+        assertThat(planItemInstance.getName()).isEqualTo("Case Page Task One");
+
         planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().involvedUser("johndoe2").singleResult();
-        assertNull(planItemInstance);
-        
+        assertThat(planItemInstance).isNull();
+
         List<String> groups = new ArrayList<>();
         groups.add("sales");
         planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().involvedGroups(groups).singleResult();
-        assertEquals("Case Page Task One", planItemInstance.getName());
-        
+        assertThat(planItemInstance.getName()).isEqualTo("Case Page Task One");
+
         planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().involvedUser("johndoe").involvedGroups(groups).singleResult();
-        assertEquals("Case Page Task One", planItemInstance.getName());
-        
+        assertThat(planItemInstance.getName()).isEqualTo("Case Page Task One");
+
         planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().involvedUser("nonexisting").involvedGroups(groups).singleResult();
-        assertEquals("Case Page Task One", planItemInstance.getName());
-        
+        assertThat(planItemInstance.getName()).isEqualTo("Case Page Task One");
+
         List<String> nonMatchingGroups = new ArrayList<>();
         nonMatchingGroups.add("management");
         planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().involvedGroups(nonMatchingGroups).singleResult();
-        assertNull(planItemInstance);
-        
+        assertThat(planItemInstance).isNull();
+
         planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().involvedUser("nonexisting").involvedGroups(nonMatchingGroups).singleResult();
-        assertNull(planItemInstance);
-        
+        assertThat(planItemInstance).isNull();
+
         planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().involvedUser("johndoe").involvedGroups(nonMatchingGroups).singleResult();
-        assertEquals("Case Page Task One", planItemInstance.getName());
-        
+        assertThat(planItemInstance.getName()).isEqualTo("Case Page Task One");
+
         List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-                        .caseInstanceId(caseInstance.getId())
-                        .planItemInstanceState(PlanItemInstanceState.ACTIVE)
-                        .orderByName().asc()
-                        .list();
-        assertEquals(4, planItemInstances.size());
-       
+                .caseInstanceId(caseInstance.getId())
+                .planItemInstanceState(PlanItemInstanceState.ACTIVE)
+                .orderByName().asc()
+                .list();
+        assertThat(planItemInstances).hasSize(4);
+
         // Finishing task 2 should complete the stage
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(3).getId());
-        
+
         planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-                        .caseInstanceId(caseInstance.getId())
-                        .planItemInstanceState(PlanItemInstanceState.ACTIVE)
-                        .orderByName().asc()
-                        .list();
-       
+                .caseInstanceId(caseInstance.getId())
+                .planItemInstanceState(PlanItemInstanceState.ACTIVE)
+                .orderByName().asc()
+                .list();
+
         // Finish case instance
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(0).getId());
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().count());
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
-        
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
+
         List<HistoricIdentityLink> historicIdentityLinks = cmmnHistoryService.getHistoricIdentityLinksForPlanItemInstance(pagePlanItemInstance.getId());
-        assertEquals(5, historicIdentityLinks.size());
-        
-        List<HistoricIdentityLink> historicAssigneeLink = historicIdentityLinks.stream().filter(identityLink -> identityLink.getType().equals(IdentityLinkType.ASSIGNEE)).collect(Collectors.toList());
-        assertEquals(1, historicAssigneeLink.size());
-        assertEquals("johndoe", historicAssigneeLink.get(0).getUserId());
-        
-        List<HistoricIdentityLink> historicOwnerLink = historicIdentityLinks.stream().filter(identityLink -> identityLink.getType().equals(IdentityLinkType.OWNER)).collect(Collectors.toList());
-        assertEquals(1, historicOwnerLink.size());
-        assertEquals("janedoe", historicOwnerLink.get(0).getUserId());
-        
-        List<HistoricIdentityLink> historicCandidateUserLinks = historicIdentityLinks.stream().filter(identityLink -> identityLink.getType().equals(IdentityLinkType.CANDIDATE) && 
+        assertThat(historicIdentityLinks).hasSize(5);
+
+        List<HistoricIdentityLink> historicAssigneeLink = historicIdentityLinks.stream()
+                .filter(identityLink -> identityLink.getType().equals(IdentityLinkType.ASSIGNEE)).collect(Collectors.toList());
+        assertThat(historicAssigneeLink)
+                .extracting(HistoricIdentityLink::getUserId)
+                .containsExactly("johndoe");
+
+        List<HistoricIdentityLink> historicOwnerLink = historicIdentityLinks.stream()
+                .filter(identityLink -> identityLink.getType().equals(IdentityLinkType.OWNER)).collect(Collectors.toList());
+        assertThat(historicOwnerLink)
+                .extracting(HistoricIdentityLink::getUserId)
+                .containsExactly("janedoe");
+
+        List<HistoricIdentityLink> historicCandidateUserLinks = historicIdentityLinks.stream()
+                .filter(identityLink -> identityLink.getType().equals(IdentityLinkType.CANDIDATE) &&
                         identityLink.getUserId() != null).collect(Collectors.toList());
-        assertEquals(2, historicCandidateUserLinks.size());
-        linkValues = new ArrayList<>();
-        for (HistoricIdentityLink candidateLink : historicCandidateUserLinks) {
-            linkValues.add(candidateLink.getUserId());
-        }
-        assertTrue(linkValues.contains("johndoe"));
-        assertTrue(linkValues.contains("janedoe"));
-        
-        List<HistoricIdentityLink> historicGroupLink = historicIdentityLinks.stream().filter(identityLink -> identityLink.getType().equals(IdentityLinkType.CANDIDATE) &&
+        assertThat(historicCandidateUserLinks)
+                .extracting(HistoricIdentityLink::getUserId)
+                .containsExactlyInAnyOrder("johndoe", "janedoe");
+
+        List<HistoricIdentityLink> historicGroupLink = historicIdentityLinks.stream()
+                .filter(identityLink -> identityLink.getType().equals(IdentityLinkType.CANDIDATE) &&
                         identityLink.getGroupId() != null).collect(Collectors.toList());
-        assertEquals(1, historicGroupLink.size());
-        assertEquals("sales", historicGroupLink.get(0).getGroupId());
+        assertThat(historicGroupLink)
+                .extracting(HistoricIdentityLink::getGroupId)
+                .containsExactly("sales");
     }
 }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CaseTaskTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CaseTaskTest.java
@@ -13,12 +13,8 @@
 package org.flowable.cmmn.test.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -31,7 +27,6 @@ import org.flowable.cmmn.api.runtime.PlanItemInstance;
 import org.flowable.cmmn.api.runtime.PlanItemInstanceState;
 import org.flowable.cmmn.api.runtime.UserEventListenerInstance;
 import org.flowable.cmmn.engine.test.CmmnDeployment;
-import org.flowable.cmmn.engine.test.CmmnDeploymentId;
 import org.flowable.cmmn.engine.test.FlowableCmmnTestCase;
 import org.flowable.common.engine.api.FlowableObjectNotFoundException;
 import org.flowable.common.engine.api.scope.ScopeTypes;
@@ -45,9 +40,7 @@ import org.flowable.task.api.Task;
 import org.flowable.task.api.history.HistoricTaskInstance;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 /**
  * @author Joram Barrez
@@ -56,9 +49,6 @@ import org.junit.rules.ExpectedException;
 public class CaseTaskTest extends FlowableCmmnTestCase {
 
     protected String oneTaskCaseDeploymentId;
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Before
     public void deployOneTaskCaseDefinition() {
@@ -82,20 +72,20 @@ public class CaseTaskTest extends FlowableCmmnTestCase {
     @CmmnDeployment
     public void testCaseReferenceExpression() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("myCase")
-            .variable("myVar", "oneTaskCase")
-            .start();
+                .caseDefinitionKey("myCase")
+                .variable("myVar", "oneTaskCase")
+                .start();
         assertBlockingCaseTaskFlow(caseInstance);
     }
 
     @Test
     public void testBasicBlockingWithTenant() {
         cmmnRepositoryService.deleteDeployment(oneTaskCaseDeploymentId, true);
-        oneTaskCaseDeploymentId = cmmnRepositoryService.createDeployment().
-                tenantId("flowable").
-                addClasspathResource("org/flowable/cmmn/test/runtime/CaseTaskTest.testBasicBlocking.cmmn").
-                addClasspathResource("org/flowable/cmmn/test/runtime/oneTaskCase.cmmn").
-                deploy().getId();
+        oneTaskCaseDeploymentId = cmmnRepositoryService.createDeployment()
+                .tenantId("flowable")
+                .addClasspathResource("org/flowable/cmmn/test/runtime/CaseTaskTest.testBasicBlocking.cmmn")
+                .addClasspathResource("org/flowable/cmmn/test/runtime/oneTaskCase.cmmn")
+                .deploy().getId();
 
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("myCase").tenantId("flowable").start();
         assertBlockingCaseTaskFlow(caseInstance);
@@ -111,50 +101,49 @@ public class CaseTaskTest extends FlowableCmmnTestCase {
                 tenantId("flowable").
                 addClasspathResource("org/flowable/cmmn/test/runtime/CaseTaskTest.testBasicBlocking.cmmn").
                 deploy().getId();
-        try {
-            CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("myCase").tenantId("flowable").start();
-            this.expectedException.expect(FlowableObjectNotFoundException.class);
-            this.expectedException.expectMessage("Case definition was not found by key 'oneTaskCase' and tenant 'flowable'");
-            assertBlockingCaseTaskFlow(caseInstance);
-        } finally {
-            cmmnRepositoryService.deleteDeployment(parentCaseDeploymentId, true);
-        }
+
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("myCase").tenantId("flowable").start();
+        assertThatThrownBy(() -> assertBlockingCaseTaskFlow(caseInstance))
+                .isInstanceOf(FlowableObjectNotFoundException.class)
+                .hasMessage("Case definition was not found by key 'oneTaskCase' and tenant 'flowable'");
+        cmmnRepositoryService.deleteDeployment(parentCaseDeploymentId, true);
     }
 
     @Test
     @CmmnDeployment(resources = {
-        "org/flowable/cmmn/test/runtime/CaseTaskTest.testSimpleBlockingSubCase.cmmn",
-        "org/flowable/cmmn/test/runtime/CaseTaskTest.testSimpleBlockingSubCaseChildCase.cmmn"
+            "org/flowable/cmmn/test/runtime/CaseTaskTest.testSimpleBlockingSubCase.cmmn",
+            "org/flowable/cmmn/test/runtime/CaseTaskTest.testSimpleBlockingSubCaseChildCase.cmmn"
     })
     public void testSimpleBlockingSubCase() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("endEndCase").start();
 
         // Verify case task plan item instance
         PlanItemInstance caseTaskPlanItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .planItemDefinitionType(PlanItemDefinitionType.CASE_TASK)
-            .singleResult();
-        assertEquals(PlanItemInstanceState.ACTIVE, caseTaskPlanItemInstance.getState());
+                .planItemDefinitionType(PlanItemDefinitionType.CASE_TASK)
+                .singleResult();
+        assertThat(caseTaskPlanItemInstance.getState()).isEqualTo(PlanItemInstanceState.ACTIVE);
 
         // Verify child case instance
         CaseInstance childCaseInstance = cmmnRuntimeService.createCaseInstanceQuery().caseInstanceParentId(caseInstance.getId()).singleResult();
         PlanItemInstance humanTaskPlanItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .caseInstanceId(childCaseInstance.getId())
-            .planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK)
-            .singleResult();
-        assertEquals(PlanItemInstanceState.ACTIVE, humanTaskPlanItemInstance.getState());
+                .caseInstanceId(childCaseInstance.getId())
+                .planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK)
+                .singleResult();
+        assertThat(humanTaskPlanItemInstance.getState()).isEqualTo(PlanItemInstanceState.ACTIVE);
 
         if (cmmnEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.ACTIVITY)) {
-            HistoricCaseInstance historicChildCaseInstance = cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceId(childCaseInstance.getId()).singleResult();
-            assertEquals(cmmnRuntimeService.createPlanItemInstanceQuery()
-                .caseInstanceId(caseInstance.getId()).planItemDefinitionType(PlanItemDefinitionType.CASE_TASK).singleResult().getId(), historicChildCaseInstance.getCallbackId());
-            assertEquals(CallbackTypes.PLAN_ITEM_CHILD_CASE, historicChildCaseInstance.getCallbackType());
+            HistoricCaseInstance historicChildCaseInstance = cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceId(childCaseInstance.getId())
+                    .singleResult();
+            assertThat(historicChildCaseInstance.getCallbackId()).isEqualTo(cmmnRuntimeService.createPlanItemInstanceQuery()
+                    .caseInstanceId(caseInstance.getId()).planItemDefinitionType(PlanItemDefinitionType.CASE_TASK).singleResult().getId());
+            assertThat(historicChildCaseInstance.getCallbackType()).isEqualTo(CallbackTypes.PLAN_ITEM_CHILD_CASE);
         }
 
         PlanItemInstance stagePlanItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .caseInstanceId(childCaseInstance.getId())
-            .planItemDefinitionType(PlanItemDefinitionType.STAGE)
-            .singleResult();
-        assertEquals(PlanItemInstanceState.ACTIVE, stagePlanItemInstance.getState());
+                .caseInstanceId(childCaseInstance.getId())
+                .planItemDefinitionType(PlanItemDefinitionType.STAGE)
+                .singleResult();
+        assertThat(stagePlanItemInstance.getState()).isEqualTo(PlanItemInstanceState.ACTIVE);
 
         // Completing the task should complete both case instances
         cmmnTaskService.complete(cmmnTaskService.createTaskQuery().caseInstanceId(childCaseInstance.getId()).singleResult().getId());
@@ -166,47 +155,39 @@ public class CaseTaskTest extends FlowableCmmnTestCase {
     @CmmnDeployment
     public void testBasicSubHumanTask() {
         String oneHumanTaskDeploymentId = cmmnRepositoryService.createDeployment()
-                        .addClasspathResource("org/flowable/cmmn/test/runtime/oneHumanTaskCase.cmmn").deploy().getId();
+                .addClasspathResource("org/flowable/cmmn/test/runtime/oneHumanTaskCase.cmmn").deploy().getId();
 
         try {
             CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("myCase").start();
             Task taskBeforeSubTask = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
-            assertEquals("Task One", taskBeforeSubTask.getName());
+            assertThat(taskBeforeSubTask.getName()).isEqualTo("Task One");
             Task childTask = cmmnTaskService.createTaskQuery().caseInstanceIdWithChildren(caseInstance.getId()).singleResult();
-            assertEquals(taskBeforeSubTask.getId(), childTask.getId());
+            assertThat(childTask.getId()).isEqualTo(taskBeforeSubTask.getId());
 
             cmmnTaskService.complete(taskBeforeSubTask.getId());
 
             Task taskInSubTask = cmmnTaskService.createTaskQuery().singleResult();
-            assertEquals("Sub task", taskInSubTask.getName());
+            assertThat(taskInSubTask.getName()).isEqualTo("Sub task");
             childTask = cmmnTaskService.createTaskQuery().caseInstanceIdWithChildren(caseInstance.getId()).singleResult();
-            assertEquals(taskInSubTask.getId(), childTask.getId());
+            assertThat(childTask.getId()).isEqualTo(taskInSubTask.getId());
 
-            List<HistoricTaskInstance> childTasks = cmmnHistoryService.createHistoricTaskInstanceQuery().caseInstanceIdWithChildren(caseInstance.getId()).list();
-            assertEquals(2, childTasks.size());
-            List<String> taskIds = new ArrayList<>();
-            for (HistoricTaskInstance task : childTasks) {
-                taskIds.add(task.getId());
-            }
-            assertTrue(taskIds.contains(taskBeforeSubTask.getId()));
-            assertTrue(taskIds.contains(taskInSubTask.getId()));
+            List<HistoricTaskInstance> childTasks = cmmnHistoryService.createHistoricTaskInstanceQuery().caseInstanceIdWithChildren(caseInstance.getId())
+                    .list();
+            assertThat(childTasks)
+                    .extracting(HistoricTaskInstance::getId)
+                    .containsExactlyInAnyOrder(taskBeforeSubTask.getId(), taskInSubTask.getId());
 
             cmmnTaskService.complete(taskInSubTask.getId());
 
             Task taskAfterSubTask = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
-            assertEquals("Task Two", taskAfterSubTask.getName());
+            assertThat(taskAfterSubTask.getName()).isEqualTo("Task Two");
             childTask = cmmnTaskService.createTaskQuery().caseInstanceIdWithChildren(caseInstance.getId()).singleResult();
-            assertEquals(taskAfterSubTask.getId(), childTask.getId());
+            assertThat(childTask.getId()).isEqualTo(taskAfterSubTask.getId());
 
             childTasks = cmmnHistoryService.createHistoricTaskInstanceQuery().caseInstanceIdWithChildren(caseInstance.getId()).list();
-            assertEquals(3, childTasks.size());
-            taskIds = new ArrayList<>();
-            for (HistoricTaskInstance task : childTasks) {
-                taskIds.add(task.getId());
-            }
-            assertTrue(taskIds.contains(taskBeforeSubTask.getId()));
-            assertTrue(taskIds.contains(taskInSubTask.getId()));
-            assertTrue(taskIds.contains(taskAfterSubTask.getId()));
+            assertThat(childTasks)
+                    .extracting(HistoricTaskInstance::getId)
+                    .containsExactlyInAnyOrder(taskBeforeSubTask.getId(), taskInSubTask.getId(), taskAfterSubTask.getId());
 
         } finally {
             cmmnRepositoryService.deleteDeployment(oneHumanTaskDeploymentId, true);
@@ -215,95 +196,95 @@ public class CaseTaskTest extends FlowableCmmnTestCase {
     }
 
     protected void assertBlockingCaseTaskFlow(CaseInstance caseInstance) {
-        assertNotNull(caseInstance);
-        assertEquals(1, cmmnRuntimeService.createCaseInstanceQuery().count());
-        assertEquals(0, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count());
+        assertThat(caseInstance).isNotNull();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(1);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isEqualTo(1);
 
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .singleResult();
-        assertNotNull(planItemInstance);
+        assertThat(planItemInstance).isNotNull();
 
         List<EntityLink> entityLinks = cmmnRuntimeService.getEntityLinkChildrenForCaseInstance(caseInstance.getId());
-        assertEquals(0, entityLinks.size());
+        assertThat(entityLinks).isEmpty();
 
         // Triggering the task should start the child case instance
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
-        assertEquals(2, cmmnRuntimeService.createCaseInstanceQuery().count());
-        assertEquals(0, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(2);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(0);
         List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .orderByName().asc()
                 .list();
-        assertEquals(2, planItemInstances.size());
-        assertEquals("The Case", planItemInstances.get(0).getName());
-        assertEquals("The Task", planItemInstances.get(1).getName());
-        assertEquals(planItemInstance.getTenantId(), planItemInstances.get(1).getTenantId());
+        assertThat(planItemInstances)
+                .extracting(PlanItemInstance::getName)
+                .containsExactly("The Case", "The Task");
+        assertThat(planItemInstances.get(1).getTenantId()).isEqualTo(planItemInstance.getTenantId());
 
         entityLinks = cmmnRuntimeService.getEntityLinkChildrenForCaseInstance(caseInstance.getId());
-        assertEquals(1, entityLinks.size());
+        assertThat(entityLinks).hasSize(1);
         EntityLink entityLink = entityLinks.get(0);
 
         checkEntityLink(entityLink, caseInstance, planItemInstances.get(1).getCaseInstanceId());
 
         List<EntityLink> entityLinkParentsForCaseInstance = cmmnRuntimeService.getEntityLinkParentsForCaseInstance(entityLink.getReferenceScopeId());
-        assertEquals(1, entityLinkParentsForCaseInstance.size());
+        assertThat(entityLinkParentsForCaseInstance).hasSize(1);
 
         checkEntityLink(entityLinkParentsForCaseInstance.get(0), caseInstance, planItemInstances.get(1).getCaseInstanceId());
 
         // Triggering the task from the child case instance should complete the child case instance
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(1).getId());
-        assertEquals(1, cmmnRuntimeService.createCaseInstanceQuery().count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(1);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isEqualTo(1);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
 
         planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .singleResult();
-        assertEquals("Task Two", planItemInstance.getName());
+        assertThat(planItemInstance.getName()).isEqualTo("Task Two");
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
 
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
-        assertEquals(0, cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count());
-        assertEquals(2, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(2);
 
         List<HistoricEntityLink> historicEntityLinks = cmmnHistoryService.getHistoricEntityLinkChildrenForCaseInstance(caseInstance.getId());
-        assertEquals(1, historicEntityLinks.size());
+        assertThat(historicEntityLinks).hasSize(1);
 
         checkHistoricEntityLink(historicEntityLinks.get(0), caseInstance, planItemInstances.get(1).getCaseInstanceId());
 
         List<HistoricEntityLink> historicEntityLinkParentForCaseInstance = cmmnHistoryService
-            .getHistoricEntityLinkParentsForCaseInstance(entityLink.getReferenceScopeId());
-        assertEquals(1, historicEntityLinkParentForCaseInstance.size());
+                .getHistoricEntityLinkParentsForCaseInstance(entityLink.getReferenceScopeId());
+        assertThat(historicEntityLinkParentForCaseInstance).hasSize(1);
 
         checkHistoricEntityLink(historicEntityLinkParentForCaseInstance.get(0), caseInstance, planItemInstances.get(1).getCaseInstanceId());
     }
 
     private void checkEntityLink(EntityLink entityLink, CaseInstance caseInstance, String referenceScopeId) {
-        assertEquals(EntityLinkType.CHILD, entityLink.getLinkType());
-        assertNotNull(entityLink.getCreateTime());
-        assertEquals(caseInstance.getId(), entityLink.getScopeId());
-        assertEquals(ScopeTypes.CMMN, entityLink.getScopeType());
-        assertNull(entityLink.getScopeDefinitionId());
-        assertEquals(referenceScopeId, entityLink.getReferenceScopeId());
-        assertEquals(ScopeTypes.CMMN, entityLink.getReferenceScopeType());
-        assertNull(entityLink.getReferenceScopeDefinitionId());
-        assertEquals(HierarchyType.ROOT, entityLink.getHierarchyType());
+        assertThat(entityLink.getLinkType()).isEqualTo(EntityLinkType.CHILD);
+        assertThat(entityLink.getCreateTime()).isNotNull();
+        assertThat(entityLink.getScopeId()).isEqualTo(caseInstance.getId());
+        assertThat(entityLink.getScopeType()).isEqualTo(ScopeTypes.CMMN);
+        assertThat(entityLink.getScopeDefinitionId()).isNull();
+        assertThat(entityLink.getReferenceScopeId()).isEqualTo(referenceScopeId);
+        assertThat(entityLink.getReferenceScopeType()).isEqualTo(ScopeTypes.CMMN);
+        assertThat(entityLink.getReferenceScopeDefinitionId()).isNull();
+        assertThat(entityLink.getHierarchyType()).isEqualTo(HierarchyType.ROOT);
     }
 
     private void checkHistoricEntityLink(HistoricEntityLink historicEntityLink, CaseInstance caseInstance, String referenceScopeId) {
-        assertEquals(EntityLinkType.CHILD, historicEntityLink.getLinkType());
-        assertNotNull(historicEntityLink.getCreateTime());
-        assertEquals(caseInstance.getId(), historicEntityLink.getScopeId());
-        assertEquals(ScopeTypes.CMMN, historicEntityLink.getScopeType());
-        assertNull(historicEntityLink.getScopeDefinitionId());
-        assertEquals(referenceScopeId, historicEntityLink.getReferenceScopeId());
-        assertEquals(ScopeTypes.CMMN, historicEntityLink.getReferenceScopeType());
-        assertNull(historicEntityLink.getReferenceScopeDefinitionId());
-        assertEquals(HierarchyType.ROOT, historicEntityLink.getHierarchyType());
+        assertThat(historicEntityLink.getLinkType()).isEqualTo(EntityLinkType.CHILD);
+        assertThat(historicEntityLink.getCreateTime()).isNotNull();
+        assertThat(historicEntityLink.getScopeId()).isEqualTo(caseInstance.getId());
+        assertThat(historicEntityLink.getScopeType()).isEqualTo(ScopeTypes.CMMN);
+        assertThat(historicEntityLink.getScopeDefinitionId()).isNull();
+        assertThat(historicEntityLink.getReferenceScopeId()).isEqualTo(referenceScopeId);
+        assertThat(historicEntityLink.getReferenceScopeType()).isEqualTo(ScopeTypes.CMMN);
+        assertThat(historicEntityLink.getReferenceScopeDefinitionId()).isNull();
+        assertThat(historicEntityLink.getHierarchyType()).isEqualTo(HierarchyType.ROOT);
     }
 
     // Same as testBasicBlocking(), but now with a non-blocking case task
@@ -311,159 +292,159 @@ public class CaseTaskTest extends FlowableCmmnTestCase {
     @CmmnDeployment
     public void testBasicNonBlocking() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("myCase").start();
-        assertNotNull(caseInstance);
-        assertEquals(1, cmmnRuntimeService.createCaseInstanceQuery().count());
-        assertEquals(0, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count());
+        assertThat(caseInstance).isNotNull();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(1);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isEqualTo(1);
 
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .singleResult();
-        assertNotNull(planItemInstance);
+        assertThat(planItemInstance).isNotNull();
 
         // Triggering the task should start the case instance (which is non-blocking -> directly go to task two)
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
 
-        assertEquals(2, cmmnRuntimeService.createCaseInstanceQuery().count());
-        assertEquals(0, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(2);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(0);
         List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .orderByName().asc()
                 .list();
-        assertEquals(2, planItemInstances.size());
-        assertEquals("Task Two", planItemInstances.get(0).getName());
-        assertEquals("The Task", planItemInstances.get(1).getName());
+        assertThat(planItemInstances)
+                .extracting(PlanItemInstance::getName)
+                .containsExactly("Task Two", "The Task");
 
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(0).getId());
-        assertEquals(1, cmmnRuntimeService.createCaseInstanceQuery().count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(1);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isEqualTo(1);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
 
         planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .singleResult();
-        assertEquals("The Task", planItemInstance.getName());
+        assertThat(planItemInstance.getName()).isEqualTo("The Task");
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
 
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
-        assertEquals(0, cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count());
-        assertEquals(2, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(2);
     }
 
     @Test
     @CmmnDeployment
     public void testRuntimeServiceTriggerCasePlanItemInstance() {
         cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("myCase").start();
-        assertEquals(2, cmmnRuntimeService.createCaseInstanceQuery().count());
-        assertEquals(0, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
-        assertEquals(2, cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(2);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isEqualTo(2);
 
         List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .orderByName().asc()
                 .list();
-        assertEquals(3, planItemInstances.size());
-        assertEquals("Task One", planItemInstances.get(0).getName());
-        assertEquals("The Case", planItemInstances.get(1).getName());
-        assertEquals("The Task", planItemInstances.get(2).getName());
+        assertThat(planItemInstances)
+                .extracting(PlanItemInstance::getName)
+                .containsExactly("Task One", "The Case", "The Task");
 
         // Triggering the planitem of the case should terminate the case and go to task two
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(1).getId());
 
-        assertEquals(1, cmmnRuntimeService.createCaseInstanceQuery().count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(1);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isEqualTo(1);
 
         planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .orderByName().asc()
                 .list();
-        assertEquals(2, planItemInstances.size());
-        assertEquals("Task One", planItemInstances.get(0).getName());
-        assertEquals("Task Two", planItemInstances.get(1).getName());
+        assertThat(planItemInstances)
+                .extracting(PlanItemInstance::getName)
+                .containsExactly("Task One", "Task Two");
     }
 
     @Test
     @CmmnDeployment
     public void testRuntimeServiceTriggerNonBlockingCasePlanItem() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("myCase").start();
-        assertEquals(2, cmmnRuntimeService.createCaseInstanceQuery().count());
-        assertEquals(0, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
-        assertEquals(2, cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(2);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isEqualTo(2);
 
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .orderByName().asc()
                 .singleResult();
-        assertEquals("Task One", planItemInstance.getName());
+        assertThat(planItemInstance.getName()).isEqualTo("Task One");
 
         // Triggering the task plan item completes the parent case, but the child case remains
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
-        assertEquals(1, cmmnRuntimeService.createCaseInstanceQuery().count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(1);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isEqualTo(1);
 
         planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .orderByName().asc()
                 .singleResult();
-        assertEquals("The Task", planItemInstance.getName());
+        assertThat(planItemInstance.getName()).isEqualTo("The Task");
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
-        assertEquals(2, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
-        assertEquals(0, cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(2);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isEqualTo(0);
     }
 
     @Test
     @CmmnDeployment
     public void testTerminateCaseInstanceWithNonBlockingCaseTask() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("myCase").start();
-        assertEquals(0, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
-        assertEquals(2, cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count());
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isEqualTo(2);
 
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .singleResult();
-        assertEquals("Task One", planItemInstance.getName());
+        assertThat(planItemInstance.getName()).isEqualTo("Task One");
 
         // Terminating the parent case instance should not terminate the child (it's non-blocking)
         cmmnRuntimeService.terminateCaseInstance(caseInstance.getId());
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isEqualTo(1);
 
         // Terminate child
         CaseInstance childCaseInstance = cmmnRuntimeService.createCaseInstanceQuery().caseInstanceParentId(caseInstance.getId()).singleResult();
-        assertNotNull(childCaseInstance);
-        HistoricCaseInstance historicChildCaseInstance = cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceParentId(caseInstance.getId()).singleResult();
-        assertNotNull(historicChildCaseInstance);
+        assertThat(childCaseInstance).isNotNull();
+        HistoricCaseInstance historicChildCaseInstance = cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceParentId(caseInstance.getId())
+                .singleResult();
+        assertThat(historicChildCaseInstance).isNotNull();
 
         cmmnRuntimeService.terminateCaseInstance(childCaseInstance.getId());
-        assertEquals(2, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
-        assertEquals(0, cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count());
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(2);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isEqualTo(0);
     }
 
     @Test
     @CmmnDeployment(resources = {
-        "org/flowable/cmmn/test/runtime/CaseTaskTest.terminateAvailableCaseTask.cmmn",
-        "org/flowable/cmmn/test/runtime/oneHumanTaskCase.cmmn"
+            "org/flowable/cmmn/test/runtime/CaseTaskTest.terminateAvailableCaseTask.cmmn",
+            "org/flowable/cmmn/test/runtime/oneHumanTaskCase.cmmn"
     })
     public void testTerminateAvailableCaseTask() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("terminateAvailableCaseTask").start();
 
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .planItemDefinitionType(PlanItemDefinitionType.CASE_TASK)
-            .planItemInstanceStateAvailable().singleResult();
-        assertEquals("myCase", planItemInstance.getName());
+                .caseInstanceId(caseInstance.getId())
+                .planItemDefinitionType(PlanItemDefinitionType.CASE_TASK)
+                .planItemInstanceStateAvailable().singleResult();
+        assertThat(planItemInstance.getName()).isEqualTo("myCase");
 
         // When the event listener now occurs, the stage should be exited, also exiting the case task plan item
         UserEventListenerInstance userEventListenerInstance = cmmnRuntimeService.createUserEventListenerInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .singleResult();
+                .caseInstanceId(caseInstance.getId())
+                .singleResult();
         cmmnRuntimeService.completeUserEventListenerInstance(userEventListenerInstance.getId());
 
         assertCaseInstanceEnded(caseInstance);
@@ -473,51 +454,51 @@ public class CaseTaskTest extends FlowableCmmnTestCase {
     @CmmnDeployment
     public void testTerminateCaseInstanceWithNestedCaseTasks() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("myCase").start();
-        assertEquals(0, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
-        assertEquals(4, cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count());
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isEqualTo(4);
 
         cmmnRuntimeService.terminateCaseInstance(caseInstance.getId());
-        assertEquals(4, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
-        assertEquals(0, cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count());
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(4);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isEqualTo(0);
 
     }
 
     @Test
     @CmmnDeployment
     public void testFallbackToDefaultTenant() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("myCase").
-            tenantId("flowable").
-            overrideCaseDefinitionTenantId("flowable").
-            fallbackToDefaultTenant().
-            start();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("myCase")
+                .tenantId("flowable")
+                .overrideCaseDefinitionTenantId("flowable")
+                .fallbackToDefaultTenant()
+                .start();
 
         assertBlockingCaseTaskFlow(caseInstance);
-        assertEquals("flowable", caseInstance.getTenantId());
+        assertThat(caseInstance.getTenantId()).isEqualTo("flowable");
     }
 
     @Test
-    @CmmnDeployment(resources="org/flowable/cmmn/test/runtime/CaseTaskTest.testGlobalFallbackToDefaultTenant.cmmn", tenantId="defaultFlowable")
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/runtime/CaseTaskTest.testGlobalFallbackToDefaultTenant.cmmn", tenantId = "defaultFlowable")
     public void testGlobalFallbackToDefaultTenant() {
         String tenantDeploymentId = cmmnRepositoryService.createDeployment()
-                        .addClasspathResource("org/flowable/cmmn/test/runtime/oneTaskCase.cmmn")
-                        .tenantId("defaultFlowable")
-                        .deploy()
-                        .getId();
+                .addClasspathResource("org/flowable/cmmn/test/runtime/oneTaskCase.cmmn")
+                .tenantId("defaultFlowable")
+                .deploy()
+                .getId();
 
         DefaultTenantProvider originalDefaultTenantProvider = cmmnEngineConfiguration.getDefaultTenantProvider();
         cmmnEngineConfiguration.setFallbackToDefaultTenant(true);
         cmmnEngineConfiguration.setDefaultTenantValue("defaultFlowable");
         try {
-            CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-                caseDefinitionKey("myCase").
-                tenantId("flowable").
-                overrideCaseDefinitionTenantId("flowable").
-                fallbackToDefaultTenant().
-                start();
+            CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                    .caseDefinitionKey("myCase")
+                    .tenantId("flowable")
+                    .overrideCaseDefinitionTenantId("flowable")
+                    .fallbackToDefaultTenant()
+                    .start();
 
             assertBlockingCaseTaskFlow(caseInstance);
-            assertEquals("flowable", caseInstance.getTenantId());
+            assertThat(caseInstance.getTenantId()).isEqualTo("flowable");
 
         } finally {
             cmmnEngineConfiguration.setFallbackToDefaultTenant(false);
@@ -527,22 +508,20 @@ public class CaseTaskTest extends FlowableCmmnTestCase {
     }
 
     @Test
-    @CmmnDeployment(resources="org/flowable/cmmn/test/runtime/CaseTaskTest.testGlobalFallbackToDefaultTenant.cmmn", tenantId="defaultFlowable")
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/runtime/CaseTaskTest.testGlobalFallbackToDefaultTenant.cmmn", tenantId = "defaultFlowable")
     public void testGlobalFallbackToDefaultTenantNoDefinition() {
         DefaultTenantProvider originalDefaultTenantProvider = cmmnEngineConfiguration.getDefaultTenantProvider();
         cmmnEngineConfiguration.setFallbackToDefaultTenant(true);
         cmmnEngineConfiguration.setDefaultTenantValue("defaultFlowable");
         try {
-            CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-                caseDefinitionKey("myCase").
-                tenantId("flowable").
-                overrideCaseDefinitionTenantId("flowable").
-                fallbackToDefaultTenant().
-                start();
-
-            this.expectedException.expect(FlowableObjectNotFoundException.class);
-            assertBlockingCaseTaskFlow(caseInstance);
-
+            CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                    .caseDefinitionKey("myCase")
+                    .tenantId("flowable")
+                    .overrideCaseDefinitionTenantId("flowable")
+                    .fallbackToDefaultTenant()
+                    .start();
+            assertThatThrownBy(() -> assertBlockingCaseTaskFlow(caseInstance))
+                    .isInstanceOf(FlowableObjectNotFoundException.class);
         } finally {
             cmmnEngineConfiguration.setFallbackToDefaultTenant(false);
             cmmnEngineConfiguration.setDefaultTenantProvider(originalDefaultTenantProvider);
@@ -552,16 +531,15 @@ public class CaseTaskTest extends FlowableCmmnTestCase {
     @Test
     @CmmnDeployment
     public void testFallbackToDefaultTenantFalse() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("myCase").
-            tenantId("flowable").
-            overrideCaseDefinitionTenantId("flowable").
-            fallbackToDefaultTenant().
-            start();
-
-        this.expectedException.expect(FlowableObjectNotFoundException.class);
-        this.expectedException.expectMessage("Case definition was not found by key 'oneTaskCase' and tenant 'flowable'");
-        assertBlockingCaseTaskFlow(caseInstance);
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("myCase")
+                .tenantId("flowable")
+                .overrideCaseDefinitionTenantId("flowable")
+                .fallbackToDefaultTenant()
+                .start();
+        assertThatThrownBy(() -> assertBlockingCaseTaskFlow(caseInstance))
+                .isInstanceOf(FlowableObjectNotFoundException.class)
+                .hasMessage("Case definition was not found by key 'oneTaskCase' and tenant 'flowable'");
     }
 
     @Test
@@ -708,7 +686,7 @@ public class CaseTaskTest extends FlowableCmmnTestCase {
     }
 
     @Test
-    @CmmnDeployment(resources={
+    @CmmnDeployment(resources = {
             "org/flowable/cmmn/test/runtime/CaseTaskTest.testSameDeploymentGlobal.cmmn",
             "org/flowable/cmmn/test/runtime/oneTaskCase.cmmn"
     })
@@ -846,24 +824,24 @@ public class CaseTaskTest extends FlowableCmmnTestCase {
     @Test
     public void testEntityLinksAreDeleted() {
         String deploymentId = cmmnRepositoryService.createDeployment()
-            .addClasspathResource("org/flowable/cmmn/test/runtime/oneHumanTaskCase.cmmn").deploy().getId();
+                .addClasspathResource("org/flowable/cmmn/test/runtime/oneHumanTaskCase.cmmn").deploy().getId();
 
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("oneHumanTaskCase").start();
         try {
             Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
-            assertEquals("Sub task", task.getName());
+            assertThat(task.getName()).isEqualTo("Sub task");
 
-            assertEquals(1, cmmnRuntimeService.getEntityLinkChildrenForCaseInstance(caseInstance.getId()).size());
-            assertEquals(1, cmmnHistoryService.getHistoricEntityLinkChildrenForCaseInstance(caseInstance.getId()).size());
+            assertThat(cmmnRuntimeService.getEntityLinkChildrenForCaseInstance(caseInstance.getId())).hasSize(1);
+            assertThat(cmmnHistoryService.getHistoricEntityLinkChildrenForCaseInstance(caseInstance.getId())).hasSize(1);
 
             cmmnTaskService.complete(task.getId());
 
-            assertEquals(1, cmmnHistoryService.getHistoricEntityLinkChildrenForCaseInstance(caseInstance.getId()).size());
+            assertThat(cmmnHistoryService.getHistoricEntityLinkChildrenForCaseInstance(caseInstance.getId())).hasSize(1);
         } finally {
             cmmnRepositoryService.deleteDeployment(deploymentId, true);
         }
 
-        assertEquals(0, cmmnHistoryService.getHistoricEntityLinkChildrenForCaseInstance(caseInstance.getId()).size());
+        assertThat(cmmnHistoryService.getHistoricEntityLinkChildrenForCaseInstance(caseInstance.getId())).isEmpty();
     }
 
     @Test
@@ -1002,29 +980,29 @@ public class CaseTaskTest extends FlowableCmmnTestCase {
     @CmmnDeployment
     public void testIdVariableName() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("testIdVariableName")
-            .start();
+                .caseDefinitionKey("testIdVariableName")
+                .start();
 
         CaseInstance subCase = cmmnRuntimeService.createCaseInstanceQuery()
-            .caseDefinitionKey("oneTaskCase")
-            .singleResult();
+                .caseDefinitionKey("oneTaskCase")
+                .singleResult();
 
-        assertEquals(subCase.getId(), cmmnRuntimeService.getVariable(caseInstance.getId(), "caseIdVariable"));
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "caseIdVariable")).isEqualTo(subCase.getId());
     }
 
     @Test
     @CmmnDeployment
     public void testIdVariableNameExpression() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("testIdVariableName")
-            .variable("idVariableName", "test")
-            .start();
+                .caseDefinitionKey("testIdVariableName")
+                .variable("idVariableName", "test")
+                .start();
 
         CaseInstance subCase = cmmnRuntimeService.createCaseInstanceQuery()
-            .caseDefinitionKey("oneTaskCase")
-            .singleResult();
+                .caseDefinitionKey("oneTaskCase")
+                .singleResult();
 
-        assertEquals(subCase.getId(), cmmnRuntimeService.getVariable(caseInstance.getId(), "test"));
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "test")).isEqualTo(subCase.getId());
     }
 
 }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CmmnRuntimeServiceTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CmmnRuntimeServiceTest.java
@@ -12,11 +12,8 @@
  */
 package org.flowable.cmmn.test.runtime;
 
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.flowable.cmmn.api.CallbackTypes;
 import org.flowable.cmmn.api.runtime.CaseInstance;
@@ -27,182 +24,170 @@ import org.flowable.cmmn.engine.test.impl.CmmnJobTestHelper;
 import org.flowable.common.engine.api.FlowableIllegalArgumentException;
 import org.flowable.common.engine.api.FlowableObjectNotFoundException;
 import org.flowable.common.engine.impl.DefaultTenantProvider;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 /**
  * This class tests {@link CmmnRuntimeServiceImpl} implementation
  */
 public class CmmnRuntimeServiceTest extends FlowableCmmnTestCase {
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
     @Test
     @CmmnDeployment(resources = "org/flowable/cmmn/test/runtime/oneTaskCase.cmmn")
     public void createCaseInstanceWithCallBacks() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            callbackId("testCallBackId").
-            callbackType(CallbackTypes.CASE_ADHOC_CHILD).
-            start();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .callbackId("testCallBackId")
+                .callbackType(CallbackTypes.CASE_ADHOC_CHILD)
+                .start();
 
         // in fact it must be possible to set any callbackType and Id
-        assertThat(caseInstance.getCallbackType(), is(CallbackTypes.CASE_ADHOC_CHILD));
-        assertThat(caseInstance.getCallbackId(), is("testCallBackId"));
+        assertThat(caseInstance.getCallbackType()).isEqualTo(CallbackTypes.CASE_ADHOC_CHILD);
+        assertThat(caseInstance.getCallbackId()).isEqualTo("testCallBackId");
     }
 
     @Test
     @CmmnDeployment(resources = "org/flowable/cmmn/test/runtime/oneTaskCase.cmmn")
     public void createCaseInstanceWithoutCallBacks() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            start();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .start();
 
         // default values for callbacks are null
-        assertThat(caseInstance.getCallbackType(), nullValue());
-        assertThat(caseInstance.getCallbackId(), nullValue());
+        assertThat(caseInstance.getCallbackType()).isNull();
+        assertThat(caseInstance.getCallbackId()).isNull();
     }
 
     @Test
     @CmmnDeployment(resources = "org/flowable/cmmn/test/runtime/oneTaskCase.cmmn")
     public void updateCaseName() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            start();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .start();
 
         // default name is empty
-        assertThat(caseInstance.getName(), nullValue());
+        assertThat(caseInstance.getName()).isNull();
 
         cmmnRuntimeService.setCaseInstanceName(caseInstance.getId(), "My case name");
 
         caseInstance = cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult();
-        assertEquals("My case name", caseInstance.getName());
+        assertThat(caseInstance.getName()).isEqualTo("My case name");
     }
 
     @Test
     @CmmnDeployment(resources = "org/flowable/cmmn/test/runtime/oneTaskCase.cmmn")
     public void updateBusinessKey() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            start();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .start();
 
         // default business key is empty
-        assertThat(caseInstance.getName(), nullValue());
+        assertThat(caseInstance.getName()).isNull();
 
         cmmnRuntimeService.updateBusinessKey(caseInstance.getId(), "bzKey");
 
         caseInstance = cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult();
-        assertEquals("bzKey", caseInstance.getBusinessKey());
+        assertThat(caseInstance.getBusinessKey()).isEqualTo("bzKey");
     }
 
     @Test
     @CmmnDeployment(resources = "org/flowable/cmmn/test/runtime/oneTaskCase.cmmn")
     public void updateCaseNameSetEmpty() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            start();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .start();
 
         // default name is empty
-        assertThat(caseInstance.getName(), nullValue());
+        assertThat(caseInstance.getName()).isNull();
 
         cmmnRuntimeService.setCaseInstanceName(caseInstance.getId(), "My case name");
 
         caseInstance = cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult();
-        assertEquals("My case name", caseInstance.getName());
+        assertThat(caseInstance.getName()).isEqualTo("My case name");
 
         cmmnRuntimeService.setCaseInstanceName(caseInstance.getId(), null);
 
         caseInstance = cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult();
-        assertThat(caseInstance.getName(), nullValue());
+        assertThat(caseInstance.getName()).isNull();
     }
 
     @Test
     @CmmnDeployment(resources = "org/flowable/cmmn/test/runtime/oneTaskCase.cmmn")
     public void createCaseInstanceAsync() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            startAsync();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .startAsync();
 
-        assertThat(caseInstance, is(notNullValue()));
-        assertThat("Plan items are created asynchronously", this.cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count(), is(0l));
+        assertThat(caseInstance).isNotNull();
+        assertThat(this.cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count())
+                .as("Plan items are created asynchronously").isEqualTo(0l);
 
         CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 7000L, 200, true);
-        assertThat(this.cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count(), is(1l));
+        assertThat(this.cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1l);
     }
 
     @Test
     public void createCaseInstanceAsyncWithoutDef() {
-        expectedException.expect(FlowableIllegalArgumentException.class);
-        expectedException.expectMessage("caseDefinitionKey and caseDefinitionId are null");
-
-        cmmnRuntimeService.createCaseInstanceBuilder().
-            startAsync();
+        assertThatThrownBy(() -> cmmnRuntimeService.createCaseInstanceBuilder().startAsync())
+                .isInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage("caseDefinitionKey and caseDefinitionId are null");
     }
 
     @Test
     public void createCaseInstanceAsyncWithNonExistingDefKey() {
-        expectedException.expect(FlowableObjectNotFoundException.class);
-        expectedException.expectMessage("No case definition found for key nonExistingDefinition");
-
-        cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("nonExistingDefinition").
-            startAsync();
+        assertThatThrownBy(() -> cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("nonExistingDefinition").startAsync())
+                .isInstanceOf(FlowableObjectNotFoundException.class)
+                .hasMessage("No case definition found for key nonExistingDefinition");
     }
 
     @Test
     public void createCaseInstanceAsyncWithNonExistingDefId() {
-        expectedException.expect(FlowableObjectNotFoundException.class);
-        expectedException.expectMessage("No case definition found for id nonExistingDefinition");
-
-        cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionId("nonExistingDefinition").
-            startAsync();
+        assertThatThrownBy(() -> cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionId("nonExistingDefinition").startAsync())
+                .isInstanceOf(FlowableObjectNotFoundException.class)
+                .hasMessage("No case definition found for id nonExistingDefinition");
     }
 
     @Test
     @CmmnDeployment(resources = "org/flowable/cmmn/test/runtime/oneTaskCase.cmmn")
     public void createCaseInstanceWithFallback() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            tenantId("flowable").
-            overrideCaseDefinitionTenantId("flowable").
-            fallbackToDefaultTenant().
-            start();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .tenantId("flowable")
+                .overrideCaseDefinitionTenantId("flowable")
+                .fallbackToDefaultTenant()
+                .start();
 
-        assertThat(caseInstance, is(notNullValue()));
-        assertThat(caseInstance.getTenantId(), is("flowable"));
+        assertThat(caseInstance).isNotNull();
+        assertThat(caseInstance.getTenantId()).isEqualTo("flowable");
     }
-    
+
     @Test
-    @CmmnDeployment(resources = "org/flowable/cmmn/test/runtime/oneTaskCase.cmmn", tenantId="defaultFlowable")
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/runtime/oneTaskCase.cmmn", tenantId = "defaultFlowable")
     public void createCaseInstanceWithFallbackAndOverrideTenantId() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            tenantId("defaultFlowable").
-            overrideCaseDefinitionTenantId("someTenant").
-            start();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .tenantId("defaultFlowable")
+                .overrideCaseDefinitionTenantId("someTenant")
+                .start();
 
-        assertThat(caseInstance, is(notNullValue()));
-        assertThat(caseInstance.getTenantId(), is("someTenant"));
+        assertThat(caseInstance).isNotNull();
+        assertThat(caseInstance.getTenantId()).isEqualTo("someTenant");
     }
-    
+
     @Test
-    @CmmnDeployment(resources = "org/flowable/cmmn/test/runtime/oneTaskCase.cmmn", tenantId="defaultFlowable")
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/runtime/oneTaskCase.cmmn", tenantId = "defaultFlowable")
     public void createCaseInstanceWithGlobalFallbackAndDefaultTenantValue() {
         DefaultTenantProvider originalDefaultTenantProvider = cmmnEngineConfiguration.getDefaultTenantProvider();
         cmmnEngineConfiguration.setFallbackToDefaultTenant(true);
         cmmnEngineConfiguration.setDefaultTenantValue("defaultFlowable");
         try {
-            CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-                caseDefinitionKey("oneTaskCase").
-                tenantId("someTenant").
-                start();
-    
-            assertThat(caseInstance, is(notNullValue()));
-            assertThat(caseInstance.getTenantId(), is("someTenant"));
-            
+            CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                    .caseDefinitionKey("oneTaskCase")
+                    .tenantId("someTenant")
+                    .start();
+
+            assertThat(caseInstance).isNotNull();
+            assertThat(caseInstance.getTenantId()).isEqualTo("someTenant");
+
         } finally {
             cmmnEngineConfiguration.setFallbackToDefaultTenant(false);
             cmmnEngineConfiguration.setDefaultTenantProvider(originalDefaultTenantProvider);
@@ -211,59 +196,54 @@ public class CmmnRuntimeServiceTest extends FlowableCmmnTestCase {
 
     @Test
     public void createCaseInstanceWithFallbackDefinitionNotFound() {
-        this.expectedException.expect(FlowableObjectNotFoundException.class);
-        this.expectedException.expectMessage("Case definition was not found by key 'oneTaskCase'. Fallback to default tenant was also used.");
-
-        cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            tenantId("flowable").
-            fallbackToDefaultTenant().
-            start();
+        assertThatThrownBy(() -> cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .tenantId("flowable")
+                .fallbackToDefaultTenant()
+                .start())
+                .isInstanceOf(FlowableObjectNotFoundException.class)
+                .hasMessage("Case definition was not found by key 'oneTaskCase'. Fallback to default tenant was also used.");
     }
-    
+
     @Test
-    @CmmnDeployment(resources = "org/flowable/cmmn/test/runtime/oneTaskCase.cmmn", tenantId="tenant1")
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/runtime/oneTaskCase.cmmn", tenantId = "tenant1")
     public void createCaseInstanceWithGlobalFallbackDefinitionNotFound() {
         DefaultTenantProvider originalDefaultTenantProvider = cmmnEngineConfiguration.getDefaultTenantProvider();
         cmmnEngineConfiguration.setFallbackToDefaultTenant(true);
         cmmnEngineConfiguration.setDefaultTenantValue("defaultFlowable");
-        
-        this.expectedException.expect(FlowableObjectNotFoundException.class);
-        
-        try {
-            cmmnRuntimeService.createCaseInstanceBuilder().
-                caseDefinitionKey("oneTaskCase").
-                tenantId("someTenant").
-                start();
-            
-        } finally {
-            cmmnEngineConfiguration.setFallbackToDefaultTenant(false);
-            cmmnEngineConfiguration.setDefaultTenantProvider(originalDefaultTenantProvider);
-        }
+
+        assertThatThrownBy(() -> cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .tenantId("someTenant")
+                .start())
+                .isInstanceOf(FlowableObjectNotFoundException.class)
+                .hasMessage("Case definition was not found by key 'oneTaskCase'. Fallback to default tenant was also used.");
+
+        cmmnEngineConfiguration.setFallbackToDefaultTenant(false);
+        cmmnEngineConfiguration.setDefaultTenantProvider(originalDefaultTenantProvider);
     }
 
     @Test
     @CmmnDeployment(resources = "org/flowable/cmmn/test/runtime/oneTaskCase.cmmn")
     public void createCaseInstanceAsyncWithFallback() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            tenantId("flowable").
-            fallbackToDefaultTenant().
-            startAsync();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .tenantId("flowable")
+                .fallbackToDefaultTenant()
+                .startAsync();
 
-        assertThat(caseInstance, is(notNullValue()));
+        assertThat(caseInstance).isNotNull();
     }
 
     @Test
     public void createCaseInstanceAsyncWithFallbackDefinitionNotFound() {
-        this.expectedException.expect(FlowableObjectNotFoundException.class);
-        this.expectedException.expectMessage("Case definition was not found by key 'oneTaskCase'. Fallback to default tenant was also used.");
-
-        cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCase").
-            tenantId("flowable").
-            fallbackToDefaultTenant().
-            startAsync();
+        assertThatThrownBy(() -> cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .tenantId("flowable")
+                .fallbackToDefaultTenant()
+                .startAsync())
+                .isInstanceOf(FlowableObjectNotFoundException.class)
+                .hasMessage("Case definition was not found by key 'oneTaskCase'. Fallback to default tenant was also used.");
     }
 
 }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/ExitSentryConditionWithSentryCombinationTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/ExitSentryConditionWithSentryCombinationTest.java
@@ -12,9 +12,9 @@
  */
 package org.flowable.cmmn.test.runtime;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.ACTIVE;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.AVAILABLE;
-import static org.junit.Assert.assertEquals;
 
 import java.util.List;
 
@@ -37,7 +37,7 @@ public class ExitSentryConditionWithSentryCombinationTest extends FlowableCmmnTe
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testSentry-test").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "stage 1", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "start", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "fireMe1", AVAILABLE);
@@ -45,7 +45,7 @@ public class ExitSentryConditionWithSentryCombinationTest extends FlowableCmmnTe
 
         cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "start", AVAILABLE));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(5, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(5);
         assertPlanItemInstanceState(planItemInstances, "stage 1", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "fireMe1", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Complete Stage 1", AVAILABLE);
@@ -56,7 +56,7 @@ public class ExitSentryConditionWithSentryCombinationTest extends FlowableCmmnTe
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
         // the Milestone becomes orphaned as it can never be activated anymore as stage 1 is terminated
-        assertEquals(1, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(1);
         assertPlanItemInstanceState(planItemInstances, "Milestone", AVAILABLE);
     }
 }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/GenericEventListenerTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/GenericEventListenerTest.java
@@ -13,9 +13,6 @@
 package org.flowable.cmmn.test.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 
 import java.util.Comparator;
 import java.util.List;
@@ -46,56 +43,70 @@ public class GenericEventListenerTest extends FlowableCmmnTestCase {
     public void testSimpleEnableTask() {
         //Simple use of the UserEventListener as EntryCriteria of a Task
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey(name.getMethodName()).start();
-        assertNotNull(caseInstance);
-        assertEquals(1, cmmnRuntimeService.createCaseInstanceQuery().count());
+        assertThat(caseInstance).isNotNull();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(1);
 
         //3 PlanItems reachable
-        assertEquals(3, cmmnRuntimeService.createPlanItemInstanceQuery().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(3);
 
         //1 User Event Listener
-        PlanItemInstance listenerInstance = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.GENERIC_EVENT_LISTENER).singleResult();
-        assertNotNull(listenerInstance);
-        assertEquals("eventListener", listenerInstance.getPlanItemDefinitionId());
-        assertEquals(PlanItemInstanceState.AVAILABLE, listenerInstance.getState());
-        
+        PlanItemInstance listenerInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
+                .planItemDefinitionType(PlanItemDefinitionType.GENERIC_EVENT_LISTENER).singleResult();
+        assertThat(listenerInstance).isNotNull();
+        assertThat(listenerInstance.getPlanItemDefinitionId()).isEqualTo("eventListener");
+        assertThat(listenerInstance.getState()).isEqualTo(PlanItemInstanceState.AVAILABLE);
+
         // Verify same result is returned from query
-        GenericEventListenerInstance eventListenerInstance = cmmnRuntimeService.createGenericEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult();
-        assertNotNull(eventListenerInstance);
-        assertEquals(eventListenerInstance.getId(), listenerInstance.getId());
-        assertEquals(eventListenerInstance.getCaseDefinitionId(), listenerInstance.getCaseDefinitionId());
-        assertEquals(eventListenerInstance.getCaseInstanceId(), listenerInstance.getCaseInstanceId());
-        assertEquals(eventListenerInstance.getElementId(), listenerInstance.getElementId());
-        assertEquals(eventListenerInstance.getName(), listenerInstance.getName());
-        assertEquals(eventListenerInstance.getPlanItemDefinitionId(), listenerInstance.getPlanItemDefinitionId());
-        assertEquals(eventListenerInstance.getStageInstanceId(), listenerInstance.getStageInstanceId());
-        assertEquals(eventListenerInstance.getState(), listenerInstance.getState());
-        
-        assertEquals(1, cmmnRuntimeService.createGenericEventListenerInstanceQuery().count());
-        assertEquals(1, cmmnRuntimeService.createGenericEventListenerInstanceQuery().list().size());
-        
-        assertNotNull(cmmnRuntimeService.createGenericEventListenerInstanceQuery().caseDefinitionId(listenerInstance.getCaseDefinitionId()).singleResult());
-        assertNotNull(cmmnRuntimeService.createGenericEventListenerInstanceQuery().caseDefinitionId(listenerInstance.getCaseDefinitionId()).singleResult());
+        GenericEventListenerInstance eventListenerInstance = cmmnRuntimeService.createGenericEventListenerInstanceQuery().caseInstanceId(caseInstance.getId())
+                .singleResult();
+        assertThat(eventListenerInstance).isNotNull();
+        assertThat(listenerInstance.getId()).isEqualTo(eventListenerInstance.getId());
+        assertThat(listenerInstance.getCaseDefinitionId()).isEqualTo(eventListenerInstance.getCaseDefinitionId());
+        assertThat(listenerInstance.getCaseInstanceId()).isEqualTo(eventListenerInstance.getCaseInstanceId());
+        assertThat(listenerInstance.getElementId()).isEqualTo(eventListenerInstance.getElementId());
+        assertThat(listenerInstance.getName()).isEqualTo(eventListenerInstance.getName());
+        assertThat(listenerInstance.getPlanItemDefinitionId()).isEqualTo(eventListenerInstance.getPlanItemDefinitionId());
+        assertThat(listenerInstance.getStageInstanceId()).isEqualTo(eventListenerInstance.getStageInstanceId());
+        assertThat(listenerInstance.getState()).isEqualTo(eventListenerInstance.getState());
+
+        assertThat(cmmnRuntimeService.createGenericEventListenerInstanceQuery().count()).isEqualTo(1);
+        assertThat(cmmnRuntimeService.createGenericEventListenerInstanceQuery().list()).hasSize(1);
+
+        assertThat(cmmnRuntimeService.createGenericEventListenerInstanceQuery().caseDefinitionId(listenerInstance.getCaseDefinitionId()).singleResult())
+                .isNotNull();
+        assertThat(cmmnRuntimeService.createGenericEventListenerInstanceQuery().caseDefinitionId(listenerInstance.getCaseDefinitionId()).singleResult())
+                .isNotNull();
 
         //2 HumanTasks ... one active and other waiting (available)
-        assertEquals(2, cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK).count());
-        PlanItemInstance active = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK).planItemInstanceStateActive().singleResult();
-        assertNotNull(active);
-        assertEquals("taskA", active.getPlanItemDefinitionId());
-        PlanItemInstance available = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK).planItemInstanceStateAvailable().singleResult();
-        assertNotNull(available);
-        assertEquals("taskB", available.getPlanItemDefinitionId());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK).count()).isEqualTo(2);
+        PlanItemInstance active = cmmnRuntimeService.createPlanItemInstanceQuery()
+                .planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK)
+                .planItemInstanceStateActive()
+                .singleResult();
+        assertThat(active).isNotNull();
+        assertThat(active.getPlanItemDefinitionId()).isEqualTo("taskA");
+        PlanItemInstance available = cmmnRuntimeService.createPlanItemInstanceQuery()
+                .planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK)
+                .planItemInstanceStateAvailable()
+                .singleResult();
+        assertThat(available).isNotNull();
+        assertThat(available.getPlanItemDefinitionId()).isEqualTo("taskB");
 
         //Trigger the listener
         cmmnRuntimeService.completeGenericEventListenerInstance(listenerInstance.getId());
 
         //UserEventListener should be completed
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.GENERIC_EVENT_LISTENER).count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.GENERIC_EVENT_LISTENER).count()).isEqualTo(0);
 
         //Only 2 PlanItems left
-        assertEquals(2, cmmnRuntimeService.createPlanItemInstanceQuery().list().size());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().list()).hasSize(2);
 
         //Both Human task should be "active" now, as the sentry kicks on the UserEventListener transition
-        assertEquals(2, cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK).planItemInstanceStateActive().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery()
+                .planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK)
+                .planItemInstanceStateActive()
+                .count())
+                .isEqualTo(2);
 
         //Finish the caseInstance
         assertCaseInstanceNotEnded(caseInstance);
@@ -108,38 +119,41 @@ public class GenericEventListenerTest extends FlowableCmmnTestCase {
     public void testTerminateTask() {
         //Test case where the EventListener is used to complete (ExitCriteria) of a task
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey(name.getMethodName()).start();
-        assertNotNull(caseInstance);
-        assertEquals(1, cmmnRuntimeService.createCaseInstanceQuery().count());
+        assertThat(caseInstance).isNotNull();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(1);
 
         //4 PlanItems reachable
-        assertEquals(4, cmmnRuntimeService.createPlanItemInstanceQuery().list().size());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().list()).hasSize(4);
 
         //1 Stage
-        assertEquals(1, cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.STAGE).count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.STAGE).count()).isEqualTo(1);
 
         //1 Event Listener
-        PlanItemInstance listenerInstance = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.GENERIC_EVENT_LISTENER).singleResult();
-        assertNotNull(listenerInstance);
-        assertEquals("eventListener", listenerInstance.getPlanItemDefinitionId());
-        assertEquals("eventListenerPlanItem", listenerInstance.getElementId());
-        assertEquals(PlanItemInstanceState.AVAILABLE, listenerInstance.getState());
+        PlanItemInstance listenerInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
+                .planItemDefinitionType(PlanItemDefinitionType.GENERIC_EVENT_LISTENER).singleResult();
+        assertThat(listenerInstance).isNotNull();
+        assertThat(listenerInstance.getPlanItemDefinitionId()).isEqualTo("eventListener");
+        assertThat(listenerInstance.getElementId()).isEqualTo("eventListenerPlanItem");
+        assertThat(listenerInstance.getState()).isEqualTo(PlanItemInstanceState.AVAILABLE);
 
         //2 Tasks on Active state
         List<PlanItemInstance> tasks = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType("task").list();
-        assertEquals(2, tasks.size());
-        tasks.forEach(t -> assertEquals(PlanItemInstanceState.ACTIVE, t.getState()));
+        assertThat(tasks)
+                .extracting(PlanItemInstance::getState)
+                .containsExactly(PlanItemInstanceState.ACTIVE, PlanItemInstanceState.ACTIVE);
 
         //Trigger the listener
         cmmnRuntimeService.triggerPlanItemInstance(listenerInstance.getId());
 
         //UserEventListener should be completed
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER).count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER).count()).isEqualTo(0);
 
         //Only 2 PlanItems left (1 stage & 1 active task)
-        assertEquals(2, cmmnRuntimeService.createPlanItemInstanceQuery().list().size());
-        PlanItemInstance activeTask = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType("task").planItemInstanceStateActive().singleResult();
-        assertNotNull(activeTask);
-        assertEquals("taskB", activeTask.getPlanItemDefinitionId());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().list()).hasSize(2);
+        PlanItemInstance activeTask = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType("task").planItemInstanceStateActive()
+                .singleResult();
+        assertThat(activeTask).isNotNull();
+        assertThat(activeTask.getPlanItemDefinitionId()).isEqualTo("taskB");
 
         //Finish the caseInstance
         assertCaseInstanceNotEnded(caseInstance);
@@ -152,27 +166,28 @@ public class GenericEventListenerTest extends FlowableCmmnTestCase {
     public void testTerminateStage() {
         //Test case where the GenericEventListener is used to complete (ExitCriteria) of a Stage
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey(name.getMethodName()).start();
-        assertNotNull(caseInstance);
-        assertEquals(1, cmmnRuntimeService.createCaseInstanceQuery().count());
+        assertThat(caseInstance).isNotNull();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(1);
 
         //3 PlanItems reachable
-        assertEquals(3, cmmnRuntimeService.createPlanItemInstanceQuery().list().size());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().list()).hasSize(3);
 
         //1 Stage
         PlanItemInstance stage = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.STAGE).singleResult();
-        assertNotNull(stage);
+        assertThat(stage).isNotNull();
 
         //1 User Event Listener
-        PlanItemInstance listenerInstance = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.GENERIC_EVENT_LISTENER).singleResult();
-        assertNotNull(listenerInstance);
-        assertEquals("eventListener", listenerInstance.getPlanItemDefinitionId());
-        assertEquals(PlanItemInstanceState.AVAILABLE, listenerInstance.getState());
+        PlanItemInstance listenerInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
+                .planItemDefinitionType(PlanItemDefinitionType.GENERIC_EVENT_LISTENER).singleResult();
+        assertThat(listenerInstance).isNotNull();
+        assertThat(listenerInstance.getPlanItemDefinitionId()).isEqualTo("eventListener");
+        assertThat(listenerInstance.getState()).isEqualTo(PlanItemInstanceState.AVAILABLE);
 
         //1 Tasks on Active state
         PlanItemInstance task = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType("task").singleResult();
-        assertNotNull(task);
-        assertEquals(PlanItemInstanceState.ACTIVE, task.getState());
-        assertEquals(stage.getId(), task.getStageInstanceId());
+        assertThat(task).isNotNull();
+        assertThat(task.getState()).isEqualTo(PlanItemInstanceState.ACTIVE);
+        assertThat(task.getStageInstanceId()).isEqualTo(stage.getId());
 
         //Trigger the listener
         assertCaseInstanceNotEnded(caseInstance);
@@ -187,37 +202,39 @@ public class GenericEventListenerTest extends FlowableCmmnTestCase {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
                 .caseDefinitionKey(name.getMethodName())
                 .start();
-        assertNotNull(caseInstance);
-        assertEquals(1, cmmnRuntimeService.createCaseInstanceQuery().count());
+        assertThat(caseInstance).isNotNull();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(1);
 
         //All planItemInstances
-        assertEquals(8, cmmnRuntimeService.createPlanItemInstanceQuery().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(8);
 
-        //UserEventListenerIntances
-        assertEquals(6, cmmnRuntimeService.createGenericEventListenerInstanceQuery().stateAvailable().count());
+        //UserEventListenerInstances
+        assertThat(cmmnRuntimeService.createGenericEventListenerInstanceQuery().stateAvailable().count()).isEqualTo(6);
 
         List<GenericEventListenerInstance> events = cmmnRuntimeService.createGenericEventListenerInstanceQuery().list();
-        assertEquals(6, events.size());
+        assertThat(events).hasSize(6);
 
-        //All different Intances id's
-        assertEquals(6, events.stream().map(GenericEventListenerInstance::getId).distinct().count());
+        //All different Instances id's
+        assertThat(events.stream().map(GenericEventListenerInstance::getId).distinct().count()).isEqualTo(6);
 
-        //UserEventListenerIntances inside Stage1
-        String stage1Id = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.STAGE).planItemDefinitionId("stage1").singleResult().getId();
-        assertEquals(2, cmmnRuntimeService.createGenericEventListenerInstanceQuery().stageInstanceId(stage1Id).count());
+        //UserEventListenerInstances inside Stage1
+        String stage1Id = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.STAGE).planItemDefinitionId("stage1")
+                .singleResult().getId();
+        assertThat(cmmnRuntimeService.createGenericEventListenerInstanceQuery().stageInstanceId(stage1Id).count()).isEqualTo(2);
 
-        //UserEventListenerIntances inside Stage2
-        String stage2Id = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.STAGE).planItemDefinitionId("stage2").singleResult().getId();
-        assertEquals(2, cmmnRuntimeService.createGenericEventListenerInstanceQuery().stageInstanceId(stage2Id).count());
+        //UserEventListenerInstances inside Stage2
+        String stage2Id = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.STAGE).planItemDefinitionId("stage2")
+                .singleResult().getId();
+        assertThat(cmmnRuntimeService.createGenericEventListenerInstanceQuery().stageInstanceId(stage2Id).count()).isEqualTo(2);
 
-        //UserEventListenerIntances not in a Stage
-        assertEquals(2, events.stream().filter(e -> e.getStageInstanceId() == null).count());
+        //UserEventListenerInstances not in a Stage
+        assertThat(events.stream().filter(e -> e.getStageInstanceId() == null).count()).isEqualTo(2);
 
         //Test query by elementId
-        assertNotNull(cmmnRuntimeService.createGenericEventListenerInstanceQuery().elementId("caseEventListenerOne").singleResult());
+        assertThat(cmmnRuntimeService.createGenericEventListenerInstanceQuery().elementId("caseEventListenerOne").singleResult()).isNotNull();
 
         //Test query by planItemDefinitionId
-        assertEquals(2, cmmnRuntimeService.createGenericEventListenerInstanceQuery().planItemDefinitionId("caseUEL1").count());
+        assertThat(cmmnRuntimeService.createGenericEventListenerInstanceQuery().planItemDefinitionId("caseUEL1").count()).isEqualTo(2);
 
         //Test sort Order - using the names because equals is not implemented in UserEventListenerInstance
         List<String> names = events.stream().map(GenericEventListenerInstance::getName).sorted(Comparator.reverseOrder()).collect(Collectors.toList());
@@ -234,52 +251,57 @@ public class GenericEventListenerTest extends FlowableCmmnTestCase {
 
         // Verify the model setup
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testOrphanEventListenerMultipleSentries").start();
-        assertNotNull(cmmnRuntimeService.createGenericEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult());
+        assertThat(cmmnRuntimeService.createGenericEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult()).isNotNull();
         List<Task> tasks = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).orderByTaskName().asc().list();
-        assertEquals(2, tasks.size());
-        assertEquals("A", tasks.get(0).getName());
-        assertEquals("C", tasks.get(1).getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("A", "C");
 
         // Completing one tasks should not have impact on the event listener
         cmmnTaskService.complete(tasks.get(0).getId());
-        assertNotNull(cmmnRuntimeService.createGenericEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult());
+        assertThat(cmmnRuntimeService.createGenericEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult()).isNotNull();
         tasks = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).orderByTaskName().asc().list();
-        assertEquals(1, tasks.size());
-        assertEquals("C", tasks.get(0).getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("C");
 
         // Completing the other task with the exit sentry should still keep the event, as it's reference by the entry of B
         cmmnTaskService.complete(tasks.get(0).getId());
-        assertNotNull(cmmnRuntimeService.createGenericEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult());
-        assertEquals(0, cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count());
+        assertThat(cmmnRuntimeService.createGenericEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult()).isNotNull();
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
 
         // Firing the event listener should start B
-        cmmnRuntimeService.completeGenericEventListenerInstance(cmmnRuntimeService.createGenericEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult().getId());
-        assertNull(cmmnRuntimeService.createGenericEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult());
-        assertEquals(1, cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count());
+        cmmnRuntimeService.completeGenericEventListenerInstance(
+                cmmnRuntimeService.createGenericEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult().getId());
+        assertThat(cmmnRuntimeService.createGenericEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult()).isNull();
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
     }
 
     @Test
     @CmmnDeployment
     public void testMultipleEventListenersAsEntry() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testMultipleEventListenersAsEntry").start();
-        assertEquals(0, cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count());
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
 
         List<GenericEventListenerInstance> eventListenerInstances = cmmnRuntimeService.createGenericEventListenerInstanceQuery()
-            .caseInstanceId(caseInstance.getId()).orderByName().asc().list();
-        assertThat(eventListenerInstances).extracting(GenericEventListenerInstance::getName).containsExactly("A", "B", "C");
+                .caseInstanceId(caseInstance.getId()).orderByName().asc().list();
+        assertThat(eventListenerInstances)
+                .extracting(GenericEventListenerInstance::getName)
+                .containsExactly("A", "B", "C");
 
         // Completing A should change nothing
         cmmnRuntimeService.completeGenericEventListenerInstance(eventListenerInstances.get(0).getId());
-        assertEquals(0, cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count());
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
         eventListenerInstances = cmmnRuntimeService.createGenericEventListenerInstanceQuery()
-            .caseInstanceId(caseInstance.getId()).orderByName().asc().list();
-        assertThat(eventListenerInstances).extracting(GenericEventListenerInstance::getName).containsExactly("B", "C");
+                .caseInstanceId(caseInstance.getId()).orderByName().asc().list();
+        assertThat(eventListenerInstances)
+                .extracting(GenericEventListenerInstance::getName)
+                .containsExactly("B", "C");
 
         // Completing B should activate the stage and remove the orphan event listener C
         cmmnRuntimeService.completeGenericEventListenerInstance(eventListenerInstances.get(0).getId());
-        assertEquals(1, cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count());
-        assertEquals(0, cmmnRuntimeService.createGenericEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).count());
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
+        assertThat(cmmnRuntimeService.createGenericEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
     }
 
 }
-

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/HumanTaskTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/HumanTaskTest.java
@@ -14,12 +14,6 @@ package org.flowable.cmmn.test.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
@@ -55,25 +49,25 @@ public class HumanTaskTest extends FlowableCmmnTestCase {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
                         .caseDefinitionKey("myCase")
                         .start();
-        assertNotNull(caseInstance);
+        assertThat(caseInstance).isNotNull();
 
         Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
-        assertEquals("Task One", task.getName());
-        assertEquals("JohnDoe", task.getAssignee());
+        assertThat(task.getName()).isEqualTo("Task One");
+        assertThat(task.getAssignee()).isEqualTo("JohnDoe");
         String task1Id = task.getId();
         
         List<EntityLink> entityLinks = cmmnRuntimeService.getEntityLinkChildrenForCaseInstance(caseInstance.getId());
-        assertEquals(1, entityLinks.size());
+        assertThat(entityLinks).hasSize(1);
         EntityLink entityLink = entityLinks.get(0);
-        assertEquals(EntityLinkType.CHILD, entityLink.getLinkType());
-        assertNotNull(entityLink.getCreateTime());
-        assertEquals(caseInstance.getId(), entityLink.getScopeId());
-        assertEquals(ScopeTypes.CMMN, entityLink.getScopeType());
-        assertNull(entityLink.getScopeDefinitionId());
-        assertEquals(task.getId(), entityLink.getReferenceScopeId());
-        assertEquals(ScopeTypes.TASK, entityLink.getReferenceScopeType());
-        assertNull(entityLink.getReferenceScopeDefinitionId());
-        assertEquals(HierarchyType.ROOT, entityLink.getHierarchyType());
+        assertThat(entityLink.getLinkType()).isEqualTo(EntityLinkType.CHILD);
+        assertThat(entityLink.getCreateTime()).isNotNull();
+        assertThat(entityLink.getScopeId()).isEqualTo(caseInstance.getId());
+        assertThat(entityLink.getScopeType()).isEqualTo(ScopeTypes.CMMN);
+        assertThat(entityLink.getScopeDefinitionId()).isNull();
+        assertThat(entityLink.getReferenceScopeId()).isEqualTo(task.getId());
+        assertThat(entityLink.getReferenceScopeType()).isEqualTo(ScopeTypes.TASK);
+        assertThat(entityLink.getReferenceScopeDefinitionId()).isNull();
+        assertThat(entityLink.getHierarchyType()).isEqualTo(HierarchyType.ROOT);
 
         assertThat(cmmnTaskService.getIdentityLinksForTask(task1Id))
             .extracting(IdentityLink::getType, IdentityLink::getUserId, IdentityLink::getGroupId)
@@ -84,15 +78,15 @@ public class HumanTaskTest extends FlowableCmmnTestCase {
         cmmnTaskService.complete(task.getId());
 
         task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
-        assertEquals("Task Two", task.getName());
-        assertNull(task.getAssignee());
+        assertThat(task.getName()).isEqualTo("Task Two");
+        assertThat(task.getAssignee()).isNull();
         String task2Id = task.getId();
 
         task = cmmnTaskService.createTaskQuery().taskCandidateGroup("test").caseInstanceId(caseInstance.getId()).singleResult();
-        assertEquals("Task Two", task.getName());
+        assertThat(task.getName()).isEqualTo("Task Two");
 
         task = cmmnTaskService.createTaskQuery().taskCandidateUser("test2").caseInstanceId(caseInstance.getId()).singleResult();
-        assertEquals("Task Two", task.getName());
+        assertThat(task.getName()).isEqualTo("Task Two");
 
         assertThat(cmmnTaskService.getIdentityLinksForTask(task2Id))
             .extracting(IdentityLink::getType, IdentityLink::getUserId, IdentityLink::getGroupId)
@@ -104,39 +98,29 @@ public class HumanTaskTest extends FlowableCmmnTestCase {
 
         cmmnTaskService.complete(task.getId());
 
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
 
         if (cmmnEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.ACTIVITY)) {
-            assertEquals("JohnDoe", cmmnHistoryService.createHistoricVariableInstanceQuery()
-                            .caseInstanceId(caseInstance.getId())
-                            .variableName("var1")
-                            .singleResult().getValue());
+            assertThat(cmmnHistoryService.createHistoricVariableInstanceQuery()
+                    .caseInstanceId(caseInstance.getId())
+                    .variableName("var1")
+                    .singleResult().getValue()).isEqualTo("JohnDoe");
             
             List<HistoricEntityLink> historicEntityLinks = cmmnHistoryService.getHistoricEntityLinkChildrenForCaseInstance(caseInstance.getId());
-            assertEquals(2, historicEntityLinks.size());
-            boolean hasTask1 = false;
-            boolean hasTask2 = false;
             for (HistoricEntityLink historicEntityLink : historicEntityLinks) {
-                assertEquals(EntityLinkType.CHILD, historicEntityLink.getLinkType());
-                assertNotNull(historicEntityLink.getCreateTime());
-                assertEquals(caseInstance.getId(), historicEntityLink.getScopeId());
-                assertEquals(ScopeTypes.CMMN, historicEntityLink.getScopeType());
-                assertNull(historicEntityLink.getScopeDefinitionId());
-                if (task1Id.equals(historicEntityLink.getReferenceScopeId())) {
-                    hasTask1 = true;
-                }
-                
-                if (task2Id.equals(historicEntityLink.getReferenceScopeId())) {
-                    hasTask2 = true;
-                }
-                
-                assertEquals(ScopeTypes.TASK, historicEntityLink.getReferenceScopeType());
-                assertNull(historicEntityLink.getReferenceScopeDefinitionId());
-                assertEquals(HierarchyType.ROOT, entityLink.getHierarchyType());
+                assertThat(historicEntityLink.getLinkType()).isEqualTo(EntityLinkType.CHILD);
+                assertThat(historicEntityLink.getCreateTime()).isNotNull();
+                assertThat(historicEntityLink.getScopeId()).isEqualTo(caseInstance.getId());
+                assertThat(historicEntityLink.getScopeType()).isEqualTo(ScopeTypes.CMMN);
+                assertThat(historicEntityLink.getScopeDefinitionId()).isNull();
+                assertThat(historicEntityLink.getReferenceScopeType()).isEqualTo(ScopeTypes.TASK);
+                assertThat(historicEntityLink.getReferenceScopeDefinitionId()).isNull();
+                assertThat(entityLink.getHierarchyType()).isEqualTo(HierarchyType.ROOT);
             }
-            
-            assertTrue(hasTask1);
-            assertTrue(hasTask2);
+
+            assertThat(historicEntityLinks)
+                    .extracting(HistoricEntityLink::getReferenceScopeId)
+                    .containsExactlyInAnyOrder(task1Id, task2Id);
 
             assertThat(cmmnHistoryService.getHistoricIdentityLinksForTask(task1Id))
                 .extracting(HistoricIdentityLink::getType, HistoricIdentityLink::getUserId, HistoricIdentityLink::getGroupId)
@@ -162,28 +146,28 @@ public class HumanTaskTest extends FlowableCmmnTestCase {
         org.flowable.cmmn.api.repository.CmmnDeployment deployment = cmmnRepositoryService.createDeployment().tenantId("flowable").
                 addClasspathResource("org/flowable/cmmn/test/runtime/HumanTaskTest.testHumanTask.cmmn").deploy();
         try {
-            assertThat(deployment.getTenantId(), is("flowable"));
+            assertThat(deployment.getTenantId()).isEqualTo("flowable");
 
             CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
                     .caseDefinitionKey("myCase")
                     .tenantId("flowable")
                     .start();
-            assertNotNull(caseInstance);
-            assertEquals("flowable", caseInstance.getTenantId());
+            assertThat(caseInstance).isNotNull();
+            assertThat(caseInstance.getTenantId()).isEqualTo("flowable");
 
             Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
-            assertEquals("Task One", task.getName());
-            assertEquals("JohnDoe", task.getAssignee());
-            assertEquals("flowable", task.getTenantId());
+            assertThat(task.getName()).isEqualTo("Task One");
+            assertThat(task.getAssignee()).isEqualTo("JohnDoe");
+            assertThat(task.getTenantId()).isEqualTo("flowable");
 
             cmmnTaskService.complete(task.getId());
 
             task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
-            assertEquals("Task Two", task.getName());
-            assertEquals("flowable", task.getTenantId());
+            assertThat(task.getName()).isEqualTo("Task Two");
+            assertThat(task.getTenantId()).isEqualTo("flowable");
             cmmnTaskService.complete(task.getId());
 
-            assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
 
         } finally {
             cmmnRepositoryService.deleteDeployment(deployment.getId(), true);
@@ -198,29 +182,29 @@ public class HumanTaskTest extends FlowableCmmnTestCase {
         org.flowable.cmmn.api.repository.CmmnDeployment deployment = cmmnRepositoryService.createDeployment().tenantId("flowable").
                 addClasspathResource("org/flowable/cmmn/test/runtime/HumanTaskTest.testHumanTask.cmmn").deploy();
         try {
-            assertThat(deployment.getTenantId(), is("flowable"));
+            assertThat(deployment.getTenantId()).isEqualTo("flowable");
             CaseDefinition caseDefinition = cmmnRepositoryService.createCaseDefinitionQuery().deploymentId(deployment.getId()).singleResult();
-            assertThat(caseDefinition.getTenantId(), is("flowable"));
+            assertThat(caseDefinition.getTenantId()).isEqualTo("flowable");
 
             CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
                     .caseDefinitionId(caseDefinition.getId())
                     .tenantId("flowable")
                     .start();
-            assertNotNull(caseInstance);
-            assertEquals("flowable", caseInstance.getTenantId());
+            assertThat(caseInstance).isNotNull();
+            assertThat(caseInstance.getTenantId()).isEqualTo("flowable");
 
             Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
-            assertEquals("Task One", task.getName());
-            assertEquals("JohnDoe", task.getAssignee());
-            assertEquals("flowable", task.getTenantId());
+            assertThat(task.getName()).isEqualTo("Task One");
+            assertThat(task.getAssignee()).isEqualTo("JohnDoe");
+            assertThat(task.getTenantId()).isEqualTo("flowable");
 
             cmmnTaskService.complete(task.getId());
 
             task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
-            assertEquals("flowable", task.getTenantId());
+            assertThat(task.getTenantId()).isEqualTo("flowable");
             cmmnTaskService.complete(task.getId());
 
-            assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
         } finally {
             cmmnRepositoryService.deleteDeployment(deployment.getId(), true);
             Authentication.setAuthenticatedUserId(null);
@@ -234,25 +218,25 @@ public class HumanTaskTest extends FlowableCmmnTestCase {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
                 .caseDefinitionKey("humanTaskCompletionExits")
                 .start();
-        assertNotNull(caseInstance);
+        assertThat(caseInstance).isNotNull();
 
         List<Task> tasks = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).orderByTaskName().asc().list();
-        assertEquals("A", tasks.get(0).getName());
-        assertEquals("B", tasks.get(1).getName());
-        assertEquals("C", tasks.get(2).getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("A", "B", "C");
 
         // Completing A should delete B and C
         cmmnTaskService.complete(tasks.get(0).getId());
-        assertEquals(0, cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count());
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
         assertCaseInstanceEnded(caseInstance);
 
         List<HistoricTaskInstance> historicTaskInstances = cmmnHistoryService.createHistoricTaskInstanceQuery().list();
-        assertEquals(3, historicTaskInstances.size());
+        assertThat(historicTaskInstances).hasSize(3);
         for (HistoricTaskInstance historicTaskInstance : historicTaskInstances) {
-            assertNotNull(historicTaskInstance.getStartTime());
-            assertNotNull(historicTaskInstance.getEndTime());
+            assertThat(historicTaskInstance.getStartTime()).isNotNull();
+            assertThat(historicTaskInstance.getEndTime()).isNotNull();
             if (!historicTaskInstance.getName().equals("A")) {
-                assertEquals("cmmn-state-transition-terminate-case", historicTaskInstance.getDeleteReason());
+                assertThat(historicTaskInstance.getDeleteReason()).isEqualTo("cmmn-state-transition-terminate-case");
             }
         }
 
@@ -260,22 +244,22 @@ public class HumanTaskTest extends FlowableCmmnTestCase {
         CaseInstance caseInstance2 = cmmnRuntimeService.createCaseInstanceBuilder()
                 .caseDefinitionKey("humanTaskCompletionExits")
                 .start();
-        assertNotNull(caseInstance2);
+        assertThat(caseInstance2).isNotNull();
         tasks = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance2.getId()).orderByTaskName().asc().list();
         cmmnTaskService.complete(tasks.get(2).getId());
 
         Task taskA = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance2.getId()).orderByTaskName().asc().singleResult();
-        assertNotNull(taskA);
+        assertThat(taskA).isNotNull();
         cmmnTaskService.complete(taskA.getId());
         assertCaseInstanceEnded(caseInstance2);
 
         historicTaskInstances = cmmnHistoryService.createHistoricTaskInstanceQuery().caseInstanceId(caseInstance2.getId()).list();
-        assertEquals(3, historicTaskInstances.size());
+        assertThat(historicTaskInstances).hasSize(3);
         for (HistoricTaskInstance historicTaskInstance : historicTaskInstances) {
-            assertNotNull(historicTaskInstance.getStartTime());
-            assertNotNull(historicTaskInstance.getEndTime());
+            assertThat(historicTaskInstance.getStartTime()).isNotNull();
+            assertThat(historicTaskInstance.getEndTime()).isNotNull();
             if (historicTaskInstance.getName().equals("B")) {
-                assertEquals("cmmn-state-transition-exit", historicTaskInstance.getDeleteReason());
+                assertThat(historicTaskInstance.getDeleteReason()).isEqualTo("cmmn-state-transition-exit");
             }
         }
     }
@@ -286,14 +270,14 @@ public class HumanTaskTest extends FlowableCmmnTestCase {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
             .caseDefinitionKey("myCase")
             .start();
-        assertNotNull(caseInstance);
+        assertThat(caseInstance).isNotNull();
 
 
         Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
-        assertEquals("Task One", task.getName());
-        assertNull(task.getAssignee());
+        assertThat(task.getName()).isEqualTo("Task One");
+        assertThat(task.getAssignee()).isNull();
 
-        assertEquals(0, cmmnRuntimeService.getIdentityLinksForCaseInstance(caseInstance.getId()).size());
+        assertThat(cmmnRuntimeService.getIdentityLinksForCaseInstance(caseInstance.getId())).isEmpty();
 
         String prevUserId = Authentication.getAuthenticatedUserId();
         Authentication.setAuthenticatedUserId("JohnDoe");

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/IfPartTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/IfPartTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,9 +12,7 @@
  */
 package org.flowable.cmmn.test.runtime;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.Serializable;
 import java.util.List;
@@ -31,7 +29,7 @@ import org.junit.Test;
  * @author Joram Barrez
  */
 public class IfPartTest extends FlowableCmmnTestCase {
-    
+
     @Test
     @CmmnDeployment
     public void testIfPartOnly() {
@@ -40,81 +38,88 @@ public class IfPartTest extends FlowableCmmnTestCase {
                 .caseDefinitionKey("testIfPartOnly")
                 .variable("variable", true)
                 .start();
-        assertEquals(2, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateActive().count());
-        
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateActive().count()).isEqualTo(2);
+
         // Case 2 : Passing variable after case instance start
         caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
                 .caseDefinitionKey("testIfPartOnly")
                 .start();
-        List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateActive().list();
-        assertEquals(1, planItemInstances.size());
+        List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
+                .planItemInstanceStateActive().list();
+        assertThat(planItemInstances).hasSize(1);
         cmmnRuntimeService.setVariables(caseInstance.getId(), CollectionUtil.singletonMap("variable", true));
-        assertEquals(2, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateActive().count());
-        
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateActive().count()).isEqualTo(2);
+
         // Case 3 : Completing A after start should end the case instance
         caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
                 .caseDefinitionKey("testIfPartOnly")
                 .start();
         planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateActive().list();
-        assertEquals(1, planItemInstances.size());
-        assertEquals("A", planItemInstances.get(0).getName());
+        assertThat(planItemInstances)
+                .extracting(PlanItemInstance::getName)
+                .containsExactly("A");
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(0).getId());
-        
+
         // Be should remain in the available state, until the variable is set
         planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateAvailable().list();
-        assertEquals(1, planItemInstances.size());
-        assertEquals("B", planItemInstances.get(0).getName());
+        assertThat(planItemInstances)
+                .extracting(PlanItemInstance::getName)
+                .containsExactly("B");
         cmmnRuntimeService.setVariables(caseInstance.getId(), CollectionUtil.singletonMap("variable", true));
-        
+
         planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateActive().list();
-        assertEquals(1, planItemInstances.size());
-        assertEquals("B", planItemInstances.get(0).getName());
-        
+        assertThat(planItemInstances)
+                .extracting(PlanItemInstance::getName)
+                .containsExactly("B");
+
         // Completing B ends the case instance
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(0).getId());
         assertCaseInstanceEnded(caseInstance);
     }
-    
+
     @Test
     @CmmnDeployment
     public void testOnAndIfPart() {
         // Passing the variable for the if part condition at start
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("testSimpleCondition")
-            .variable("conditionVariable", true)
-            .start();
-        
+                .caseDefinitionKey("testSimpleCondition")
+                .variable("conditionVariable", true)
+                .start();
+
         List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateActive().list();
-        assertEquals(1, planItemInstances.size());
-        assertEquals("A", planItemInstances.get(0).getName());
-        
+        assertThat(planItemInstances)
+                .extracting(PlanItemInstance::getName)
+                .containsExactly("A");
+
         // Completing plan item A should trigger B
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(0).getId());
         planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateActive().list();
-        assertEquals(1, planItemInstances.size());
-        assertEquals("B", planItemInstances.get(0).getName());
-        
+        assertThat(planItemInstances)
+                .extracting(PlanItemInstance::getName)
+                .containsExactly("B");
+
         // Completing B should end the case instance
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(0).getId());
         assertCaseInstanceEnded(caseInstance);
     }
-    
+
     @Test
     @CmmnDeployment
     public void testIfPartConditionTriggerOnSetVariables() {
         cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testSimpleCondition").start();
         List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateActive().list();
-        assertEquals(1, planItemInstances.size());
-        assertEquals("A", planItemInstances.get(0).getName());
-        
+        assertThat(planItemInstances)
+                .extracting(PlanItemInstance::getName)
+                .containsExactly("A");
+
         // Completing plan item A should not trigger B
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(0).getId());
-        
+
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().singleResult();
-        assertEquals("B", planItemInstance.getName());
-        assertEquals(PlanItemInstanceState.AVAILABLE, planItemInstance.getState());
+        assertThat(planItemInstance.getName()).isEqualTo("B");
+        assertThat(planItemInstance.getState()).isEqualTo(PlanItemInstanceState.AVAILABLE);
     }
-    
+
     @Test
     @CmmnDeployment
     public void testManualEvaluateCriteria() {
@@ -122,14 +127,14 @@ public class IfPartTest extends FlowableCmmnTestCase {
                 .caseDefinitionKey("testManualEvaluateCriteria")
                 .variable("someBean", new TestBean())
                 .start();
-        
+
         // Triggering the evaluation twice will satisfy the entry criterion for B
-        assertEquals(1, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateActive().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateActive().count()).isEqualTo(1);
         TestBean.RETURN_VALUE = true;
         cmmnRuntimeService.evaluateCriteria(caseInstance.getId());
-        assertEquals(2, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateActive().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateActive().count()).isEqualTo(2);
     }
-    
+
     @Test
     @CmmnDeployment
     public void testMultipleOnParts() {
@@ -138,114 +143,113 @@ public class IfPartTest extends FlowableCmmnTestCase {
                 .variable("conditionVariable", true)
                 .start();
         List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateActive().orderByName().asc().list();
-        assertEquals(3, planItemInstances.size());
-        assertEquals("A", planItemInstances.get(0).getName());
-        assertEquals("B", planItemInstances.get(1).getName());
-        assertEquals("C", planItemInstances.get(2).getName());
-        
+        assertThat(planItemInstances)
+                .extracting(PlanItemInstance::getName)
+                .containsExactly("A", "B", "C");
+
         for (PlanItemInstance planItemInstance : planItemInstances) {
             cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
         }
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateActive().singleResult();
-        assertEquals("D", planItemInstance.getName());
+        assertThat(planItemInstance.getName()).isEqualTo("D");
     }
-    
+
     @Test
     @CmmnDeployment
     public void testEntryAndExitConditionBothSatisfied() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("testEntryAndExitConditionBothSatisfied")
-            .start();
-        assertNull(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateActive().planItemInstanceName("A").singleResult());
-        assertNotNull(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateActive().planItemInstanceName("B").singleResult());
-        
+                .caseDefinitionKey("testEntryAndExitConditionBothSatisfied")
+                .start();
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateActive().planItemInstanceName("A").singleResult()).isNull();
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateActive().planItemInstanceName("B").singleResult()).isNotNull();
+
         // Setting the variable will trigger the entry condition of A and the exit condition of B
         cmmnRuntimeService.setVariables(caseInstance.getId(), CollectionUtil.singletonMap("conditionVariable", true));
-        
-        assertNotNull(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateActive().planItemInstanceName("A").singleResult());
-        assertNull(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateActive().planItemInstanceName("B").singleResult());
+
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateActive().planItemInstanceName("A").singleResult()).isNotNull();
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateActive().planItemInstanceName("B").singleResult()).isNull();
     }
-    
+
     @Test
     @CmmnDeployment
     public void testExitPlanModelWithIfPart() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testExitPlanModelWithIfPart").start();
         List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateActive().orderByName().asc().list();
-        assertEquals(2, planItemInstances.size());
-        assertEquals("A", planItemInstances.get(0).getName());
-        assertEquals("B", planItemInstances.get(1).getName());
-        
+        assertThat(planItemInstances)
+                .extracting(PlanItemInstance::getName)
+                .containsExactly("A", "B");
+
         // Completing B terminates the case through one of the exit criteria
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(1).getId());
         assertCaseInstanceEnded(caseInstance);
-        
+
         // Now B isn't completed, but A is. When the variable is set, the case is terminated
         caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testExitPlanModelWithIfPart").start();
         planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateActive().orderByName().asc().list();
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(0).getId());
-        assertEquals(1, cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateActive().count());
-        
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateActive().count()).isEqualTo(1);
+
         cmmnRuntimeService.setVariables(caseInstance.getId(), CollectionUtil.singletonMap("exitPlanModelVariable", true));
         assertCaseInstanceEnded(caseInstance);
     }
-    
+
     @Test
     @CmmnDeployment
     public void testNestedStagesWithIfPart() {
         // Start case, activate inner nested stage
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testNestedStagesWithIfPart").start();
         List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateActive().orderByName().asc().list();
-        assertEquals(4, planItemInstances.size());
-        assertEquals("A", planItemInstances.get(0).getName());
-        assertEquals("C", planItemInstances.get(1).getName());
-        assertEquals("Stage1", planItemInstances.get(2).getName());
-        assertEquals("Stage2", planItemInstances.get(3).getName());
-        assertNotNull(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateAvailable().planItemInstanceName("Stage3").singleResult());
-        
+        assertThat(planItemInstances)
+                .extracting(PlanItemInstance::getName)
+                .containsExactly("A", "C", "Stage1", "Stage2");
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateAvailable().planItemInstanceName("Stage3").singleResult()).isNotNull();
+
         cmmnRuntimeService.setVariables(caseInstance.getId(), CollectionUtil.singletonMap("nestedStageEntryVariable", true));
-        assertEquals(6, cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateActive().orderByName().asc().count());
-        PlanItemInstance planItemInstanceB = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateActive().planItemInstanceName("B").singleResult();
-        assertNotNull(planItemInstanceB);
-        
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateActive().orderByName().asc().count()).isEqualTo(6);
+        PlanItemInstance planItemInstanceB = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateActive().planItemInstanceName("B")
+                .singleResult();
+        assertThat(planItemInstanceB).isNotNull();
+
         // Triggering B should delete all stages
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstanceB.getId());
         planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateActive().orderByName().asc().list();
-        assertEquals(1, planItemInstances.size());
-        assertEquals("A", planItemInstances.get(0).getName());
+        assertThat(planItemInstances).hasSize(1);
+        assertThat(planItemInstances.get(0).getName()).isEqualTo("A");
 
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(0).getId());
         assertCaseInstanceEnded(caseInstance);
     }
-    
+
     @Test
     @CmmnDeployment
     public void testNestedStagesWithIfPart2() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testNestedStagesWithIfPart").start();
         List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateActive().orderByName().asc().list();
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
 
         // Setting the destroyStages variables, deletes all stages
         cmmnRuntimeService.setVariables(caseInstance.getId(), CollectionUtil.singletonMap("destroyStages", true));
-        
+
         planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateActive().orderByName().asc().list();
-        assertEquals(1, planItemInstances.size());
-        assertEquals("A", planItemInstances.get(0).getName());
+        assertThat(planItemInstances)
+                .extracting(PlanItemInstance::getName)
+                .containsExactly("A");
 
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(0).getId());
         assertCaseInstanceEnded(caseInstance);
     }
-    
+
     @Test
     @CmmnDeployment
     public void testNestedStagesWithIfPart3() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testNestedStagesWithIfPart").start();
-        assertEquals(4, cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateActive().count());
-        
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateActive().count()).isEqualTo(4);
+
         /// Setting the destroyAll variable should terminate all
         cmmnRuntimeService.setVariables(caseInstance.getId(), CollectionUtil.singletonMap("destroyAll", true));
         assertCaseInstanceEnded(caseInstance);
     }
-    
+
     @Test
     @CmmnDeployment
     public void testStageWithExitIfPart() {
@@ -254,16 +258,15 @@ public class IfPartTest extends FlowableCmmnTestCase {
                 .variable("enableStage", true)
                 .start();
         List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateActive().orderByName().asc().list();
-        assertEquals(4, planItemInstances.size());
-        assertEquals("A", planItemInstances.get(0).getName());
-        assertEquals("B", planItemInstances.get(1).getName());
-        assertEquals("C", planItemInstances.get(2).getName());
-        
+        assertThat(planItemInstances)
+                .extracting(PlanItemInstance::getName)
+                .containsExactly("A", "B", "C", "The Stage");
+
         // Triggering A should terminate the stage and thus also the case
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(0).getId());
         assertCaseInstanceEnded(caseInstance);
     }
-    
+
     @Test
     @CmmnDeployment
     public void testStageWithExitIfPart2() {
@@ -272,21 +275,22 @@ public class IfPartTest extends FlowableCmmnTestCase {
                 .caseDefinitionKey("testStageWithExitIfPart")
                 .start();
         List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateActive().orderByName().asc().list();
-        assertEquals(1, planItemInstances.size());
-        assertEquals("A", planItemInstances.get(0).getName());
-        
+        assertThat(planItemInstances)
+                .extracting(PlanItemInstance::getName)
+                .containsExactly("A");
+
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(0).getId());
         assertCaseInstanceEnded(caseInstance);
     }
-    
+
     public static class TestBean implements Serializable {
-        
+
         public static boolean RETURN_VALUE;
-        
+
         public boolean isSatisfied() {
             return RETURN_VALUE;
         }
-        
+
     }
 
 }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/MilestoneQueryTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/MilestoneQueryTest.java
@@ -12,9 +12,7 @@
  */
 package org.flowable.cmmn.test.runtime;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Calendar;
 import java.util.Date;
@@ -41,15 +39,15 @@ public class MilestoneQueryTest extends FlowableCmmnTestCase {
         //Check setup
         assertCaseInstanceNotEnded(caseInstance);
         List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery().list();
-        assertEquals(7, planItemInstances.size());
-        assertEquals(3, planItemInstances.stream().filter(p -> PlanItemDefinitionType.MILESTONE.equals(p.getPlanItemDefinitionType()))
-                .filter(p -> PlanItemInstanceState.AVAILABLE.equals(p.getState())).count());
-        assertEquals(4, planItemInstances.stream().filter(p -> PlanItemDefinitionType.USER_EVENT_LISTENER.equals(p.getPlanItemDefinitionType()))
-                .filter(p -> PlanItemInstanceState.AVAILABLE.equals(p.getState())).count());
+        assertThat(planItemInstances).hasSize(7);
+        assertThat(planItemInstances.stream().filter(p -> PlanItemDefinitionType.MILESTONE.equals(p.getPlanItemDefinitionType()))
+                .filter(p -> PlanItemInstanceState.AVAILABLE.equals(p.getState())).count()).isEqualTo(3);
+        assertThat(planItemInstances.stream().filter(p -> PlanItemDefinitionType.USER_EVENT_LISTENER.equals(p.getPlanItemDefinitionType()))
+                .filter(p -> PlanItemInstanceState.AVAILABLE.equals(p.getState())).count()).isEqualTo(4);
 
         List<MilestoneInstance> milestoneInstances = cmmnRuntimeService.createMilestoneInstanceQuery().list();
-        assertNotNull(milestoneInstances);
-        assertTrue(milestoneInstances.isEmpty());
+        assertThat(milestoneInstances).isNotNull();
+        assertThat(milestoneInstances).isEmpty();
 
         //event triggering
         setClockTo(new Date(System.currentTimeMillis() + 60_000L));
@@ -82,53 +80,51 @@ public class MilestoneQueryTest extends FlowableCmmnTestCase {
         afterThirdCalendar.add(Calendar.MINUTE, 1);
         Date afterThirdTrigger = afterThirdCalendar.getTime();
 
-        assertEquals(3, cmmnRuntimeService.createMilestoneInstanceQuery().milestoneInstanceCaseInstanceId(caseInstance.getId()).count());
+        assertThat(cmmnRuntimeService.createMilestoneInstanceQuery().milestoneInstanceCaseInstanceId(caseInstance.getId()).count()).isEqualTo(3);
 
         //There are two named milestones
         MilestoneInstance abcMilestone = cmmnRuntimeService.createMilestoneInstanceQuery().milestoneInstanceName("abcMilestone").singleResult();
-        assertNotNull(abcMilestone);
-        assertEquals("abcMilestone", abcMilestone.getName());
+        assertThat(abcMilestone).isNotNull();
+        assertThat(abcMilestone.getName()).isEqualTo("abcMilestone");
 
         MilestoneInstance xyzMilestone = cmmnRuntimeService.createMilestoneInstanceQuery().milestoneInstanceName("xyzMilestone").singleResult();
-        assertNotNull(xyzMilestone);
-        assertEquals("xyzMilestone", xyzMilestone.getName());
+        assertThat(xyzMilestone).isNotNull();
+        assertThat(xyzMilestone.getName()).isEqualTo("xyzMilestone");
 
         MilestoneInstance one = cmmnRuntimeService.createMilestoneInstanceQuery().milestoneInstanceName("1").singleResult();
-        assertNotNull(one);
-        assertEquals("1", one.getName());
+        assertThat(one).isNotNull();
+        assertThat(one.getName()).isEqualTo("1");
 
         //One Milestone has no name
         List<MilestoneInstance> list = cmmnRuntimeService.createMilestoneInstanceQuery().orderByMilestoneName().asc().list();
-        assertEquals(3, list.size());
-        //assertNull(list.get(0).getName());
-        assertEquals("1", list.get(0).getName());
-        assertEquals("abcMilestone", list.get(1).getName());
-        assertEquals("xyzMilestone", list.get(2).getName());
+        assertThat(list)
+                .extracting(MilestoneInstance::getName)
+                .containsExactly("1", "abcMilestone", "xyzMilestone");
 
         //Query timestamps
         MilestoneInstance milestone1 = cmmnRuntimeService.createMilestoneInstanceQuery()
                 .milestoneInstanceReachedAfter(beforeFirstTrigger)
                 .milestoneInstanceReachedBefore(afterFirstTrigger)
                 .singleResult();
-        assertNotNull(milestone1);
-        assertEquals("milestonePlanItem1", milestone1.getElementId());
+        assertThat(milestone1).isNotNull();
+        assertThat(milestone1.getElementId()).isEqualTo("milestonePlanItem1");
         MilestoneInstance milestone2 = cmmnRuntimeService.createMilestoneInstanceQuery()
                 .milestoneInstanceReachedAfter(beforeSecondTrigger)
                 .milestoneInstanceReachedBefore(afterSecondTrigger)
                 .singleResult();
-        assertNotNull(milestone2);
-        assertEquals("milestonePlanItem2", milestone2.getElementId());
+        assertThat(milestone2).isNotNull();
+        assertThat(milestone2.getElementId()).isEqualTo("milestonePlanItem2");
         MilestoneInstance milestone3 = cmmnRuntimeService.createMilestoneInstanceQuery()
                 .milestoneInstanceReachedAfter(beforeThirdTrigger)
                 .milestoneInstanceReachedBefore(afterThirdTrigger)
                 .singleResult();
-        assertNotNull(milestone3);
-        assertEquals("milestonePlanItem3", milestone3.getElementId());
+        assertThat(milestone3).isNotNull();
+        assertThat(milestone3.getElementId()).isEqualTo("milestonePlanItem3");
 
         list = cmmnRuntimeService.createMilestoneInstanceQuery().orderByTimeStamp().desc().list();
-        assertEquals("milestonePlanItem3", list.get(0).getElementId());
-        assertEquals("milestonePlanItem2", list.get(1).getElementId());
-        assertEquals("milestonePlanItem1", list.get(2).getElementId());
+        assertThat(list)
+                .extracting(MilestoneInstance::getElementId)
+                .containsExactly("milestonePlanItem3", "milestonePlanItem2", "milestonePlanItem1");
 
         //Finish Case by triggering the last event
         event = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("event4").singleResult();

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/MultiEntrySentryActivationTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/MultiEntrySentryActivationTest.java
@@ -12,9 +12,9 @@
  */
 package org.flowable.cmmn.test.runtime;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.ACTIVE;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.AVAILABLE;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 
@@ -22,7 +22,6 @@ import org.flowable.cmmn.api.runtime.CaseInstance;
 import org.flowable.cmmn.api.runtime.PlanItemInstance;
 import org.flowable.cmmn.engine.test.CmmnDeployment;
 import org.flowable.cmmn.engine.test.FlowableCmmnTestCase;
-import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -36,11 +35,11 @@ public class MultiEntrySentryActivationTest extends FlowableCmmnTestCase {
     @CmmnDeployment
     public void testMultiSentryActivation() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("caseActivationExampleWithMoreThanOneIncomingSentry")
-            .start();
+                .caseDefinitionKey("caseActivationExampleWithMoreThanOneIncomingSentry")
+                .start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
 
         assertPlanItemInstanceState(planItemInstances, "Initial Stage", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Main Form", ACTIVE);
@@ -48,12 +47,12 @@ public class MultiEntrySentryActivationTest extends FlowableCmmnTestCase {
         assertPlanItemInstanceState(planItemInstances, "Stage B", AVAILABLE);
 
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(getPlanItemInstanceIdByNameAndState(planItemInstances, "Main Form", ACTIVE))
-            .variable("activateStageA", true)
-            .variable("activateStageB", false)
-            .trigger();
+                .variable("activateStageA", true)
+                .variable("activateStageB", false)
+                .trigger();
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
 
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage A Form", ACTIVE);
@@ -62,7 +61,7 @@ public class MultiEntrySentryActivationTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Stage A Form", ACTIVE));
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(2, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(2);
 
         assertPlanItemInstanceState(planItemInstances, "Stage B", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B Form", ACTIVE);
@@ -70,19 +69,19 @@ public class MultiEntrySentryActivationTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Stage B Form", ACTIVE));
 
         assertCaseInstanceEnded(caseInstance);
-        Assert.assertEquals(0L, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count());
-        Assert.assertEquals(0L, cmmnRuntimeService.createCaseInstanceQuery().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0L);
     }
 
     @Test
     @CmmnDeployment(resources = "org/flowable/cmmn/test/runtime/MultiEntrySentryActivationTest.testMultiSentryActivation.cmmn")
     public void testMultiSentryActivationAlternatePath() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("caseActivationExampleWithMoreThanOneIncomingSentry")
-            .start();
+                .caseDefinitionKey("caseActivationExampleWithMoreThanOneIncomingSentry")
+                .start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
 
         assertPlanItemInstanceState(planItemInstances, "Initial Stage", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Main Form", ACTIVE);
@@ -90,12 +89,12 @@ public class MultiEntrySentryActivationTest extends FlowableCmmnTestCase {
         assertPlanItemInstanceState(planItemInstances, "Stage B", AVAILABLE);
 
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(getPlanItemInstanceIdByNameAndState(planItemInstances, "Main Form", ACTIVE))
-            .variable("activateStageA", false)
-            .variable("activateStageB", true)
-            .trigger();
+                .variable("activateStageA", false)
+                .variable("activateStageB", true)
+                .trigger();
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
 
         assertPlanItemInstanceState(planItemInstances, "Stage A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", ACTIVE);
@@ -104,7 +103,7 @@ public class MultiEntrySentryActivationTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.setVariable(caseInstance.getId(), "activateStageA", true);
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
 
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage A Form", ACTIVE);
@@ -114,7 +113,7 @@ public class MultiEntrySentryActivationTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Stage A Form", ACTIVE));
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(2, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(2);
 
         assertPlanItemInstanceState(planItemInstances, "Stage B", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B Form", ACTIVE);
@@ -122,20 +121,19 @@ public class MultiEntrySentryActivationTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Stage B Form", ACTIVE));
 
         assertCaseInstanceEnded(caseInstance);
-        Assert.assertEquals(0L, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count());
-        Assert.assertEquals(0L, cmmnRuntimeService.createCaseInstanceQuery().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0L);
     }
-
 
     @Test
     @CmmnDeployment(resources = "org/flowable/cmmn/test/runtime/MultiEntrySentryActivationTest.testMultiSentryActivation.cmmn")
     public void testMultiSentryActivationSameTime() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("caseActivationExampleWithMoreThanOneIncomingSentry")
-            .start();
+                .caseDefinitionKey("caseActivationExampleWithMoreThanOneIncomingSentry")
+                .start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
 
         assertPlanItemInstanceState(planItemInstances, "Initial Stage", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Main Form", ACTIVE);
@@ -143,12 +141,12 @@ public class MultiEntrySentryActivationTest extends FlowableCmmnTestCase {
         assertPlanItemInstanceState(planItemInstances, "Stage B", AVAILABLE);
 
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(getPlanItemInstanceIdByNameAndState(planItemInstances, "Main Form", ACTIVE))
-            .variable("activateStageA", true)
-            .variable("activateStageB", true)
-            .trigger();
+                .variable("activateStageA", true)
+                .variable("activateStageB", true)
+                .trigger();
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
 
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage A Form", ACTIVE);
@@ -158,7 +156,7 @@ public class MultiEntrySentryActivationTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Stage A Form", ACTIVE));
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(2, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(2);
 
         assertPlanItemInstanceState(planItemInstances, "Stage B", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B Form", ACTIVE);
@@ -166,7 +164,7 @@ public class MultiEntrySentryActivationTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Stage B Form", ACTIVE));
 
         assertCaseInstanceEnded(caseInstance);
-        Assert.assertEquals(0L, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count());
-        Assert.assertEquals(0L, cmmnRuntimeService.createCaseInstanceQuery().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0L);
     }
 }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/PlanItemCompletionTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/PlanItemCompletionTest.java
@@ -12,13 +12,13 @@
  */
 package org.flowable.cmmn.test.runtime;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.ACTIVE;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.AVAILABLE;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.COMPLETED;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.ENABLED;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.UNAVAILABLE;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.WAITING_FOR_REPETITION;
-import static org.junit.Assert.assertEquals;
 
 import java.util.List;
 
@@ -42,7 +42,7 @@ public class PlanItemCompletionTest extends FlowableCmmnTestCase {
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ENABLED);
         assertPlanItemInstanceState(planItemInstances, "User Listener A", UNAVAILABLE);
@@ -53,7 +53,7 @@ public class PlanItemCompletionTest extends FlowableCmmnTestCase {
 
         planItemInstances = getAllPlanItemInstances(caseInstance.getId());
 
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ENABLED, COMPLETED);
         assertPlanItemInstanceState(planItemInstances, "User Listener A", AVAILABLE);
@@ -61,9 +61,9 @@ public class PlanItemCompletionTest extends FlowableCmmnTestCase {
         // trigger user listener to complete stage
         cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByName(planItemInstances, "User Listener A"));
 
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().count());
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
     @Test
@@ -73,7 +73,7 @@ public class PlanItemCompletionTest extends FlowableCmmnTestCase {
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ENABLED);
         assertPlanItemInstanceState(planItemInstances, "User Listener A", AVAILABLE);
@@ -85,7 +85,7 @@ public class PlanItemCompletionTest extends FlowableCmmnTestCase {
 
         planItemInstances = getAllPlanItemInstances(caseInstance.getId());
 
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ENABLED, COMPLETED);
         assertPlanItemInstanceState(planItemInstances, "User Listener A", AVAILABLE);
@@ -93,9 +93,9 @@ public class PlanItemCompletionTest extends FlowableCmmnTestCase {
         // trigger user listener to complete stage
         cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByName(planItemInstances, "User Listener A"));
 
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().count());
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
     @Test
@@ -105,7 +105,7 @@ public class PlanItemCompletionTest extends FlowableCmmnTestCase {
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ENABLED);
         assertPlanItemInstanceState(planItemInstances, "User Listener A", UNAVAILABLE);
@@ -114,9 +114,9 @@ public class PlanItemCompletionTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task A"));
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task A"));
 
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().count());
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
     @Test
@@ -126,7 +126,7 @@ public class PlanItemCompletionTest extends FlowableCmmnTestCase {
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(7, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(7);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ENABLED);
@@ -141,7 +141,7 @@ public class PlanItemCompletionTest extends FlowableCmmnTestCase {
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(6, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(6);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ENABLED);
@@ -154,7 +154,7 @@ public class PlanItemCompletionTest extends FlowableCmmnTestCase {
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(5, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(5);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ENABLED);
@@ -166,7 +166,7 @@ public class PlanItemCompletionTest extends FlowableCmmnTestCase {
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(5, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(5);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE);
@@ -178,16 +178,16 @@ public class PlanItemCompletionTest extends FlowableCmmnTestCase {
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(1, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(1);
         assertPlanItemInstanceState(planItemInstances, "Task E", ENABLED);
 
         // start and complete Task E -> case must be completed, as Task E is ignored after first completion
         cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task E"));
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task E"));
 
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().count());
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
     @Test
@@ -197,7 +197,7 @@ public class PlanItemCompletionTest extends FlowableCmmnTestCase {
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(7, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(7);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ENABLED);
@@ -212,7 +212,7 @@ public class PlanItemCompletionTest extends FlowableCmmnTestCase {
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(7, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(7);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ENABLED);
@@ -227,7 +227,7 @@ public class PlanItemCompletionTest extends FlowableCmmnTestCase {
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(5, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(5);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ENABLED);
@@ -240,7 +240,7 @@ public class PlanItemCompletionTest extends FlowableCmmnTestCase {
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ENABLED);
@@ -251,7 +251,7 @@ public class PlanItemCompletionTest extends FlowableCmmnTestCase {
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE);
@@ -262,7 +262,7 @@ public class PlanItemCompletionTest extends FlowableCmmnTestCase {
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE);
@@ -271,9 +271,9 @@ public class PlanItemCompletionTest extends FlowableCmmnTestCase {
         // complete Task B -> case must be completed now
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task B"));
 
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().count());
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
     @Test
@@ -284,7 +284,7 @@ public class PlanItemCompletionTest extends FlowableCmmnTestCase {
         // because autocompletion is off, we still stay in Stage A
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task D", WAITING_FOR_REPETITION);
         assertPlanItemInstanceState(planItemInstances, "Task E", AVAILABLE);
@@ -297,20 +297,20 @@ public class PlanItemCompletionTest extends FlowableCmmnTestCase {
         runComplexCompletionTestScenario(true);
 
         // because autocompletion is on, the case will be completed
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().count());
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
     protected CaseInstance runComplexCompletionTestScenario(boolean autocompleteEnabled) {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("testCompletionWithConditions")
-            .variable("autocompleteEnabled", autocompleteEnabled)
-            .start();
+                .caseDefinitionKey("testCompletionWithConditions")
+                .variable("autocompleteEnabled", autocompleteEnabled)
+                .start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(9, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(9);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
@@ -326,7 +326,7 @@ public class PlanItemCompletionTest extends FlowableCmmnTestCase {
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(9, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(9);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ENABLED);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
@@ -341,7 +341,7 @@ public class PlanItemCompletionTest extends FlowableCmmnTestCase {
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(9, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(9);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ENABLED);
         assertPlanItemInstanceState(planItemInstances, "Task C", ACTIVE);
@@ -358,7 +358,7 @@ public class PlanItemCompletionTest extends FlowableCmmnTestCase {
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(8, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(8);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task D", ACTIVE, WAITING_FOR_REPETITION);
@@ -373,7 +373,7 @@ public class PlanItemCompletionTest extends FlowableCmmnTestCase {
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(6, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(6);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task D", WAITING_FOR_REPETITION);
         assertPlanItemInstanceState(planItemInstances, "Task E", AVAILABLE);
@@ -391,7 +391,7 @@ public class PlanItemCompletionTest extends FlowableCmmnTestCase {
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(5, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(5);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task D", WAITING_FOR_REPETITION);
         assertPlanItemInstanceState(planItemInstances, "Task E", AVAILABLE);
@@ -404,7 +404,7 @@ public class PlanItemCompletionTest extends FlowableCmmnTestCase {
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task D", WAITING_FOR_REPETITION);
         assertPlanItemInstanceState(planItemInstances, "Task E", AVAILABLE);

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/PlanItemExitSentryTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/PlanItemExitSentryTest.java
@@ -12,13 +12,13 @@
  */
 package org.flowable.cmmn.test.runtime;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.ACTIVE;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.AVAILABLE;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.COMPLETED;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.ENABLED;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.TERMINATED;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.WAITING_FOR_REPETITION;
-import static org.junit.Assert.assertEquals;
 
 import java.util.List;
 
@@ -42,7 +42,7 @@ public class PlanItemExitSentryTest extends FlowableCmmnTestCase {
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Kill active and enabled tasks B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks B", AVAILABLE);
@@ -55,11 +55,11 @@ public class PlanItemExitSentryTest extends FlowableCmmnTestCase {
         assertPlanItemInstanceState(planItemInstances, "Task F", AVAILABLE);
 
         // trigger exit sentry with Task A still in enabled state -> nothing must be changed
-        cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByName(planItemInstances,"Kill active tasks A"));
+        cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByName(planItemInstances, "Kill active tasks A"));
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Kill active and enabled tasks B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks B", AVAILABLE);
@@ -79,7 +79,7 @@ public class PlanItemExitSentryTest extends FlowableCmmnTestCase {
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Kill active and enabled tasks B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks B", AVAILABLE);
@@ -94,13 +94,13 @@ public class PlanItemExitSentryTest extends FlowableCmmnTestCase {
         // start Task A, check it to be in active state and then trigger its exit sentry, which will kill active task a, but leave it in enabled state
         cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task A"));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByName(planItemInstances, "Kill active tasks A"));
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Kill active and enabled tasks B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks B", AVAILABLE);
@@ -120,7 +120,7 @@ public class PlanItemExitSentryTest extends FlowableCmmnTestCase {
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Kill active and enabled tasks B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks B", AVAILABLE);
@@ -133,11 +133,11 @@ public class PlanItemExitSentryTest extends FlowableCmmnTestCase {
         assertPlanItemInstanceState(planItemInstances, "Task F", AVAILABLE);
 
         // trigger exit sentry with Task B still in available state -> nothing must be changed
-        cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByName(planItemInstances,"Kill active tasks B"));
+        cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByName(planItemInstances, "Kill active tasks B"));
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Kill active and enabled tasks B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks B", AVAILABLE);
@@ -157,7 +157,7 @@ public class PlanItemExitSentryTest extends FlowableCmmnTestCase {
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Kill active and enabled tasks B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks B", AVAILABLE);
@@ -175,11 +175,11 @@ public class PlanItemExitSentryTest extends FlowableCmmnTestCase {
         assertPlanItemInstanceState(planItemInstances, "Task B", ENABLED, WAITING_FOR_REPETITION);
 
         // trigger exit sentry with Task B still in enabled state -> nothing must be changed
-        cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByName(planItemInstances,"Kill active tasks B"));
+        cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByName(planItemInstances, "Kill active tasks B"));
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(11, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(11);
         assertPlanItemInstanceState(planItemInstances, "Kill active and enabled tasks B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks B", AVAILABLE);
@@ -199,7 +199,7 @@ public class PlanItemExitSentryTest extends FlowableCmmnTestCase {
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Kill active and enabled tasks B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks B", AVAILABLE);
@@ -217,12 +217,12 @@ public class PlanItemExitSentryTest extends FlowableCmmnTestCase {
         assertPlanItemInstanceState(planItemInstances, "Task B", ENABLED, WAITING_FOR_REPETITION);
 
         // now even start Task B, so it becomes active
-        cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances,"Task B", ENABLED));
+        cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task B", ENABLED));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
         assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE, WAITING_FOR_REPETITION);
 
         // trigger exit sentry with Task B still in active state -> must terminate the active task B, but leave it in witing for repetition state
-        cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByName(planItemInstances,"Kill active tasks B"));
+        cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByName(planItemInstances, "Kill active tasks B"));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
         assertPlanItemInstanceState(planItemInstances, "Task B", WAITING_FOR_REPETITION);
 
@@ -233,7 +233,7 @@ public class PlanItemExitSentryTest extends FlowableCmmnTestCase {
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(11, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(11);
         assertPlanItemInstanceState(planItemInstances, "Kill active and enabled tasks B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks B", AVAILABLE);
@@ -253,7 +253,7 @@ public class PlanItemExitSentryTest extends FlowableCmmnTestCase {
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Kill active and enabled tasks B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks B", AVAILABLE);
@@ -271,7 +271,7 @@ public class PlanItemExitSentryTest extends FlowableCmmnTestCase {
         assertPlanItemInstanceState(planItemInstances, "Task B", ENABLED, WAITING_FOR_REPETITION);
 
         // trigger exit sentry with Task B still in enabled state -> must terminate the enabled task B, but leave it in waiting for repetition state
-        cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByName(planItemInstances,"Kill active and enabled tasks B"));
+        cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByName(planItemInstances, "Kill active and enabled tasks B"));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
         assertPlanItemInstanceState(planItemInstances, "Task B", WAITING_FOR_REPETITION);
 
@@ -282,7 +282,7 @@ public class PlanItemExitSentryTest extends FlowableCmmnTestCase {
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(11, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(11);
         assertPlanItemInstanceState(planItemInstances, "Kill active and enabled tasks B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks B", AVAILABLE);
@@ -302,7 +302,7 @@ public class PlanItemExitSentryTest extends FlowableCmmnTestCase {
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Kill active and enabled tasks B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks B", AVAILABLE);
@@ -320,12 +320,12 @@ public class PlanItemExitSentryTest extends FlowableCmmnTestCase {
         assertPlanItemInstanceState(planItemInstances, "Task B", ENABLED, WAITING_FOR_REPETITION);
 
         // now even start Task B, so it becomes active
-        cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances,"Task B", ENABLED));
+        cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task B", ENABLED));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
         assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE, WAITING_FOR_REPETITION);
 
         // trigger exit sentry with Task B still in active state -> must terminate the active task B, but leave it in witing for repetition state
-        cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByName(planItemInstances,"Kill active and enabled tasks B"));
+        cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByName(planItemInstances, "Kill active and enabled tasks B"));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
         assertPlanItemInstanceState(planItemInstances, "Task B", WAITING_FOR_REPETITION);
 
@@ -336,7 +336,7 @@ public class PlanItemExitSentryTest extends FlowableCmmnTestCase {
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(11, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(11);
         assertPlanItemInstanceState(planItemInstances, "Kill active and enabled tasks B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks B", AVAILABLE);
@@ -356,7 +356,7 @@ public class PlanItemExitSentryTest extends FlowableCmmnTestCase {
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Kill active and enabled tasks B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks B", AVAILABLE);
@@ -374,23 +374,22 @@ public class PlanItemExitSentryTest extends FlowableCmmnTestCase {
         assertPlanItemInstanceState(planItemInstances, "Task B", ENABLED, WAITING_FOR_REPETITION);
 
         // now even start Task B, so it becomes active
-        cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances,"Task B", ENABLED));
+        cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task B", ENABLED));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
         assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE, WAITING_FOR_REPETITION);
 
         // repeat this for another two new tasks
         cmmnRuntimeService.setVariable(caseInstance.getId(), "enableTaskB", true);
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances,"Task B", ENABLED));
+        cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task B", ENABLED));
         cmmnRuntimeService.setVariable(caseInstance.getId(), "enableTaskB", true);
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances,"Task B", ENABLED));
+        cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task B", ENABLED));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
         assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE, ACTIVE, ACTIVE, WAITING_FOR_REPETITION);
 
-
         // trigger exit sentry with Task B still in active state -> must terminate the active task B, but leave it in witing for repetition state
-        cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByName(planItemInstances,"Kill active and enabled tasks B"));
+        cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByName(planItemInstances, "Kill active and enabled tasks B"));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
         assertPlanItemInstanceState(planItemInstances, "Task B", WAITING_FOR_REPETITION);
 
@@ -401,7 +400,7 @@ public class PlanItemExitSentryTest extends FlowableCmmnTestCase {
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(11, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(11);
         assertPlanItemInstanceState(planItemInstances, "Kill active and enabled tasks B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks B", AVAILABLE);
@@ -421,7 +420,7 @@ public class PlanItemExitSentryTest extends FlowableCmmnTestCase {
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Kill active and enabled tasks B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks B", AVAILABLE);
@@ -452,7 +451,7 @@ public class PlanItemExitSentryTest extends FlowableCmmnTestCase {
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Kill active and enabled tasks B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks B", AVAILABLE);
@@ -487,7 +486,7 @@ public class PlanItemExitSentryTest extends FlowableCmmnTestCase {
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Kill active and enabled tasks B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks B", AVAILABLE);
@@ -524,7 +523,7 @@ public class PlanItemExitSentryTest extends FlowableCmmnTestCase {
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Kill active and enabled tasks B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks B", AVAILABLE);

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/PlanItemInjectionTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/PlanItemInjectionTest.java
@@ -12,11 +12,9 @@
  */
 package org.flowable.cmmn.test.runtime;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.ACTIVE;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.AVAILABLE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
@@ -45,7 +43,6 @@ public class PlanItemInjectionTest extends FlowableCmmnTestCase {
 
     protected CmmnDeploymentManager deploymentManager;
 
-
     @Test
     @CmmnDeployment
     public void testDynamicPlanItemInjection() {
@@ -53,58 +50,59 @@ public class PlanItemInjectionTest extends FlowableCmmnTestCase {
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
 
         // inject new plan item into Stage A
         PlanItemInstance injectedTask = dynamicCmmnService
-            .createInjectedPlanItemInstanceBuilder()
-            .name("Injected Task A")
-            .caseDefinitionId(caseInstance.getCaseDefinitionId())
-            .elementId(getPlanItemInstanceByName(planItemInstances, "Task A", ACTIVE).getElementId())
-            .createInStage(getPlanItemInstanceIdByNameAndState(planItemInstances, "Stage A", ACTIVE));
+                .createInjectedPlanItemInstanceBuilder()
+                .name("Injected Task A")
+                .caseDefinitionId(caseInstance.getCaseDefinitionId())
+                .elementId(getPlanItemInstanceByName(planItemInstances, "Task A", ACTIVE).getElementId())
+                .createInStage(getPlanItemInstanceIdByNameAndState(planItemInstances, "Stage A", ACTIVE));
 
-        assertNotNull(injectedTask);
-        assertEquals(ACTIVE, injectedTask.getState());
+        assertThat(injectedTask).isNotNull();
+        assertThat(injectedTask.getState()).isEqualTo(ACTIVE);
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Injected Task A", ACTIVE);
 
         List<Task> tasks = cmmnTaskService.createTaskQuery()
-            .caseInstanceId(caseInstance.getId())
-            .active()
-            .list();
+                .caseInstanceId(caseInstance.getId())
+                .active()
+                .list();
 
-        assertNotNull(tasks);
-        assertEquals(2, tasks.size());
+        assertThat(tasks).isNotNull();
+        assertThat(tasks).hasSize(2);
         assertSingleTaskExists(tasks, "Task A");
         assertSingleTaskExists(tasks, "Injected Task A");
 
         // test the query for the derived case definition (in this unit test, it will be the same as the running one)
         List<PlanItemInstance> derivedPlanItems = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .derivedCaseDefinitionId(caseInstance.getCaseDefinitionId())
-            .list();
+                .derivedCaseDefinitionId(caseInstance.getCaseDefinitionId())
+                .list();
 
-        assertNotNull(derivedPlanItems);
-        assertEquals(1, derivedPlanItems.size());
-        assertEquals("Injected Task A", derivedPlanItems.get(0).getName());
+        assertThat(derivedPlanItems).isNotNull();
+        assertThat(derivedPlanItems)
+                .extracting(PlanItemInstance::getName)
+                .containsExactly("Injected Task A");
 
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Injected Task A", ACTIVE);
 
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Injected Task A", ACTIVE));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(2, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(2);
         assertPlanItemInstanceState(planItemInstances, "Stage B", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE);
     }
@@ -116,300 +114,306 @@ public class PlanItemInjectionTest extends FlowableCmmnTestCase {
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
 
         // inject new plan item into case instance
         PlanItemInstance injectedTask = dynamicCmmnService
-            .createInjectedPlanItemInstanceBuilder()
-            .name("Injected Task A")
-            .caseDefinitionId(caseInstance.getCaseDefinitionId())
-            .elementId(getPlanItemInstanceByName(planItemInstances, "Task A", ACTIVE).getElementId())
-            .createInCase(caseInstance.getId());
+                .createInjectedPlanItemInstanceBuilder()
+                .name("Injected Task A")
+                .caseDefinitionId(caseInstance.getCaseDefinitionId())
+                .elementId(getPlanItemInstanceByName(planItemInstances, "Task A", ACTIVE).getElementId())
+                .createInCase(caseInstance.getId());
 
-        assertNotNull(injectedTask);
-        assertEquals(ACTIVE, injectedTask.getState());
+        assertThat(injectedTask).isNotNull();
+        assertThat(injectedTask.getState()).isEqualTo(ACTIVE);
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Injected Task A", ACTIVE);
 
         List<Task> tasks = cmmnTaskService.createTaskQuery()
-            .caseInstanceId(caseInstance.getId())
-            .active()
-            .list();
+                .caseInstanceId(caseInstance.getId())
+                .active()
+                .list();
 
-        assertNotNull(tasks);
-        assertEquals(2, tasks.size());
+        assertThat(tasks).isNotNull();
+        assertThat(tasks).hasSize(2);
         assertSingleTaskExists(tasks, "Task A");
         assertSingleTaskExists(tasks, "Injected Task A");
 
         // test the query for the derived case definition (in this unit test, it will be the same as the running one)
         List<PlanItemInstance> derivedPlanItems = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .derivedCaseDefinitionId(caseInstance.getCaseDefinitionId())
-            .list();
+                .derivedCaseDefinitionId(caseInstance.getCaseDefinitionId())
+                .list();
 
-        assertNotNull(derivedPlanItems);
-        assertEquals(1, derivedPlanItems.size());
-        assertEquals("Injected Task A", derivedPlanItems.get(0).getName());
+        assertThat(derivedPlanItems).isNotNull();
+        assertThat(derivedPlanItems)
+                .extracting(PlanItemInstance::getName)
+                .containsExactly("Injected Task A");
 
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Stage B", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Injected Task A", ACTIVE);
 
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task B", ACTIVE));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(1, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(1);
         assertPlanItemInstanceState(planItemInstances, "Injected Task A", ACTIVE);
 
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Injected Task A", ACTIVE));
 
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().count());
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
 
         List<HistoricPlanItemInstance> historicPlanItemInstances = cmmnHistoryService.createHistoricPlanItemInstanceQuery()
-            .planItemInstanceDerivedCaseDefinitionId(caseInstance.getCaseDefinitionId())
-            .list();
+                .planItemInstanceDerivedCaseDefinitionId(caseInstance.getCaseDefinitionId())
+                .list();
 
-        assertNotNull(historicPlanItemInstances);
-        assertEquals(1, historicPlanItemInstances.size());
-        assertEquals("Injected Task A", historicPlanItemInstances.get(0).getName());
+        assertThat(historicPlanItemInstances).isNotNull();
+        assertThat(historicPlanItemInstances)
+                .extracting(HistoricPlanItemInstance::getName)
+                .containsExactly("Injected Task A");
     }
 
     @Test
     @CmmnDeployment(resources = { "org/flowable/cmmn/test/runtime/PlanItemInjectionTest.testDynamicPlanItemInjection.cmmn",
-        "org/flowable/cmmn/test/runtime/PlanItemInjectionTest.dynamicPlanItemTemplates.cmmn" })
+            "org/flowable/cmmn/test/runtime/PlanItemInjectionTest.dynamicPlanItemTemplates.cmmn" })
     public void testDynamicPlanItemInjectionFromTemplate() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("dynamicPlanItemInjection").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
 
         CaseDefinition dynamicPlanItemCase = cmmnRepositoryService.createCaseDefinitionQuery()
-            .caseDefinitionKey("dynamicPlanItemCase")
-            .latestVersion()
-            .singleResult();
+                .caseDefinitionKey("dynamicPlanItemCase")
+                .latestVersion()
+                .singleResult();
 
         CaseElement templateTask = getCase(dynamicPlanItemCase.getId()).getAllCaseElements().get("planItem1");
 
         // inject new plan item into Stage A
         PlanItemInstance injectedTask = dynamicCmmnService
-            .createInjectedPlanItemInstanceBuilder()
-            .name("Injected Task A")
-            .caseDefinitionId(dynamicPlanItemCase.getId())
-            .elementId(templateTask.getId())
-            .createInStage(getPlanItemInstanceIdByNameAndState(planItemInstances, "Stage A", ACTIVE));
+                .createInjectedPlanItemInstanceBuilder()
+                .name("Injected Task A")
+                .caseDefinitionId(dynamicPlanItemCase.getId())
+                .elementId(templateTask.getId())
+                .createInStage(getPlanItemInstanceIdByNameAndState(planItemInstances, "Stage A", ACTIVE));
 
-        assertNotNull(injectedTask);
-        assertEquals(ACTIVE, injectedTask.getState());
+        assertThat(injectedTask).isNotNull();
+        assertThat(injectedTask.getState()).isEqualTo(ACTIVE);
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Injected Task A", ACTIVE);
 
         List<Task> tasks = cmmnTaskService.createTaskQuery()
-            .caseInstanceId(caseInstance.getId())
-            .active()
-            .list();
+                .caseInstanceId(caseInstance.getId())
+                .active()
+                .list();
 
-        assertNotNull(tasks);
-        assertEquals(2, tasks.size());
+        assertThat(tasks).isNotNull();
+        assertThat(tasks).hasSize(2);
         assertSingleTaskExists(tasks, "Task A");
         assertSingleTaskExists(tasks, "Injected Task A");
 
         // test the query for the derived case definition (in this unit test, it will be a different one from the running case one)
         List<PlanItemInstance> derivedPlanItems = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .derivedCaseDefinitionId(dynamicPlanItemCase.getId())
-            .list();
+                .derivedCaseDefinitionId(dynamicPlanItemCase.getId())
+                .list();
 
-        assertNotNull(derivedPlanItems);
-        assertEquals(1, derivedPlanItems.size());
-        assertEquals("Injected Task A", derivedPlanItems.get(0).getName());
+        assertThat(derivedPlanItems).isNotNull();
+        assertThat(derivedPlanItems)
+                .extracting(PlanItemInstance::getName)
+                .containsExactly("Injected Task A");
 
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Injected Task A", ACTIVE);
 
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Injected Task A", ACTIVE));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(2, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(2);
         assertPlanItemInstanceState(planItemInstances, "Stage B", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE);
 
         List<HistoricPlanItemInstance> historicPlanItemInstances = cmmnHistoryService.createHistoricPlanItemInstanceQuery()
-            .planItemInstanceDerivedCaseDefinitionId(dynamicPlanItemCase.getId())
-            .list();
+                .planItemInstanceDerivedCaseDefinitionId(dynamicPlanItemCase.getId())
+                .list();
 
-        assertNotNull(historicPlanItemInstances);
-        assertEquals(1, historicPlanItemInstances.size());
-        assertEquals("Injected Task A", historicPlanItemInstances.get(0).getName());
+        assertThat(historicPlanItemInstances).isNotNull();
+        assertThat(historicPlanItemInstances)
+                .extracting(HistoricPlanItemInstance::getName)
+                .containsExactly("Injected Task A");
     }
 
     @Test
     @CmmnDeployment(resources = { "org/flowable/cmmn/test/runtime/PlanItemInjectionTest.testDynamicPlanItemInjection.cmmn",
-        "org/flowable/cmmn/test/runtime/PlanItemInjectionTest.dynamicPlanItemTemplates.cmmn" })
+            "org/flowable/cmmn/test/runtime/PlanItemInjectionTest.dynamicPlanItemTemplates.cmmn" })
     public void testDynamicPlanItemInjectionFromTemplateInCase() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("dynamicPlanItemInjection").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
 
         CaseDefinition dynamicPlanItemCase = cmmnRepositoryService.createCaseDefinitionQuery()
-            .caseDefinitionKey("dynamicPlanItemCase")
-            .latestVersion()
-            .singleResult();
+                .caseDefinitionKey("dynamicPlanItemCase")
+                .latestVersion()
+                .singleResult();
 
         CaseElement templateTask = getCase(dynamicPlanItemCase.getId()).getAllCaseElements().get("planItem1");
 
         // inject new plan item into case instance
         PlanItemInstance injectedTask = dynamicCmmnService
-            .createInjectedPlanItemInstanceBuilder()
-            .name("Injected Task A")
-            .caseDefinitionId(dynamicPlanItemCase.getId())
-            .elementId(templateTask.getId())
-            .createInCase(caseInstance.getId());
+                .createInjectedPlanItemInstanceBuilder()
+                .name("Injected Task A")
+                .caseDefinitionId(dynamicPlanItemCase.getId())
+                .elementId(templateTask.getId())
+                .createInCase(caseInstance.getId());
 
-        assertNotNull(injectedTask);
-        assertEquals(ACTIVE, injectedTask.getState());
+        assertThat(injectedTask).isNotNull();
+        assertThat(injectedTask.getState()).isEqualTo(ACTIVE);
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Injected Task A", ACTIVE);
 
         List<Task> tasks = cmmnTaskService.createTaskQuery()
-            .caseInstanceId(caseInstance.getId())
-            .active()
-            .list();
+                .caseInstanceId(caseInstance.getId())
+                .active()
+                .list();
 
-        assertNotNull(tasks);
-        assertEquals(2, tasks.size());
+        assertThat(tasks).isNotNull();
+        assertThat(tasks).hasSize(2);
         assertSingleTaskExists(tasks, "Task A");
         assertSingleTaskExists(tasks, "Injected Task A");
 
         // test the query for the derived case definition (in this unit test, it will be a different one from the running case one)
         List<PlanItemInstance> derivedPlanItems = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .derivedCaseDefinitionId(dynamicPlanItemCase.getId())
-            .list();
+                .derivedCaseDefinitionId(dynamicPlanItemCase.getId())
+                .list();
 
-        assertNotNull(derivedPlanItems);
-        assertEquals(1, derivedPlanItems.size());
-        assertEquals("Injected Task A", derivedPlanItems.get(0).getName());
+        assertThat(derivedPlanItems).isNotNull();
+        assertThat(derivedPlanItems)
+                .extracting(PlanItemInstance::getName)
+                .containsExactly("Injected Task A");
 
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Stage B", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Injected Task A", ACTIVE);
 
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task B", ACTIVE));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(1, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(1);
         assertPlanItemInstanceState(planItemInstances, "Injected Task A", ACTIVE);
 
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Injected Task A", ACTIVE));
 
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().count());
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
 
         List<HistoricPlanItemInstance> historicPlanItemInstances = cmmnHistoryService.createHistoricPlanItemInstanceQuery()
-            .planItemInstanceDerivedCaseDefinitionId(dynamicPlanItemCase.getId())
-            .list();
+                .planItemInstanceDerivedCaseDefinitionId(dynamicPlanItemCase.getId())
+                .list();
 
-        assertNotNull(historicPlanItemInstances);
-        assertEquals(1, historicPlanItemInstances.size());
-        assertEquals("Injected Task A", historicPlanItemInstances.get(0).getName());
+        assertThat(historicPlanItemInstances).isNotNull();
+        assertThat(historicPlanItemInstances)
+                .extracting(HistoricPlanItemInstance::getName)
+                .containsExactly("Injected Task A");
     }
 
     @Test
     @CmmnDeployment(resources = { "org/flowable/cmmn/test/runtime/PlanItemInjectionTest.testDynamicPlanItemInjection.cmmn",
-        "org/flowable/cmmn/test/runtime/PlanItemInjectionTest.dynamicPlanItemTemplates.cmmn" })
+            "org/flowable/cmmn/test/runtime/PlanItemInjectionTest.dynamicPlanItemTemplates.cmmn" })
     public void testDynamicStagePlanItemInjectionFromTemplate() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("dynamicPlanItemInjection").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
 
         CaseDefinition dynamicPlanItemCase = cmmnRepositoryService.createCaseDefinitionQuery()
-            .caseDefinitionKey("dynamicPlanItemCase")
-            .latestVersion()
-            .singleResult();
+                .caseDefinitionKey("dynamicPlanItemCase")
+                .latestVersion()
+                .singleResult();
 
         CaseElement templateStage = getCase(dynamicPlanItemCase.getId()).getAllCaseElements().get("planItem5");
 
         // inject new plan item into Stage A
         PlanItemInstance injectedStage = dynamicCmmnService
-            .createInjectedPlanItemInstanceBuilder()
-            .name("Injected Stage")
-            .caseDefinitionId(dynamicPlanItemCase.getId())
-            .elementId(templateStage.getId())
-            .createInStage(getPlanItemInstanceIdByNameAndState(planItemInstances, "Stage A", ACTIVE));
+                .createInjectedPlanItemInstanceBuilder()
+                .name("Injected Stage")
+                .caseDefinitionId(dynamicPlanItemCase.getId())
+                .elementId(templateStage.getId())
+                .createInStage(getPlanItemInstanceIdByNameAndState(planItemInstances, "Stage A", ACTIVE));
 
-        assertNotNull(injectedStage);
-        assertEquals(ACTIVE, injectedStage.getState());
+        assertThat(injectedStage).isNotNull();
+        assertThat(injectedStage.getState()).isEqualTo(ACTIVE);
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(6, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(6);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Injected Stage", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Injected Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Injected Task B", AVAILABLE);
-        assertTrue(getPlanItemInstanceByName(planItemInstances, "Injected Stage", ACTIVE).isStage());
+        assertThat(getPlanItemInstanceByName(planItemInstances, "Injected Stage", ACTIVE).isStage()).isTrue();
 
         List<Task> tasks = cmmnTaskService.createTaskQuery()
-            .caseInstanceId(caseInstance.getId())
-            .active()
-            .list();
+                .caseInstanceId(caseInstance.getId())
+                .active()
+                .list();
 
-        assertNotNull(tasks);
-        assertEquals(2, tasks.size());
+        assertThat(tasks).isNotNull();
+        assertThat(tasks).hasSize(2);
         assertSingleTaskExists(tasks, "Task A");
         assertSingleTaskExists(tasks, "Injected Task A");
 
         // test the query for the derived case definition (in this unit test, it will be a different one from the running case one)
         List<PlanItemInstance> derivedPlanItems = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .derivedCaseDefinitionId(dynamicPlanItemCase.getId())
-            .list();
+                .derivedCaseDefinitionId(dynamicPlanItemCase.getId())
+                .list();
 
-        assertNotNull(derivedPlanItems);
-        assertEquals(3, derivedPlanItems.size());
+        assertThat(derivedPlanItems).isNotNull();
+        assertThat(derivedPlanItems).hasSize(3);
 
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(5, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(5);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Injected Stage", ACTIVE);
@@ -418,7 +422,7 @@ public class PlanItemInjectionTest extends FlowableCmmnTestCase {
 
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Injected Task A", ACTIVE));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Injected Stage", ACTIVE);
@@ -426,80 +430,80 @@ public class PlanItemInjectionTest extends FlowableCmmnTestCase {
 
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Injected Task B", ACTIVE));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(2, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(2);
         assertPlanItemInstanceState(planItemInstances, "Stage B", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE);
 
         List<HistoricPlanItemInstance> historicPlanItemInstances = cmmnHistoryService.createHistoricPlanItemInstanceQuery()
-            .planItemInstanceDerivedCaseDefinitionId(dynamicPlanItemCase.getId())
-            .list();
+                .planItemInstanceDerivedCaseDefinitionId(dynamicPlanItemCase.getId())
+                .list();
 
-        assertNotNull(historicPlanItemInstances);
-        assertEquals(3, historicPlanItemInstances.size());
+        assertThat(historicPlanItemInstances).isNotNull();
+        assertThat(historicPlanItemInstances).hasSize(3);
     }
 
     @Test
     @CmmnDeployment(resources = { "org/flowable/cmmn/test/runtime/PlanItemInjectionTest.testDynamicPlanItemInjection.cmmn",
-        "org/flowable/cmmn/test/runtime/PlanItemInjectionTest.dynamicPlanItemTemplates.cmmn" })
+            "org/flowable/cmmn/test/runtime/PlanItemInjectionTest.dynamicPlanItemTemplates.cmmn" })
     public void testDynamicStagePlanItemInjectionFromTemplateInCase() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("dynamicPlanItemInjection").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
 
         CaseDefinition dynamicPlanItemCase = cmmnRepositoryService.createCaseDefinitionQuery()
-            .caseDefinitionKey("dynamicPlanItemCase")
-            .latestVersion()
-            .singleResult();
+                .caseDefinitionKey("dynamicPlanItemCase")
+                .latestVersion()
+                .singleResult();
 
         CaseElement templateStage = getCase(dynamicPlanItemCase.getId()).getAllCaseElements().get("planItem5");
 
         // inject new plan item into running case
         PlanItemInstance injectedStage = dynamicCmmnService
-            .createInjectedPlanItemInstanceBuilder()
-            .name("Injected Stage")
-            .caseDefinitionId(dynamicPlanItemCase.getId())
-            .elementId(templateStage.getId())
-            .createInCase(caseInstance.getId());
+                .createInjectedPlanItemInstanceBuilder()
+                .name("Injected Stage")
+                .caseDefinitionId(dynamicPlanItemCase.getId())
+                .elementId(templateStage.getId())
+                .createInCase(caseInstance.getId());
 
-        assertNotNull(injectedStage);
-        assertEquals(ACTIVE, injectedStage.getState());
+        assertThat(injectedStage).isNotNull();
+        assertThat(injectedStage.getState()).isEqualTo(ACTIVE);
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(6, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(6);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Injected Stage", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Injected Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Injected Task B", AVAILABLE);
-        assertTrue(getPlanItemInstanceByName(planItemInstances, "Injected Stage", ACTIVE).isStage());
+        assertThat(getPlanItemInstanceByName(planItemInstances, "Injected Stage", ACTIVE).isStage()).isTrue();
 
         List<Task> tasks = cmmnTaskService.createTaskQuery()
-            .caseInstanceId(caseInstance.getId())
-            .active()
-            .list();
+                .caseInstanceId(caseInstance.getId())
+                .active()
+                .list();
 
-        assertNotNull(tasks);
-        assertEquals(2, tasks.size());
+        assertThat(tasks).isNotNull();
+        assertThat(tasks).hasSize(2);
         assertSingleTaskExists(tasks, "Task A");
         assertSingleTaskExists(tasks, "Injected Task A");
 
         // test the query for the derived case definition (in this unit test, it will be a different one from the running case one)
         List<PlanItemInstance> derivedPlanItems = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .derivedCaseDefinitionId(dynamicPlanItemCase.getId())
-            .list();
+                .derivedCaseDefinitionId(dynamicPlanItemCase.getId())
+                .list();
 
-        assertNotNull(derivedPlanItems);
-        assertEquals(3, derivedPlanItems.size());
+        assertThat(derivedPlanItems).isNotNull();
+        assertThat(derivedPlanItems).hasSize(3);
 
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(5, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(5);
         assertPlanItemInstanceState(planItemInstances, "Stage B", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Injected Stage", ACTIVE);
@@ -508,7 +512,7 @@ public class PlanItemInjectionTest extends FlowableCmmnTestCase {
 
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Injected Task A", ACTIVE));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Stage B", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Injected Stage", ACTIVE);
@@ -516,41 +520,41 @@ public class PlanItemInjectionTest extends FlowableCmmnTestCase {
 
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task B", ACTIVE));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(2, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(2);
         assertPlanItemInstanceState(planItemInstances, "Injected Stage", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Injected Task B", ACTIVE);
 
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Injected Task B", ACTIVE));
 
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().count());
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
 
         List<HistoricPlanItemInstance> historicPlanItemInstances = cmmnHistoryService.createHistoricPlanItemInstanceQuery()
-            .planItemInstanceDerivedCaseDefinitionId(dynamicPlanItemCase.getId())
-            .list();
+                .planItemInstanceDerivedCaseDefinitionId(dynamicPlanItemCase.getId())
+                .list();
 
-        assertNotNull(historicPlanItemInstances);
-        assertEquals(3, historicPlanItemInstances.size());
+        assertThat(historicPlanItemInstances).isNotNull();
+        assertThat(historicPlanItemInstances).hasSize(3);
     }
 
     @Test
     @CmmnDeployment(resources = { "org/flowable/cmmn/test/runtime/PlanItemInjectionTest.testDynamicPlanItemInjection.cmmn",
-        "org/flowable/cmmn/test/runtime/PlanItemInjectionTest.dynamicPlanItemTemplates.cmmn" })
+            "org/flowable/cmmn/test/runtime/PlanItemInjectionTest.dynamicPlanItemTemplates.cmmn" })
     public void testDynamicStagePlanItemInjectionWithSentryFromTemplate() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("dynamicPlanItemInjection").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
 
         CaseDefinition dynamicPlanItemCase = cmmnRepositoryService.createCaseDefinitionQuery()
-            .caseDefinitionKey("dynamicPlanItemCase")
-            .latestVersion()
-            .singleResult();
+                .caseDefinitionKey("dynamicPlanItemCase")
+                .latestVersion()
+                .singleResult();
 
         // already make sure the condition for the injected stage entry sentry will be satisfied when the stage will be injected
         cmmnRuntimeService.setVariable(caseInstance.getId(), "injectedStageEnabled", true);
@@ -559,17 +563,17 @@ public class PlanItemInjectionTest extends FlowableCmmnTestCase {
 
         // inject new plan item into Stage A
         PlanItemInstance injectedStage = dynamicCmmnService
-            .createInjectedPlanItemInstanceBuilder()
-            .name("Injected Stage")
-            .caseDefinitionId(dynamicPlanItemCase.getId())
-            .elementId(templateStage.getId())
-            .createInStage(getPlanItemInstanceIdByNameAndState(planItemInstances, "Stage A", ACTIVE));
+                .createInjectedPlanItemInstanceBuilder()
+                .name("Injected Stage")
+                .caseDefinitionId(dynamicPlanItemCase.getId())
+                .elementId(templateStage.getId())
+                .createInStage(getPlanItemInstanceIdByNameAndState(planItemInstances, "Stage A", ACTIVE));
 
-        assertNotNull(injectedStage);
-        assertEquals(ACTIVE, injectedStage.getState());
+        assertThat(injectedStage).isNotNull();
+        assertThat(injectedStage.getState()).isEqualTo(ACTIVE);
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(6, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(6);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Injected Stage", ACTIVE);
@@ -578,27 +582,27 @@ public class PlanItemInjectionTest extends FlowableCmmnTestCase {
         assertPlanItemInstanceState(planItemInstances, "Task Y", ACTIVE);
 
         List<Task> tasks = cmmnTaskService.createTaskQuery()
-            .caseInstanceId(caseInstance.getId())
-            .active()
-            .list();
+                .caseInstanceId(caseInstance.getId())
+                .active()
+                .list();
 
-        assertNotNull(tasks);
-        assertEquals(3, tasks.size());
+        assertThat(tasks).isNotNull();
+        assertThat(tasks).hasSize(3);
         assertSingleTaskExists(tasks, "Task A");
         assertSingleTaskExists(tasks, "Task X");
         assertSingleTaskExists(tasks, "Task Y");
 
         // test the query for the derived case definition (in this unit test, it will be a different one from the running case one)
         List<PlanItemInstance> derivedPlanItems = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .derivedCaseDefinitionId(dynamicPlanItemCase.getId())
-            .list();
+                .derivedCaseDefinitionId(dynamicPlanItemCase.getId())
+                .list();
 
-        assertNotNull(derivedPlanItems);
-        assertEquals(3, derivedPlanItems.size());
+        assertThat(derivedPlanItems).isNotNull();
+        assertThat(derivedPlanItems).hasSize(3);
 
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(5, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(5);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Injected Stage", ACTIVE);
@@ -607,7 +611,7 @@ public class PlanItemInjectionTest extends FlowableCmmnTestCase {
 
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task X", ACTIVE));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Injected Stage", ACTIVE);
@@ -615,28 +619,28 @@ public class PlanItemInjectionTest extends FlowableCmmnTestCase {
 
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task Y", ACTIVE));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(2, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(2);
         assertPlanItemInstanceState(planItemInstances, "Stage B", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE);
     }
 
     @Test
     @CmmnDeployment(resources = { "org/flowable/cmmn/test/runtime/PlanItemInjectionTest.testDynamicPlanItemInjection.cmmn",
-        "org/flowable/cmmn/test/runtime/PlanItemInjectionTest.dynamicPlanItemTemplates.cmmn" })
+            "org/flowable/cmmn/test/runtime/PlanItemInjectionTest.dynamicPlanItemTemplates.cmmn" })
     public void testDynamicStagePlanItemInjectionWithSentryFromTemplateInCase() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("dynamicPlanItemInjection").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
 
         CaseDefinition dynamicPlanItemCase = cmmnRepositoryService.createCaseDefinitionQuery()
-            .caseDefinitionKey("dynamicPlanItemCase")
-            .latestVersion()
-            .singleResult();
+                .caseDefinitionKey("dynamicPlanItemCase")
+                .latestVersion()
+                .singleResult();
 
         // already make sure the condition for the injected stage entry sentry will be satisfied when the stage will be injected
         cmmnRuntimeService.setVariable(caseInstance.getId(), "injectedStageEnabled", true);
@@ -645,17 +649,17 @@ public class PlanItemInjectionTest extends FlowableCmmnTestCase {
 
         // inject new plan item into running case
         PlanItemInstance injectedStage = dynamicCmmnService
-            .createInjectedPlanItemInstanceBuilder()
-            .name("Injected Stage")
-            .caseDefinitionId(dynamicPlanItemCase.getId())
-            .elementId(templateStage.getId())
-            .createInCase(caseInstance.getId());
+                .createInjectedPlanItemInstanceBuilder()
+                .name("Injected Stage")
+                .caseDefinitionId(dynamicPlanItemCase.getId())
+                .elementId(templateStage.getId())
+                .createInCase(caseInstance.getId());
 
-        assertNotNull(injectedStage);
-        assertEquals(ACTIVE, injectedStage.getState());
+        assertThat(injectedStage).isNotNull();
+        assertThat(injectedStage.getState()).isEqualTo(ACTIVE);
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(6, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(6);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Injected Stage", ACTIVE);
@@ -664,27 +668,27 @@ public class PlanItemInjectionTest extends FlowableCmmnTestCase {
         assertPlanItemInstanceState(planItemInstances, "Task Y", ACTIVE);
 
         List<Task> tasks = cmmnTaskService.createTaskQuery()
-            .caseInstanceId(caseInstance.getId())
-            .active()
-            .list();
+                .caseInstanceId(caseInstance.getId())
+                .active()
+                .list();
 
-        assertNotNull(tasks);
-        assertEquals(3, tasks.size());
+        assertThat(tasks).isNotNull();
+        assertThat(tasks).hasSize(3);
         assertSingleTaskExists(tasks, "Task A");
         assertSingleTaskExists(tasks, "Task X");
         assertSingleTaskExists(tasks, "Task Y");
 
         // test the query for the derived case definition (in this unit test, it will be a different one from the running case one)
         List<PlanItemInstance> derivedPlanItems = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .derivedCaseDefinitionId(dynamicPlanItemCase.getId())
-            .list();
+                .derivedCaseDefinitionId(dynamicPlanItemCase.getId())
+                .list();
 
-        assertNotNull(derivedPlanItems);
-        assertEquals(3, derivedPlanItems.size());
+        assertThat(derivedPlanItems).isNotNull();
+        assertThat(derivedPlanItems).hasSize(3);
 
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(5, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(5);
         assertPlanItemInstanceState(planItemInstances, "Stage B", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Injected Stage", ACTIVE);
@@ -693,7 +697,7 @@ public class PlanItemInjectionTest extends FlowableCmmnTestCase {
 
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task X", ACTIVE));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Stage B", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Injected Stage", ACTIVE);
@@ -701,66 +705,66 @@ public class PlanItemInjectionTest extends FlowableCmmnTestCase {
 
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task B", ACTIVE));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(2, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(2);
         assertPlanItemInstanceState(planItemInstances, "Injected Stage", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task Y", ACTIVE);
 
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task Y", ACTIVE));
 
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().count());
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
 
         List<HistoricPlanItemInstance> historicPlanItemInstances = cmmnHistoryService.createHistoricPlanItemInstanceQuery()
-            .planItemInstanceDerivedCaseDefinitionId(dynamicPlanItemCase.getId())
-            .list();
+                .planItemInstanceDerivedCaseDefinitionId(dynamicPlanItemCase.getId())
+                .list();
 
-        assertNotNull(historicPlanItemInstances);
-        assertEquals(3, historicPlanItemInstances.size());
+        assertThat(historicPlanItemInstances).isNotNull();
+        assertThat(historicPlanItemInstances).hasSize(3);
     }
 
     @Test
     @CmmnDeployment(resources = { "org/flowable/cmmn/test/runtime/PlanItemInjectionTest.testDynamicPlanItemInjection.cmmn",
-        "org/flowable/cmmn/test/runtime/PlanItemInjectionTest.dynamicPlanItemTemplates.cmmn" })
+            "org/flowable/cmmn/test/runtime/PlanItemInjectionTest.dynamicPlanItemTemplates.cmmn" })
     public void testDynamicStagePlanItemInjectionWithSentryConditionFromTemplate() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("dynamicPlanItemInjection").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
 
         CaseDefinition dynamicPlanItemCase = cmmnRepositoryService.createCaseDefinitionQuery()
-            .caseDefinitionKey("dynamicPlanItemCase")
-            .latestVersion()
-            .singleResult();
+                .caseDefinitionKey("dynamicPlanItemCase")
+                .latestVersion()
+                .singleResult();
 
         CaseElement templateStage = getCase(dynamicPlanItemCase.getId()).getAllCaseElements().get("planItem8");
 
         // inject new plan item into Stage A
         PlanItemInstance injectedStage = dynamicCmmnService
-            .createInjectedPlanItemInstanceBuilder()
-            .name("Injected Stage")
-            .caseDefinitionId(dynamicPlanItemCase.getId())
-            .elementId(templateStage.getId())
-            .createInStage(getPlanItemInstanceIdByNameAndState(planItemInstances, "Stage A", ACTIVE));
+                .createInjectedPlanItemInstanceBuilder()
+                .name("Injected Stage")
+                .caseDefinitionId(dynamicPlanItemCase.getId())
+                .elementId(templateStage.getId())
+                .createInStage(getPlanItemInstanceIdByNameAndState(planItemInstances, "Stage A", ACTIVE));
 
-        assertNotNull(injectedStage);
-        assertEquals(AVAILABLE, injectedStage.getState());
+        assertThat(injectedStage).isNotNull();
+        assertThat(injectedStage.getState()).isEqualTo(AVAILABLE);
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Injected Stage", AVAILABLE);
-        assertTrue(getPlanItemInstanceByName(planItemInstances, "Injected Stage", AVAILABLE).isStage());
+        assertThat(getPlanItemInstanceByName(planItemInstances, "Injected Stage", AVAILABLE).isStage()).isTrue();
 
         cmmnRuntimeService.setVariable(caseInstance.getId(), "injectedStageEnabled", true);
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(6, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(6);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Injected Stage", ACTIVE);
@@ -769,27 +773,27 @@ public class PlanItemInjectionTest extends FlowableCmmnTestCase {
         assertPlanItemInstanceState(planItemInstances, "Task Y", ACTIVE);
 
         List<Task> tasks = cmmnTaskService.createTaskQuery()
-            .caseInstanceId(caseInstance.getId())
-            .active()
-            .list();
+                .caseInstanceId(caseInstance.getId())
+                .active()
+                .list();
 
-        assertNotNull(tasks);
-        assertEquals(3, tasks.size());
+        assertThat(tasks).isNotNull();
+        assertThat(tasks).hasSize(3);
         assertSingleTaskExists(tasks, "Task A");
         assertSingleTaskExists(tasks, "Task X");
         assertSingleTaskExists(tasks, "Task Y");
 
         // test the query for the derived case definition (in this unit test, it will be a different one from the running case one)
         List<PlanItemInstance> derivedPlanItems = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .derivedCaseDefinitionId(dynamicPlanItemCase.getId())
-            .list();
+                .derivedCaseDefinitionId(dynamicPlanItemCase.getId())
+                .list();
 
-        assertNotNull(derivedPlanItems);
-        assertEquals(3, derivedPlanItems.size());
+        assertThat(derivedPlanItems).isNotNull();
+        assertThat(derivedPlanItems).hasSize(3);
 
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(5, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(5);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Injected Stage", ACTIVE);
@@ -798,7 +802,7 @@ public class PlanItemInjectionTest extends FlowableCmmnTestCase {
 
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task X", ACTIVE));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Injected Stage", ACTIVE);
@@ -806,53 +810,53 @@ public class PlanItemInjectionTest extends FlowableCmmnTestCase {
 
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task Y", ACTIVE));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(2, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(2);
         assertPlanItemInstanceState(planItemInstances, "Stage B", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE);
     }
 
     @Test
     @CmmnDeployment(resources = { "org/flowable/cmmn/test/runtime/PlanItemInjectionTest.testDynamicPlanItemInjection.cmmn",
-        "org/flowable/cmmn/test/runtime/PlanItemInjectionTest.dynamicPlanItemTemplates.cmmn" })
+            "org/flowable/cmmn/test/runtime/PlanItemInjectionTest.dynamicPlanItemTemplates.cmmn" })
     public void testDynamicStagePlanItemInjectionWithSentryConditionFromTemplateInCase() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("dynamicPlanItemInjection").start();
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(3, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(3);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
 
         CaseDefinition dynamicPlanItemCase = cmmnRepositoryService.createCaseDefinitionQuery()
-            .caseDefinitionKey("dynamicPlanItemCase")
-            .latestVersion()
-            .singleResult();
+                .caseDefinitionKey("dynamicPlanItemCase")
+                .latestVersion()
+                .singleResult();
 
         CaseElement templateStage = getCase(dynamicPlanItemCase.getId()).getAllCaseElements().get("planItem8");
 
         // inject new plan item into running case
         PlanItemInstance injectedStage = dynamicCmmnService
-            .createInjectedPlanItemInstanceBuilder()
-            .name("Injected Stage")
-            .caseDefinitionId(dynamicPlanItemCase.getId())
-            .elementId(templateStage.getId())
-            .createInCase(caseInstance.getId());
+                .createInjectedPlanItemInstanceBuilder()
+                .name("Injected Stage")
+                .caseDefinitionId(dynamicPlanItemCase.getId())
+                .elementId(templateStage.getId())
+                .createInCase(caseInstance.getId());
 
-        assertNotNull(injectedStage);
-        assertEquals(AVAILABLE, injectedStage.getState());
+        assertThat(injectedStage).isNotNull();
+        assertThat(injectedStage.getState()).isEqualTo(AVAILABLE);
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Injected Stage", AVAILABLE);
-        assertTrue(getPlanItemInstanceByName(planItemInstances, "Injected Stage", AVAILABLE).isStage());
+        assertThat(getPlanItemInstanceByName(planItemInstances, "Injected Stage", AVAILABLE).isStage()).isTrue();
 
         cmmnRuntimeService.setVariable(caseInstance.getId(), "injectedStageEnabled", true);
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(6, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(6);
         assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Stage B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Injected Stage", ACTIVE);
@@ -861,27 +865,27 @@ public class PlanItemInjectionTest extends FlowableCmmnTestCase {
         assertPlanItemInstanceState(planItemInstances, "Task Y", ACTIVE);
 
         List<Task> tasks = cmmnTaskService.createTaskQuery()
-            .caseInstanceId(caseInstance.getId())
-            .active()
-            .list();
+                .caseInstanceId(caseInstance.getId())
+                .active()
+                .list();
 
-        assertNotNull(tasks);
-        assertEquals(3, tasks.size());
+        assertThat(tasks).isNotNull();
+        assertThat(tasks).hasSize(3);
         assertSingleTaskExists(tasks, "Task A");
         assertSingleTaskExists(tasks, "Task X");
         assertSingleTaskExists(tasks, "Task Y");
 
         // test the query for the derived case definition (in this unit test, it will be a different one from the running case one)
         List<PlanItemInstance> derivedPlanItems = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .derivedCaseDefinitionId(dynamicPlanItemCase.getId())
-            .list();
+                .derivedCaseDefinitionId(dynamicPlanItemCase.getId())
+                .list();
 
-        assertNotNull(derivedPlanItems);
-        assertEquals(3, derivedPlanItems.size());
+        assertThat(derivedPlanItems).isNotNull();
+        assertThat(derivedPlanItems).hasSize(3);
 
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(5, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(5);
         assertPlanItemInstanceState(planItemInstances, "Stage B", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Injected Stage", ACTIVE);
@@ -890,7 +894,7 @@ public class PlanItemInjectionTest extends FlowableCmmnTestCase {
 
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task X", ACTIVE));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(4, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(4);
         assertPlanItemInstanceState(planItemInstances, "Stage B", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Injected Stage", ACTIVE);
@@ -898,22 +902,22 @@ public class PlanItemInjectionTest extends FlowableCmmnTestCase {
 
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task B", ACTIVE));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(2, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(2);
         assertPlanItemInstanceState(planItemInstances, "Injected Stage", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task Y", ACTIVE);
 
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task Y", ACTIVE));
 
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().count());
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
 
         List<HistoricPlanItemInstance> historicPlanItemInstances = cmmnHistoryService.createHistoricPlanItemInstanceQuery()
-            .planItemInstanceDerivedCaseDefinitionId(dynamicPlanItemCase.getId())
-            .list();
+                .planItemInstanceDerivedCaseDefinitionId(dynamicPlanItemCase.getId())
+                .list();
 
-        assertNotNull(historicPlanItemInstances);
-        assertEquals(3, historicPlanItemInstances.size());
+        assertThat(historicPlanItemInstances).isNotNull();
+        assertThat(historicPlanItemInstances).hasSize(3);
     }
 
     @Override

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/PlanItemInstanceQueryTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/PlanItemInstanceQueryTest.java
@@ -14,7 +14,6 @@ package org.flowable.cmmn.test.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
-import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -44,13 +43,13 @@ public class PlanItemInstanceQueryTest extends FlowableCmmnTestCase {
     @Before
     public void deployCaseDefinition() {
         this.deploymentId = cmmnRepositoryService.createDeployment()
-            .addClasspathResource("org/flowable/cmmn/test/runtime/PlanItemInstanceQueryTest.testPlanItemInstanceQuery.cmmn")
-            .deploy()
-            .getId();
+                .addClasspathResource("org/flowable/cmmn/test/runtime/PlanItemInstanceQueryTest.testPlanItemInstanceQuery.cmmn")
+                .deploy()
+                .getId();
         caseDefinitionId = cmmnRepositoryService.createCaseDefinitionQuery()
-            .deploymentId(deploymentId)
-            .singleResult()
-            .getId();
+                .deploymentId(deploymentId)
+                .singleResult()
+                .getId();
     }
 
     @After
@@ -61,14 +60,14 @@ public class PlanItemInstanceQueryTest extends FlowableCmmnTestCase {
     @Test
     public void testByCaseDefinitionId() {
         startInstances(5);
-        assertEquals(20, cmmnRuntimeService.createPlanItemInstanceQuery().list().size());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().list()).hasSize(20);
     }
 
     @Test
     public void testByCaseInstanceId() {
         List<String> caseInstanceIds = startInstances(3);
         for (String caseInstanceId : caseInstanceIds) {
-            assertEquals(4, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstanceId).list().size());
+            assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstanceId).list()).hasSize(4);
         }
     }
 
@@ -76,10 +75,10 @@ public class PlanItemInstanceQueryTest extends FlowableCmmnTestCase {
     public void testByStageInstanceId() {
         startInstances(1);
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .planItemDefinitionType(PlanItemDefinitionType.STAGE)
-            .planItemInstanceName("Stage one")
-            .singleResult();
-        assertEquals(2, cmmnRuntimeService.createPlanItemInstanceQuery().stageInstanceId(planItemInstance.getId()).count());
+                .planItemDefinitionType(PlanItemDefinitionType.STAGE)
+                .planItemInstanceName("Stage one")
+                .singleResult();
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().stageInstanceId(planItemInstance.getId()).count()).isEqualTo(2);
     }
 
     @Test
@@ -87,58 +86,59 @@ public class PlanItemInstanceQueryTest extends FlowableCmmnTestCase {
         startInstances(1);
         List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery().list();
         for (PlanItemInstance planItemInstance : planItemInstances) {
-            assertEquals(1L, cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceId(planItemInstance.getId()).count());
+            assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceId(planItemInstance.getId()).count()).isEqualTo(1L);
         }
     }
 
     @Test
     public void testByElementId() {
         startInstances(4);
-        assertEquals(4, cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceElementId("planItem3").list().size());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceElementId("planItem3").list()).hasSize(4);
     }
 
     @Test
     public void testByName() {
         startInstances(9);
-        assertEquals(9, cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceName("B").list().size());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceName("B").list()).hasSize(9);
     }
 
     @Test
     public void testByState() {
         startInstances(1);
-        assertEquals(2, cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceState(PlanItemInstanceState.ACTIVE).list().size());
-        assertEquals(2, cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateActive().list().size());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceState(PlanItemInstanceState.ACTIVE).list()).hasSize(2);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateActive().list()).hasSize(2);
 
-        assertEquals(1, cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceState(PlanItemInstanceState.AVAILABLE).list().size());
-        assertEquals(1, cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateAvailable().list().size());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceState(PlanItemInstanceState.AVAILABLE).list()).hasSize(1);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateAvailable().list()).hasSize(1);
 
-        assertEquals(1, cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceState(PlanItemInstanceState.ENABLED).list().size());
-        assertEquals(1, cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateEnabled().list().size());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceState(PlanItemInstanceState.ENABLED).list()).hasSize(1);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateEnabled().list()).hasSize(1);
     }
 
     @Test
     public void testByPlanItemDefinitionType() {
         startInstances(3);
-        assertEquals(6, cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK).list().size());
-        assertEquals(6, cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.STAGE).list().size());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK).list()).hasSize(6);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.STAGE).list()).hasSize(6);
     }
 
     @Test
     public void testByPlanItemDefinitionTypes() {
         startInstances(2);
-        assertEquals(8, cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionTypes(Arrays.asList(PlanItemDefinitionType.STAGE, PlanItemDefinitionType.HUMAN_TASK)).list().size());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery()
+                .planItemDefinitionTypes(Arrays.asList(PlanItemDefinitionType.STAGE, PlanItemDefinitionType.HUMAN_TASK)).list()).hasSize(8);
     }
-
 
     @Test
     public void testByStateEnabled() {
         startInstances(4);
         List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .planItemInstanceStateEnabled()
-            .list();
+                .planItemInstanceStateEnabled()
+                .list();
         assertThat(planItemInstances)
-            .hasSize(4)
-            .extracting(PlanItemInstance::getName).containsOnly("B");
+                .hasSize(4)
+                .extracting(PlanItemInstance::getName)
+                .containsOnly("B");
     }
 
     @Test
@@ -146,14 +146,14 @@ public class PlanItemInstanceQueryTest extends FlowableCmmnTestCase {
         startInstances(5);
 
         List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .planItemInstanceStateEnabled()
-            .list();
+                .planItemInstanceStateEnabled()
+                .list();
         cmmnRuntimeService.disablePlanItemInstance(planItemInstances.get(0).getId());
         cmmnRuntimeService.disablePlanItemInstance(planItemInstances.get(1).getId());
 
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateDisabled().list())
-            .hasSize(2)
-            .extracting(PlanItemInstance::getName).containsOnly("B");
+                .hasSize(2)
+                .extracting(PlanItemInstance::getName).containsOnly("B");
     }
 
     @Test
@@ -161,13 +161,14 @@ public class PlanItemInstanceQueryTest extends FlowableCmmnTestCase {
         startInstances(3);
 
         List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .planItemInstanceStateAvailable()
-            .orderByName().asc()
-            .list();
+                .planItemInstanceStateAvailable()
+                .orderByName().asc()
+                .list();
 
         assertThat(planItemInstances)
-            .hasSize(3)
-            .extracting(PlanItemInstance::getName).containsOnly("Stage two");
+                .hasSize(3)
+                .extracting(PlanItemInstance::getName)
+                .containsOnly("Stage two");
     }
 
     @Test
@@ -175,27 +176,28 @@ public class PlanItemInstanceQueryTest extends FlowableCmmnTestCase {
         startInstances(2);
 
         List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .planItemInstanceStateActive()
-            .orderByName().asc()
-            .list();
+                .planItemInstanceStateActive()
+                .orderByName().asc()
+                .list();
 
         assertThat(planItemInstances)
-            .hasSize(4)
-            .extracting(PlanItemInstance::getName).containsExactly("A", "A", "Stage one", "Stage one");
+                .hasSize(4)
+                .extracting(PlanItemInstance::getName)
+                .containsExactly("A", "A", "Stage one", "Stage one");
     }
 
     @Test
     public void testByStateAndType() {
         startInstances(3);
-        assertEquals(3, cmmnRuntimeService.createPlanItemInstanceQuery()
-            .planItemInstanceState(PlanItemInstanceState.ACTIVE)
-            .planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK)
-            .list().size());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery()
+                .planItemInstanceState(PlanItemInstanceState.ACTIVE)
+                .planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK)
+                .list()).hasSize(3);
 
-        assertEquals(3, cmmnRuntimeService.createPlanItemInstanceQuery()
-            .planItemInstanceState(PlanItemInstanceState.ENABLED)
-            .planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK)
-            .list().size());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery()
+                .planItemInstanceState(PlanItemInstanceState.ENABLED)
+                .planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK)
+                .list()).hasSize(3);
     }
 
     @Test
@@ -208,46 +210,47 @@ public class PlanItemInstanceQueryTest extends FlowableCmmnTestCase {
         cmmnTaskService.complete(tasks.get(3).getId());
 
         List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .planItemInstanceStateCompleted()
-            .ended()
-            .list();
+                .planItemInstanceStateCompleted()
+                .ended()
+                .list();
         assertThat(planItemInstances)
-            .hasSize(3)
-            .extracting(PlanItemInstance::getName).containsOnly("A");
+                .hasSize(3)
+                .extracting(PlanItemInstance::getName)
+                .containsOnly("A");
 
         // includeEnded should also return the same result
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateCompleted().includeEnded().list()).hasSize(3);
 
         // Without ended, should only return runtime plan item instances
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateCompleted().list()).hasSize(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateCompleted().list()).isEmpty();
     }
 
     @Test
     @CmmnDeployment
     public void testByStateTerminated() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("testQueryByStateTerminated").start();
+                .caseDefinitionKey("testQueryByStateTerminated").start();
 
         List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .ended()
-            .planItemInstanceStateTerminated()
-            .list();
-        assertThat(planItemInstances).hasSize(0);
+                .ended()
+                .planItemInstanceStateTerminated()
+                .list();
+        assertThat(planItemInstances).isEmpty();
 
         // Completing the user event will terminate A/C/Stage for c
         UserEventListenerInstance userEventListenerInstance = cmmnRuntimeService.createUserEventListenerInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .singleResult();
+                .caseInstanceId(caseInstance.getId())
+                .singleResult();
         cmmnRuntimeService.completeUserEventListenerInstance(userEventListenerInstance.getId());
 
         planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .ended()
-            .planItemInstanceStateTerminated()
-            .orderByName().asc()
-            .list();
+                .ended()
+                .planItemInstanceStateTerminated()
+                .orderByName().asc()
+                .list();
         assertThat(planItemInstances)
-            .extracting(PlanItemInstance::getName)
-            .containsExactly("A", "C", "The Stage");
+                .extracting(PlanItemInstance::getName)
+                .containsExactly("A", "C", "The Stage");
     }
 
     @Test
@@ -279,17 +282,17 @@ public class PlanItemInstanceQueryTest extends FlowableCmmnTestCase {
         startInstances(4);
 
         List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .planItemInstanceName("A")
-            .planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK)
-            .planItemInstanceCreatedBefore(new Date(now.getTime() + 10000))
-            .list();
+                .planItemInstanceName("A")
+                .planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK)
+                .planItemInstanceCreatedBefore(new Date(now.getTime() + 10000))
+                .list();
         assertThat(planItemInstances).hasSize(3);
 
         planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .planItemInstanceName("A")
-            .planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK)
-            .planItemInstanceCreatedBefore(new Date(now.getTime() + 30000))
-            .list();
+                .planItemInstanceName("A")
+                .planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK)
+                .planItemInstanceCreatedBefore(new Date(now.getTime() + 30000))
+                .list();
         assertThat(planItemInstances).hasSize(7);
     }
 
@@ -302,17 +305,17 @@ public class PlanItemInstanceQueryTest extends FlowableCmmnTestCase {
         startInstances(8);
 
         List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .planItemInstanceName("A")
-            .planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK)
-            .planItemInstanceCreatedAfter(new Date(now.getTime() - 10000))
-            .list();
+                .planItemInstanceName("A")
+                .planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK)
+                .planItemInstanceCreatedAfter(new Date(now.getTime() - 10000))
+                .list();
         assertThat(planItemInstances).hasSize(10);
 
         planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .planItemInstanceName("A")
-            .planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK)
-            .planItemInstanceCreatedAfter(new Date(now.getTime() + 10000))
-            .list();
+                .planItemInstanceName("A")
+                .planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK)
+                .planItemInstanceCreatedAfter(new Date(now.getTime() + 10000))
+                .list();
         assertThat(planItemInstances).hasSize(8);
     }
 
@@ -325,31 +328,31 @@ public class PlanItemInstanceQueryTest extends FlowableCmmnTestCase {
         startInstances(5);
 
         List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .planItemInstanceName("A")
-            .planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK)
-            .planItemInstanceLastAvailableAfter(new Date(now.getTime() - 10000))
-            .list();
+                .planItemInstanceName("A")
+                .planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK)
+                .planItemInstanceLastAvailableAfter(new Date(now.getTime() - 10000))
+                .list();
         assertThat(planItemInstances).hasSize(8);
 
         planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .planItemInstanceName("A")
-            .planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK)
-            .planItemInstanceLastAvailableBefore(new Date(now.getTime() - 10000))
-            .list();
-        assertThat(planItemInstances).hasSize(0);
+                .planItemInstanceName("A")
+                .planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK)
+                .planItemInstanceLastAvailableBefore(new Date(now.getTime() - 10000))
+                .list();
+        assertThat(planItemInstances).isEmpty();
 
         planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .planItemInstanceName("A")
-            .planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK)
-            .planItemInstanceLastAvailableAfter(new Date(now.getTime() + 10000))
-            .list();
+                .planItemInstanceName("A")
+                .planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK)
+                .planItemInstanceLastAvailableAfter(new Date(now.getTime() + 10000))
+                .list();
         assertThat(planItemInstances).hasSize(5);
 
         planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .planItemInstanceName("A")
-            .planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK)
-            .planItemInstanceLastAvailableBefore(new Date(now.getTime() + 10000))
-            .list();
+                .planItemInstanceName("A")
+                .planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK)
+                .planItemInstanceLastAvailableBefore(new Date(now.getTime() + 10000))
+                .list();
         assertThat(planItemInstances).hasSize(3);
     }
 
@@ -358,30 +361,30 @@ public class PlanItemInstanceQueryTest extends FlowableCmmnTestCase {
         Date now = new Date();
         setClockTo(now);
         startInstances(2);
-        setClockTo(now.getTime() +  10000);
+        setClockTo(now.getTime() + 10000);
         startInstances(3);
 
         // Before
         List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .planItemInstanceLastEnabledBefore(new Date(now.getTime() + 30000)).list();
+                .planItemInstanceLastEnabledBefore(new Date(now.getTime() + 30000)).list();
         assertThat(planItemInstances).hasSize(5);
 
         planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .planItemInstanceLastEnabledBefore(new Date(now.getTime() + 5000)).list();
+                .planItemInstanceLastEnabledBefore(new Date(now.getTime() + 5000)).list();
         assertThat(planItemInstances).hasSize(2);
 
         planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .planItemInstanceLastEnabledBefore(new Date(now.getTime() - 1000)).list();
-        assertThat(planItemInstances).hasSize(0);
+                .planItemInstanceLastEnabledBefore(new Date(now.getTime() - 1000)).list();
+        assertThat(planItemInstances).isEmpty();
 
         // After
         planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .planItemInstanceLastEnabledAfter(new Date(now.getTime() - 5000)).list();
+                .planItemInstanceLastEnabledAfter(new Date(now.getTime() - 5000)).list();
         assertThat(planItemInstances).hasSize(5);
 
         planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .planItemInstanceLastEnabledAfter(new Date(now.getTime() + 250000)).list();
-        assertThat(planItemInstances).hasSize(0);
+                .planItemInstanceLastEnabledAfter(new Date(now.getTime() + 250000)).list();
+        assertThat(planItemInstances).isEmpty();
     }
 
     @Test
@@ -391,22 +394,22 @@ public class PlanItemInstanceQueryTest extends FlowableCmmnTestCase {
         startInstances(3);
 
         String planItemInstanceId = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .planItemInstanceName("B").planItemInstanceStateEnabled().listPage(0, 1).get(0).getId();
+                .planItemInstanceName("B").planItemInstanceStateEnabled().listPage(0, 1).get(0).getId();
         cmmnRuntimeService.disablePlanItemInstance(planItemInstanceId);
 
-        setClockTo(now.getTime() +  10000);
+        setClockTo(now.getTime() + 10000);
         cmmnRuntimeService.disablePlanItemInstance(cmmnRuntimeService.createPlanItemInstanceQuery()
-            .planItemInstanceName("B").planItemInstanceStateEnabled().listPage(0, 1).get(0).getId());
+                .planItemInstanceName("B").planItemInstanceStateEnabled().listPage(0, 1).get(0).getId());
 
         // Before
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceLastDisabledBefore(new Date(now.getTime() + 20000)).list()).hasSize(2);
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceLastDisabledBefore(new Date(now.getTime() + 5000)).list()).hasSize(1);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceLastDisabledBefore(new Date(now.getTime() - 5000)).list()).hasSize(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceLastDisabledBefore(new Date(now.getTime() - 5000)).list()).isEmpty();
 
         // After
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceLastDisabledAfter(new Date(now.getTime())).list()).hasSize(2);
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceLastDisabledAfter(new Date(now.getTime() + 5000)).list()).hasSize(1);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceLastDisabledAfter(new Date(now.getTime() + 11000)).list()).hasSize(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceLastDisabledAfter(new Date(now.getTime() + 11000)).list()).isEmpty();
 
         // Re-enable and disable
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceId(planItemInstanceId).singleResult();
@@ -422,10 +425,10 @@ public class PlanItemInstanceQueryTest extends FlowableCmmnTestCase {
 
         // Recheck queries
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceLastDisabledBefore(new Date(now.getTime() + 20000)).list()).hasSize(1);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceLastDisabledBefore(new Date(now.getTime() + 5000)).list()).hasSize(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceLastDisabledBefore(new Date(now.getTime() + 5000)).list()).isEmpty();
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceLastDisabledAfter(new Date(now.getTime())).list()).hasSize(2);
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceLastDisabledAfter(new Date(now.getTime() + 15000)).list()).hasSize(1);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceLastDisabledAfter(new Date(now.getTime() + 35000)).list()).hasSize(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceLastDisabledAfter(new Date(now.getTime() + 35000)).list()).isEmpty();
     }
 
     @Test
@@ -435,23 +438,23 @@ public class PlanItemInstanceQueryTest extends FlowableCmmnTestCase {
         startInstances(4);
 
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceLastStartedAfter(new Date(now.getTime() - 1000)).list()).hasSize(8);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceLastStartedAfter(new Date(now.getTime() + 1000)).list()).hasSize(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceLastStartedAfter(new Date(now.getTime() + 1000)).list()).isEmpty();
 
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceLastStartedBefore(new Date(now.getTime() + 1000)).list()).hasSize(8);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceLastStartedBefore(new Date(now.getTime() - 1000)).list()).hasSize(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceLastStartedBefore(new Date(now.getTime() - 1000)).list()).isEmpty();
 
         // Starting an enabled planitem
         setClockTo(now.getTime() + 10000);
         cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceName("B").listPage(0, 2)
-            .forEach(p -> cmmnRuntimeService.startPlanItemInstance(p.getId()));
+                .forEach(p -> cmmnRuntimeService.startPlanItemInstance(p.getId()));
 
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceLastStartedAfter(new Date(now.getTime() - 1000)).list()).hasSize(10);
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceLastStartedAfter(new Date(now.getTime() + 5000)).list()).hasSize(2);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceLastStartedAfter(new Date(now.getTime() + 15000)).list()).hasSize(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceLastStartedAfter(new Date(now.getTime() + 15000)).list()).isEmpty();
 
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceLastStartedBefore(new Date(now.getTime() + 1000)).list()).hasSize(8);
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceLastStartedBefore(new Date(now.getTime() + 15000)).list()).hasSize(10);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceLastStartedBefore(new Date(now.getTime() - 1000)).list()).hasSize(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceLastStartedBefore(new Date(now.getTime() - 1000)).list()).isEmpty();
 
     }
 
@@ -468,24 +471,30 @@ public class PlanItemInstanceQueryTest extends FlowableCmmnTestCase {
         cmmnTaskService.complete(tasks.get(1).getId());
 
         // Completed
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceCompletedBefore(new Date(now.getTime() + 30000)).list()).hasSize(0);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceCompletedBefore(new Date(now.getTime() + 30000)).includeEnded().list()).hasSize(2);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceCompletedBefore(new Date(now.getTime() + 15000)).includeEnded().list()).hasSize(1);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceCompletedBefore(new Date(now.getTime() + 30000)).list()).isEmpty();
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceCompletedBefore(new Date(now.getTime() + 30000)).includeEnded().list())
+                .hasSize(2);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceCompletedBefore(new Date(now.getTime() + 15000)).includeEnded().list())
+                .hasSize(1);
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceCompletedAfter(new Date(now.getTime())).list()).hasSize(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceCompletedAfter(new Date(now.getTime())).list()).isEmpty();
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceCompletedAfter(new Date(now.getTime())).includeEnded().list()).hasSize(2);
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceCompletedAfter(new Date(now.getTime())).ended().list()).hasSize(2);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceCompletedAfter(new Date(now.getTime() +  15000)).includeEnded().list()).hasSize(1);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceCompletedAfter(new Date(now.getTime() + 15000)).includeEnded().list())
+                .hasSize(1);
 
         // Same queries, but with endedBefore/After
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceEndedBefore(new Date(now.getTime() + 30000)).list()).hasSize(0);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceEndedBefore(new Date(now.getTime() + 30000)).includeEnded().list()).hasSize(2);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceEndedBefore(new Date(now.getTime() + 15000)).includeEnded().list()).hasSize(1);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceEndedBefore(new Date(now.getTime() + 30000)).list()).isEmpty();
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceEndedBefore(new Date(now.getTime() + 30000)).includeEnded().list())
+                .hasSize(2);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceEndedBefore(new Date(now.getTime() + 15000)).includeEnded().list())
+                .hasSize(1);
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceEndedAfter(new Date(now.getTime())).list()).hasSize(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceEndedAfter(new Date(now.getTime())).list()).isEmpty();
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceEndedAfter(new Date(now.getTime())).includeEnded().list()).hasSize(2);
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceEndedAfter(new Date(now.getTime())).ended().list()).hasSize(2);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceEndedAfter(new Date(now.getTime() +  15000)).includeEnded().list()).hasSize(1);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceEndedAfter(new Date(now.getTime() + 15000)).includeEnded().list())
+                .hasSize(1);
     }
 
     @Test
@@ -495,21 +504,27 @@ public class PlanItemInstanceQueryTest extends FlowableCmmnTestCase {
         startInstances(2);
 
         cmmnRuntimeService.completeStagePlanItemInstance(cmmnRuntimeService.createPlanItemInstanceQuery()
-            .planItemInstanceName("Stage one").listPage(0, 1).get(0).getId(), true);
+                .planItemInstanceName("Stage one").listPage(0, 1).get(0).getId(), true);
 
-        setClockTo(now.getTime() +  10000);
+        setClockTo(now.getTime() + 10000);
         cmmnRuntimeService.completeStagePlanItemInstance(cmmnRuntimeService.createPlanItemInstanceQuery()
-            .planItemInstanceName("Stage one").listPage(0, 1).get(0).getId(), true);
+                .planItemInstanceName("Stage one").listPage(0, 1).get(0).getId(), true);
 
         // Occurred (milestone)
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceOccurredAfter(new Date(now.getTime() - 1000)).list()).hasSize(0);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceOccurredAfter(new Date(now.getTime() - 1000)).includeEnded().list()).hasSize(2);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceOccurredAfter(new Date(now.getTime() + 1000)).includeEnded().list()).hasSize(1);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceOccurredAfter(new Date(now.getTime() + 15000)).includeEnded().list()).hasSize(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceOccurredAfter(new Date(now.getTime() - 1000)).list()).isEmpty();
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceOccurredAfter(new Date(now.getTime() - 1000)).includeEnded().list())
+                .hasSize(2);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceOccurredAfter(new Date(now.getTime() + 1000)).includeEnded().list())
+                .hasSize(1);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceOccurredAfter(new Date(now.getTime() + 15000)).includeEnded().list())
+                .isEmpty();
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceOccurredBefore(new Date(now.getTime() + 20000)).includeEnded().list()).hasSize(2);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceOccurredBefore(new Date(now.getTime() + 5000)).includeEnded().list()).hasSize(1);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceOccurredBefore(new Date(now.getTime() - 1000)).includeEnded().list()).hasSize(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceOccurredBefore(new Date(now.getTime() + 20000)).includeEnded().list())
+                .hasSize(2);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceOccurredBefore(new Date(now.getTime() + 5000)).includeEnded().list())
+                .hasSize(1);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceOccurredBefore(new Date(now.getTime() - 1000)).includeEnded().list())
+                .isEmpty();
     }
 
     @Test
@@ -530,24 +545,34 @@ public class PlanItemInstanceQueryTest extends FlowableCmmnTestCase {
         // Terminated before/after
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().includeEnded().planItemInstanceExitAfter(new Date(now.getTime() - 1000)).list()).hasSize(6);
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().includeEnded().planItemInstanceExitAfter(new Date(now.getTime() + 1000)).list()).hasSize(3);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().includeEnded().planItemInstanceExitAfter(new Date(now.getTime() + 20000)).list()).hasSize(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().includeEnded().planItemInstanceExitAfter(new Date(now.getTime() + 20000)).list())
+                .isEmpty();
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().includeEnded().planItemInstanceExitBefore(new Date(now.getTime() - 1000)).list()).hasSize(0);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().includeEnded().planItemInstanceExitBefore(new Date(now.getTime() + 1000)).list()).hasSize(3);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().includeEnded().planItemInstanceExitBefore(new Date(now.getTime() + 20000)).list()).hasSize(6);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().includeEnded().planItemInstanceExitBefore(new Date(now.getTime() - 1000)).list())
+                .isEmpty();
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().includeEnded().planItemInstanceExitBefore(new Date(now.getTime() + 1000)).list())
+                .hasSize(3);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().includeEnded().planItemInstanceExitBefore(new Date(now.getTime() + 20000)).list())
+                .hasSize(6);
 
         // Ended before/after
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().includeEnded().planItemInstanceEndedAfter(new Date(now.getTime() - 1000)).list()).hasSize(8); // + 2 for user event listener
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().includeEnded().planItemInstanceEndedAfter(new Date(now.getTime() + 1000)).list()).hasSize(4);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().includeEnded().planItemInstanceEndedAfter(new Date(now.getTime() + 20000)).list()).hasSize(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().includeEnded().planItemInstanceEndedAfter(new Date(now.getTime() - 1000)).list())
+                .hasSize(8); // + 2 for user event listener
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().includeEnded().planItemInstanceEndedAfter(new Date(now.getTime() + 1000)).list())
+                .hasSize(4);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().includeEnded().planItemInstanceEndedAfter(new Date(now.getTime() + 20000)).list())
+                .isEmpty();
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().includeEnded().planItemInstanceEndedBefore(new Date(now.getTime() - 1000)).list()).hasSize(0);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().includeEnded().planItemInstanceEndedBefore(new Date(now.getTime() + 1000)).list()).hasSize(4);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().includeEnded().planItemInstanceEndedBefore(new Date(now.getTime() + 20000)).list()).hasSize(8);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().includeEnded().planItemInstanceEndedBefore(new Date(now.getTime() - 1000)).list())
+                .isEmpty();
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().includeEnded().planItemInstanceEndedBefore(new Date(now.getTime() + 1000)).list())
+                .hasSize(4);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().includeEnded().planItemInstanceEndedBefore(new Date(now.getTime() + 20000)).list())
+                .hasSize(8);
 
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().includeEnded()
-            .planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER)
-            .planItemInstanceEndedAfter(new Date(now.getTime() - 1000)).list()).hasSize(2);
+                .planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER)
+                .planItemInstanceEndedAfter(new Date(now.getTime() - 1000)).list()).hasSize(2);
 
     }
 
@@ -559,62 +584,70 @@ public class PlanItemInstanceQueryTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testTerminate").start();
 
         PlanItemInstance stagePlanItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .planItemDefinitionType(PlanItemDefinitionType.STAGE)
-            .planItemInstanceName("The Stage")
-            .singleResult();
+                .planItemDefinitionType(PlanItemDefinitionType.STAGE)
+                .planItemInstanceName("The Stage")
+                .singleResult();
 
         cmmnRuntimeService.terminatePlanItemInstance(stagePlanItemInstance.getId());
         assertThat(cmmnTaskService.createTaskQuery().taskName("D").singleResult()).isNotNull();
 
         // Terminated
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().includeEnded().planItemInstanceTerminatedBefore(new Date(now.getTime() + 1000)).list()).hasSize(2); // 2 -> stage and C
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().includeEnded().planItemInstanceTerminatedBefore(new Date(now.getTime() - 1000)).list()).hasSize(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().includeEnded().planItemInstanceTerminatedBefore(new Date(now.getTime() + 1000)).list())
+                .hasSize(2); // 2 -> stage and C
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().includeEnded().planItemInstanceTerminatedBefore(new Date(now.getTime() - 1000)).list())
+                .isEmpty();
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().includeEnded().planItemInstanceTerminatedAfter(new Date(now.getTime() + 1000)).list()).hasSize(0);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().includeEnded().planItemInstanceTerminatedAfter(new Date(now.getTime() - 1000)).list()).hasSize(2);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().includeEnded().planItemInstanceTerminatedAfter(new Date(now.getTime() + 1000)).list())
+                .isEmpty();
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().includeEnded().planItemInstanceTerminatedAfter(new Date(now.getTime() - 1000)).list())
+                .hasSize(2);
 
         // Ended
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().includeEnded().planItemInstanceEndedBefore(new Date(now.getTime() + 1000)).list()).hasSize(2); // 2 -> stage and C
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().includeEnded().planItemInstanceEndedBefore(new Date(now.getTime() - 1000)).list()).hasSize(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().includeEnded().planItemInstanceEndedBefore(new Date(now.getTime() + 1000)).list())
+                .hasSize(2); // 2 -> stage and C
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().includeEnded().planItemInstanceEndedBefore(new Date(now.getTime() - 1000)).list())
+                .isEmpty();
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().includeEnded().planItemInstanceEndedAfter(new Date(now.getTime() + 1000)).list()).hasSize(0);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().includeEnded().planItemInstanceEndedAfter(new Date(now.getTime() - 1000)).list()).hasSize(2);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().includeEnded().planItemInstanceEndedAfter(new Date(now.getTime() + 1000)).list())
+                .isEmpty();
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().includeEnded().planItemInstanceEndedAfter(new Date(now.getTime() - 1000)).list())
+                .hasSize(2);
     }
 
     @Test
     @CmmnDeployment
     public void testWaitRepetitionOfNestedStages() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("testWaitRepetitionOfNestedStages")
-            .variable("stage1", false)
-            .variable("stage11", false)
-            .variable("stage12", false)
-            .start();
-        
+                .caseDefinitionKey("testWaitRepetitionOfNestedStages")
+                .variable("stage1", false)
+                .variable("stage11", false)
+                .variable("stage12", false)
+                .start();
+
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().list())
-            .extracting(PlanItemInstance::getPlanItemDefinitionId, PlanItemInstance::getState)
-            .containsExactlyInAnyOrder(
-                tuple("oneexpandedstage1", "available"),
-                tuple("oneexpandedstage2", "available")
-            );
+                .extracting(PlanItemInstance::getPlanItemDefinitionId, PlanItemInstance::getState)
+                .containsExactlyInAnyOrder(
+                        tuple("oneexpandedstage1", "available"),
+                        tuple("oneexpandedstage2", "available")
+                );
 
         cmmnRuntimeService.createChangePlanItemStateBuilder()
-            .caseInstanceId(caseInstance.getId())
-            .activatePlanItemDefinitionIds(Arrays.asList("oneexpandedstage4"))
-            .changeState();
+                .caseInstanceId(caseInstance.getId())
+                .activatePlanItemDefinitionIds(Arrays.asList("oneexpandedstage4"))
+                .changeState();
 
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().list())
-            .extracting(PlanItemInstance::getPlanItemDefinitionId, PlanItemInstance::getState)
-            .containsExactlyInAnyOrder(
-                tuple("oneexpandedstage1", "active"),
-                tuple("oneexpandedstage1", "wait_repetition"),
-                tuple("oneexpandedstage2", "available"),
-                tuple("oneexpandedstage6", "available"),
-                tuple("oneexpandedstage4", "active"),
-                tuple("oneexpandedstage4", "wait_repetition"), // FIXME: this plan item instance is missing
-                tuple("oneeventlistener1", "available"),
-                tuple("onehumantask1", "available")
-            );
+                .extracting(PlanItemInstance::getPlanItemDefinitionId, PlanItemInstance::getState)
+                .containsExactlyInAnyOrder(
+                        tuple("oneexpandedstage1", "active"),
+                        tuple("oneexpandedstage1", "wait_repetition"),
+                        tuple("oneexpandedstage2", "available"),
+                        tuple("oneexpandedstage6", "available"),
+                        tuple("oneexpandedstage4", "active"),
+                        tuple("oneexpandedstage4", "wait_repetition"), // FIXME: this plan item instance is missing
+                        tuple("oneeventlistener1", "available"),
+                        tuple("onehumantask1", "available")
+                );
     }
 
     private List<String> startInstances(int numberOfInstances) {

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/PlanItemInstanceTransitionBuilderTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/PlanItemInstanceTransitionBuilderTest.java
@@ -36,7 +36,7 @@ public class PlanItemInstanceTransitionBuilderTest extends FlowableCmmnTestCase 
 
         PlanItemInstance planItemInstanceA = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceName("A").singleResult();
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(planItemInstanceA.getId())
-            .trigger();
+                .trigger();
 
         assertThat(cmmnTaskService.createTaskQuery().taskName("A").singleResult()).isNull();
     }
@@ -49,14 +49,15 @@ public class PlanItemInstanceTransitionBuilderTest extends FlowableCmmnTestCase 
 
         PlanItemInstance planItemInstanceA = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceName("A").singleResult();
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(planItemInstanceA.getId())
-            .variables(CollectionUtil.map("var1", 123, "var2", 456))
-            .trigger();
+                .variables(CollectionUtil.map("var1", 123, "var2", 456))
+                .trigger();
 
         assertThat(cmmnTaskService.createTaskQuery().taskName("A").singleResult()).isNull();
-        assertThat(cmmnRuntimeService.getVariables(caseInstance.getId())).containsOnly(
-            entry("var1", 123),
-            entry("var2", 456)
-        );
+        assertThat(cmmnRuntimeService.getVariables(caseInstance.getId()))
+                .containsOnly(
+                        entry("var1", 123),
+                        entry("var2", 456)
+                );
     }
 
     @Test
@@ -67,17 +68,17 @@ public class PlanItemInstanceTransitionBuilderTest extends FlowableCmmnTestCase 
 
         PlanItemInstance planItemInstanceA = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceName("A").singleResult();
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(planItemInstanceA.getId())
-            .variable("var1", 123)
-            .variable("var2", 456)
-            .trigger();
+                .variable("var1", 123)
+                .variable("var2", 456)
+                .trigger();
 
         assertThat(cmmnTaskService.createTaskQuery().taskName("A").singleResult()).isNull();
-        assertThat(cmmnRuntimeService.getVariables(caseInstance.getId())).containsOnly(
-            entry("var1", 123),
-            entry("var2", 456)
-        );
+        assertThat(cmmnRuntimeService.getVariables(caseInstance.getId()))
+                .containsOnly(
+                        entry("var1", 123),
+                        entry("var2", 456)
+                );
     }
-
 
     @Test
     @CmmnDeployment
@@ -87,8 +88,8 @@ public class PlanItemInstanceTransitionBuilderTest extends FlowableCmmnTestCase 
 
         PlanItemInstance planItemInstanceA = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceName("A").singleResult();
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(planItemInstanceA.getId())
-            .transientVariables(CollectionUtil.map("sentryVar", true, "otherVar", 123456))
-            .trigger();
+                .transientVariables(CollectionUtil.map("sentryVar", true, "otherVar", 123456))
+                .trigger();
 
         assertThat(cmmnTaskService.createTaskQuery().taskName("A").singleResult()).isNull();
         assertThat(cmmnRuntimeService.getVariables(caseInstance.getId())).isEmpty();
@@ -105,9 +106,9 @@ public class PlanItemInstanceTransitionBuilderTest extends FlowableCmmnTestCase 
 
         PlanItemInstance planItemInstanceA = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceName("A").singleResult();
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(planItemInstanceA.getId())
-            .transientVariable("sentryVar", true)
-            .transientVariable("otherVar", 123456)
-            .trigger();
+                .transientVariable("sentryVar", true)
+                .transientVariable("otherVar", 123456)
+                .trigger();
 
         assertThat(cmmnTaskService.createTaskQuery().taskName("A").singleResult()).isNull();
         assertThat(cmmnRuntimeService.getVariables(caseInstance.getId())).isEmpty();
@@ -135,17 +136,18 @@ public class PlanItemInstanceTransitionBuilderTest extends FlowableCmmnTestCase 
 
         PlanItemInstance planItemInstanceB = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceName("B").singleResult();
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(planItemInstanceB.getId())
-            .variable("var1", "hello")
-            .variable("var2", "world")
-            .enable();
+                .variable("var1", "hello")
+                .variable("var2", "world")
+                .enable();
 
         planItemInstanceB = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceName("B").singleResult();
         assertThat(planItemInstanceB.getState()).isEqualTo(PlanItemInstanceState.ENABLED);
 
-        assertThat(cmmnRuntimeService.getVariables(caseInstance.getId())).containsOnly(
-            entry("var1", "hello"),
-            entry("var2", "world")
-        );
+        assertThat(cmmnRuntimeService.getVariables(caseInstance.getId()))
+                .containsOnly(
+                        entry("var1", "hello"),
+                        entry("var2", "world")
+                );
     }
 
     @Test
@@ -155,16 +157,17 @@ public class PlanItemInstanceTransitionBuilderTest extends FlowableCmmnTestCase 
 
         PlanItemInstance planItemInstanceB = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceName("B").singleResult();
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(planItemInstanceB.getId())
-            .variables(CollectionUtil.map("var1", "hello", "var2", "world"))
-            .enable();
+                .variables(CollectionUtil.map("var1", "hello", "var2", "world"))
+                .enable();
 
         planItemInstanceB = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceName("B").singleResult();
         assertThat(planItemInstanceB.getState()).isEqualTo(PlanItemInstanceState.ENABLED);
 
-        assertThat(cmmnRuntimeService.getVariables(caseInstance.getId())).containsOnly(
-            entry("var1", "hello"),
-            entry("var2", "world")
-        );
+        assertThat(cmmnRuntimeService.getVariables(caseInstance.getId()))
+                .containsOnly(
+                        entry("var1", "hello"),
+                        entry("var2", "world")
+                );
     }
 
     @Test
@@ -174,16 +177,17 @@ public class PlanItemInstanceTransitionBuilderTest extends FlowableCmmnTestCase 
 
         PlanItemInstance planItemInstanceB = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceName("B").singleResult();
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(planItemInstanceB.getId())
-            .localVariable("localVariable", "hello")
-            .variable("caseInstanceVar", "world")
-            .enable();
+                .localVariable("localVariable", "hello")
+                .variable("caseInstanceVar", "world")
+                .enable();
 
         planItemInstanceB = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceName("B").singleResult();
         assertThat(planItemInstanceB.getState()).isEqualTo(PlanItemInstanceState.ENABLED);
 
-        assertThat(cmmnRuntimeService.getVariables(caseInstance.getId())).containsOnly(
-            entry("caseInstanceVar", "world")
-        );
+        assertThat(cmmnRuntimeService.getVariables(caseInstance.getId()))
+                .containsOnly(
+                        entry("caseInstanceVar", "world")
+                );
     }
 
     @Test
@@ -193,9 +197,9 @@ public class PlanItemInstanceTransitionBuilderTest extends FlowableCmmnTestCase 
 
         PlanItemInstance planItemInstanceB = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceName("B").singleResult();
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(planItemInstanceB.getId())
-            .transientVariable("sentryVar", true)
-            .transientVariable("otherVar", 123)
-            .enable();
+                .transientVariable("sentryVar", true)
+                .transientVariable("otherVar", 123)
+                .enable();
 
         planItemInstanceB = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceName("B").singleResult();
         assertThat(planItemInstanceB.getState()).isEqualTo(PlanItemInstanceState.ENABLED);
@@ -211,15 +215,15 @@ public class PlanItemInstanceTransitionBuilderTest extends FlowableCmmnTestCase 
 
         PlanItemInstance planItemInstanceB = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceName("B").singleResult();
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(planItemInstanceB.getId())
-            .transientVariables(CollectionUtil.map("sentryVar", true, "otherVar", 123))
-            .variable("persistentVar", 456)
-            .enable();
+                .transientVariables(CollectionUtil.map("sentryVar", true, "otherVar", 123))
+                .variable("persistentVar", 456)
+                .enable();
 
         planItemInstanceB = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceName("B").singleResult();
         assertThat(planItemInstanceB.getState()).isEqualTo(PlanItemInstanceState.ENABLED);
 
         assertThat(cmmnRuntimeService.getVariables(caseInstance.getId())).containsOnly(
-            entry("persistentVar", 456)
+                entry("persistentVar", 456)
         );
         assertThat(cmmnTaskService.createTaskQuery().taskName("D").singleResult()).isNotNull();
     }
@@ -249,14 +253,14 @@ public class PlanItemInstanceTransitionBuilderTest extends FlowableCmmnTestCase 
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(planItemInstanceB.getId()).enable();
 
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(planItemInstanceB.getId())
-            .variable("var1", "test")
-            .disable();
+                .variable("var1", "test")
+                .disable();
 
         planItemInstanceB = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceName("B").singleResult();
         assertThat(planItemInstanceB.getState()).isEqualTo(PlanItemInstanceState.DISABLED);
 
         assertThat(cmmnRuntimeService.getVariables(caseInstance.getId())).containsOnly(
-            entry("var1", "test")
+                entry("var1", "test")
         );
     }
 
@@ -270,16 +274,17 @@ public class PlanItemInstanceTransitionBuilderTest extends FlowableCmmnTestCase 
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(planItemInstanceB.getId()).enable();
 
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(planItemInstanceB.getId())
-            .variables(CollectionUtil.map("var1", "test", "var2", "anotherTest"))
-            .disable();
+                .variables(CollectionUtil.map("var1", "test", "var2", "anotherTest"))
+                .disable();
 
         planItemInstanceB = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceName("B").singleResult();
         assertThat(planItemInstanceB.getState()).isEqualTo(PlanItemInstanceState.DISABLED);
 
-        assertThat(cmmnRuntimeService.getVariables(caseInstance.getId())).containsOnly(
-            entry("var1", "test"),
-            entry("var2", "anotherTest")
-        );
+        assertThat(cmmnRuntimeService.getVariables(caseInstance.getId()))
+                .containsOnly(
+                        entry("var1", "test"),
+                        entry("var2", "anotherTest")
+                );
     }
 
     @Test
@@ -294,17 +299,18 @@ public class PlanItemInstanceTransitionBuilderTest extends FlowableCmmnTestCase 
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(planItemInstanceB.getId()).enable();
 
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(planItemInstanceB.getId())
-            .variables(CollectionUtil.map("var1", "test", "var2", "anotherTest"))
-            .transientVariable("sentryVar", true)
-            .disable();
+                .variables(CollectionUtil.map("var1", "test", "var2", "anotherTest"))
+                .transientVariable("sentryVar", true)
+                .disable();
 
         planItemInstanceB = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceName("B").singleResult();
         assertThat(planItemInstanceB.getState()).isEqualTo(PlanItemInstanceState.DISABLED);
 
-        assertThat(cmmnRuntimeService.getVariables(caseInstance.getId())).containsOnly(
-            entry("var1", "test"),
-            entry("var2", "anotherTest")
-        );
+        assertThat(cmmnRuntimeService.getVariables(caseInstance.getId()))
+                .containsOnly(
+                        entry("var1", "test"),
+                        entry("var2", "anotherTest")
+                );
 
         planItemInstanceD = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceName("D").singleResult();
         assertThat(planItemInstanceD.getState()).isEqualTo(PlanItemInstanceState.ACTIVE);
@@ -322,8 +328,8 @@ public class PlanItemInstanceTransitionBuilderTest extends FlowableCmmnTestCase 
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(planItemInstanceB.getId()).enable();
 
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(planItemInstanceB.getId())
-            .transientVariables(CollectionUtil.map("sentryVar", true, "otherVar", "test"))
-            .disable();
+                .transientVariables(CollectionUtil.map("sentryVar", true, "otherVar", "test"))
+                .disable();
 
         planItemInstanceB = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceName("B").singleResult();
         assertThat(planItemInstanceB.getState()).isEqualTo(PlanItemInstanceState.DISABLED);
@@ -360,18 +366,19 @@ public class PlanItemInstanceTransitionBuilderTest extends FlowableCmmnTestCase 
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(5);
 
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(planItemInstanceA.getId())
-            .variable("var1", "hello")
-            .variable("var2", "world")
-            .terminate();
+                .variable("var1", "hello")
+                .variable("var2", "world")
+                .terminate();
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(4);
 
         planItemInstanceA = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceName("A").includeEnded().singleResult();
         assertThat(planItemInstanceA.getState()).isEqualTo(PlanItemInstanceState.TERMINATED);
 
-        assertThat(cmmnRuntimeService.getVariables(caseInstance.getId())).containsOnly(
-            entry("var1", "hello"),
-            entry("var2", "world")
-        );
+        assertThat(cmmnRuntimeService.getVariables(caseInstance.getId()))
+                .containsOnly(
+                        entry("var1", "hello"),
+                        entry("var2", "world")
+                );
     }
 
     @Test
@@ -384,15 +391,15 @@ public class PlanItemInstanceTransitionBuilderTest extends FlowableCmmnTestCase 
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(5);
 
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(planItemInstanceA.getId())
-            .variables(CollectionUtil.map("var1", "hello"))
-            .terminate();
+                .variables(CollectionUtil.map("var1", "hello"))
+                .terminate();
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(4);
 
         planItemInstanceA = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceName("A").includeEnded().singleResult();
         assertThat(planItemInstanceA.getState()).isEqualTo(PlanItemInstanceState.TERMINATED);
 
         assertThat(cmmnRuntimeService.getVariables(caseInstance.getId())).containsOnly(
-            entry("var1", "hello")
+                entry("var1", "hello")
         );
     }
 
@@ -407,19 +414,20 @@ public class PlanItemInstanceTransitionBuilderTest extends FlowableCmmnTestCase 
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(5);
 
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(planItemInstanceA.getId())
-            .variable("var1", "hello")
-            .variable("var2", "world")
-            .transientVariable("sentryVar", true)
-            .terminate();
+                .variable("var1", "hello")
+                .variable("var2", "world")
+                .transientVariable("sentryVar", true)
+                .terminate();
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(4);
 
         planItemInstanceA = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceName("A").includeEnded().singleResult();
         assertThat(planItemInstanceA.getState()).isEqualTo(PlanItemInstanceState.TERMINATED);
 
-        assertThat(cmmnRuntimeService.getVariables(caseInstance.getId())).containsOnly(
-            entry("var1", "hello"),
-            entry("var2", "world")
-        );
+        assertThat(cmmnRuntimeService.getVariables(caseInstance.getId()))
+                .containsOnly(
+                        entry("var1", "hello"),
+                        entry("var2", "world")
+                );
 
         assertThat(cmmnTaskService.createTaskQuery().taskName("D").singleResult()).isNotNull();
     }
@@ -435,8 +443,8 @@ public class PlanItemInstanceTransitionBuilderTest extends FlowableCmmnTestCase 
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(5);
 
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(planItemInstanceA.getId())
-            .transientVariables(CollectionUtil.map("sentryVar", true))
-            .terminate();
+                .transientVariables(CollectionUtil.map("sentryVar", true))
+                .terminate();
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(4);
 
         planItemInstanceA = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceName("A").includeEnded().singleResult();
@@ -448,8 +456,8 @@ public class PlanItemInstanceTransitionBuilderTest extends FlowableCmmnTestCase 
 
     @Test
     @CmmnDeployment(resources = {
-        "org/flowable/cmmn/test/runtime/PlanItemInstanceTransitionBuilderTest.testStartCaseTask.cmmn",
-        "org/flowable/cmmn/test/runtime/PlanItemInstanceTransitionBuilderTest.childcase.cmmn"
+            "org/flowable/cmmn/test/runtime/PlanItemInstanceTransitionBuilderTest.testStartCaseTask.cmmn",
+            "org/flowable/cmmn/test/runtime/PlanItemInstanceTransitionBuilderTest.childcase.cmmn"
     })
     public void testStartCaseTask() {
         CaseInstance parentCaseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testStartChildCase").start();
@@ -464,8 +472,8 @@ public class PlanItemInstanceTransitionBuilderTest extends FlowableCmmnTestCase 
 
     @Test
     @CmmnDeployment(resources = {
-        "org/flowable/cmmn/test/runtime/PlanItemInstanceTransitionBuilderTest.testStartCaseTask.cmmn",
-        "org/flowable/cmmn/test/runtime/PlanItemInstanceTransitionBuilderTest.childcase.cmmn"
+            "org/flowable/cmmn/test/runtime/PlanItemInstanceTransitionBuilderTest.testStartCaseTask.cmmn",
+            "org/flowable/cmmn/test/runtime/PlanItemInstanceTransitionBuilderTest.childcase.cmmn"
     })
     public void testStartCaseTaskWithVariable() {
         CaseInstance parentCaseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testStartChildCase").start();
@@ -475,20 +483,23 @@ public class PlanItemInstanceTransitionBuilderTest extends FlowableCmmnTestCase 
         assertThat(planItemInstance.getState()).isEqualTo(PlanItemInstanceState.ENABLED);
 
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(planItemInstance.getId())
-            .variable("someVar", "someValue")
-            .start();
+                .variable("someVar", "someValue")
+                .start();
 
         CaseInstance childCaseInstance = cmmnRuntimeService.createCaseInstanceQuery().caseInstanceParentId(parentCaseInstance.getId()).singleResult();
         assertThat(childCaseInstance).isNotNull();
 
-        assertThat(cmmnRuntimeService.getVariables(parentCaseInstance.getId())).containsOnly(entry("someVar", "someValue"));
+        assertThat(cmmnRuntimeService.getVariables(parentCaseInstance.getId()))
+                .containsOnly(
+                        entry("someVar", "someValue")
+                );
         assertThat(cmmnRuntimeService.getVariables(childCaseInstance.getId())).isEmpty();
     }
 
     @Test
     @CmmnDeployment(resources = {
-        "org/flowable/cmmn/test/runtime/PlanItemInstanceTransitionBuilderTest.testStartCaseTask.cmmn",
-        "org/flowable/cmmn/test/runtime/PlanItemInstanceTransitionBuilderTest.childcase.cmmn"
+            "org/flowable/cmmn/test/runtime/PlanItemInstanceTransitionBuilderTest.testStartCaseTask.cmmn",
+            "org/flowable/cmmn/test/runtime/PlanItemInstanceTransitionBuilderTest.childcase.cmmn"
     })
     public void testStartCaseTaskWithVariables() {
         CaseInstance parentCaseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testStartChildCase").start();
@@ -498,23 +509,24 @@ public class PlanItemInstanceTransitionBuilderTest extends FlowableCmmnTestCase 
         assertThat(planItemInstance.getState()).isEqualTo(PlanItemInstanceState.ENABLED);
 
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(planItemInstance.getId())
-            .variables(CollectionUtil.map("someVar", "someValue", "otherVar", 123))
-            .start();
+                .variables(CollectionUtil.map("someVar", "someValue", "otherVar", 123))
+                .start();
 
         CaseInstance childCaseInstance = cmmnRuntimeService.createCaseInstanceQuery().caseInstanceParentId(parentCaseInstance.getId()).singleResult();
         assertThat(childCaseInstance).isNotNull();
 
-        assertThat(cmmnRuntimeService.getVariables(parentCaseInstance.getId())).containsOnly(
-            entry("someVar", "someValue"),
-            entry("otherVar", 123)
-        );
+        assertThat(cmmnRuntimeService.getVariables(parentCaseInstance.getId()))
+                .containsOnly(
+                        entry("someVar", "someValue"),
+                        entry("otherVar", 123)
+                );
         assertThat(cmmnRuntimeService.getVariables(childCaseInstance.getId())).isEmpty();
     }
 
     @Test
     @CmmnDeployment(resources = {
-        "org/flowable/cmmn/test/runtime/PlanItemInstanceTransitionBuilderTest.testStartCaseTask.cmmn",
-        "org/flowable/cmmn/test/runtime/PlanItemInstanceTransitionBuilderTest.childcase.cmmn"
+            "org/flowable/cmmn/test/runtime/PlanItemInstanceTransitionBuilderTest.testStartCaseTask.cmmn",
+            "org/flowable/cmmn/test/runtime/PlanItemInstanceTransitionBuilderTest.childcase.cmmn"
     })
     public void testStartCaseTaskWithChildTaskVariable() {
         CaseInstance parentCaseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testStartChildCase").start();
@@ -524,29 +536,31 @@ public class PlanItemInstanceTransitionBuilderTest extends FlowableCmmnTestCase 
         assertThat(planItemInstance.getState()).isEqualTo(PlanItemInstanceState.ENABLED);
 
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(planItemInstance.getId())
-            .variable("parentVar1", 123)
-            .childTaskVariable("childVar1", 1)
-            .childTaskVariable("childVar2", 2)
-            .childTaskVariable("childVar3", 3)
-            .start();
+                .variable("parentVar1", 123)
+                .childTaskVariable("childVar1", 1)
+                .childTaskVariable("childVar2", 2)
+                .childTaskVariable("childVar3", 3)
+                .start();
 
         CaseInstance childCaseInstance = cmmnRuntimeService.createCaseInstanceQuery().caseInstanceParentId(parentCaseInstance.getId()).singleResult();
         assertThat(childCaseInstance).isNotNull();
 
-        assertThat(cmmnRuntimeService.getVariables(parentCaseInstance.getId())).containsOnly(
-            entry("parentVar1", 123)
-        );
-        assertThat(cmmnRuntimeService.getVariables(childCaseInstance.getId())).containsOnly(
-            entry("childVar1", 1),
-            entry("childVar2", 2),
-            entry("childVar3", 3)
-        );
+        assertThat(cmmnRuntimeService.getVariables(parentCaseInstance.getId()))
+                .containsOnly(
+                        entry("parentVar1", 123)
+                );
+        assertThat(cmmnRuntimeService.getVariables(childCaseInstance.getId()))
+                .containsOnly(
+                        entry("childVar1", 1),
+                        entry("childVar2", 2),
+                        entry("childVar3", 3)
+                );
     }
 
     @Test
     @CmmnDeployment(resources = {
-        "org/flowable/cmmn/test/runtime/PlanItemInstanceTransitionBuilderTest.testStartCaseTask.cmmn",
-        "org/flowable/cmmn/test/runtime/PlanItemInstanceTransitionBuilderTest.childcase.cmmn"
+            "org/flowable/cmmn/test/runtime/PlanItemInstanceTransitionBuilderTest.testStartCaseTask.cmmn",
+            "org/flowable/cmmn/test/runtime/PlanItemInstanceTransitionBuilderTest.childcase.cmmn"
     })
     public void testStartCaseTaskWithChildTaskVariables() {
         CaseInstance parentCaseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testStartChildCase").start();
@@ -556,20 +570,22 @@ public class PlanItemInstanceTransitionBuilderTest extends FlowableCmmnTestCase 
         assertThat(planItemInstance.getState()).isEqualTo(PlanItemInstanceState.ENABLED);
 
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(planItemInstance.getId())
-            .variable("parentVar1", 123)
-            .childTaskVariables(CollectionUtil.map("childVar1", 1, "childVar2", 2))
-            .start();
+                .variable("parentVar1", 123)
+                .childTaskVariables(CollectionUtil.map("childVar1", 1, "childVar2", 2))
+                .start();
 
         CaseInstance childCaseInstance = cmmnRuntimeService.createCaseInstanceQuery().caseInstanceParentId(parentCaseInstance.getId()).singleResult();
         assertThat(childCaseInstance).isNotNull();
 
-        assertThat(cmmnRuntimeService.getVariables(parentCaseInstance.getId())).containsOnly(
-            entry("parentVar1", 123)
-        );
-        assertThat(cmmnRuntimeService.getVariables(childCaseInstance.getId())).containsOnly(
-            entry("childVar1", 1),
-            entry("childVar2", 2)
-        );
+        assertThat(cmmnRuntimeService.getVariables(parentCaseInstance.getId()))
+                .containsOnly(
+                        entry("parentVar1", 123)
+                );
+        assertThat(cmmnRuntimeService.getVariables(childCaseInstance.getId()))
+                .containsOnly(
+                        entry("childVar1", 1),
+                        entry("childVar2", 2)
+                );
     }
 
 }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/PlanItemNoRepetitionExitSentryTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/PlanItemNoRepetitionExitSentryTest.java
@@ -12,10 +12,10 @@
  */
 package org.flowable.cmmn.test.runtime;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.ACTIVE;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.AVAILABLE;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.ENABLED;
-import static org.junit.Assert.assertEquals;
 
 import java.util.List;
 
@@ -39,7 +39,7 @@ public class PlanItemNoRepetitionExitSentryTest extends FlowableCmmnTestCase {
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Kill active and enabled tasks B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks B", AVAILABLE);
@@ -56,7 +56,7 @@ public class PlanItemNoRepetitionExitSentryTest extends FlowableCmmnTestCase {
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Kill active and enabled tasks B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks B", AVAILABLE);
@@ -76,7 +76,7 @@ public class PlanItemNoRepetitionExitSentryTest extends FlowableCmmnTestCase {
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Kill active and enabled tasks B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks B", AVAILABLE);
@@ -91,13 +91,13 @@ public class PlanItemNoRepetitionExitSentryTest extends FlowableCmmnTestCase {
         // start Task A, check it to be in active state and then trigger its exit sentry, which will kill active task a
         cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task A"));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByName(planItemInstances, "Kill active tasks A"));
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(8, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(8);
         assertNoPlanItemInstance(planItemInstances, "Task A");
         assertPlanItemInstanceState(planItemInstances, "Kill active and enabled tasks B", AVAILABLE);
         assertNoPlanItemInstance(planItemInstances, "Kill active tasks A");
@@ -117,7 +117,7 @@ public class PlanItemNoRepetitionExitSentryTest extends FlowableCmmnTestCase {
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Kill active and enabled tasks B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks B", AVAILABLE);
@@ -134,7 +134,7 @@ public class PlanItemNoRepetitionExitSentryTest extends FlowableCmmnTestCase {
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Kill active and enabled tasks B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks B", AVAILABLE);
@@ -154,7 +154,7 @@ public class PlanItemNoRepetitionExitSentryTest extends FlowableCmmnTestCase {
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Kill active and enabled tasks B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks B", AVAILABLE);
@@ -176,7 +176,7 @@ public class PlanItemNoRepetitionExitSentryTest extends FlowableCmmnTestCase {
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Kill active and enabled tasks B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks B", AVAILABLE);
@@ -196,7 +196,7 @@ public class PlanItemNoRepetitionExitSentryTest extends FlowableCmmnTestCase {
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Kill active and enabled tasks B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks B", AVAILABLE);
@@ -222,7 +222,7 @@ public class PlanItemNoRepetitionExitSentryTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByName(planItemInstances,"Kill active tasks B"));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(7, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(7);
         assertNoPlanItemInstance(planItemInstances, "Task B");
         assertNoPlanItemInstance(planItemInstances, "Kill active and enabled tasks B");
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks A", AVAILABLE);
@@ -242,7 +242,7 @@ public class PlanItemNoRepetitionExitSentryTest extends FlowableCmmnTestCase {
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Kill active and enabled tasks B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks B", AVAILABLE);
@@ -263,7 +263,7 @@ public class PlanItemNoRepetitionExitSentryTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByName(planItemInstances,"Kill active and enabled tasks B"));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(7, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(7);
         assertNoPlanItemInstance(planItemInstances, "Task B");
         assertNoPlanItemInstance(planItemInstances, "Kill active and enabled tasks B");
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks A", AVAILABLE);
@@ -283,7 +283,7 @@ public class PlanItemNoRepetitionExitSentryTest extends FlowableCmmnTestCase {
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Kill active and enabled tasks B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks B", AVAILABLE);
@@ -309,7 +309,7 @@ public class PlanItemNoRepetitionExitSentryTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByName(planItemInstances,"Kill active and enabled tasks B"));
 
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(7, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(7);
         assertNoPlanItemInstance(planItemInstances, "Task B");
         assertNoPlanItemInstance(planItemInstances, "Kill active and enabled tasks B");
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks A", AVAILABLE);
@@ -329,7 +329,7 @@ public class PlanItemNoRepetitionExitSentryTest extends FlowableCmmnTestCase {
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Kill active and enabled tasks B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks B", AVAILABLE);
@@ -350,7 +350,7 @@ public class PlanItemNoRepetitionExitSentryTest extends FlowableCmmnTestCase {
         // trigger exit sentry on Task D which must kill it
         cmmnRuntimeService.setVariable(caseInstance.getId(), "exitActiveTasksD", true);
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(8, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(8);
         assertNoPlanItemInstance(planItemInstances, "Task D");
     }
 
@@ -361,7 +361,7 @@ public class PlanItemNoRepetitionExitSentryTest extends FlowableCmmnTestCase {
 
         List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
 
-        assertEquals(10, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(10);
         assertPlanItemInstanceState(planItemInstances, "Kill active and enabled tasks B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks A", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Kill active tasks B", AVAILABLE);
@@ -387,7 +387,7 @@ public class PlanItemNoRepetitionExitSentryTest extends FlowableCmmnTestCase {
         // trigger exit sentry on Task F which must kill it
         cmmnRuntimeService.setVariable(caseInstance.getId(), "exitActiveTasksF", true);
         planItemInstances = getPlanItemInstances(caseInstance.getId());
-        assertEquals(8, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(8);
         assertNoPlanItemInstance(planItemInstances, "Task F");
     }
 }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/RuntimeServiceTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/RuntimeServiceTest.java
@@ -13,15 +13,8 @@
 package org.flowable.cmmn.test.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.tuple;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.time.Instant;
 import java.util.Collections;
@@ -61,6 +54,7 @@ import org.junit.Test;
 public class RuntimeServiceTest extends FlowableCmmnTestCase {
 
     private static final Map<String, Object> VARIABLES = new HashMap<>();
+
     static {
         VARIABLES.put("var", "test");
         VARIABLES.put("numberVar", 10);
@@ -70,28 +64,28 @@ public class RuntimeServiceTest extends FlowableCmmnTestCase {
     @CmmnDeployment
     public void testStartSimplePassthroughCase() {
         CaseDefinition caseDefinition = cmmnRepositoryService.createCaseDefinitionQuery().singleResult();
-        assertEquals("myCase", caseDefinition.getKey());
-        assertNotNull(caseDefinition.getResourceName());
-        assertNotNull(caseDefinition.getDeploymentId());
-        assertTrue(caseDefinition.getVersion() > 0);
+        assertThat(caseDefinition.getKey()).isEqualTo("myCase");
+        assertThat(caseDefinition.getResourceName()).isNotNull();
+        assertThat(caseDefinition.getDeploymentId()).isNotNull();
+        assertThat(caseDefinition.getVersion()).isPositive();
 
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionId(caseDefinition.getId()).start();
-        assertNotNull(caseInstance);
-        assertEquals(caseDefinition.getId(), caseInstance.getCaseDefinitionId());
-        assertNotNull(caseInstance.getStartTime());
-        assertEquals(CaseInstanceState.COMPLETED, caseInstance.getState());
+        assertThat(caseInstance).isNotNull();
+        assertThat(caseInstance.getCaseDefinitionId()).isEqualTo(caseDefinition.getId());
+        assertThat(caseInstance.getStartTime()).isNotNull();
+        assertThat(caseInstance.getState()).isEqualTo(CaseInstanceState.COMPLETED);
 
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
-        assertEquals(0, cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
 
         List<HistoricMilestoneInstance> milestoneInstances = cmmnHistoryService.createHistoricMilestoneInstanceQuery()
                 .milestoneInstanceCaseInstanceId(caseInstance.getId())
                 .orderByMilestoneName().asc()
                 .list();
-        assertEquals(2, milestoneInstances.size());
-        assertEquals("PlanItem Milestone One", milestoneInstances.get(0).getName());
-        assertEquals("PlanItem Milestone Two", milestoneInstances.get(1).getName());
+        assertThat(milestoneInstances)
+                .extracting(HistoricMilestoneInstance::getName)
+                .containsExactly("PlanItem Milestone One", "PlanItem Milestone Two");
     }
 
     @Test
@@ -99,83 +93,86 @@ public class RuntimeServiceTest extends FlowableCmmnTestCase {
     public void testStartSimplePassthroughCaseWithBlockingTask() {
         CaseDefinition caseDefinition = cmmnRepositoryService.createCaseDefinitionQuery().singleResult();
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionId(caseDefinition.getId()).start();
-        assertEquals(CaseInstanceState.ACTIVE, caseInstance.getState());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count());
-        assertEquals(0, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
+        assertThat(caseInstance.getState()).isEqualTo(CaseInstanceState.ACTIVE);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isEqualTo(1);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(0);
 
-        assertEquals(4, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(4);
 
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .singleResult();
-        assertNotNull(planItemInstance);
-        assertEquals("Task A", planItemInstance.getName());
+        assertThat(planItemInstance).isNotNull();
+        assertThat(planItemInstance.getName()).isEqualTo("Task A");
 
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
         List<MilestoneInstance> mileStones = cmmnRuntimeService.createMilestoneInstanceQuery()
                 .milestoneInstanceCaseInstanceId(caseInstance.getId())
                 .list();
-        assertEquals(1, mileStones.size());
-        assertEquals("PlanItem Milestone One", mileStones.get(0).getName());
+        assertThat(mileStones)
+                .extracting(MilestoneInstance::getName)
+                .containsExactly("PlanItem Milestone One");
 
         List<HistoricMilestoneInstance> historicMilestoneInstances = cmmnHistoryService.createHistoricMilestoneInstanceQuery()
                 .milestoneInstanceCaseInstanceId(caseInstance.getId())
                 .list();
-        assertEquals(1, historicMilestoneInstances.size());
-        assertEquals("PlanItem Milestone One", historicMilestoneInstances.get(0).getName());
+        assertThat(historicMilestoneInstances)
+                .extracting(HistoricMilestoneInstance::getName)
+                .containsExactly("PlanItem Milestone One");
 
         planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .singleResult();
-        assertNotNull(planItemInstance);
-        assertEquals("Task B", planItemInstance.getName());
+        assertThat(planItemInstance).isNotNull();
+        assertThat(planItemInstance.getName()).isEqualTo("Task B");
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
 
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
-        assertEquals(0, cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
-        assertEquals(2, cmmnHistoryService.createHistoricMilestoneInstanceQuery().milestoneInstanceCaseInstanceId(caseInstance.getId()).count());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
+        assertThat(cmmnHistoryService.createHistoricMilestoneInstanceQuery().milestoneInstanceCaseInstanceId(caseInstance.getId()).count()).isEqualTo(2);
 
         if (cmmnEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.ACTIVITY)) {
-            HistoricCaseInstance historicCaseInstance = cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult();
-            assertNotNull(historicCaseInstance);
-            assertNotNull(historicCaseInstance.getStartTime());
-            assertNotNull(historicCaseInstance.getEndTime());
-            assertEquals(CaseInstanceState.COMPLETED, historicCaseInstance.getState());
+            HistoricCaseInstance historicCaseInstance = cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceId(caseInstance.getId())
+                    .singleResult();
+            assertThat(historicCaseInstance).isNotNull();
+            assertThat(historicCaseInstance.getStartTime()).isNotNull();
+            assertThat(historicCaseInstance.getEndTime()).isNotNull();
+            assertThat(historicCaseInstance.getState()).isEqualTo(CaseInstanceState.COMPLETED);
         }
     }
-    
+
     @Test
-    @CmmnDeployment(resources = {"org/flowable/cmmn/test/runtime/RuntimeServiceTest.testStartSimplePassthroughCaseWithBlockingTask.cmmn"})
+    @CmmnDeployment(resources = { "org/flowable/cmmn/test/runtime/RuntimeServiceTest.testStartSimplePassthroughCaseWithBlockingTask.cmmn" })
     public void testBlockingTaskWithStartInterceptor() {
         TestStartCaseInstanceInterceptor testStartCaseInstanceInterceptor = new TestStartCaseInstanceInterceptor();
         cmmnEngineConfiguration.setStartCaseInstanceInterceptor(testStartCaseInstanceInterceptor);
-        
+
         try {
             CaseDefinition caseDefinition = cmmnRepositoryService.createCaseDefinitionQuery().singleResult();
             CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionId(caseDefinition.getId()).start();
-            assertEquals(CaseInstanceState.ACTIVE, caseInstance.getState());
-            
-            assertEquals(1, testStartCaseInstanceInterceptor.getBeforeStartCaseInstanceCounter());
-            assertEquals(1, testStartCaseInstanceInterceptor.getAfterStartCaseInstanceCounter());
-            
-            assertEquals("testKey", caseInstance.getBusinessKey());
-            assertEquals("test", cmmnRuntimeService.getVariable(caseInstance.getId(), "beforeContextVar"));
-            
+            assertThat(caseInstance.getState()).isEqualTo(CaseInstanceState.ACTIVE);
+
+            assertThat(testStartCaseInstanceInterceptor.getBeforeStartCaseInstanceCounter()).isEqualTo(1);
+            assertThat(testStartCaseInstanceInterceptor.getAfterStartCaseInstanceCounter()).isEqualTo(1);
+
+            assertThat(caseInstance.getBusinessKey()).isEqualTo("testKey");
+            assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "beforeContextVar")).isEqualTo("test");
+
         } finally {
             cmmnEngineConfiguration.setStartCaseInstanceInterceptor(null);
         }
     }
 
     @Test
-    @CmmnDeployment(resources = {"org/flowable/cmmn/test/runtime/RuntimeServiceTest.testStartSimplePassthroughCaseWithBlockingTask.cmmn"})
+    @CmmnDeployment(resources = { "org/flowable/cmmn/test/runtime/RuntimeServiceTest.testStartSimplePassthroughCaseWithBlockingTask.cmmn" })
     public void testVariableQueryWithBlockingTask() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-                        .caseDefinitionKey("myCase")
-                        .variables(VARIABLES)
-                        .start();
+                .caseDefinitionKey("myCase")
+                .variables(VARIABLES)
+                .start();
 
         assertNonEmptyQueryIncludeVariables(1, VARIABLES,
                 cmmnRuntimeService.createCaseInstanceQuery().variableValueEquals("var", "test"),
@@ -262,8 +259,8 @@ public class RuntimeServiceTest extends FlowableCmmnTestCase {
                 .caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .singleResult();
-        assertNotNull(planItemInstance);
-        assertEquals("Task A", planItemInstance.getName());
+        assertThat(planItemInstance).isNotNull();
+        assertThat(planItemInstance.getName()).isEqualTo("Task A");
 
         Map<String, Object> varMap = new HashMap<>();
         varMap.put("numberVar", 11);
@@ -299,7 +296,8 @@ public class RuntimeServiceTest extends FlowableCmmnTestCase {
         );
 
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
-        planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceState(PlanItemInstanceState.ACTIVE).singleResult();
+        planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
+                .planItemInstanceState(PlanItemInstanceState.ACTIVE).singleResult();
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
 
         assertEmptyQuery(
@@ -309,125 +307,119 @@ public class RuntimeServiceTest extends FlowableCmmnTestCase {
     }
 
     private void assertNonEmptyQueryIncludeVariables(int expectedCount, Map<String, Object> expectedVariables,
-                                                     CaseInstanceQuery caseInstanceQuery,
-                                                     HistoricCaseInstanceQuery historicCaseInstanceQuery) {
-        assertEquals(expectedCount, caseInstanceQuery.count());
+            CaseInstanceQuery caseInstanceQuery,
+            HistoricCaseInstanceQuery historicCaseInstanceQuery) {
+        assertThat(caseInstanceQuery.count()).isEqualTo(expectedCount);
         if (historicCaseInstanceQuery != null) {
-            assertEquals(expectedCount, historicCaseInstanceQuery.count());
+            assertThat(historicCaseInstanceQuery.count()).isEqualTo(expectedCount);
         }
         // assert singleResult
         if (expectedCount == 1) {
             CaseInstance fetchedCaseInstance = caseInstanceQuery.includeCaseVariables().singleResult();
-            assertThat(fetchedCaseInstance.getCaseVariables(), is(expectedVariables));
+            assertThat(fetchedCaseInstance.getCaseVariables()).isEqualTo(expectedVariables);
             if (historicCaseInstanceQuery != null) {
                 HistoricCaseInstance fetchedHistoricCaseInstance = historicCaseInstanceQuery.includeCaseVariables().singleResult();
-                assertThat(fetchedHistoricCaseInstance.getCaseVariables(), is(expectedVariables));
+                assertThat(fetchedHistoricCaseInstance.getCaseVariables()).isEqualTo(expectedVariables);
             }
         } else if (expectedCount > 1) {
-            try {
-                caseInstanceQuery.includeCaseVariables().singleResult();
-                fail("Exception expected");
-            } catch (FlowableException e) {
-                assertThat(e.getMessage(), is("Query return " + expectedCount + " results instead of max 1"));
-            }
+            assertThatThrownBy(() -> caseInstanceQuery.includeCaseVariables().singleResult())
+                    .isInstanceOf(FlowableException.class)
+                    .hasMessage("Query return " + expectedCount + " results instead of max 1");
+
             if (historicCaseInstanceQuery != null) {
-                try {
-                    historicCaseInstanceQuery.includeCaseVariables().singleResult();
-                    fail("Exception expected");
-                } catch (FlowableException e) {
-                    assertThat(e.getMessage(), is("Query return " + expectedCount + " results instead of max 1"));
-                }
+                assertThatThrownBy(() -> historicCaseInstanceQuery.includeCaseVariables().singleResult())
+                        .isInstanceOf(FlowableException.class)
+                        .hasMessage("Query return " + expectedCount + " results instead of max 1");
             }
         }
 
         // assert query list
         List<CaseInstance> caseInstances = caseInstanceQuery.includeCaseVariables().list();
-        assertThat(caseInstances.size(), is(expectedCount));
+        assertThat(caseInstances).hasSize(expectedCount);
         for (CaseInstance caseInstance : caseInstances) {
-            assertThat(caseInstance.getCaseVariables(), is(expectedVariables));
+            assertThat(caseInstance.getCaseVariables()).isEqualTo(expectedVariables);
         }
         if (historicCaseInstanceQuery != null) {
             List<HistoricCaseInstance> historicCaseInstances = historicCaseInstanceQuery.includeCaseVariables().list();
-            assertThat(historicCaseInstances.size(), is(expectedCount));
+            assertThat(historicCaseInstances).hasSize(expectedCount);
             for (HistoricCaseInstance historicCaseInstance : historicCaseInstances) {
-                assertThat(historicCaseInstance.getCaseVariables(), is(expectedVariables));
+                assertThat(historicCaseInstance.getCaseVariables()).isEqualTo(expectedVariables);
             }
         }
     }
 
-
     private void assertPaginationQueryIncludeVariables(int expectedStart, int expectedCount, List<CaseInstance> caseInstances) {
-        assertThat(caseInstances.size(), is(expectedCount));
+        assertThat(caseInstances).hasSize(expectedCount);
         Map<String, Object> expectedVariables = new HashMap<>(VARIABLES);
         for (int i = 0; i < expectedCount; i++) {
             CaseInstance caseInstance = caseInstances.get(i);
             expectedVariables.put("counter", expectedStart + i);
-            assertThat(caseInstance.getName(), is("A" + (expectedStart + i)));
-            assertThat(caseInstance.getCaseVariables(), is(expectedVariables));
+            assertThat(caseInstance.getName()).isEqualTo("A" + (expectedStart + i));
+            assertThat(caseInstance.getCaseVariables()).isEqualTo(expectedVariables);
         }
     }
 
     private void assertPaginationHistoricQueryIncludeVariables(int expectedStart, int expectedCount, List<HistoricCaseInstance> caseInstances) {
-        assertThat(caseInstances.size(), is(expectedCount));
+        assertThat(caseInstances).hasSize(expectedCount);
         Map<String, Object> expectedVariables = new HashMap<>(VARIABLES);
         for (int i = 0; i < expectedCount; i++) {
             HistoricCaseInstance caseInstance = caseInstances.get(i);
             expectedVariables.put("counter", expectedStart + i);
-            assertThat(caseInstance.getName(), is("A" + (expectedStart + i)));
-            assertThat(caseInstance.getCaseVariables(), is(expectedVariables));
+            assertThat(caseInstance.getName()).isEqualTo("A" + (expectedStart + i));
+            assertThat(caseInstance.getCaseVariables()).isEqualTo(expectedVariables);
         }
     }
 
     private void assertEmptyQuery(CaseInstanceQuery caseInstanceQuery, HistoricCaseInstanceQuery historicCaseInstanceQuery) {
-        assertEquals(0, caseInstanceQuery.count());
-        assertThat(caseInstanceQuery.includeCaseVariables().singleResult(), is(nullValue()));
+        assertThat(caseInstanceQuery.count()).isEqualTo(0);
+        assertThat(caseInstanceQuery.includeCaseVariables().singleResult()).isNull();
         List<CaseInstance> caseInstances = caseInstanceQuery.includeCaseVariables().list();
-        assertThat(caseInstances.size(), is(0));
+        assertThat(caseInstances).isEmpty();
 
         if (historicCaseInstanceQuery != null) {
-            assertEquals(0, historicCaseInstanceQuery.count());
-            assertThat(historicCaseInstanceQuery.includeCaseVariables().singleResult(), is(nullValue()));
+            assertThat(historicCaseInstanceQuery.count()).isEqualTo(0);
+            assertThat(historicCaseInstanceQuery.includeCaseVariables().singleResult()).isNull();
             List<HistoricCaseInstance> historicCaseInstances = historicCaseInstanceQuery.includeCaseVariables().list();
-            assertThat(historicCaseInstances.size(), is(0));
+            assertThat(historicCaseInstances).isEmpty();
         }
     }
 
     @Test
-    @CmmnDeployment(resources = {"org/flowable/cmmn/test/runtime/RuntimeServiceTest.testStartSimplePassthroughCaseWithBlockingTask.cmmn"})
+    @CmmnDeployment(resources = { "org/flowable/cmmn/test/runtime/RuntimeServiceTest.testStartSimplePassthroughCaseWithBlockingTask.cmmn" })
     public void testPlanItemVariableQueryWithBlockingTask() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-                        .caseDefinitionKey("myCase")
-                        .variable("var", "test")
-                        .variable("numberVar", 10)
-                        .start();
+                .caseDefinitionKey("myCase")
+                .variable("var", "test")
+                .variable("numberVar", 10)
+                .start();
 
-        assertEquals(4, cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueEquals("var", "test").count());
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueEquals("var", "test2").count());
-        assertEquals(4, cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueEqualsIgnoreCase("var", "TEST").count());
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueEqualsIgnoreCase("var", "TEST2").count());
-        assertEquals(4, cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueNotEquals("var", "test2").count());
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueNotEquals("var", "test").count());
-        assertEquals(4, cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueNotEqualsIgnoreCase("var", "TEST2").count());
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueNotEqualsIgnoreCase("var", "TEST").count());
-        assertEquals(4, cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueLike("var", "te%").count());
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueLike("var", "te2%").count());
-        assertEquals(4, cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueLikeIgnoreCase("var", "TE%").count());
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueLikeIgnoreCase("var", "TE2%").count());
-        assertEquals(4, cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueGreaterThan("numberVar", 5).count());
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueGreaterThan("numberVar", 11).count());
-        assertEquals(4, cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueGreaterThanOrEqual("numberVar", 10).count());
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueGreaterThanOrEqual("numberVar", 11).count());
-        assertEquals(4, cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueLessThan("numberVar", 20).count());
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueLessThan("numberVar", 5).count());
-        assertEquals(4, cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueLessThanOrEqual("numberVar", 10).count());
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueLessThanOrEqual("numberVar", 9).count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueEquals("var", "test").count()).isEqualTo(4);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueEquals("var", "test2").count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueEqualsIgnoreCase("var", "TEST").count()).isEqualTo(4);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueEqualsIgnoreCase("var", "TEST2").count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueNotEquals("var", "test2").count()).isEqualTo(4);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueNotEquals("var", "test").count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueNotEqualsIgnoreCase("var", "TEST2").count()).isEqualTo(4);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueNotEqualsIgnoreCase("var", "TEST").count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueLike("var", "te%").count()).isEqualTo(4);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueLike("var", "te2%").count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueLikeIgnoreCase("var", "TE%").count()).isEqualTo(4);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueLikeIgnoreCase("var", "TE2%").count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueGreaterThan("numberVar", 5).count()).isEqualTo(4);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueGreaterThan("numberVar", 11).count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueGreaterThanOrEqual("numberVar", 10).count()).isEqualTo(4);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueGreaterThanOrEqual("numberVar", 11).count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueLessThan("numberVar", 20).count()).isEqualTo(4);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueLessThan("numberVar", 5).count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueLessThanOrEqual("numberVar", 10).count()).isEqualTo(4);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueLessThanOrEqual("numberVar", 9).count()).isEqualTo(0);
 
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .singleResult();
-        assertNotNull(planItemInstance);
-        assertEquals("Task A", planItemInstance.getName());
+        assertThat(planItemInstance).isNotNull();
+        assertThat(planItemInstance.getName()).isEqualTo("Task A");
 
         Map<String, Object> varMap = new HashMap<>();
         varMap.put("numberVar", 11);
@@ -438,43 +430,44 @@ public class RuntimeServiceTest extends FlowableCmmnTestCase {
         localVarMap.put("localNumberVar", 15);
         cmmnRuntimeService.setLocalVariables(planItemInstance.getId(), localVarMap);
 
-        assertEquals(4, cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueGreaterThan("numberVar", 10).count());
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueGreaterThan("numberVar", 11).count());
-        assertEquals(4, cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueGreaterThanOrEqual("numberVar", 11).count());
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueGreaterThanOrEqual("numberVar", 12).count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueGreaterThan("numberVar", 10).count()).isEqualTo(4);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueGreaterThan("numberVar", 11).count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueGreaterThanOrEqual("numberVar", 11).count()).isEqualTo(4);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueGreaterThanOrEqual("numberVar", 12).count()).isEqualTo(0);
 
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueEquals("localVar", "test").count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueEquals("localVar", "test").count()).isEqualTo(0);
 
-        assertEquals(1, cmmnRuntimeService.createPlanItemInstanceQuery().variableValueEquals("localVar", "test").count());
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().variableValueEquals("localVar", "test2").count());
-        assertEquals(1, cmmnRuntimeService.createPlanItemInstanceQuery().variableValueEqualsIgnoreCase("localVar", "TEST").count());
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().variableValueEqualsIgnoreCase("localVar", "TEST2").count());
-        assertEquals(1, cmmnRuntimeService.createPlanItemInstanceQuery().variableValueNotEquals("localVar", "test2").count());
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().variableValueNotEquals("localVar", "test").count());
-        assertEquals(1, cmmnRuntimeService.createPlanItemInstanceQuery().variableValueNotEqualsIgnoreCase("localVar", "TEST2").count());
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().variableValueNotEqualsIgnoreCase("localVar", "TEST").count());
-        assertEquals(1, cmmnRuntimeService.createPlanItemInstanceQuery().variableValueLike("localVar", "te%").count());
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().variableValueLike("localVar", "te2%").count());
-        assertEquals(1, cmmnRuntimeService.createPlanItemInstanceQuery().variableValueLikeIgnoreCase("localVar", "TE%").count());
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().variableValueLikeIgnoreCase("localVar", "TE2%").count());
-        assertEquals(1, cmmnRuntimeService.createPlanItemInstanceQuery().variableValueGreaterThan("localNumberVar", 5).count());
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().variableValueGreaterThan("localNumberVar", 17).count());
-        assertEquals(1, cmmnRuntimeService.createPlanItemInstanceQuery().variableValueGreaterThanOrEqual("localNumberVar", 15).count());
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().variableValueGreaterThanOrEqual("localNumberVar", 16).count());
-        assertEquals(1, cmmnRuntimeService.createPlanItemInstanceQuery().variableValueLessThan("localNumberVar", 20).count());
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().variableValueLessThan("localNumberVar", 5).count());
-        assertEquals(1, cmmnRuntimeService.createPlanItemInstanceQuery().variableValueLessThanOrEqual("localNumberVar", 15).count());
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().variableValueLessThanOrEqual("localNumberVar", 9).count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueEquals("localVar", "test").count()).isEqualTo(1);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueEquals("localVar", "test2").count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueEqualsIgnoreCase("localVar", "TEST").count()).isEqualTo(1);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueEqualsIgnoreCase("localVar", "TEST2").count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueNotEquals("localVar", "test2").count()).isEqualTo(1);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueNotEquals("localVar", "test").count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueNotEqualsIgnoreCase("localVar", "TEST2").count()).isEqualTo(1);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueNotEqualsIgnoreCase("localVar", "TEST").count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueLike("localVar", "te%").count()).isEqualTo(1);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueLike("localVar", "te2%").count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueLikeIgnoreCase("localVar", "TE%").count()).isEqualTo(1);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueLikeIgnoreCase("localVar", "TE2%").count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueGreaterThan("localNumberVar", 5).count()).isEqualTo(1);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueGreaterThan("localNumberVar", 17).count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueGreaterThanOrEqual("localNumberVar", 15).count()).isEqualTo(1);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueGreaterThanOrEqual("localNumberVar", 16).count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueLessThan("localNumberVar", 20).count()).isEqualTo(1);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueLessThan("localNumberVar", 5).count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueLessThanOrEqual("localNumberVar", 15).count()).isEqualTo(1);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueLessThanOrEqual("localNumberVar", 9).count()).isEqualTo(0);
 
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
-        planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceState(PlanItemInstanceState.ACTIVE).singleResult();
+        planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
+                .planItemInstanceState(PlanItemInstanceState.ACTIVE).singleResult();
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
 
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
     }
 
     @Test
-    @CmmnDeployment(resources = {"org/flowable/cmmn/test/runtime/RuntimeServiceTest.testStartSimplePassthroughCaseWithBlockingTask.cmmn"})
+    @CmmnDeployment(resources = { "org/flowable/cmmn/test/runtime/RuntimeServiceTest.testStartSimplePassthroughCaseWithBlockingTask.cmmn" })
     public void testLocalVariablesWithBlockingTask() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("myCase").start();
 
@@ -482,16 +475,16 @@ public class RuntimeServiceTest extends FlowableCmmnTestCase {
                 .caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .singleResult();
-        assertNotNull(planItemInstance);
-        assertEquals("Task A", planItemInstance.getName());
+        assertThat(planItemInstance).isNotNull();
+        assertThat(planItemInstance.getName()).isEqualTo("Task A");
 
         Map<String, Object> varMap = new HashMap<>();
         varMap.put("localVar", "test");
         cmmnRuntimeService.setLocalVariables(planItemInstance.getId(), varMap);
 
-        assertEquals("test", cmmnRuntimeService.getLocalVariable(planItemInstance.getId(), "localVar"));
-        assertEquals(1, cmmnRuntimeService.getLocalVariables(planItemInstance.getId()).size());
-        assertNull(cmmnRuntimeService.getVariable(caseInstance.getId(), "localVar"));
+        assertThat(cmmnRuntimeService.getLocalVariable(planItemInstance.getId(), "localVar")).isEqualTo("test");
+        assertThat(cmmnRuntimeService.getLocalVariables(planItemInstance.getId())).hasSize(1);
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "localVar")).isNull();
 
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
 
@@ -499,18 +492,18 @@ public class RuntimeServiceTest extends FlowableCmmnTestCase {
                 .caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .singleResult();
-        assertNotNull(planItemInstance);
-        assertEquals("Task B", planItemInstance.getName());
+        assertThat(planItemInstance).isNotNull();
+        assertThat(planItemInstance.getName()).isEqualTo("Task B");
 
-        assertNull(cmmnRuntimeService.getLocalVariable(planItemInstance.getId(), "localVar"));
+        assertThat(cmmnRuntimeService.getLocalVariable(planItemInstance.getId(), "localVar")).isNull();
 
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
 
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
     }
 
     @Test
-    @CmmnDeployment(resources = {"org/flowable/cmmn/test/runtime/RuntimeServiceTest.testStartSimplePassthroughCaseWithBlockingTask.cmmn"})
+    @CmmnDeployment(resources = { "org/flowable/cmmn/test/runtime/RuntimeServiceTest.testStartSimplePassthroughCaseWithBlockingTask.cmmn" })
     public void testRemoveLocalVariablesWithBlockingTask() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("myCase").start();
 
@@ -518,8 +511,8 @@ public class RuntimeServiceTest extends FlowableCmmnTestCase {
                 .caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .singleResult();
-        assertNotNull(planItemInstance);
-        assertEquals("Task A", planItemInstance.getName());
+        assertThat(planItemInstance).isNotNull();
+        assertThat(planItemInstance.getName()).isEqualTo("Task A");
 
         Map<String, Object> localVarMap = new HashMap<>();
         localVarMap.put("localVar", "test");
@@ -529,14 +522,14 @@ public class RuntimeServiceTest extends FlowableCmmnTestCase {
         varMap.put("var", "test");
         cmmnRuntimeService.setVariables(caseInstance.getId(), varMap);
 
-        assertEquals("test", cmmnRuntimeService.getLocalVariable(planItemInstance.getId(), "localVar"));
-        assertEquals(1, cmmnRuntimeService.getLocalVariables(planItemInstance.getId()).size());
+        assertThat(cmmnRuntimeService.getLocalVariable(planItemInstance.getId(), "localVar")).isEqualTo("test");
+        assertThat(cmmnRuntimeService.getLocalVariables(planItemInstance.getId())).hasSize(1);
 
-        assertEquals("test", cmmnRuntimeService.getVariable(caseInstance.getId(), "var"));
-        assertEquals(1, cmmnRuntimeService.getVariables(caseInstance.getId()).size());
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "var")).isEqualTo("test");
+        assertThat(cmmnRuntimeService.getVariables(caseInstance.getId())).hasSize(1);
 
         cmmnRuntimeService.removeLocalVariable(planItemInstance.getId(), "localVar");
-        assertNull(cmmnRuntimeService.getLocalVariable(planItemInstance.getId(), "localVar"));
+        assertThat(cmmnRuntimeService.getLocalVariable(planItemInstance.getId(), "localVar")).isNull();
 
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
 
@@ -544,24 +537,24 @@ public class RuntimeServiceTest extends FlowableCmmnTestCase {
                 .caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .singleResult();
-        assertNotNull(planItemInstance);
-        assertEquals("Task B", planItemInstance.getName());
+        assertThat(planItemInstance).isNotNull();
+        assertThat(planItemInstance.getName()).isEqualTo("Task B");
 
-        assertEquals("test", cmmnRuntimeService.getVariable(caseInstance.getId(), "var"));
-        assertEquals(1, cmmnRuntimeService.getVariables(caseInstance.getId()).size());
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "var")).isEqualTo("test");
+        assertThat(cmmnRuntimeService.getVariables(caseInstance.getId())).hasSize(1);
 
         cmmnRuntimeService.removeVariable(caseInstance.getId(), "var");
-        assertNull(cmmnRuntimeService.getVariable(caseInstance.getId(), "var"));
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "var")).isNull();
 
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
 
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
-        assertEquals(0, cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
     @Test
-    @CmmnDeployment(resources = {"org/flowable/cmmn/test/runtime/RuntimeServiceTest.testStartSimplePassthroughCaseWithBlockingTask.cmmn"})
+    @CmmnDeployment(resources = { "org/flowable/cmmn/test/runtime/RuntimeServiceTest.testStartSimplePassthroughCaseWithBlockingTask.cmmn" })
     public void testIncludeVariableSingleResultQueryWithBlockingTask() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
                 .caseDefinitionKey("myCase")
@@ -584,7 +577,7 @@ public class RuntimeServiceTest extends FlowableCmmnTestCase {
     }
 
     @Test
-    @CmmnDeployment(resources = {"org/flowable/cmmn/test/runtime/RuntimeServiceTest.testStartSimplePassthroughCaseWithBlockingTask.cmmn"})
+    @CmmnDeployment(resources = { "org/flowable/cmmn/test/runtime/RuntimeServiceTest.testStartSimplePassthroughCaseWithBlockingTask.cmmn" })
     public void testIncludeVariableListQueryWithBlockingTask() {
         Map<String, Object> variablesA = new HashMap<>();
         variablesA.put("var", "test");
@@ -613,24 +606,23 @@ public class RuntimeServiceTest extends FlowableCmmnTestCase {
                 .start();
 
         List<CaseInstance> caseInstancesWithVariables = cmmnRuntimeService.createCaseInstanceQuery().includeCaseVariables().orderByStartTime().asc().list();
-        assertThat(caseInstancesWithVariables.size(), is(3));
-        assertThat(caseInstancesWithVariables.get(0).getCaseVariables(), is(variablesA));
-        assertThat(caseInstancesWithVariables.get(1).getCaseVariables(), is(variablesB));
-        assertThat(caseInstancesWithVariables.get(2).getCaseVariables(), is(Collections.EMPTY_MAP));
+        assertThat(caseInstancesWithVariables)
+                .extracting(CaseInstance::getCaseVariables)
+                .containsExactly(variablesA, variablesB, Collections.EMPTY_MAP);
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().includeCaseVariables().orderByStartTime().asc().count(), is(3L));
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().includeCaseVariables().orderByStartTime().asc().count()).isEqualTo(3L);
 
-        List<HistoricCaseInstance> historicCaseInstancesWithVariables = cmmnHistoryService.createHistoricCaseInstanceQuery().includeCaseVariables().orderByStartTime().asc().list();
-        assertThat(historicCaseInstancesWithVariables.size(), is(3));
-        assertThat(historicCaseInstancesWithVariables.get(0).getCaseVariables(), is(variablesA));
-        assertThat(historicCaseInstancesWithVariables.get(1).getCaseVariables(), is(variablesB));
-        assertThat(historicCaseInstancesWithVariables.get(2).getCaseVariables(), is(Collections.EMPTY_MAP));
+        List<HistoricCaseInstance> historicCaseInstancesWithVariables = cmmnHistoryService.createHistoricCaseInstanceQuery().includeCaseVariables()
+                .orderByStartTime().asc().list();
+        assertThat(historicCaseInstancesWithVariables)
+                .extracting(HistoricCaseInstance::getCaseVariables)
+                .containsExactly(variablesA, variablesB, Collections.EMPTY_MAP);
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().includeCaseVariables().orderByStartTime().asc().count(), is(3L));
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().includeCaseVariables().orderByStartTime().asc().count()).isEqualTo(3L);
     }
 
     @Test
-    @CmmnDeployment(resources = {"org/flowable/cmmn/test/runtime/RuntimeServiceTest.testStartSimplePassthroughCaseWithBlockingTask.cmmn"})
+    @CmmnDeployment(resources = { "org/flowable/cmmn/test/runtime/RuntimeServiceTest.testStartSimplePassthroughCaseWithBlockingTask.cmmn" })
     public void testIncludeSameVariableListQueryWithBlockingTask() {
         Instant now = setClockFixedToCurrentTime().toInstant();
         cmmnRuntimeService.createCaseInstanceBuilder()
@@ -658,59 +650,104 @@ public class RuntimeServiceTest extends FlowableCmmnTestCase {
     }
 
     @Test
-    @CmmnDeployment(resources = {"org/flowable/cmmn/test/runtime/RuntimeServiceTest.testStartSimplePassthroughCaseWithBlockingTask.cmmn"})
+    @CmmnDeployment(resources = { "org/flowable/cmmn/test/runtime/RuntimeServiceTest.testStartSimplePassthroughCaseWithBlockingTask.cmmn" })
     public void includeVariablesWithPaginationQueries() {
         createCaseInstances();
 
         testIncludeVariablesWithPagination(cmmnRuntimeService.createCaseInstanceQuery().includeCaseVariables().orderByStartTime().asc());
-        testIncludeVariablesWithPagination(cmmnRuntimeService.createCaseInstanceQuery().variableValueEquals("var", "test").includeCaseVariables().orderByStartTime().asc());
-        testIncludeVariablesWithPagination(cmmnRuntimeService.createCaseInstanceQuery().variableValueEqualsIgnoreCase("var", "TEST").includeCaseVariables().orderByStartTime().asc());
-        testIncludeVariablesWithPagination(cmmnRuntimeService.createCaseInstanceQuery().variableValueNotEquals("var", "test2").includeCaseVariables().orderByStartTime().asc());
-        testIncludeVariablesWithPagination(cmmnRuntimeService.createCaseInstanceQuery().variableValueNotEqualsIgnoreCase("var", "TEST2").includeCaseVariables().orderByStartTime().asc());
-        testIncludeVariablesWithPagination(cmmnRuntimeService.createCaseInstanceQuery().variableValueLike("var", "te%").includeCaseVariables().orderByStartTime().asc());
-        testIncludeVariablesWithPagination(cmmnRuntimeService.createCaseInstanceQuery().variableValueLikeIgnoreCase("var", "TE%").includeCaseVariables().orderByStartTime().asc());
-        testIncludeVariablesWithPagination(cmmnRuntimeService.createCaseInstanceQuery().variableValueGreaterThan("numberVar", 5).includeCaseVariables().orderByStartTime().asc());
-        testIncludeVariablesWithPagination(cmmnRuntimeService.createCaseInstanceQuery().variableValueGreaterThanOrEqual("numberVar", 10).includeCaseVariables().orderByStartTime().asc());
-        testIncludeVariablesWithPagination(cmmnRuntimeService.createCaseInstanceQuery().variableValueLessThan("numberVar", 20).includeCaseVariables().orderByStartTime().asc());
-        testIncludeVariablesWithPagination(cmmnRuntimeService.createCaseInstanceQuery().variableValueLessThanOrEqual("numberVar", 10).includeCaseVariables().orderByStartTime().asc());
+        testIncludeVariablesWithPagination(
+                cmmnRuntimeService.createCaseInstanceQuery().variableValueEquals("var", "test").includeCaseVariables().orderByStartTime().asc());
+        testIncludeVariablesWithPagination(
+                cmmnRuntimeService.createCaseInstanceQuery().variableValueEqualsIgnoreCase("var", "TEST").includeCaseVariables().orderByStartTime().asc());
+        testIncludeVariablesWithPagination(
+                cmmnRuntimeService.createCaseInstanceQuery().variableValueNotEquals("var", "test2").includeCaseVariables().orderByStartTime().asc());
+        testIncludeVariablesWithPagination(
+                cmmnRuntimeService.createCaseInstanceQuery().variableValueNotEqualsIgnoreCase("var", "TEST2").includeCaseVariables().orderByStartTime().asc());
+        testIncludeVariablesWithPagination(
+                cmmnRuntimeService.createCaseInstanceQuery().variableValueLike("var", "te%").includeCaseVariables().orderByStartTime().asc());
+        testIncludeVariablesWithPagination(
+                cmmnRuntimeService.createCaseInstanceQuery().variableValueLikeIgnoreCase("var", "TE%").includeCaseVariables().orderByStartTime().asc());
+        testIncludeVariablesWithPagination(
+                cmmnRuntimeService.createCaseInstanceQuery().variableValueGreaterThan("numberVar", 5).includeCaseVariables().orderByStartTime().asc());
+        testIncludeVariablesWithPagination(
+                cmmnRuntimeService.createCaseInstanceQuery().variableValueGreaterThanOrEqual("numberVar", 10).includeCaseVariables().orderByStartTime().asc());
+        testIncludeVariablesWithPagination(
+                cmmnRuntimeService.createCaseInstanceQuery().variableValueLessThan("numberVar", 20).includeCaseVariables().orderByStartTime().asc());
+        testIncludeVariablesWithPagination(
+                cmmnRuntimeService.createCaseInstanceQuery().variableValueLessThanOrEqual("numberVar", 10).includeCaseVariables().orderByStartTime().asc());
 
         testIncludeVariablesWithPagination(cmmnHistoryService.createHistoricCaseInstanceQuery().includeCaseVariables().orderByStartTime().asc());
-        testIncludeVariablesWithPagination(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueEquals("var", "test").includeCaseVariables().orderByStartTime().asc());
-        testIncludeVariablesWithPagination(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueEqualsIgnoreCase("var", "TEST").includeCaseVariables().orderByStartTime().asc());
-        testIncludeVariablesWithPagination(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueNotEquals("var", "test2").includeCaseVariables().orderByStartTime().asc());
-        testIncludeVariablesWithPagination(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueLike("var", "te%").includeCaseVariables().orderByStartTime().asc());
-        testIncludeVariablesWithPagination(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueLikeIgnoreCase("var", "TE%").includeCaseVariables().orderByStartTime().asc());
-        testIncludeVariablesWithPagination(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueGreaterThan("numberVar", 5).includeCaseVariables().orderByStartTime().asc());
-        testIncludeVariablesWithPagination(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueGreaterThanOrEqual("numberVar", 10).includeCaseVariables().orderByStartTime().asc());
-        testIncludeVariablesWithPagination(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueLessThan("numberVar", 20).includeCaseVariables().orderByStartTime().asc());
-        testIncludeVariablesWithPagination(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueLessThanOrEqual("numberVar", 10).includeCaseVariables().orderByStartTime().asc());
+        testIncludeVariablesWithPagination(
+                cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueEquals("var", "test").includeCaseVariables().orderByStartTime().asc());
+        testIncludeVariablesWithPagination(
+                cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueEqualsIgnoreCase("var", "TEST").includeCaseVariables().orderByStartTime()
+                        .asc());
+        testIncludeVariablesWithPagination(
+                cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueNotEquals("var", "test2").includeCaseVariables().orderByStartTime().asc());
+        testIncludeVariablesWithPagination(
+                cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueLike("var", "te%").includeCaseVariables().orderByStartTime().asc());
+        testIncludeVariablesWithPagination(
+                cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueLikeIgnoreCase("var", "TE%").includeCaseVariables().orderByStartTime().asc());
+        testIncludeVariablesWithPagination(
+                cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueGreaterThan("numberVar", 5).includeCaseVariables().orderByStartTime().asc());
+        testIncludeVariablesWithPagination(
+                cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueGreaterThanOrEqual("numberVar", 10).includeCaseVariables().orderByStartTime()
+                        .asc());
+        testIncludeVariablesWithPagination(
+                cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueLessThan("numberVar", 20).includeCaseVariables().orderByStartTime().asc());
+        testIncludeVariablesWithPagination(
+                cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueLessThanOrEqual("numberVar", 10).includeCaseVariables().orderByStartTime()
+                        .asc());
     }
 
     @Test
-    @CmmnDeployment(resources = {"org/flowable/cmmn/test/runtime/RuntimeServiceTest.testStartSimplePassthroughCaseWithBlockingTask.cmmn"})
+    @CmmnDeployment(resources = { "org/flowable/cmmn/test/runtime/RuntimeServiceTest.testStartSimplePassthroughCaseWithBlockingTask.cmmn" })
     public void includeVariablesWithEmptyPaginationQueries() {
         createCaseInstances();
 
-        testIncludeVariablesOnEmptyQueryWithPagination(cmmnRuntimeService.createCaseInstanceQuery().variableValueEquals("var", "test2").includeCaseVariables().orderByStartTime().asc());
-        testIncludeVariablesOnEmptyQueryWithPagination(cmmnRuntimeService.createCaseInstanceQuery().variableValueEqualsIgnoreCase("var", "TEST2").includeCaseVariables().orderByStartTime().asc());
-        testIncludeVariablesOnEmptyQueryWithPagination(cmmnRuntimeService.createCaseInstanceQuery().variableValueNotEquals("var", "test").includeCaseVariables().orderByStartTime().asc());
-        testIncludeVariablesOnEmptyQueryWithPagination(cmmnRuntimeService.createCaseInstanceQuery().variableValueNotEqualsIgnoreCase("var", "TEST").includeCaseVariables().orderByStartTime().asc());
-        testIncludeVariablesOnEmptyQueryWithPagination(cmmnRuntimeService.createCaseInstanceQuery().variableValueLike("var", "te2%").includeCaseVariables().orderByStartTime().asc());
-        testIncludeVariablesOnEmptyQueryWithPagination(cmmnRuntimeService.createCaseInstanceQuery().variableValueLikeIgnoreCase("var", "TE2%").includeCaseVariables().orderByStartTime().asc());
-        testIncludeVariablesOnEmptyQueryWithPagination(cmmnRuntimeService.createCaseInstanceQuery().variableValueGreaterThan("numberVar", 11).includeCaseVariables().orderByStartTime().asc());
-        testIncludeVariablesOnEmptyQueryWithPagination(cmmnRuntimeService.createCaseInstanceQuery().variableValueGreaterThanOrEqual("numberVar", 11).includeCaseVariables().orderByStartTime().asc());
-        testIncludeVariablesOnEmptyQueryWithPagination(cmmnRuntimeService.createCaseInstanceQuery().variableValueLessThan("numberVar", 5).includeCaseVariables().orderByStartTime().asc());
-        testIncludeVariablesOnEmptyQueryWithPagination(cmmnRuntimeService.createCaseInstanceQuery().variableValueLessThanOrEqual("numberVar", 9).includeCaseVariables().orderByStartTime().asc());
+        testIncludeVariablesOnEmptyQueryWithPagination(
+                cmmnRuntimeService.createCaseInstanceQuery().variableValueEquals("var", "test2").includeCaseVariables().orderByStartTime().asc());
+        testIncludeVariablesOnEmptyQueryWithPagination(
+                cmmnRuntimeService.createCaseInstanceQuery().variableValueEqualsIgnoreCase("var", "TEST2").includeCaseVariables().orderByStartTime().asc());
+        testIncludeVariablesOnEmptyQueryWithPagination(
+                cmmnRuntimeService.createCaseInstanceQuery().variableValueNotEquals("var", "test").includeCaseVariables().orderByStartTime().asc());
+        testIncludeVariablesOnEmptyQueryWithPagination(
+                cmmnRuntimeService.createCaseInstanceQuery().variableValueNotEqualsIgnoreCase("var", "TEST").includeCaseVariables().orderByStartTime().asc());
+        testIncludeVariablesOnEmptyQueryWithPagination(
+                cmmnRuntimeService.createCaseInstanceQuery().variableValueLike("var", "te2%").includeCaseVariables().orderByStartTime().asc());
+        testIncludeVariablesOnEmptyQueryWithPagination(
+                cmmnRuntimeService.createCaseInstanceQuery().variableValueLikeIgnoreCase("var", "TE2%").includeCaseVariables().orderByStartTime().asc());
+        testIncludeVariablesOnEmptyQueryWithPagination(
+                cmmnRuntimeService.createCaseInstanceQuery().variableValueGreaterThan("numberVar", 11).includeCaseVariables().orderByStartTime().asc());
+        testIncludeVariablesOnEmptyQueryWithPagination(
+                cmmnRuntimeService.createCaseInstanceQuery().variableValueGreaterThanOrEqual("numberVar", 11).includeCaseVariables().orderByStartTime().asc());
+        testIncludeVariablesOnEmptyQueryWithPagination(
+                cmmnRuntimeService.createCaseInstanceQuery().variableValueLessThan("numberVar", 5).includeCaseVariables().orderByStartTime().asc());
+        testIncludeVariablesOnEmptyQueryWithPagination(
+                cmmnRuntimeService.createCaseInstanceQuery().variableValueLessThanOrEqual("numberVar", 9).includeCaseVariables().orderByStartTime().asc());
 
-        testIncludeVariablesOnEmptyQueryWithPagination(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueEquals("var", "test2").includeCaseVariables().orderByStartTime().asc());
-        testIncludeVariablesOnEmptyQueryWithPagination(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueEqualsIgnoreCase("var", "TEST2").includeCaseVariables().orderByStartTime().asc());
-        testIncludeVariablesOnEmptyQueryWithPagination(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueNotEquals("var", "test").includeCaseVariables().orderByStartTime().asc());
-        testIncludeVariablesOnEmptyQueryWithPagination(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueLike("var", "te2%").includeCaseVariables().orderByStartTime().asc());
-        testIncludeVariablesOnEmptyQueryWithPagination(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueLikeIgnoreCase("var", "TE2%").includeCaseVariables().orderByStartTime().asc());
-        testIncludeVariablesOnEmptyQueryWithPagination(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueGreaterThan("numberVar", 11).includeCaseVariables().orderByStartTime().asc());
-        testIncludeVariablesOnEmptyQueryWithPagination(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueGreaterThanOrEqual("numberVar", 11).includeCaseVariables().orderByStartTime().asc());
-        testIncludeVariablesOnEmptyQueryWithPagination(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueLessThan("numberVar", 5).includeCaseVariables().orderByStartTime().asc());
-        testIncludeVariablesOnEmptyQueryWithPagination(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueLessThanOrEqual("numberVar", 9).includeCaseVariables().orderByStartTime().asc());
+        testIncludeVariablesOnEmptyQueryWithPagination(
+                cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueEquals("var", "test2").includeCaseVariables().orderByStartTime().asc());
+        testIncludeVariablesOnEmptyQueryWithPagination(
+                cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueEqualsIgnoreCase("var", "TEST2").includeCaseVariables().orderByStartTime()
+                        .asc());
+        testIncludeVariablesOnEmptyQueryWithPagination(
+                cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueNotEquals("var", "test").includeCaseVariables().orderByStartTime().asc());
+        testIncludeVariablesOnEmptyQueryWithPagination(
+                cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueLike("var", "te2%").includeCaseVariables().orderByStartTime().asc());
+        testIncludeVariablesOnEmptyQueryWithPagination(
+                cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueLikeIgnoreCase("var", "TE2%").includeCaseVariables().orderByStartTime()
+                        .asc());
+        testIncludeVariablesOnEmptyQueryWithPagination(
+                cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueGreaterThan("numberVar", 11).includeCaseVariables().orderByStartTime().asc());
+        testIncludeVariablesOnEmptyQueryWithPagination(
+                cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueGreaterThanOrEqual("numberVar", 11).includeCaseVariables().orderByStartTime()
+                        .asc());
+        testIncludeVariablesOnEmptyQueryWithPagination(
+                cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueLessThan("numberVar", 5).includeCaseVariables().orderByStartTime().asc());
+        testIncludeVariablesOnEmptyQueryWithPagination(
+                cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueLessThanOrEqual("numberVar", 9).includeCaseVariables().orderByStartTime()
+                        .asc());
     }
 
     private void createCaseInstances() {
@@ -730,8 +767,8 @@ public class RuntimeServiceTest extends FlowableCmmnTestCase {
     }
 
     private void testIncludeVariablesWithPagination(CaseInstanceQuery caseInstanceQuery) {
-        assertPaginationQueryIncludeVariables(20, 10, caseInstanceQuery.listPage(20,10));
-        assertPaginationQueryIncludeVariables(0, 100, caseInstanceQuery.listPage(0,0));
+        assertPaginationQueryIncludeVariables(20, 10, caseInstanceQuery.listPage(20, 10));
+        assertPaginationQueryIncludeVariables(0, 100, caseInstanceQuery.listPage(0, 0));
         assertPaginationQueryIncludeVariables(0, 100, caseInstanceQuery.listPage(0, -1));
         assertPaginationQueryIncludeVariables(0, 100, caseInstanceQuery.listPage(-1, -1));
         assertPaginationQueryIncludeVariables(0, 100, caseInstanceQuery.listPage(-1, -2));
@@ -740,17 +777,14 @@ public class RuntimeServiceTest extends FlowableCmmnTestCase {
         assertPaginationQueryIncludeVariables(0, 20, caseInstanceQuery.listPage(-10, 20));
         assertPaginationQueryIncludeVariables(0, 100, caseInstanceQuery.listPage(0, Integer.MAX_VALUE));
 
-        try {
-            caseInstanceQuery.listPage(20, -1);
-            fail("IllegalArgumentException expected");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage(), is("fromIndex(20) > toIndex(19)"));
-        }
+        assertThatThrownBy(() -> caseInstanceQuery.listPage(20, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("fromIndex(20) > toIndex(19)");
     }
 
     private void testIncludeVariablesWithPagination(HistoricCaseInstanceQuery caseInstanceQuery) {
-        assertPaginationHistoricQueryIncludeVariables(20, 10, caseInstanceQuery.listPage(20,10));
-        assertPaginationHistoricQueryIncludeVariables(0, 100, caseInstanceQuery.listPage(0,0));
+        assertPaginationHistoricQueryIncludeVariables(20, 10, caseInstanceQuery.listPage(20, 10));
+        assertPaginationHistoricQueryIncludeVariables(0, 100, caseInstanceQuery.listPage(0, 0));
         assertPaginationHistoricQueryIncludeVariables(0, 100, caseInstanceQuery.listPage(0, -1));
         assertPaginationHistoricQueryIncludeVariables(0, 100, caseInstanceQuery.listPage(-1, -1));
         assertPaginationHistoricQueryIncludeVariables(0, 100, caseInstanceQuery.listPage(-1, -2));
@@ -759,17 +793,14 @@ public class RuntimeServiceTest extends FlowableCmmnTestCase {
         assertPaginationHistoricQueryIncludeVariables(0, 20, caseInstanceQuery.listPage(-10, 20));
         assertPaginationHistoricQueryIncludeVariables(0, 100, caseInstanceQuery.listPage(0, Integer.MAX_VALUE));
 
-        try {
-            caseInstanceQuery.listPage(20, -1);
-            fail("IllegalArgumentException expected");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage(), is("fromIndex(20) > toIndex(19)"));
-        }
+        assertThatThrownBy(() -> caseInstanceQuery.listPage(20, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("fromIndex(20) > toIndex(19)");
     }
 
     private void testIncludeVariablesOnEmptyQueryWithPagination(CaseInstanceQuery caseInstanceQuery) {
-        assertPaginationQueryIncludeVariables(0, 0, caseInstanceQuery.listPage(20,10));
-        assertPaginationQueryIncludeVariables(0, 0, caseInstanceQuery.listPage(0,0));
+        assertPaginationQueryIncludeVariables(0, 0, caseInstanceQuery.listPage(20, 10));
+        assertPaginationQueryIncludeVariables(0, 0, caseInstanceQuery.listPage(0, 0));
         assertPaginationQueryIncludeVariables(0, 0, caseInstanceQuery.listPage(0, -1));
         assertPaginationQueryIncludeVariables(0, 0, caseInstanceQuery.listPage(-1, -1));
         assertPaginationQueryIncludeVariables(0, 0, caseInstanceQuery.listPage(-1, -2));
@@ -781,8 +812,8 @@ public class RuntimeServiceTest extends FlowableCmmnTestCase {
     }
 
     private void testIncludeVariablesOnEmptyQueryWithPagination(HistoricCaseInstanceQuery caseInstanceQuery) {
-        assertPaginationHistoricQueryIncludeVariables(0, 0, caseInstanceQuery.listPage(20,10));
-        assertPaginationHistoricQueryIncludeVariables(0, 0, caseInstanceQuery.listPage(0,0));
+        assertPaginationHistoricQueryIncludeVariables(0, 0, caseInstanceQuery.listPage(20, 10));
+        assertPaginationHistoricQueryIncludeVariables(0, 0, caseInstanceQuery.listPage(0, 0));
         assertPaginationHistoricQueryIncludeVariables(0, 0, caseInstanceQuery.listPage(0, -1));
         assertPaginationHistoricQueryIncludeVariables(0, 0, caseInstanceQuery.listPage(-1, -1));
         assertPaginationHistoricQueryIncludeVariables(0, 0, caseInstanceQuery.listPage(-1, -2));
@@ -810,11 +841,12 @@ public class RuntimeServiceTest extends FlowableCmmnTestCase {
         assertCaseInstanceEnded(caseInstance, 1);
 
         if (cmmnEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.ACTIVITY)) {
-            HistoricCaseInstance historicCaseInstance = cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult();
-            assertNotNull(historicCaseInstance);
-            assertNotNull(historicCaseInstance.getStartTime());
-            assertNotNull(historicCaseInstance.getEndTime());
-            assertEquals(CaseInstanceState.TERMINATED, historicCaseInstance.getState());
+            HistoricCaseInstance historicCaseInstance = cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceId(caseInstance.getId())
+                    .singleResult();
+            assertThat(historicCaseInstance).isNotNull();
+            assertThat(historicCaseInstance.getStartTime()).isNotNull();
+            assertThat(historicCaseInstance.getEndTime()).isNotNull();
+            assertThat(historicCaseInstance.getState()).isEqualTo(CaseInstanceState.TERMINATED);
         }
     }
 
@@ -822,17 +854,17 @@ public class RuntimeServiceTest extends FlowableCmmnTestCase {
     @CmmnDeployment
     public void testTerminateCaseInstanceWithNestedStages() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("myCase").start();
-        assertEquals(8, cmmnRuntimeService.createPlanItemInstanceQuery()
-                .caseInstanceId(caseInstance.getId()).count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(8);
         cmmnRuntimeService.terminateCaseInstance(caseInstance.getId());
         assertCaseInstanceEnded(caseInstance, 0);
 
         if (cmmnEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.ACTIVITY)) {
-            HistoricCaseInstance historicCaseInstance = cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult();
-            assertNotNull(historicCaseInstance);
-            assertNotNull(historicCaseInstance.getStartTime());
-            assertNotNull(historicCaseInstance.getEndTime());
-            assertEquals(CaseInstanceState.TERMINATED, historicCaseInstance.getState());
+            HistoricCaseInstance historicCaseInstance = cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceId(caseInstance.getId())
+                    .singleResult();
+            assertThat(historicCaseInstance).isNotNull();
+            assertThat(historicCaseInstance.getStartTime()).isNotNull();
+            assertThat(historicCaseInstance.getEndTime()).isNotNull();
+            assertThat(historicCaseInstance.getState()).isEqualTo(CaseInstanceState.TERMINATED);
         }
     }
 
@@ -846,8 +878,8 @@ public class RuntimeServiceTest extends FlowableCmmnTestCase {
                 .start();
 
         caseInstance = cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult();
-        assertEquals("test name", caseInstance.getName());
-        assertEquals("test business key", caseInstance.getBusinessKey());
+        assertThat(caseInstance.getName()).isEqualTo("test name");
+        assertThat(caseInstance.getBusinessKey()).isEqualTo("test business key");
     }
 
     @Test
@@ -858,19 +890,19 @@ public class RuntimeServiceTest extends FlowableCmmnTestCase {
         Authentication.setAuthenticatedUserId(null);
 
         List<IdentityLink> caseIdentityLinks = cmmnRuntimeService.getIdentityLinksForCaseInstance(caseInstance.getId());
-        assertEquals(1, caseIdentityLinks.size());
-        assertEquals(caseInstance.getId(), caseIdentityLinks.get(0).getScopeId());
-        assertEquals(ScopeTypes.CMMN, caseIdentityLinks.get(0).getScopeType());
-        assertEquals(IdentityLinkType.STARTER, caseIdentityLinks.get(0).getType());
-        assertEquals("testUser", caseIdentityLinks.get(0).getUserId());
+        assertThat(caseIdentityLinks)
+                .extracting(IdentityLink::getScopeId, IdentityLink::getScopeType, IdentityLink::getType, IdentityLink::getUserId)
+                .containsExactly(tuple(caseInstance.getId(), ScopeTypes.CMMN, IdentityLinkType.STARTER, "testUser"));
 
         if (cmmnEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.AUDIT)) {
             List<HistoricIdentityLink> historicIdentityLinks = cmmnHistoryService.getHistoricIdentityLinksForCaseInstance(caseInstance.getId());
-            assertEquals(1, historicIdentityLinks.size());
-            assertEquals(caseInstance.getId(), historicIdentityLinks.get(0).getScopeId());
-            assertEquals(ScopeTypes.CMMN, historicIdentityLinks.get(0).getScopeType());
-            assertEquals(IdentityLinkType.STARTER, historicIdentityLinks.get(0).getType());
-            assertEquals("testUser", historicIdentityLinks.get(0).getUserId());
+            assertThat(historicIdentityLinks)
+                    .extracting(
+                            HistoricIdentityLink::getScopeId,
+                            HistoricIdentityLink::getScopeType,
+                            HistoricIdentityLink::getType,
+                            HistoricIdentityLink::getUserId)
+                    .containsExactly(tuple(caseInstance.getId(), ScopeTypes.CMMN, IdentityLinkType.STARTER, "testUser"));
         }
     }
 
@@ -878,13 +910,13 @@ public class RuntimeServiceTest extends FlowableCmmnTestCase {
     @CmmnDeployment(resources = { "org/flowable/cmmn/test/runtime/RuntimeServiceTest.testStartSimplePassthroughCaseWithBlockingTask.cmmn" })
     public void planItemQueryWithoutTenant() {
         cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("myCase")
-            .variable("var", "test")
-            .variable("numberVar", 10)
-            .start();
+                .caseDefinitionKey("myCase")
+                .variable("var", "test")
+                .variable("numberVar", 10)
+                .start();
 
-        assertEquals(1, cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceName("Task A").planItemInstanceWithoutTenantId().count());
-        assertEquals(1, cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceName("Task A").planItemInstanceWithoutTenantId().list().size());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceName("Task A").planItemInstanceWithoutTenantId().count()).isEqualTo(1);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceName("Task A").planItemInstanceWithoutTenantId().list()).hasSize(1);
     }
 
     @Test
@@ -894,99 +926,99 @@ public class RuntimeServiceTest extends FlowableCmmnTestCase {
         setClockTo(Date.from(now));
 
         CaseInstance case1 = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("myCase")
-            .businessKey("firstCase")
-            .start();
+                .caseDefinitionKey("myCase")
+                .businessKey("firstCase")
+                .start();
 
         setClockTo(Date.from(now.plusSeconds(10)));
 
         CaseInstance case2 = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("myCase")
-            .businessKey("secondCase")
-            .start();
+                .caseDefinitionKey("myCase")
+                .businessKey("secondCase")
+                .start();
 
         setClockTo(Date.from(now.plusSeconds(40)));
 
         CaseInstance case3 = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("myCase")
-            .businessKey("thirdCase")
-            .start();
+                .caseDefinitionKey("myCase")
+                .businessKey("thirdCase")
+                .start();
 
         setClockTo(Date.from(now.plusSeconds(70)));
 
         CaseInstance case4 = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("myCase")
-            .businessKey("fourthCase")
-            .start();
+                .caseDefinitionKey("myCase")
+                .businessKey("fourthCase")
+                .start();
 
         setClockTo(Date.from(now.plusSeconds(100)));
 
         CaseInstance case5 = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("myCase")
-            .businessKey("fifthCase")
-            .start();
+                .caseDefinitionKey("myCase")
+                .businessKey("fifthCase")
+                .start();
 
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().orderByStartTime().asc().list())
-            .extracting(CaseInstance::getId, CaseInstance::getBusinessKey)
-            .containsExactly(
-                tuple(case1.getId(), "firstCase"),
-                tuple(case2.getId(), "secondCase"),
-                tuple(case3.getId(), "thirdCase"),
-                tuple(case4.getId(), "fourthCase"),
-                tuple(case5.getId(), "fifthCase")
-            );
+                .extracting(CaseInstance::getId, CaseInstance::getBusinessKey)
+                .containsExactly(
+                        tuple(case1.getId(), "firstCase"),
+                        tuple(case2.getId(), "secondCase"),
+                        tuple(case3.getId(), "thirdCase"),
+                        tuple(case4.getId(), "fourthCase"),
+                        tuple(case5.getId(), "fifthCase")
+                );
 
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().orderByStartTime().asc().listPage(0, 3))
-            .extracting(CaseInstance::getId, CaseInstance::getBusinessKey)
-            .containsExactly(
-                tuple(case1.getId(), "firstCase"),
-                tuple(case2.getId(), "secondCase"),
-                tuple(case3.getId(), "thirdCase")
-            );
+                .extracting(CaseInstance::getId, CaseInstance::getBusinessKey)
+                .containsExactly(
+                        tuple(case1.getId(), "firstCase"),
+                        tuple(case2.getId(), "secondCase"),
+                        tuple(case3.getId(), "thirdCase")
+                );
 
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().orderByStartTime().asc().listPage(3, 10))
-            .extracting(CaseInstance::getId, CaseInstance::getBusinessKey)
-            .containsExactly(
-                tuple(case4.getId(), "fourthCase"),
-                tuple(case5.getId(), "fifthCase")
-            );
+                .extracting(CaseInstance::getId, CaseInstance::getBusinessKey)
+                .containsExactly(
+                        tuple(case4.getId(), "fourthCase"),
+                        tuple(case5.getId(), "fifthCase")
+                );
 
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().orderByStartTime().asc().listPage(10, 20))
-            .extracting(CaseInstance::getId, CaseInstance::getBusinessKey)
-            .isEmpty();
+                .extracting(CaseInstance::getId, CaseInstance::getBusinessKey)
+                .isEmpty();
 
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().orderByStartTime().asc().list())
-            .extracting(HistoricCaseInstance::getId, HistoricCaseInstance::getBusinessKey)
-            .containsExactly(
-                tuple(case1.getId(), "firstCase"),
-                tuple(case2.getId(), "secondCase"),
-                tuple(case3.getId(), "thirdCase"),
-                tuple(case4.getId(), "fourthCase"),
-                tuple(case5.getId(), "fifthCase")
-            );
+                .extracting(HistoricCaseInstance::getId, HistoricCaseInstance::getBusinessKey)
+                .containsExactly(
+                        tuple(case1.getId(), "firstCase"),
+                        tuple(case2.getId(), "secondCase"),
+                        tuple(case3.getId(), "thirdCase"),
+                        tuple(case4.getId(), "fourthCase"),
+                        tuple(case5.getId(), "fifthCase")
+                );
 
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().orderByStartTime().asc().listPage(0, 3))
-            .extracting(HistoricCaseInstance::getId, HistoricCaseInstance::getBusinessKey)
-            .containsExactly(
-                tuple(case1.getId(), "firstCase"),
-                tuple(case2.getId(), "secondCase"),
-                tuple(case3.getId(), "thirdCase")
-            );
+                .extracting(HistoricCaseInstance::getId, HistoricCaseInstance::getBusinessKey)
+                .containsExactly(
+                        tuple(case1.getId(), "firstCase"),
+                        tuple(case2.getId(), "secondCase"),
+                        tuple(case3.getId(), "thirdCase")
+                );
 
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().orderByStartTime().asc().listPage(3, 10))
-            .extracting(HistoricCaseInstance::getId, HistoricCaseInstance::getBusinessKey)
-            .containsExactly(
-                tuple(case4.getId(), "fourthCase"),
-                tuple(case5.getId(), "fifthCase")
-            );
+                .extracting(HistoricCaseInstance::getId, HistoricCaseInstance::getBusinessKey)
+                .containsExactly(
+                        tuple(case4.getId(), "fourthCase"),
+                        tuple(case5.getId(), "fifthCase")
+                );
 
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().orderByStartTime().asc().listPage(10, 20))
-            .extracting(HistoricCaseInstance::getId, HistoricCaseInstance::getBusinessKey)
-            .isEmpty();
+                .extracting(HistoricCaseInstance::getId, HistoricCaseInstance::getBusinessKey)
+                .isEmpty();
     }
-    
+
     protected class TestStartCaseInstanceInterceptor implements StartCaseInstanceInterceptor {
-        
+
         protected int beforeStartCaseInstanceCounter = 0;
         protected int afterStartCaseInstanceCounter = 0;
 

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/ServiceTaskTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/ServiceTaskTest.java
@@ -13,8 +13,6 @@
 package org.flowable.cmmn.test.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.flowable.cmmn.api.delegate.DelegatePlanItemInstance;
@@ -37,174 +35,174 @@ import org.junit.Test;
  * @author Joram Barrez
  */
 public class ServiceTaskTest extends FlowableCmmnTestCase {
-    
+
     @Test
     @CmmnDeployment
     public void testJavaServiceTask() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-                        .caseDefinitionKey("myCase")
-                        .variable("test", "test2")
-                        .start();
-        assertNotNull(caseInstance);
-        
+                .caseDefinitionKey("myCase")
+                .variable("test", "test2")
+                .start();
+        assertThat(caseInstance).isNotNull();
+
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .singleResult();
-        assertNotNull(planItemInstance);
-        
-        assertEquals("executed", cmmnRuntimeService.getVariable(caseInstance.getId(), "javaDelegate"));
-        assertEquals("test2", cmmnRuntimeService.getVariable(caseInstance.getId(), "test"));
-        
+        assertThat(planItemInstance).isNotNull();
+
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "javaDelegate")).isEqualTo("executed");
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "test")).isEqualTo("test2");
+
         // Triggering the task should start the child case instance
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
-        
-        assertEquals("executed", cmmnHistoryService.createHistoricVariableInstanceQuery()
-                        .caseInstanceId(caseInstance.getId())
-                        .variableName("javaDelegate")
-                        .singleResult().getValue());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+
+        assertThat(cmmnHistoryService.createHistoricVariableInstanceQuery()
+                .caseInstanceId(caseInstance.getId())
+                .variableName("javaDelegate")
+                .singleResult().getValue()).isEqualTo("executed");
     }
-    
+
     @Test
     @CmmnDeployment
     public void testJavaServiceTaskFields() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-                        .caseDefinitionKey("myCase")
-                        .variable("test", "test")
-                        .start();
-        assertNotNull(caseInstance);
-        
+                .caseDefinitionKey("myCase")
+                .variable("test", "test")
+                .start();
+        assertThat(caseInstance).isNotNull();
+
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .singleResult();
-        assertNotNull(planItemInstance);
-        
-        assertEquals("test", cmmnRuntimeService.getVariable(caseInstance.getId(), "testValue"));
-        assertEquals(true, cmmnRuntimeService.getVariable(caseInstance.getId(), "testExpression"));
-        
+        assertThat(planItemInstance).isNotNull();
+
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "testValue")).isEqualTo("test");
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "testExpression")).isEqualTo(true);
+
         // Triggering the task should start the child case instance
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
-        
-        assertEquals("test", cmmnHistoryService.createHistoricVariableInstanceQuery()
-                        .caseInstanceId(caseInstance.getId())
-                        .variableName("testValue")
-                        .singleResult().getValue());
-        assertEquals(true, cmmnHistoryService.createHistoricVariableInstanceQuery()
-                        .caseInstanceId(caseInstance.getId())
-                        .variableName("testExpression")
-                        .singleResult().getValue());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+
+        assertThat(cmmnHistoryService.createHistoricVariableInstanceQuery()
+                .caseInstanceId(caseInstance.getId())
+                .variableName("testValue")
+                .singleResult().getValue()).isEqualTo("test");
+        assertThat(cmmnHistoryService.createHistoricVariableInstanceQuery()
+                .caseInstanceId(caseInstance.getId())
+                .variableName("testExpression")
+                .singleResult().getValue()).isEqualTo(true);
     }
-    
+
     @Test
     @CmmnDeployment
     public void testResultVariableName() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-                        .caseDefinitionKey("myCase")
-                        .variable("test", "test")
-                        .start();
-        assertNotNull(caseInstance);
-        
+                .caseDefinitionKey("myCase")
+                .variable("test", "test")
+                .start();
+        assertThat(caseInstance).isNotNull();
+
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .singleResult();
-        assertNotNull(planItemInstance);
-        
-        assertEquals("hello test", cmmnRuntimeService.getVariable(caseInstance.getId(), "beanResponse"));
-        
+        assertThat(planItemInstance).isNotNull();
+
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "beanResponse")).isEqualTo("hello test");
+
         // Triggering the task should start the child case instance
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
-        
-        assertEquals("hello test", cmmnHistoryService.createHistoricVariableInstanceQuery()
-                        .caseInstanceId(caseInstance.getId())
-                        .variableName("beanResponse")
-                        .singleResult().getValue());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+
+        assertThat(cmmnHistoryService.createHistoricVariableInstanceQuery()
+                .caseInstanceId(caseInstance.getId())
+                .variableName("beanResponse")
+                .singleResult().getValue()).isEqualTo("hello test");
     }
-    
+
     @Test
     @CmmnDeployment
     public void testDelegateExpression() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-                        .caseDefinitionKey("myCase")
-                        .variable("test", "test2")
-                        .start();
-        assertNotNull(caseInstance);
-        
+                .caseDefinitionKey("myCase")
+                .variable("test", "test2")
+                .start();
+        assertThat(caseInstance).isNotNull();
+
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .singleResult();
-        assertNotNull(planItemInstance);
-        
-        assertEquals("executed", cmmnRuntimeService.getVariable(caseInstance.getId(), "javaDelegate"));
-        assertEquals("test2", cmmnRuntimeService.getVariable(caseInstance.getId(), "test"));
-        
+        assertThat(planItemInstance).isNotNull();
+
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "javaDelegate")).isEqualTo("executed");
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "test")).isEqualTo("test2");
+
         // Triggering the task should start the child case instance
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
-        
-        assertEquals("executed", cmmnHistoryService.createHistoricVariableInstanceQuery()
-                        .caseInstanceId(caseInstance.getId())
-                        .variableName("javaDelegate")
-                        .singleResult().getValue());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+
+        assertThat(cmmnHistoryService.createHistoricVariableInstanceQuery()
+                .caseInstanceId(caseInstance.getId())
+                .variableName("javaDelegate")
+                .singleResult().getValue()).isEqualTo("executed");
     }
-    
+
     @Test
     @CmmnDeployment
     public void testDelegateExpressionFields() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-                        .caseDefinitionKey("myCase")
-                        .variable("test", "test")
-                        .start();
-        assertNotNull(caseInstance);
-        
+                .caseDefinitionKey("myCase")
+                .variable("test", "test")
+                .start();
+        assertThat(caseInstance).isNotNull();
+
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .singleResult();
-        assertNotNull(planItemInstance);
-        
-        assertEquals("test", cmmnRuntimeService.getVariable(caseInstance.getId(), "testValue"));
-        assertEquals(true, cmmnRuntimeService.getVariable(caseInstance.getId(), "testExpression"));
-        
+        assertThat(planItemInstance).isNotNull();
+
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "testValue")).isEqualTo("test");
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "testExpression")).isEqualTo(true);
+
         // Triggering the task should start the child case instance
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
-        
-        assertEquals("test", cmmnHistoryService.createHistoricVariableInstanceQuery()
-                        .caseInstanceId(caseInstance.getId())
-                        .variableName("testValue")
-                        .singleResult().getValue());
-        assertEquals(true, cmmnHistoryService.createHistoricVariableInstanceQuery()
-                        .caseInstanceId(caseInstance.getId())
-                        .variableName("testExpression")
-                        .singleResult().getValue());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+
+        assertThat(cmmnHistoryService.createHistoricVariableInstanceQuery()
+                .caseInstanceId(caseInstance.getId())
+                .variableName("testValue")
+                .singleResult().getValue()).isEqualTo("test");
+        assertThat(cmmnHistoryService.createHistoricVariableInstanceQuery()
+                .caseInstanceId(caseInstance.getId())
+                .variableName("testExpression")
+                .singleResult().getValue()).isEqualTo(true);
     }
 
     @Test
     @CmmnDeployment
     public void testGetCmmnModelWithDelegateHelper() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("myCase")
-            .start();
+                .caseDefinitionKey("myCase")
+                .start();
 
         assertThat(TestJavaDelegate01.cmmnModel).isNotNull();
         assertThat(TestJavaDelegate01.cmmnElement)
-            .asInstanceOf(InstanceOfAssertFactories.type(PlanItem.class))
-            .extracting(PlanItem::getName)
-            .isEqualTo("Task One");
+                .asInstanceOf(InstanceOfAssertFactories.type(PlanItem.class))
+                .extracting(PlanItem::getName)
+                .isEqualTo("Task One");
     }
 
     @Test
     @CmmnDeployment
     public void testCreateFieldExpressionWithDelegateHelper() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("myCase")
-            .start();
+                .caseDefinitionKey("myCase")
+                .start();
 
         Number variable = (Number) cmmnRuntimeService.getVariable(caseInstance.getId(), "delegateVariable");
         assertThat(variable).isEqualTo(2L);
@@ -214,8 +212,8 @@ public class ServiceTaskTest extends FlowableCmmnTestCase {
     @CmmnDeployment
     public void testCreateFieldExpressionForLifecycleListenerWithDelegateHelper() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("myCase")
-            .start();
+                .caseDefinitionKey("myCase")
+                .start();
 
         Number variable = (Number) cmmnRuntimeService.getVariable(caseInstance.getId(), "listenerVar");
         assertThat(variable).isEqualTo(99L);
@@ -264,6 +262,5 @@ public class ServiceTaskTest extends FlowableCmmnTestCase {
         }
 
     }
-
 
 }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/SignalEventListenerTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/SignalEventListenerTest.java
@@ -12,9 +12,7 @@
  */
 package org.flowable.cmmn.test.runtime;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.cmmn.api.runtime.CaseInstance;
 import org.flowable.cmmn.api.runtime.PlanItemDefinitionType;
@@ -42,66 +40,74 @@ public class SignalEventListenerTest extends FlowableCmmnTestCase {
     public void testSimpleEnableTask() {
         //Simple use of the UserEventListener as EntryCriteria of a Task
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey(name.getMethodName()).start();
-        assertNotNull(caseInstance);
-        assertEquals(1, cmmnRuntimeService.createCaseInstanceQuery().count());
+        assertThat(caseInstance).isNotNull();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(1);
 
         //3 PlanItems reachable
-        assertEquals(3, cmmnRuntimeService.createPlanItemInstanceQuery().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(3);
 
         //1 User Event Listener
-        PlanItemInstance listenerInstance = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.SIGNAL_EVENT_LISTENER).singleResult();
-        assertNotNull(listenerInstance);
-        assertEquals("eventListener", listenerInstance.getPlanItemDefinitionId());
-        assertEquals(PlanItemInstanceState.ACTIVE, listenerInstance.getState());
-        
+        PlanItemInstance listenerInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
+                .planItemDefinitionType(PlanItemDefinitionType.SIGNAL_EVENT_LISTENER).singleResult();
+        assertThat(listenerInstance).isNotNull();
+        assertThat(listenerInstance.getPlanItemDefinitionId()).isEqualTo("eventListener");
+        assertThat(listenerInstance.getState()).isEqualTo(PlanItemInstanceState.ACTIVE);
+
         // Verify same result is returned from query
-        SignalEventListenerInstance eventListenerInstance = cmmnRuntimeService.createSignalEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult();
-        assertNotNull(eventListenerInstance);
-        assertEquals(eventListenerInstance.getId(), listenerInstance.getId());
-        assertEquals(eventListenerInstance.getCaseDefinitionId(), listenerInstance.getCaseDefinitionId());
-        assertEquals(eventListenerInstance.getCaseInstanceId(), listenerInstance.getCaseInstanceId());
-        assertEquals(eventListenerInstance.getElementId(), listenerInstance.getElementId());
-        assertEquals(eventListenerInstance.getName(), listenerInstance.getName());
-        assertEquals(eventListenerInstance.getPlanItemDefinitionId(), listenerInstance.getPlanItemDefinitionId());
-        assertEquals(eventListenerInstance.getStageInstanceId(), listenerInstance.getStageInstanceId());
-        assertEquals(eventListenerInstance.getState(), listenerInstance.getState());
-        
-        assertEquals(1, cmmnRuntimeService.createSignalEventListenerInstanceQuery().count());
-        assertEquals(1, cmmnRuntimeService.createSignalEventListenerInstanceQuery().list().size());
-        
-        assertNotNull(cmmnRuntimeService.createSignalEventListenerInstanceQuery().caseDefinitionId(listenerInstance.getCaseDefinitionId()).singleResult());
-        assertNotNull(cmmnRuntimeService.createSignalEventListenerInstanceQuery().caseDefinitionId(listenerInstance.getCaseDefinitionId()).singleResult());
+        SignalEventListenerInstance eventListenerInstance = cmmnRuntimeService.createSignalEventListenerInstanceQuery().caseInstanceId(caseInstance.getId())
+                .singleResult();
+        assertThat(eventListenerInstance).isNotNull();
+        assertThat(listenerInstance.getId()).isEqualTo(eventListenerInstance.getId());
+        assertThat(listenerInstance.getCaseDefinitionId()).isEqualTo(eventListenerInstance.getCaseDefinitionId());
+        assertThat(listenerInstance.getCaseInstanceId()).isEqualTo(eventListenerInstance.getCaseInstanceId());
+        assertThat(listenerInstance.getElementId()).isEqualTo(eventListenerInstance.getElementId());
+        assertThat(listenerInstance.getName()).isEqualTo(eventListenerInstance.getName());
+        assertThat(listenerInstance.getPlanItemDefinitionId()).isEqualTo(eventListenerInstance.getPlanItemDefinitionId());
+        assertThat(listenerInstance.getStageInstanceId()).isEqualTo(eventListenerInstance.getStageInstanceId());
+        assertThat(listenerInstance.getState()).isEqualTo(eventListenerInstance.getState());
+
+        assertThat(cmmnRuntimeService.createSignalEventListenerInstanceQuery().count()).isEqualTo(1);
+        assertThat(cmmnRuntimeService.createSignalEventListenerInstanceQuery().list()).hasSize(1);
+
+        assertThat(cmmnRuntimeService.createSignalEventListenerInstanceQuery().caseDefinitionId(listenerInstance.getCaseDefinitionId()).singleResult())
+                .isNotNull();
+        assertThat(cmmnRuntimeService.createSignalEventListenerInstanceQuery().caseDefinitionId(listenerInstance.getCaseDefinitionId()).singleResult())
+                .isNotNull();
 
         //2 HumanTasks ... one active and other waiting (available)
-        assertEquals(2, cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK).count());
-        PlanItemInstance active = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK).planItemInstanceStateActive().singleResult();
-        assertNotNull(active);
-        assertEquals("taskA", active.getPlanItemDefinitionId());
-        PlanItemInstance available = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK).planItemInstanceStateAvailable().singleResult();
-        assertNotNull(available);
-        assertEquals("taskB", available.getPlanItemDefinitionId());
-        
-        EventSubscription eventSubscription = cmmnRuntimeService.createEventSubscriptionQuery().scopeId(eventListenerInstance.getCaseInstanceId()).singleResult();
-        assertNotNull(eventSubscription);
-        assertEquals(eventListenerInstance.getId(), eventSubscription.getSubScopeId());
-        assertEquals(eventListenerInstance.getCaseDefinitionId(), eventSubscription.getScopeDefinitionId());
-        assertEquals(ScopeTypes.CMMN, eventSubscription.getScopeType());
-        assertEquals("testSignal", eventSubscription.getEventName());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK).count()).isEqualTo(2);
+        PlanItemInstance active = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK)
+                .planItemInstanceStateActive().singleResult();
+        assertThat(active).isNotNull();
+        assertThat(active.getPlanItemDefinitionId()).isEqualTo("taskA");
+        PlanItemInstance available = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK)
+                .planItemInstanceStateAvailable().singleResult();
+        assertThat(available).isNotNull();
+        assertThat(available.getPlanItemDefinitionId()).isEqualTo("taskB");
+
+        EventSubscription eventSubscription = cmmnRuntimeService.createEventSubscriptionQuery().scopeId(eventListenerInstance.getCaseInstanceId())
+                .singleResult();
+        assertThat(eventSubscription).isNotNull();
+        assertThat(eventSubscription.getSubScopeId()).isEqualTo(eventListenerInstance.getId());
+        assertThat(eventSubscription.getScopeDefinitionId()).isEqualTo(eventListenerInstance.getCaseDefinitionId());
+        assertThat(eventSubscription.getScopeType()).isEqualTo(ScopeTypes.CMMN);
+        assertThat(eventSubscription.getEventName()).isEqualTo("testSignal");
 
         // Trigger the signal
         cmmnRuntimeService.triggerPlanItemInstance(listenerInstance.getId());
 
         // SignalEventListener should be completed
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.SIGNAL_EVENT_LISTENER).count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.SIGNAL_EVENT_LISTENER).count()).isEqualTo(0);
 
         // Only 2 PlanItems left
-        assertEquals(2, cmmnRuntimeService.createPlanItemInstanceQuery().list().size());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().list()).hasSize(2);
 
         // Both Human task should be "active" now, as the sentry kicks on the SignalEventListener transition
-        assertEquals(2, cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK).planItemInstanceStateActive().count());
-        
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK).planItemInstanceStateActive()
+                .count()).isEqualTo(2);
+
         eventSubscription = cmmnRuntimeService.createEventSubscriptionQuery().scopeId(eventListenerInstance.getCaseInstanceId()).singleResult();
-        assertNull(eventSubscription);
+        assertThat(eventSubscription).isNull();
 
         // Finish the case instance
         assertCaseInstanceNotEnded(caseInstance);
@@ -114,27 +120,28 @@ public class SignalEventListenerTest extends FlowableCmmnTestCase {
     public void testTerminateStage() {
         //Test case where the SignalEventListener is used to complete (ExitCriteria) of a Stage
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey(name.getMethodName()).start();
-        assertNotNull(caseInstance);
-        assertEquals(1, cmmnRuntimeService.createCaseInstanceQuery().count());
+        assertThat(caseInstance).isNotNull();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(1);
 
         //3 PlanItems reachable
-        assertEquals(3, cmmnRuntimeService.createPlanItemInstanceQuery().list().size());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().list()).hasSize(3);
 
         //1 Stage
         PlanItemInstance stage = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.STAGE).singleResult();
-        assertNotNull(stage);
+        assertThat(stage).isNotNull();
 
         //1 User Event Listener
-        PlanItemInstance listenerInstance = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.SIGNAL_EVENT_LISTENER).singleResult();
-        assertNotNull(listenerInstance);
-        assertEquals("eventListener", listenerInstance.getPlanItemDefinitionId());
-        assertEquals(PlanItemInstanceState.ACTIVE, listenerInstance.getState());
+        PlanItemInstance listenerInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
+                .planItemDefinitionType(PlanItemDefinitionType.SIGNAL_EVENT_LISTENER).singleResult();
+        assertThat(listenerInstance).isNotNull();
+        assertThat(listenerInstance.getPlanItemDefinitionId()).isEqualTo("eventListener");
+        assertThat(listenerInstance.getState()).isEqualTo(PlanItemInstanceState.ACTIVE);
 
         //1 Task on Active state
         PlanItemInstance task = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType("task").singleResult();
-        assertNotNull(task);
-        assertEquals(PlanItemInstanceState.ACTIVE, task.getState());
-        assertEquals(stage.getId(), task.getStageInstanceId());
+        assertThat(task).isNotNull();
+        assertThat(task.getState()).isEqualTo(PlanItemInstanceState.ACTIVE);
+        assertThat(task.getStageInstanceId()).isEqualTo(stage.getId());
 
         //Trigger the listener
         assertCaseInstanceNotEnded(caseInstance);

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/StartCaseWithFormTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/StartCaseWithFormTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,7 +12,7 @@
  */
 package org.flowable.cmmn.test.runtime;
 
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.cmmn.api.repository.CaseDefinition;
 import org.flowable.cmmn.api.runtime.CaseInstance;
@@ -33,7 +33,7 @@ public class StartCaseWithFormTest extends FlowableCmmnTestCase {
                 .caseDefinitionId(caseDefinition.getId())
                 .variable("test", "test2")
                 .startWithForm();
-        assertNotNull(caseInstance);
+        assertThat(caseInstance).isNotNull();
 
     }
 
@@ -45,6 +45,6 @@ public class StartCaseWithFormTest extends FlowableCmmnTestCase {
                 .caseDefinitionId(caseDefinition.getId())
                 .variable("test", "test2")
                 .startWithForm();
-        assertNotNull("It must be possible to start case without form repository service", caseInstance);
+        assertThat(caseInstance).as("It must be possible to start case without form repository service").isNotNull();
     }
 }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/TimerEventListenerTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/TimerEventListenerTest.java
@@ -12,8 +12,7 @@
  */
 package org.flowable.cmmn.test.runtime;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Calendar;
 import java.util.Date;
@@ -38,38 +37,40 @@ import org.junit.Test;
  * @author Joram Barrez
  */
 public class TimerEventListenerTest extends FlowableCmmnTestCase {
-    
+
     @Test
     @CmmnDeployment
     public void testTimerExpressionDuration() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testTimerExpression").start();
-        assertNotNull(caseInstance);
-        assertEquals(1, cmmnRuntimeService.createCaseInstanceQuery().count());
-        
-        assertNotNull(cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.TIMER_EVENT_LISTENER).planItemInstanceStateAvailable().singleResult());
-        assertNotNull(cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK).planItemInstanceStateAvailable().singleResult());
-        
-        assertEquals(1L, cmmnManagementService.createTimerJobQuery().count());
-        assertEquals(1L, cmmnManagementService.createTimerJobQuery().scopeId(caseInstance.getId()).scopeType(ScopeTypes.CMMN).count());
-        
+        assertThat(caseInstance).isNotNull();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(1);
+
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.TIMER_EVENT_LISTENER)
+                .planItemInstanceStateAvailable().singleResult()).isNotNull();
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK).planItemInstanceStateAvailable()
+                .singleResult()).isNotNull();
+
+        assertThat(cmmnManagementService.createTimerJobQuery().count()).isEqualTo(1L);
+        assertThat(cmmnManagementService.createTimerJobQuery().scopeId(caseInstance.getId()).scopeType(ScopeTypes.CMMN).count()).isEqualTo(1L);
+
         // User task should not be active before the timer triggers
-        assertEquals(0L, cmmnTaskService.createTaskQuery().count());
-        
+        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(0L);
+
         Job timerJob = cmmnManagementService.createTimerJobQuery().scopeDefinitionId(caseInstance.getCaseDefinitionId()).singleResult();
-        assertNotNull(timerJob);
-        assertEquals("timerListener", timerJob.getElementId());
-        assertEquals("Timer listener", timerJob.getElementName());
-        
+        assertThat(timerJob).isNotNull();
+        assertThat(timerJob.getElementId()).isEqualTo("timerListener");
+        assertThat(timerJob.getElementName()).isEqualTo("Timer listener");
+
         cmmnManagementService.moveTimerToExecutableJob(timerJob.getId());
         cmmnManagementService.executeJob(timerJob.getId());
-        
+
         // User task should be active after the timer has triggered
-        assertEquals(1L, cmmnTaskService.createTaskQuery().count());
+        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(1L);
     }
-    
+
     /**
-     * Similar test as #testTimerExpressionDuration but with the real async executor, 
-     * instead of manually triggering the timer. 
+     * Similar test as #testTimerExpressionDuration but with the real async executor,
+     * instead of manually triggering the timer.
      */
     @Test
     @CmmnDeployment
@@ -82,10 +83,10 @@ public class TimerEventListenerTest extends FlowableCmmnTestCase {
                 .planItemInstanceState(PlanItemInstanceState.AVAILABLE)
                 .planItemDefinitionType(PlanItemDefinitionType.TIMER_EVENT_LISTENER)
                 .singleResult();
-        assertNotNull(planItemInstance);
+        assertThat(planItemInstance).isNotNull();
 
         // User task should not be active before the timer triggers
-        assertEquals(0L, cmmnTaskService.createTaskQuery().count());
+        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(0L);
 
         // Timer fires after 1 hour, so setting it to 1 hours + 1 second
         setClockTo(new Date(startTime.getTime() + (60 * 60 * 1000 + 1)));
@@ -93,89 +94,91 @@ public class TimerEventListenerTest extends FlowableCmmnTestCase {
         CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 7000L, 200L, true);
 
         // User task should be active after the timer has triggered 
-        assertEquals(1L, cmmnTaskService.createTaskQuery().count());
+        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(1L);
     }
-    
+
     @Test
     @CmmnDeployment
     public void testStageAfterTimer() {
         Date startTime = setClockFixedToCurrentTime();
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testStageAfterTimerEventListener").start();
-        
+
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.AVAILABLE)
                 .planItemDefinitionType(PlanItemDefinitionType.TIMER_EVENT_LISTENER)
                 .singleResult();
-        assertNotNull(planItemInstance);
-        
-        assertEquals(0L, cmmnTaskService.createTaskQuery().count());
-        
+        assertThat(planItemInstance).isNotNull();
+
+        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(0L);
+
         // Timer fires after 1 day, so setting it to 1 day + 1 second
         setClockTo(new Date(startTime.getTime() + (24 * 60 * 60 * 1000 + 1)));
-        
+
         CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 7000L, 200L, true);
-        
+
         // User task should be active after the timer has triggered 
-        assertEquals(2L, cmmnTaskService.createTaskQuery().count());
+        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(2L);
     }
-    
+
     @Test
     @CmmnDeployment
     public void testTimerInStage() {
         Date startTime = setClockFixedToCurrentTime();
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testTimerInStage").start();
-        
-        assertEquals(1L, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceState(PlanItemInstanceState.ACTIVE).count());
+
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceState(PlanItemInstanceState.ACTIVE)
+                .count()).isEqualTo(1L);
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.AVAILABLE)
                 .planItemDefinitionType(PlanItemDefinitionType.TIMER_EVENT_LISTENER)
                 .singleResult();
-        assertNotNull(planItemInstance);
-        
-        assertEquals(1L, cmmnTaskService.createTaskQuery().count());
-        
+        assertThat(planItemInstance).isNotNull();
+
+        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(1L);
+
         // Timer fires after 3 hours, so setting it to 3 hours + 1 second
         setClockTo(new Date(startTime.getTime() + (3 * 60 * 60 * 1000 + 1)));
-        
+
         CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 7000L, 200L, true);
-        
+
         // User task should be active after the timer has triggered
         List<Task> tasks = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).orderByTaskName().asc().list();
-        assertEquals(2, tasks.size());
-        assertEquals("A", tasks.get(0).getName());
-        assertEquals("B", tasks.get(1).getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("A", "B");
     }
-    
+
     @Test
     @CmmnDeployment
     public void testExitPlanModelOnTimerOccurrence() {
         Date startTime = setClockFixedToCurrentTime();
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testStageExitOnTimerOccurrence").start();
-        
-        assertEquals(3L, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
-                .planItemInstanceState(PlanItemInstanceState.ACTIVE).planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK).count());
-        assertEquals(1L, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
-                .planItemInstanceState(PlanItemInstanceState.AVAILABLE).planItemDefinitionType(PlanItemDefinitionType.TIMER_EVENT_LISTENER).count());
-        assertEquals(1L, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
-                .planItemInstanceState(PlanItemInstanceState.ACTIVE).planItemDefinitionType(PlanItemDefinitionType.STAGE).count());
-        assertEquals(4L, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
-                .planItemInstanceState(PlanItemInstanceState.ACTIVE).count());
-        
+
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
+                .planItemInstanceState(PlanItemInstanceState.ACTIVE).planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK).count()).isEqualTo(3L);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
+                .planItemInstanceState(PlanItemInstanceState.AVAILABLE).planItemDefinitionType(PlanItemDefinitionType.TIMER_EVENT_LISTENER).count())
+                .isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
+                .planItemInstanceState(PlanItemInstanceState.ACTIVE).planItemDefinitionType(PlanItemDefinitionType.STAGE).count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
+                .planItemInstanceState(PlanItemInstanceState.ACTIVE).count()).isEqualTo(4L);
+
         // Timer fires after 24 hours, so setting it to 24 hours + 1 second
         setClockTo(new Date(startTime.getTime() + (24 * 60 * 60 * 1000 + 1)));
-        
+
         CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 7000L, 200L, true);
-        
-        assertEquals(0L, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count());
-        assertEquals(0L, cmmnRuntimeService.createCaseInstanceQuery().count());
+
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0L);
     }
-    
+
     @Test
     @CmmnDeployment
     public void testDateExpression() {
-        
+
         // Timer will fire on 2017-12-05T10:00
         // So moving the clock to the day before
         Calendar calendar = Calendar.getInstance();
@@ -186,37 +189,42 @@ public class TimerEventListenerTest extends FlowableCmmnTestCase {
         calendar.set(Calendar.MINUTE, 0);
         Date dayBefore = calendar.getTime();
         setClockTo(dayBefore);
-        
+
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testDateExpression").start();
-        
-        assertEquals(1L, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
-                .planItemInstanceState(PlanItemInstanceState.AVAILABLE).planItemDefinitionType(TimerEventListener.class.getSimpleName().toLowerCase()).count());
-        assertEquals(2L, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
-                .planItemInstanceState(PlanItemInstanceState.AVAILABLE).planItemDefinitionType(Stage.class.getSimpleName().toLowerCase()).count());
-        assertEquals(0L, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
-                .planItemInstanceState(PlanItemInstanceState.ACTIVE).planItemDefinitionType(Stage.class.getSimpleName().toLowerCase()).count());
-        assertEquals(0L, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
-                .planItemInstanceState(PlanItemInstanceState.ACTIVE).planItemDefinitionType(HumanTask.class.getSimpleName().toLowerCase()).count());
-        assertEquals(1L, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
-                .planItemInstanceState(PlanItemInstanceState.AVAILABLE).planItemDefinitionType(HumanTask.class.getSimpleName().toLowerCase()).count());
-        
-        assertEquals(0L, cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count());
-        
+
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
+                .planItemInstanceState(PlanItemInstanceState.AVAILABLE).planItemDefinitionType(TimerEventListener.class.getSimpleName().toLowerCase()).count())
+                .isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
+                .planItemInstanceState(PlanItemInstanceState.AVAILABLE).planItemDefinitionType(Stage.class.getSimpleName().toLowerCase()).count())
+                .isEqualTo(2L);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
+                .planItemInstanceState(PlanItemInstanceState.ACTIVE).planItemDefinitionType(Stage.class.getSimpleName().toLowerCase()).count()).isEqualTo(0L);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
+                .planItemInstanceState(PlanItemInstanceState.ACTIVE).planItemDefinitionType(HumanTask.class.getSimpleName().toLowerCase()).count())
+                .isEqualTo(0L);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
+                .planItemInstanceState(PlanItemInstanceState.AVAILABLE).planItemDefinitionType(HumanTask.class.getSimpleName().toLowerCase()).count())
+                .isEqualTo(1L);
+
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0L);
+
         setClockTo(new Date(dayBefore.getTime() + (24 * 60 * 60 * 1000)));
         CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 7000L, 200L, true);
-        
-        assertEquals(0L, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
-                .planItemInstanceState(PlanItemInstanceState.ACTIVE).planItemDefinitionType(TimerEventListener.class.getSimpleName().toLowerCase()).count());
-        
+
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
+                .planItemInstanceState(PlanItemInstanceState.ACTIVE).planItemDefinitionType(TimerEventListener.class.getSimpleName().toLowerCase()).count())
+                .isEqualTo(0L);
+
         List<Task> tasks = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).list();
-        assertEquals(3, tasks.size());
+        assertThat(tasks).hasSize(3);
         for (Task task : tasks) {
             cmmnTaskService.complete(task.getId());
         }
-        
+
         assertCaseInstanceEnded(caseInstance);
     }
-    
+
     @Test
     @CmmnDeployment
     public void testTimerWithBeanExpression() {
@@ -225,111 +233,113 @@ public class TimerEventListenerTest extends FlowableCmmnTestCase {
                 .caseDefinitionKey("testBean")
                 .variable("startTime", startTime)
                 .start();
-        
-        assertEquals(2L, cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count());
-        
-        assertEquals(2L, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
-                .planItemInstanceState(PlanItemInstanceState.ACTIVE).planItemDefinitionType(Stage.class.getSimpleName().toLowerCase()).count());
-        assertEquals(2L, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
-                .planItemInstanceState(PlanItemInstanceState.ACTIVE).planItemDefinitionType(HumanTask.class.getSimpleName().toLowerCase()).count());
-        
+
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(2L);
+
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
+                .planItemInstanceState(PlanItemInstanceState.ACTIVE).planItemDefinitionType(Stage.class.getSimpleName().toLowerCase()).count()).isEqualTo(2L);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
+                .planItemInstanceState(PlanItemInstanceState.ACTIVE).planItemDefinitionType(HumanTask.class.getSimpleName().toLowerCase()).count())
+                .isEqualTo(2L);
+
         setClockTo(new Date(startTime.getTime() + (2 * 60 * 60 * 1000)));
         CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 7000L, 200L, true);
-        
+
         Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
-        assertEquals("A", task.getName());
+        assertThat(task.getName()).isEqualTo("A");
         cmmnTaskService.complete(task.getId());
         assertCaseInstanceEnded(caseInstance);
     }
-    
+
     @Test
     @CmmnDeployment
     public void testTimerStartTrigger() {
         // Completing the stage will be the start trigger for the timer.
         // The timer event will exit the whole plan model
-        
+
         Date startTime = setClockFixedToCurrentTime();
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testStartTrigger").start();
-        
-        assertEquals(1L, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
-                .planItemDefinitionType(TimerEventListener.class.getSimpleName().toLowerCase()).count());
-        
+
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
+                .planItemDefinitionType(TimerEventListener.class.getSimpleName().toLowerCase()).count()).isEqualTo(1L);
+
         Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
-        assertEquals("A", task.getName());
+        assertThat(task.getName()).isEqualTo("A");
         cmmnTaskService.complete(task.getId());
         task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
-        assertEquals("B", task.getName());
+        assertThat(task.getName()).isEqualTo("B");
         cmmnTaskService.complete(task.getId());
         task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
-        assertEquals("C", task.getName());
-        
-        assertEquals(1L, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
-                .planItemInstanceState(PlanItemInstanceState.AVAILABLE).planItemDefinitionType(TimerEventListener.class.getSimpleName().toLowerCase()).count());
-        
+        assertThat(task.getName()).isEqualTo("C");
+
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
+                .planItemInstanceState(PlanItemInstanceState.AVAILABLE).planItemDefinitionType(TimerEventListener.class.getSimpleName().toLowerCase()).count())
+                .isEqualTo(1L);
+
         setClockTo(new Date(startTime.getTime() + (3 * 60 * 60 * 1000)));
         CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 7000L, 200L, true);
         assertCaseInstanceEnded(caseInstance);
     }
-    
+
     @Test
     @CmmnDeployment
     public void testExitNestedStageThroughTimer() {
         Date startTime = setClockFixedToCurrentTime();
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testExitNestedStageThroughTimer").start();
-        assertEquals(3L, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemDefinitionType(PlanItemDefinitionType.STAGE).count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemDefinitionType(PlanItemDefinitionType.STAGE)
+                .count()).isEqualTo(3L);
         Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
-        assertEquals("The task", task.getName());
-        
+        assertThat(task.getName()).isEqualTo("The task");
+
         setClockTo(new Date(startTime.getTime() + (5 * 60 * 60 * 1000)));
         CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 10000L, 100L, true);
-        assertEquals(0L, cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count());
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0L);
         assertCaseInstanceEnded(caseInstance);
     }
-    
+
     @Test
     @CmmnDeployment
     public void timerActivatesAndExitStages() {
         Date startTime = setClockFixedToCurrentTime();
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("timerActivatesAndExitStages").start();
-        
+
         List<Task> tasks = cmmnTaskService.createTaskQuery()
                 .caseInstanceId(caseInstance.getId())
                 .orderByTaskName().asc()
                 .list();
-        assertEquals(2, tasks.size());
-        assertEquals("A", tasks.get(0).getName());
-        assertEquals("B", tasks.get(1).getName());
-        
-        assertEquals(0L, cmmnManagementService.createTimerJobQuery().count());
-        
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("A", "B");
+
+        assertThat(cmmnManagementService.createTimerJobQuery().count()).isEqualTo(0L);
+
         // Completing A activates the stage and the timer event listener
         cmmnTaskService.complete(tasks.get(0).getId());
         cmmnTaskService.complete(tasks.get(1).getId());
-        
+
         // Timer event listener created a timer job
-        assertEquals(1L, cmmnManagementService.createTimerJobQuery().count());
+        assertThat(cmmnManagementService.createTimerJobQuery().count()).isEqualTo(1L);
         tasks = cmmnTaskService.createTaskQuery()
                 .caseInstanceId(caseInstance.getId())
                 .orderByTaskName().asc()
                 .list();
-        assertEquals(3, tasks.size());
-        assertEquals("Stage 1 task", tasks.get(0).getName());
-        assertEquals("Stage 3 task 1", tasks.get(1).getName());
-        assertEquals("Stage 3 task 2", tasks.get(2).getName());
-        
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("Stage 1 task", "Stage 3 task 1", "Stage 3 task 2");
+
         // Timer is set to 10 hours
         setClockTo(new Date(startTime.getTime() + (11 * 60 * 60 * 1000)));
         CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 10000L, 100L, true);
-        
+
         tasks = cmmnTaskService.createTaskQuery()
                 .caseInstanceId(caseInstance.getId())
                 .orderByTaskName().asc()
                 .list();
-        assertEquals(2, tasks.size());
-        assertEquals("Stage 1 task", tasks.get(0).getName());
-        assertEquals("Stage 2 task", tasks.get(1).getName());
-        
-        for(Task task : tasks) {
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("Stage 1 task", "Stage 2 task");
+
+        for (Task task : tasks) {
             cmmnTaskService.complete(task.getId());
         }
         assertCaseInstanceEnded(caseInstance);
@@ -344,17 +354,17 @@ public class TimerEventListenerTest extends FlowableCmmnTestCase {
                 .caseInstanceId(caseInstance.getId())
                 .orderByTaskName().asc()
                 .list();
-        assertEquals(1, tasks.size());
+        assertThat(tasks).hasSize(1);
 
         // Should have a TimerJob
-        assertEquals(1L, cmmnManagementService.createTimerJobQuery().count());
+        assertThat(cmmnManagementService.createTimerJobQuery().count()).isEqualTo(1L);
 
-        for(Task task : tasks) {
+        for (Task task : tasks) {
             cmmnTaskService.complete(task.getId());
         }
 
         // TimerJob should be deleted after all tasks have completed in the stage
-        assertEquals(0L, cmmnManagementService.createTimerJobQuery().count());
+        assertThat(cmmnManagementService.createTimerJobQuery().count()).isEqualTo(0L);
     }
 
     @Test
@@ -362,34 +372,38 @@ public class TimerEventListenerTest extends FlowableCmmnTestCase {
     public void testTimerWithAvailableCondition() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testTimerExpression").start();
 
-        assertEquals(0L, cmmnManagementService.createTimerJobQuery().count());
+        assertThat(cmmnManagementService.createTimerJobQuery().count()).isEqualTo(0L);
 
         // Setting the variable should make the timer available and create the timer job
         cmmnRuntimeService.setVariable(caseInstance.getId(), "timerVar", true);
-        assertEquals(1L, cmmnManagementService.createTimerJobQuery().count());
+        assertThat(cmmnManagementService.createTimerJobQuery().count()).isEqualTo(1L);
 
-        PlanItemInstance timerPlanItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.TIMER_EVENT_LISTENER).singleResult();
-        assertEquals(PlanItemInstanceState.AVAILABLE, timerPlanItemInstance.getState());
+        PlanItemInstance timerPlanItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
+                .planItemDefinitionType(PlanItemDefinitionType.TIMER_EVENT_LISTENER).singleResult();
+        assertThat(timerPlanItemInstance.getState()).isEqualTo(PlanItemInstanceState.AVAILABLE);
 
         // Setting the variable to false again will dismiss the timer
         cmmnRuntimeService.setVariable(caseInstance.getId(), "timerVar", false);
-        assertEquals(0L, cmmnManagementService.createTimerJobQuery().count());
-        timerPlanItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.TIMER_EVENT_LISTENER).singleResult();
-        assertEquals(PlanItemInstanceState.UNAVAILABLE, timerPlanItemInstance.getState());
+        assertThat(cmmnManagementService.createTimerJobQuery().count()).isEqualTo(0L);
+        timerPlanItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.TIMER_EVENT_LISTENER)
+                .singleResult();
+        assertThat(timerPlanItemInstance.getState()).isEqualTo(PlanItemInstanceState.UNAVAILABLE);
 
         cmmnRuntimeService.setVariable(caseInstance.getId(), "timerVar", true);
-        assertEquals(1L, cmmnManagementService.createTimerJobQuery().count());
-        timerPlanItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.TIMER_EVENT_LISTENER).singleResult();
-        assertEquals(PlanItemInstanceState.AVAILABLE, timerPlanItemInstance.getState());
+        assertThat(cmmnManagementService.createTimerJobQuery().count()).isEqualTo(1L);
+        timerPlanItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.TIMER_EVENT_LISTENER)
+                .singleResult();
+        assertThat(timerPlanItemInstance.getState()).isEqualTo(PlanItemInstanceState.AVAILABLE);
 
         // Execute the job
         Job timerJob = cmmnManagementService.createTimerJobQuery().scopeDefinitionId(caseInstance.getCaseDefinitionId()).singleResult();
-        assertNotNull(timerJob);
+        assertThat(timerJob).isNotNull();
         cmmnManagementService.moveTimerToExecutableJob(timerJob.getId());
         cmmnManagementService.executeJob(timerJob.getId());
 
-        timerPlanItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.TIMER_EVENT_LISTENER).includeEnded().singleResult();
-        assertEquals(PlanItemInstanceState.COMPLETED, timerPlanItemInstance.getState());
+        timerPlanItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.TIMER_EVENT_LISTENER)
+                .includeEnded().singleResult();
+        assertThat(timerPlanItemInstance.getState()).isEqualTo(PlanItemInstanceState.COMPLETED);
     }
-    
+
 }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/UserEventListenerTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/UserEventListenerTest.java
@@ -12,6 +12,14 @@
  */
 package org.flowable.cmmn.test.runtime;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.flowable.cmmn.api.runtime.CaseInstance;
 import org.flowable.cmmn.api.runtime.PlanItemDefinitionType;
 import org.flowable.cmmn.api.runtime.PlanItemInstance;
@@ -23,18 +31,6 @@ import org.flowable.task.api.Task;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
-
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author Dennis Federico
@@ -50,56 +46,63 @@ public class UserEventListenerTest extends FlowableCmmnTestCase {
     public void testSimpleEnableTask() {
         //Simple use of the UserEventListener as EntryCriteria of a Task
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey(name.getMethodName()).start();
-        assertNotNull(caseInstance);
-        assertEquals(1, cmmnRuntimeService.createCaseInstanceQuery().count());
+        assertThat(caseInstance).isNotNull();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(1);
 
         //3 PlanItems reachable
-        assertEquals(3, cmmnRuntimeService.createPlanItemInstanceQuery().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(3);
 
         //1 User Event Listener
-        PlanItemInstance listenerInstance = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER).singleResult();
-        assertNotNull(listenerInstance);
-        assertEquals("userEventListener", listenerInstance.getPlanItemDefinitionId());
-        assertEquals(PlanItemInstanceState.AVAILABLE, listenerInstance.getState());
-        
+        PlanItemInstance listenerInstance = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER)
+                .singleResult();
+        assertThat(listenerInstance).isNotNull();
+        assertThat(listenerInstance.getPlanItemDefinitionId()).isEqualTo("userEventListener");
+        assertThat(listenerInstance.getState()).isEqualTo(PlanItemInstanceState.AVAILABLE);
+
         // Verify same result is returned from query
-        UserEventListenerInstance userEventListenerInstance = cmmnRuntimeService.createUserEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult();
-        assertNotNull(userEventListenerInstance);
-        assertEquals(userEventListenerInstance.getId(), listenerInstance.getId());
-        assertEquals(userEventListenerInstance.getCaseDefinitionId(), listenerInstance.getCaseDefinitionId());
-        assertEquals(userEventListenerInstance.getCaseInstanceId(), listenerInstance.getCaseInstanceId());
-        assertEquals(userEventListenerInstance.getElementId(), listenerInstance.getElementId());
-        assertEquals(userEventListenerInstance.getName(), listenerInstance.getName());
-        assertEquals(userEventListenerInstance.getPlanItemDefinitionId(), listenerInstance.getPlanItemDefinitionId());
-        assertEquals(userEventListenerInstance.getStageInstanceId(), listenerInstance.getStageInstanceId());
-        assertEquals(userEventListenerInstance.getState(), listenerInstance.getState());
-        
-        assertEquals(1, cmmnRuntimeService.createUserEventListenerInstanceQuery().count());
-        assertEquals(1, cmmnRuntimeService.createUserEventListenerInstanceQuery().list().size());
-        
-        assertNotNull(cmmnRuntimeService.createUserEventListenerInstanceQuery().caseDefinitionId(listenerInstance.getCaseDefinitionId()).singleResult());
-        assertNotNull(cmmnRuntimeService.createUserEventListenerInstanceQuery().caseDefinitionId(listenerInstance.getCaseDefinitionId()).singleResult());
+        UserEventListenerInstance userEventListenerInstance = cmmnRuntimeService.createUserEventListenerInstanceQuery().caseInstanceId(caseInstance.getId())
+                .singleResult();
+        assertThat(userEventListenerInstance).isNotNull();
+        assertThat(listenerInstance.getId()).isEqualTo(userEventListenerInstance.getId());
+        assertThat(listenerInstance.getCaseDefinitionId()).isEqualTo(userEventListenerInstance.getCaseDefinitionId());
+        assertThat(listenerInstance.getCaseInstanceId()).isEqualTo(userEventListenerInstance.getCaseInstanceId());
+        assertThat(listenerInstance.getElementId()).isEqualTo(userEventListenerInstance.getElementId());
+        assertThat(listenerInstance.getName()).isEqualTo(userEventListenerInstance.getName());
+        assertThat(listenerInstance.getPlanItemDefinitionId()).isEqualTo(userEventListenerInstance.getPlanItemDefinitionId());
+        assertThat(listenerInstance.getStageInstanceId()).isEqualTo(userEventListenerInstance.getStageInstanceId());
+        assertThat(listenerInstance.getState()).isEqualTo(userEventListenerInstance.getState());
+
+        assertThat(cmmnRuntimeService.createUserEventListenerInstanceQuery().count()).isEqualTo(1);
+        assertThat(cmmnRuntimeService.createUserEventListenerInstanceQuery().list()).hasSize(1);
+
+        assertThat(cmmnRuntimeService.createUserEventListenerInstanceQuery().caseDefinitionId(listenerInstance.getCaseDefinitionId()).singleResult())
+                .isNotNull();
+        assertThat(cmmnRuntimeService.createUserEventListenerInstanceQuery().caseDefinitionId(listenerInstance.getCaseDefinitionId()).singleResult())
+                .isNotNull();
 
         //2 HumanTasks ... one active and other waiting (available)
-        assertEquals(2, cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK).count());
-        PlanItemInstance active = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK).planItemInstanceStateActive().singleResult();
-        assertNotNull(active);
-        assertEquals("taskA", active.getPlanItemDefinitionId());
-        PlanItemInstance available = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK).planItemInstanceStateAvailable().singleResult();
-        assertNotNull(available);
-        assertEquals("taskB", available.getPlanItemDefinitionId());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK).count()).isEqualTo(2);
+        PlanItemInstance active = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK)
+                .planItemInstanceStateActive().singleResult();
+        assertThat(active).isNotNull();
+        assertThat(active.getPlanItemDefinitionId()).isEqualTo("taskA");
+        PlanItemInstance available = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK)
+                .planItemInstanceStateAvailable().singleResult();
+        assertThat(available).isNotNull();
+        assertThat(available.getPlanItemDefinitionId()).isEqualTo("taskB");
 
         //Trigger the listener
         cmmnRuntimeService.completeUserEventListenerInstance(listenerInstance.getId());
 
         //UserEventListener should be completed
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER).count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER).count()).isEqualTo(0);
 
         //Only 2 PlanItems left
-        assertEquals(2, cmmnRuntimeService.createPlanItemInstanceQuery().list().size());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().list()).hasSize(2);
 
         //Both Human task should be "active" now, as the sentry kicks on the UserEventListener transition
-        assertEquals(2, cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK).planItemInstanceStateActive().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK).planItemInstanceStateActive()
+                .count()).isEqualTo(2);
 
         //Finish the caseInstance
         assertCaseInstanceNotEnded(caseInstance);
@@ -112,38 +115,41 @@ public class UserEventListenerTest extends FlowableCmmnTestCase {
     public void testTerminateTask() {
         //Test case where the UserEventListener is used to complete (ExitCriteria) of a task
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey(name.getMethodName()).start();
-        assertNotNull(caseInstance);
-        assertEquals(1, cmmnRuntimeService.createCaseInstanceQuery().count());
+        assertThat(caseInstance).isNotNull();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(1);
 
         //4 PlanItems reachable
-        assertEquals(4, cmmnRuntimeService.createPlanItemInstanceQuery().list().size());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().list()).hasSize(4);
 
         //1 Stage
-        assertEquals(1, cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.STAGE).count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.STAGE).count()).isEqualTo(1);
 
         //1 User Event Listener
-        PlanItemInstance listenerInstance = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER).singleResult();
-        assertNotNull(listenerInstance);
-        assertEquals("userEventListener", listenerInstance.getPlanItemDefinitionId());
-        assertEquals("userEventListenerPlanItem", listenerInstance.getElementId());
-        assertEquals(PlanItemInstanceState.AVAILABLE, listenerInstance.getState());
+        PlanItemInstance listenerInstance = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER)
+                .singleResult();
+        assertThat(listenerInstance).isNotNull();
+        assertThat(listenerInstance.getPlanItemDefinitionId()).isEqualTo("userEventListener");
+        assertThat(listenerInstance.getElementId()).isEqualTo("userEventListenerPlanItem");
+        assertThat(listenerInstance.getState()).isEqualTo(PlanItemInstanceState.AVAILABLE);
 
         //2 Tasks on Active state
         List<PlanItemInstance> tasks = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType("task").list();
-        assertEquals(2, tasks.size());
-        tasks.forEach(t -> assertEquals(PlanItemInstanceState.ACTIVE, t.getState()));
+        assertThat(tasks)
+                .extracting(PlanItemInstance::getState)
+                .containsExactly(PlanItemInstanceState.ACTIVE, PlanItemInstanceState.ACTIVE);
 
         //Trigger the listener
         cmmnRuntimeService.triggerPlanItemInstance(listenerInstance.getId());
 
         //UserEventListener should be completed
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER).count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER).count()).isEqualTo(0);
 
         //Only 2 PlanItems left (1 stage & 1 active task)
-        assertEquals(2, cmmnRuntimeService.createPlanItemInstanceQuery().list().size());
-        PlanItemInstance activeTask = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType("task").planItemInstanceStateActive().singleResult();
-        assertNotNull(activeTask);
-        assertEquals("taskB", activeTask.getPlanItemDefinitionId());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().list()).hasSize(2);
+        PlanItemInstance activeTask = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType("task").planItemInstanceStateActive()
+                .singleResult();
+        assertThat(activeTask).isNotNull();
+        assertThat(activeTask.getPlanItemDefinitionId()).isEqualTo("taskB");
 
         //Finish the caseInstance
         assertCaseInstanceNotEnded(caseInstance);
@@ -156,27 +162,28 @@ public class UserEventListenerTest extends FlowableCmmnTestCase {
     public void testTerminateStage() {
         //Test case where the UserEventListener is used to complete (ExitCriteria) of a Stage
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey(name.getMethodName()).start();
-        assertNotNull(caseInstance);
-        assertEquals(1, cmmnRuntimeService.createCaseInstanceQuery().count());
+        assertThat(caseInstance).isNotNull();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(1);
 
         //3 PlanItems reachable
-        assertEquals(3, cmmnRuntimeService.createPlanItemInstanceQuery().list().size());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().list()).hasSize(3);
 
         //1 Stage
         PlanItemInstance stage = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.STAGE).singleResult();
-        assertNotNull(stage);
+        assertThat(stage).isNotNull();
 
         //1 User Event Listener
-        PlanItemInstance listenerInstance = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER).singleResult();
-        assertNotNull(listenerInstance);
-        assertEquals("userEventListener", listenerInstance.getPlanItemDefinitionId());
-        assertEquals(PlanItemInstanceState.AVAILABLE, listenerInstance.getState());
+        PlanItemInstance listenerInstance = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER)
+                .singleResult();
+        assertThat(listenerInstance).isNotNull();
+        assertThat(listenerInstance.getPlanItemDefinitionId()).isEqualTo("userEventListener");
+        assertThat(listenerInstance.getState()).isEqualTo(PlanItemInstanceState.AVAILABLE);
 
         //1 Tasks on Active state
         PlanItemInstance task = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType("task").singleResult();
-        assertNotNull(task);
-        assertEquals(PlanItemInstanceState.ACTIVE, task.getState());
-        assertEquals(stage.getId(), task.getStageInstanceId());
+        assertThat(task).isNotNull();
+        assertThat(task.getState()).isEqualTo(PlanItemInstanceState.ACTIVE);
+        assertThat(task.getStageInstanceId()).isEqualTo(stage.getId());
 
         //Trigger the listener
         assertCaseInstanceNotEnded(caseInstance);
@@ -193,7 +200,7 @@ public class UserEventListenerTest extends FlowableCmmnTestCase {
                 .variable("whileTrue", "true")
                 .start();
 
-        assertNotNull(caseInstance);
+        assertThat(caseInstance).isNotNull();
 
         for (int i = 0; i < 3; i++) {
             Task taskA = cmmnTaskService.createTaskQuery().active().taskDefinitionKey("taskA").singleResult();
@@ -201,7 +208,8 @@ public class UserEventListenerTest extends FlowableCmmnTestCase {
             assertCaseInstanceNotEnded(caseInstance);
         }
 
-        PlanItemInstance userEvent = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER).singleResult();
+        PlanItemInstance userEvent = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER)
+                .singleResult();
         cmmnRuntimeService.triggerPlanItemInstance(userEvent.getId());
         assertCaseInstanceEnded(caseInstance);
     }
@@ -215,18 +223,20 @@ public class UserEventListenerTest extends FlowableCmmnTestCase {
                 .variable("whileRepeatTaskA", "true")
                 .start();
 
-        assertNotNull(caseInstance);
+        assertThat(caseInstance).isNotNull();
 
         //TaskA on available state until the entry criteria occurs
-        PlanItemInstance taskA = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK).planItemDefinitionId("taskA").singleResult();
-        assertEquals(PlanItemInstanceState.AVAILABLE, taskA.getState());
+        PlanItemInstance taskA = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK)
+                .planItemDefinitionId("taskA").singleResult();
+        assertThat(taskA.getState()).isEqualTo(PlanItemInstanceState.AVAILABLE);
 
         //Trigger the userEvent
-        PlanItemInstance userEvent = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER).singleResult();
+        PlanItemInstance userEvent = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER)
+                .singleResult();
         cmmnRuntimeService.triggerPlanItemInstance(userEvent.getId());
 
         //UserEventListener is consumed
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER).count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER).count()).isEqualTo(0);
 
         //Task is om Active state and a second task instance waiting for repetition
         Map<String, List<PlanItemInstance>> tasks = cmmnRuntimeService.createPlanItemInstanceQuery()
@@ -234,11 +244,11 @@ public class UserEventListenerTest extends FlowableCmmnTestCase {
                 .planItemDefinitionId("taskA")
                 .list().stream()
                 .collect(Collectors.groupingBy(PlanItemInstance::getState));
-        assertEquals(2, tasks.size());
-        assertTrue(tasks.containsKey(PlanItemInstanceState.ACTIVE));
-        assertEquals(1, tasks.get(PlanItemInstanceState.ACTIVE).size());
-        assertTrue(tasks.containsKey(PlanItemInstanceState.WAITING_FOR_REPETITION));
-        assertEquals(1, tasks.get(PlanItemInstanceState.WAITING_FOR_REPETITION).size());
+        assertThat(tasks).hasSize(2);
+        assertThat(tasks.containsKey(PlanItemInstanceState.ACTIVE)).isTrue();
+        assertThat(tasks.get(PlanItemInstanceState.ACTIVE)).hasSize(1);
+        assertThat(tasks.containsKey(PlanItemInstanceState.WAITING_FOR_REPETITION)).isTrue();
+        assertThat(tasks.get(PlanItemInstanceState.WAITING_FOR_REPETITION)).hasSize(1);
 
         //Complete active task
         cmmnTaskService.complete(cmmnTaskService.createTaskQuery().taskDefinitionKey("taskA").active().singleResult().getId());
@@ -247,9 +257,9 @@ public class UserEventListenerTest extends FlowableCmmnTestCase {
         tasks = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK)
                 .list().stream().collect(Collectors.groupingBy(PlanItemInstance::getPlanItemDefinitionId));
-        assertEquals(2, tasks.size());
-        assertEquals(PlanItemInstanceState.ACTIVE, tasks.get("taskB").get(0).getState());
-        assertEquals(PlanItemInstanceState.WAITING_FOR_REPETITION, tasks.get("taskA").get(0).getState());
+        assertThat(tasks).hasSize(2);
+        assertThat(tasks.get("taskB").get(0).getState()).isEqualTo(PlanItemInstanceState.ACTIVE);
+        assertThat(tasks.get("taskA").get(0).getState()).isEqualTo(PlanItemInstanceState.WAITING_FOR_REPETITION);
 
         //Since WAITING_FOR_REPETITION is a "Semi-terminal", completing taskB should complete the stage and case
         cmmnTaskService.complete(cmmnTaskService.createTaskQuery().active().singleResult().getId());
@@ -263,26 +273,26 @@ public class UserEventListenerTest extends FlowableCmmnTestCase {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
                 .caseDefinitionKey(name.getMethodName())
                 .start();
-        assertNotNull(caseInstance);
-        assertEquals(1, cmmnRuntimeService.createCaseInstanceQuery().count());
+        assertThat(caseInstance).isNotNull();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(1);
 
         Map<String, List<PlanItemInstance>> planItems = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .list().stream().collect(Collectors.groupingBy(PlanItemInstance::getPlanItemDefinitionType));
 
         //3 types of planItems
-        assertEquals(3, planItems.size());
+        assertThat(planItems).hasSize(3);
 
         //1 User Event Listener
-        assertEquals(1, planItems.getOrDefault(PlanItemDefinitionType.USER_EVENT_LISTENER, Collections.emptyList()).size());
+        assertThat(planItems.getOrDefault(PlanItemDefinitionType.USER_EVENT_LISTENER, Collections.emptyList())).hasSize(1);
         //1 Stage
-        assertEquals(1, planItems.getOrDefault(PlanItemDefinitionType.STAGE, Collections.emptyList()).size());
+        assertThat(planItems.getOrDefault(PlanItemDefinitionType.STAGE, Collections.emptyList())).hasSize(1);
         PlanItemInstance stage = planItems.get(PlanItemDefinitionType.STAGE).get(0);
 
         //1 Active Task (inside the stage)
-        assertEquals(1, planItems.getOrDefault("task", Collections.emptyList()).size());
+        assertThat(planItems.getOrDefault("task", Collections.emptyList())).hasSize(1);
         PlanItemInstance task = planItems.get("task").get(0);
-        assertEquals(PlanItemInstanceState.ACTIVE, task.getState());
-        assertEquals(stage.getId(), task.getStageInstanceId());
+        assertThat(task.getState()).isEqualTo(PlanItemInstanceState.ACTIVE);
+        assertThat(task.getStageInstanceId()).isEqualTo(stage.getId());
 
         //Complete the Task
         cmmnRuntimeService.triggerPlanItemInstance(task.getId());
@@ -290,7 +300,7 @@ public class UserEventListenerTest extends FlowableCmmnTestCase {
         //Listener should be deleted as it's an orphan
         planItems = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .list().stream().collect(Collectors.groupingBy(PlanItemInstance::getPlanItemDefinitionType));
-        assertEquals(0, planItems.size());
+        assertThat(planItems).isEmpty();
 
         //Stage and case instance should have ended...
         assertCaseInstanceEnded(caseInstance);
@@ -303,29 +313,29 @@ public class UserEventListenerTest extends FlowableCmmnTestCase {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
                 .caseDefinitionKey(name.getMethodName())
                 .start();
-        assertNotNull(caseInstance);
-        assertEquals(1, cmmnRuntimeService.createCaseInstanceQuery().count());
+        assertThat(caseInstance).isNotNull();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(1);
 
         Map<String, List<PlanItemInstance>> planItems = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .list().stream().collect(Collectors.groupingBy(PlanItemInstance::getPlanItemDefinitionType));
 
         //3 types of planItems
-        assertEquals(3, planItems.size());
+        assertThat(planItems).hasSize(3);
 
         //1 Stage
-        assertEquals(1, planItems.getOrDefault(PlanItemDefinitionType.STAGE, Collections.emptyList()).size());
+        assertThat(planItems.getOrDefault(PlanItemDefinitionType.STAGE, Collections.emptyList())).hasSize(1);
         PlanItemInstance stage = planItems.get(PlanItemDefinitionType.STAGE).get(0);
 
         //1 Active Task (inside the stage)
-        assertEquals(1, planItems.getOrDefault("task", Collections.emptyList()).size());
+        assertThat(planItems.getOrDefault("task", Collections.emptyList())).hasSize(1);
         PlanItemInstance task = planItems.get("task").get(0);
-        assertEquals(PlanItemInstanceState.ACTIVE, task.getState());
-        assertEquals(stage.getId(), task.getStageInstanceId());
+        assertThat(task.getState()).isEqualTo(PlanItemInstanceState.ACTIVE);
+        assertThat(task.getStageInstanceId()).isEqualTo(stage.getId());
 
         //1 Available User Event Listener (outside the stage)
-        assertEquals(1, planItems.getOrDefault(PlanItemDefinitionType.USER_EVENT_LISTENER, Collections.emptyList()).size());
+        assertThat(planItems.getOrDefault(PlanItemDefinitionType.USER_EVENT_LISTENER, Collections.emptyList())).hasSize(1);
         PlanItemInstance listener = planItems.get(PlanItemDefinitionType.USER_EVENT_LISTENER).get(0);
-        assertNull(listener.getStageInstanceId());
+        assertThat(listener.getStageInstanceId()).isNull();
 
         //Complete the Task
         cmmnRuntimeService.triggerPlanItemInstance(task.getId());
@@ -333,7 +343,7 @@ public class UserEventListenerTest extends FlowableCmmnTestCase {
         //Listener should be terminated as it's orphaned
         planItems = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .list().stream().collect(Collectors.groupingBy(PlanItemInstance::getPlanItemDefinitionType));
-        assertEquals(0, planItems.size());
+        assertThat(planItems).isEmpty();
         assertCaseInstanceEnded(caseInstance);
     }
 
@@ -344,26 +354,28 @@ public class UserEventListenerTest extends FlowableCmmnTestCase {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
                 .caseDefinitionKey(name.getMethodName())
                 .start();
-        assertNotNull(caseInstance);
-        assertEquals(1, cmmnRuntimeService.createCaseInstanceQuery().count());
+        assertThat(caseInstance).isNotNull();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(1);
 
         //3 PlanItems reachable
-        assertEquals(3, cmmnRuntimeService.createPlanItemInstanceQuery().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(3);
 
         //1 Stage
         PlanItemInstance stage = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.STAGE).singleResult();
-        assertNotNull(stage);
+        assertThat(stage).isNotNull();
 
         //1 User Event Listener
-        List<PlanItemInstance> listeners = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER).list();
-        assertEquals(1, listeners.size());
-        listeners.forEach(l -> assertEquals(PlanItemInstanceState.AVAILABLE, l.getState()));
+        List<PlanItemInstance> listeners = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER)
+                .list();
+        assertThat(listeners)
+                .extracting(PlanItemInstance::getState)
+                .containsExactly(PlanItemInstanceState.AVAILABLE);
 
         //1 Tasks on Active state
         PlanItemInstance task = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType("task").singleResult();
-        assertNotNull(task);
-        assertEquals(PlanItemInstanceState.ACTIVE, task.getState());
-        assertEquals(stage.getId(), task.getStageInstanceId());
+        assertThat(task).isNotNull();
+        assertThat(task.getState()).isEqualTo(PlanItemInstanceState.ACTIVE);
+        assertThat(task.getStageInstanceId()).isEqualTo(stage.getId());
 
         //Complete the Task
         cmmnRuntimeService.triggerPlanItemInstance(task.getId());
@@ -379,37 +391,39 @@ public class UserEventListenerTest extends FlowableCmmnTestCase {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
                 .caseDefinitionKey(name.getMethodName())
                 .start();
-        assertNotNull(caseInstance);
-        assertEquals(1, cmmnRuntimeService.createCaseInstanceQuery().count());
+        assertThat(caseInstance).isNotNull();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(1);
 
         //All planItemInstances
-        assertEquals(8, cmmnRuntimeService.createPlanItemInstanceQuery().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(8);
 
-        //UserEventListenerIntances
-        assertEquals(6, cmmnRuntimeService.createUserEventListenerInstanceQuery().stateAvailable().count());
+        //UserEventListenerInstances
+        assertThat(cmmnRuntimeService.createUserEventListenerInstanceQuery().stateAvailable().count()).isEqualTo(6);
 
         List<UserEventListenerInstance> events = cmmnRuntimeService.createUserEventListenerInstanceQuery().list();
-        assertEquals(6, events.size());
+        assertThat(events).hasSize(6);
 
-        //All different Intances id's
-        assertEquals(6, events.stream().map(UserEventListenerInstance::getId).distinct().count());
+        //All different Instances id's
+        assertThat(events.stream().map(UserEventListenerInstance::getId).distinct().count()).isEqualTo(6);
 
-        //UserEventListenerIntances inside Stage1
-        String stage1Id = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.STAGE).planItemDefinitionId("stage1").singleResult().getId();
-        assertEquals(2, cmmnRuntimeService.createUserEventListenerInstanceQuery().stageInstanceId(stage1Id).count());
+        //UserEventListenerInstances inside Stage1
+        String stage1Id = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.STAGE).planItemDefinitionId("stage1")
+                .singleResult().getId();
+        assertThat(cmmnRuntimeService.createUserEventListenerInstanceQuery().stageInstanceId(stage1Id).count()).isEqualTo(2);
 
-        //UserEventListenerIntances inside Stage2
-        String stage2Id = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.STAGE).planItemDefinitionId("stage2").singleResult().getId();
-        assertEquals(2, cmmnRuntimeService.createUserEventListenerInstanceQuery().stageInstanceId(stage2Id).count());
+        //UserEventListenerInstances inside Stage2
+        String stage2Id = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.STAGE).planItemDefinitionId("stage2")
+                .singleResult().getId();
+        assertThat(cmmnRuntimeService.createUserEventListenerInstanceQuery().stageInstanceId(stage2Id).count()).isEqualTo(2);
 
-        //UserEventListenerIntances not in a Stage
-        assertEquals(2, events.stream().filter(e -> e.getStageInstanceId() == null).count());
+        //UserEventListenerInstances not in a Stage
+        assertThat(events.stream().filter(e -> e.getStageInstanceId() == null).count()).isEqualTo(2);
 
         //Test query by elementId
-        assertNotNull(cmmnRuntimeService.createUserEventListenerInstanceQuery().elementId("caseUserEventListenerOne").singleResult());
+        assertThat(cmmnRuntimeService.createUserEventListenerInstanceQuery().elementId("caseUserEventListenerOne").singleResult()).isNotNull();
 
         //Test query by planItemDefinitionId
-        assertEquals(2, cmmnRuntimeService.createUserEventListenerInstanceQuery().planItemDefinitionId("caseUEL1").count());
+        assertThat(cmmnRuntimeService.createUserEventListenerInstanceQuery().planItemDefinitionId("caseUEL1").count()).isEqualTo(2);
 
         //Test sort Order - using the names because equals is not implemented in UserEventListenerInstance
         List<String> names = events.stream().map(UserEventListenerInstance::getName).sorted(Comparator.reverseOrder()).collect(Collectors.toList());
@@ -426,18 +440,18 @@ public class UserEventListenerTest extends FlowableCmmnTestCase {
     public void testUserEventInstanceDeletedWhenNotReferencedByExitSentry() {
 
         cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testUserEvent").start();
-        assertNotNull(cmmnRuntimeService.createUserEventListenerInstanceQuery().singleResult());
+        assertThat(cmmnRuntimeService.createUserEventListenerInstanceQuery().singleResult()).isNotNull();
 
         // Completing task A and B completes Stage A.
         // This should also remove the user event listener, as nothing is referencing it anymore
 
         List<Task> tasks = cmmnTaskService.createTaskQuery().list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
         tasks.forEach(t -> cmmnTaskService.complete(t.getId()));
 
-        assertNull(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceName("Stage A").singleResult());
-        assertNotNull(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceName("Stage A").includeEnded().singleResult());
-        assertNull(cmmnRuntimeService.createUserEventListenerInstanceQuery().singleResult());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceName("Stage A").singleResult()).isNull();
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceName("Stage A").includeEnded().singleResult()).isNotNull();
+        assertThat(cmmnRuntimeService.createUserEventListenerInstanceQuery().singleResult()).isNull();
     }
 
     @Test
@@ -448,28 +462,30 @@ public class UserEventListenerTest extends FlowableCmmnTestCase {
 
         // Verify the model setup
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testOrphanEventListenerMultipleSentries").start();
-        assertNotNull(cmmnRuntimeService.createUserEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult());
+        assertThat(cmmnRuntimeService.createUserEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult()).isNotNull();
         List<Task> tasks = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).orderByTaskName().asc().list();
-        assertEquals(2, tasks.size());
-        assertEquals("A", tasks.get(0).getName());
-        assertEquals("C", tasks.get(1).getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("A", "C");
 
         // Completing one tasks should not have impact on the user event listener
         cmmnTaskService.complete(tasks.get(0).getId());
-        assertNotNull(cmmnRuntimeService.createUserEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult());
+        assertThat(cmmnRuntimeService.createUserEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult()).isNotNull();
         tasks = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).orderByTaskName().asc().list();
-        assertEquals(1, tasks.size());
-        assertEquals("C", tasks.get(0).getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("C");
 
         // Completing the other task with the exit sentry should still keep the user event, as it's reference by the entry of B
         cmmnTaskService.complete(tasks.get(0).getId());
-        assertNotNull(cmmnRuntimeService.createUserEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult());
-        assertEquals(0, cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count());
+        assertThat(cmmnRuntimeService.createUserEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult()).isNotNull();
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
 
         // Firing the user event listener should start B
-        cmmnRuntimeService.completeUserEventListenerInstance(cmmnRuntimeService.createUserEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult().getId());
-        assertNull(cmmnRuntimeService.createUserEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult());
-        assertEquals(1, cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count());
+        cmmnRuntimeService.completeUserEventListenerInstance(
+                cmmnRuntimeService.createUserEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult().getId());
+        assertThat(cmmnRuntimeService.createUserEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult()).isNull();
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
     }
 
     @Test
@@ -478,10 +494,11 @@ public class UserEventListenerTest extends FlowableCmmnTestCase {
 
         // Firing the event listener should exit A and C, and activate B
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testOrphanEventListenerMultipleSentries").start();
-        cmmnRuntimeService.completeUserEventListenerInstance(cmmnRuntimeService.createUserEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult().getId());
+        cmmnRuntimeService.completeUserEventListenerInstance(
+                cmmnRuntimeService.createUserEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult().getId());
 
         Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
-        assertEquals("B", task.getName());
+        assertThat(task.getName()).isEqualTo("B");
 
         cmmnTaskService.complete(task.getId());
         assertCaseInstanceEnded(caseInstance);
@@ -491,39 +508,45 @@ public class UserEventListenerTest extends FlowableCmmnTestCase {
     @CmmnDeployment
     public void testMultipleEventListenersAsEntry() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testMultipleEventListenersAsEntry").start();
-        assertEquals(0, cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count());
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
 
         List<UserEventListenerInstance> userEventListenerInstances = cmmnRuntimeService.createUserEventListenerInstanceQuery()
-            .caseInstanceId(caseInstance.getId()).orderByName().asc().list();
-        assertThat(userEventListenerInstances).extracting(UserEventListenerInstance::getName).containsExactly("A", "B", "C");
+                .caseInstanceId(caseInstance.getId()).orderByName().asc().list();
+        assertThat(userEventListenerInstances)
+                .extracting(UserEventListenerInstance::getName)
+                .containsExactly("A", "B", "C");
 
         // Completing A should change nothing
         cmmnRuntimeService.completeUserEventListenerInstance(userEventListenerInstances.get(0).getId());
-        assertEquals(0, cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count());
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
         userEventListenerInstances = cmmnRuntimeService.createUserEventListenerInstanceQuery()
-            .caseInstanceId(caseInstance.getId()).orderByName().asc().list();
-        assertThat(userEventListenerInstances).extracting(UserEventListenerInstance::getName).containsExactly("B", "C");
+                .caseInstanceId(caseInstance.getId()).orderByName().asc().list();
+        assertThat(userEventListenerInstances)
+                .extracting(UserEventListenerInstance::getName)
+                .containsExactly("B", "C");
 
         // Completing B should activate the stage and remove the orphan event listener C
         cmmnRuntimeService.completeUserEventListenerInstance(userEventListenerInstances.get(0).getId());
-        assertEquals(1, cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count());
-        assertEquals(0, cmmnRuntimeService.createUserEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).count());
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
+        assertThat(cmmnRuntimeService.createUserEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
     }
 
     @Test
     @CmmnDeployment
     public void testMultipleEventListenersAsExit() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testMultipleEventListenersAsExit").start();
-        assertEquals(2, cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count());
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(2);
 
         List<UserEventListenerInstance> userEventListenerInstances = cmmnRuntimeService.createUserEventListenerInstanceQuery()
-            .caseInstanceId(caseInstance.getId()).orderByName().asc().list();
-        assertThat(userEventListenerInstances).extracting(UserEventListenerInstance::getName).containsExactly("A", "B", "C");
+                .caseInstanceId(caseInstance.getId()).orderByName().asc().list();
+        assertThat(userEventListenerInstances)
+                .extracting(UserEventListenerInstance::getName)
+                .containsExactly("A", "B", "C");
 
         // Completing C should also remove A and B
         cmmnRuntimeService.completeUserEventListenerInstance(userEventListenerInstances.get(2).getId());
-        assertEquals(0, cmmnRuntimeService.createUserEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).count());
-        assertEquals("Outside stage", cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult().getName());
+        assertThat(cmmnRuntimeService.createUserEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult().getName()).isEqualTo("Outside stage");
 
     }
 
@@ -532,37 +555,44 @@ public class UserEventListenerTest extends FlowableCmmnTestCase {
     public void testMultipleEventListenersMixed() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testMultipleEventListenersMixed").start();
         List<UserEventListenerInstance> userEventListenerInstances = cmmnRuntimeService.createUserEventListenerInstanceQuery()
-            .caseInstanceId(caseInstance.getId()).orderByName().asc().list();
-        assertThat(userEventListenerInstances).extracting(UserEventListenerInstance::getName).containsExactly("A", "B", "C");
-        assertNull(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).taskName("The task").singleResult());
+                .caseInstanceId(caseInstance.getId()).orderByName().asc().list();
+        assertThat(userEventListenerInstances)
+                .extracting(UserEventListenerInstance::getName)
+                .containsExactly("A", "B", "C");
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).taskName("The task").singleResult()).isNull();
 
         // Completing C should make The task active
         cmmnRuntimeService.completeUserEventListenerInstance(userEventListenerInstances.get(2).getId());
-        assertNotNull(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).taskName("The task").singleResult());
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).taskName("The task").singleResult()).isNotNull();
 
         userEventListenerInstances = cmmnRuntimeService.createUserEventListenerInstanceQuery()
-            .caseInstanceId(caseInstance.getId()).orderByName().asc().list();
-        assertThat(userEventListenerInstances).extracting(UserEventListenerInstance::getName).containsExactly("A", "B");
+                .caseInstanceId(caseInstance.getId()).orderByName().asc().list();
+        assertThat(userEventListenerInstances)
+                .extracting(UserEventListenerInstance::getName)
+                .containsExactly("A", "B");
     }
 
     @Test
     @CmmnDeployment
     public void testTimerAndUserEventListenerForEntry() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testTimerAndUserEventListenerForEntry").start();
-        assertEquals(4, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count());
-        assertNotNull(cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.TIMER_EVENT_LISTENER).singleResult());
-        assertNull(cmmnTaskService.createTaskQuery().taskName("A").singleResult());
-        assertNotNull(cmmnManagementService.createTimerJobQuery().caseInstanceId(caseInstance.getId()).singleResult());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(4);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.TIMER_EVENT_LISTENER).singleResult())
+                .isNotNull();
+        assertThat(cmmnTaskService.createTaskQuery().taskName("A").singleResult()).isNull();
+        assertThat(cmmnManagementService.createTimerJobQuery().caseInstanceId(caseInstance.getId()).singleResult()).isNotNull();
 
         // Completing the user event listener should terminate the timer event listener
-        UserEventListenerInstance userEventListenerInstance = cmmnRuntimeService.createUserEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult();
+        UserEventListenerInstance userEventListenerInstance = cmmnRuntimeService.createUserEventListenerInstanceQuery().caseInstanceId(caseInstance.getId())
+                .singleResult();
         cmmnRuntimeService.completeUserEventListenerInstance(userEventListenerInstance.getId());
-        assertEquals(2, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count());
-        assertNotNull(cmmnTaskService.createTaskQuery().taskName("A").singleResult());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(2);
+        assertThat(cmmnTaskService.createTaskQuery().taskName("A").singleResult()).isNotNull();
 
-        assertNull(cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER).singleResult());
-        assertNull(cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.TIMER_EVENT_LISTENER).singleResult());
-        assertNull(cmmnManagementService.createTimerJobQuery().caseInstanceId(caseInstance.getId()).singleResult());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER).singleResult()).isNull();
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.TIMER_EVENT_LISTENER).singleResult())
+                .isNull();
+        assertThat(cmmnManagementService.createTimerJobQuery().caseInstanceId(caseInstance.getId()).singleResult()).isNull();
     }
 
     @Test
@@ -576,7 +606,9 @@ public class UserEventListenerTest extends FlowableCmmnTestCase {
         assertThat(cmmnRuntimeService.createUserEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
 
         List<Task> tasks = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).orderByTaskName().asc().list();
-        assertThat(tasks).extracting(Task::getName).containsExactly("A", "B");
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("A", "B");
         tasks.forEach(task -> cmmnTaskService.complete(task.getId()));
 
         Task taskC = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
@@ -597,7 +629,9 @@ public class UserEventListenerTest extends FlowableCmmnTestCase {
         assertThat(cmmnRuntimeService.createUserEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
 
         List<Task> tasks = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).orderByTaskName().asc().list();
-        assertThat(tasks).extracting(Task::getName).containsExactly("D");
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("D");
 
         // Complete the task on the same level should not trigger the deletion of the user event listener
         cmmnTaskService.complete(tasks.get(0).getId());
@@ -606,7 +640,9 @@ public class UserEventListenerTest extends FlowableCmmnTestCase {
         // Setting the variable that guards the stage will make the nested task active
         cmmnRuntimeService.setVariable(caseInstance.getId(), "activateStage", true);
         tasks = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).orderByTaskName().asc().list();
-        assertThat(tasks).extracting(Task::getName).containsExactly("A", "B", "C");
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("A", "B", "C");
 
         // Completing task C should remove the user event listener
         cmmnTaskService.complete(tasks.get(2).getId());
@@ -618,8 +654,10 @@ public class UserEventListenerTest extends FlowableCmmnTestCase {
     public void testUserEventListenerForEntryAndExit() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testUserEventListenerForEntryAndExit").start();
         List<UserEventListenerInstance> userEventListenerInstances = cmmnRuntimeService.createUserEventListenerInstanceQuery()
-            .caseInstanceId(caseInstance.getId()).orderByName().asc().list();
-        assertThat(userEventListenerInstances).extracting(UserEventListenerInstance::getName).containsExactly("EventListenerA", "EventListenerB");
+                .caseInstanceId(caseInstance.getId()).orderByName().asc().list();
+        assertThat(userEventListenerInstances)
+                .extracting(UserEventListenerInstance::getName)
+                .containsExactly("EventListenerA", "EventListenerB");
 
         List<Task> tasks = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).orderByTaskName().asc().list();
         assertThat(tasks).isEmpty();
@@ -627,7 +665,9 @@ public class UserEventListenerTest extends FlowableCmmnTestCase {
         // Completing event listener A will activate task A and task B. User event listener B becomes obsolete is gets removed.
         cmmnRuntimeService.completeUserEventListenerInstance(userEventListenerInstances.get(0).getId());
         tasks = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).orderByTaskName().asc().list();
-        assertThat(tasks).extracting(Task::getName).containsExactly("Task A", "Task B");
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("Task A", "Task B");
         assertThat(cmmnRuntimeService.createUserEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).list()).isEmpty();
     }
 
@@ -636,7 +676,8 @@ public class UserEventListenerTest extends FlowableCmmnTestCase {
     public void testUserEventListenerInNonAutoCompletableStage() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("tesUserEventListenerInNonAutoCompletableStage").start();
 
-        UserEventListenerInstance userEventListenerInstance = cmmnRuntimeService.createUserEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult();
+        UserEventListenerInstance userEventListenerInstance = cmmnRuntimeService.createUserEventListenerInstanceQuery().caseInstanceId(caseInstance.getId())
+                .singleResult();
         cmmnRuntimeService.completeUserEventListenerInstance(userEventListenerInstance.getId());
 
         List<Task> tasks = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).list();
@@ -660,8 +701,10 @@ public class UserEventListenerTest extends FlowableCmmnTestCase {
     @Test
     @CmmnDeployment
     public void testRequiredUserEventListenerInAutoCompletableStage() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testRequiredUserEventListenerInAutoCompletableStage").start();
-        UserEventListenerInstance userEventListenerInstance = cmmnRuntimeService.createUserEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testRequiredUserEventListenerInAutoCompletableStage")
+                .start();
+        UserEventListenerInstance userEventListenerInstance = cmmnRuntimeService.createUserEventListenerInstanceQuery().caseInstanceId(caseInstance.getId())
+                .singleResult();
         cmmnRuntimeService.completeUserEventListenerInstance(userEventListenerInstance.getId());
         assertCaseInstanceEnded(caseInstance);
     }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/VariablesTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/VariablesTest.java
@@ -13,12 +13,7 @@
 package org.flowable.cmmn.test.runtime;
 
 import static java.util.stream.Collectors.toMap;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.Serializable;
 import java.util.Collections;
@@ -30,7 +25,6 @@ import java.util.stream.Stream;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
-import org.assertj.core.api.Assertions;
 import org.flowable.cmmn.api.delegate.DelegatePlanItemInstance;
 import org.flowable.cmmn.api.delegate.PlanItemJavaDelegate;
 import org.flowable.cmmn.api.history.HistoricMilestoneInstance;
@@ -57,7 +51,7 @@ import org.junit.rules.ExpectedException;
  * @author Joram Barrez
  */
 public class VariablesTest extends FlowableCmmnTestCase {
-    
+
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
@@ -70,35 +64,35 @@ public class VariablesTest extends FlowableCmmnTestCase {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("myCase").variables(variables).start();
 
         Map<String, Object> variablesFromGet = cmmnRuntimeService.getVariables(caseInstance.getId());
-        assertTrue(variablesFromGet.containsKey("stringVar"));
-        assertEquals("Hello World", variablesFromGet.get("stringVar"));
-        assertTrue(variablesFromGet.containsKey("intVar"));
-        assertEquals(42, ((Integer) variablesFromGet.get("intVar")).intValue());
-        
-        Map<String, VariableInstance> variableInstancesFromGet = cmmnRuntimeService.getVariableInstances(caseInstance.getId());
-        assertTrue(variableInstancesFromGet.containsKey("stringVar"));
-        VariableInstance variableInstance = variableInstancesFromGet.get("stringVar");
-        assertEquals("Hello World", variableInstance.getValue());
-        assertEquals("string", variableInstance.getTypeName());
-        assertTrue(variableInstancesFromGet.containsKey("intVar"));
-        variableInstance = variableInstancesFromGet.get("intVar");
-        assertEquals(42, ((Integer) variableInstance.getValue()).intValue());
-        assertEquals("integer", variableInstance.getTypeName());
+        assertThat(variablesFromGet.containsKey("stringVar")).isTrue();
+        assertThat(variablesFromGet.get("stringVar")).isEqualTo("Hello World");
+        assertThat(variablesFromGet.containsKey("intVar")).isTrue();
+        assertThat(((Integer) variablesFromGet.get("intVar")).intValue()).isEqualTo(42);
 
-        assertEquals("Hello World", (String) cmmnRuntimeService.getVariable(caseInstance.getId(), "stringVar"));
-        assertEquals(42, ((Integer) cmmnRuntimeService.getVariable(caseInstance.getId(), "intVar")).intValue());
-        assertNull(cmmnRuntimeService.getVariable(caseInstance.getId(), "doesNotExist"));
-        
+        Map<String, VariableInstance> variableInstancesFromGet = cmmnRuntimeService.getVariableInstances(caseInstance.getId());
+        assertThat(variableInstancesFromGet.containsKey("stringVar")).isTrue();
+        VariableInstance variableInstance = variableInstancesFromGet.get("stringVar");
+        assertThat(variableInstance.getValue()).isEqualTo("Hello World");
+        assertThat(variableInstance.getTypeName()).isEqualTo("string");
+        assertThat(variableInstancesFromGet.containsKey("intVar")).isTrue();
+        variableInstance = variableInstancesFromGet.get("intVar");
+        assertThat(((Integer) variableInstance.getValue()).intValue()).isEqualTo(42);
+        assertThat(variableInstance.getTypeName()).isEqualTo("integer");
+
+        assertThat((String) cmmnRuntimeService.getVariable(caseInstance.getId(), "stringVar")).isEqualTo("Hello World");
+        assertThat(((Integer) cmmnRuntimeService.getVariable(caseInstance.getId(), "intVar")).intValue()).isEqualTo(42);
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "doesNotExist")).isNull();
+
         variableInstance = cmmnRuntimeService.getVariableInstance(caseInstance.getId(), "stringVar");
-        assertEquals("Hello World", variableInstance.getValue());
-        assertEquals("string", variableInstance.getTypeName());
+        assertThat(variableInstance.getValue()).isEqualTo("Hello World");
+        assertThat(variableInstance.getTypeName()).isEqualTo("string");
         variableInstance = cmmnRuntimeService.getVariableInstance(caseInstance.getId(), "intVar");
-        assertEquals(42, ((Integer) variableInstance.getValue()).intValue());
-        assertEquals("integer", variableInstance.getTypeName());
+        assertThat(((Integer) variableInstance.getValue()).intValue()).isEqualTo(42);
+        assertThat(variableInstance.getTypeName()).isEqualTo("integer");
         variableInstance = cmmnRuntimeService.getVariableInstance(caseInstance.getId(), "doesNotExist");
-        assertNull(variableInstance);
+        assertThat(variableInstance).isNull();
     }
-    
+
     @Test
     @CmmnDeployment
     public void testGetLocalVariables() {
@@ -106,42 +100,43 @@ public class VariablesTest extends FlowableCmmnTestCase {
         variables.put("stringVar", "Hello World");
         variables.put("intVar", 42);
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("myCase").variables(variables).start();
-        
-        PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("nestedTask").caseInstanceId(caseInstance.getId()).singleResult();
+
+        PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionId("nestedTask")
+                .caseInstanceId(caseInstance.getId()).singleResult();
         cmmnRuntimeService.setLocalVariable(planItemInstance.getId(), "stringVar", "Changed value");
         cmmnRuntimeService.setLocalVariable(planItemInstance.getId(), "intVar", 21);
-        
+
         Map<String, Object> variablesFromGet = cmmnRuntimeService.getVariables(caseInstance.getId());
-        assertTrue(variablesFromGet.containsKey("stringVar"));
-        assertEquals("Hello World", variablesFromGet.get("stringVar"));
-        assertTrue(variablesFromGet.containsKey("intVar"));
-        assertEquals(42, ((Integer) variablesFromGet.get("intVar")).intValue());
-        
+        assertThat(variablesFromGet.containsKey("stringVar")).isTrue();
+        assertThat(variablesFromGet.get("stringVar")).isEqualTo("Hello World");
+        assertThat(variablesFromGet.containsKey("intVar")).isTrue();
+        assertThat(((Integer) variablesFromGet.get("intVar")).intValue()).isEqualTo(42);
+
         Map<String, VariableInstance> variableInstancesFromGet = cmmnRuntimeService.getVariableInstances(caseInstance.getId());
-        assertTrue(variableInstancesFromGet.containsKey("stringVar"));
+        assertThat(variableInstancesFromGet.containsKey("stringVar")).isTrue();
         VariableInstance variableInstance = variableInstancesFromGet.get("stringVar");
-        assertEquals("Hello World", variableInstance.getValue());
-        assertEquals("string", variableInstance.getTypeName());
-        assertTrue(variableInstancesFromGet.containsKey("intVar"));
+        assertThat(variableInstance.getValue()).isEqualTo("Hello World");
+        assertThat(variableInstance.getTypeName()).isEqualTo("string");
+        assertThat(variableInstancesFromGet.containsKey("intVar")).isTrue();
         variableInstance = variableInstancesFromGet.get("intVar");
-        assertEquals(42, ((Integer) variableInstance.getValue()).intValue());
-        assertEquals("integer", variableInstance.getTypeName());
+        assertThat(((Integer) variableInstance.getValue()).intValue()).isEqualTo(42);
+        assertThat(variableInstance.getTypeName()).isEqualTo("integer");
 
         Map<String, Object> localVariablesFromGet = cmmnRuntimeService.getLocalVariables(planItemInstance.getId());
-        assertTrue(localVariablesFromGet.containsKey("stringVar"));
-        assertEquals("Changed value", localVariablesFromGet.get("stringVar"));
-        assertTrue(localVariablesFromGet.containsKey("intVar"));
-        assertEquals(21, ((Integer) localVariablesFromGet.get("intVar")).intValue());
-        
+        assertThat(localVariablesFromGet.containsKey("stringVar")).isTrue();
+        assertThat(localVariablesFromGet.get("stringVar")).isEqualTo("Changed value");
+        assertThat(localVariablesFromGet.containsKey("intVar")).isTrue();
+        assertThat(((Integer) localVariablesFromGet.get("intVar")).intValue()).isEqualTo(21);
+
         Map<String, VariableInstance> localVariableInstancesFromGet = cmmnRuntimeService.getLocalVariableInstances(planItemInstance.getId());
-        assertTrue(localVariableInstancesFromGet.containsKey("stringVar"));
+        assertThat(localVariableInstancesFromGet.containsKey("stringVar")).isTrue();
         variableInstance = localVariableInstancesFromGet.get("stringVar");
-        assertEquals("Changed value", variableInstance.getValue());
-        assertEquals("string", variableInstance.getTypeName());
-        assertTrue(variableInstancesFromGet.containsKey("intVar"));
+        assertThat(variableInstance.getValue()).isEqualTo("Changed value");
+        assertThat(variableInstance.getTypeName()).isEqualTo("string");
+        assertThat(variableInstancesFromGet.containsKey("intVar")).isTrue();
         variableInstance = localVariableInstancesFromGet.get("intVar");
-        assertEquals(21, ((Integer) variableInstance.getValue()).intValue());
-        assertEquals("integer", variableInstance.getTypeName());
+        assertThat(((Integer) variableInstance.getValue()).intValue()).isEqualTo(21);
+        assertThat(variableInstance.getTypeName()).isEqualTo("integer");
     }
 
     @Test
@@ -153,9 +148,9 @@ public class VariablesTest extends FlowableCmmnTestCase {
         variables.put("intVar", 42);
         cmmnRuntimeService.setVariables(caseInstance.getId(), variables);
 
-        assertEquals("Hello World", (String) cmmnRuntimeService.getVariable(caseInstance.getId(), "stringVar"));
-        assertEquals(42, ((Integer) cmmnRuntimeService.getVariable(caseInstance.getId(), "intVar")).intValue());
-        assertNull(cmmnRuntimeService.getVariable(caseInstance.getId(), "doesNotExist"));
+        assertThat((String) cmmnRuntimeService.getVariable(caseInstance.getId(), "stringVar")).isEqualTo("Hello World");
+        assertThat(((Integer) cmmnRuntimeService.getVariable(caseInstance.getId(), "intVar")).intValue()).isEqualTo(42);
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "doesNotExist")).isNull();
     }
 
     @Test
@@ -165,37 +160,37 @@ public class VariablesTest extends FlowableCmmnTestCase {
         variables.put("stringVar", "Hello World");
         variables.put("intVar", 42);
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("myCase").variables(variables).start();
-        assertEquals(2, cmmnRuntimeService.getVariables(caseInstance.getId()).size());
+        assertThat(cmmnRuntimeService.getVariables(caseInstance.getId())).hasSize(2);
 
         cmmnRuntimeService.removeVariable(caseInstance.getId(), "stringVar");
-        assertEquals(1, cmmnRuntimeService.getVariables(caseInstance.getId()).size());
-        assertNull(cmmnRuntimeService.getVariable(caseInstance.getId(), "StringVar"));
-        assertNotNull(cmmnRuntimeService.getVariable(caseInstance.getId(), "intVar"));
+        assertThat(cmmnRuntimeService.getVariables(caseInstance.getId())).hasSize(1);
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "StringVar")).isNull();
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "intVar")).isNotNull();
     }
-    
+
     @Test
     @CmmnDeployment
     public void testSerializableVariable() {
         Map<String, Object> variables = new HashMap<>();
         variables.put("myVariable", new MyVariable("Hello World"));
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("myCase").variables(variables).start();
-        
+
         MyVariable myVariable = (MyVariable) cmmnRuntimeService.getVariable(caseInstance.getId(), "myVariable");
-        assertEquals("Hello World", myVariable.value);
-        
+        assertThat(myVariable.value).isEqualTo("Hello World");
+
         cmmnEngineConfiguration.getCommandExecutor().execute(new Command<Void>() {
 
             @Override
             public Void execute(CommandContext commandContext) {
                 VariableInstance variableInstance = cmmnRuntimeService.getVariableInstance(caseInstance.getId(), "myVariable");
                 MyVariable myVariable = (MyVariable) variableInstance.getValue();
-                assertEquals("Hello World", myVariable.value);
-                
+                assertThat(myVariable.value).isEqualTo("Hello World");
+
                 return null;
             }
         });
     }
-    
+
     @Test
     @CmmnDeployment
     public void testResolveMilestoneNameAsExpression() {
@@ -207,9 +202,9 @@ public class VariablesTest extends FlowableCmmnTestCase {
 
         HistoricMilestoneInstance historicMilestoneInstance = cmmnHistoryService.createHistoricMilestoneInstanceQuery()
                 .milestoneInstanceCaseInstanceId(caseInstance.getId()).singleResult();
-        assertEquals("Milestone Hello from test and delegate", historicMilestoneInstance.getName());
+        assertThat(historicMilestoneInstance.getName()).isEqualTo("Milestone Hello from test and delegate");
     }
-    
+
     @Test
     @CmmnDeployment
     public void testHistoricVariables() {
@@ -218,46 +213,47 @@ public class VariablesTest extends FlowableCmmnTestCase {
         variables.put("intVar", 123);
         variables.put("doubleVar", 123.123);
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("myCase").variables(variables).start();
-        
+
         // verify variables
-        assertEquals("test", cmmnRuntimeService.getVariable(caseInstance.getId(), "stringVar"));
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "stringVar")).isEqualTo("test");
         HistoricVariableInstance historicVariableInstance = cmmnHistoryService.createHistoricVariableInstanceQuery().variableName("stringVar").singleResult();
-        assertEquals(caseInstance.getId(), historicVariableInstance.getScopeId());
-        assertEquals(ScopeTypes.CMMN, historicVariableInstance.getScopeType());
-        assertEquals("test", historicVariableInstance.getValue());
-        assertNull(historicVariableInstance.getSubScopeId());
-        
-        assertEquals(123, cmmnRuntimeService.getVariable(caseInstance.getId(), "intVar"));
+        assertThat(historicVariableInstance.getScopeId()).isEqualTo(caseInstance.getId());
+        assertThat(historicVariableInstance.getScopeType()).isEqualTo(ScopeTypes.CMMN);
+        assertThat(historicVariableInstance.getValue()).isEqualTo("test");
+        assertThat(historicVariableInstance.getSubScopeId()).isNull();
+
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "intVar")).isEqualTo(123);
         historicVariableInstance = cmmnHistoryService.createHistoricVariableInstanceQuery().variableName("intVar").singleResult();
-        assertEquals(caseInstance.getId(), historicVariableInstance.getScopeId());
-        assertEquals(ScopeTypes.CMMN, historicVariableInstance.getScopeType());
-        assertEquals(123, historicVariableInstance.getValue());
-        assertNull(historicVariableInstance.getSubScopeId());
-        
-        assertEquals(123.123, cmmnRuntimeService.getVariable(caseInstance.getId(), "doubleVar"));
+        assertThat(historicVariableInstance.getScopeId()).isEqualTo(caseInstance.getId());
+        assertThat(historicVariableInstance.getScopeType()).isEqualTo(ScopeTypes.CMMN);
+        assertThat(historicVariableInstance.getValue()).isEqualTo(123);
+        assertThat(historicVariableInstance.getSubScopeId()).isNull();
+
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "doubleVar")).isEqualTo(123.123);
         historicVariableInstance = cmmnHistoryService.createHistoricVariableInstanceQuery().variableName("doubleVar").singleResult();
-        assertEquals(caseInstance.getId(), historicVariableInstance.getScopeId());
-        assertEquals(ScopeTypes.CMMN, historicVariableInstance.getScopeType());
-        assertEquals(123.123, historicVariableInstance.getValue());
-        assertNull(historicVariableInstance.getSubScopeId());
-        
+        assertThat(historicVariableInstance.getScopeId()).isEqualTo(caseInstance.getId());
+        assertThat(historicVariableInstance.getScopeType()).isEqualTo(ScopeTypes.CMMN);
+        assertThat(historicVariableInstance.getValue()).isEqualTo(123.123);
+        assertThat(historicVariableInstance.getSubScopeId()).isNull();
+
         // Update variables
         Map<String, Object> newVariables = new HashMap<>();
         newVariables.put("stringVar", "newValue");
-        newVariables.put("otherStringVar", "test number 2");        
+        newVariables.put("otherStringVar", "test number 2");
         cmmnRuntimeService.setVariables(caseInstance.getId(), newVariables);
-        
-        assertEquals("newValue", cmmnRuntimeService.getVariable(caseInstance.getId(), "stringVar"));
-        assertEquals("newValue", cmmnHistoryService.createHistoricVariableInstanceQuery().variableName("stringVar").singleResult().getValue());
-        assertEquals("test number 2", cmmnHistoryService.createHistoricVariableInstanceQuery().variableName("otherStringVar").singleResult().getValue());
-        
+
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "stringVar")).isEqualTo("newValue");
+        assertThat(cmmnHistoryService.createHistoricVariableInstanceQuery().variableName("stringVar").singleResult().getValue()).isEqualTo("newValue");
+        assertThat(cmmnHistoryService.createHistoricVariableInstanceQuery().variableName("otherStringVar").singleResult().getValue())
+                .isEqualTo("test number 2");
+
         // Delete variables
         cmmnRuntimeService.removeVariable(caseInstance.getId(), "stringVar");
-        assertNull(cmmnRuntimeService.getVariable(caseInstance.getId(), "stringVar"));
-        assertNull(cmmnHistoryService.createHistoricVariableInstanceQuery().variableName("stringVar").singleResult());
-        assertNotNull(cmmnHistoryService.createHistoricVariableInstanceQuery().variableName("otherStringVar").singleResult());
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "stringVar")).isNull();
+        assertThat(cmmnHistoryService.createHistoricVariableInstanceQuery().variableName("stringVar").singleResult()).isNull();
+        assertThat(cmmnHistoryService.createHistoricVariableInstanceQuery().variableName("otherStringVar").singleResult()).isNotNull();
     }
-    
+
     @Test
     @CmmnDeployment
     public void testTransientVariables() {
@@ -265,16 +261,16 @@ public class VariablesTest extends FlowableCmmnTestCase {
         variables.put("transientStartVar", "Hello from test");
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
                 .caseDefinitionKey("myCase").transientVariables(variables).start();
-        
+
         HistoricMilestoneInstance historicMilestoneInstance = cmmnHistoryService.createHistoricMilestoneInstanceQuery()
                 .milestoneInstanceCaseInstanceId(caseInstance.getId()).singleResult();
-        assertEquals("Milestone Hello from test and delegate", historicMilestoneInstance.getName());
-        
+        assertThat(historicMilestoneInstance.getName()).isEqualTo("Milestone Hello from test and delegate");
+
         // Variables should not be persisted
-        assertEquals(0, cmmnRuntimeService.getVariables(caseInstance.getId()).size());
-        assertEquals(0, cmmnHistoryService.createHistoricVariableInstanceQuery().caseInstanceId(caseInstance.getId()).count());
+        assertThat(cmmnRuntimeService.getVariables(caseInstance.getId())).isEmpty();
+        assertThat(cmmnHistoryService.createHistoricVariableInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
     }
-    
+
     @Test
     @CmmnDeployment
     public void testBlockingExpressionBasedOnVariable() {
@@ -284,31 +280,32 @@ public class VariablesTest extends FlowableCmmnTestCase {
                 .variable("nameVar", "First Task")
                 .variable("blockB", true)
                 .start();
-        
+
         List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
                 .planItemInstanceStateActive()
                 .orderByName().asc()
                 .list();
-        assertEquals(2, planItemInstances.size());
-        assertEquals("B", planItemInstances.get(0).getName());
-        assertEquals("First Task", planItemInstances.get(1).getName());
-        
+        assertThat(planItemInstances).hasSize(2);
+        assertThat(planItemInstances.get(0).getName()).isEqualTo("B");
+        assertThat(planItemInstances.get(1).getName()).isEqualTo("First Task");
+
         // Non-blocking
         caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
                 .caseDefinitionKey("testBlockingExpression")
                 .variable("nameVar", "Second Task")
                 .variable("blockB", false)
                 .start();
-        
+
         planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
                 .planItemInstanceStateActive()
                 .list();
-        assertEquals(1, planItemInstances.size());
-        assertEquals("Second Task", planItemInstances.get(0).getName());
+        assertThat(planItemInstances)
+                .extracting(PlanItemInstance::getName)
+                .containsExactly("Second Task");
     }
-    
+
     @Test
     @CmmnDeployment(resources = "org/flowable/cmmn/test/task/CmmnTaskServiceTest.testOneHumanTaskCase.cmmn")
     public void testSetVariableOnRootCase() {
@@ -323,7 +320,7 @@ public class VariablesTest extends FlowableCmmnTestCase {
                 caseInstanceId(caseInstance.getId()).
                 includeCaseVariables().
                 singleResult();
-        assertThat(updatedCaseInstance.getCaseVariables().get("varToUpdate"), is("newValue"));
+        assertThat(updatedCaseInstance.getCaseVariables().get("varToUpdate")).isEqualTo("newValue");
     }
 
     @Test
@@ -358,8 +355,8 @@ public class VariablesTest extends FlowableCmmnTestCase {
                 caseInstanceId(caseInstance.getId()).
                 includeCaseVariables().
                 singleResult();
-        assertThat("resolving variable name expressions does not make sense when it is set locally",
-                updatedCaseInstance.getCaseVariables().get("varToUpdate"), is("newValue"));
+        assertThat(updatedCaseInstance.getCaseVariables().get("varToUpdate"))
+                .as("resolving variable name expressions does not make sense when it is set locally").isEqualTo("newValue");
     }
 
     @Test
@@ -379,7 +376,7 @@ public class VariablesTest extends FlowableCmmnTestCase {
                 caseInstanceId(subCaseInstance.getId()).
                 includeCaseVariables().
                 singleResult();
-        assertThat(updatedCaseInstance.getCaseVariables().get("varToUpdate"), is("newValue"));
+        assertThat(updatedCaseInstance.getCaseVariables().get("varToUpdate")).isEqualTo("newValue");
     }
 
     @Test
@@ -389,7 +386,7 @@ public class VariablesTest extends FlowableCmmnTestCase {
                 .variable("varToUpdate", "initialValue")
                 .caseDefinitionKey("oneHumanTaskCase")
                 .start();
-        Map<String, Object> variables = Stream.of( new ImmutablePair<String, Object>("varToUpdate", "newValue")).collect(
+        Map<String, Object> variables = Stream.of(new ImmutablePair<String, Object>("varToUpdate", "newValue")).collect(
                 toMap(Pair::getKey, Pair::getValue)
         );
         cmmnRuntimeService.setVariables(caseInstance.getId(), variables);
@@ -398,7 +395,7 @@ public class VariablesTest extends FlowableCmmnTestCase {
                 caseInstanceId(caseInstance.getId()).
                 includeCaseVariables().
                 singleResult();
-        assertThat(updatedCaseInstance.getCaseVariables(), is(variables));
+        assertThat(updatedCaseInstance.getCaseVariables()).isEqualTo(variables);
     }
 
     @Test
@@ -445,25 +442,25 @@ public class VariablesTest extends FlowableCmmnTestCase {
                 caseInstanceId(subCaseInstance.getId()).
                 includeCaseVariables().
                 singleResult();
-        assertThat(updatedCaseInstance.getCaseVariables(), is(variables));
+        assertThat(updatedCaseInstance.getCaseVariables()).isEqualTo(variables);
     }
 
     @Test
     @CmmnDeployment(resources = "org/flowable/cmmn/test/task/CmmnTaskServiceTest.testOneHumanTaskCase.cmmn")
     public void testIncludeVariablesWithSerializableVariable() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("oneHumanTaskCase")
-            .variable("myVar", new CustomTestVariable("test", 123))
-            .start();
+                .caseDefinitionKey("oneHumanTaskCase")
+                .variable("myVar", new CustomTestVariable("test", 123))
+                .start();
 
         CaseInstance caseInstanceWithVariables = cmmnRuntimeService.createCaseInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .includeCaseVariables()
-            .singleResult();
+                .caseInstanceId(caseInstance.getId())
+                .includeCaseVariables()
+                .singleResult();
 
         CustomTestVariable customTestVariable = (CustomTestVariable) caseInstanceWithVariables.getCaseVariables().get("myVar");
-        assertEquals("test", customTestVariable.someValue);
-        assertEquals(123, customTestVariable.someInt);
+        assertThat(customTestVariable.someValue).isEqualTo("test");
+        assertThat(customTestVariable.someInt).isEqualTo(123);
     }
 
     @Test
@@ -473,59 +470,59 @@ public class VariablesTest extends FlowableCmmnTestCase {
 
         CustomAccessCaseType customVar = new CustomAccessCaseType();
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("oneHumanTaskCase")
-            .variable("customVar", customVar)
-            .start();
+                .caseDefinitionKey("oneHumanTaskCase")
+                .variable("customVar", customVar)
+                .start();
 
-        Assertions.assertThat(customVar.getProcessInstanceId())
-            .as("custom var process instance id")
-            .isNull();
+        assertThat(customVar.getProcessInstanceId())
+                .as("custom var process instance id")
+                .isNull();
 
-        Assertions.assertThat(customVar.getExecutionId())
-            .as("custom var execution id")
-            .isNull();
+        assertThat(customVar.getExecutionId())
+                .as("custom var execution id")
+                .isNull();
 
-        Assertions.assertThat(customVar.getTaskId())
-            .as("custom var task id")
-            .isNull();
+        assertThat(customVar.getTaskId())
+                .as("custom var task id")
+                .isNull();
 
-        Assertions.assertThat(customVar.getScopeId())
-            .as("custom var scope id")
-            .isEqualTo(caseInstance.getId());
+        assertThat(customVar.getScopeId())
+                .as("custom var scope id")
+                .isEqualTo(caseInstance.getId());
 
-        Assertions.assertThat(customVar.getSubScopeId())
-            .as("custom var sub scope id")
-            .isNull();
+        assertThat(customVar.getSubScopeId())
+                .as("custom var sub scope id")
+                .isNull();
 
-        Assertions.assertThat(customVar.getScopeType())
-            .as("custom var scope type")
-            .isEqualTo(ScopeTypes.CMMN);
+        assertThat(customVar.getScopeType())
+                .as("custom var scope type")
+                .isEqualTo(ScopeTypes.CMMN);
 
         customVar = (CustomAccessCaseType) cmmnRuntimeService.getVariable(caseInstance.getId(), "customVar");
 
-        Assertions.assertThat(customVar.getProcessInstanceId())
-            .as("custom var process instance id")
-            .isNull();
+        assertThat(customVar.getProcessInstanceId())
+                .as("custom var process instance id")
+                .isNull();
 
-        Assertions.assertThat(customVar.getExecutionId())
-            .as("custom var execution id")
-            .isNull();
+        assertThat(customVar.getExecutionId())
+                .as("custom var execution id")
+                .isNull();
 
-        Assertions.assertThat(customVar.getTaskId())
-            .as("custom var task id")
-            .isNull();
+        assertThat(customVar.getTaskId())
+                .as("custom var task id")
+                .isNull();
 
-        Assertions.assertThat(customVar.getScopeId())
-            .as("custom var scope id")
-            .isEqualTo(caseInstance.getId());
+        assertThat(customVar.getScopeId())
+                .as("custom var scope id")
+                .isEqualTo(caseInstance.getId());
 
-        Assertions.assertThat(customVar.getSubScopeId())
-            .as("custom var sub scope id")
-            .isNull();
+        assertThat(customVar.getSubScopeId())
+                .as("custom var sub scope id")
+                .isNull();
 
-        Assertions.assertThat(customVar.getScopeType())
-            .as("custom var scope type")
-            .isEqualTo(ScopeTypes.CMMN);
+        assertThat(customVar.getScopeType())
+                .as("custom var scope type")
+                .isEqualTo(ScopeTypes.CMMN);
     }
 
     @Test
@@ -534,67 +531,67 @@ public class VariablesTest extends FlowableCmmnTestCase {
         addVariableTypeIfNotExists(CustomAccessCaseInstanceVariableType.INSTANCE);
 
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("oneHumanTaskCase")
-            .start();
+                .caseDefinitionKey("oneHumanTaskCase")
+                .start();
 
         Task task = cmmnTaskService.createTaskQuery()
-            .caseInstanceId(caseInstance.getId())
-            .singleResult();
+                .caseInstanceId(caseInstance.getId())
+                .singleResult();
 
-        Assertions.assertThat(task).isNotNull();
+        assertThat(task).isNotNull();
 
         CustomAccessCaseType customVar = new CustomAccessCaseType();
         cmmnTaskService.setVariableLocal(task.getId(), "customTaskVar", customVar);
 
-        Assertions.assertThat(customVar.getProcessInstanceId())
-            .as("custom var process instance id")
-            .isNull();
+        assertThat(customVar.getProcessInstanceId())
+                .as("custom var process instance id")
+                .isNull();
 
-        Assertions.assertThat(customVar.getExecutionId())
-            .as("custom var execution id")
-            .isNull();
+        assertThat(customVar.getExecutionId())
+                .as("custom var execution id")
+                .isNull();
 
-        Assertions.assertThat(customVar.getTaskId())
-            .as("custom var task id")
-            .isEqualTo(task.getId());
+        assertThat(customVar.getTaskId())
+                .as("custom var task id")
+                .isEqualTo(task.getId());
 
-        Assertions.assertThat(customVar.getScopeId())
-            .as("custom var scope id")
-            .isEqualTo(caseInstance.getId());
+        assertThat(customVar.getScopeId())
+                .as("custom var scope id")
+                .isEqualTo(caseInstance.getId());
 
-        Assertions.assertThat(customVar.getSubScopeId())
-            .as("custom var sub scope id")
-            .isEqualTo(task.getSubScopeId());
+        assertThat(customVar.getSubScopeId())
+                .as("custom var sub scope id")
+                .isEqualTo(task.getSubScopeId());
 
-        Assertions.assertThat(customVar.getScopeType())
-            .as("custom var scope type")
-            .isEqualTo(ScopeTypes.CMMN);
+        assertThat(customVar.getScopeType())
+                .as("custom var scope type")
+                .isEqualTo(ScopeTypes.CMMN);
 
         customVar = (CustomAccessCaseType) cmmnTaskService.getVariableLocal(task.getId(), "customTaskVar");
 
-        Assertions.assertThat(customVar.getProcessInstanceId())
-            .as("custom var process instance id")
-            .isNull();
+        assertThat(customVar.getProcessInstanceId())
+                .as("custom var process instance id")
+                .isNull();
 
-        Assertions.assertThat(customVar.getExecutionId())
-            .as("custom var execution id")
-            .isNull();
+        assertThat(customVar.getExecutionId())
+                .as("custom var execution id")
+                .isNull();
 
-        Assertions.assertThat(customVar.getTaskId())
-            .as("custom var task id")
-            .isEqualTo(task.getId());
+        assertThat(customVar.getTaskId())
+                .as("custom var task id")
+                .isEqualTo(task.getId());
 
-        Assertions.assertThat(customVar.getScopeId())
-            .as("custom var scope id")
-            .isEqualTo(caseInstance.getId());
+        assertThat(customVar.getScopeId())
+                .as("custom var scope id")
+                .isEqualTo(caseInstance.getId());
 
-        Assertions.assertThat(customVar.getSubScopeId())
-            .as("custom var sub scope id")
-            .isEqualTo(task.getSubScopeId());
+        assertThat(customVar.getSubScopeId())
+                .as("custom var sub scope id")
+                .isEqualTo(task.getSubScopeId());
 
-        Assertions.assertThat(customVar.getScopeType())
-            .as("custom var scope type")
-            .isEqualTo(ScopeTypes.CMMN);
+        assertThat(customVar.getScopeType())
+                .as("custom var scope type")
+                .isEqualTo(ScopeTypes.CMMN);
     }
 
     @Test
@@ -603,67 +600,67 @@ public class VariablesTest extends FlowableCmmnTestCase {
         addVariableTypeIfNotExists(CustomAccessCaseInstanceVariableType.INSTANCE);
 
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("oneHumanTaskCase")
-            .start();
+                .caseDefinitionKey("oneHumanTaskCase")
+                .start();
 
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .planItemDefinitionId("theTask")
-            .singleResult();
+                .planItemDefinitionId("theTask")
+                .singleResult();
 
-        Assertions.assertThat(planItemInstance).isNotNull();
+        assertThat(planItemInstance).isNotNull();
 
         CustomAccessCaseType customVar = new CustomAccessCaseType();
         cmmnRuntimeService.setLocalVariable(planItemInstance.getId(), "customPlanItemVar", customVar);
 
-        Assertions.assertThat(customVar.getProcessInstanceId())
-            .as("custom var process instance id")
-            .isNull();
+        assertThat(customVar.getProcessInstanceId())
+                .as("custom var process instance id")
+                .isNull();
 
-        Assertions.assertThat(customVar.getExecutionId())
-            .as("custom var execution id")
-            .isNull();
+        assertThat(customVar.getExecutionId())
+                .as("custom var execution id")
+                .isNull();
 
-        Assertions.assertThat(customVar.getTaskId())
-            .as("custom var task id")
-            .isNull();
+        assertThat(customVar.getTaskId())
+                .as("custom var task id")
+                .isNull();
 
-        Assertions.assertThat(customVar.getScopeId())
-            .as("custom var scope id")
-            .isEqualTo(caseInstance.getId());
+        assertThat(customVar.getScopeId())
+                .as("custom var scope id")
+                .isEqualTo(caseInstance.getId());
 
-        Assertions.assertThat(customVar.getSubScopeId())
-            .as("custom var sub scope id")
-            .isEqualTo(planItemInstance.getId());
+        assertThat(customVar.getSubScopeId())
+                .as("custom var sub scope id")
+                .isEqualTo(planItemInstance.getId());
 
-        Assertions.assertThat(customVar.getScopeType())
-            .as("custom var scope type")
-            .isEqualTo(ScopeTypes.CMMN);
+        assertThat(customVar.getScopeType())
+                .as("custom var scope type")
+                .isEqualTo(ScopeTypes.CMMN);
 
         customVar = (CustomAccessCaseType) cmmnRuntimeService.getLocalVariable(planItemInstance.getId(), "customPlanItemVar");
 
-        Assertions.assertThat(customVar.getProcessInstanceId())
-            .as("custom var process instance id")
-            .isNull();
+        assertThat(customVar.getProcessInstanceId())
+                .as("custom var process instance id")
+                .isNull();
 
-        Assertions.assertThat(customVar.getExecutionId())
-            .as("custom var execution id")
-            .isNull();
+        assertThat(customVar.getExecutionId())
+                .as("custom var execution id")
+                .isNull();
 
-        Assertions.assertThat(customVar.getTaskId())
-            .as("custom var task id")
-            .isNull();
+        assertThat(customVar.getTaskId())
+                .as("custom var task id")
+                .isNull();
 
-        Assertions.assertThat(customVar.getScopeId())
-            .as("custom var scope id")
-            .isEqualTo(caseInstance.getId());
+        assertThat(customVar.getScopeId())
+                .as("custom var scope id")
+                .isEqualTo(caseInstance.getId());
 
-        Assertions.assertThat(customVar.getSubScopeId())
-            .as("custom var sub scope id")
-            .isEqualTo(planItemInstance.getId());
+        assertThat(customVar.getSubScopeId())
+                .as("custom var sub scope id")
+                .isEqualTo(planItemInstance.getId());
 
-        Assertions.assertThat(customVar.getScopeType())
-            .as("custom var scope type")
-            .isEqualTo(ScopeTypes.CMMN);
+        assertThat(customVar.getScopeType())
+                .as("custom var scope type")
+                .isEqualTo(ScopeTypes.CMMN);
     }
 
     protected void addVariableTypeIfNotExists(VariableType variableType) {
@@ -765,13 +762,13 @@ public class VariablesTest extends FlowableCmmnTestCase {
             customValue.setScopeType(valueFields.getScopeType());
 
             String textValue = new StringJoiner(",")
-                .add(customValue.getProcessInstanceId())
-                .add(customValue.getExecutionId())
-                .add(customValue.getTaskId())
-                .add(customValue.getScopeId())
-                .add(customValue.getSubScopeId())
-                .add(customValue.getScopeType())
-                .toString();
+                    .add(customValue.getProcessInstanceId())
+                    .add(customValue.getExecutionId())
+                    .add(customValue.getTaskId())
+                    .add(customValue.getScopeId())
+                    .add(customValue.getSubScopeId())
+                    .add(customValue.getScopeType())
+                    .toString();
             valueFields.setTextValue(textValue);
         }
 
@@ -798,21 +795,22 @@ public class VariablesTest extends FlowableCmmnTestCase {
 
             return null;
         }
+
         protected String getValue(String value) {
             return "null".equals(value) ? null : value;
         }
     }
 
     public static class MyVariable implements Serializable {
-        
+
         private static final long serialVersionUID = 1L;
-        
+
         private String value;
-        
+
         public MyVariable(String value) {
             this.value = value;
         }
-        
+
     }
 
     public static class SetVariableDelegate implements PlanItemJavaDelegate {
@@ -824,15 +822,15 @@ public class VariablesTest extends FlowableCmmnTestCase {
         }
 
     }
-    
+
     public static class SetTransientVariableDelegate implements PlanItemJavaDelegate {
-        
+
         @Override
         public void execute(DelegatePlanItemInstance planItemInstance) {
             String variableValue = (String) planItemInstance.getVariable("transientStartVar");
             planItemInstance.setTransientVariable("transientVar", variableValue + " and delegate");
         }
-        
+
     }
 
     public static class CustomTestVariable implements Serializable {


### PR DESCRIPTION
Use assertj fluent style in flowable-cmmn-engine (part 10)

This is the last part of the `org.flowable.cmmn.test` package changes; specifically the file in the 
`org.flowable.cmmn.test.runtime` package.