### PR TITLE
Use assertj fluent style in flowable-cmmn-engine-configurator.

### DIFF
--- a/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/AbstractProcessEngineIntegrationTest.java
+++ b/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/AbstractProcessEngineIntegrationTest.java
@@ -12,7 +12,7 @@
  */
 package org.flowable.cmmn.test;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Date;
 import java.util.List;
@@ -103,7 +103,7 @@ public abstract class AbstractProcessEngineIntegrationTest {
             cmmnRepositoryService.deleteDeployment(deployment.getId(), true);
         }
     }
-    
+
     protected Date setCmmnClockFixedToCurrentTime() {
         Date date = new Date();
         cmmnEngineConfiguration.getClock().setCurrentTime(date);
@@ -112,9 +112,9 @@ public abstract class AbstractProcessEngineIntegrationTest {
 
     protected void assertCaseInstanceEnded(CaseInstance caseInstance) {
         long count = cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count();
-        assertEquals(createCaseInstanceEndedErrorMessage(caseInstance, count), 0, count);
-        assertEquals("Runtime case instance found", 0, cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceId(caseInstance.getId()).finished().count());
+        assertThat(count).as(createCaseInstanceEndedErrorMessage(caseInstance, count)).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).as("Runtime case instance found").isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceId(caseInstance.getId()).finished().count()).isEqualTo(1);
     }
 
     protected String createCaseInstanceEndedErrorMessage(CaseInstance caseInstance, long count) {
@@ -122,8 +122,8 @@ public abstract class AbstractProcessEngineIntegrationTest {
         if (count != 0) {
             List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).list();
             String names = planItemInstances.stream()
-                .map(planItemInstance -> planItemInstance.getName() + "(" + planItemInstance.getPlanItemDefinitionType() + ")")
-                .collect(Collectors.joining(", "));
+                    .map(planItemInstance -> planItemInstance.getName() + "(" + planItemInstance.getPlanItemDefinitionType() + ")")
+                    .collect(Collectors.joining(", "));
             errorMessage += names;
         }
         return errorMessage;

--- a/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/BpmnTimerTaskTest.java
+++ b/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/BpmnTimerTaskTest.java
@@ -12,9 +12,8 @@
  */
 package org.flowable.cmmn.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Calendar;
 import java.util.List;
@@ -34,63 +33,60 @@ import org.junit.Test;
  * @author Tijs Rademakers
  */
 public class BpmnTimerTaskTest extends AbstractProcessEngineIntegrationTest {
-    
+
     @Before
     public void deployTimerProcess() {
         if (processEngineRepositoryService.createDeploymentQuery().count() == 0) {
             processEngineRepositoryService.createDeployment().addClasspathResource("org/flowable/cmmn/test/taskTimerProcess.bpmn20.xml").deploy();
         }
     }
-    
+
     @Test
     public void testBpmnTimerTask() {
         ProcessInstance processInstance = processEngineRuntimeService.startProcessInstanceByKey("timerProcess");
         List<Task> processTasks = processEngineTaskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(1, processTasks.size());
-        
+        assertThat(processTasks).hasSize(1);
+
         List<Job> timerJobs = processEngineManagementService.createTimerJobQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(1, timerJobs.size());
-        
+        assertThat(timerJobs).hasSize(1);
+
         timerJobs = cmmnManagementService.createTimerJobQuery().processInstanceId(processInstance.getId()).executable().list();
-        assertEquals(0, timerJobs.size());
-        
+        assertThat(timerJobs).isEmpty();
+
         Clock clock = cmmnEngineConfiguration.getClock();
         Calendar currentCalendar = clock.getCurrentCalendar();
         currentCalendar.add(Calendar.MINUTE, 15);
         clock.setCurrentCalendar(currentCalendar);
-        
+
         timerJobs = cmmnManagementService.createTimerJobQuery().processInstanceId(processInstance.getId()).executable().list();
-        assertEquals(1, timerJobs.size());
+        assertThat(timerJobs).hasSize(1);
         String timerJobId = timerJobs.get(0).getId();
-        
-        try {
-            CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 7000, 200, true);
-            fail("should throw time limit exceeded");
-        } catch (FlowableException e) {
-            assertEquals("Time limit of 7000 was exceeded", e.getMessage());
-        }
-        
+
+        assertThatThrownBy(() -> CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 7000, 200, true))
+                .isInstanceOf(FlowableException.class)
+                .hasMessage("Time limit of 7000 was exceeded");
+
         processEngine.getProcessEngineConfiguration().setClock(clock);
-        
+
         timerJobs = processEngineManagementService.createTimerJobQuery().processInstanceId(processInstance.getId()).executable().list();
-        assertEquals(1, timerJobs.size());
-        assertEquals(timerJobId, timerJobs.get(0).getId());
-        
+        assertThat(timerJobs).hasSize(1);
+        assertThat(timerJobs.get(0).getId()).isEqualTo(timerJobId);
+
         JobTestHelper.waitForJobExecutorToProcessAllJobs(processEngine.getProcessEngineConfiguration(), processEngineManagementService, 7000, 200, true);
-        
+
         timerJobs = processEngineManagementService.createTimerJobQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(0, timerJobs.size());
-        
+        assertThat(timerJobs).isEmpty();
+
         Task task = processEngineTaskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(task);
-        assertEquals("secondTask", task.getTaskDefinitionKey());
-        
+        assertThat(task).isNotNull();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
+
         processEngineTaskService.complete(task.getId());
-        
-        assertEquals(0, processEngineRuntimeService.createProcessInstanceQuery().count());
-        
+
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+
         cmmnEngineConfiguration.resetClock();
         ((ProcessEngineConfigurationImpl) processEngine.getProcessEngineConfiguration()).resetClock();
     }
-    
+
 }

--- a/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/ChangeStateProcessTaskTest.java
+++ b/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/ChangeStateProcessTaskTest.java
@@ -12,10 +12,7 @@
  */
 package org.flowable.cmmn.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
@@ -34,372 +31,375 @@ import org.junit.Test;
  * @author Tijs Rademakers
  */
 public class ChangeStateProcessTaskTest extends AbstractProcessEngineIntegrationTest {
-    
+
     @Before
     public void deployOneTaskProcess() {
         if (processEngineRepositoryService.createDeploymentQuery().count() == 0) {
             processEngineRepositoryService.createDeployment().addClasspathResource("org/flowable/cmmn/test/oneTaskProcess.bpmn20.xml").deploy();
         }
     }
-    
+
     @Test
     @CmmnDeployment
     public void testActivateProcessTask() {
         CaseInstance caseInstance = startCaseInstanceWithOneTaskProcess("activateFirstTask", false);
         cmmnRuntimeService.createChangePlanItemStateBuilder()
-            .caseInstanceId(caseInstance.getId())
-            .activatePlanItemDefinitionId("theProcess")
-            .changeState();
-    
+                .caseInstanceId(caseInstance.getId())
+                .activatePlanItemDefinitionId("theProcess")
+                .changeState();
+
         ProcessInstance processInstance = processEngineRuntimeService.createProcessInstanceQuery().singleResult();
-        assertNotNull(processInstance);
-        
+        assertThat(processInstance).isNotNull();
+
         Task task = processEngineTaskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("my task", task.getName());
-    
+        assertThat(task.getName()).isEqualTo("my task");
+
         processEngineTaskService.complete(task.getId());
-        
-        assertEquals(0, cmmnTaskService.createTaskQuery().count());
-        assertEquals(0, processEngineRuntimeService.createProcessInstanceQuery().count());
-        
-        assertEquals(1, cmmnRuntimeService.createCaseInstanceQuery().count());
-        
+
+        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(0);
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(1);
+
         cmmnRuntimeService.createChangePlanItemStateBuilder()
-            .caseInstanceId(caseInstance.getId())
-            .activatePlanItemDefinitionId("theTask")
-            .changeState();
-        
+                .caseInstanceId(caseInstance.getId())
+                .activatePlanItemDefinitionId("theTask")
+                .changeState();
+
         List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .list();
-        assertEquals(1, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(1);
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(0).getId());
-        
-        assertEquals(0, cmmnTaskService.createTaskQuery().count());
-        assertEquals(0, processEngineRuntimeService.createProcessInstanceQuery().count());
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
+
+        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(0);
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
     }
-    
+
     @Test
-    @CmmnDeployment(resources = {"org/flowable/cmmn/test/ChangeStateProcessTaskTest.testActivateProcessTask.cmmn"})
+    @CmmnDeployment(resources = { "org/flowable/cmmn/test/ChangeStateProcessTaskTest.testActivateProcessTask.cmmn" })
     public void testMoveToProcessTask() {
         CaseInstance caseInstance = startCaseInstanceWithOneTaskProcess("activateFirstTask", true);
-        
+
         cmmnRuntimeService.createChangePlanItemStateBuilder()
-            .caseInstanceId(caseInstance.getId())
-            .movePlanItemDefinitionIdTo("theTask", "theProcess")
-            .changeState();
-    
+                .caseInstanceId(caseInstance.getId())
+                .movePlanItemDefinitionIdTo("theTask", "theProcess")
+                .changeState();
+
         ProcessInstance processInstance = processEngineRuntimeService.createProcessInstanceQuery().singleResult();
-        assertNotNull(processInstance);
-        
+        assertThat(processInstance).isNotNull();
+
         Task task = processEngineTaskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("my task", task.getName());
-    
+        assertThat(task.getName()).isEqualTo("my task");
+
         processEngineTaskService.complete(task.getId());
-        
-        assertEquals(0, cmmnTaskService.createTaskQuery().count());
-        assertEquals(0, processEngineRuntimeService.createProcessInstanceQuery().count());
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
+
+        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(0);
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
     }
-    
+
     @Test
-    @CmmnDeployment(resources = {"org/flowable/cmmn/test/ChangeStateProcessTaskTest.testActivateProcessTask.cmmn"})
+    @CmmnDeployment(resources = { "org/flowable/cmmn/test/ChangeStateProcessTaskTest.testActivateProcessTask.cmmn" })
     public void testActivateProcessTaskWithInitialTask() {
         CaseInstance caseInstance = startCaseInstanceWithOneTaskProcess("activateFirstTask", true);
-        
+
         List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .list();
-        assertEquals(1, planItemInstances.size());
-        
+        assertThat(planItemInstances).hasSize(1);
+
         cmmnRuntimeService.createChangePlanItemStateBuilder()
-            .caseInstanceId(caseInstance.getId())
-            .activatePlanItemDefinitionId("theProcess")
-            .changeState();
-    
+                .caseInstanceId(caseInstance.getId())
+                .activatePlanItemDefinitionId("theProcess")
+                .changeState();
+
         ProcessInstance processInstance = processEngineRuntimeService.createProcessInstanceQuery().singleResult();
-        assertNotNull(processInstance);
-        
+        assertThat(processInstance).isNotNull();
+
         Task task = processEngineTaskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("my task", task.getName());
-        
+        assertThat(task.getName()).isEqualTo("my task");
+
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(0).getId());
-    
+
         processEngineTaskService.complete(task.getId());
-        
-        assertEquals(0, cmmnTaskService.createTaskQuery().count());
-        assertEquals(0, processEngineRuntimeService.createProcessInstanceQuery().count());
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
+
+        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(0);
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
     }
-    
+
     @Test
     @CmmnDeployment
     public void testActivateProcessTaskInStage() {
         CaseInstance caseInstance = startCaseInstanceWithOneTaskProcess("activateStage", false);
-        
-        assertEquals(0, processEngineRuntimeService.createProcessInstanceQuery().count());
-        
+
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+
         cmmnRuntimeService.createChangePlanItemStateBuilder()
-            .caseInstanceId(caseInstance.getId())
-            .activatePlanItemDefinitionId("theProcess")
-            .changeState();
-    
+                .caseInstanceId(caseInstance.getId())
+                .activatePlanItemDefinitionId("theProcess")
+                .changeState();
+
         ProcessInstance processInstance = processEngineRuntimeService.createProcessInstanceQuery().singleResult();
-        assertNotNull(processInstance);
-        
+        assertThat(processInstance).isNotNull();
+
         Task task = processEngineTaskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("my task", task.getName());
-        
+        assertThat(task.getName()).isEqualTo("my task");
+
         cmmnRuntimeService.createChangePlanItemStateBuilder()
-            .caseInstanceId(caseInstance.getId())
-            .activatePlanItemDefinitionId("theProcess2")
-            .changeState();
-        
-        assertEquals(2, processEngineRuntimeService.createProcessInstanceQuery().count());
-        assertEquals(2, processEngineTaskService.createTaskQuery().count());
-    
+                .caseInstanceId(caseInstance.getId())
+                .activatePlanItemDefinitionId("theProcess2")
+                .changeState();
+
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(2);
+        assertThat(processEngineTaskService.createTaskQuery().count()).isEqualTo(2);
+
         processEngineTaskService.complete(task.getId());
-        
+
         ProcessInstance processInstance2 = processEngineRuntimeService.createProcessInstanceQuery().singleResult();
-        assertNotNull(processInstance2);
-        assertNotEquals(processInstance.getId(), processInstance2.getId());
-        
+        assertThat(processInstance2).isNotNull();
+        assertThat(processInstance2.getId()).isNotEqualTo(processInstance.getId());
+
         task = processEngineTaskService.createTaskQuery().processInstanceId(processInstance2.getId()).singleResult();
-        assertEquals("my task", task.getName());
-        
-        assertEquals(1, processEngineRuntimeService.createProcessInstanceQuery().count());
-        assertEquals(1, processEngineTaskService.createTaskQuery().count());
-        
+        assertThat(task.getName()).isEqualTo("my task");
+
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(1);
+        assertThat(processEngineTaskService.createTaskQuery().count()).isEqualTo(1);
+
         processEngineTaskService.complete(task.getId());
-        
-        assertEquals(0, cmmnTaskService.createTaskQuery().count());
-        assertEquals(0, processEngineRuntimeService.createProcessInstanceQuery().count());
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
+
+        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(0);
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
     }
-    
+
     @Test
-    @CmmnDeployment(resources = {"org/flowable/cmmn/test/ChangeStateProcessTaskTest.testActivateProcessTaskInStage.cmmn"})
+    @CmmnDeployment(resources = { "org/flowable/cmmn/test/ChangeStateProcessTaskTest.testActivateProcessTaskInStage.cmmn" })
     public void testActivateProcessTaskInStageWithInitialStage() {
         CaseInstance caseInstance = startCaseInstanceWithOneTaskProcess("activateStage", true);
-        
-        assertEquals(1, processEngineRuntimeService.createProcessInstanceQuery().count());
+
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(1);
         ProcessInstance processInstance = processEngineRuntimeService.createProcessInstanceQuery().singleResult();
-        assertNotNull(processInstance);
-        
+        assertThat(processInstance).isNotNull();
+
         cmmnRuntimeService.createChangePlanItemStateBuilder()
-            .caseInstanceId(caseInstance.getId())
-            .activatePlanItemDefinitionId("theProcess2")
-            .changeState();
-    
-        assertEquals(2, processEngineRuntimeService.createProcessInstanceQuery().count());
-        assertEquals(2, processEngineTaskService.createTaskQuery().count());
-    
+                .caseInstanceId(caseInstance.getId())
+                .activatePlanItemDefinitionId("theProcess2")
+                .changeState();
+
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(2);
+        assertThat(processEngineTaskService.createTaskQuery().count()).isEqualTo(2);
+
         Task task = processEngineTaskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("my task", task.getName());
-        
+        assertThat(task.getName()).isEqualTo("my task");
+
         processEngineTaskService.complete(task.getId());
-        
+
         ProcessInstance processInstance2 = processEngineRuntimeService.createProcessInstanceQuery().singleResult();
-        assertNotNull(processInstance2);
-        
+        assertThat(processInstance2).isNotNull();
+
         task = processEngineTaskService.createTaskQuery().processInstanceId(processInstance2.getId()).singleResult();
-        assertEquals("my task", task.getName());
-        
+        assertThat(task.getName()).isEqualTo("my task");
+
         processEngineTaskService.complete(task.getId());
-        
-        assertEquals(0, cmmnTaskService.createTaskQuery().count());
-        assertEquals(0, processEngineRuntimeService.createProcessInstanceQuery().count());
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
+
+        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(0);
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
     }
-    
+
     @Test
-    @CmmnDeployment(resources = {"org/flowable/cmmn/test/ChangeStateProcessTaskTest.testActivateProcessTask.cmmn"})
+    @CmmnDeployment(resources = { "org/flowable/cmmn/test/ChangeStateProcessTaskTest.testActivateProcessTask.cmmn" })
     public void testActivateProcessTaskWithVariables() {
         CaseInstance caseInstance = startCaseInstanceWithOneTaskProcess("activateFirstTask", true);
-        
+
         cmmnRuntimeService.createChangePlanItemStateBuilder()
-            .caseInstanceId(caseInstance.getId())
-            .activatePlanItemDefinitionId("theProcess")
-            .childInstanceTaskVariable("theProcess", "textVar", "Some text")
-            .childInstanceTaskVariable("theProcess", "numVar", 10)
-            .changeState();
-    
+                .caseInstanceId(caseInstance.getId())
+                .activatePlanItemDefinitionId("theProcess")
+                .childInstanceTaskVariable("theProcess", "textVar", "Some text")
+                .childInstanceTaskVariable("theProcess", "numVar", 10)
+                .changeState();
+
         ProcessInstance processInstance = processEngineRuntimeService.createProcessInstanceQuery().singleResult();
-        assertNotNull(processInstance);
-        
-        assertEquals("Some text", processEngineRuntimeService.getVariable(processInstance.getId(), "textVar"));
-        assertEquals(10, processEngineRuntimeService.getVariable(processInstance.getId(), "numVar"));
-        assertNull(cmmnRuntimeService.getVariable(caseInstance.getId(), "textVar"));
-        assertNull(cmmnRuntimeService.getVariable(caseInstance.getId(), "numVar"));
-        
+        assertThat(processInstance).isNotNull();
+
+        assertThat(processEngineRuntimeService.getVariable(processInstance.getId(), "textVar")).isEqualTo("Some text");
+        assertThat(processEngineRuntimeService.getVariable(processInstance.getId(), "numVar")).isEqualTo(10);
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "textVar")).isNull();
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "numVar")).isNull();
+
         Task task = processEngineTaskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("my task", task.getName());
-    
+        assertThat(task.getName()).isEqualTo("my task");
+
         processEngineTaskService.complete(task.getId());
-        
-        assertEquals("Some text", processEngineHistoryService.createHistoricVariableInstanceQuery()
-                        .processInstanceId(processInstance.getId())
-                        .variableName("textVar")
-                        .singleResult().getValue());
-        
-        assertEquals(10, processEngineHistoryService.createHistoricVariableInstanceQuery()
-                        .processInstanceId(processInstance.getId())
-                        .variableName("numVar")
-                        .singleResult().getValue());
-        
-        assertNull(cmmnRuntimeService.getVariable(caseInstance.getId(), "textVar"));
-        assertNull(cmmnRuntimeService.getVariable(caseInstance.getId(), "numVar"));
-        
+
+        assertThat(processEngineHistoryService.createHistoricVariableInstanceQuery()
+                .processInstanceId(processInstance.getId())
+                .variableName("textVar")
+                .singleResult().getValue()).isEqualTo("Some text");
+
+        assertThat(processEngineHistoryService.createHistoricVariableInstanceQuery()
+                .processInstanceId(processInstance.getId())
+                .variableName("numVar")
+                .singleResult().getValue()).isEqualTo(10);
+
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "textVar")).isNull();
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "numVar")).isNull();
+
         List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-                        .caseInstanceId(caseInstance.getId())
-                        .planItemInstanceState(PlanItemInstanceState.ACTIVE)
-                        .list();
+                .caseInstanceId(caseInstance.getId())
+                .planItemInstanceState(PlanItemInstanceState.ACTIVE)
+                .list();
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(0).getId());
-        
-        assertEquals(0, cmmnTaskService.createTaskQuery().count());
-        assertEquals(0, processEngineRuntimeService.createProcessInstanceQuery().count());
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
+
+        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(0);
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
     }
-    
+
     @Test
-    @CmmnDeployment(resources = {"org/flowable/cmmn/test/twoTasksWithProcessTask.cmmn"})
+    @CmmnDeployment(resources = { "org/flowable/cmmn/test/twoTasksWithProcessTask.cmmn" })
     public void testActivateProcessTaskAndMoveStateWithVariables() {
         CaseInstance caseInstance = startCaseInstanceWithOneTaskProcess("activateFirstTask", true);
-        
+
         List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-                        .caseInstanceId(caseInstance.getId())
-                        .planItemInstanceState(PlanItemInstanceState.ACTIVE)
-                        .list();
-        assertEquals(1, planItemInstances.size());
-        assertEquals("theTask", planItemInstances.get(0).getPlanItemDefinitionId());
-        
+                .caseInstanceId(caseInstance.getId())
+                .planItemInstanceState(PlanItemInstanceState.ACTIVE)
+                .list();
+        assertThat(planItemInstances).hasSize(1);
+        assertThat(planItemInstances.get(0).getPlanItemDefinitionId()).isEqualTo("theTask");
+
         cmmnRuntimeService.createChangePlanItemStateBuilder()
-            .caseInstanceId(caseInstance.getId())
-            .movePlanItemDefinitionIdTo("theTask", "theTask2")
-            .activatePlanItemDefinitionId("theProcess")
-            .childInstanceTaskVariable("theProcess", "textVar", "Some text")
-            .childInstanceTaskVariable("theProcess", "numVar", 10)
-            .changeState();
-        
+                .caseInstanceId(caseInstance.getId())
+                .movePlanItemDefinitionIdTo("theTask", "theTask2")
+                .activatePlanItemDefinitionId("theProcess")
+                .childInstanceTaskVariable("theProcess", "textVar", "Some text")
+                .childInstanceTaskVariable("theProcess", "numVar", 10)
+                .changeState();
+
         planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-                        .caseInstanceId(caseInstance.getId())
-                        .planItemInstanceState(PlanItemInstanceState.ACTIVE)
-                        .list();
-        assertEquals(2, planItemInstances.size());
-        
+                .caseInstanceId(caseInstance.getId())
+                .planItemInstanceState(PlanItemInstanceState.ACTIVE)
+                .list();
+        assertThat(planItemInstances).hasSize(2);
+
         planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-                        .caseInstanceId(caseInstance.getId())
-                        .planItemInstanceState(PlanItemInstanceState.ACTIVE)
-                        .planItemDefinitionId("theProcess")
-                        .list();
-        assertEquals(1, planItemInstances.size());        
-        assertEquals("theProcess", planItemInstances.get(0).getPlanItemDefinitionId());
-        
+                .caseInstanceId(caseInstance.getId())
+                .planItemInstanceState(PlanItemInstanceState.ACTIVE)
+                .planItemDefinitionId("theProcess")
+                .list();
+        assertThat(planItemInstances)
+                .extracting(PlanItemInstance::getPlanItemDefinitionId)
+                .containsExactly("theProcess");
+
         planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-                        .caseInstanceId(caseInstance.getId())
-                        .planItemInstanceState(PlanItemInstanceState.ACTIVE)
-                        .planItemDefinitionId("theTask2")
-                        .list();
-        assertEquals(1, planItemInstances.size());        
-        assertEquals("theTask2", planItemInstances.get(0).getPlanItemDefinitionId());
-        
+                .caseInstanceId(caseInstance.getId())
+                .planItemInstanceState(PlanItemInstanceState.ACTIVE)
+                .planItemDefinitionId("theTask2")
+                .list();
+        assertThat(planItemInstances)
+                .extracting(PlanItemInstance::getPlanItemDefinitionId)
+                .containsExactly("theTask2");
+
         planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-                        .caseInstanceId(caseInstance.getId())
-                        .planItemInstanceState(PlanItemInstanceState.TERMINATED)
-                        .planItemDefinitionId("theTask")
-                        .includeEnded()
-                        .list();
-        assertEquals(1, planItemInstances.size());        
-        assertEquals("theTask", planItemInstances.get(0).getPlanItemDefinitionId());
-    
+                .caseInstanceId(caseInstance.getId())
+                .planItemInstanceState(PlanItemInstanceState.TERMINATED)
+                .planItemDefinitionId("theTask")
+                .includeEnded()
+                .list();
+        assertThat(planItemInstances)
+                .extracting(PlanItemInstance::getPlanItemDefinitionId)
+                .containsExactly("theTask");
+
         ProcessInstance processInstance = processEngineRuntimeService.createProcessInstanceQuery().singleResult();
-        assertNotNull(processInstance);
-        
-        assertEquals("Some text", processEngineRuntimeService.getVariable(processInstance.getId(), "textVar"));
-        assertEquals(10, processEngineRuntimeService.getVariable(processInstance.getId(), "numVar"));
-        assertNull(cmmnRuntimeService.getVariable(caseInstance.getId(), "textVar"));
-        assertNull(cmmnRuntimeService.getVariable(caseInstance.getId(), "numVar"));
-        
+        assertThat(processInstance).isNotNull();
+
+        assertThat(processEngineRuntimeService.getVariable(processInstance.getId(), "textVar")).isEqualTo("Some text");
+        assertThat(processEngineRuntimeService.getVariable(processInstance.getId(), "numVar")).isEqualTo(10);
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "textVar")).isNull();
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "numVar")).isNull();
+
         Task task = processEngineTaskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("my task", task.getName());
-    
+        assertThat(task.getName()).isEqualTo("my task");
+
         processEngineTaskService.complete(task.getId());
-        
-        assertEquals("Some text", processEngineHistoryService.createHistoricVariableInstanceQuery()
-                        .processInstanceId(processInstance.getId())
-                        .variableName("textVar")
-                        .singleResult().getValue());
-        
-        assertEquals(10, processEngineHistoryService.createHistoricVariableInstanceQuery()
-                        .processInstanceId(processInstance.getId())
-                        .variableName("numVar")
-                        .singleResult().getValue());
-        
-        assertNull(cmmnRuntimeService.getVariable(caseInstance.getId(), "textVar"));
-        assertNull(cmmnRuntimeService.getVariable(caseInstance.getId(), "numVar"));
-        
+
+        assertThat(processEngineHistoryService.createHistoricVariableInstanceQuery()
+                .processInstanceId(processInstance.getId())
+                .variableName("textVar")
+                .singleResult().getValue()).isEqualTo("Some text");
+
+        assertThat(processEngineHistoryService.createHistoricVariableInstanceQuery()
+                .processInstanceId(processInstance.getId())
+                .variableName("numVar")
+                .singleResult().getValue()).isEqualTo(10);
+
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "textVar")).isNull();
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "numVar")).isNull();
+
         planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-                        .caseInstanceId(caseInstance.getId())
-                        .planItemInstanceState(PlanItemInstanceState.ACTIVE)
-                        .list();
-        assertEquals(1, planItemInstances.size());
+                .caseInstanceId(caseInstance.getId())
+                .planItemInstanceState(PlanItemInstanceState.ACTIVE)
+                .list();
+        assertThat(planItemInstances).hasSize(1);
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(0).getId());
-        
-        assertEquals(0, cmmnTaskService.createTaskQuery().count());
-        assertEquals(0, processEngineRuntimeService.createProcessInstanceQuery().count());
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
+
+        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(0);
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
     }
-    
+
     @Test
-    @CmmnDeployment(resources = {"org/flowable/cmmn/test/ChangeStateProcessTaskTest.testActivateProcessTask.cmmn"})
+    @CmmnDeployment(resources = { "org/flowable/cmmn/test/ChangeStateProcessTaskTest.testActivateProcessTask.cmmn" })
     public void testMoveProcessTaskWithVariables() {
         CaseInstance caseInstance = startCaseInstanceWithOneTaskProcess("activateFirstTask", true);
-        
+
         cmmnRuntimeService.createChangePlanItemStateBuilder()
-            .caseInstanceId(caseInstance.getId())
-            .movePlanItemDefinitionIdTo("theTask", "theProcess")
-            .childInstanceTaskVariable("theProcess", "textVar", "Some text")
-            .childInstanceTaskVariable("theProcess", "numVar", 10)
-            .changeState();
-    
+                .caseInstanceId(caseInstance.getId())
+                .movePlanItemDefinitionIdTo("theTask", "theProcess")
+                .childInstanceTaskVariable("theProcess", "textVar", "Some text")
+                .childInstanceTaskVariable("theProcess", "numVar", 10)
+                .changeState();
+
         ProcessInstance processInstance = processEngineRuntimeService.createProcessInstanceQuery().singleResult();
-        assertNotNull(processInstance);
-        
-        assertEquals("Some text", processEngineRuntimeService.getVariable(processInstance.getId(), "textVar"));
-        assertEquals(10, processEngineRuntimeService.getVariable(processInstance.getId(), "numVar"));
-        assertNull(cmmnRuntimeService.getVariable(caseInstance.getId(), "textVar"));
-        assertNull(cmmnRuntimeService.getVariable(caseInstance.getId(), "numVar"));
-        
+        assertThat(processInstance).isNotNull();
+
+        assertThat(processEngineRuntimeService.getVariable(processInstance.getId(), "textVar")).isEqualTo("Some text");
+        assertThat(processEngineRuntimeService.getVariable(processInstance.getId(), "numVar")).isEqualTo(10);
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "textVar")).isNull();
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "numVar")).isNull();
+
         Task task = processEngineTaskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("my task", task.getName());
-    
+        assertThat(task.getName()).isEqualTo("my task");
+
         processEngineTaskService.complete(task.getId());
-        
-        assertEquals("Some text", processEngineHistoryService.createHistoricVariableInstanceQuery()
-                        .processInstanceId(processInstance.getId())
-                        .variableName("textVar")
-                        .singleResult().getValue());
-        
-        assertEquals(10, processEngineHistoryService.createHistoricVariableInstanceQuery()
-                        .processInstanceId(processInstance.getId())
-                        .variableName("numVar")
-                        .singleResult().getValue());
-        
-        assertEquals(0, cmmnTaskService.createTaskQuery().count());
-        assertEquals(0, processEngineRuntimeService.createProcessInstanceQuery().count());
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
+
+        assertThat(processEngineHistoryService.createHistoricVariableInstanceQuery()
+                .processInstanceId(processInstance.getId())
+                .variableName("textVar")
+                .singleResult().getValue()).isEqualTo("Some text");
+
+        assertThat(processEngineHistoryService.createHistoricVariableInstanceQuery()
+                .processInstanceId(processInstance.getId())
+                .variableName("numVar")
+                .singleResult().getValue()).isEqualTo(10);
+
+        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(0);
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
     }
 
     protected CaseInstance startCaseInstanceWithOneTaskProcess(String variableName, boolean activate) {
         CaseDefinitionQuery caseDefinitionQuery = cmmnRepositoryService.createCaseDefinitionQuery();
         String caseDefinitionId = caseDefinitionQuery.singleResult().getId();
         CaseInstanceBuilder caseInstanceBuilder = cmmnRuntimeService.createCaseInstanceBuilder()
-                        .caseDefinitionId(caseDefinitionId)
-                        .variable(variableName, activate);
-        
+                .caseDefinitionId(caseDefinitionId)
+                .variable(variableName, activate);
+
         CaseInstance caseInstance = caseInstanceBuilder.start();
         return caseInstance;
     }

--- a/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/CmmnEngineConfiguratorAsyncHistoryTest.java
+++ b/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/CmmnEngineConfiguratorAsyncHistoryTest.java
@@ -12,9 +12,7 @@
  */
 package org.flowable.cmmn.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.cmmn.api.runtime.PlanItemInstanceState;
 import org.flowable.cmmn.engine.CmmnEngine;
@@ -35,68 +33,70 @@ import org.junit.Test;
  * @author Joram Barrez
  */
 public class CmmnEngineConfiguratorAsyncHistoryTest {
-    
+
     private ProcessEngine processEngine;
     private CmmnEngine cmmnEngine;
-    
+
     @Before
     public void setup() {
         processEngine = ProcessEngineConfiguration.createProcessEngineConfigurationFromResource("flowable.async.history.cfg.xml").buildProcessEngine();
         cmmnEngine = CmmnEngines.getDefaultCmmnEngine();
     }
-    
+
     @After
     public void cleanup() {
         processEngine.getRepositoryService()
-            .createDeploymentQuery()
-            .list()
-            .forEach(deployment -> processEngine.getRepositoryService().deleteDeployment(deployment.getId(), true));
+                .createDeploymentQuery()
+                .list()
+                .forEach(deployment -> processEngine.getRepositoryService().deleteDeployment(deployment.getId(), true));
         cmmnEngine.getCmmnRepositoryService()
-            .createDeploymentQuery()
-            .list()
-            .forEach(deployment -> cmmnEngine.getCmmnRepositoryService().deleteDeployment(deployment.getId(), true));
+                .createDeploymentQuery()
+                .list()
+                .forEach(deployment -> cmmnEngine.getCmmnRepositoryService().deleteDeployment(deployment.getId(), true));
         // Execute history jobs for the delete deployments
         processEngine.getManagementService().createHistoryJobQuery().list()
-            .forEach(historyJob -> processEngine.getManagementService().executeHistoryJob(historyJob.getId()));
-        
+                .forEach(historyJob -> processEngine.getManagementService().executeHistoryJob(historyJob.getId()));
+
         cmmnEngine.close();
         processEngine.close();
     }
-    
+
     @Test
     public void testSharedAsyncHistoryExecutor() {
         // The async history executor should be the same instance
         AsyncExecutor processEngineAsyncExecutor = processEngine.getProcessEngineConfiguration().getAsyncHistoryExecutor();
         AsyncExecutor cmmnEngineAsyncExecutor = cmmnEngine.getCmmnEngineConfiguration().getAsyncHistoryExecutor();
-        assertNotNull(processEngineAsyncExecutor);
-        assertNotNull(cmmnEngineAsyncExecutor);
-        assertSame(processEngineAsyncExecutor, cmmnEngineAsyncExecutor);
-        
+        assertThat(processEngineAsyncExecutor).isNotNull();
+        assertThat(cmmnEngineAsyncExecutor).isNotNull();
+        assertThat(cmmnEngineAsyncExecutor).isSameAs(processEngineAsyncExecutor);
+
         // Running them together should have moved the job execution scope to 'all' (from process which is null)
-        assertEquals(JobServiceConfiguration.JOB_EXECUTION_SCOPE_ALL, 
-                processEngine.getProcessEngineConfiguration().getAsyncHistoryExecutor().getJobServiceConfiguration().getHistoryJobExecutionScope());
-        
+        assertThat(processEngine.getProcessEngineConfiguration().getAsyncHistoryExecutor().getJobServiceConfiguration().getHistoryJobExecutionScope())
+                .isEqualTo(JobServiceConfiguration.JOB_EXECUTION_SCOPE_ALL);
+
         // 2 job handlers / engine
-        assertEquals(4, processEngineAsyncExecutor.getJobServiceConfiguration().getHistoryJobHandlers().size());
-        
+        assertThat(processEngineAsyncExecutor.getJobServiceConfiguration().getHistoryJobHandlers()).hasSize(4);
+
         // Deploy and start test processes/cases
         // Trigger one plan item instance to start the process
         processEngine.getRepositoryService().createDeployment().addClasspathResource("org/flowable/cmmn/test/oneTaskProcess.bpmn20.xml").deploy();
-        cmmnEngine.getCmmnRepositoryService().createDeployment().addClasspathResource("org/flowable/cmmn/test/ProcessTaskTest.testOneTaskProcessNonBlocking.cmmn").deploy();
+        cmmnEngine.getCmmnRepositoryService().createDeployment()
+                .addClasspathResource("org/flowable/cmmn/test/ProcessTaskTest.testOneTaskProcessNonBlocking.cmmn").deploy();
         cmmnEngine.getCmmnRuntimeService().createCaseInstanceBuilder().caseDefinitionKey("myCase").start();
-        cmmnEngine.getCmmnRuntimeService().triggerPlanItemInstance(cmmnEngine.getCmmnRuntimeService().createPlanItemInstanceQuery().planItemInstanceState(PlanItemInstanceState.ACTIVE).singleResult().getId());
-        
+        cmmnEngine.getCmmnRuntimeService().triggerPlanItemInstance(
+                cmmnEngine.getCmmnRuntimeService().createPlanItemInstanceQuery().planItemInstanceState(PlanItemInstanceState.ACTIVE).singleResult().getId());
+
         // As async history is enabled, there should be  no historical entries yet, but there should be history jobs
-        assertEquals(0, cmmnEngine.getCmmnHistoryService().createHistoricCaseInstanceQuery().count());
-        assertEquals(0, processEngine.getHistoryService().createHistoricProcessInstanceQuery().count());
-        
+        assertThat(cmmnEngine.getCmmnHistoryService().createHistoricCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(processEngine.getHistoryService().createHistoricProcessInstanceQuery().count()).isEqualTo(0);
+
         // 3 history jobs expected:
         // - one for the case instance start
         // - one for the plan item instance trigger
         // - one for the process instance start
-        assertEquals(3, cmmnEngine.getCmmnManagementService().createHistoryJobQuery().count());
-        assertEquals(3, processEngine.getManagementService().createHistoryJobQuery().count());
-        
+        assertThat(cmmnEngine.getCmmnManagementService().createHistoryJobQuery().count()).isEqualTo(3);
+        assertThat(processEngine.getManagementService().createHistoryJobQuery().count()).isEqualTo(3);
+
         // Expected 2 jobs originating from the cmmn engine and 1 for the process engine
         int cmmnHistoryJobs = 0;
         int bpmnHistoryJobs = 0;
@@ -108,31 +108,31 @@ public class CmmnEngineConfiguratorAsyncHistoryTest {
                     || historyJob.getJobHandlerType().equals(HistoryJsonConstants.JOB_HANDLER_TYPE_DEFAULT_ASYNC_HISTORY_ZIPPED)) {
                 bpmnHistoryJobs++;
             }
-            
+
             // Execution scope should be all (see the CmmnEngineConfigurator)
-            assertEquals(JobServiceConfiguration.JOB_EXECUTION_SCOPE_ALL, historyJob.getScopeType());
+            assertThat(historyJob.getScopeType()).isEqualTo(JobServiceConfiguration.JOB_EXECUTION_SCOPE_ALL);
         }
-        assertEquals(1, bpmnHistoryJobs);
-        assertEquals(2, cmmnHistoryJobs);
-        
+        assertThat(bpmnHistoryJobs).isEqualTo(1);
+        assertThat(cmmnHistoryJobs).isEqualTo(2);
+
         // Starting the async history executor should process all of these
         CmmnJobTestHelper.waitForAsyncHistoryExecutorToProcessAllJobs(cmmnEngine.getCmmnEngineConfiguration(), 10000L, 200L, true);
-        
-        assertEquals(1, cmmnEngine.getCmmnHistoryService().createHistoricCaseInstanceQuery().count());
-        assertEquals(1, processEngine.getHistoryService().createHistoricProcessInstanceQuery().count());
-        assertEquals(0, cmmnEngine.getCmmnManagementService().createHistoryJobQuery().count());
-        assertEquals(0, processEngine.getManagementService().createHistoryJobQuery().count());
+
+        assertThat(cmmnEngine.getCmmnHistoryService().createHistoricCaseInstanceQuery().count()).isEqualTo(1);
+        assertThat(processEngine.getHistoryService().createHistoricProcessInstanceQuery().count()).isEqualTo(1);
+        assertThat(cmmnEngine.getCmmnManagementService().createHistoryJobQuery().count()).isEqualTo(0);
+        assertThat(processEngine.getManagementService().createHistoryJobQuery().count()).isEqualTo(0);
     }
-    
+
     @Test
     public void testProcessAsyncHistoryNotChanged() {
         // This test validates that the shared async history executor does not intervene when running a process regularly
         processEngine.getRepositoryService().createDeployment().addClasspathResource("org/flowable/cmmn/test/oneTaskProcess.bpmn20.xml").deploy();
         processEngine.getRuntimeService().startProcessInstanceByKey("oneTask");
-        assertEquals(1, processEngine.getManagementService().createHistoryJobQuery().count());
-        
+        assertThat(processEngine.getManagementService().createHistoryJobQuery().count()).isEqualTo(1);
+
         HistoryJob historyJob = processEngine.getManagementService().createHistoryJobQuery().singleResult();
-        assertEquals(HistoryJsonConstants.JOB_HANDLER_TYPE_DEFAULT_ASYNC_HISTORY, historyJob.getJobHandlerType());
+        assertThat(historyJob.getJobHandlerType()).isEqualTo(HistoryJsonConstants.JOB_HANDLER_TYPE_DEFAULT_ASYNC_HISTORY);
         processEngine.getManagementService().executeHistoryJob(historyJob.getId());
     }
 

--- a/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/CmmnTimerTaskTest.java
+++ b/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/CmmnTimerTaskTest.java
@@ -12,9 +12,8 @@
  */
 package org.flowable.cmmn.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Date;
 import java.util.List;
@@ -38,69 +37,69 @@ import org.junit.Test;
  * @author Tijs Rademakers
  */
 public class CmmnTimerTaskTest extends AbstractProcessEngineIntegrationTest {
-    
+
     @Before
     public void deployTimerProcess() {
         if (cmmnRepositoryService.createDeploymentQuery().count() == 0) {
             cmmnRepositoryService.createDeployment().addClasspathResource("org/flowable/cmmn/test/timerInStage.cmmn").deploy();
         }
     }
-    
+
     @Test
     public void testCmmnTimerTask() {
         Date startTime = setCmmnClockFixedToCurrentTime();
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testTimerInStage").start();
-        
-        assertEquals(1L, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceState(PlanItemInstanceState.ACTIVE).count());
+
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceState(PlanItemInstanceState.ACTIVE)
+                .count()).isEqualTo(1L);
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.AVAILABLE)
                 .planItemDefinitionType(PlanItemDefinitionType.TIMER_EVENT_LISTENER)
                 .singleResult();
-        assertNotNull(planItemInstance);
-        
-        assertEquals(1L, cmmnTaskService.createTaskQuery().count());
-        
+        assertThat(planItemInstance).isNotNull();
+
+        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(1L);
+
         List<Job> timerJobs = processEngineManagementService.createTimerJobQuery().scopeId(caseInstance.getId()).scopeType(ScopeTypes.CMMN).list();
-        assertEquals(1, timerJobs.size());
+        assertThat(timerJobs).hasSize(1);
         String timerJobId = timerJobs.get(0).getId();
-        
+
         timerJobs = processEngineManagementService.createTimerJobQuery().scopeId(caseInstance.getId()).scopeType(ScopeTypes.CMMN).executable().list();
-        assertEquals(0, timerJobs.size());
-        
+        assertThat(timerJobs).isEmpty();
+
         processEngine.getProcessEngineConfiguration().getClock().setCurrentTime(new Date(startTime.getTime() + (3 * 60 * 60 * 1000 + 1)));
-        
+
         timerJobs = processEngineManagementService.createTimerJobQuery().scopeId(caseInstance.getId()).scopeType(ScopeTypes.CMMN).executable().list();
-        assertEquals(1, timerJobs.size());
-        
-        try {
-            JobTestHelper.waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(processEngine.getProcessEngineConfiguration(), processEngineManagementService, 7000, 200, true);
-            fail("should throw time limit exceeded");
-        } catch (FlowableException e) {
-            assertEquals("time limit of 7000 was exceeded", e.getMessage());
-        }
-        
+        assertThat(timerJobs).hasSize(1);
+
+        assertThatThrownBy(() -> JobTestHelper
+                .waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(processEngine.getProcessEngineConfiguration(), processEngineManagementService, 7000,
+                        200, true))
+                .isInstanceOf(FlowableException.class)
+                .hasMessage("time limit of 7000 was exceeded");
+
         // Timer fires after 3 hours, so setting it to 3 hours + 1 second
         cmmnEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + (3 * 60 * 60 * 1000 + 1)));
-        
+
         timerJobs = cmmnManagementService.createTimerJobQuery().caseInstanceId(caseInstance.getId()).executable().list();
-        assertEquals(1, timerJobs.size());
-        assertEquals(timerJobId, timerJobs.get(0).getId());
-        
+        assertThat(timerJobs).hasSize(1);
+        assertThat(timerJobs.get(0).getId()).isEqualTo(timerJobId);
+
         CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 7000L, 200L, true);
-        
+
         // User task should be active after the timer has triggered
         List<Task> tasks = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).orderByTaskName().asc().list();
-        assertEquals(2, tasks.size());
-        assertEquals("A", tasks.get(0).getName());
-        assertEquals("B", tasks.get(1).getName());
-        
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("A", "B");
+
         cmmnEngineConfiguration.resetClock();
         ((ProcessEngineConfigurationImpl) processEngine.getProcessEngineConfiguration()).resetClock();
-        
+
         for (CmmnDeployment deployment : cmmnRepositoryService.createDeploymentQuery().list()) {
             cmmnRepositoryService.deleteDeployment(deployment.getId(), true);
         }
     }
-    
+
 }

--- a/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/HumanTaskTest.java
+++ b/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/HumanTaskTest.java
@@ -12,8 +12,7 @@
  */
 package org.flowable.cmmn.test;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.cmmn.api.runtime.CaseInstance;
 import org.flowable.cmmn.engine.test.CmmnDeployment;
@@ -36,7 +35,7 @@ public class HumanTaskTest extends AbstractProcessEngineIntegrationTest {
     public void setup() {
         super.setupServices();
         FormEngineConfiguration formEngineConfiguration = (FormEngineConfiguration) processEngine.getProcessEngineConfiguration()
-            .getEngineConfigurations().get(EngineConfigurationConstants.KEY_FORM_ENGINE_CONFIG);
+                .getEngineConfigurations().get(EngineConfigurationConstants.KEY_FORM_ENGINE_CONFIG);
         this.formRepositoryService = formEngineConfiguration.getFormRepositoryService();
 
         formRepositoryService.createDeployment().addClasspathResource("org/flowable/cmmn/test/simple.form").deploy();
@@ -45,7 +44,7 @@ public class HumanTaskTest extends AbstractProcessEngineIntegrationTest {
     @After
     public void deleteFormDeployment() {
         this.formRepositoryService.createDeploymentQuery().list().forEach(
-            formDeployment -> formRepositoryService.deleteDeployment(formDeployment.getId())
+                formDeployment -> formRepositoryService.deleteDeployment(formDeployment.getId())
         );
     }
 
@@ -53,18 +52,19 @@ public class HumanTaskTest extends AbstractProcessEngineIntegrationTest {
     @CmmnDeployment(resources = "org/flowable/cmmn/test/CaseTaskTest.testCaseTask.cmmn")
     public void completeHumanTaskWithoutVariables() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("myCase").
-            start();
-        assertNotNull(caseInstance);
+                caseDefinitionKey("myCase").
+                start();
+        assertThat(caseInstance).isNotNull();
 
         Task caseTask = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
-        assertNotNull(caseTask);
+        assertThat(caseTask).isNotNull();
 
-        cmmnTaskService.completeTaskWithForm(caseTask.getId(), formRepositoryService.createFormDefinitionQuery().formDefinitionKey("form1").singleResult().getId(),
-            "__COMPLETE", null);
+        cmmnTaskService
+                .completeTaskWithForm(caseTask.getId(), formRepositoryService.createFormDefinitionQuery().formDefinitionKey("form1").singleResult().getId(),
+                        "__COMPLETE", null);
 
         CaseInstance dbCaseInstance = cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult();
-        assertNull(dbCaseInstance);
+        assertThat(dbCaseInstance).isNull();
     }
 
 }

--- a/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/ProcessTaskTest.java
+++ b/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/ProcessTaskTest.java
@@ -12,22 +12,15 @@
  */
 package org.flowable.cmmn.test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.tuple;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.assertj.core.api.Assertions;
 import org.flowable.cmmn.api.CallbackTypes;
 import org.flowable.cmmn.api.history.HistoricMilestoneInstance;
 import org.flowable.cmmn.api.repository.CaseDefinitionQuery;
@@ -66,35 +59,35 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
  * @author Filip Hrisafov
  */
 public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
-    
+
     @Before
     public void deployOneTaskProcess() {
         if (processEngineRepositoryService.createDeploymentQuery().count() == 0) {
             processEngineRepositoryService.createDeployment().addClasspathResource("org/flowable/cmmn/test/oneTaskProcess.bpmn20.xml").deploy();
         }
     }
-    
+
     @Test
     @CmmnDeployment
     public void testOneTaskProcessNonBlocking() {
         CaseInstance caseInstance = startCaseInstanceWithOneTaskProcess();
         List<Task> processTasks = processEngine.getTaskService().createTaskQuery().list();
-        assertEquals(1, processTasks.size());
-        
+        assertThat(processTasks).hasSize(1);
+
         // Non-blocking process task, plan item should have been completed
-        List<PlanItemInstance>  planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
+        List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .list();
-        assertEquals(1, planItemInstances.size());
-        assertEquals("Task Two", planItemInstances.get(0).getName());
-        
-        assertEquals(1, cmmnHistoryService.createHistoricMilestoneInstanceQuery().count());
-        
+        assertThat(planItemInstances)
+                .extracting(PlanItemInstance::getName)
+                .containsExactly("Task Two");
+        assertThat(cmmnHistoryService.createHistoricMilestoneInstanceQuery().count()).isEqualTo(1);
+
         processEngine.getTaskService().complete(processTasks.get(0).getId());
-        assertEquals(0, processEngineRuntimeService.createProcessInstanceQuery().count());
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
     }
-    
+
     @Test
     @CmmnDeployment
     public void testOneCallActivityProcessBlocking() {
@@ -102,34 +95,35 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
                 .addClasspathResource("org/flowable/cmmn/test/oneCallActivityProcess.bpmn20.xml")
                 .addClasspathResource("org/flowable/cmmn/test/oneTaskProcess.bpmn20.xml")
                 .deploy();
-        
+
         try {
             CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-                            .caseDefinitionKey("myCase")
-                            .start();
-             
+                    .caseDefinitionKey("myCase")
+                    .start();
+
             List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-                            .caseInstanceId(caseInstance.getId())
-                            .planItemInstanceState(PlanItemInstanceState.ACTIVE)
-                            .list();
-             
-            assertEquals(1, planItemInstances.size());
+                    .caseInstanceId(caseInstance.getId())
+                    .planItemInstanceState(PlanItemInstanceState.ACTIVE)
+                    .list();
+
+            assertThat(planItemInstances).hasSize(1);
             cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(0).getId());
 
             List<Task> processTasks = processEngine.getTaskService().createTaskQuery().list();
-            assertEquals(1, processTasks.size());
+            assertThat(processTasks).hasSize(1);
             Task processTask = processTasks.get(0);
             String subProcessInstanceId = processTask.getProcessInstanceId();
-            ProcessInstance processInstance = processEngine.getRuntimeService().createProcessInstanceQuery().subProcessInstanceId(subProcessInstanceId).singleResult();
-            
+            ProcessInstance processInstance = processEngine.getRuntimeService().createProcessInstanceQuery().subProcessInstanceId(subProcessInstanceId)
+                    .singleResult();
+
             Task task = cmmnTaskService.createTaskQuery().caseInstanceIdWithChildren(caseInstance.getId()).singleResult();
-            assertEquals(processTask.getId(), task.getId());
-            
+            assertThat(task.getId()).isEqualTo(processTask.getId());
+
             task = cmmnTaskService.createTaskQuery().processInstanceIdWithChildren(processInstance.getId()).singleResult();
-            assertEquals(processTask.getId(), task.getId());
-            
+            assertThat(task.getId()).isEqualTo(processTask.getId());
+
             List<EntityLink> entityLinks = cmmnRuntimeService.getEntityLinkChildrenForCaseInstance(caseInstance.getId());
-            assertEquals(3, entityLinks.size());
+            assertThat(entityLinks).hasSize(3);
             EntityLink processEntityLink = null;
             EntityLink subProcessEntityLink = null;
             EntityLink taskEntityLink = null;
@@ -140,86 +134,87 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
                     } else {
                         subProcessEntityLink = entityLink;
                     }
-                    
+
                 } else if (ScopeTypes.TASK.equals(entityLink.getReferenceScopeType())) {
                     taskEntityLink = entityLink;
                 }
             }
-            
-            assertEquals(EntityLinkType.CHILD, processEntityLink.getLinkType());
-            assertNotNull(processEntityLink.getCreateTime());
-            assertEquals(caseInstance.getId(), processEntityLink.getScopeId());
-            assertEquals(ScopeTypes.CMMN, processEntityLink.getScopeType());
-            assertNull(processEntityLink.getScopeDefinitionId());
-            assertEquals(processInstance.getId(), processEntityLink.getReferenceScopeId());
-            assertEquals(ScopeTypes.BPMN, processEntityLink.getReferenceScopeType());
-            assertNull(processEntityLink.getReferenceScopeDefinitionId());
-            assertEquals(HierarchyType.ROOT, processEntityLink.getHierarchyType());
-            
-            assertEquals(EntityLinkType.CHILD, subProcessEntityLink.getLinkType());
-            assertNotNull(subProcessEntityLink.getCreateTime());
-            assertEquals(caseInstance.getId(), subProcessEntityLink.getScopeId());
-            assertEquals(ScopeTypes.CMMN, subProcessEntityLink.getScopeType());
-            assertNull(subProcessEntityLink.getScopeDefinitionId());
-            assertEquals(subProcessInstanceId, subProcessEntityLink.getReferenceScopeId());
-            assertEquals(ScopeTypes.BPMN, subProcessEntityLink.getReferenceScopeType());
-            assertNull(subProcessEntityLink.getReferenceScopeDefinitionId());
-            assertEquals(HierarchyType.ROOT, subProcessEntityLink.getHierarchyType());
-            
-            assertEquals(EntityLinkType.CHILD, taskEntityLink.getLinkType());
-            assertNotNull(taskEntityLink.getCreateTime());
-            assertEquals(caseInstance.getId(), taskEntityLink.getScopeId());
-            assertEquals(ScopeTypes.CMMN, taskEntityLink.getScopeType());
-            assertNull(taskEntityLink.getScopeDefinitionId());
-            assertEquals(processTasks.get(0).getId(), taskEntityLink.getReferenceScopeId());
-            assertEquals(ScopeTypes.TASK, taskEntityLink.getReferenceScopeType());
-            assertNull(taskEntityLink.getReferenceScopeDefinitionId());
-            assertEquals(HierarchyType.ROOT, taskEntityLink.getHierarchyType());
-            
+
+            assertThat(processEntityLink.getLinkType()).isEqualTo(EntityLinkType.CHILD);
+            assertThat(processEntityLink.getCreateTime()).isNotNull();
+            assertThat(processEntityLink.getScopeId()).isEqualTo(caseInstance.getId());
+            assertThat(processEntityLink.getScopeType()).isEqualTo(ScopeTypes.CMMN);
+            assertThat(processEntityLink.getScopeDefinitionId()).isNull();
+            assertThat(processEntityLink.getReferenceScopeId()).isEqualTo(processInstance.getId());
+            assertThat(processEntityLink.getReferenceScopeType()).isEqualTo(ScopeTypes.BPMN);
+            assertThat(processEntityLink.getReferenceScopeDefinitionId()).isNull();
+            assertThat(processEntityLink.getHierarchyType()).isEqualTo(HierarchyType.ROOT);
+
+            assertThat(subProcessEntityLink.getLinkType()).isEqualTo(EntityLinkType.CHILD);
+            assertThat(subProcessEntityLink.getCreateTime()).isNotNull();
+            assertThat(subProcessEntityLink.getScopeId()).isEqualTo(caseInstance.getId());
+            assertThat(subProcessEntityLink.getScopeType()).isEqualTo(ScopeTypes.CMMN);
+            assertThat(subProcessEntityLink.getScopeDefinitionId()).isNull();
+            assertThat(subProcessEntityLink.getReferenceScopeId()).isEqualTo(subProcessInstanceId);
+            assertThat(subProcessEntityLink.getReferenceScopeType()).isEqualTo(ScopeTypes.BPMN);
+            assertThat(subProcessEntityLink.getReferenceScopeDefinitionId()).isNull();
+            assertThat(subProcessEntityLink.getHierarchyType()).isEqualTo(HierarchyType.ROOT);
+
+            assertThat(taskEntityLink.getLinkType()).isEqualTo(EntityLinkType.CHILD);
+            assertThat(taskEntityLink.getCreateTime()).isNotNull();
+            assertThat(taskEntityLink.getScopeId()).isEqualTo(caseInstance.getId());
+            assertThat(taskEntityLink.getScopeType()).isEqualTo(ScopeTypes.CMMN);
+            assertThat(taskEntityLink.getScopeDefinitionId()).isNull();
+            assertThat(taskEntityLink.getReferenceScopeId()).isEqualTo(processTasks.get(0).getId());
+            assertThat(taskEntityLink.getReferenceScopeType()).isEqualTo(ScopeTypes.TASK);
+            assertThat(taskEntityLink.getReferenceScopeDefinitionId()).isNull();
+            assertThat(taskEntityLink.getHierarchyType()).isEqualTo(HierarchyType.ROOT);
+
             entityLinks = processEngine.getRuntimeService().getEntityLinkChildrenForProcessInstance(processInstance.getId());
-            assertEquals(2, entityLinks.size());
-            
+            assertThat(entityLinks).hasSize(2);
+
             entityLinks = processEngine.getRuntimeService().getEntityLinkChildrenForProcessInstance(subProcessInstanceId);
-            assertEquals(1, entityLinks.size());
+            assertThat(entityLinks).hasSize(1);
             EntityLink entityLink = entityLinks.get(0);
-            assertEquals(EntityLinkType.CHILD, entityLink.getLinkType());
-            assertNotNull(entityLink.getCreateTime());
-            assertEquals(subProcessInstanceId, entityLink.getScopeId());
-            assertEquals(ScopeTypes.BPMN, entityLink.getScopeType());
-            assertNull(entityLink.getScopeDefinitionId());
-            assertEquals(processTasks.get(0).getId(), entityLink.getReferenceScopeId());
-            assertEquals(ScopeTypes.TASK, entityLink.getReferenceScopeType());
-            assertNull(entityLink.getReferenceScopeDefinitionId());
-            assertEquals(HierarchyType.PARENT, entityLink.getHierarchyType());
+            assertThat(entityLink.getLinkType()).isEqualTo(EntityLinkType.CHILD);
+            assertThat(entityLink.getCreateTime()).isNotNull();
+            assertThat(entityLink.getScopeId()).isEqualTo(subProcessInstanceId);
+            assertThat(entityLink.getScopeType()).isEqualTo(ScopeTypes.BPMN);
+            assertThat(entityLink.getScopeDefinitionId()).isNull();
+            assertThat(entityLink.getReferenceScopeId()).isEqualTo(processTasks.get(0).getId());
+            assertThat(entityLink.getReferenceScopeType()).isEqualTo(ScopeTypes.TASK);
+            assertThat(entityLink.getReferenceScopeDefinitionId()).isNull();
+            assertThat(entityLink.getHierarchyType()).isEqualTo(HierarchyType.PARENT);
 
             entityLinks = processEngine.getRuntimeService().getEntityLinkParentsForTask(processTask.getId());
-            assertEquals(3, entityLinks.size());
+            assertThat(entityLinks).hasSize(3);
             entityLink = entityLinks.get(0);
-            assertEquals(EntityLinkType.CHILD, entityLink.getLinkType());
-            assertNotNull(entityLink.getCreateTime());
+            assertThat(entityLink.getLinkType()).isEqualTo(EntityLinkType.CHILD);
+            assertThat(entityLink.getCreateTime()).isNotNull();
 
             processEngine.getTaskService().complete(processTasks.get(0).getId());
-            assertEquals(0, processEngineRuntimeService.createProcessInstanceQuery().count());
-            
+            assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+
             List<HistoricEntityLink> historicEntityLinks = cmmnHistoryService.getHistoricEntityLinkChildrenForCaseInstance(caseInstance.getId());
-            assertEquals(3, historicEntityLinks.size());
-            
+            assertThat(historicEntityLinks).hasSize(3);
+
             historicEntityLinks = processEngine.getHistoryService().getHistoricEntityLinkChildrenForProcessInstance(processInstance.getId());
-            assertEquals(2, historicEntityLinks.size());
-            
+            assertThat(historicEntityLinks).hasSize(2);
+
             historicEntityLinks = processEngine.getHistoryService().getHistoricEntityLinkChildrenForProcessInstance(subProcessInstanceId);
-            assertEquals(1, historicEntityLinks.size());
-            assertEquals(HierarchyType.PARENT, historicEntityLinks.get(0).getHierarchyType());
+            assertThat(historicEntityLinks).hasSize(1);
+            assertThat(historicEntityLinks.get(0).getHierarchyType()).isEqualTo(HierarchyType.PARENT);
 
             historicEntityLinks = processEngine.getHistoryService().getHistoricEntityLinkParentsForTask(processTasks.get(0).getId());
-            assertEquals(3, historicEntityLinks.size());
-            
-            HistoricTaskInstance historicTask = cmmnHistoryService.createHistoricTaskInstanceQuery().caseInstanceIdWithChildren(caseInstance.getId()).singleResult();
-            assertEquals(processTask.getId(), historicTask.getId());
-            
+            assertThat(historicEntityLinks).hasSize(3);
+
+            HistoricTaskInstance historicTask = cmmnHistoryService.createHistoricTaskInstanceQuery().caseInstanceIdWithChildren(caseInstance.getId())
+                    .singleResult();
+            assertThat(historicTask.getId()).isEqualTo(processTask.getId());
+
             historicTask = cmmnHistoryService.createHistoricTaskInstanceQuery().processInstanceIdWithChildren(processInstance.getId()).singleResult();
-            assertEquals(processTask.getId(), historicTask.getId());
-            
+            assertThat(historicTask.getId()).isEqualTo(processTask.getId());
+
         } finally {
             processEngine.getRepositoryService().deleteDeployment(deployment.getId(), true);
         }
@@ -229,65 +224,67 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
     @CmmnDeployment
     public void testOneTaskProcessBlocking() {
         CaseInstance caseInstance = startCaseInstanceWithOneTaskProcess();
-        
+
         Task task = processEngine.getTaskService().createTaskQuery().singleResult();
-        
+
         // Blocking process task, plan item should be in state ACTIVE
         List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .list();
-        assertEquals(1, planItemInstances.size());
-        assertEquals("The Process", planItemInstances.get(0).getName());
-        assertNotNull(planItemInstances.get(0).getReferenceId());
-        assertEquals(ReferenceTypes.PLAN_ITEM_CHILD_PROCESS, planItemInstances.get(0).getReferenceType());
-        assertEquals(0, cmmnHistoryService.createHistoricMilestoneInstanceQuery().count());
+        assertThat(planItemInstances).hasSize(1);
+        assertThat(planItemInstances.get(0).getName()).isEqualTo("The Process");
+        assertThat(planItemInstances.get(0).getReferenceId()).isNotNull();
+        assertThat(planItemInstances.get(0).getReferenceType()).isEqualTo(ReferenceTypes.PLAN_ITEM_CHILD_PROCESS);
+        assertThat(cmmnHistoryService.createHistoricMilestoneInstanceQuery().count()).isEqualTo(0);
 
         ProcessInstance processInstance = processEngine.getRuntimeService().createProcessInstanceQuery().singleResult();
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
-        PlanItemInstance processTaskPlanItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.PROCESS_TASK).singleResult();
-        assertEquals(processTaskPlanItemInstance.getId(), processInstance.getCallbackId());
-        assertEquals(CallbackTypes.PLAN_ITEM_CHILD_PROCESS, processInstance.getCallbackType());
+        PlanItemInstance processTaskPlanItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
+                .planItemDefinitionType(PlanItemDefinitionType.PROCESS_TASK).singleResult();
+        assertThat(processInstance.getCallbackId()).isEqualTo(processTaskPlanItemInstance.getId());
+        assertThat(processInstance.getCallbackType()).isEqualTo(CallbackTypes.PLAN_ITEM_CHILD_PROCESS);
 
-        assertEquals(processInstance.getId(), processEngine.getRuntimeService().createProcessInstanceQuery()
-            .processInstanceCallbackId(processInstance.getCallbackId()).singleResult().getId());
-        assertEquals(processInstance.getId(), processEngine.getRuntimeService().createProcessInstanceQuery()
-            .processInstanceCallbackType(CallbackTypes.PLAN_ITEM_CHILD_PROCESS).singleResult().getId());
-        assertEquals(processInstance.getId(), processEngine.getRuntimeService().createProcessInstanceQuery()
-            .processInstanceCallbackId(processTaskPlanItemInstance.getId())
-            .processInstanceCallbackType(CallbackTypes.PLAN_ITEM_CHILD_PROCESS).singleResult().getId());
+        assertThat(processEngine.getRuntimeService().createProcessInstanceQuery()
+                .processInstanceCallbackId(processInstance.getCallbackId()).singleResult().getId()).isEqualTo(processInstance.getId());
+        assertThat(processEngine.getRuntimeService().createProcessInstanceQuery()
+                .processInstanceCallbackType(CallbackTypes.PLAN_ITEM_CHILD_PROCESS).singleResult().getId()).isEqualTo(processInstance.getId());
+        assertThat(processEngine.getRuntimeService().createProcessInstanceQuery()
+                .processInstanceCallbackId(processTaskPlanItemInstance.getId())
+                .processInstanceCallbackType(CallbackTypes.PLAN_ITEM_CHILD_PROCESS).singleResult().getId()).isEqualTo(processInstance.getId());
 
         if (processEngine.getProcessEngineConfiguration().getHistoryLevel().isAtLeast(HistoryLevel.ACTIVITY)) {
             HistoricProcessInstance historicProcessInstance = processEngine.getHistoryService().createHistoricProcessInstanceQuery()
                     .processInstanceId(processInstance.getId()).singleResult();
-            assertEquals(processInstance.getCallbackId(), historicProcessInstance.getCallbackId());
-            assertEquals(processInstance.getCallbackType(), historicProcessInstance.getCallbackType());
+            assertThat(historicProcessInstance.getCallbackId()).isEqualTo(processInstance.getCallbackId());
+            assertThat(historicProcessInstance.getCallbackType()).isEqualTo(processInstance.getCallbackType());
 
-            assertEquals(processInstance.getId(), processEngine.getHistoryService().createHistoricProcessInstanceQuery()
-                .processInstanceCallbackId(processInstance.getCallbackId()).singleResult().getId());
-            assertEquals(processInstance.getId(), processEngine.getHistoryService().createHistoricProcessInstanceQuery()
-                .processInstanceCallbackType(CallbackTypes.PLAN_ITEM_CHILD_PROCESS).singleResult().getId());
-            assertEquals(processInstance.getId(), processEngine.getHistoryService().createHistoricProcessInstanceQuery()
-                .processInstanceCallbackId(processTaskPlanItemInstance.getId())
-                .processInstanceCallbackType(CallbackTypes.PLAN_ITEM_CHILD_PROCESS).singleResult().getId());
+            assertThat(processEngine.getHistoryService().createHistoricProcessInstanceQuery()
+                    .processInstanceCallbackId(processInstance.getCallbackId()).singleResult().getId()).isEqualTo(processInstance.getId());
+            assertThat(processEngine.getHistoryService().createHistoricProcessInstanceQuery()
+                    .processInstanceCallbackType(CallbackTypes.PLAN_ITEM_CHILD_PROCESS).singleResult().getId()).isEqualTo(processInstance.getId());
+            assertThat(processEngine.getHistoryService().createHistoricProcessInstanceQuery()
+                    .processInstanceCallbackId(processTaskPlanItemInstance.getId())
+                    .processInstanceCallbackType(CallbackTypes.PLAN_ITEM_CHILD_PROCESS).singleResult().getId()).isEqualTo(processInstance.getId());
         }
-        
+
         // Completing task will trigger completion of process task plan item
         processEngine.getTaskService().complete(task.getId());
-        
+
         planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .list();
-        assertEquals(1, planItemInstances.size());
-        assertEquals("Task Two", planItemInstances.get(0).getName());
-        assertEquals(1, cmmnHistoryService.createHistoricMilestoneInstanceQuery().count());
+        assertThat(planItemInstances)
+                .extracting(PlanItemInstance::getName)
+                .containsExactly("Task Two");
+        assertThat(cmmnHistoryService.createHistoricMilestoneInstanceQuery().count()).isEqualTo(1);
     }
 
     @Test
     @CmmnDeployment(tenantId = "flowable",
-    resources = "org/flowable/cmmn/test/ProcessTaskTest.testOneTaskProcessBlocking.cmmn")
+            resources = "org/flowable/cmmn/test/ProcessTaskTest.testOneTaskProcessBlocking.cmmn")
     public void testOneTaskProcessBlockingWithTenant() {
         try {
             if (processEngineRepositoryService.createDeploymentQuery().count() == 1) {
@@ -302,10 +299,10 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
             CaseInstance caseInstance = startCaseInstanceWithOneTaskProcess("flowable");
 
             ProcessInstance processInstance = processEngine.getRuntimeService().createProcessInstanceQuery().singleResult();
-            assertEquals("flowable", processInstance.getTenantId());
+            assertThat(processInstance.getTenantId()).isEqualTo("flowable");
 
             Task task = processEngine.getTaskService().createTaskQuery().singleResult();
-            assertEquals("flowable", task.getTenantId());
+            assertThat(task.getTenantId()).isEqualTo("flowable");
 
             this.cmmnRuntimeService.terminateCaseInstance(caseInstance.getId());
         } finally {
@@ -314,7 +311,8 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
                 processEngineRepositoryService.deleteDeployment(deployment.getId());
             }
             if (processEngine.getProcessEngineConfiguration().getHistoryService().createHistoricTaskInstanceQuery().count() == 1) {
-                HistoricTaskInstance historicTaskInstance = processEngine.getProcessEngineConfiguration().getHistoryService().createHistoricTaskInstanceQuery().singleResult();
+                HistoricTaskInstance historicTaskInstance = processEngine.getProcessEngineConfiguration().getHistoryService().createHistoricTaskInstanceQuery()
+                        .singleResult();
                 processEngine.getProcessEngineConfiguration().getHistoryService().deleteHistoricTaskInstance(historicTaskInstance.getId());
             }
 
@@ -326,7 +324,7 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
             }
         }
     }
-    
+
     @Test
     @CmmnDeployment(resources = "org/flowable/cmmn/test/ProcessTaskTest.testOneTaskProcessBlocking.cmmn")
     public void testTwoTaskProcessBlocking() {
@@ -342,8 +340,8 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
             CaseInstance caseInstance = startCaseInstanceWithOneTaskProcess();
 
             Task task = processEngineTaskService.createTaskQuery().singleResult();
-            assertEquals("my task", task.getName());
-            
+            assertThat(task.getName()).isEqualTo("my task");
+
             EntityLink taskEntityLink = null;
             List<EntityLink> entityLinks = cmmnRuntimeService.getEntityLinkChildrenForCaseInstance(caseInstance.getId());
             for (EntityLink entityLink : entityLinks) {
@@ -351,17 +349,17 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
                     taskEntityLink = entityLink;
                 }
             }
-            
-            assertNotNull(taskEntityLink);
-            assertEquals(task.getId(), taskEntityLink.getReferenceScopeId());
-            assertEquals(ScopeTypes.TASK, taskEntityLink.getReferenceScopeType());
-            assertEquals(HierarchyType.ROOT, taskEntityLink.getHierarchyType());
-            
+
+            assertThat(taskEntityLink).isNotNull();
+            assertThat(taskEntityLink.getReferenceScopeId()).isEqualTo(task.getId());
+            assertThat(taskEntityLink.getReferenceScopeType()).isEqualTo(ScopeTypes.TASK);
+            assertThat(taskEntityLink.getHierarchyType()).isEqualTo(HierarchyType.ROOT);
+
             processEngineTaskService.complete(task.getId());
-            
+
             Task task2 = processEngineTaskService.createTaskQuery().singleResult();
-            assertEquals("my task2", task2.getName());
-            
+            assertThat(task2.getName()).isEqualTo("my task2");
+
             EntityLink taskEntityLink2 = null;
             entityLinks = cmmnRuntimeService.getEntityLinkChildrenForCaseInstance(caseInstance.getId());
             for (EntityLink entityLink : entityLinks) {
@@ -369,26 +367,27 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
                     taskEntityLink2 = entityLink;
                 }
             }
-            
-            assertNotNull(taskEntityLink2);
-            assertEquals(task2.getId(), taskEntityLink2.getReferenceScopeId());
-            assertEquals(ScopeTypes.TASK, taskEntityLink2.getReferenceScopeType());
-            assertEquals(HierarchyType.ROOT, taskEntityLink2.getHierarchyType());
-            
+
+            assertThat(taskEntityLink2).isNotNull();
+            assertThat(taskEntityLink2.getReferenceScopeId()).isEqualTo(task2.getId());
+            assertThat(taskEntityLink2.getReferenceScopeType()).isEqualTo(ScopeTypes.TASK);
+            assertThat(taskEntityLink2.getHierarchyType()).isEqualTo(HierarchyType.ROOT);
+
             processEngineTaskService.complete(task2.getId());
-            
+
             List<ProcessInstance> processInstances = processEngineRuntimeService.createProcessInstanceQuery().processDefinitionKey("oneTask").list();
-            assertEquals(0, processInstances.size());
+            assertThat(processInstances).isEmpty();
 
             this.cmmnRuntimeService.terminateCaseInstance(caseInstance.getId());
-            
+
         } finally {
             if (processEngineRepositoryService.createDeploymentQuery().count() == 1) {
                 Deployment deployment = processEngineRepositoryService.createDeploymentQuery().singleResult();
                 processEngineRepositoryService.deleteDeployment(deployment.getId(), true);
             }
             if (processEngine.getProcessEngineConfiguration().getHistoryService().createHistoricTaskInstanceQuery().count() == 1) {
-                HistoricTaskInstance historicTaskInstance = processEngine.getProcessEngineConfiguration().getHistoryService().createHistoricTaskInstanceQuery().singleResult();
+                HistoricTaskInstance historicTaskInstance = processEngine.getProcessEngineConfiguration().getHistoryService().createHistoricTaskInstanceQuery()
+                        .singleResult();
                 processEngine.getProcessEngineConfiguration().getHistoryService().deleteHistoricTaskInstance(historicTaskInstance.getId());
             }
         }
@@ -400,22 +399,23 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
         Map<String, Object> variables = new HashMap<>();
         variables.put("processDefinitionKey", "oneTask");
         cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionId(cmmnRepositoryService.createCaseDefinitionQuery().singleResult().getId())
-            .variables(variables)
-            .start();
-        
+                .caseDefinitionId(cmmnRepositoryService.createCaseDefinitionQuery().singleResult().getId())
+                .variables(variables)
+                .start();
+
         Task task = processEngine.getTaskService().createTaskQuery().singleResult();
-        assertNotNull(task);
-        
+        assertThat(task).isNotNull();
+
         // Completing task will trigger completion of process task plan item
         processEngine.getTaskService().complete(task.getId());
-        
+
         List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .planItemInstanceStateActive()
                 .list();
-        assertEquals(1, planItemInstances.size());
-        assertEquals("Task Two", planItemInstances.get(0).getName());
-        assertEquals(1, cmmnHistoryService.createHistoricMilestoneInstanceQuery().count());
+        assertThat(planItemInstances)
+                .extracting(PlanItemInstance::getName)
+                .containsExactly("Task Two");
+        assertThat(cmmnHistoryService.createHistoricMilestoneInstanceQuery().count()).isEqualTo(1);
     }
 
     @Test
@@ -430,7 +430,7 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
                 .start();
 
         Task task = processEngine.getTaskService().createTaskQuery().singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
 
         // Completing task will trigger completion of process task plan item
         processEngine.getTaskService().complete(task.getId());
@@ -439,10 +439,11 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
                 .planItemInstanceStateActive()
                 .list();
 
-        assertEquals(1, planItemInstances.size());
-        assertEquals("Task Two", planItemInstances.get(0).getName());
-        assertEquals(123, cmmnRuntimeService.getVariable(caseInstance.getId(), "num3"));
-        assertEquals(1, cmmnHistoryService.createHistoricMilestoneInstanceQuery().count());
+        assertThat(planItemInstances)
+                .extracting(PlanItemInstance::getName)
+                .containsExactly("Task Two");
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "num3")).isEqualTo(123);
+        assertThat(cmmnHistoryService.createHistoricMilestoneInstanceQuery().count()).isEqualTo(1);
 
     }
 
@@ -450,18 +451,18 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
     @CmmnDeployment
     public void testProcessIOParameterExpressions() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionId(cmmnRepositoryService.createCaseDefinitionQuery().singleResult().getId())
-            .variable("processDefinitionKey", "oneTask")
-            .start();
+                .caseDefinitionId(cmmnRepositoryService.createCaseDefinitionQuery().singleResult().getId())
+                .variable("processDefinitionKey", "oneTask")
+                .start();
 
         Task task = processEngine.getTaskService().createTaskQuery().singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
 
         // Completing task will trigger completion of process task plan item
-        assertEquals(2L, ((Number) processEngine.getRuntimeService().getVariable(task.getProcessInstanceId(), "numberVariable")).longValue());
+        assertThat(((Number) processEngine.getRuntimeService().getVariable(task.getProcessInstanceId(), "numberVariable")).longValue()).isEqualTo(2L);
         processEngine.getTaskService().complete(task.getId(), Collections.singletonMap("processVariable", "Hello World"));
 
-        assertEquals("Hello World", cmmnRuntimeService.getVariable(caseInstance.getId(), "stringVariable"));
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "stringVariable")).isEqualTo("Hello World");
 
     }
 
@@ -469,29 +470,29 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
     @CmmnDeployment
     public void testIOParameterCombinations() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("testProcessTaskParameterExpressions")
-            .variable("caseVariableA", "variable A from the case instance")
-            .variable("caseVariableName1", "aCaseString1")
-            .variable("caseVariableName2", "aCaseString2")
-            .start();
+                .caseDefinitionKey("testProcessTaskParameterExpressions")
+                .variable("caseVariableA", "variable A from the case instance")
+                .variable("caseVariableName1", "aCaseString1")
+                .variable("caseVariableName2", "aCaseString2")
+                .start();
 
         PlanItemInstance processTaskPlanItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .planItemDefinitionType(PlanItemDefinitionType.PROCESS_TASK)
-            .singleResult();
+                .caseInstanceId(caseInstance.getId())
+                .planItemDefinitionType(PlanItemDefinitionType.PROCESS_TASK)
+                .singleResult();
         String processInstanceId = processTaskPlanItemInstance.getReferenceId();
         ProcessInstance processInstance = processEngineRuntimeService.createProcessInstanceQuery().processInstanceId(processInstanceId).singleResult();
-        Assertions.assertThat(processInstance).isNotNull();
+        assertThat(processInstance).isNotNull();
 
         // In parameters
-        Assertions.assertThat(processEngineRuntimeService.getVariable(processInstanceId, "caseVariableA")).isNull();
-        Assertions.assertThat(processEngineRuntimeService.getVariable(processInstanceId, "caseVariableName1")).isNull();
-        Assertions.assertThat(processEngineRuntimeService.getVariable(processInstanceId, "caseVariableName2")).isNull();
+        assertThat(processEngineRuntimeService.getVariable(processInstanceId, "caseVariableA")).isNull();
+        assertThat(processEngineRuntimeService.getVariable(processInstanceId, "caseVariableName1")).isNull();
+        assertThat(processEngineRuntimeService.getVariable(processInstanceId, "caseVariableName2")).isNull();
 
-        Assertions.assertThat(processEngineRuntimeService.getVariable(processInstanceId, "processVariableA")).isEqualTo("variable A from the case instance");
-        Assertions.assertThat(processEngineRuntimeService.getVariable(processInstanceId, "aCaseString1")).isEqualTo("variable A from the case instance");
-        Assertions.assertThat(processEngineRuntimeService.getVariable(processInstanceId, "processVariableB")).isEqualTo(2L);
-        Assertions.assertThat(processEngineRuntimeService.getVariable(processInstanceId, "aCaseString2")).isEqualTo(4L);
+        assertThat(processEngineRuntimeService.getVariable(processInstanceId, "processVariableA")).isEqualTo("variable A from the case instance");
+        assertThat(processEngineRuntimeService.getVariable(processInstanceId, "aCaseString1")).isEqualTo("variable A from the case instance");
+        assertThat(processEngineRuntimeService.getVariable(processInstanceId, "processVariableB")).isEqualTo(2L);
+        assertThat(processEngineRuntimeService.getVariable(processInstanceId, "aCaseString2")).isEqualTo(4L);
 
         // Out parameters
         Task task = processEngineTaskService.createTaskQuery().processInstanceId(processInstanceId).singleResult();
@@ -502,26 +503,28 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
         variables.put("processVariableName2", "processString2");
         processEngineTaskService.complete(task.getId(), variables);
 
-        Assertions.assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "processVariableC")).isNull();
-        Assertions.assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "processVariableD")).isNull();
-        Assertions.assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "processVariableName1")).isNull();
-        Assertions.assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "processVariableName2")).isNull();
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "processVariableC")).isNull();
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "processVariableD")).isNull();
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "processVariableName1")).isNull();
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "processVariableName2")).isNull();
 
-        Assertions.assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "caseVariableC")).isEqualTo("hello");
-        Assertions.assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "processString1")).isEqualTo("hello");
-        Assertions.assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "caseVariableD")).isEqualTo(124L);
-        Assertions.assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "processString2")).isEqualTo(6L);
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "caseVariableC")).isEqualTo("hello");
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "processString1")).isEqualTo("hello");
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "caseVariableD")).isEqualTo(124L);
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "processString2")).isEqualTo(6L);
 
-        Assertions.assertThat(cmmnRuntimeService.getVariables(caseInstance.getId())).hasSize(3 + 4); // 3 from start, 4 from out mapping
-        Assertions.assertThat(processEngineHistoryService.createHistoricVariableInstanceQuery().processInstanceId(processInstanceId).list()).hasSize(4 + 4); // 4 from in mapping, 4 from task complete
+        assertThat(cmmnRuntimeService.getVariables(caseInstance.getId())).hasSize(3 + 4); // 3 from start, 4 from out mapping
+        assertThat(processEngineHistoryService.createHistoricVariableInstanceQuery().processInstanceId(processInstanceId).list())
+                .hasSize(4 + 4); // 4 from in mapping, 4 from task complete
     }
-    
+
     @Test
     @CmmnDeployment
     public void testProcessTaskWithSkipExpressions() {
         processEngineRepositoryService.createDeployment().addClasspathResource("org/flowable/cmmn/test/processWithSkipExpressions.bpmn20.xml").deploy();
 
-        ProcessDefinition processDefinition = processEngineRepositoryService.createProcessDefinitionQuery().processDefinitionKey("testSkipExpressionProcess").singleResult();
+        ProcessDefinition processDefinition = processEngineRepositoryService.createProcessDefinitionQuery().processDefinitionKey("testSkipExpressionProcess")
+                .singleResult();
         ObjectNode infoNode = processEngineDynamicBpmnService.enableSkipExpression();
 
         // skip test user task
@@ -530,116 +533,116 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
 
         cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("skipExpressionCaseTest").start();
 
-        assertTrue(processEngineTaskService.createTaskQuery().list().isEmpty());
-        assertTrue(processEngineRuntimeService.createProcessInstanceQuery().list().isEmpty());
+        assertThat(processEngineTaskService.createTaskQuery().list().isEmpty()).isTrue();
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().list().isEmpty()).isTrue();
     }
-    
+
     @Test
     @CmmnDeployment
     public void testProcessTaskWithInclusiveGateway() {
-        Deployment deployment = processEngineRepositoryService.createDeployment().addClasspathResource("org/flowable/cmmn/test/processWithInclusiveGateway.bpmn20.xml").deploy();
+        Deployment deployment = processEngineRepositoryService.createDeployment()
+                .addClasspathResource("org/flowable/cmmn/test/processWithInclusiveGateway.bpmn20.xml").deploy();
         try {
             CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("myCase").start();
-            assertEquals(0, cmmnHistoryService.createHistoricMilestoneInstanceQuery().count());
-            assertEquals(0, processEngineRuntimeService.createProcessInstanceQuery().count());
+            assertThat(cmmnHistoryService.createHistoricMilestoneInstanceQuery().count()).isEqualTo(0);
+            assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
 
             List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
                     .caseInstanceId(caseInstance.getId())
                     .planItemDefinitionId("theTask")
                     .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                     .list();
-            assertEquals(1, planItemInstances.size());
+            assertThat(planItemInstances).hasSize(1);
             cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(0).getId());
-            assertEquals("No process instance started", 1L, processEngineRuntimeService.createProcessInstanceQuery().count());
-            
-            assertEquals(2, processEngineTaskService.createTaskQuery().count());
-            
+            assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).as("No process instance started").isEqualTo(1L);
+
+            assertThat(processEngineTaskService.createTaskQuery().count()).isEqualTo(2);
+
             List<Task> tasks = processEngineTaskService.createTaskQuery().list();
             processEngine.getTaskService().complete(tasks.get(0).getId());
             processEngine.getTaskService().complete(tasks.get(1).getId());
-            
-            assertEquals(0, processEngineTaskService.createTaskQuery().count());
-            assertEquals(0, processEngineRuntimeService.createProcessInstanceQuery().count());
-            
+
+            assertThat(processEngineTaskService.createTaskQuery().count()).isEqualTo(0);
+            assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+
             planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
                     .caseInstanceId(caseInstance.getId())
                     .planItemDefinitionId("theTask2")
                     .list();
-            assertEquals(1, planItemInstances.size());
-            assertEquals("Task Two", planItemInstances.get(0).getName());
-            assertEquals(PlanItemInstanceState.ENABLED, planItemInstances.get(0).getState());
-            
+            assertThat(planItemInstances)
+                    .extracting(PlanItemInstance::getName, PlanItemInstance::getState)
+                    .containsExactly(tuple("Task Two", PlanItemInstanceState.ENABLED));
+
         } finally {
             processEngineRepositoryService.deleteDeployment(deployment.getId(), true);
         }
     }
-    
+
     protected CaseInstance startCaseInstanceWithOneTaskProcess() {
         return startCaseInstanceWithOneTaskProcess(null);
     }
-    
+
     protected CaseInstance startCaseInstanceWithOneTaskProcess(String tenantId) {
         CaseDefinitionQuery caseDefinitionQuery = cmmnRepositoryService.createCaseDefinitionQuery();
         if (tenantId != null) {
             caseDefinitionQuery.caseDefinitionTenantId(tenantId);
         }
-        
+
         String caseDefinitionId = caseDefinitionQuery.singleResult().getId();
         CaseInstanceBuilder caseInstanceBuilder = cmmnRuntimeService.createCaseInstanceBuilder().
                 caseDefinitionId(caseDefinitionId);
         if (tenantId != null) {
             caseInstanceBuilder.tenantId(tenantId);
         }
-        
+
         CaseInstance caseInstance = caseInstanceBuilder.start();
 
-        assertEquals(0, cmmnHistoryService.createHistoricMilestoneInstanceQuery().count());
-        assertEquals(0, processEngineRuntimeService.createProcessInstanceQuery().count());
+        assertThat(cmmnHistoryService.createHistoricMilestoneInstanceQuery().count()).isEqualTo(0);
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
 
         List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .list();
-        assertEquals(1, planItemInstances.size());
+        assertThat(planItemInstances).hasSize(1);
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(0).getId());
-        assertEquals("No process instance started", 1L, processEngineRuntimeService.createProcessInstanceQuery().count());
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).as("No process instance started").isEqualTo(1L);
         return caseInstance;
     }
 
     @Test
     @CmmnDeployment
     public void testTransactionRollback() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionId(cmmnRepositoryService.createCaseDefinitionQuery().singleResult().getId()).start();
-        
-        PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionId(cmmnRepositoryService.createCaseDefinitionQuery().singleResult().getId()).start();
+
+        final PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .singleResult();
-        assertEquals("Task One", planItemInstance.getName());
-        assertEquals(0, processEngineRuntimeService.createProcessInstanceQuery().count());
-        
+        assertThat(planItemInstance.getName()).isEqualTo("Task One");
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+
         /*
          * Triggering the plan item will lead to the plan item that starts the one task process in a non-blocking way.
          * Due to the non-blocking, the plan item completes and the new task, mile stone and service task are called.
-         * The service task throws an exception. The process should also roll back now and never have been inserted. 
+         * The service task throws an exception. The process should also roll back now and never have been inserted.
          */
-        try {
-            cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
-            fail();
-        } catch (Exception e) { }
-        
+        assertThatThrownBy(() -> cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId()))
+                .isInstanceOf(RuntimeException.class);
+
         // Without shared transaction, following would be 1
-        assertEquals(0, processEngineRuntimeService.createProcessInstanceQuery().count());
-        
-        planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+
+        PlanItemInstance planItemInstance2 = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .singleResult();
-        
+
         // Both case and process should have rolled back
-        assertEquals("Task One", planItemInstance.getName());
+        assertThat(planItemInstance2.getName()).isEqualTo("Task One");
     }
-    
+
     @Test
     @CmmnDeployment
     public void testTriggerUnfinishedProcessPlanItem() {
@@ -648,234 +651,230 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
                 .caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .singleResult();
-        assertEquals("The Process", planItemInstance.getName());
-        assertEquals("my task", processEngine.getTaskService().createTaskQuery().singleResult().getName());
-        
+        assertThat(planItemInstance.getName()).isEqualTo("The Process");
+        assertThat(processEngine.getTaskService().createTaskQuery().singleResult().getName()).isEqualTo("my task");
+
         // Triggering the process plan item should cancel the process instance
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
-        assertEquals(0, processEngine.getTaskService().createTaskQuery().count());
-        assertEquals(0, processEngineRuntimeService.createProcessInstanceQuery().count());
+        assertThat(processEngine.getTaskService().createTaskQuery().count()).isEqualTo(0);
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
 
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
         HistoricMilestoneInstance historicMilestoneInstance = cmmnHistoryService.createHistoricMilestoneInstanceQuery().singleResult();
-        assertEquals("Process planitem done", historicMilestoneInstance.getName());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
+        assertThat(historicMilestoneInstance.getName()).isEqualTo("Process planitem done");
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
-    
+
     @Test
     @CmmnDeployment
     public void testStartProcessInstanceNonBlockingAndCaseInstanceFinished() {
         cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("myCase").start();
-        
-        assertEquals(1, processEngine.getTaskService().createTaskQuery().count());
-        assertEquals(1, processEngineRuntimeService.createProcessInstanceQuery().count());
 
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().count());
+        assertThat(processEngine.getTaskService().createTaskQuery().count()).isEqualTo(1);
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(1);
+
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
         HistoricMilestoneInstance historicMilestoneInstance = cmmnHistoryService.createHistoricMilestoneInstanceQuery().singleResult();
-        assertEquals("Process planitem done", historicMilestoneInstance.getName());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
+        assertThat(historicMilestoneInstance.getName()).isEqualTo("Process planitem done");
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
-    
+
     @Test
     @CmmnDeployment
     public void testStartMultipleProcessInstancesBlocking() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("myCase").start();
-        
+
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .singleResult();
-        assertEquals("Task One", planItemInstance.getName());
+        assertThat(planItemInstance.getName()).isEqualTo("Task One");
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
-        
-        assertEquals(4, processEngine.getTaskService().createTaskQuery().count());
-        assertEquals(4, processEngineRuntimeService.createProcessInstanceQuery().count());
-        
+
+        assertThat(processEngine.getTaskService().createTaskQuery().count()).isEqualTo(4);
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(4);
+
         // Completing all the tasks should lead to the milestone
         for (Task task : processEngineTaskService.createTaskQuery().list()) {
             processEngineTaskService.complete(task.getId());
         }
-        
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().count());
+
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
         HistoricMilestoneInstance historicMilestoneInstance = cmmnHistoryService.createHistoricMilestoneInstanceQuery().singleResult();
-        assertEquals("Processes done", historicMilestoneInstance.getName());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
+        assertThat(historicMilestoneInstance.getName()).isEqualTo("Processes done");
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
-    
+
     @Test
     @CmmnDeployment
     public void testTerminateCaseInstanceWithBlockingProcessTask() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("myCase").start();
-        assertEquals(8, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count());
-        assertEquals(3, cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
-                .planItemInstanceState(PlanItemInstanceState.ACTIVE).count());
-        
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(8);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
+                .planItemInstanceState(PlanItemInstanceState.ACTIVE).count()).isEqualTo(3);
+
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .planItemInstanceName("Task One")
                 .singleResult();
-        assertNotNull(planItemInstance);
-        
+        assertThat(planItemInstance).isNotNull();
+
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
-        
-        assertEquals(4, processEngine.getTaskService().createTaskQuery().count());
-        assertEquals(4, processEngineRuntimeService.createProcessInstanceQuery().count());
-        
-        assertEquals(0, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
+
+        assertThat(processEngine.getTaskService().createTaskQuery().count()).isEqualTo(4);
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(4);
+
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(0);
         cmmnRuntimeService.terminateCaseInstance(caseInstance.getId());
-        
-        assertEquals(0, cmmnRuntimeService.createPlanItemInstanceQuery().count());
-        assertEquals(0, processEngine.getTaskService().createTaskQuery().count());
-        assertEquals(0, processEngineRuntimeService.createProcessInstanceQuery().count());
-        assertEquals(1, cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count());
+
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
+        assertThat(processEngine.getTaskService().createTaskQuery().count()).isEqualTo(0);
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
     @Test
     @CmmnDeployment(resources = {
-        "org/flowable/cmmn/test/ProcessTaskTest.testParentStageTerminatedBeforeProcessStarted.cmmn",
-        "org/flowable/cmmn/test/oneTaskProcess.bpmn20.xml"
+            "org/flowable/cmmn/test/ProcessTaskTest.testParentStageTerminatedBeforeProcessStarted.cmmn",
+            "org/flowable/cmmn/test/oneTaskProcess.bpmn20.xml"
     })
     public void testParentStageTerminatedBeforeProcessStarted() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testProcessTask").start();
 
         Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
-        assertEquals("A", task.getName());
+        assertThat(task.getName()).isEqualTo("A");
 
-        UserEventListenerInstance userEventListenerInstance = cmmnRuntimeService.createUserEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult();
-        assertEquals("Complete stage", userEventListenerInstance.getName());
+        UserEventListenerInstance userEventListenerInstance = cmmnRuntimeService.createUserEventListenerInstanceQuery().caseInstanceId(caseInstance.getId())
+                .singleResult();
+        assertThat(userEventListenerInstance.getName()).isEqualTo("Complete stage");
         cmmnRuntimeService.completeUserEventListenerInstance(userEventListenerInstance.getId());
 
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
     }
 
     @Test
     @CmmnDeployment(
-        resources = {"org/flowable/cmmn/test/ProcessTaskTest.testOneTaskProcessFallbackToDefaultTenant.cmmn"},
-        tenantId = "flowable"
+            resources = { "org/flowable/cmmn/test/ProcessTaskTest.testOneTaskProcessFallbackToDefaultTenant.cmmn" },
+            tenantId = "flowable"
     )
     public void testOneTaskProcessFallbackToDefaultTenant() {
         Deployment deployment = this.processEngineRepositoryService.createDeployment().
-            addClasspathResource("org/flowable/cmmn/test/oneTaskProcess.bpmn20.xml").
-            deploy();
+                addClasspathResource("org/flowable/cmmn/test/oneTaskProcess.bpmn20.xml").
+                deploy();
         try {
             CaseInstance caseInstance = startCaseInstanceWithOneTaskProcess("flowable");
             List<Task> processTasks = processEngine.getTaskService().createTaskQuery().list();
-            assertEquals(1, processTasks.size());
-            assertEquals("flowable", processTasks.get(0).getTenantId());
+            assertThat(processTasks).hasSize(1);
+            assertThat(processTasks.get(0).getTenantId()).isEqualTo("flowable");
             ProcessInstance processInstance = processEngine.getRuntimeService().createProcessInstanceQuery()
-                            .processInstanceId(processTasks.get(0).getProcessInstanceId()).singleResult();
-            assertNotNull(processInstance);
-            assertEquals("flowable", processInstance.getTenantId());
+                    .processInstanceId(processTasks.get(0).getProcessInstanceId()).singleResult();
+            assertThat(processInstance).isNotNull();
+            assertThat(processInstance.getTenantId()).isEqualTo("flowable");
 
             // Non-blocking process task, plan item should have been completed
             List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-                .caseInstanceId(caseInstance.getId())
-                .planItemInstanceState(PlanItemInstanceState.ACTIVE)
-                .list();
-            assertEquals(1, planItemInstances.size());
-            assertEquals("Task Two", planItemInstances.get(0).getName());
+                    .caseInstanceId(caseInstance.getId())
+                    .planItemInstanceState(PlanItemInstanceState.ACTIVE)
+                    .list();
+            assertThat(planItemInstances)
+                    .extracting(PlanItemInstance::getName)
+                    .containsExactly("Task Two");
 
-            assertEquals(1, cmmnHistoryService.createHistoricMilestoneInstanceQuery().count());
+            assertThat(cmmnHistoryService.createHistoricMilestoneInstanceQuery().count()).isEqualTo(1);
 
             processEngine.getTaskService().complete(processTasks.get(0).getId());
-            assertEquals(0, processEngineRuntimeService.createProcessInstanceQuery().count());
+            assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
         } finally {
             processEngineRepositoryService.deleteDeployment(deployment.getId(), true);
         }
     }
-    
+
     @Test
     @CmmnDeployment(
-        resources = {"org/flowable/cmmn/test/ProcessTaskTest.testOneTaskProcessNonBlocking.cmmn"},
-        tenantId = "someTenant"
+            resources = { "org/flowable/cmmn/test/ProcessTaskTest.testOneTaskProcessNonBlocking.cmmn" },
+            tenantId = "someTenant"
     )
     public void testOneTaskProcessGlobalFallbackToDefaultTenant() {
         Deployment deployment = this.processEngineRepositoryService.createDeployment().
-            addClasspathResource("org/flowable/cmmn/test/oneTaskProcess.bpmn20.xml").
-            tenantId("defaultFlowable").
-            deploy();
-        
+                addClasspathResource("org/flowable/cmmn/test/oneTaskProcess.bpmn20.xml").
+                tenantId("defaultFlowable").
+                deploy();
+
         DefaultTenantProvider originalDefaultTenantProvider = this.processEngineConfiguration.getDefaultTenantProvider();
         this.processEngineConfiguration.setFallbackToDefaultTenant(true);
         this.processEngineConfiguration.setDefaultTenantValue("defaultFlowable");
-        
+
         try {
             CaseInstance caseInstance = startCaseInstanceWithOneTaskProcess("someTenant");
             List<Task> processTasks = processEngine.getTaskService().createTaskQuery().list();
-            assertEquals(1, processTasks.size());
-            assertEquals("someTenant", processTasks.get(0).getTenantId());
+            assertThat(processTasks)
+                    .extracting(Task::getTenantId)
+                    .containsExactly("someTenant");
             ProcessInstance processInstance = processEngine.getRuntimeService().createProcessInstanceQuery()
-                            .processInstanceId(processTasks.get(0).getProcessInstanceId()).singleResult();
-            assertNotNull(processInstance);
-            assertEquals("someTenant", processInstance.getTenantId());
+                    .processInstanceId(processTasks.get(0).getProcessInstanceId()).singleResult();
+            assertThat(processInstance).isNotNull();
+            assertThat(processInstance.getTenantId()).isEqualTo("someTenant");
 
             // Non-blocking process task, plan item should have been completed
             List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
-                .caseInstanceId(caseInstance.getId())
-                .planItemInstanceState(PlanItemInstanceState.ACTIVE)
-                .list();
-            assertEquals(1, planItemInstances.size());
-            assertEquals("Task Two", planItemInstances.get(0).getName());
+                    .caseInstanceId(caseInstance.getId())
+                    .planItemInstanceState(PlanItemInstanceState.ACTIVE)
+                    .list();
+            assertThat(planItemInstances)
+                    .extracting(PlanItemInstance::getName)
+                    .containsExactly("Task Two");
 
-            assertEquals(1, cmmnHistoryService.createHistoricMilestoneInstanceQuery().count());
+            assertThat(cmmnHistoryService.createHistoricMilestoneInstanceQuery().count()).isEqualTo(1);
 
             processEngine.getTaskService().complete(processTasks.get(0).getId());
-            assertEquals(0, processEngineRuntimeService.createProcessInstanceQuery().count());
-            
+            assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+
         } finally {
             this.processEngineConfiguration.setFallbackToDefaultTenant(false);
             this.processEngineConfiguration.setDefaultTenantProvider(originalDefaultTenantProvider);
             processEngineRepositoryService.deleteDeployment(deployment.getId(), true);
         }
     }
-    
+
     @Test
     @CmmnDeployment(
-        resources = {"org/flowable/cmmn/test/ProcessTaskTest.testOneTaskProcessNonBlocking.cmmn"},
-        tenantId = "someTenant"
+            resources = { "org/flowable/cmmn/test/ProcessTaskTest.testOneTaskProcessNonBlocking.cmmn" },
+            tenantId = "someTenant"
     )
     public void testOneTaskProcessGlobalFallbackToDefaultTenantNoDefinition() {
         Deployment deployment = this.processEngineRepositoryService.createDeployment().
-            addClasspathResource("org/flowable/cmmn/test/oneTaskProcess.bpmn20.xml").
-            tenantId("tenant1").
-            deploy();
-        
+                addClasspathResource("org/flowable/cmmn/test/oneTaskProcess.bpmn20.xml").
+                tenantId("tenant1").
+                deploy();
+
         DefaultTenantProvider originalDefaultTenantProvider = this.processEngineConfiguration.getDefaultTenantProvider();
         this.processEngineConfiguration.setFallbackToDefaultTenant(true);
         this.processEngineConfiguration.setDefaultTenantValue("defaultFlowable");
-        
-        try {
-            startCaseInstanceWithOneTaskProcess("someTenant");
-            fail();
-            
-        } catch (FlowableObjectNotFoundException e) {
-            // expected
-            
-        } finally {
-            this.processEngineConfiguration.setFallbackToDefaultTenant(false);
-            this.processEngineConfiguration.setDefaultTenantProvider(originalDefaultTenantProvider);
-            processEngineRepositoryService.deleteDeployment(deployment.getId(), true);
-        }
+
+        assertThatThrownBy(() -> startCaseInstanceWithOneTaskProcess("someTenant"))
+                .isInstanceOf(FlowableObjectNotFoundException.class);
+
+        this.processEngineConfiguration.setFallbackToDefaultTenant(false);
+        this.processEngineConfiguration.setDefaultTenantProvider(originalDefaultTenantProvider);
+        processEngineRepositoryService.deleteDeployment(deployment.getId(), true);
     }
 
     @Test
     @CmmnDeployment(
-        resources = {"org/flowable/cmmn/test/ProcessTaskTest.testOneTaskProcessFallbackToDefaultTenantFalse.cmmn"},
-        tenantId = "flowable"
+            resources = { "org/flowable/cmmn/test/ProcessTaskTest.testOneTaskProcessFallbackToDefaultTenantFalse.cmmn" },
+            tenantId = "flowable"
     )
     public void testOneTaskProcessFallbackToDefaultTenantFalse() {
         Deployment deployment = this.processEngineRepositoryService.createDeployment().
-            addClasspathResource("org/flowable/cmmn/test/oneTaskProcess.bpmn20.xml").
-            deploy();
-        try {
-            startCaseInstanceWithOneTaskProcess("flowable");
-            fail();
-        } catch (FlowableObjectNotFoundException e) {
-            assertThat(e.getMessage(), is("Process definition with key 'oneTask' and tenantId 'flowable' was not found"));
-        } finally {
-            processEngineRepositoryService.deleteDeployment(deployment.getId(), true);
-        }
+                addClasspathResource("org/flowable/cmmn/test/oneTaskProcess.bpmn20.xml").
+                deploy();
+
+        assertThatThrownBy(() -> startCaseInstanceWithOneTaskProcess("flowable"))
+                .isInstanceOf(FlowableObjectNotFoundException.class)
+                .hasMessage("Process definition with key 'oneTask' and tenantId 'flowable' was not found");
+
+        processEngineRepositoryService.deleteDeployment(deployment.getId(), true);
     }
 
     @Test
@@ -886,202 +885,202 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
         Task task = processEngine.getTaskService().createTaskQuery().singleResult();
 
         assertThatThrownBy(() -> cmmnTaskService.deleteTask(task.getId()))
-            .isExactlyInstanceOf(FlowableException.class)
-            .hasMessageContaining("The task cannot be deleted")
-            .hasMessageContaining("running process");
+                .isExactlyInstanceOf(FlowableException.class)
+                .hasMessageContaining("The task cannot be deleted")
+                .hasMessageContaining("running process");
     }
-    
+
     @Test
     @CmmnDeployment
     public void testChangeActiveStagesWithProcessTasks() {
 
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("activatePlanItemTest").start();
 
-        Assertions.assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).list())
-            .extracting(PlanItemInstance::getPlanItemDefinitionId, PlanItemInstance::getState)
-            .containsExactlyInAnyOrder(
-                tuple("oneexpandedstage2", "available"),
-                tuple("oneexpandedstage1", "available"),
-                tuple("oneprocesstask1", "active")
-            );
-        
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).list())
+                .extracting(PlanItemInstance::getPlanItemDefinitionId, PlanItemInstance::getState)
+                .containsExactlyInAnyOrder(
+                        tuple("oneexpandedstage2", "available"),
+                        tuple("oneexpandedstage1", "available"),
+                        tuple("oneprocesstask1", "active")
+                );
+
         Task task = processEngineTaskService.createTaskQuery().taskDefinitionKey("theTask").singleResult();
         processEngineTaskService.complete(task.getId());
-        
-        Assertions.assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).list())
-            .extracting(PlanItemInstance::getPlanItemDefinitionId, PlanItemInstance::getState)
-            .containsExactlyInAnyOrder(
-                tuple("oneexpandedstage1", "active"),
-                tuple("oneexpandedstage2", "available"),
-                tuple("oneexpandedstage1", "wait_repetition"),
-                tuple("oneprocesstask2", "active"),
-                tuple("oneprocesstask4", "active")
-            );
+
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).list())
+                .extracting(PlanItemInstance::getPlanItemDefinitionId, PlanItemInstance::getState)
+                .containsExactlyInAnyOrder(
+                        tuple("oneexpandedstage1", "active"),
+                        tuple("oneexpandedstage2", "available"),
+                        tuple("oneexpandedstage1", "wait_repetition"),
+                        tuple("oneprocesstask2", "active"),
+                        tuple("oneprocesstask4", "active")
+                );
 
         cmmnRuntimeService.createChangePlanItemStateBuilder()
-            .caseInstanceId(caseInstance.getId())
-            .movePlanItemDefinitionIdTo("oneexpandedstage1", "oneprocesstask3")
-            .changeState();
+                .caseInstanceId(caseInstance.getId())
+                .movePlanItemDefinitionIdTo("oneexpandedstage1", "oneprocesstask3")
+                .changeState();
 
-        Assertions.assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).list())
-            .extracting(PlanItemInstance::getPlanItemDefinitionId, PlanItemInstance::getState)
-            .containsExactlyInAnyOrder(
-                tuple("oneexpandedstage1", "wait_repetition"),
-                tuple("oneexpandedstage2", "active"),
-                tuple("oneexpandedstage2", "wait_repetition"),
-                tuple("oneprocesstask3", "active")
-            );
-        
-        assertEquals(1, processEngineRuntimeService.createProcessInstanceQuery().processDefinitionKey("oneTask").count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).list())
+                .extracting(PlanItemInstance::getPlanItemDefinitionId, PlanItemInstance::getState)
+                .containsExactlyInAnyOrder(
+                        tuple("oneexpandedstage1", "wait_repetition"),
+                        tuple("oneexpandedstage2", "active"),
+                        tuple("oneexpandedstage2", "wait_repetition"),
+                        tuple("oneprocesstask3", "active")
+                );
+
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().processDefinitionKey("oneTask").count()).isEqualTo(1);
         task = processEngineTaskService.createTaskQuery().taskDefinitionKey("theTask").singleResult();
         processEngineTaskService.complete(task.getId());
-        
-        Assertions.assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).list())
-            .extracting(PlanItemInstance::getPlanItemDefinitionId, PlanItemInstance::getState)
-            .containsExactlyInAnyOrder(
-                tuple("oneexpandedstage1", "active"),
-                tuple("oneexpandedstage1", "wait_repetition"),
-                tuple("oneexpandedstage2", "wait_repetition"),
-                tuple("oneprocesstask2", "active"),
-                tuple("oneprocesstask4", "active")
-            );
-        
-        assertEquals(2, processEngineRuntimeService.createProcessInstanceQuery().processDefinitionKey("oneTask").count());
+
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).list())
+                .extracting(PlanItemInstance::getPlanItemDefinitionId, PlanItemInstance::getState)
+                .containsExactlyInAnyOrder(
+                        tuple("oneexpandedstage1", "active"),
+                        tuple("oneexpandedstage1", "wait_repetition"),
+                        tuple("oneexpandedstage2", "wait_repetition"),
+                        tuple("oneprocesstask2", "active"),
+                        tuple("oneprocesstask4", "active")
+                );
+
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().processDefinitionKey("oneTask").count()).isEqualTo(2);
     }
-    
+
     @Test
     @CmmnDeployment
     public void testChangeActiveStagesWithManualProcessTasks() {
 
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("activatePlanItemTest").start();
 
-        Assertions.assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).list())
-            .extracting(PlanItemInstance::getPlanItemDefinitionId, PlanItemInstance::getState)
-            .containsExactlyInAnyOrder(
-                tuple("oneexpandedstage2", "available"),
-                tuple("oneexpandedstage1", "available"),
-                tuple("oneprocesstask1", "active")
-            );
-        
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).list())
+                .extracting(PlanItemInstance::getPlanItemDefinitionId, PlanItemInstance::getState)
+                .containsExactlyInAnyOrder(
+                        tuple("oneexpandedstage2", "available"),
+                        tuple("oneexpandedstage1", "available"),
+                        tuple("oneprocesstask1", "active")
+                );
+
         Task task = processEngineTaskService.createTaskQuery().taskDefinitionKey("theTask").singleResult();
         processEngineTaskService.complete(task.getId());
-        
-        Assertions.assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).list())
-            .extracting(PlanItemInstance::getPlanItemDefinitionId, PlanItemInstance::getState)
-            .containsExactlyInAnyOrder(
-                tuple("oneexpandedstage1", "active"),
-                tuple("oneexpandedstage2", "available"),
-                tuple("oneexpandedstage1", "wait_repetition"),
-                tuple("oneprocesstask2", "enabled"),
-                tuple("oneprocesstask4", "enabled")
-            );
+
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).list())
+                .extracting(PlanItemInstance::getPlanItemDefinitionId, PlanItemInstance::getState)
+                .containsExactlyInAnyOrder(
+                        tuple("oneexpandedstage1", "active"),
+                        tuple("oneexpandedstage2", "available"),
+                        tuple("oneexpandedstage1", "wait_repetition"),
+                        tuple("oneprocesstask2", "enabled"),
+                        tuple("oneprocesstask4", "enabled")
+                );
 
         cmmnRuntimeService.createChangePlanItemStateBuilder()
-            .caseInstanceId(caseInstance.getId())
-            .movePlanItemDefinitionIdTo("oneexpandedstage1", "oneprocesstask3")
-            .changeState();
+                .caseInstanceId(caseInstance.getId())
+                .movePlanItemDefinitionIdTo("oneexpandedstage1", "oneprocesstask3")
+                .changeState();
 
-        Assertions.assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).list())
-            .extracting(PlanItemInstance::getPlanItemDefinitionId, PlanItemInstance::getState)
-            .containsExactlyInAnyOrder(
-                tuple("oneexpandedstage1", "wait_repetition"),
-                tuple("oneexpandedstage2", "active"),
-                tuple("oneexpandedstage2", "wait_repetition"),
-                tuple("oneprocesstask3", "active")
-            );
-        
-        assertEquals(1, processEngineRuntimeService.createProcessInstanceQuery().processDefinitionKey("oneTask").count());
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).list())
+                .extracting(PlanItemInstance::getPlanItemDefinitionId, PlanItemInstance::getState)
+                .containsExactlyInAnyOrder(
+                        tuple("oneexpandedstage1", "wait_repetition"),
+                        tuple("oneexpandedstage2", "active"),
+                        tuple("oneexpandedstage2", "wait_repetition"),
+                        tuple("oneprocesstask3", "active")
+                );
+
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().processDefinitionKey("oneTask").count()).isEqualTo(1);
         task = processEngineTaskService.createTaskQuery().taskDefinitionKey("theTask").singleResult();
         processEngineTaskService.complete(task.getId());
-        
-        Assertions.assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).list())
-            .extracting(PlanItemInstance::getPlanItemDefinitionId, PlanItemInstance::getState)
-            .containsExactlyInAnyOrder(
-                tuple("oneexpandedstage1", "active"),
-                tuple("oneexpandedstage1", "wait_repetition"),
-                tuple("oneexpandedstage2", "wait_repetition"),
-                tuple("oneprocesstask2", "enabled"),
-                tuple("oneprocesstask4", "enabled")
-            );
-        
-        assertEquals(0, processEngineRuntimeService.createProcessInstanceQuery().processDefinitionKey("oneTask").count());
+
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).list())
+                .extracting(PlanItemInstance::getPlanItemDefinitionId, PlanItemInstance::getState)
+                .containsExactlyInAnyOrder(
+                        tuple("oneexpandedstage1", "active"),
+                        tuple("oneexpandedstage1", "wait_repetition"),
+                        tuple("oneexpandedstage2", "wait_repetition"),
+                        tuple("oneprocesstask2", "enabled"),
+                        tuple("oneprocesstask4", "enabled")
+                );
+
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().processDefinitionKey("oneTask").count()).isEqualTo(0);
     }
-    
+
     @Test
     @CmmnDeployment
     public void testChangeActiveStages() {
 
         Deployment deployment = this.processEngineRepositoryService.createDeployment().
-            addClasspathResource("org/flowable/cmmn/test/emptyProcess.bpmn20.xml").
-            deploy();
+                addClasspathResource("org/flowable/cmmn/test/emptyProcess.bpmn20.xml").
+                deploy();
 
         try {
             CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("activatePlanItemTest").start();
-            
-            assertEquals(1, processEngineHistoryService.createHistoricProcessInstanceQuery().processDefinitionKey("oneTask").count());
-            assertEquals(0, processEngineHistoryService.createHistoricProcessInstanceQuery().processDefinitionKey("oneTask").finished().count());
-            
-            Assertions.assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).list())
-                .extracting(PlanItemInstance::getPlanItemDefinitionId, PlanItemInstance::getState)
-                .containsExactlyInAnyOrder(
-                    tuple("oneprocesstask1", "active"),
-                    tuple("oneexpandedstage1", "available"),
-                    tuple("oneexpandedstage2", "available")
-                );
-            
+
+            assertThat(processEngineHistoryService.createHistoricProcessInstanceQuery().processDefinitionKey("oneTask").count()).isEqualTo(1);
+            assertThat(processEngineHistoryService.createHistoricProcessInstanceQuery().processDefinitionKey("oneTask").finished().count()).isEqualTo(0);
+
+            assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).list())
+                    .extracting(PlanItemInstance::getPlanItemDefinitionId, PlanItemInstance::getState)
+                    .containsExactlyInAnyOrder(
+                            tuple("oneprocesstask1", "active"),
+                            tuple("oneexpandedstage1", "available"),
+                            tuple("oneexpandedstage2", "available")
+                    );
+
             Task task = processEngineTaskService.createTaskQuery().processDefinitionKey("oneTask").singleResult();
             processEngineTaskService.complete(task.getId());
-            
-            assertEquals(1, processEngineHistoryService.createHistoricProcessInstanceQuery().processDefinitionKey("oneTask").finished().count());
 
-            Assertions.assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).list())
-                .extracting(PlanItemInstance::getPlanItemDefinitionId, PlanItemInstance::getState)
-                .containsExactlyInAnyOrder(
-                    tuple("oneexpandedstage1", "active"),
-                    tuple("oneexpandedstage2", "available"),
-                    tuple("oneexpandedstage1", "wait_repetition"),
-                    tuple("oneprocesstask2", "enabled"),
-                    tuple("oneprocesstask4", "enabled")
-                );
+            assertThat(processEngineHistoryService.createHistoricProcessInstanceQuery().processDefinitionKey("oneTask").finished().count()).isEqualTo(1);
+
+            assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).list())
+                    .extracting(PlanItemInstance::getPlanItemDefinitionId, PlanItemInstance::getState)
+                    .containsExactlyInAnyOrder(
+                            tuple("oneexpandedstage1", "active"),
+                            tuple("oneexpandedstage2", "available"),
+                            tuple("oneexpandedstage1", "wait_repetition"),
+                            tuple("oneprocesstask2", "enabled"),
+                            tuple("oneprocesstask4", "enabled")
+                    );
 
             cmmnRuntimeService.createChangePlanItemStateBuilder()
-                .caseInstanceId(caseInstance.getId())
-                .movePlanItemDefinitionIdTo("oneexpandedstage1", "oneprocesstask3")
-                .changeState();
-            
-            assertEquals(2, processEngineHistoryService.createHistoricProcessInstanceQuery().processDefinitionKey("oneTask").count());
-            assertEquals(1, processEngineHistoryService.createHistoricProcessInstanceQuery().processDefinitionKey("oneTask").finished().count());
-            
+                    .caseInstanceId(caseInstance.getId())
+                    .movePlanItemDefinitionIdTo("oneexpandedstage1", "oneprocesstask3")
+                    .changeState();
+
+            assertThat(processEngineHistoryService.createHistoricProcessInstanceQuery().processDefinitionKey("oneTask").count()).isEqualTo(2);
+            assertThat(processEngineHistoryService.createHistoricProcessInstanceQuery().processDefinitionKey("oneTask").finished().count()).isEqualTo(1);
+
             task = processEngineTaskService.createTaskQuery().processDefinitionKey("oneTask").singleResult();
             processEngineTaskService.complete(task.getId());
 
-            Assertions.assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).list())
-                .extracting(PlanItemInstance::getPlanItemDefinitionId, PlanItemInstance::getState)
-                .containsExactlyInAnyOrder(
-                    tuple("oneexpandedstage1", "active"),
-                    tuple("oneexpandedstage1", "wait_repetition"),
-                    tuple("oneexpandedstage2", "wait_repetition"),
-                    tuple("oneprocesstask2", "enabled"),
-                    tuple("oneprocesstask4", "enabled")
-                );
-            
+            assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).list())
+                    .extracting(PlanItemInstance::getPlanItemDefinitionId, PlanItemInstance::getState)
+                    .containsExactlyInAnyOrder(
+                            tuple("oneexpandedstage1", "active"),
+                            tuple("oneexpandedstage1", "wait_repetition"),
+                            tuple("oneexpandedstage2", "wait_repetition"),
+                            tuple("oneprocesstask2", "enabled"),
+                            tuple("oneprocesstask4", "enabled")
+                    );
+
             PlanItemInstance deactivateInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
-                            .planItemDefinitionId("oneprocesstask4")
-                            .planItemInstanceState("enabled")
-                            .singleResult();
+                    .planItemDefinitionId("oneprocesstask4")
+                    .planItemInstanceState("enabled")
+                    .singleResult();
             cmmnRuntimeService.startPlanItemInstance(deactivateInstance.getId());
-            
-            assertEquals(2, processEngineHistoryService.createHistoricProcessInstanceQuery().processDefinitionKey("oneTask").finished().count());
-            assertEquals(1, processEngineHistoryService.createHistoricProcessInstanceQuery().processDefinitionKey("emptyProcess").finished().count());
-            
-            Assertions.assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).list())
-                .extracting(PlanItemInstance::getPlanItemDefinitionId, PlanItemInstance::getState)
-                .containsExactlyInAnyOrder(
-                    tuple("oneexpandedstage1", "wait_repetition"),
-                    tuple("oneexpandedstage2", "active"),
-                    tuple("oneexpandedstage2", "wait_repetition"),
-                    tuple("oneprocesstask3", "enabled")
-                );
+
+            assertThat(processEngineHistoryService.createHistoricProcessInstanceQuery().processDefinitionKey("oneTask").finished().count()).isEqualTo(2);
+            assertThat(processEngineHistoryService.createHistoricProcessInstanceQuery().processDefinitionKey("emptyProcess").finished().count()).isEqualTo(1);
+
+            assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).list())
+                    .extracting(PlanItemInstance::getPlanItemDefinitionId, PlanItemInstance::getState)
+                    .containsExactlyInAnyOrder(
+                            tuple("oneexpandedstage1", "wait_repetition"),
+                            tuple("oneexpandedstage2", "active"),
+                            tuple("oneexpandedstage2", "wait_repetition"),
+                            tuple("oneprocesstask3", "enabled")
+                    );
 
         } finally {
             processEngineRepositoryService.deleteDeployment(deployment.getId(), true);
@@ -1091,137 +1090,139 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
     @Test
     @CmmnDeployment
     public void testPassChildTaskVariables() {
-        assertEquals(0, processEngineRuntimeService.createProcessInstanceQuery().count());
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
 
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("startChildProcess").start();
         PlanItemInstance processPlanItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .planItemInstanceStateEnabled()
-            .singleResult();
+                .caseInstanceId(caseInstance.getId())
+                .planItemInstanceStateEnabled()
+                .singleResult();
 
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(processPlanItemInstance.getId())
-            .variable("caseVar", "caseValue")
-            .childTaskVariable("processVar1", "processValue")
-            .childTaskVariables(CollectionUtil.map("processVar2", 123, "processVar3", 456))
-            .start();
+                .variable("caseVar", "caseValue")
+                .childTaskVariable("processVar1", "processValue")
+                .childTaskVariables(CollectionUtil.map("processVar2", 123, "processVar3", 456))
+                .start();
 
         Map<String, Object> variables = cmmnRuntimeService.getVariables(caseInstance.getId());
         // also includes initiator variable
-        assertEquals(2, variables.size());
-        assertEquals("caseValue", variables.get("caseVar"));
+        assertThat(variables).hasSize(2);
+        assertThat(variables.get("caseVar")).isEqualTo("caseValue");
 
         ProcessInstance processInstance = processEngineRuntimeService.createProcessInstanceQuery()
-            .processInstanceCallbackId(processPlanItemInstance.getId())
-            .singleResult();
+                .processInstanceCallbackId(processPlanItemInstance.getId())
+                .singleResult();
         Map<String, Object> processInstanceVariables = processEngineRuntimeService.getVariables(processInstance.getId());
-        assertEquals(3, processInstanceVariables.size());
-        assertEquals("processValue", processInstanceVariables.get("processVar1"));
-        assertEquals(123, processInstanceVariables.get("processVar2"));
-        assertEquals(456, processInstanceVariables.get("processVar3"));
+        assertThat(processInstanceVariables).hasSize(3);
+        assertThat(processInstanceVariables.get("processVar1")).isEqualTo("processValue");
+        assertThat(processInstanceVariables.get("processVar2")).isEqualTo(123);
+        assertThat(processInstanceVariables.get("processVar3")).isEqualTo(456);
     }
 
     @Test
     @CmmnDeployment
     public void testExitAvailableProcessTaskThroughExitSentryOnStage() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("testExitAvailableProcessTaskThroughExitSentryOnStage")
-            .start();
+                .caseDefinitionKey("testExitAvailableProcessTaskThroughExitSentryOnStage")
+                .start();
 
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .planItemInstanceStateAvailable()
-            .planItemDefinitionType(PlanItemDefinitionType.PROCESS_TASK)
-            .singleResult();
-        assertEquals("theProcess", planItemInstance.getName());
+                .planItemInstanceStateAvailable()
+                .planItemDefinitionType(PlanItemDefinitionType.PROCESS_TASK)
+                .singleResult();
+        assertThat(planItemInstance.getName()).isEqualTo("theProcess");
 
-        assertNull(cmmnTaskService.createTaskQuery().taskName("task2").singleResult());
+        assertThat(cmmnTaskService.createTaskQuery().taskName("task2").singleResult()).isNull();
 
         // When the event listener now occurs, the stage should be exited, also exiting the process task plan item
         UserEventListenerInstance userEventListenerInstance = cmmnRuntimeService.createUserEventListenerInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .singleResult();
+                .caseInstanceId(caseInstance.getId())
+                .singleResult();
         cmmnRuntimeService.completeUserEventListenerInstance(userEventListenerInstance.getId());
 
-        assertNotNull(cmmnTaskService.createTaskQuery().taskName("task2").singleResult());
-        assertNull(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateAvailable().planItemDefinitionType(PlanItemDefinitionType.PROCESS_TASK).singleResult());
+        assertThat(cmmnTaskService.createTaskQuery().taskName("task2").singleResult()).isNotNull();
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateAvailable().planItemDefinitionType(PlanItemDefinitionType.PROCESS_TASK)
+                .singleResult()).isNull();
     }
 
     @Test
     @CmmnDeployment
     public void testExitActiveProcessTaskThroughExitSentryOnStage() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("testExitActiveProcessTaskThroughExitSentryOnStage")
-            .variable("myVar", "test")
-            .start();
+                .caseDefinitionKey("testExitActiveProcessTaskThroughExitSentryOnStage")
+                .variable("myVar", "test")
+                .start();
 
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .planItemInstanceStateActive()
-            .planItemDefinitionType(PlanItemDefinitionType.PROCESS_TASK)
-            .singleResult();
-        assertEquals("theProcess", planItemInstance.getName());
+                .planItemInstanceStateActive()
+                .planItemDefinitionType(PlanItemDefinitionType.PROCESS_TASK)
+                .singleResult();
+        assertThat(planItemInstance.getName()).isEqualTo("theProcess");
 
-        assertNull(cmmnTaskService.createTaskQuery().taskName("task2").singleResult());
-        assertNotNull(processEngineRuntimeService.createProcessInstanceQuery().processInstanceId(planItemInstance.getReferenceId()).singleResult());
+        assertThat(cmmnTaskService.createTaskQuery().taskName("task2").singleResult()).isNull();
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().processInstanceId(planItemInstance.getReferenceId()).singleResult()).isNotNull();
 
         // When the event listener now occurs, the stage should be exited, also exiting the process task plan item
         UserEventListenerInstance userEventListenerInstance = cmmnRuntimeService.createUserEventListenerInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .singleResult();
+                .caseInstanceId(caseInstance.getId())
+                .singleResult();
         cmmnRuntimeService.completeUserEventListenerInstance(userEventListenerInstance.getId());
 
-        assertNotNull(cmmnTaskService.createTaskQuery().taskName("task2").singleResult());
-        assertNull(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateAvailable().planItemDefinitionType(PlanItemDefinitionType.PROCESS_TASK).singleResult());
-        assertNull(processEngineRuntimeService.createProcessInstanceQuery().processInstanceId(planItemInstance.getReferenceId()).singleResult());
+        assertThat(cmmnTaskService.createTaskQuery().taskName("task2").singleResult()).isNotNull();
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateAvailable().planItemDefinitionType(PlanItemDefinitionType.PROCESS_TASK)
+                .singleResult()).isNull();
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().processInstanceId(planItemInstance.getReferenceId()).singleResult()).isNull();
     }
 
     @Test
     @CmmnDeployment
     public void testExitCaseInstanceOnProcessInstanceComplete() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("testExitCaseInstanceOnProcessInstanceComplete")
-            .start();
+                .caseDefinitionKey("testExitCaseInstanceOnProcessInstanceComplete")
+                .start();
 
-        assertEquals(0, processEngineRuntimeService.createProcessInstanceQuery().count());
-        assertEquals(1, cmmnTaskService.createTaskQuery().count());
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(1);
 
         // Process task is manually activated
         cmmnRuntimeService.startPlanItemInstance(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateEnabled().singleResult().getId());
-        assertEquals(1, processEngineRuntimeService.createProcessInstanceQuery().count());
-        assertEquals(2, cmmnTaskService.createTaskQuery().count());
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(1);
+        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(2);
 
         // Completing the task from the process should terminate the case
         Task userTaskFromProcess = processEngineTaskService.createTaskQuery()
-            .processInstanceId(processEngineRuntimeService.createProcessInstanceQuery().singleResult().getId())
-            .singleResult();
+                .processInstanceId(processEngineRuntimeService.createProcessInstanceQuery().singleResult().getId())
+                .singleResult();
         processEngineTaskService.complete(userTaskFromProcess.getId());
 
-        assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().count());
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
     }
 
     @Test
     @CmmnDeployment
     public void testIdVariableName() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("testIdVariableName")
-            .start();
+                .caseDefinitionKey("testIdVariableName")
+                .start();
 
-        assertEquals(1, processEngineRuntimeService.createProcessInstanceQuery().count());
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(1);
 
         String processIdVariable = (String) cmmnRuntimeService.getVariable(caseInstance.getId(), "processIdVariable");
-        assertEquals(processEngineRuntimeService.createProcessInstanceQuery().singleResult().getId(), processIdVariable);
+        assertThat(processIdVariable).isEqualTo(processEngineRuntimeService.createProcessInstanceQuery().singleResult().getId());
     }
 
     @Test
     @CmmnDeployment
     public void testIdVariableNameExpression() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("testIdVariableName")
-            .variable("testVar", "A")
-            .start();
+                .caseDefinitionKey("testIdVariableName")
+                .variable("testVar", "A")
+                .start();
 
-        assertEquals(1, processEngineRuntimeService.createProcessInstanceQuery().count());
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(1);
 
         String processIdVariable = (String) cmmnRuntimeService.getVariable(caseInstance.getId(), "variableA");
-        assertEquals(processEngineRuntimeService.createProcessInstanceQuery().singleResult().getId(), processIdVariable);
+        assertThat(processIdVariable).isEqualTo(processEngineRuntimeService.createProcessInstanceQuery().singleResult().getId());
     }
 
     @Test
@@ -1236,12 +1237,12 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
                 .start();
 
         ProcessInstance processInstance = processEngineRuntimeService.createProcessInstanceQuery().singleResult();
-        Assertions.assertThat(processInstance).isNotNull();
-        Assertions.assertThat(processInstance.getProcessDefinitionName()).isEqualTo("One Task");
+        assertThat(processInstance).isNotNull();
+        assertThat(processInstance.getProcessDefinitionName()).isEqualTo("One Task");
 
         Task task = processEngineTaskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        Assertions.assertThat(task).isNotNull();
-        Assertions.assertThat(task.getName()).isEqualTo("my task");
+        assertThat(task).isNotNull();
+        assertThat(task.getName()).isEqualTo("my task");
 
         processEngineTaskService.complete(task.getId());
 
@@ -1254,12 +1255,12 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
                 .start();
 
         processInstance = processEngineRuntimeService.createProcessInstanceQuery().singleResult();
-        Assertions.assertThat(processInstance).isNotNull();
-        Assertions.assertThat(processInstance.getProcessDefinitionName()).isEqualTo("One Task");
+        assertThat(processInstance).isNotNull();
+        assertThat(processInstance.getProcessDefinitionName()).isEqualTo("One Task");
 
         task = processEngineTaskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        Assertions.assertThat(task).isNotNull();
-        Assertions.assertThat(task.getName()).isEqualTo("my task");
+        assertThat(task).isNotNull();
+        assertThat(task.getName()).isEqualTo("my task");
     }
 
     @Test
@@ -1276,13 +1277,13 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
                 .start();
 
         ProcessInstance processInstance = processEngineRuntimeService.createProcessInstanceQuery().singleResult();
-        Assertions.assertThat(processInstance).isNotNull();
-        Assertions.assertThat(processInstance.getProcessDefinitionName()).isEqualTo("One Task");
-        Assertions.assertThat(processInstance.getTenantId()).isEqualTo("flowable");
+        assertThat(processInstance).isNotNull();
+        assertThat(processInstance.getProcessDefinitionName()).isEqualTo("One Task");
+        assertThat(processInstance.getTenantId()).isEqualTo("flowable");
 
         Task task = processEngineTaskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        Assertions.assertThat(task).isNotNull();
-        Assertions.assertThat(task.getName()).isEqualTo("my task");
+        assertThat(task).isNotNull();
+        assertThat(task.getName()).isEqualTo("my task");
 
         processEngineTaskService.complete(task.getId());
 
@@ -1297,13 +1298,13 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
                 .start();
 
         processInstance = processEngineRuntimeService.createProcessInstanceQuery().singleResult();
-        Assertions.assertThat(processInstance).isNotNull();
-        Assertions.assertThat(processInstance.getProcessDefinitionName()).isEqualTo("One Task");
-        Assertions.assertThat(processInstance.getTenantId()).isEqualTo("flowable");
+        assertThat(processInstance).isNotNull();
+        assertThat(processInstance.getProcessDefinitionName()).isEqualTo("One Task");
+        assertThat(processInstance.getTenantId()).isEqualTo("flowable");
 
         task = processEngineTaskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        Assertions.assertThat(task).isNotNull();
-        Assertions.assertThat(task.getName()).isEqualTo("my task");
+        assertThat(task).isNotNull();
+        assertThat(task.getName()).isEqualTo("my task");
     }
 
     @Test
@@ -1318,12 +1319,12 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
                 .start();
 
         ProcessInstance processInstance = processEngineRuntimeService.createProcessInstanceQuery().singleResult();
-        Assertions.assertThat(processInstance).isNotNull();
-        Assertions.assertThat(processInstance.getProcessDefinitionName()).isEqualTo("One Task");
+        assertThat(processInstance).isNotNull();
+        assertThat(processInstance.getProcessDefinitionName()).isEqualTo("One Task");
 
         Task task = processEngineTaskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        Assertions.assertThat(task).isNotNull();
-        Assertions.assertThat(task.getName()).isEqualTo("my task");
+        assertThat(task).isNotNull();
+        assertThat(task.getName()).isEqualTo("my task");
 
         processEngineTaskService.complete(task.getId());
 
@@ -1336,11 +1337,11 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
                 .start();
 
         processInstance = processEngineRuntimeService.createProcessInstanceQuery().singleResult();
-        Assertions.assertThat(processInstance).isNotNull();
-        Assertions.assertThat(processInstance.getProcessDefinitionName()).isEqualTo("One Task V2");
+        assertThat(processInstance).isNotNull();
+        assertThat(processInstance.getProcessDefinitionName()).isEqualTo("One Task V2");
 
         task = processEngineTaskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        Assertions.assertThat(task).isNotNull();
-        Assertions.assertThat(task.getName()).isEqualTo("Task V2");
+        assertThat(task).isNotNull();
+        assertThat(task.getName()).isEqualTo("Task V2");
     }
 }

--- a/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/SignalEventTest.java
+++ b/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/SignalEventTest.java
@@ -12,9 +12,7 @@
  */
 package org.flowable.cmmn.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.cmmn.api.runtime.CaseInstance;
 import org.flowable.cmmn.engine.test.CmmnDeployment;
@@ -24,249 +22,244 @@ import org.flowable.task.api.Task;
 import org.junit.Test;
 
 public class SignalEventTest extends AbstractProcessEngineIntegrationTest {
-    
+
     @Test
-    @CmmnDeployment(resources = {"org/flowable/cmmn/test/processTaskWithSignalListener.cmmn"})
+    @CmmnDeployment(resources = { "org/flowable/cmmn/test/processTaskWithSignalListener.cmmn" })
     public void testSignal() {
         Deployment deployment = this.processEngineRepositoryService.createDeployment().
-            addClasspathResource("org/flowable/cmmn/test/signalProcess.bpmn20.xml").
-            deploy();
-        
+                addClasspathResource("org/flowable/cmmn/test/signalProcess.bpmn20.xml").
+                deploy();
+
         try {
             CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("signalCase").start();
-            
-            assertEquals(0, cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count());
-            
+
+            assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+
             Task task = processEngineTaskService.createTaskQuery().caseInstanceIdWithChildren(caseInstance.getId()).singleResult();
-            assertNotNull(task);
-            assertEquals("theTask", task.getTaskDefinitionKey());
-            assertEquals("my task", task.getName());
-            
+            assertThat(task).isNotNull();
+            assertThat(task.getTaskDefinitionKey()).isEqualTo("theTask");
+            assertThat(task.getName()).isEqualTo("my task");
+
             EventSubscription eventSubscription = cmmnRuntimeService.createEventSubscriptionQuery().scopeId(caseInstance.getId()).singleResult();
-            assertEquals("testSignal", eventSubscription.getEventName());
-            
+            assertThat(eventSubscription.getEventName()).isEqualTo("testSignal");
+
             processEngineTaskService.complete(task.getId());
-            
+
             eventSubscription = cmmnRuntimeService.createEventSubscriptionQuery().scopeId(caseInstance.getId()).singleResult();
-            assertNull(eventSubscription);
-            
+            assertThat(eventSubscription).isNull();
+
             Task task2 = processEngineTaskService.createTaskQuery().processInstanceId(task.getProcessInstanceId()).singleResult();
-            assertNotNull(task2);
-            assertEquals("theTask2", task2.getTaskDefinitionKey());
-            assertEquals("my task2", task2.getName());
-            
+            assertThat(task2).isNotNull();
+            assertThat(task2.getTaskDefinitionKey()).isEqualTo("theTask2");
+            assertThat(task2.getName()).isEqualTo("my task2");
+
             Task cmmnTask = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
-            assertNotNull(cmmnTask);
-            assertEquals("theTask", cmmnTask.getTaskDefinitionKey());
-            assertEquals("Test task", cmmnTask.getName());
-            
+            assertThat(cmmnTask).isNotNull();
+            assertThat(cmmnTask.getTaskDefinitionKey()).isEqualTo("theTask");
+            assertThat(cmmnTask.getName()).isEqualTo("Test task");
+
             processEngineTaskService.complete(task2.getId());
-            
-            assertEquals(0, processEngineRuntimeService.createProcessInstanceQuery().processInstanceId(task.getProcessInstanceId()).count());
-            
+
+            assertThat(processEngineRuntimeService.createProcessInstanceQuery().processInstanceId(task.getProcessInstanceId()).count()).isEqualTo(0);
+
             cmmnTaskService.complete(cmmnTask.getId());
-            
-            assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count());
-            
-        
+
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+
         } finally {
             processEngine.getRepositoryService().deleteDeployment(deployment.getId(), true);
         }
     }
-    
+
     @Test
-    @CmmnDeployment(resources = {"org/flowable/cmmn/test/processTaskWithSignalListener.cmmn"})
+    @CmmnDeployment(resources = { "org/flowable/cmmn/test/processTaskWithSignalListener.cmmn" })
     public void testMultipleSignals() {
         Deployment deployment = this.processEngineRepositoryService.createDeployment().
-            addClasspathResource("org/flowable/cmmn/test/signalProcess.bpmn20.xml").
-            deploy();
-        
+                addClasspathResource("org/flowable/cmmn/test/signalProcess.bpmn20.xml").
+                deploy();
+
         try {
             CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("signalCase").start();
-            
+
             CaseInstance anotherCaseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("signalCase").start();
-            
-            assertEquals(0, cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count());
-            
+
+            assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+
             Task task = processEngineTaskService.createTaskQuery().caseInstanceIdWithChildren(caseInstance.getId()).singleResult();
-            assertNotNull(task);
-            assertEquals("theTask", task.getTaskDefinitionKey());
-            assertEquals("my task", task.getName());
-            
+            assertThat(task).isNotNull();
+            assertThat(task.getTaskDefinitionKey()).isEqualTo("theTask");
+            assertThat(task.getName()).isEqualTo("my task");
+
             EventSubscription eventSubscription = cmmnRuntimeService.createEventSubscriptionQuery().scopeId(caseInstance.getId()).singleResult();
-            assertEquals("testSignal", eventSubscription.getEventName());
-            
+            assertThat(eventSubscription.getEventName()).isEqualTo("testSignal");
+
             EventSubscription anotherEventSubscription = cmmnRuntimeService.createEventSubscriptionQuery().scopeId(anotherCaseInstance.getId()).singleResult();
-            assertEquals("testSignal", anotherEventSubscription.getEventName());
-            
+            assertThat(anotherEventSubscription.getEventName()).isEqualTo("testSignal");
+
             processEngineTaskService.complete(task.getId());
-            
+
             eventSubscription = cmmnRuntimeService.createEventSubscriptionQuery().scopeId(caseInstance.getId()).singleResult();
-            assertNull(eventSubscription);
-            
+            assertThat(eventSubscription).isNull();
+
             anotherEventSubscription = cmmnRuntimeService.createEventSubscriptionQuery().scopeId(anotherCaseInstance.getId()).singleResult();
-            assertNull(anotherEventSubscription);
-            
+            assertThat(anotherEventSubscription).isNull();
+
             Task task2 = processEngineTaskService.createTaskQuery().processInstanceId(task.getProcessInstanceId()).singleResult();
-            assertNotNull(task2);
-            assertEquals("theTask2", task2.getTaskDefinitionKey());
-            assertEquals("my task2", task2.getName());
-            
+            assertThat(task2).isNotNull();
+            assertThat(task2.getTaskDefinitionKey()).isEqualTo("theTask2");
+            assertThat(task2.getName()).isEqualTo("my task2");
+
             Task cmmnTask = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
-            assertNotNull(cmmnTask);
-            assertEquals("theTask", cmmnTask.getTaskDefinitionKey());
-            assertEquals("Test task", cmmnTask.getName());
-            
+            assertThat(cmmnTask).isNotNull();
+            assertThat(cmmnTask.getTaskDefinitionKey()).isEqualTo("theTask");
+            assertThat(cmmnTask.getName()).isEqualTo("Test task");
+
             Task anotherCmmnTask = cmmnTaskService.createTaskQuery().caseInstanceId(anotherCaseInstance.getId()).singleResult();
-            assertNotNull(anotherCmmnTask);
-            assertEquals("theTask", cmmnTask.getTaskDefinitionKey());
-            
+            assertThat(anotherCmmnTask).isNotNull();
+            assertThat(cmmnTask.getTaskDefinitionKey()).isEqualTo("theTask");
+
             processEngineTaskService.complete(task2.getId());
-            
-            assertEquals(0, processEngineRuntimeService.createProcessInstanceQuery().processInstanceId(task.getProcessInstanceId()).count());
-            
+
+            assertThat(processEngineRuntimeService.createProcessInstanceQuery().processInstanceId(task.getProcessInstanceId()).count()).isEqualTo(0);
+
             cmmnTaskService.complete(cmmnTask.getId());
-            
-            assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count());
-            
-        
+
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+
         } finally {
             processEngine.getRepositoryService().deleteDeployment(deployment.getId(), true);
         }
     }
-    
+
     @Test
-    @CmmnDeployment(resources = {"org/flowable/cmmn/test/processTaskWithSignalListener.cmmn"})
+    @CmmnDeployment(resources = { "org/flowable/cmmn/test/processTaskWithSignalListener.cmmn" })
     public void testSignalWithInstanceScope() {
         Deployment deployment = this.processEngineRepositoryService.createDeployment().
-            addClasspathResource("org/flowable/cmmn/test/instanceScopeSignalProcess.bpmn20.xml").
-            deploy();
-        
+                addClasspathResource("org/flowable/cmmn/test/instanceScopeSignalProcess.bpmn20.xml").
+                deploy();
+
         try {
             CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("signalCase").start();
-            
-            assertEquals(0, cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count());
-            
+
+            assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+
             Task task = processEngineTaskService.createTaskQuery().caseInstanceIdWithChildren(caseInstance.getId()).singleResult();
-            assertNotNull(task);
-            assertEquals("theTask", task.getTaskDefinitionKey());
-            assertEquals("my task", task.getName());
-            
+            assertThat(task).isNotNull();
+            assertThat(task.getTaskDefinitionKey()).isEqualTo("theTask");
+            assertThat(task.getName()).isEqualTo("my task");
+
             EventSubscription eventSubscription = cmmnRuntimeService.createEventSubscriptionQuery().scopeId(caseInstance.getId()).singleResult();
-            assertEquals("testSignal", eventSubscription.getEventName());
-            
+            assertThat(eventSubscription.getEventName()).isEqualTo("testSignal");
+
             processEngineTaskService.complete(task.getId());
-            
+
             eventSubscription = cmmnRuntimeService.createEventSubscriptionQuery().scopeId(caseInstance.getId()).singleResult();
-            assertNull(eventSubscription);
-            
+            assertThat(eventSubscription).isNull();
+
             Task task2 = processEngineTaskService.createTaskQuery().processInstanceId(task.getProcessInstanceId()).singleResult();
-            assertNotNull(task2);
-            assertEquals("theTask2", task2.getTaskDefinitionKey());
-            assertEquals("my task2", task2.getName());
-            
+            assertThat(task2).isNotNull();
+            assertThat(task2.getTaskDefinitionKey()).isEqualTo("theTask2");
+            assertThat(task2.getName()).isEqualTo("my task2");
+
             Task cmmnTask = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
-            assertNotNull(cmmnTask);
-            assertEquals("theTask", cmmnTask.getTaskDefinitionKey());
-            assertEquals("Test task", cmmnTask.getName());
-            
+            assertThat(cmmnTask).isNotNull();
+            assertThat(cmmnTask.getTaskDefinitionKey()).isEqualTo("theTask");
+            assertThat(cmmnTask.getName()).isEqualTo("Test task");
+
             processEngineTaskService.complete(task2.getId());
-            
-            assertEquals(0, processEngineRuntimeService.createProcessInstanceQuery().processInstanceId(task.getProcessInstanceId()).count());
-            
+
+            assertThat(processEngineRuntimeService.createProcessInstanceQuery().processInstanceId(task.getProcessInstanceId()).count()).isEqualTo(0);
+
             cmmnTaskService.complete(cmmnTask.getId());
-            
-            assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count());
-            
-        
+
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+
         } finally {
             processEngine.getRepositoryService().deleteDeployment(deployment.getId(), true);
         }
     }
-    
+
     @Test
-    @CmmnDeployment(resources = {"org/flowable/cmmn/test/processTaskWithSignalListener.cmmn"})
+    @CmmnDeployment(resources = { "org/flowable/cmmn/test/processTaskWithSignalListener.cmmn" })
     public void testMultipleSignalWithInstanceScope() {
         Deployment deployment = this.processEngineRepositoryService.createDeployment().
-            addClasspathResource("org/flowable/cmmn/test/instanceScopeSignalProcess.bpmn20.xml").
-            deploy();
-        
+                addClasspathResource("org/flowable/cmmn/test/instanceScopeSignalProcess.bpmn20.xml").
+                deploy();
+
         try {
             CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("signalCase").start();
-            
+
             CaseInstance anotherCaseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("signalCase").start();
-            
-            assertEquals(0, cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count());
-            
+
+            assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+
             EventSubscription eventSubscription = cmmnRuntimeService.createEventSubscriptionQuery().scopeId(caseInstance.getId()).singleResult();
-            assertEquals("testSignal", eventSubscription.getEventName());
-            
+            assertThat(eventSubscription.getEventName()).isEqualTo("testSignal");
+
             EventSubscription anotherEventSubscription = cmmnRuntimeService.createEventSubscriptionQuery().scopeId(anotherCaseInstance.getId()).singleResult();
-            assertEquals("testSignal", anotherEventSubscription.getEventName());
-            
+            assertThat(anotherEventSubscription.getEventName()).isEqualTo("testSignal");
+
             Task task = processEngineTaskService.createTaskQuery().caseInstanceIdWithChildren(caseInstance.getId()).singleResult();
             processEngineTaskService.complete(task.getId());
-            
+
             eventSubscription = cmmnRuntimeService.createEventSubscriptionQuery().scopeId(caseInstance.getId()).singleResult();
-            assertNull(eventSubscription);
-            
+            assertThat(eventSubscription).isNull();
+
             anotherEventSubscription = cmmnRuntimeService.createEventSubscriptionQuery().scopeId(anotherCaseInstance.getId()).singleResult();
-            assertEquals("testSignal", anotherEventSubscription.getEventName());
-            
+            assertThat(anotherEventSubscription.getEventName()).isEqualTo("testSignal");
+
             Task task2 = processEngineTaskService.createTaskQuery().processInstanceId(task.getProcessInstanceId()).singleResult();
-            assertNotNull(task2);
-            assertEquals("theTask2", task2.getTaskDefinitionKey());
-            assertEquals("my task2", task2.getName());
-            
+            assertThat(task2).isNotNull();
+            assertThat(task2.getTaskDefinitionKey()).isEqualTo("theTask2");
+            assertThat(task2.getName()).isEqualTo("my task2");
+
             Task cmmnTask = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
-            assertNotNull(cmmnTask);
-            assertEquals("theTask", cmmnTask.getTaskDefinitionKey());
-            assertEquals("Test task", cmmnTask.getName());
-            
+            assertThat(cmmnTask).isNotNull();
+            assertThat(cmmnTask.getTaskDefinitionKey()).isEqualTo("theTask");
+            assertThat(cmmnTask.getName()).isEqualTo("Test task");
+
             processEngineTaskService.complete(task2.getId());
-            
-            assertEquals(0, processEngineRuntimeService.createProcessInstanceQuery().processInstanceId(task.getProcessInstanceId()).count());
-            
+
+            assertThat(processEngineRuntimeService.createProcessInstanceQuery().processInstanceId(task.getProcessInstanceId()).count()).isEqualTo(0);
+
             cmmnTaskService.complete(cmmnTask.getId());
-            
-            assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count());
-            
+
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+
             anotherEventSubscription = cmmnRuntimeService.createEventSubscriptionQuery().scopeId(anotherCaseInstance.getId()).singleResult();
-            assertEquals("testSignal", anotherEventSubscription.getEventName());
-            
-            assertEquals(1, cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(anotherCaseInstance.getId()).count());
-            
-        
+            assertThat(anotherEventSubscription.getEventName()).isEqualTo("testSignal");
+
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(anotherCaseInstance.getId()).count()).isEqualTo(1);
+
         } finally {
             processEngine.getRepositoryService().deleteDeployment(deployment.getId(), true);
         }
     }
-    
+
     @Test
-    @CmmnDeployment(resources = {"org/flowable/cmmn/test/processTaskWithSignalListener.cmmn"})
+    @CmmnDeployment(resources = { "org/flowable/cmmn/test/processTaskWithSignalListener.cmmn" })
     public void testTerminateCaseInstanceWithSignal() {
         Deployment deployment = this.processEngineRepositoryService.createDeployment().
-            addClasspathResource("org/flowable/cmmn/test/signalProcess.bpmn20.xml").
-            deploy();
-        
+                addClasspathResource("org/flowable/cmmn/test/signalProcess.bpmn20.xml").
+                deploy();
+
         try {
             CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("signalCase").start();
-            
+
             Task task = processEngineTaskService.createTaskQuery().caseInstanceIdWithChildren(caseInstance.getId()).singleResult();
-            assertNotNull(task);
-            
-            assertEquals(0, cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count());
-            
+            assertThat(task).isNotNull();
+
+            assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+
             EventSubscription eventSubscription = cmmnRuntimeService.createEventSubscriptionQuery().scopeId(caseInstance.getId()).singleResult();
-            assertEquals("testSignal", eventSubscription.getEventName());
-            
+            assertThat(eventSubscription.getEventName()).isEqualTo("testSignal");
+
             cmmnRuntimeService.terminateCaseInstance(caseInstance.getId());
-            
-            assertEquals(0, processEngineRuntimeService.createProcessInstanceQuery().processInstanceId(task.getProcessInstanceId()).count());
-            
-            assertEquals(0, cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count());
-            
-        
+
+            assertThat(processEngineRuntimeService.createProcessInstanceQuery().processInstanceId(task.getProcessInstanceId()).count()).isEqualTo(0);
+
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+
         } finally {
             processEngine.getRepositoryService().deleteDeployment(deployment.getId(), true);
         }

--- a/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/StagePropagationTest.java
+++ b/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/StagePropagationTest.java
@@ -12,8 +12,7 @@
  */
 package org.flowable.cmmn.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
@@ -45,22 +44,22 @@ public class StagePropagationTest extends AbstractProcessEngineIntegrationTest {
     @CmmnDeployment(resources = "org/flowable/cmmn/test/StagePropagationTest.multipleTests.cmmn")
     public void testStageOnTaskPropagation() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
-            .caseDefinitionKey("stagePropagationTest")
-            .start();
+                .caseDefinitionKey("stagePropagationTest")
+                .start();
 
         List<PlanItemInstance> stages = cmmnRuntimeService.createPlanItemInstanceQuery()
-            .caseInstanceId(caseInstance.getId())
-            .onlyStages()
-            .orderByName().asc()
-            .planItemInstanceStateActive()
-            .list();
+                .caseInstanceId(caseInstance.getId())
+                .onlyStages()
+                .orderByName().asc()
+                .planItemInstanceStateActive()
+                .list();
 
-        assertNotNull(stages);
-        assertEquals(2, stages.size());
+        assertThat(stages).isNotNull();
+        assertThat(stages).hasSize(2);
 
         List<Task> tasks = cmmnTaskService.createTaskQuery().active().list();
-        assertNotNull(tasks);
-        assertEquals(5, tasks.size());
+        assertThat(tasks).isNotNull();
+        assertThat(tasks).hasSize(5);
 
         assertStageInstanceId(tasks, "Task A", stages.get(0).getId());
         assertStageInstanceId(tasks, "Task B", stages.get(0).getId());
@@ -70,39 +69,39 @@ public class StagePropagationTest extends AbstractProcessEngineIntegrationTest {
 
         // test the various query options
         tasks = cmmnTaskService.createTaskQuery()
-            .active()
-            .propagatedStageInstanceId(stages.get(0).getId())
-            .list();
+                .active()
+                .propagatedStageInstanceId(stages.get(0).getId())
+                .list();
 
-        assertNotNull(tasks);
-        assertEquals(3, tasks.size());
+        assertThat(tasks).isNotNull();
+        assertThat(tasks).hasSize(3);
 
         assertStageInstanceId(tasks, "Task A", stages.get(0).getId());
         assertStageInstanceId(tasks, "Task B", stages.get(0).getId());
         assertStageInstanceId(tasks, "Task C", stages.get(0).getId());
 
         tasks = cmmnTaskService.createTaskQuery()
-            .active()
-            .propagatedStageInstanceId(stages.get(1).getId())
-            .list();
+                .active()
+                .propagatedStageInstanceId(stages.get(1).getId())
+                .list();
 
-        assertNotNull(tasks);
-        assertEquals(1, tasks.size());
+        assertThat(tasks).isNotNull();
+        assertThat(tasks).hasSize(1);
 
         assertStageInstanceId(tasks, "Task D", stages.get(1).getId());
 
         // now complete the tasks to move the to the history
         tasks = cmmnTaskService.createTaskQuery().active().caseInstanceId(caseInstance.getId()).list();
-        assertNotNull(tasks);
-        assertEquals(3, tasks.size());
+        assertThat(tasks).isNotNull();
+        assertThat(tasks).hasSize(3);
 
         for (Task task : tasks) {
             cmmnTaskService.complete(task.getId());
         }
 
         tasks = processEngineTaskService.createTaskQuery().active().list();
-        assertNotNull(tasks);
-        assertEquals(2, tasks.size());
+        assertThat(tasks).isNotNull();
+        assertThat(tasks).hasSize(2);
 
         for (Task task : tasks) {
             processEngineTaskService.complete(task.getId());
@@ -113,10 +112,10 @@ public class StagePropagationTest extends AbstractProcessEngineIntegrationTest {
 
         // so query the completed tasks through the history
         List<HistoricTaskInstance> historicTasks = cmmnHistoryService.createHistoricTaskInstanceQuery()
-            .list();
+                .list();
 
-        assertNotNull(historicTasks);
-        assertEquals(5, historicTasks.size());
+        assertThat(historicTasks).isNotNull();
+        assertThat(historicTasks).hasSize(5);
 
         assertStageInstanceId(historicTasks, "Task A", stages.get(0).getId());
         assertStageInstanceId(historicTasks, "Task B", stages.get(0).getId());
@@ -125,22 +124,22 @@ public class StagePropagationTest extends AbstractProcessEngineIntegrationTest {
         assertStageInstanceId(historicTasks, "Task E", null);
 
         historicTasks = cmmnHistoryService.createHistoricTaskInstanceQuery()
-            .propagatedStageInstanceId(stages.get(0).getId())
-            .list();
+                .propagatedStageInstanceId(stages.get(0).getId())
+                .list();
 
-        assertNotNull(historicTasks);
-        assertEquals(3, historicTasks.size());
+        assertThat(historicTasks).isNotNull();
+        assertThat(historicTasks).hasSize(3);
 
         assertStageInstanceId(historicTasks, "Task A", stages.get(0).getId());
         assertStageInstanceId(historicTasks, "Task B", stages.get(0).getId());
         assertStageInstanceId(historicTasks, "Task C", stages.get(0).getId());
 
         historicTasks = cmmnHistoryService.createHistoricTaskInstanceQuery()
-            .propagatedStageInstanceId(stages.get(1).getId())
-            .list();
+                .propagatedStageInstanceId(stages.get(1).getId())
+                .list();
 
-        assertNotNull(historicTasks);
-        assertEquals(1, historicTasks.size());
+        assertThat(historicTasks).isNotNull();
+        assertThat(historicTasks).hasSize(1);
 
         assertStageInstanceId(historicTasks, "Task D", stages.get(1).getId());
     }
@@ -153,7 +152,7 @@ public class StagePropagationTest extends AbstractProcessEngineIntegrationTest {
                 break;
             }
         }
-        assertNotNull(taskToAssert);
-        assertEquals(stageInstanceId, taskToAssert.getPropagatedStageInstanceId());
+        assertThat(taskToAssert).isNotNull();
+        assertThat(taskToAssert.getPropagatedStageInstanceId()).isEqualTo(stageInstanceId);
     }
 }

--- a/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/validate/CaseWithFormTest.java
+++ b/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/validate/CaseWithFormTest.java
@@ -12,11 +12,8 @@
  */
 package org.flowable.cmmn.test.validate;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Collections;
 import java.util.Date;
@@ -41,27 +38,27 @@ import org.junit.Test;
 public class CaseWithFormTest extends AbstractProcessEngineIntegrationTest {
 
     public static final String ONE_TASK_CASE = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-        + "<definitions xmlns=\"http://www.omg.org/spec/CMMN/20151109/MODEL\"\n"
-        + "             xmlns:flowable=\"http://flowable.org/cmmn\"\n"
-        + "\n"
-        + "             targetNamespace=\"http://flowable.org/cmmn\">\n"
-        + "\n"
-        + "\n"
-        + "    <case id=\"oneTaskCaseWithForm\">\n"
-        + "        <casePlanModel id=\"myPlanModel\" name=\"My CasePlanModel\" flowable:formKey=\"form1\" flowable:formFieldValidation=\"CASE_VALIDATE_VALUE\">\n"
-        + "\n"
-        + "            <planItem id=\"planItem1\" name=\"Task One\" definitionRef=\"theTask\" />\n"
-        + "\n"
-        + "            <humanTask id=\"theTask\" name=\"The Task\" flowable:formKey=\"form1\" flowable:formFieldValidation=\"TASK_VALIDATE_VALUE\">\n"
-        + "                <extensionElements>\n"
-        + "                    <flowable:taskListener event=\"create\" class=\"org.flowable.cmmn.test.validate.SideEffectTaskListener\"></flowable:taskListener>\n"
-        + "                    <flowable:taskListener event=\"complete\" class=\"org.flowable.cmmn.test.validate.SideEffectTaskListener\"></flowable:taskListener>\n"
-        + "                </extensionElements>\n"
-        + "            </humanTask>\n"
-        + "\n"
-        + "        </casePlanModel>\n"
-        + "    </case>\n"
-        + "</definitions>\n";
+            + "<definitions xmlns=\"http://www.omg.org/spec/CMMN/20151109/MODEL\"\n"
+            + "             xmlns:flowable=\"http://flowable.org/cmmn\"\n"
+            + "\n"
+            + "             targetNamespace=\"http://flowable.org/cmmn\">\n"
+            + "\n"
+            + "\n"
+            + "    <case id=\"oneTaskCaseWithForm\">\n"
+            + "        <casePlanModel id=\"myPlanModel\" name=\"My CasePlanModel\" flowable:formKey=\"form1\" flowable:formFieldValidation=\"CASE_VALIDATE_VALUE\">\n"
+            + "\n"
+            + "            <planItem id=\"planItem1\" name=\"Task One\" definitionRef=\"theTask\" />\n"
+            + "\n"
+            + "            <humanTask id=\"theTask\" name=\"The Task\" flowable:formKey=\"form1\" flowable:formFieldValidation=\"TASK_VALIDATE_VALUE\">\n"
+            + "                <extensionElements>\n"
+            + "                    <flowable:taskListener event=\"create\" class=\"org.flowable.cmmn.test.validate.SideEffectTaskListener\"></flowable:taskListener>\n"
+            + "                    <flowable:taskListener event=\"complete\" class=\"org.flowable.cmmn.test.validate.SideEffectTaskListener\"></flowable:taskListener>\n"
+            + "                </extensionElements>\n"
+            + "            </humanTask>\n"
+            + "\n"
+            + "        </casePlanModel>\n"
+            + "    </case>\n"
+            + "</definitions>\n";
 
     protected FormRepositoryService formRepositoryService;
 
@@ -72,16 +69,16 @@ public class CaseWithFormTest extends AbstractProcessEngineIntegrationTest {
 
         formRepositoryService = FormEngines.getDefaultFormEngine().getFormRepositoryService();
         formRepositoryService.createDeployment().
-            addClasspathResource("org/flowable/cmmn/test/simple.form").
-            deploy();
+                addClasspathResource("org/flowable/cmmn/test/simple.form").
+                deploy();
         cmmnHistoryService = cmmnEngineConfiguration.getCmmnHistoryService();
 
         cmmnEngineConfiguration.getCmmnRepositoryService().createDeployment().
-            addString("org/flowable/cmmn/test/oneTasksCaseWithForm.cmmn", ONE_TASK_CASE.
-                replace("CASE_VALIDATE_VALUE", "true").
-                replace("TASK_VALIDATE_VALUE", "true")
-            ).
-            deploy();
+                addString("org/flowable/cmmn/test/oneTasksCaseWithForm.cmmn", ONE_TASK_CASE.
+                        replace("CASE_VALIDATE_VALUE", "true").
+                        replace("TASK_VALIDATE_VALUE", "true")
+                ).
+                deploy();
         SideEffectTaskListener.reset();
         TestValidationFormEngineConfigurator.ThrowExceptionOnValidationFormService.activate();
     }
@@ -90,37 +87,34 @@ public class CaseWithFormTest extends AbstractProcessEngineIntegrationTest {
     public void cleanDeployments() {
         TestValidationFormEngineConfigurator.ThrowExceptionOnValidationFormService.deactivate();
         formRepositoryService.createDeploymentQuery().list().forEach(
-            formDeployment -> formRepositoryService.deleteDeployment(formDeployment.getId())
+                formDeployment -> formRepositoryService.deleteDeployment(formDeployment.getId())
         );
         CmmnRepositoryService cmmnRepositoryService = cmmnEngineConfiguration.getCmmnRepositoryService();
         cmmnRepositoryService.createDeploymentQuery().list().forEach(
-            cmmnDeployment -> cmmnRepositoryService.deleteDeployment(cmmnDeployment.getId(), true)
+                cmmnDeployment -> cmmnRepositoryService.deleteDeployment(cmmnDeployment.getId(), true)
         );
 
         cmmnHistoryService.createHistoricTaskLogEntryQuery().list().forEach(
-            historicTaskLogEntry -> cmmnHistoryService.deleteHistoricTaskLogEntry(historicTaskLogEntry.getLogNumber())
+                historicTaskLogEntry -> cmmnHistoryService.deleteHistoricTaskLogEntry(historicTaskLogEntry.getLogNumber())
         );
     }
 
     @Test
     public void startCaseWithForm() {
-        try {
-            cmmnRuntimeService.createCaseInstanceBuilder().
-                caseDefinitionKey("oneTaskCaseWithForm").
-                startFormVariables(Collections.singletonMap("variable", "VariableValue")).
-                startWithForm();
-            fail("Validation exception expected");
-        } catch (FlowableFormValidationException e) {
-            assertThat("Validation failed by default", is(e.getMessage()));
-        }
-        assertThat(SideEffectTaskListener.getSideEffect(), is(0));
+        assertThatThrownBy(() -> cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCaseWithForm")
+                .startFormVariables(Collections.singletonMap("variable", "VariableValue"))
+                .startWithForm())
+                .isInstanceOf(FlowableFormValidationException.class)
+                .hasMessageStartingWith("Validation failed by default");
+        assertThat(SideEffectTaskListener.getSideEffect()).isEqualTo(0);
     }
 
     @Test
     public void completeTaskWithFormAndCheckTaskLogEntries() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCaseWithForm").
-            start();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCaseWithForm")
+                .start();
 
         Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
         FormDefinition formDefinition = formRepositoryService.createFormDefinitionQuery().formDefinitionKey(task.getFormKey()).singleResult();
@@ -137,38 +131,39 @@ public class CaseWithFormTest extends AbstractProcessEngineIntegrationTest {
         cmmnTaskService.deleteGroupIdentityLink(task.getId(), "testGroup", IdentityLinkType.PARTICIPANT);
         cmmnTaskService.completeTaskWithForm(task.getId(), formDefinition.getId(), "__COMPLETE", Collections.singletonMap("doNotThrowException", ""));
 
-        assertEquals(11l, cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).count());
-        assertEquals(1l, cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_CREATED.name()).count());
-        assertEquals(1l,
-            cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_NAME_CHANGED.name()).count());
-        assertEquals(1l,
-            cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_PRIORITY_CHANGED.name()).count());
-        assertEquals(1l,
-            cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_ASSIGNEE_CHANGED.name()).count());
-        assertEquals(1l,
-            cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_OWNER_CHANGED.name()).count());
-        assertEquals(1l,
-            cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_DUEDATE_CHANGED.name()).count());
-        assertEquals(2l,
-            cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_IDENTITY_LINK_ADDED.name()).count());
-        assertEquals(2l,
-            cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_IDENTITY_LINK_REMOVED.name()).count());
-        assertEquals(1l,
-            cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_COMPLETED.name()).count());
+        assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).count()).isEqualTo(11l);
+        assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_CREATED.name()).count())
+                .isEqualTo(1l);
+        assertThat(
+                cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_NAME_CHANGED.name()).count())
+                .isEqualTo(1l);
+        assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_PRIORITY_CHANGED.name())
+                .count()).isEqualTo(1l);
+        assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_ASSIGNEE_CHANGED.name())
+                .count()).isEqualTo(1l);
+        assertThat(
+                cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_OWNER_CHANGED.name()).count())
+                .isEqualTo(1l);
+        assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_DUEDATE_CHANGED.name())
+                .count()).isEqualTo(1l);
+        assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_IDENTITY_LINK_ADDED.name())
+                .count()).isEqualTo(2l);
+        assertThat(
+                cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_IDENTITY_LINK_REMOVED.name())
+                        .count()).isEqualTo(2l);
+        assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_COMPLETED.name()).count())
+                .isEqualTo(1l);
     }
 
     @Test
     public void startCaseAsyncWithForm() {
-        try {
-            cmmnRuntimeService.createCaseInstanceBuilder().
-                caseDefinitionKey("oneTaskCaseWithForm").
-                startFormVariables(Collections.singletonMap("variable", "VariableValue")).
-                startWithForm();
-            fail("Validation exception expected");
-        } catch (FlowableFormValidationException e) {
-            assertThat("Validation failed by default", is(e.getMessage()));
-        }
-        assertThat(SideEffectTaskListener.getSideEffect(), is(0));
+        assertThatThrownBy(() -> cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCaseWithForm")
+                .startFormVariables(Collections.singletonMap("variable", "VariableValue"))
+                .startWithForm())
+                .isInstanceOf(FlowableFormValidationException.class)
+                .hasMessageStartingWith("Validation failed by default");
+        assertThat(SideEffectTaskListener.getSideEffect()).isEqualTo(0);
     }
 
     @Test
@@ -176,12 +171,12 @@ public class CaseWithFormTest extends AbstractProcessEngineIntegrationTest {
         cmmnEngineConfiguration.setFormFieldValidationEnabled(false);
         try {
             CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-                caseDefinitionKey("oneTaskCaseWithForm").
-                startFormVariables(Collections.singletonMap("variable", "VariableValue")).
-                startWithForm();
+                    caseDefinitionKey("oneTaskCaseWithForm").
+                    startFormVariables(Collections.singletonMap("variable", "VariableValue")).
+                    startWithForm();
 
-            assertThat(caseInstance, is(notNullValue()));
-            assertThat(SideEffectTaskListener.getSideEffect(), is(1));
+            assertThat(caseInstance).isNotNull();
+            assertThat(SideEffectTaskListener.getSideEffect()).isEqualTo(1);
         } finally {
             cmmnEngineConfiguration.setFormFieldValidationEnabled(true);
         }
@@ -189,15 +184,12 @@ public class CaseWithFormTest extends AbstractProcessEngineIntegrationTest {
 
     @Test
     public void startCaseWithFormWithoutVariables() {
-        try {
-            cmmnRuntimeService.createCaseInstanceBuilder().
-                caseDefinitionKey("oneTaskCaseWithForm").
-                startWithForm();
-            fail("Validation exception expected");
-        } catch (FlowableFormValidationException e) {
-            assertThat("Validation failed by default", is(e.getMessage()));
-        }
-        assertThat(SideEffectTaskListener.getSideEffect(), is(0));
+        assertThatThrownBy(() -> cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCaseWithForm")
+                .startWithForm())
+                .isInstanceOf(FlowableFormValidationException.class)
+                .hasMessageStartingWith("Validation failed by default");
+        assertThat(SideEffectTaskListener.getSideEffect()).isEqualTo(0);
     }
 
     @Test
@@ -205,15 +197,15 @@ public class CaseWithFormTest extends AbstractProcessEngineIntegrationTest {
         cmmnEngineConfiguration.setFormFieldValidationEnabled(false);
         try {
             CaseInstance caze = cmmnRuntimeService.createCaseInstanceBuilder().
-                caseDefinitionKey("oneTaskCaseWithForm").
-                start();
+                    caseDefinitionKey("oneTaskCaseWithForm").
+                    start();
             Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caze.getId()).singleResult();
             FormDefinition formDefinition = formRepositoryService.createFormDefinitionQuery().formDefinitionKey("form1").singleResult();
-            assertThat(SideEffectTaskListener.getSideEffect(), is(1));
+            assertThat(SideEffectTaskListener.getSideEffect()).isEqualTo(1);
             SideEffectTaskListener.reset();
 
             cmmnTaskService.completeTaskWithForm(task.getId(), formDefinition.getId(), "__COMPLETE", Collections.singletonMap("var", "value"));
-            assertThat(SideEffectTaskListener.getSideEffect(), is(1));
+            assertThat(SideEffectTaskListener.getSideEffect()).isEqualTo(1);
         } finally {
             cmmnEngineConfiguration.setFormFieldValidationEnabled(true);
         }
@@ -222,178 +214,154 @@ public class CaseWithFormTest extends AbstractProcessEngineIntegrationTest {
     @Test
     public void completeCaseTaskWithForm() {
         CaseInstance caze = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCaseWithForm").
-            start();
+                caseDefinitionKey("oneTaskCaseWithForm").
+                start();
         Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caze.getId()).singleResult();
         FormDefinition formDefinition = formRepositoryService.createFormDefinitionQuery().formDefinitionKey("form1").singleResult();
-        assertThat(SideEffectTaskListener.getSideEffect(), is(1));
+        assertThat(SideEffectTaskListener.getSideEffect()).isEqualTo(1);
         SideEffectTaskListener.reset();
-
-        try {
-            cmmnTaskService.completeTaskWithForm(task.getId(), formDefinition.getId(), "__COMPLETE", Collections.singletonMap("var", "value"));
-            fail("Validation exception expected");
-        } catch (FlowableFormValidationException e) {
-            assertThat("Validation failed by default", is(e.getMessage()));
-        }
-        assertThat(SideEffectTaskListener.getSideEffect(), is(0));
+        assertThatThrownBy(
+                () -> cmmnTaskService.completeTaskWithForm(task.getId(), formDefinition.getId(), "__COMPLETE", Collections.singletonMap("var", "value")))
+                .isInstanceOf(FlowableFormValidationException.class)
+                .hasMessageStartingWith("Validation failed by default");
+        assertThat(SideEffectTaskListener.getSideEffect()).isEqualTo(0);
     }
 
     @Test
     public void completeCaseTaskWithFormWithoutVariables() {
         CaseInstance caze = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCaseWithForm").
-            start();
+                caseDefinitionKey("oneTaskCaseWithForm").
+                start();
         Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caze.getId()).singleResult();
         FormDefinition formDefinition = formRepositoryService.createFormDefinitionQuery().formDefinitionKey("form1").singleResult();
-        assertThat(SideEffectTaskListener.getSideEffect(), is(1));
+        assertThat(SideEffectTaskListener.getSideEffect()).isEqualTo(1);
         SideEffectTaskListener.reset();
-
-        try {
-            cmmnTaskService.completeTaskWithForm(task.getId(), formDefinition.getId(), "__COMPLETE", null);
-            fail("Validation exception expected");
-        } catch (FlowableFormValidationException e) {
-            assertThat("Validation failed by default", is(e.getMessage()));
-        }
-        assertThat(SideEffectTaskListener.getSideEffect(), is(0));
+        assertThatThrownBy(() -> cmmnTaskService.completeTaskWithForm(task.getId(), formDefinition.getId(), "__COMPLETE", null))
+                .isInstanceOf(FlowableFormValidationException.class)
+                .hasMessageStartingWith("Validation failed by default");
+        assertThat(SideEffectTaskListener.getSideEffect()).isEqualTo(0);
     }
 
     @Test
     public void completeTaskWithoutValidationOnModelLevel() {
         cmmnEngineConfiguration.getCmmnRepositoryService().createDeployment().
-            addString("org/flowable/cmmn/test/oneTasksCaseWithForm.cmmn", ONE_TASK_CASE.
-                replace("CASE_VALIDATE_VALUE", "false").
-                replace("TASK_VALIDATE_VALUE", "false")
-            ).
-            deploy();
+                addString("org/flowable/cmmn/test/oneTasksCaseWithForm.cmmn", ONE_TASK_CASE.
+                        replace("CASE_VALIDATE_VALUE", "false").
+                        replace("TASK_VALIDATE_VALUE", "false")
+                ).
+                deploy();
         CaseInstance caze = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCaseWithForm").
-            start();
+                caseDefinitionKey("oneTaskCaseWithForm").
+                start();
         Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caze.getId()).singleResult();
         FormDefinition formDefinition = formRepositoryService.createFormDefinitionQuery().formDefinitionKey("form1").singleResult();
-        assertThat(SideEffectTaskListener.getSideEffect(), is(1));
+        assertThat(SideEffectTaskListener.getSideEffect()).isEqualTo(1);
         SideEffectTaskListener.reset();
 
         cmmnTaskService.completeTaskWithForm(task.getId(), formDefinition.getId(), "__COMPLETE", null);
-        assertThat(SideEffectTaskListener.getSideEffect(), is(1));
+        assertThat(SideEffectTaskListener.getSideEffect()).isEqualTo(1);
     }
 
     @Test
     public void completeTaskWithoutValidationOnModelLevelExpression() {
         cmmnEngineConfiguration.getCmmnRepositoryService().createDeployment().
-            addString("org/flowable/cmmn/test/oneTasksCaseWithForm.cmmn", ONE_TASK_CASE.
-                replace("CASE_VALIDATE_VALUE", "${true}").
-                replace("TASK_VALIDATE_VALUE", "${allowValidation}")
-            ).
-            deploy();
+                addString("org/flowable/cmmn/test/oneTasksCaseWithForm.cmmn", ONE_TASK_CASE.
+                        replace("CASE_VALIDATE_VALUE", "${true}").
+                        replace("TASK_VALIDATE_VALUE", "${allowValidation}")
+                ).
+                deploy();
 
-        try {
-            cmmnRuntimeService.createCaseInstanceBuilder().
-                caseDefinitionKey("oneTaskCaseWithForm").
-                startFormVariables(Collections.singletonMap("allowValidation", true)).
-                startWithForm();
-            fail("Validation exception expected");
-        } catch (FlowableFormValidationException e) {
-            assertThat("Validation failed by default", is(e.getMessage()));
-        }
-        assertThat(SideEffectTaskListener.getSideEffect(), is(0));
+        assertThatThrownBy(() -> cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCaseWithForm")
+                .startFormVariables(Collections.singletonMap("allowValidation", true))
+                .startWithForm())
+                .isInstanceOf(FlowableFormValidationException.class)
+                .hasMessageStartingWith("Validation failed by default");
+        assertThat(SideEffectTaskListener.getSideEffect()).isEqualTo(0);
 
         CaseInstance caze = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCaseWithForm").
-            variables(Collections.singletonMap("allowValidation", true)).
-            start();
-        assertThat(SideEffectTaskListener.getSideEffect(), is(1));
+                caseDefinitionKey("oneTaskCaseWithForm").
+                variables(Collections.singletonMap("allowValidation", true)).
+                start();
+        assertThat(SideEffectTaskListener.getSideEffect()).isEqualTo(1);
         SideEffectTaskListener.reset();
 
         Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caze.getId()).singleResult();
         FormDefinition formDefinition = formRepositoryService.createFormDefinitionQuery().formDefinitionKey("form1").singleResult();
 
-        try {
-            cmmnTaskService.completeTaskWithForm(task.getId(), formDefinition.getId(), "__COMPLETE", null);
-            fail("Validation exception expected");
-        } catch (FlowableFormValidationException e) {
-            assertThat("Validation failed by default", is(e.getMessage()));
-        }
-        assertThat(SideEffectTaskListener.getSideEffect(), is(0));
-
-
+        assertThatThrownBy(() -> cmmnTaskService.completeTaskWithForm(task.getId(), formDefinition.getId(), "__COMPLETE", null))
+                .isInstanceOf(FlowableFormValidationException.class)
+                .hasMessageStartingWith("Validation failed by default");
+        assertThat(SideEffectTaskListener.getSideEffect()).isEqualTo(0);
     }
 
     @Test
     public void completeTaskWithoutValidationOnModelLevelBadExpression() {
         cmmnEngineConfiguration.getCmmnRepositoryService().createDeployment().
-            addString("org/flowable/cmmn/test/oneTasksCaseWithForm.cmmn", ONE_TASK_CASE.
-                replace("CASE_VALIDATE_VALUE", "true").
-                replace("TASK_VALIDATE_VALUE", "${BAD_EXPRESSION}")
-            ).
-            deploy();
+                addString("org/flowable/cmmn/test/oneTasksCaseWithForm.cmmn", ONE_TASK_CASE.
+                        replace("CASE_VALIDATE_VALUE", "true").
+                        replace("TASK_VALIDATE_VALUE", "${BAD_EXPRESSION}")
+                ).
+                deploy();
 
         CaseInstance caze = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCaseWithForm").
-            start();
+                caseDefinitionKey("oneTaskCaseWithForm").
+                start();
         Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caze.getId()).singleResult();
         FormDefinition formDefinition = formRepositoryService.createFormDefinitionQuery().formDefinitionKey("form1").singleResult();
-        assertThat(SideEffectTaskListener.getSideEffect(), is(1));
+        assertThat(SideEffectTaskListener.getSideEffect()).isEqualTo(1);
         SideEffectTaskListener.reset();
 
-        try {
-            cmmnTaskService.completeTaskWithForm(task.getId(), formDefinition.getId(), "__COMPLETE", null);
-            fail("Validation exception expected");
-        } catch (RuntimeException e) {
-            assertThat("Unknown property used in expression: ${BAD_EXPRESSION}", is(e.getMessage()));
-        }
-        assertThat(SideEffectTaskListener.getSideEffect(), is(0));
+        assertThatThrownBy(() -> cmmnTaskService.completeTaskWithForm(task.getId(), formDefinition.getId(), "__COMPLETE", null))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageStartingWith("Unknown property used in expression: ${BAD_EXPRESSION}");
+        assertThat(SideEffectTaskListener.getSideEffect()).isEqualTo(0);
     }
 
     @Test
     public void completeTaskWithValidationOnModelLevelStringExpression() {
         cmmnEngineConfiguration.getCmmnRepositoryService().createDeployment().
-            addString("org/flowable/cmmn/test/oneTasksCaseWithForm.cmmn", ONE_TASK_CASE.
-                replace("CASE_VALIDATE_VALUE", "true").
-                replace("TASK_VALIDATE_VALUE", "${true}")
-            ).
-            deploy();
+                addString("org/flowable/cmmn/test/oneTasksCaseWithForm.cmmn", ONE_TASK_CASE.
+                        replace("CASE_VALIDATE_VALUE", "true").
+                        replace("TASK_VALIDATE_VALUE", "${true}")
+                ).
+                deploy();
 
         CaseInstance caze = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCaseWithForm").
-            start();
+                caseDefinitionKey("oneTaskCaseWithForm").
+                start();
         Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caze.getId()).singleResult();
         FormDefinition formDefinition = formRepositoryService.createFormDefinitionQuery().formDefinitionKey("form1").singleResult();
-        assertThat(SideEffectTaskListener.getSideEffect(), is(1));
+        assertThat(SideEffectTaskListener.getSideEffect()).isEqualTo(1);
         SideEffectTaskListener.reset();
 
-        try {
-            cmmnTaskService.completeTaskWithForm(task.getId(), formDefinition.getId(), "__COMPLETE", null);
-            fail("Validation exception expected");
-        } catch (FlowableFormValidationException e) {
-            assertThat("Validation failed by default", is(e.getMessage()));
-        }
-        assertThat(SideEffectTaskListener.getSideEffect(), is(0));
+        assertThatThrownBy(() -> cmmnTaskService.completeTaskWithForm(task.getId(), formDefinition.getId(), "__COMPLETE", null))
+                .isInstanceOf(FlowableFormValidationException.class)
+                .hasMessageStartingWith("Validation failed by default");
+        assertThat(SideEffectTaskListener.getSideEffect()).isEqualTo(0);
     }
 
     @Test
     public void completeTaskWithoutValidationOnMissingModelLevel() {
         cmmnEngineConfiguration.getCmmnRepositoryService().createDeployment().
-            addString("org/flowable/cmmn/test/oneTasksCaseWithForm.cmmn", ONE_TASK_CASE.
-                replace("flowable:formFieldValidation=\"CASE_VALIDATE_VALUE\"", "").
-                replace("flowable:formFieldValidation=\"TASK_VALIDATE_VALUE\"", "")
-            ).
-            deploy();
+                addString("org/flowable/cmmn/test/oneTasksCaseWithForm.cmmn", ONE_TASK_CASE.
+                        replace("flowable:formFieldValidation=\"CASE_VALIDATE_VALUE\"", "").
+                        replace("flowable:formFieldValidation=\"TASK_VALIDATE_VALUE\"", "")
+                ).
+                deploy();
 
         CaseInstance caze = cmmnRuntimeService.createCaseInstanceBuilder().
-            caseDefinitionKey("oneTaskCaseWithForm").
-            start();
+                caseDefinitionKey("oneTaskCaseWithForm").
+                start();
         Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caze.getId()).singleResult();
         FormDefinition formDefinition = formRepositoryService.createFormDefinitionQuery().formDefinitionKey("form1").singleResult();
-        assertThat(SideEffectTaskListener.getSideEffect(), is(1));
+        assertThat(SideEffectTaskListener.getSideEffect()).isEqualTo(1);
         SideEffectTaskListener.reset();
 
-        try {
-            cmmnTaskService.completeTaskWithForm(task.getId(), formDefinition.getId(), "__COMPLETE", null);
-            fail("Validation exception expected");
-        } catch (FlowableFormValidationException e) {
-            assertThat("Validation failed by default", is(e.getMessage()));
-        }
-        assertThat(SideEffectTaskListener.getSideEffect(), is(0));
+        assertThatThrownBy(() -> cmmnTaskService.completeTaskWithForm(task.getId(), formDefinition.getId(), "__COMPLETE", null))
+                .isInstanceOf(FlowableFormValidationException.class)
+                .hasMessageStartingWith("Validation failed by default");
+        assertThat(SideEffectTaskListener.getSideEffect()).isEqualTo(0);
     }
 
 }


### PR DESCRIPTION
Continuing quest to use only a single style in each file and in the module.

