### PR TITLE
Use assertj fluent style in flowable-cmmn-json-converter.

### DIFF
--- a/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/AbstractConverterTest.java
+++ b/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/AbstractConverterTest.java
@@ -16,11 +16,11 @@ import java.io.InputStream;
 
 import org.flowable.cmmn.editor.json.converter.CmmnJsonConverter;
 import org.flowable.cmmn.model.CmmnModel;
+import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.junit.Test;
 
 public abstract class AbstractConverterTest {
 

--- a/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/CaseTaskJsonConverterTest.java
+++ b/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/CaseTaskJsonConverterTest.java
@@ -13,9 +13,7 @@
 package org.flowable.cmmn.editor;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.tuple;
 
 import org.flowable.cmmn.model.Case;
 import org.flowable.cmmn.model.CaseTask;
@@ -29,6 +27,7 @@ import org.flowable.cmmn.model.Stage;
  * @author martin.grofcik
  */
 public class CaseTaskJsonConverterTest extends AbstractConverterTest {
+
     @Override
     protected String getResource() {
         return "test.caseTaskModel.json";
@@ -37,32 +36,28 @@ public class CaseTaskJsonConverterTest extends AbstractConverterTest {
     @Override
     protected void validateModel(CmmnModel model) {
         Case caseModel = model.getPrimaryCase();
-        assertEquals("caseTaskModelId", caseModel.getId());
-        assertEquals("caseTaskModelName", caseModel.getName());
+        assertThat(caseModel.getId()).isEqualTo("caseTaskModelId");
+        assertThat(caseModel.getName()).isEqualTo("caseTaskModelName");
 
         Stage planModelStage = caseModel.getPlanModel();
-        assertNotNull(planModelStage);
-        assertEquals("casePlanModel", planModelStage.getId());
+        assertThat(planModelStage).isNotNull();
+        assertThat(planModelStage.getId()).isEqualTo("casePlanModel");
 
         PlanItem planItem = planModelStage.findPlanItemInPlanFragmentOrUpwards("planItem1");
-        assertNotNull(planItem);
-        assertEquals("planItem1", planItem.getId());
-        assertEquals("caseTaskName", planItem.getName());
+        assertThat(planItem).isNotNull();
+        assertThat(planItem.getId()).isEqualTo("planItem1");
+        assertThat(planItem.getName()).isEqualTo("caseTaskName");
         PlanItemDefinition planItemDefinition = planItem.getPlanItemDefinition();
-        assertNotNull(planItemDefinition);
-        assertTrue(planItemDefinition instanceof CaseTask);
+        assertThat(planItemDefinition).isNotNull();
+        assertThat(planItemDefinition).isInstanceOf(CaseTask.class);
         CaseTask caseTask = (CaseTask) planItemDefinition;
-        assertEquals("sid-E06221FA-0225-4EF8-A1E8-8DC177326B77", caseTask.getId());
-        assertEquals("caseTaskName", caseTask.getName());
-        assertTrue(caseTask.getFallbackToDefaultTenant());
-        assertTrue(caseTask.isSameDeployment());
+        assertThat(caseTask.getId()).isEqualTo("sid-E06221FA-0225-4EF8-A1E8-8DC177326B77");
+        assertThat(caseTask.getName()).isEqualTo("caseTaskName");
+        assertThat(caseTask.getFallbackToDefaultTenant()).isTrue();
+        assertThat(caseTask.isSameDeployment()).isTrue();
 
         assertThat(caseTask.getInParameters())
-                .isNotNull()
-                .hasSize(1);
-        IOParameter inParameter = caseTask.getInParameters().get(0);
-        assertThat(inParameter).isNotNull();
-        assertThat(inParameter.getSource()).isEqualTo("testSource");
-        assertThat(inParameter.getTarget()).isEqualTo("testTarget");
+                .extracting(IOParameter::getSource, IOParameter::getTarget)
+                .containsExactly(tuple("testSource", "testTarget"));
     }
 }

--- a/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/DecisionTaskJsonConverterTest.java
+++ b/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/DecisionTaskJsonConverterTest.java
@@ -14,9 +14,6 @@ package org.flowable.cmmn.editor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 import org.flowable.cmmn.model.Case;
 import org.flowable.cmmn.model.CmmnModel;
@@ -30,6 +27,7 @@ import org.flowable.cmmn.model.Stage;
  * @author martin.grofcik
  */
 public class DecisionTaskJsonConverterTest extends AbstractConverterTest {
+
     @Override
     protected String getResource() {
         return "test.dmnTaskModel.json";
@@ -38,31 +36,31 @@ public class DecisionTaskJsonConverterTest extends AbstractConverterTest {
     @Override
     protected void validateModel(CmmnModel model) {
         Case caseModel = model.getPrimaryCase();
-        assertEquals("dmnExportCase", caseModel.getId());
-        assertEquals("dmnExportCase", caseModel.getName());
+        assertThat(caseModel.getId()).isEqualTo("dmnExportCase");
+        assertThat(caseModel.getName()).isEqualTo("dmnExportCase");
 
         Stage planModelStage = caseModel.getPlanModel();
-        assertNotNull(planModelStage);
-        assertEquals("casePlanModel", planModelStage.getId());
+        assertThat(planModelStage).isNotNull();
+        assertThat(planModelStage.getId()).isEqualTo("casePlanModel");
 
         PlanItem planItem = planModelStage.findPlanItemInPlanFragmentOrUpwards("planItem1");
-        assertNotNull(planItem);
-        assertEquals("planItem1", planItem.getId());
-        assertEquals("dmnTask", planItem.getName());
+        assertThat(planItem).isNotNull();
+        assertThat(planItem.getId()).isEqualTo("planItem1");
+        assertThat(planItem.getName()).isEqualTo("dmnTask");
         PlanItemDefinition planItemDefinition = planItem.getPlanItemDefinition();
-        assertNotNull(planItemDefinition);
-        assertTrue(planItemDefinition instanceof DecisionTask);
+        assertThat(planItemDefinition).isNotNull();
+        assertThat(planItemDefinition).isInstanceOf(DecisionTask.class);
         DecisionTask decisionTask = (DecisionTask) planItemDefinition;
-        assertEquals("sid-F4BCA0C7-8737-4279-B50F-59272C7C65A2", decisionTask.getId());
-        assertEquals("dmnTask", decisionTask.getName());
+        assertThat(decisionTask.getId()).isEqualTo("sid-F4BCA0C7-8737-4279-B50F-59272C7C65A2");
+        assertThat(decisionTask.getName()).isEqualTo("dmnTask");
 
         assertThat(decisionTask.getFieldExtensions())
-            .extracting(FieldExtension::getFieldName, FieldExtension::getStringValue)
-            .as("fieldName, stringValue")
-            .contains(
-                tuple("fallbackToDefaultTenant", "true"),
-                tuple("decisionTaskThrowErrorOnNoHits", "false")
-            );
+                .extracting(FieldExtension::getFieldName, FieldExtension::getStringValue)
+                .as("fieldName, stringValue")
+                .contains(
+                        tuple("fallbackToDefaultTenant", "true"),
+                        tuple("decisionTaskThrowErrorOnNoHits", "false")
+                );
     }
 
 }

--- a/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/ExitCriterionOnStageConverterTest.java
+++ b/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/ExitCriterionOnStageConverterTest.java
@@ -12,9 +12,7 @@
  */
 package org.flowable.cmmn.editor;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.cmmn.model.Case;
 import org.flowable.cmmn.model.CmmnModel;
@@ -35,15 +33,15 @@ public class ExitCriterionOnStageConverterTest extends AbstractConverterTest {
         Case caseModel = model.getPrimaryCase();
         Stage planModelStage = caseModel.getPlanModel();
         PlanItemDefinition planItemDefinition = planModelStage.findPlanItemDefinitionInStageOrDownwards("sid-46EAD2FE-4D89-42ED-9B1E-5005AE5BF2F7");
-        assertTrue(planItemDefinition instanceof Stage);
+        assertThat(planItemDefinition).isInstanceOf(Stage.class);
 
         PlanItem planItem = planModelStage.findPlanItemInPlanFragmentOrDownwards(planItemDefinition.getPlanItemRef());
-        assertEquals(1, planItem.getEntryCriteria().size());
+        assertThat(planItem.getEntryCriteria()).hasSize(1);
         Criterion entryCriterion = planItem.getEntryCriteria().get(0);
-        assertNotNull(entryCriterion.getSentryRef());
+        assertThat(entryCriterion.getSentryRef()).isNotNull();
 
-        assertEquals(1, planItem.getExitCriteria().size());
+        assertThat(planItem.getExitCriteria()).hasSize(1);
         Criterion exitCriterion = planItem.getExitCriteria().get(0);
-        assertNotNull(exitCriterion.getSentryRef());
+        assertThat(exitCriterion.getSentryRef()).isNotNull();
     }
 }

--- a/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/HttpTaskJsonConverterTest.java
+++ b/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/HttpTaskJsonConverterTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,6 +12,11 @@
  */
 package org.flowable.cmmn.editor;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import org.flowable.cmmn.model.Case;
 import org.flowable.cmmn.model.CmmnModel;
 import org.flowable.cmmn.model.FieldExtension;
@@ -19,20 +24,12 @@ import org.flowable.cmmn.model.PlanItem;
 import org.flowable.cmmn.model.PlanItemDefinition;
 import org.flowable.cmmn.model.ServiceTask;
 import org.flowable.cmmn.model.Stage;
-import org.hamcrest.core.Is;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author martin.grofcik
  */
 public class HttpTaskJsonConverterTest extends AbstractConverterTest {
+
     @Override
     protected String getResource() {
         return "test.httpTaskModel.json";
@@ -41,26 +38,26 @@ public class HttpTaskJsonConverterTest extends AbstractConverterTest {
     @Override
     protected void validateModel(CmmnModel model) {
         Case caseModel = model.getPrimaryCase();
-        assertEquals("dmnExportCase", caseModel.getId());
-        assertEquals("dmnExportCase", caseModel.getName());
+        assertThat(caseModel.getId()).isEqualTo("dmnExportCase");
+        assertThat(caseModel.getName()).isEqualTo("dmnExportCase");
 
         Stage planModelStage = caseModel.getPlanModel();
-        assertNotNull(planModelStage);
-        assertEquals("casePlanModel", planModelStage.getId());
+        assertThat(planModelStage).isNotNull();
+        assertThat(planModelStage.getId()).isEqualTo("casePlanModel");
 
         PlanItem planItem = planModelStage.findPlanItemInPlanFragmentOrUpwards("planItem1");
-        assertNotNull(planItem);
-        assertEquals("planItem1", planItem.getId());
-        assertEquals("HttpTaskName", planItem.getName());
+        assertThat(planItem).isNotNull();
+        assertThat(planItem.getId()).isEqualTo("planItem1");
+        assertThat(planItem.getName()).isEqualTo("HttpTaskName");
         PlanItemDefinition planItemDefinition = planItem.getPlanItemDefinition();
-        assertNotNull(planItemDefinition);
-        assertTrue(planItemDefinition instanceof ServiceTask);
+        assertThat(planItemDefinition).isNotNull();
+        assertThat(planItemDefinition).isInstanceOf(ServiceTask.class);
         ServiceTask serviceTask = (ServiceTask) planItemDefinition;
-        assertEquals("http", serviceTask.getType());
-        assertEquals("sid-24B595C4-EE31-4A3E-A94F-CF2D2B13247B", serviceTask.getId());
-        assertEquals("HttpTaskName", serviceTask.getName());
-        assertEquals("documentation", serviceTask.getDocumentation());
-        assertEquals("AbcClass", serviceTask.getImplementation());
+        assertThat(serviceTask.getType()).isEqualTo("http");
+        assertThat(serviceTask.getId()).isEqualTo("sid-24B595C4-EE31-4A3E-A94F-CF2D2B13247B");
+        assertThat(serviceTask.getName()).isEqualTo("HttpTaskName");
+        assertThat(serviceTask.getDocumentation()).isEqualTo("documentation");
+        assertThat(serviceTask.getImplementation()).isEqualTo("AbcClass");
 
         List<FieldExtension> fieldExtensions = new ArrayList<>();
         fieldExtensions.add(createFieldExtension("requestMethod", "httptaskrequestmethod"));
@@ -71,15 +68,12 @@ public class HttpTaskJsonConverterTest extends AbstractConverterTest {
         fieldExtensions.add(createFieldExtension("disallowRedirects", "httptaskdisallowredirects"));
         fieldExtensions.add(createFieldExtension("failStatusCodes", "httptaskfailstatuscodes"));
         fieldExtensions.add(createFieldExtension("handleStatusCodes", "httptaskhandlestatuscodes"));
-        fieldExtensions.add(createFieldExtension("ignoreException","httptaskignoreexception"));
-        fieldExtensions.add(createFieldExtension("saveRequestVariables","httptasksaverequestvariables"));
-        fieldExtensions.add(createFieldExtension("saveResponseParameters","httptasksaveresponseparameters"));
-        fieldExtensions.add(createFieldExtension("resultVariablePrefix","httptaskresultvariableprefix"));
+        fieldExtensions.add(createFieldExtension("ignoreException", "httptaskignoreexception"));
+        fieldExtensions.add(createFieldExtension("saveRequestVariables", "httptasksaverequestvariables"));
+        fieldExtensions.add(createFieldExtension("saveResponseParameters", "httptasksaveresponseparameters"));
+        fieldExtensions.add(createFieldExtension("resultVariablePrefix", "httptaskresultvariableprefix"));
 
-        assertThat(((ServiceTask) planItemDefinition).getFieldExtensions(), Is.is(
-                    fieldExtensions
-                )
-        );
+        assertThat(((ServiceTask) planItemDefinition).getFieldExtensions()).isEqualTo(fieldExtensions);
     }
 
     protected FieldExtension createFieldExtension(String name, String value) {

--- a/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/MailTaskJsonConverterTest.java
+++ b/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/MailTaskJsonConverterTest.java
@@ -46,19 +46,19 @@ public class MailTaskJsonConverterTest extends AbstractConverterTest {
         ServiceTask mailServiceTask = (ServiceTask) mailTaskDefinition;
         assertThat(mailServiceTask.getType()).isEqualTo(ServiceTask.MAIL_TASK);
         assertThat(mailServiceTask.getFieldExtensions())
-            .extracting(FieldExtension::getFieldName, FieldExtension::getStringValue)
-            .containsExactlyInAnyOrder(
-                tuple("headers", "X-Test: test"),
-                tuple("to", "test-to@test.com"),
-                tuple("from", "test-from@test.com"),
-                tuple("subject", "Test Subject"),
-                tuple("cc", "test-cc@test.com"),
-                tuple("bcc", "test-bcc@test.com"),
-                tuple("text", "Test Text"),
-                tuple("textVar", "testTextVar"),
-                tuple("html", "Test HTML"),
-                tuple("htmlVar", "testHtmlVar"),
-                tuple("charset", "UTF-8")
-            );
+                .extracting(FieldExtension::getFieldName, FieldExtension::getStringValue)
+                .containsExactlyInAnyOrder(
+                        tuple("headers", "X-Test: test"),
+                        tuple("to", "test-to@test.com"),
+                        tuple("from", "test-from@test.com"),
+                        tuple("subject", "Test Subject"),
+                        tuple("cc", "test-cc@test.com"),
+                        tuple("bcc", "test-bcc@test.com"),
+                        tuple("text", "Test Text"),
+                        tuple("textVar", "testTextVar"),
+                        tuple("html", "Test HTML"),
+                        tuple("htmlVar", "testHtmlVar"),
+                        tuple("charset", "UTF-8")
+                );
     }
 }

--- a/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/PlanItemControlConverterTest.java
+++ b/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/PlanItemControlConverterTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,12 +12,8 @@
  */
 package org.flowable.cmmn.editor;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.List;
 
@@ -30,7 +26,7 @@ import org.flowable.cmmn.model.Stage;
  * @author Joram Barrez
  */
 public class PlanItemControlConverterTest extends AbstractConverterTest {
-    
+
     @Override
     protected String getResource() {
         return "test.planItemControl.json";
@@ -38,78 +34,78 @@ public class PlanItemControlConverterTest extends AbstractConverterTest {
 
     @Override
     protected void validateModel(CmmnModel cmmnModel) {
-        
+
         // The plan model should have auto complete enabled
         Stage planModel = cmmnModel.getPrimaryCase().getPlanModel();
-        assertTrue(planModel.isAutoComplete());
-        
+        assertThat(planModel.isAutoComplete()).isTrue();
+
         // Stage A should not have auto complete disabled
         Stage stageA = findStageByName(planModel, "Stage A");
-        assertFalse(stageA.isAutoComplete());
-        assertNull(stageA.getAutoCompleteCondition());
-        
+        assertThat(stageA.isAutoComplete()).isFalse();
+        assertThat(stageA.getAutoCompleteCondition()).isNull();
+
         // Stage A, Task A, Task B and Task D should not have any item control set
         assertNoItemControlsSet(cmmnModel, "Stage A");
         assertNoItemControlsSet(cmmnModel, "A");
         assertNoItemControlsSet(cmmnModel, "B");
         assertNoItemControlsSet(cmmnModel, "D");
-        
+
         // Stage B should have everything enabled
         Stage stageB = findStageByName(planModel, "Stage B");
-        assertTrue(stageB.isAutoComplete());
-        assertNull(stageB.getAutoCompleteCondition());
-        
+        assertThat(stageB.isAutoComplete()).isTrue();
+        assertThat(stageB.getAutoCompleteCondition()).isNull();
+
         PlanItem stageBPlanItem = findPlanItemByName(planModel, "Stage B");
-        assertNotNull(stageBPlanItem.getItemControl().getRequiredRule());
-        assertNull(stageBPlanItem.getItemControl().getRequiredRule().getCondition());
-        assertNotNull(stageBPlanItem.getItemControl().getManualActivationRule());
-        assertNull(stageBPlanItem.getItemControl().getManualActivationRule().getCondition());
-        assertNotNull(stageBPlanItem.getItemControl().getRepetitionRule());
-        assertNull(stageBPlanItem.getItemControl().getRepetitionRule().getCondition());
-        
+        assertThat(stageBPlanItem.getItemControl().getRequiredRule()).isNotNull();
+        assertThat(stageBPlanItem.getItemControl().getRequiredRule().getCondition()).isNull();
+        assertThat(stageBPlanItem.getItemControl().getManualActivationRule()).isNotNull();
+        assertThat(stageBPlanItem.getItemControl().getManualActivationRule().getCondition()).isNull();
+        assertThat(stageBPlanItem.getItemControl().getRepetitionRule()).isNotNull();
+        assertThat(stageBPlanItem.getItemControl().getRepetitionRule().getCondition()).isNull();
+
         // Stage C should have an autocomplete condition set
         Stage stageC = findStageByName(planModel, "Stage C");
-        assertTrue(stageC.isAutoComplete());
-        assertEquals("${someVariable}", stageC.getAutoCompleteCondition());
+        assertThat(stageC.isAutoComplete()).isTrue();
+        assertThat(stageC.getAutoCompleteCondition()).isEqualTo("${someVariable}");
         assertNoItemControlsSet(cmmnModel, "Stage C");
-        
+
         // Task C should have all item controls enabled
         assertAllItemControlsSet(cmmnModel, "C");
-        
+
         PlanItem taskCPlanItem = findPlanItemByName(planModel, "C");
-        assertNull(taskCPlanItem.getItemControl().getRequiredRule().getCondition());
-        assertNull(taskCPlanItem.getItemControl().getRepetitionRule().getCondition());
-        assertNull(taskCPlanItem.getItemControl().getManualActivationRule().getCondition());
-        
+        assertThat(taskCPlanItem.getItemControl().getRequiredRule().getCondition()).isNull();
+        assertThat(taskCPlanItem.getItemControl().getRepetitionRule().getCondition()).isNull();
+        assertThat(taskCPlanItem.getItemControl().getManualActivationRule().getCondition()).isNull();
+
         // Task E should have a condition set for all item controls
         assertAllItemControlsSet(cmmnModel, "C");
-        
+
         PlanItem taskEPlanItem = findPlanItemByName(planModel, "E");
-        assertEquals("${requiredCondition}", taskEPlanItem.getItemControl().getRequiredRule().getCondition());
-        assertEquals("${repetitionCondition}", taskEPlanItem.getItemControl().getRepetitionRule().getCondition());
-        assertEquals("${manualActivationCondition}", taskEPlanItem.getItemControl().getManualActivationRule().getCondition());
+        assertThat(taskEPlanItem.getItemControl().getRequiredRule().getCondition()).isEqualTo("${requiredCondition}");
+        assertThat(taskEPlanItem.getItemControl().getRepetitionRule().getCondition()).isEqualTo("${repetitionCondition}");
+        assertThat(taskEPlanItem.getItemControl().getManualActivationRule().getCondition()).isEqualTo("${manualActivationCondition}");
     }
 
     protected void assertNoItemControlsSet(CmmnModel cmmnModel, String planItemName) {
-        PlanItem planItem = findPlanItemByName(cmmnModel.getPrimaryCase().getPlanModel(),planItemName);
-        assertNotNull("No plan item found with name " + planItemName, planItem);
+        PlanItem planItem = findPlanItemByName(cmmnModel.getPrimaryCase().getPlanModel(), planItemName);
+        assertThat(planItem).as("No plan item found with name " + planItemName).isNotNull();
         if (planItem.getItemControl() != null) {
-            assertNull(planItem.getItemControl().getRequiredRule());
-            assertNull(planItem.getItemControl().getRepetitionRule());
-            assertNull(planItem.getItemControl().getManualActivationRule());
+            assertThat(planItem.getItemControl().getRequiredRule()).isNull();
+            assertThat(planItem.getItemControl().getRepetitionRule()).isNull();
+            assertThat(planItem.getItemControl().getManualActivationRule()).isNull();
         } else {
-            assertNull(planItem.getItemControl());
+            assertThat(planItem.getItemControl()).isNull();
         }
     }
-    
+
     protected void assertAllItemControlsSet(CmmnModel cmmnModel, String planItemName) {
-        PlanItem planItem = findPlanItemByName(cmmnModel.getPrimaryCase().getPlanModel(),planItemName);
-        assertNotNull("No plan item found with name " + planItemName, planItem);
-        assertNotNull(planItem.getItemControl().getRequiredRule());
-        assertNotNull(planItem.getItemControl().getRepetitionRule());
-        assertNotNull(planItem.getItemControl().getManualActivationRule());
+        PlanItem planItem = findPlanItemByName(cmmnModel.getPrimaryCase().getPlanModel(), planItemName);
+        assertThat(planItem).as("No plan item found with name " + planItemName).isNotNull();
+        assertThat(planItem.getItemControl().getRequiredRule()).isNotNull();
+        assertThat(planItem.getItemControl().getRepetitionRule()).isNotNull();
+        assertThat(planItem.getItemControl().getManualActivationRule()).isNotNull();
     }
-    
+
     protected Stage findStageByName(Stage planModel, String stageName) {
         List<Stage> stages = planModel.findPlanItemDefinitionsOfType(Stage.class, true);
         for (Stage stage : stages) {
@@ -120,16 +116,16 @@ public class PlanItemControlConverterTest extends AbstractConverterTest {
         fail("No stage found with name " + stageName);
         return null;
     }
-    
+
     protected PlanItem findPlanItemByName(PlanFragment planFragment, String planItemName) {
         List<PlanItem> planItems = planFragment.getPlanItems();
         if (planItems != null) {
             for (PlanItem planItem : planItems) {
-                
+
                 if (planItemName.equals(planItem.getName())) {
                     return planItem;
                 }
-                
+
                 if (planItem.getPlanItemDefinition() instanceof PlanFragment) {
                     PlanItem p = findPlanItemByName((PlanFragment) planItem.getPlanItemDefinition(), planItemName);
                     if (p != null) {

--- a/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/ProcessTaskJsonConverterTest.java
+++ b/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/ProcessTaskJsonConverterTest.java
@@ -12,9 +12,7 @@
  */
 package org.flowable.cmmn.editor;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.cmmn.model.Case;
 import org.flowable.cmmn.model.CmmnModel;
@@ -27,6 +25,7 @@ import org.flowable.cmmn.model.Stage;
  * @author martin.grofcik
  */
 public class ProcessTaskJsonConverterTest extends AbstractConverterTest {
+
     @Override
     protected String getResource() {
         return "test.processTaskModel.json";
@@ -35,23 +34,23 @@ public class ProcessTaskJsonConverterTest extends AbstractConverterTest {
     @Override
     protected void validateModel(CmmnModel model) {
         Case caseModel = model.getPrimaryCase();
-        assertEquals("processTaskModelId", caseModel.getId());
-        assertEquals("processTaskModelName", caseModel.getName());
+        assertThat(caseModel.getId()).isEqualTo("processTaskModelId");
+        assertThat(caseModel.getName()).isEqualTo("processTaskModelName");
 
         Stage planModelStage = caseModel.getPlanModel();
-        assertNotNull(planModelStage);
-        assertEquals("casePlanModel", planModelStage.getId());
+        assertThat(planModelStage).isNotNull();
+        assertThat(planModelStage.getId()).isEqualTo("casePlanModel");
 
         PlanItem planItem = planModelStage.findPlanItemInPlanFragmentOrUpwards("planItem1");
-        assertNotNull(planItem);
-        assertEquals("planItem1", planItem.getId());
-        assertEquals("processTaskName", planItem.getName());
+        assertThat(planItem).isNotNull();
+        assertThat(planItem.getId()).isEqualTo("planItem1");
+        assertThat(planItem.getName()).isEqualTo("processTaskName");
         PlanItemDefinition planItemDefinition = planItem.getPlanItemDefinition();
-        assertNotNull(planItemDefinition);
-        assertTrue(planItemDefinition instanceof ProcessTask);
+        assertThat(planItemDefinition).isNotNull();
+        assertThat(planItemDefinition).isInstanceOf(ProcessTask.class);
         ProcessTask processTask = (ProcessTask) planItemDefinition;
-        assertEquals("sid-5E1BEB30-72F7-463C-A1CB-77F000CA7E0F", processTask.getId());
-        assertEquals("processTaskName", processTask.getName());
-        assertTrue(processTask.getFallbackToDefaultTenant());
+        assertThat(processTask.getId()).isEqualTo("sid-5E1BEB30-72F7-463C-A1CB-77F000CA7E0F");
+        assertThat(processTask.getName()).isEqualTo("processTaskName");
+        assertThat(processTask.getFallbackToDefaultTenant()).isTrue();
     }
 }

--- a/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/ScriptTaskConverterTest.java
+++ b/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/ScriptTaskConverterTest.java
@@ -12,9 +12,7 @@
  */
 package org.flowable.cmmn.editor;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.cmmn.model.CmmnModel;
 import org.flowable.cmmn.model.PlanItem;
@@ -30,22 +28,22 @@ public class ScriptTaskConverterTest extends AbstractConverterTest {
     protected String getResource() {
         return "test.scriptTaskModel.json";
     }
-    
+
     @Override
     protected void validateModel(CmmnModel cmmnModel) {
         Stage planModel = cmmnModel.getPrimaryCase().getPlanModel();
-        assertEquals(2, planModel.getPlanItemDefinitionMap().size());
-        
+        assertThat(planModel.getPlanItemDefinitionMap()).hasSize(2);
+
         PlanItem planItemA = planModel.getPlanItems().stream().filter(p -> p.getName().equals("A")).findFirst().get();
-        assertEquals("A", planItemA.getName());
-        assertNull(planItemA.getItemControl());
-        
+        assertThat(planItemA.getName()).isEqualTo("A");
+        assertThat(planItemA.getItemControl()).isNull();
+
         PlanItem planItemB = planModel.getPlanItems().stream().filter(p -> p.getName().equals("B")).findFirst().get();
-        assertEquals("B", planItemB.getName());
+        assertThat(planItemB.getName()).isEqualTo("B");
         PlanItemControl planItemControlB = planItemB.getItemControl();
-        assertNotNull(planItemControlB.getRequiredRule());
-        assertNotNull(planItemControlB.getRepetitionRule());
-        assertNotNull(planItemControlB.getManualActivationRule());
+        assertThat(planItemControlB.getRequiredRule()).isNotNull();
+        assertThat(planItemControlB.getRepetitionRule()).isNotNull();
+        assertThat(planItemControlB.getManualActivationRule()).isNotNull();
     }
 
 }

--- a/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/SentryConverterTest.java
+++ b/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/SentryConverterTest.java
@@ -12,6 +12,11 @@
  */
 package org.flowable.cmmn.editor;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.InputStream;
+import java.util.List;
+
 import org.flowable.cmmn.editor.json.converter.CmmnJsonConverter;
 import org.flowable.cmmn.model.Case;
 import org.flowable.cmmn.model.CmmnModel;
@@ -23,14 +28,6 @@ import org.flowable.cmmn.model.SentryIfPart;
 import org.flowable.cmmn.model.Stage;
 import org.junit.Test;
 
-import java.io.InputStream;
-import java.util.List;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -40,7 +37,7 @@ public class SentryConverterTest extends AbstractConverterTest {
     protected static final String SENTRY_NODE_ID = "sid-FB0DD4A6-0EC0-46F9-9A22-72A76CCECA9D";
 
     @Test
-    public void dockerInfoShouldRemainIntact() throws  Exception{
+    public void dockerInfoShouldRemainIntact() throws Exception {
         InputStream stream = this.getClass().getClassLoader().getResourceAsStream(getResource());
         JsonNode model = new ObjectMapper().readTree(stream);
         CmmnModel cmmnModel = new CmmnJsonConverter().convertToCmmnModel(model);
@@ -60,32 +57,32 @@ public class SentryConverterTest extends AbstractConverterTest {
         PlanItem planItem = planModelStage.findPlanItemInPlanFragmentOrUpwards("planItem1");
 
         List<Sentry> sentries = planModelStage.getSentries();
-        assertEquals(1, sentries.size());
+        assertThat(sentries).hasSize(1);
 
         Sentry sentry = sentries.get(0);
 
         Criterion criterion = planItem.getEntryCriteria().get(0);
-        assertEquals(sentry.getId(), criterion.getSentryRef());
+        assertThat(criterion.getSentryRef()).isEqualTo(sentry.getId());
 
         SentryIfPart ifPart = sentry.getSentryIfPart();
-        assertNotNull(ifPart);
-        assertThat(ifPart.getCondition(), is("${true}"));
+        assertThat(ifPart).isNotNull();
+        assertThat(ifPart.getCondition()).isEqualTo("${true}");
 
-        assertThat(sentry.getName(), is("sentry name"));
-        assertThat(sentry.getDocumentation(), is("sentry doc"));
+        assertThat(sentry.getName()).isEqualTo("sentry name");
+        assertThat(sentry.getDocumentation()).isEqualTo("sentry doc");
 
         GraphicInfo sentryGraphicInfo = model.getGraphicInfo(criterion.getId());
-        assertThat(sentryGraphicInfo.getX(), is(400.73441809224767) );
-        assertThat(sentryGraphicInfo.getY(), is(110.88085470555188) );
+        assertThat(sentryGraphicInfo.getX()).isEqualTo(400.73441809224767);
+        assertThat(sentryGraphicInfo.getY()).isEqualTo(110.88085470555188);
     }
 
     protected void validate(JsonNode model) {
         ArrayNode node = (ArrayNode) model.path("childShapes").get(0).path("childShapes");
         JsonNode sentryNode = null;
 
-        for(JsonNode shape: node){
+        for (JsonNode shape : node) {
             String resourceId = shape.path("resourceId").asText();
-            if(SENTRY_NODE_ID.equals(resourceId)){
+            if (SENTRY_NODE_ID.equals(resourceId)) {
                 sentryNode = shape;
             }
         }
@@ -95,8 +92,8 @@ public class SentryConverterTest extends AbstractConverterTest {
         Double y = sentryNode.path("dockers").get(0).path("y").asDouble();
 
         //the modeler does not store a mathematical correct docker point.
-        assertThat(x,is(-1.0));
-        assertThat(y,is(34.0));
+        assertThat(x).isEqualTo(-1.0);
+        assertThat(y).isEqualTo(34.0);
     }
 
 }

--- a/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/SentryOnPartAssociationsConverterTest.java
+++ b/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/SentryOnPartAssociationsConverterTest.java
@@ -12,6 +12,14 @@
  */
 package org.flowable.cmmn.editor;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Offset.offset;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
 import org.flowable.cmmn.model.Association;
 import org.flowable.cmmn.model.CmmnModel;
 import org.flowable.cmmn.model.Criterion;
@@ -21,15 +29,6 @@ import org.flowable.cmmn.model.PlanItemDefinition;
 import org.flowable.cmmn.model.PlanItemTransition;
 import org.flowable.cmmn.model.Sentry;
 import org.flowable.cmmn.model.SentryOnPart;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 public class SentryOnPartAssociationsConverterTest extends AbstractConverterTest {
 
@@ -57,110 +56,108 @@ public class SentryOnPartAssociationsConverterTest extends AbstractConverterTest
     @Override
     protected void validateModel(CmmnModel model) {
         List<Association> associations = model.getAssociations();
-        assertNotNull(associations);
-        assertEquals(5, associations.size());
+        assertThat(associations).isNotNull();
+        assertThat(associations).hasSize(5);
 
         Map<String, List<Association>> byRelationShip = associations.stream()
                 .collect(Collectors.groupingBy(a -> buildAssociationString(model, a)));
 
-        assertEquals(5, byRelationShip.size());
-        assertTrue(byRelationShip.containsKey("taskA|taskC|complete"));
-        assertTrue(byRelationShip.containsKey("taskB|taskC|complete"));
-        assertTrue(byRelationShip.containsKey("stage1|stage2|terminate"));
+        assertThat(byRelationShip).hasSize(5);
+        assertThat(byRelationShip.containsKey("taskA|taskC|complete")).isTrue();
+        assertThat(byRelationShip.containsKey("taskB|taskC|complete")).isTrue();
+        assertThat(byRelationShip.containsKey("stage1|stage2|terminate")).isTrue();
         //EXIT CRITERIA ARE "READ" BACKWARDS
-        assertTrue(byRelationShip.containsKey("timedTask|expireTimer|occur"));
-        assertTrue(byRelationShip.containsKey("stage2|abortStageTask|complete"));
+        assertThat(byRelationShip.containsKey("timedTask|expireTimer|occur")).isTrue();
+        assertThat(byRelationShip.containsKey("stage2|abortStageTask|complete")).isTrue();
 
         //Coordinates of associations are recalculated based on other elements?
         //This is only a stub that checks the "approximate" coordinates of 1 association
         Map<String, List<GraphicInfo>> associationsGraphicInfo = associations.stream()
                 .collect(Collectors.toMap(Association::getId, a -> model.getFlowLocationGraphicInfo(a.getId())));
-        assertEquals(5, associationsGraphicInfo.size());
+        assertThat(associationsGraphicInfo).hasSize(5);
         //Coordinates have a loss of precision during conversion and re-conversion
         double delta = 5.0;
         List<GraphicInfo> gInfo = associationsGraphicInfo.get("sid-F8E5EBC5-DCBB-4C01-B7EA-3267631B2625");
-        assertEquals(286.0, gInfo.get(0).getX(), delta);
-        assertEquals(175.0, gInfo.get(0).getY(), delta);
-        assertEquals(345.0, gInfo.get(1).getX(), delta);
-        assertEquals(199.0, gInfo.get(1).getY(), delta);
-
+        assertThat(gInfo.get(0).getX()).isCloseTo(286.0, offset(delta));
+        assertThat(gInfo.get(0).getY()).isCloseTo(175.0, offset(delta));
+        assertThat(gInfo.get(1).getX()).isCloseTo(345.0, offset(delta));
+        assertThat(gInfo.get(1).getY()).isCloseTo(199.0, offset(delta));
 
         //Check the Sentries OnParts
         //TASK C Entry Sentry
         PlanItemDefinition taskC = model.findPlanItemDefinition("taskC");
-        assertNotNull(taskC);
+        assertThat(taskC).isNotNull();
         PlanItem taskBIntance = model.findPlanItem(taskC.getPlanItemRef());
-        assertNotNull(taskBIntance);
+        assertThat(taskBIntance).isNotNull();
         List<Criterion> taskCEntryCriterions = taskBIntance.getEntryCriteria();
-        assertNotNull(taskCEntryCriterions);
-        assertEquals(1, taskCEntryCriterions.size());
+        assertThat(taskCEntryCriterions).isNotNull();
+        assertThat(taskCEntryCriterions).hasSize(1);
         Criterion criterion = taskCEntryCriterions.get(0);
-        assertEquals("taskCEntrySentry", criterion.getId());
+        assertThat(criterion.getId()).isEqualTo("taskCEntrySentry");
         Sentry sentry = criterion.getSentry();
-        assertNotNull(sentry);
+        assertThat(sentry).isNotNull();
         List<SentryOnPart> onParts = sentry.getOnParts();
-        assertNotNull(onParts);
-        assertEquals(2, onParts.size());
+        assertThat(onParts).isNotNull();
+        assertThat(onParts).hasSize(2);
         SentryOnPart sentryOnPart = onParts.get(0);
-        assertEquals("taskA", sentryOnPart.getSource().getDefinitionRef());
-        assertEquals(PlanItemTransition.COMPLETE, sentryOnPart.getStandardEvent());
+        assertThat(sentryOnPart.getSource().getDefinitionRef()).isEqualTo("taskA");
+        assertThat(sentryOnPart.getStandardEvent()).isEqualTo(PlanItemTransition.COMPLETE);
         sentryOnPart = onParts.get(1);
-        assertEquals("taskB", sentryOnPart.getSource().getDefinitionRef());
-        assertEquals(PlanItemTransition.COMPLETE, sentryOnPart.getStandardEvent());
+        assertThat(sentryOnPart.getSource().getDefinitionRef()).isEqualTo("taskB");
+        assertThat(sentryOnPart.getStandardEvent()).isEqualTo(PlanItemTransition.COMPLETE);
 
         //Stage 2
         PlanItemDefinition stage2 = model.findPlanItemDefinition("stage2");
-        assertNotNull(stage2);
+        assertThat(stage2).isNotNull();
         PlanItem stage2Instance = model.findPlanItem(stage2.getPlanItemRef());
-        assertNotNull(stage2Instance);
+        assertThat(stage2Instance).isNotNull();
         //Stage 2 Entry Sentry
         List<Criterion> stage2EntryCriterions = stage2Instance.getEntryCriteria();
-        assertNotNull(stage2EntryCriterions);
-        assertEquals(1, stage2EntryCriterions.size());
+        assertThat(stage2EntryCriterions).isNotNull();
+        assertThat(stage2EntryCriterions).hasSize(1);
         criterion = stage2EntryCriterions.get(0);
-        assertEquals("stage1EntrySentry", criterion.getId());
+        assertThat(criterion.getId()).isEqualTo("stage1EntrySentry");
         sentry = criterion.getSentry();
-        assertNotNull(sentry);
+        assertThat(sentry).isNotNull();
         onParts = sentry.getOnParts();
-        assertNotNull(onParts);
-        assertEquals(1, onParts.size());
+        assertThat(onParts)
+                .extracting(SentryOnPart::getStandardEvent)
+                .containsExactly(PlanItemTransition.TERMINATE);
         sentryOnPart = onParts.get(0);
-        assertEquals("stage1", sentryOnPart.getSource().getDefinitionRef());
-        assertEquals(PlanItemTransition.TERMINATE, sentryOnPart.getStandardEvent());
+        assertThat(sentryOnPart.getSource().getDefinitionRef()).isEqualTo("stage1");
 
         //Stage 2 Exit Sentry
         List<Criterion> stage2ExitCriterions = stage2Instance.getExitCriteria();
-        assertNotNull(stage2ExitCriterions);
-        assertEquals(1, stage2ExitCriterions.size());
+        assertThat(stage2ExitCriterions).isNotNull();
+        assertThat(stage2ExitCriterions).hasSize(1);
         criterion = stage2ExitCriterions.get(0);
-        assertEquals("stage2ExitSentry", criterion.getId());
+        assertThat(criterion.getId()).isEqualTo("stage2ExitSentry");
         sentry = criterion.getSentry();
-        assertNotNull(sentry);
+        assertThat(sentry).isNotNull();
         onParts = sentry.getOnParts();
-        assertNotNull(onParts);
-        assertEquals(1, onParts.size());
+        assertThat(onParts)
+                .extracting(SentryOnPart::getStandardEvent)
+                .containsExactly(PlanItemTransition.COMPLETE);
         sentryOnPart = onParts.get(0);
-        assertEquals("abortStageTask", sentryOnPart.getSource().getDefinitionRef());
-        assertEquals(PlanItemTransition.COMPLETE, sentryOnPart.getStandardEvent());
+        assertThat(sentryOnPart.getSource().getDefinitionRef()).isEqualTo("abortStageTask");
 
         //Timed Task Exit Sentry
         PlanItemDefinition timedTask = model.findPlanItemDefinition("timedTask");
-        assertNotNull(timedTask);
+        assertThat(timedTask).isNotNull();
         PlanItem timedtaskInstance = model.findPlanItem(timedTask.getPlanItemRef());
-        assertNotNull(timedtaskInstance);
+        assertThat(timedtaskInstance).isNotNull();
         List<Criterion> timedTaskExitCriterions = timedtaskInstance.getExitCriteria();
-        assertNotNull(timedTaskExitCriterions);
-        assertEquals(1, timedTaskExitCriterions.size());
+        assertThat(timedTaskExitCriterions).isNotNull();
+        assertThat(timedTaskExitCriterions).hasSize(1);
         criterion = timedTaskExitCriterions.get(0);
-        assertEquals("timedTaskExitSentry", criterion.getId());
+        assertThat(criterion.getId()).isEqualTo("timedTaskExitSentry");
         sentry = criterion.getSentry();
-        assertNotNull(sentry);
+        assertThat(sentry).isNotNull();
         onParts = sentry.getOnParts();
-        assertNotNull(onParts);
-        assertEquals(1, onParts.size());
+        assertThat(onParts)
+                .extracting(SentryOnPart::getStandardEvent)
+                .containsExactly(PlanItemTransition.OCCUR);
         sentryOnPart = onParts.get(0);
-        assertEquals("expireTimer", sentryOnPart.getSource().getDefinitionRef());
-        assertEquals(PlanItemTransition.OCCUR, sentryOnPart.getStandardEvent());
-
+        assertThat(sentryOnPart.getSource().getDefinitionRef()).isEqualTo("expireTimer");
     }
 }

--- a/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/SentryOnPartConverterTest.java
+++ b/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/SentryOnPartConverterTest.java
@@ -12,6 +12,10 @@
  */
 package org.flowable.cmmn.editor;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
 import org.flowable.cmmn.model.CmmnModel;
 import org.flowable.cmmn.model.Criterion;
 import org.flowable.cmmn.model.PlanItem;
@@ -19,11 +23,6 @@ import org.flowable.cmmn.model.PlanItemDefinition;
 import org.flowable.cmmn.model.PlanItemTransition;
 import org.flowable.cmmn.model.Sentry;
 import org.flowable.cmmn.model.SentryOnPart;
-
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 public class SentryOnPartConverterTest extends AbstractConverterTest {
 
@@ -36,21 +35,21 @@ public class SentryOnPartConverterTest extends AbstractConverterTest {
     protected void validateModel(CmmnModel model) {
         //Confirm a EntryCriteria attached to taskB sourced by "complete" transition of taskA
         PlanItemDefinition taskB = model.findPlanItemDefinition("taskB");
-        assertNotNull(taskB);
+        assertThat(taskB).isNotNull();
         PlanItem taskBIntance = model.findPlanItem(taskB.getPlanItemRef());
-        assertNotNull(taskBIntance);
+        assertThat(taskBIntance).isNotNull();
         List<Criterion> entryCriterions = taskBIntance.getEntryCriteria();
-        assertNotNull(entryCriterions);
-        assertEquals(1, entryCriterions.size());
+        assertThat(entryCriterions)
+                .extracting(Criterion::getId)
+                .containsExactly("entryCriterion");
         Criterion criterion = entryCriterions.get(0);
-        assertEquals("entryCriterion", criterion.getId());
         Sentry sentry = criterion.getSentry();
-        assertNotNull(sentry);
+        assertThat(sentry).isNotNull();
         List<SentryOnPart> onParts = sentry.getOnParts();
-        assertNotNull(onParts);
-        assertEquals(1, onParts.size());
+        assertThat(onParts)
+                .extracting(SentryOnPart::getStandardEvent)
+                .containsExactly(PlanItemTransition.COMPLETE);
         SentryOnPart sentryOnPart = onParts.get(0);
-        assertEquals("taskA", sentryOnPart.getSource().getDefinitionRef());
-        assertEquals(PlanItemTransition.COMPLETE, sentryOnPart.getStandardEvent());
+        assertThat(sentryOnPart.getSource().getDefinitionRef()).isEqualTo("taskA");
     }
 }

--- a/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/SimpleConverterTest.java
+++ b/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/SimpleConverterTest.java
@@ -12,9 +12,9 @@
  */
 package org.flowable.cmmn.editor;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.assertj.core.data.Offset.offset;
 
 import java.util.List;
 
@@ -39,51 +39,50 @@ public class SimpleConverterTest extends AbstractConverterTest {
     @Override
     protected void validateModel(CmmnModel model) {
         Case caseModel = model.getPrimaryCase();
-        assertEquals("testModel", caseModel.getId());
-        assertEquals("Test model", caseModel.getName());
+        assertThat(caseModel.getId()).isEqualTo("testModel");
+        assertThat(caseModel.getName()).isEqualTo("Test model");
 
         Stage planModelStage = caseModel.getPlanModel();
-        assertNotNull(planModelStage);
-        assertEquals("stage1", planModelStage.getId());
+        assertThat(planModelStage).isNotNull();
+        assertThat(planModelStage.getId()).isEqualTo("stage1");
 
         GraphicInfo graphicInfo = model.getGraphicInfo("stage1");
-        assertEquals(75.0, graphicInfo.getX(), 0.1);
-        assertEquals(60.0, graphicInfo.getY(), 0.1);
-        assertEquals(718.0, graphicInfo.getWidth(), 0.1);
-        assertEquals(714.0, graphicInfo.getHeight(), 0.1);
+        assertThat(graphicInfo.getX()).isCloseTo(75.0, offset(0.1));
+        assertThat(graphicInfo.getY()).isCloseTo(60.0, offset(0.1));
+        assertThat(graphicInfo.getWidth()).isCloseTo(718.0, offset(0.1));
+        assertThat(graphicInfo.getHeight()).isCloseTo(714.0, offset(0.1));
 
         PlanItem planItem = planModelStage.findPlanItemInPlanFragmentOrUpwards("planItem1");
-        assertNotNull(planItem);
-        assertEquals("planItem1", planItem.getId());
-        assertEquals("Task B", planItem.getName());
+        assertThat(planItem).isNotNull();
+        assertThat(planItem.getId()).isEqualTo("planItem1");
+        assertThat(planItem.getName()).isEqualTo("Task B");
         PlanItemDefinition planItemDefinition = planItem.getPlanItemDefinition();
-        assertNotNull(planItemDefinition);
-        assertTrue(planItemDefinition instanceof HumanTask);
+        assertThat(planItemDefinition).isNotNull();
+        assertThat(planItemDefinition).isInstanceOf(HumanTask.class);
         HumanTask humanTask = (HumanTask) planItemDefinition;
-        assertEquals("task1", humanTask.getId());
-        assertEquals("Task B", humanTask.getName());
+        assertThat(humanTask.getId()).isEqualTo("task1");
+        assertThat(humanTask.getName()).isEqualTo("Task B");
 
-        assertEquals(1, planItem.getEntryCriteria().size());
-        assertEquals(0, planItem.getExitCriteria().size());
+        assertThat(planItem.getEntryCriteria()).hasSize(1);
+        assertThat(planItem.getExitCriteria()).isEmpty();
 
         graphicInfo = model.getGraphicInfo("planItem1");
-        assertEquals(435.0, graphicInfo.getX(), 0.1);
-        assertEquals(120.0, graphicInfo.getY(), 0.1);
-        assertEquals(100.0, graphicInfo.getWidth(), 0.1);
-        assertEquals(80.0, graphicInfo.getHeight(), 0.1);
+        assertThat(graphicInfo.getX()).isCloseTo(435.0, offset(0.1));
+        assertThat(graphicInfo.getY()).isCloseTo(120.0, offset(0.1));
+        assertThat(graphicInfo.getWidth()).isCloseTo(100.0, offset(0.1));
+        assertThat(graphicInfo.getHeight()).isCloseTo(80.0, offset(0.1));
 
         List<Sentry> sentries = planModelStage.getSentries();
-        assertEquals(1, sentries.size());
+        assertThat(sentries).hasSize(1);
 
         Sentry sentry = sentries.get(0);
 
         Criterion criterion = planItem.getEntryCriteria().get(0);
-        assertEquals(sentry.getId(), criterion.getSentryRef());
+        assertThat(criterion.getSentryRef()).isEqualTo(sentry.getId());
 
-        assertEquals(1, sentry.getOnParts().size());
-        SentryOnPart onPart = sentry.getOnParts().get(0);
-        assertEquals("complete", onPart.getStandardEvent());
-        assertEquals("planItem2", onPart.getSourceRef());
+        assertThat(sentry.getOnParts())
+                .extracting(SentryOnPart::getStandardEvent, SentryOnPart::getSourceRef)
+                .containsExactly(tuple("complete", "planItem2"));
 
     }
 }

--- a/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/StageConverterTest.java
+++ b/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/StageConverterTest.java
@@ -12,9 +12,9 @@
  */
 package org.flowable.cmmn.editor;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.assertj.core.data.Offset.offset;
 
 import java.util.List;
 
@@ -40,192 +40,188 @@ public class StageConverterTest extends AbstractConverterTest {
     @Override
     protected void validateModel(CmmnModel model) {
         Case caseModel = model.getPrimaryCase();
-        assertEquals("testCase", caseModel.getId());
-        assertEquals("Test case", caseModel.getName());
+        assertThat(caseModel.getId()).isEqualTo("testCase");
+        assertThat(caseModel.getName()).isEqualTo("Test case");
 
         Stage planModelStage = caseModel.getPlanModel();
-        assertNotNull(planModelStage);
-        assertEquals("myPlanModel", planModelStage.getId());
-        assertEquals("My plan model", planModelStage.getName());
-        assertEquals("My plan model documentation", planModelStage.getDocumentation());
-        assertEquals("formKeyDefinition", planModelStage.getFormKey());
-        assertEquals("validateFormFields", planModelStage.getValidateFormFields());
-        assertTrue(planModelStage.isPlanModel());
+        assertThat(planModelStage).isNotNull();
+        assertThat(planModelStage.getId()).isEqualTo("myPlanModel");
+        assertThat(planModelStage.getName()).isEqualTo("My plan model");
+        assertThat(planModelStage.getDocumentation()).isEqualTo("My plan model documentation");
+        assertThat(planModelStage.getFormKey()).isEqualTo("formKeyDefinition");
+        assertThat(planModelStage.getValidateFormFields()).isEqualTo("validateFormFields");
+        assertThat(planModelStage.isPlanModel()).isTrue();
 
         GraphicInfo graphicInfo = model.getGraphicInfo("myPlanModel");
-        assertEquals(30.0, graphicInfo.getX(), 0.1);
-        assertEquals(45.0, graphicInfo.getY(), 0.1);
-        assertEquals(819.0, graphicInfo.getWidth(), 0.1);
-        assertEquals(713.0, graphicInfo.getHeight(), 0.1);
+        assertThat(graphicInfo.getX()).isCloseTo(30.0, offset(0.1));
+        assertThat(graphicInfo.getY()).isCloseTo(45.0, offset(0.1));
+        assertThat(graphicInfo.getWidth()).isCloseTo(819.0, offset(0.1));
+        assertThat(graphicInfo.getHeight()).isCloseTo(713.0, offset(0.1));
 
         PlanItem planItem = planModelStage.findPlanItemInPlanFragmentOrUpwards("planItem1");
-        assertNotNull(planItem);
-        assertEquals("planItem1", planItem.getId());
-        assertEquals("Task", planItem.getName());
+        assertThat(planItem).isNotNull();
+        assertThat(planItem.getId()).isEqualTo("planItem1");
+        assertThat(planItem.getName()).isEqualTo("Task");
         PlanItemDefinition planItemDefinition = planItem.getPlanItemDefinition();
-        assertNotNull(planItemDefinition);
-        assertTrue(planItemDefinition instanceof HumanTask);
+        assertThat(planItemDefinition).isNotNull();
+        assertThat(planItemDefinition).isInstanceOf(HumanTask.class);
         HumanTask humanTask = (HumanTask) planItemDefinition;
-        assertEquals("task1", humanTask.getId());
-        assertEquals("Task", humanTask.getName());
+        assertThat(humanTask.getId()).isEqualTo("task1");
+        assertThat(humanTask.getName()).isEqualTo("Task");
 
-        assertEquals(0, planItem.getEntryCriteria().size());
-        assertEquals(0, planItem.getExitCriteria().size());
+        assertThat(planItem.getEntryCriteria()).isEmpty();
+        assertThat(planItem.getExitCriteria()).isEmpty();
 
         graphicInfo = model.getGraphicInfo("planItem1");
-        assertEquals(165.0, graphicInfo.getX(), 0.1);
-        assertEquals(122.10, graphicInfo.getY(), 0.1);
-        assertEquals(100.0, graphicInfo.getWidth(), 0.1);
-        assertEquals(80.0, graphicInfo.getHeight(), 0.1);
+        assertThat(graphicInfo.getX()).isCloseTo(165.0, offset(0.1));
+        assertThat(graphicInfo.getY()).isCloseTo(122.10, offset(0.1));
+        assertThat(graphicInfo.getWidth()).isCloseTo(100.0, offset(0.1));
+        assertThat(graphicInfo.getHeight()).isCloseTo(80.0, offset(0.1));
 
         PlanItem taskPlanItem = planModelStage.findPlanItemInPlanFragmentOrUpwards("planItem2");
-        assertNotNull(planItem);
-        assertEquals("planItem2", taskPlanItem.getId());
-        assertEquals("Task2", taskPlanItem.getName());
+        assertThat(planItem).isNotNull();
+        assertThat(taskPlanItem.getId()).isEqualTo("planItem2");
+        assertThat(taskPlanItem.getName()).isEqualTo("Task2");
         planItemDefinition = taskPlanItem.getPlanItemDefinition();
-        assertNotNull(planItemDefinition);
-        assertTrue(planItemDefinition instanceof HumanTask);
+        assertThat(planItemDefinition).isNotNull();
+        assertThat(planItemDefinition).isInstanceOf(HumanTask.class);
         humanTask = (HumanTask) planItemDefinition;
-        assertEquals("task2", humanTask.getId());
-        assertEquals("Task2", humanTask.getName());
+        assertThat(humanTask.getId()).isEqualTo("task2");
+        assertThat(humanTask.getName()).isEqualTo("Task2");
 
-        assertEquals(1, taskPlanItem.getEntryCriteria().size());
-        assertEquals(0, taskPlanItem.getExitCriteria().size());
+        assertThat(taskPlanItem.getEntryCriteria()).hasSize(1);
+        assertThat(taskPlanItem.getExitCriteria()).isEmpty();
 
         graphicInfo = model.getGraphicInfo("planItem2");
-        assertEquals(405.0, graphicInfo.getX(), 0.1);
-        assertEquals(120.0, graphicInfo.getY(), 0.1);
-        assertEquals(100.0, graphicInfo.getWidth(), 0.1);
-        assertEquals(80.0, graphicInfo.getHeight(), 0.1);
+        assertThat(graphicInfo.getX()).isCloseTo(405.0, offset(0.1));
+        assertThat(graphicInfo.getY()).isCloseTo(120.0, offset(0.1));
+        assertThat(graphicInfo.getWidth()).isCloseTo(100.0, offset(0.1));
+        assertThat(graphicInfo.getHeight()).isCloseTo(80.0, offset(0.1));
 
         PlanItem milestonePlanItem = planModelStage.findPlanItemInPlanFragmentOrUpwards("planItem6");
-        assertNotNull(milestonePlanItem);
-        assertEquals("planItem6", milestonePlanItem.getId());
-        assertEquals("Milestone 1", milestonePlanItem.getName());
+        assertThat(milestonePlanItem).isNotNull();
+        assertThat(milestonePlanItem.getId()).isEqualTo("planItem6");
+        assertThat(milestonePlanItem.getName()).isEqualTo("Milestone 1");
         planItemDefinition = milestonePlanItem.getPlanItemDefinition();
-        assertNotNull(planItemDefinition);
-        assertTrue(planItemDefinition instanceof Milestone);
+        assertThat(planItemDefinition).isNotNull();
+        assertThat(planItemDefinition).isInstanceOf(Milestone.class);
         Milestone milestone = (Milestone) planItemDefinition;
-        assertEquals("milestone1", milestone.getId());
-        assertEquals("Milestone 1", milestone.getName());
+        assertThat(milestone.getId()).isEqualTo("milestone1");
+        assertThat(milestone.getName()).isEqualTo("Milestone 1");
 
-        assertEquals(1, milestonePlanItem.getEntryCriteria().size());
-        assertEquals(0, milestonePlanItem.getExitCriteria().size());
+        assertThat(milestonePlanItem.getEntryCriteria()).hasSize(1);
+        assertThat(milestonePlanItem.getExitCriteria()).isEmpty();
 
         graphicInfo = model.getGraphicInfo("planItem6");
-        assertEquals(630.0, graphicInfo.getX(), 0.1);
-        assertEquals(133.0, graphicInfo.getY(), 0.1);
-        assertEquals(146.0, graphicInfo.getWidth(), 0.1);
-        assertEquals(54.0, graphicInfo.getHeight(), 0.1);
+        assertThat(graphicInfo.getX()).isCloseTo(630.0, offset(0.1));
+        assertThat(graphicInfo.getY()).isCloseTo(133.0, offset(0.1));
+        assertThat(graphicInfo.getWidth()).isCloseTo(146.0, offset(0.1));
+        assertThat(graphicInfo.getHeight()).isCloseTo(54.0, offset(0.1));
 
         List<Sentry> sentries = planModelStage.getSentries();
-        assertEquals(2, sentries.size());
+        assertThat(sentries).hasSize(2);
 
         Sentry sentry = sentries.get(0);
 
         Criterion criterion = taskPlanItem.getEntryCriteria().get(0);
-        assertEquals(sentry.getId(), criterion.getSentryRef());
+        assertThat(criterion.getSentryRef()).isEqualTo(sentry.getId());
 
-        assertEquals(1, sentry.getOnParts().size());
-        SentryOnPart onPart = sentry.getOnParts().get(0);
-        assertEquals("complete", onPart.getStandardEvent());
-        assertEquals("planItem1", onPart.getSourceRef());
+        assertThat(sentry.getOnParts())
+                .extracting(SentryOnPart::getStandardEvent, SentryOnPart::getSourceRef)
+                .containsExactly(tuple("complete", "planItem1"));
 
         sentry = sentries.get(1);
 
         criterion = milestonePlanItem.getEntryCriteria().get(0);
-        assertEquals(sentry.getId(), criterion.getSentryRef());
+        assertThat(criterion.getSentryRef()).isEqualTo(sentry.getId());
 
-        assertEquals(1, sentry.getOnParts().size());
-        onPart = sentry.getOnParts().get(0);
-        assertEquals("complete", onPart.getStandardEvent());
-        assertEquals("planItem2", onPart.getSourceRef());
+        assertThat(sentry.getOnParts())
+                .extracting(SentryOnPart::getStandardEvent, SentryOnPart::getSourceRef)
+                .containsExactly(tuple("complete", "planItem2"));
 
         PlanItem stagePlanItem = planModelStage.findPlanItemInPlanFragmentOrUpwards("planItem5");
-        assertNotNull(stagePlanItem);
-        assertEquals("planItem5", stagePlanItem.getId());
-        assertEquals("Child stage", stagePlanItem.getName());
+        assertThat(stagePlanItem).isNotNull();
+        assertThat(stagePlanItem.getId()).isEqualTo("planItem5");
+        assertThat(stagePlanItem.getName()).isEqualTo("Child stage");
         planItemDefinition = stagePlanItem.getPlanItemDefinition();
-        assertNotNull(planItemDefinition);
-        assertTrue(planItemDefinition instanceof Stage);
+        assertThat(planItemDefinition).isNotNull();
+        assertThat(planItemDefinition).isInstanceOf(Stage.class);
         Stage stage = (Stage) planItemDefinition;
-        assertEquals("childStage", stage.getId());
-        assertEquals("Child stage", stage.getName());
-        assertEquals(planModelStage.getId(), stagePlanItem.getParentStage().getId());
+        assertThat(stage.getId()).isEqualTo("childStage");
+        assertThat(stage.getName()).isEqualTo("Child stage");
+        assertThat(stagePlanItem.getParentStage().getId()).isEqualTo(planModelStage.getId());
 
-        assertEquals(0, stagePlanItem.getEntryCriteria().size());
-        assertEquals(0, stagePlanItem.getExitCriteria().size());
+        assertThat(stagePlanItem.getEntryCriteria()).isEmpty();
+        assertThat(stagePlanItem.getExitCriteria()).isEmpty();
 
         graphicInfo = model.getGraphicInfo("planItem5");
-        assertEquals(105.0, graphicInfo.getX(), 0.1);
-        assertEquals(240.0, graphicInfo.getY(), 0.1);
-        assertEquals(481.0, graphicInfo.getWidth(), 0.1);
-        assertEquals(241.0, graphicInfo.getHeight(), 0.1);
+        assertThat(graphicInfo.getX()).isCloseTo(105.0, offset(0.1));
+        assertThat(graphicInfo.getY()).isCloseTo(240.0, offset(0.1));
+        assertThat(graphicInfo.getWidth()).isCloseTo(481.0, offset(0.1));
+        assertThat(graphicInfo.getHeight()).isCloseTo(241.0, offset(0.1));
 
-        assertEquals(2, stage.getPlanItems().size());
+        assertThat(stage.getPlanItems()).hasSize(2);
         PlanItem subPlanItem1 = stage.findPlanItemInPlanFragmentOrUpwards("planItem3");
-        assertNotNull(subPlanItem1);
-        assertEquals("planItem3", subPlanItem1.getId());
-        assertEquals("Sub task 1", subPlanItem1.getName());
+        assertThat(subPlanItem1).isNotNull();
+        assertThat(subPlanItem1.getId()).isEqualTo("planItem3");
+        assertThat(subPlanItem1.getName()).isEqualTo("Sub task 1");
         planItemDefinition = subPlanItem1.getPlanItemDefinition();
-        assertNotNull(planItemDefinition);
-        assertTrue(planItemDefinition instanceof HumanTask);
+        assertThat(planItemDefinition).isNotNull();
+        assertThat(planItemDefinition).isInstanceOf(HumanTask.class);
         humanTask = (HumanTask) planItemDefinition;
-        assertEquals("subTask1", humanTask.getId());
-        assertEquals("Sub task 1", humanTask.getName());
-        assertEquals(stage.getId(), subPlanItem1.getParentStage().getId());
+        assertThat(humanTask.getId()).isEqualTo("subTask1");
+        assertThat(humanTask.getName()).isEqualTo("Sub task 1");
+        assertThat(subPlanItem1.getParentStage().getId()).isEqualTo(stage.getId());
 
-        assertEquals(1, subPlanItem1.getEntryCriteria().size());
-        assertEquals(0, subPlanItem1.getExitCriteria().size());
+        assertThat(subPlanItem1.getEntryCriteria()).hasSize(1);
+        assertThat(subPlanItem1.getExitCriteria()).isEmpty();
 
         graphicInfo = model.getGraphicInfo("planItem3");
-        assertEquals(194.0, graphicInfo.getX(), 0.1);
-        assertEquals(325.0, graphicInfo.getY(), 0.1);
-        assertEquals(100.0, graphicInfo.getWidth(), 0.1);
-        assertEquals(80.0, graphicInfo.getHeight(), 0.1);
+        assertThat(graphicInfo.getX()).isCloseTo(194.0, offset(0.1));
+        assertThat(graphicInfo.getY()).isCloseTo(325.0, offset(0.1));
+        assertThat(graphicInfo.getWidth()).isCloseTo(100.0, offset(0.1));
+        assertThat(graphicInfo.getHeight()).isCloseTo(80.0, offset(0.1));
 
         PlanItem subPlanItem2 = stage.findPlanItemInPlanFragmentOrUpwards("planItem4");
-        assertNotNull(subPlanItem2);
-        assertEquals("planItem4", subPlanItem2.getId());
-        assertEquals("Sub task 2", subPlanItem2.getName());
+        assertThat(subPlanItem2).isNotNull();
+        assertThat(subPlanItem2.getId()).isEqualTo("planItem4");
+        assertThat(subPlanItem2.getName()).isEqualTo("Sub task 2");
         planItemDefinition = subPlanItem2.getPlanItemDefinition();
-        assertNotNull(planItemDefinition);
-        assertTrue(planItemDefinition instanceof HumanTask);
+        assertThat(planItemDefinition).isNotNull();
+        assertThat(planItemDefinition).isInstanceOf(HumanTask.class);
         humanTask = (HumanTask) planItemDefinition;
-        assertEquals("subTask2", humanTask.getId());
-        assertEquals("Sub task 2", humanTask.getName());
-        assertEquals(stage.getId(), subPlanItem2.getParentStage().getId());
+        assertThat(humanTask.getId()).isEqualTo("subTask2");
+        assertThat(humanTask.getName()).isEqualTo("Sub task 2");
+        assertThat(subPlanItem2.getParentStage().getId()).isEqualTo(stage.getId());
 
-        assertEquals(1, subPlanItem2.getEntryCriteria().size());
-        assertEquals(0, subPlanItem2.getExitCriteria().size());
+        assertThat(subPlanItem2.getEntryCriteria()).hasSize(1);
+        assertThat(subPlanItem2.getExitCriteria()).isEmpty();
 
         graphicInfo = model.getGraphicInfo("planItem4");
-        assertEquals(390.0, graphicInfo.getX(), 0.1);
-        assertEquals(325.0, graphicInfo.getY(), 0.1);
-        assertEquals(100.0, graphicInfo.getWidth(), 0.1);
-        assertEquals(80.0, graphicInfo.getHeight(), 0.1);
+        assertThat(graphicInfo.getX()).isCloseTo(390.0, offset(0.1));
+        assertThat(graphicInfo.getY()).isCloseTo(325.0, offset(0.1));
+        assertThat(graphicInfo.getWidth()).isCloseTo(100.0, offset(0.1));
+        assertThat(graphicInfo.getHeight()).isCloseTo(80.0, offset(0.1));
 
         sentries = stage.getSentries();
-        assertEquals(2, sentries.size());
+        assertThat(sentries).hasSize(2);
 
         sentry = sentries.get(0);
 
         criterion = subPlanItem1.getEntryCriteria().get(0);
-        assertEquals(sentry.getId(), criterion.getSentryRef());
+        assertThat(criterion.getSentryRef()).isEqualTo(sentry.getId());
 
-        assertEquals(1, sentry.getOnParts().size());
-        onPart = sentry.getOnParts().get(0);
-        assertEquals("complete", onPart.getStandardEvent());
-        assertEquals("planItem2", onPart.getSourceRef());
+        assertThat(sentry.getOnParts())
+                .extracting(SentryOnPart::getStandardEvent, SentryOnPart::getSourceRef)
+                .containsExactly(tuple("complete", "planItem2"));
 
         sentry = sentries.get(1);
 
         criterion = subPlanItem2.getEntryCriteria().get(0);
-        assertEquals(sentry.getId(), criterion.getSentryRef());
+        assertThat(criterion.getSentryRef()).isEqualTo(sentry.getId());
 
-        assertEquals(1, sentry.getOnParts().size());
-        onPart = sentry.getOnParts().get(0);
-        assertEquals("complete", onPart.getStandardEvent());
-        assertEquals("planItem3", onPart.getSourceRef());
+        assertThat(sentry.getOnParts())
+                .extracting(SentryOnPart::getStandardEvent, SentryOnPart::getSourceRef)
+                .containsExactly(tuple("complete", "planItem3"));
     }
 }

--- a/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/TaskJsonConverterTest.java
+++ b/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/TaskJsonConverterTest.java
@@ -12,9 +12,7 @@
  */
 package org.flowable.cmmn.editor;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.cmmn.model.Case;
 import org.flowable.cmmn.model.CmmnModel;
@@ -29,7 +27,7 @@ import org.junit.Test;
 /**
  * @author shareniu
  */
-public class TaskJsonConverterTest  extends AbstractConverterTest{
+public class TaskJsonConverterTest extends AbstractConverterTest {
 
     @Override
     @Test
@@ -46,38 +44,38 @@ public class TaskJsonConverterTest  extends AbstractConverterTest{
     @Override
     protected void validateModel(CmmnModel model) {
         Case caseModel = model.getPrimaryCase();
-        assertEquals("shareniu_test", caseModel.getId());
-        assertEquals("shareniu_test", caseModel.getName());
+        assertThat(caseModel.getId()).isEqualTo("shareniu_test");
+        assertThat(caseModel.getName()).isEqualTo("shareniu_test");
 
         Stage planModelStage = caseModel.getPlanModel();
-        assertNotNull(planModelStage);
+        assertThat(planModelStage).isNotNull();
 
         PlanItem planItem = planModelStage.findPlanItemInPlanFragmentOrUpwards("planItem1");
-        assertNotNull(planItem);
-        assertEquals("planItem1", planItem.getId());
-        assertEquals("shareniu_task", planItem.getName());
+        assertThat(planItem).isNotNull();
+        assertThat(planItem.getId()).isEqualTo("planItem1");
+        assertThat(planItem.getName()).isEqualTo("shareniu_task");
 
         PlanItemDefinition planItemDefinition = planItem.getPlanItemDefinition();
-        assertNotNull(planItemDefinition);
-        assertTrue(planItemDefinition instanceof Task);
+        assertThat(planItemDefinition).isNotNull();
+        assertThat(planItemDefinition).isInstanceOf(Task.class);
 
         Task task = (Task) planItemDefinition;
-        assertEquals("shareniu_task", task.getId());
-        assertEquals("shareniu_task", task.getName());
-        assertEquals("${shareniu_task}",task.getBlockingExpression());
+        assertThat(task.getId()).isEqualTo("shareniu_task");
+        assertThat(task.getName()).isEqualTo("shareniu_task");
+        assertThat(task.getBlockingExpression()).isEqualTo("${shareniu_task}");
 
         PlanItem planItem2 = planModelStage.findPlanItemInPlanFragmentOrUpwards("planItem2");
-        assertNotNull(planItem2);
-        assertEquals("planItem2", planItem2.getId());
-        assertEquals("shareniu_human_task", planItem2.getName());
+        assertThat(planItem2).isNotNull();
+        assertThat(planItem2.getId()).isEqualTo("planItem2");
+        assertThat(planItem2.getName()).isEqualTo("shareniu_human_task");
 
         PlanItemDefinition planItemDefinition2 = planItem2.getPlanItemDefinition();
-        assertNotNull(planItemDefinition2);
-        assertTrue(planItemDefinition2 instanceof HumanTask);
+        assertThat(planItemDefinition2).isNotNull();
+        assertThat(planItemDefinition2).isInstanceOf(HumanTask.class);
 
         HumanTask humanTask = (HumanTask) planItemDefinition2;
-        assertEquals("shareniu_human_task", humanTask.getName());
-        assertEquals("${shareniu_human_task}",humanTask.getBlockingExpression());
+        assertThat(humanTask.getName()).isEqualTo("shareniu_human_task");
+        assertThat(humanTask.getBlockingExpression()).isEqualTo("${shareniu_human_task}");
 
     }
 

--- a/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/UserEventListenerConverterTest.java
+++ b/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/UserEventListenerConverterTest.java
@@ -12,9 +12,7 @@
  */
 package org.flowable.cmmn.editor;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.Map;
@@ -45,47 +43,45 @@ public class UserEventListenerConverterTest extends AbstractConverterTest {
     @Override
     protected void validateModel(CmmnModel cmmnModel) {
         Stage model = cmmnModel.getPrimaryCase().getPlanModel();
-        assertEquals(4, model.getPlanItemDefinitionMap().size());
+        assertThat(model.getPlanItemDefinitionMap()).hasSize(4);
 
-
-        assertNotNull(model.getPlanItemDefinitionMap().get("taskA"));
-        assertNotNull(model.getPlanItemDefinitionMap().get("taskB"));
-        assertNotNull(model.getPlanItemDefinitionMap().get("startTaskAUserEvent"));
-        assertNotNull(model.getPlanItemDefinitionMap().get("stopTaskBUserEvent"));
+        assertThat(model.getPlanItemDefinitionMap().get("taskA")).isNotNull();
+        assertThat(model.getPlanItemDefinitionMap().get("taskB")).isNotNull();
+        assertThat(model.getPlanItemDefinitionMap().get("startTaskAUserEvent")).isNotNull();
+        assertThat(model.getPlanItemDefinitionMap().get("stopTaskBUserEvent")).isNotNull();
 
         Map<String, Sentry> sentries = model.getSentries().stream()
                 .collect(Collectors.toMap(Sentry::getName, Function.identity(), (s1, s2) -> s1));
-        assertEquals(2, sentries.size());
+        assertThat(sentries).hasSize(2);
         Sentry sentry = sentries.get("entryTaskASentry");
-        assertNotNull(sentry);
+        assertThat(sentry).isNotNull();
         List<SentryOnPart> onParts = sentry.getOnParts();
-        assertEquals(1, onParts.size());
+        assertThat(onParts).hasSize(1);
         SentryOnPart onPart = onParts.get(0);
-        assertEquals(PlanItemTransition.OCCUR, onPart.getStandardEvent());
-        assertEquals("startTaskAUserEvent", onPart.getSource().getPlanItemDefinition().getId());
+        assertThat(onPart.getStandardEvent()).isEqualTo(PlanItemTransition.OCCUR);
+        assertThat(onPart.getSource().getPlanItemDefinition().getId()).isEqualTo("startTaskAUserEvent");
         PlanItem task = model.findPlanItemInPlanFragmentOrUpwards(model.findPlanItemDefinitionInStageOrUpwards("taskA").getPlanItemRef());
         List<Criterion> criterions = task.getEntryCriteria();
-        assertNotNull(criterions);
-        assertEquals(1, criterions.size());
-        assertEquals(criterions.get(0).getSentryRef(), sentry.getId());
-
+        assertThat(criterions).isNotNull();
+        assertThat(criterions).hasSize(1);
+        assertThat(sentry.getId()).isEqualTo(criterions.get(0).getSentryRef());
 
         sentry = sentries.get("exitTaskBSentry");
-        assertNotNull(sentry);
+        assertThat(sentry).isNotNull();
         onParts = sentry.getOnParts();
-        assertEquals(1, onParts.size());
+        assertThat(onParts).hasSize(1);
         onPart = onParts.get(0);
-        assertEquals(PlanItemTransition.OCCUR, onPart.getStandardEvent());
-        assertEquals("stopTaskBUserEvent", onPart.getSource().getPlanItemDefinition().getId());
+        assertThat(onPart.getStandardEvent()).isEqualTo(PlanItemTransition.OCCUR);
+        assertThat(onPart.getSource().getPlanItemDefinition().getId()).isEqualTo("stopTaskBUserEvent");
         task = model.findPlanItemInPlanFragmentOrUpwards(model.findPlanItemDefinitionInStageOrUpwards("taskB").getPlanItemRef());
         criterions = task.getExitCriteria();
-        assertNotNull(criterions);
-        assertEquals(1, criterions.size());
-        assertEquals(criterions.get(0).getSentryRef(), sentry.getId());
+        assertThat(criterions).isNotNull();
+        assertThat(criterions).hasSize(1);
+        assertThat(sentry.getId()).isEqualTo(criterions.get(0).getSentryRef());
 
         PlanItemDefinition planItemDefinition = model.findPlanItemDefinitionInStageOrDownwards("stopTaskBUserEvent");
-        assertTrue(planItemDefinition instanceof EventListener);
-        assertEquals("${someCondition}", ((EventListener) planItemDefinition).getAvailableConditionExpression());
+        assertThat(planItemDefinition).isInstanceOf(EventListener.class);
+        assertThat(((EventListener) planItemDefinition).getAvailableConditionExpression()).isEqualTo("${someCondition}");
 
     }
 


### PR DESCRIPTION
Continuing quest to use only a single style in each file and in the module.

