### PR TITLE
Use getDeclaredMethods to exclude inherited methods

### DIFF
--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/el/function/AbstractFlowableShortHandExpressionFunction.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/el/function/AbstractFlowableShortHandExpressionFunction.java
@@ -98,7 +98,7 @@ public abstract class AbstractFlowableShortHandExpressionFunction implements Flo
     }
     
     protected Method findMethod() {
-        Method[] methods = this.getClass().getMethods();
+        Method[] methods = this.getClass().getDeclaredMethods();
         for (Method method : methods) {
             if (method.getName().equals(localName)) {
                 return method;


### PR DESCRIPTION
This PR proposes to use `getDeclaredMethods` to fix problems described in #2203 

I am happy to discuss more if interested.
