### PR TITLE
Use assertj fluent style in flowable-engine.  Part 1

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ActivityEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ActivityEventsTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -11,6 +11,8 @@
  * limitations under the License.
  */
 package org.flowable.engine.test.api.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -44,7 +46,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for all {@link FlowableEvent}s related to activities.
- * 
+ *
  * @author Joram Barrez
  * @author Tijs Rademakers
  */
@@ -93,127 +95,127 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
         listener.setIgnoreRawActivityEvents(false);
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("activityProcess");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
-        assertEquals(3, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(3);
 
         // Start-event activity started
         FlowableActivityEvent activityEvent = (FlowableActivityEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("theStart", activityEvent.getActivityId());
-        assertFalse(processInstance.getId().equals(activityEvent.getExecutionId()));
-        assertEquals(processInstance.getProcessInstanceId(), activityEvent.getProcessInstanceId());
-        assertEquals(processInstance.getProcessDefinitionId(), activityEvent.getProcessDefinitionId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("theStart");
+        assertThat(processInstance.getId()).isNotEqualTo(activityEvent.getExecutionId());
+        assertThat(activityEvent.getProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
+        assertThat(activityEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
 
         // Start-event finished
         activityEvent = (FlowableActivityEvent) listener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("theStart", activityEvent.getActivityId());
-        assertFalse(processInstance.getId().equals(activityEvent.getExecutionId()));
-        assertEquals(processInstance.getProcessInstanceId(), activityEvent.getProcessInstanceId());
-        assertEquals(processInstance.getProcessDefinitionId(), activityEvent.getProcessDefinitionId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("theStart");
+        assertThat(processInstance.getId()).isNotEqualTo(activityEvent.getExecutionId());
+        assertThat(activityEvent.getProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
+        assertThat(activityEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
 
         // Usertask started
         activityEvent = (FlowableActivityEvent) listener.getEventsReceived().get(2);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("shipOrder", activityEvent.getActivityId());
-        assertFalse(processInstance.getId().equals(activityEvent.getExecutionId()));
-        assertEquals(processInstance.getProcessInstanceId(), activityEvent.getProcessInstanceId());
-        assertEquals(processInstance.getProcessDefinitionId(), activityEvent.getProcessDefinitionId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("shipOrder");
+        assertThat(processInstance.getId()).isNotEqualTo(activityEvent.getExecutionId());
+        assertThat(activityEvent.getProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
+        assertThat(activityEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
 
         // Complete usertask
         listener.clearEventsReceived();
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         taskService.complete(task.getId());
 
         // Subprocess execution is created
         Execution execution = runtimeService.createExecutionQuery().parentId(processInstance.getId()).singleResult();
-        assertNotNull(execution);
-        assertEquals(5, listener.getEventsReceived().size());
+        assertThat(execution).isNotNull();
+        assertThat(listener.getEventsReceived()).hasSize(5);
         activityEvent = (FlowableActivityEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("shipOrder", activityEvent.getActivityId());
-        assertFalse(processInstance.getId().equals(activityEvent.getExecutionId()));
-        assertEquals(processInstance.getProcessInstanceId(), activityEvent.getProcessInstanceId());
-        assertEquals(processInstance.getProcessDefinitionId(), activityEvent.getProcessDefinitionId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("shipOrder");
+        assertThat(processInstance.getId()).isNotEqualTo(activityEvent.getExecutionId());
+        assertThat(activityEvent.getProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
+        assertThat(activityEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
 
         activityEvent = (FlowableActivityEvent) listener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("subProcess", activityEvent.getActivityId());
-        assertEquals(execution.getId(), activityEvent.getExecutionId());
-        assertEquals(processInstance.getProcessInstanceId(), activityEvent.getProcessInstanceId());
-        assertEquals(processInstance.getProcessDefinitionId(), activityEvent.getProcessDefinitionId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("subProcess");
+        assertThat(activityEvent.getExecutionId()).isEqualTo(execution.getId());
+        assertThat(activityEvent.getProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
+        assertThat(activityEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
 
         activityEvent = (FlowableActivityEvent) listener.getEventsReceived().get(2);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("subProcessStart", activityEvent.getActivityId());
-        assertFalse(execution.getId().equals(activityEvent.getExecutionId()));
-        assertEquals(processInstance.getProcessInstanceId(), activityEvent.getProcessInstanceId());
-        assertEquals(processInstance.getProcessDefinitionId(), activityEvent.getProcessDefinitionId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("subProcessStart");
+        assertThat(execution.getId()).isNotEqualTo(activityEvent.getExecutionId());
+        assertThat(activityEvent.getProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
+        assertThat(activityEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
 
         activityEvent = (FlowableActivityEvent) listener.getEventsReceived().get(3);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("subProcessStart", activityEvent.getActivityId());
-        assertFalse(execution.getId().equals(activityEvent.getExecutionId()));
-        assertEquals(processInstance.getProcessInstanceId(), activityEvent.getProcessInstanceId());
-        assertEquals(processInstance.getProcessDefinitionId(), activityEvent.getProcessDefinitionId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("subProcessStart");
+        assertThat(execution.getId()).isNotEqualTo(activityEvent.getExecutionId());
+        assertThat(activityEvent.getProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
+        assertThat(activityEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
 
         activityEvent = (FlowableActivityEvent) listener.getEventsReceived().get(4);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("subTask", activityEvent.getActivityId());
-        assertFalse(execution.getId().equals(activityEvent.getExecutionId()));
-        assertEquals(processInstance.getProcessInstanceId(), activityEvent.getProcessInstanceId());
-        assertEquals(processInstance.getProcessDefinitionId(), activityEvent.getProcessDefinitionId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("subTask");
+        assertThat(execution.getId()).isNotEqualTo(activityEvent.getExecutionId());
+        assertThat(activityEvent.getProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
+        assertThat(activityEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
         listener.clearEventsReceived();
 
         // Check gateway and intermediate throw event
         org.flowable.task.api.Task subTask = taskService.createTaskQuery().processInstanceId(processInstance.getProcessInstanceId()).singleResult();
-        assertNotNull(subTask);
+        assertThat(subTask).isNotNull();
 
         taskService.complete(subTask.getId());
 
-        assertEquals(10, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(10);
 
         activityEvent = (FlowableActivityEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("subTask", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("subTask");
 
         activityEvent = (FlowableActivityEvent) listener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("gateway", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("gateway");
 
         activityEvent = (FlowableActivityEvent) listener.getEventsReceived().get(2);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("gateway", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("gateway");
 
         activityEvent = (FlowableActivityEvent) listener.getEventsReceived().get(3);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("throwMessageEvent", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("throwMessageEvent");
 
         activityEvent = (FlowableActivityEvent) listener.getEventsReceived().get(4);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("throwMessageEvent", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("throwMessageEvent");
 
         activityEvent = (FlowableActivityEvent) listener.getEventsReceived().get(5);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("endSubProcess", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("endSubProcess");
 
         activityEvent = (FlowableActivityEvent) listener.getEventsReceived().get(6);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("endSubProcess", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("endSubProcess");
 
         activityEvent = (FlowableActivityEvent) listener.getEventsReceived().get(7);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("subProcess", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("subProcess");
 
         activityEvent = (FlowableActivityEvent) listener.getEventsReceived().get(8);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("theEnd", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("theEnd");
 
         activityEvent = (FlowableActivityEvent) listener.getEventsReceived().get(9);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("theEnd", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("theEnd");
     }
 
     /**
@@ -224,52 +226,52 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
     public void testActivitySignalEvents() throws Exception {
         // Two paths are active in the process, one receive-task and one intermediate catching signal-event
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("signalProcess");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         // Check regular signal through API
         Execution executionWithSignal = runtimeService.createExecutionQuery().activityId("receivePayment").singleResult();
-        assertNotNull(executionWithSignal);
+        assertThat(executionWithSignal).isNotNull();
 
         Execution signalExecution = runtimeService.createExecutionQuery().signalEventSubscriptionName("alert").singleResult();
-        assertNotNull(signalExecution);
+        assertThat(signalExecution).isNotNull();
 
         runtimeService.trigger(executionWithSignal.getId());
-        assertEquals(2, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(2);
 
-        assertTrue(listener.getEventsReceived().get(0) instanceof FlowableSignalEvent);
+        assertThat(listener.getEventsReceived().get(0)).isInstanceOf(FlowableSignalEvent.class);
         FlowableSignalEvent signalEvent = (FlowableSignalEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ACTIVITY_SIGNAL_WAITING, signalEvent.getType());
-        assertEquals("shipOrder", signalEvent.getActivityId());
-        assertEquals(signalExecution.getId(), signalEvent.getExecutionId());
-        assertEquals(signalExecution.getProcessInstanceId(), signalEvent.getProcessInstanceId());
-        assertEquals(processInstance.getProcessDefinitionId(), signalEvent.getProcessDefinitionId());
-        assertEquals("shipOrderSignal", signalEvent.getSignalName());
-        assertNull(signalEvent.getSignalData());
+        assertThat(signalEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_SIGNAL_WAITING);
+        assertThat(signalEvent.getActivityId()).isEqualTo("shipOrder");
+        assertThat(signalEvent.getExecutionId()).isEqualTo(signalExecution.getId());
+        assertThat(signalEvent.getProcessInstanceId()).isEqualTo(signalExecution.getProcessInstanceId());
+        assertThat(signalEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(signalEvent.getSignalName()).isEqualTo("shipOrderSignal");
+        assertThat(signalEvent.getSignalData()).isNull();
 
-        assertTrue(listener.getEventsReceived().get(1) instanceof FlowableSignalEvent);
+        assertThat(listener.getEventsReceived().get(1)).isInstanceOf(FlowableSignalEvent.class);
         signalEvent = (FlowableSignalEvent) listener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.ACTIVITY_SIGNALED, signalEvent.getType());
-        assertEquals("receivePayment", signalEvent.getActivityId());
-        assertEquals(executionWithSignal.getId(), signalEvent.getExecutionId());
-        assertEquals(executionWithSignal.getProcessInstanceId(), signalEvent.getProcessInstanceId());
-        assertEquals(processInstance.getProcessDefinitionId(), signalEvent.getProcessDefinitionId());
-        assertNull(signalEvent.getSignalName());
-        assertNull(signalEvent.getSignalData());
+        assertThat(signalEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_SIGNALED);
+        assertThat(signalEvent.getActivityId()).isEqualTo("receivePayment");
+        assertThat(signalEvent.getExecutionId()).isEqualTo(executionWithSignal.getId());
+        assertThat(signalEvent.getProcessInstanceId()).isEqualTo(executionWithSignal.getProcessInstanceId());
+        assertThat(signalEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(signalEvent.getSignalName()).isNull();
+        assertThat(signalEvent.getSignalData()).isNull();
         listener.clearEventsReceived();
 
         // Check signal using event, and pass in additional payload
         Execution executionWithSignalEvent = runtimeService.createExecutionQuery().activityId("shipOrder").singleResult();
         runtimeService.signalEventReceived("alert", executionWithSignalEvent.getId(), Collections.singletonMap("test", (Object) "test"));
-        assertEquals(1, listener.getEventsReceived().size());
-        assertTrue(listener.getEventsReceived().get(0) instanceof FlowableSignalEvent);
+        assertThat(listener.getEventsReceived()).hasSize(1);
+        assertThat(listener.getEventsReceived().get(0)).isInstanceOf(FlowableSignalEvent.class);
         signalEvent = (FlowableSignalEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ACTIVITY_SIGNALED, signalEvent.getType());
-        assertEquals("shipOrder", signalEvent.getActivityId());
-        assertEquals(executionWithSignalEvent.getId(), signalEvent.getExecutionId());
-        assertEquals(executionWithSignalEvent.getProcessInstanceId(), signalEvent.getProcessInstanceId());
-        assertEquals(processInstance.getProcessDefinitionId(), signalEvent.getProcessDefinitionId());
-        assertEquals("alert", signalEvent.getSignalName());
-        assertNotNull(signalEvent.getSignalData());
+        assertThat(signalEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_SIGNALED);
+        assertThat(signalEvent.getActivityId()).isEqualTo("shipOrder");
+        assertThat(signalEvent.getExecutionId()).isEqualTo(executionWithSignalEvent.getId());
+        assertThat(signalEvent.getProcessInstanceId()).isEqualTo(executionWithSignalEvent.getProcessInstanceId());
+        assertThat(signalEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(signalEvent.getSignalName()).isEqualTo("alert");
+        assertThat(signalEvent.getSignalData()).isNotNull();
         listener.clearEventsReceived();
 
         assertDatabaseEventPresent(FlowableEngineEventType.ACTIVITY_SIGNALED);
@@ -282,35 +284,35 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
     @Deployment
     public void testActivitySignalEventsWithinProcess() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("signalProcess");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
 
         Execution executionWithSignalEvent = runtimeService.createExecutionQuery().activityId("shipOrder").singleResult();
 
         taskService.complete(task.getId());
-        assertEquals(2, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(2);
 
-        assertTrue(listener.getEventsReceived().get(0) instanceof FlowableSignalEvent);
+        assertThat(listener.getEventsReceived().get(0)).isInstanceOf(FlowableSignalEvent.class);
         FlowableSignalEvent signalEvent = (FlowableSignalEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ACTIVITY_SIGNAL_WAITING, signalEvent.getType());
-        assertEquals("shipOrder", signalEvent.getActivityId());
-        assertEquals(executionWithSignalEvent.getId(), signalEvent.getExecutionId());
-        assertEquals(executionWithSignalEvent.getProcessInstanceId(), signalEvent.getProcessInstanceId());
-        assertEquals(processInstance.getProcessDefinitionId(), signalEvent.getProcessDefinitionId());
-        assertEquals("shipOrderSignal", signalEvent.getSignalName());
-        assertNull(signalEvent.getSignalData());
+        assertThat(signalEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_SIGNAL_WAITING);
+        assertThat(signalEvent.getActivityId()).isEqualTo("shipOrder");
+        assertThat(signalEvent.getExecutionId()).isEqualTo(executionWithSignalEvent.getId());
+        assertThat(signalEvent.getProcessInstanceId()).isEqualTo(executionWithSignalEvent.getProcessInstanceId());
+        assertThat(signalEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(signalEvent.getSignalName()).isEqualTo("shipOrderSignal");
+        assertThat(signalEvent.getSignalData()).isNull();
 
-        assertTrue(listener.getEventsReceived().get(1) instanceof FlowableSignalEvent);
+        assertThat(listener.getEventsReceived().get(1)).isInstanceOf(FlowableSignalEvent.class);
         signalEvent = (FlowableSignalEvent) listener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.ACTIVITY_SIGNALED, signalEvent.getType());
-        assertEquals("shipOrder", signalEvent.getActivityId());
-        assertEquals(executionWithSignalEvent.getId(), signalEvent.getExecutionId());
-        assertEquals(executionWithSignalEvent.getProcessInstanceId(), signalEvent.getProcessInstanceId());
-        assertEquals(processInstance.getProcessDefinitionId(), signalEvent.getProcessDefinitionId());
-        assertEquals("alert", signalEvent.getSignalName());
-        assertNull(signalEvent.getSignalData());
+        assertThat(signalEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_SIGNALED);
+        assertThat(signalEvent.getActivityId()).isEqualTo("shipOrder");
+        assertThat(signalEvent.getExecutionId()).isEqualTo(executionWithSignalEvent.getId());
+        assertThat(signalEvent.getProcessInstanceId()).isEqualTo(executionWithSignalEvent.getProcessInstanceId());
+        assertThat(signalEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(signalEvent.getSignalName()).isEqualTo("alert");
+        assertThat(signalEvent.getSignalData()).isNull();
     }
 
     /**
@@ -320,35 +322,35 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
     @Deployment
     public void testActivityMessageEvents() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("messageProcess");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         Execution executionWithMessage = runtimeService.createExecutionQuery().activityId("shipOrder").singleResult();
-        assertNotNull(executionWithMessage);
+        assertThat(executionWithMessage).isNotNull();
 
         runtimeService.messageEventReceived("messageName", executionWithMessage.getId());
-        assertEquals(2, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(2);
 
         // First, a message waiting event is expected
-        assertTrue(listener.getEventsReceived().get(0) instanceof FlowableMessageEvent);
+        assertThat(listener.getEventsReceived().get(0)).isInstanceOf(FlowableMessageEvent.class);
         FlowableMessageEvent messageEvent = (FlowableMessageEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ACTIVITY_MESSAGE_WAITING, messageEvent.getType());
-        assertEquals("shipOrder", messageEvent.getActivityId());
-        assertEquals(executionWithMessage.getId(), messageEvent.getExecutionId());
-        assertEquals(executionWithMessage.getProcessInstanceId(), messageEvent.getProcessInstanceId());
-        assertEquals(processInstance.getProcessDefinitionId(), messageEvent.getProcessDefinitionId());
-        assertEquals("messageName", messageEvent.getMessageName());
-        assertNull(messageEvent.getMessageData());
+        assertThat(messageEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_MESSAGE_WAITING);
+        assertThat(messageEvent.getActivityId()).isEqualTo("shipOrder");
+        assertThat(messageEvent.getExecutionId()).isEqualTo(executionWithMessage.getId());
+        assertThat(messageEvent.getProcessInstanceId()).isEqualTo(executionWithMessage.getProcessInstanceId());
+        assertThat(messageEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(messageEvent.getMessageName()).isEqualTo("messageName");
+        assertThat(messageEvent.getMessageData()).isNull();
 
         // Second, a message received event is expected
-        assertTrue(listener.getEventsReceived().get(1) instanceof FlowableMessageEvent);
+        assertThat(listener.getEventsReceived().get(1)).isInstanceOf(FlowableMessageEvent.class);
         messageEvent = (FlowableMessageEvent) listener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.ACTIVITY_MESSAGE_RECEIVED, messageEvent.getType());
-        assertEquals("shipOrder", messageEvent.getActivityId());
-        assertEquals(executionWithMessage.getId(), messageEvent.getExecutionId());
-        assertEquals(executionWithMessage.getProcessInstanceId(), messageEvent.getProcessInstanceId());
-        assertEquals(processInstance.getProcessDefinitionId(), messageEvent.getProcessDefinitionId());
-        assertEquals("messageName", messageEvent.getMessageName());
-        assertNull(messageEvent.getMessageData());
+        assertThat(messageEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_MESSAGE_RECEIVED);
+        assertThat(messageEvent.getActivityId()).isEqualTo("shipOrder");
+        assertThat(messageEvent.getExecutionId()).isEqualTo(executionWithMessage.getId());
+        assertThat(messageEvent.getProcessInstanceId()).isEqualTo(executionWithMessage.getProcessInstanceId());
+        assertThat(messageEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(messageEvent.getMessageName()).isEqualTo("messageName");
+        assertThat(messageEvent.getMessageData()).isNull();
 
         assertDatabaseEventPresent(FlowableEngineEventType.ACTIVITY_MESSAGE_RECEIVED);
     }
@@ -360,38 +362,38 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
     @Deployment
     public void testActivityMessageEventsInEventSubprocess() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("messageProcess");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         Execution executionWithMessage = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertNotNull(executionWithMessage);
+        assertThat(executionWithMessage).isNotNull();
 
         runtimeService.messageEventReceived("messageName", executionWithMessage.getId());
 
         // Only a message events should be present, no signal-event, since the event-subprocess is
         // not signaled, but executed instead
-        assertEquals(2, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(2);
 
         // A message waiting event is expected
-        assertTrue(listener.getEventsReceived().get(0) instanceof FlowableMessageEvent);
+        assertThat(listener.getEventsReceived().get(0)).isInstanceOf(FlowableMessageEvent.class);
         FlowableMessageEvent messageEvent = (FlowableMessageEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ACTIVITY_MESSAGE_WAITING, messageEvent.getType());
-        assertEquals("catchMessage", messageEvent.getActivityId());
-        assertEquals(executionWithMessage.getId(), messageEvent.getExecutionId());
-        assertEquals(executionWithMessage.getProcessInstanceId(), messageEvent.getProcessInstanceId());
-        assertEquals(processInstance.getProcessDefinitionId(), messageEvent.getProcessDefinitionId());
-        assertEquals("messageName", messageEvent.getMessageName());
-        assertNull(messageEvent.getMessageData());
+        assertThat(messageEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_MESSAGE_WAITING);
+        assertThat(messageEvent.getActivityId()).isEqualTo("catchMessage");
+        assertThat(messageEvent.getExecutionId()).isEqualTo(executionWithMessage.getId());
+        assertThat(messageEvent.getProcessInstanceId()).isEqualTo(executionWithMessage.getProcessInstanceId());
+        assertThat(messageEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(messageEvent.getMessageName()).isEqualTo("messageName");
+        assertThat(messageEvent.getMessageData()).isNull();
 
         // A message received event is expected
-        assertTrue(listener.getEventsReceived().get(1) instanceof FlowableMessageEvent);
+        assertThat(listener.getEventsReceived().get(1)).isInstanceOf(FlowableMessageEvent.class);
         messageEvent = (FlowableMessageEvent) listener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.ACTIVITY_MESSAGE_RECEIVED, messageEvent.getType());
-        assertEquals("catchMessage", messageEvent.getActivityId());
-        assertEquals(executionWithMessage.getId(), messageEvent.getExecutionId());
-        assertEquals(executionWithMessage.getProcessInstanceId(), messageEvent.getProcessInstanceId());
-        assertEquals(processInstance.getProcessDefinitionId(), messageEvent.getProcessDefinitionId());
-        assertEquals("messageName", messageEvent.getMessageName());
-        assertNull(messageEvent.getMessageData());
+        assertThat(messageEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_MESSAGE_RECEIVED);
+        assertThat(messageEvent.getActivityId()).isEqualTo("catchMessage");
+        assertThat(messageEvent.getExecutionId()).isEqualTo(executionWithMessage.getId());
+        assertThat(messageEvent.getProcessInstanceId()).isEqualTo(executionWithMessage.getProcessInstanceId());
+        assertThat(messageEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(messageEvent.getMessageName()).isEqualTo("messageName");
+        assertThat(messageEvent.getMessageData()).isNull();
 
         assertDatabaseEventPresent(FlowableEngineEventType.ACTIVITY_MESSAGE_WAITING);
         assertDatabaseEventPresent(FlowableEngineEventType.ACTIVITY_MESSAGE_RECEIVED);
@@ -404,41 +406,41 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
     @Deployment(resources = "org/flowable/engine/test/api/event/ActivityEventsTest.testActivityMessageEventsInEventSubprocess.bpmn20.xml")
     public void testActivityMessageEventsInEventSubprocessForCancel() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("messageProcess");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         Execution executionWithMessage = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertNotNull(executionWithMessage);
+        assertThat(executionWithMessage).isNotNull();
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("Wait", task.getName());
+        assertThat(task.getName()).isEqualTo("Wait");
 
         taskService.complete(task.getId());
 
         // Only a message events should be present, no signal-event, since the event-subprocess is
         // not signaled, but executed instead
-        assertEquals(2, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(2);
 
         // A message waiting event is expected
-        assertTrue(listener.getEventsReceived().get(0) instanceof FlowableMessageEvent);
+        assertThat(listener.getEventsReceived().get(0)).isInstanceOf(FlowableMessageEvent.class);
         FlowableMessageEvent messageEvent = (FlowableMessageEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ACTIVITY_MESSAGE_WAITING, messageEvent.getType());
-        assertEquals("catchMessage", messageEvent.getActivityId());
-        assertEquals(executionWithMessage.getId(), messageEvent.getExecutionId());
-        assertEquals(executionWithMessage.getProcessInstanceId(), messageEvent.getProcessInstanceId());
-        assertEquals(processInstance.getProcessDefinitionId(), messageEvent.getProcessDefinitionId());
-        assertEquals("messageName", messageEvent.getMessageName());
-        assertNull(messageEvent.getMessageData());
+        assertThat(messageEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_MESSAGE_WAITING);
+        assertThat(messageEvent.getActivityId()).isEqualTo("catchMessage");
+        assertThat(messageEvent.getExecutionId()).isEqualTo(executionWithMessage.getId());
+        assertThat(messageEvent.getProcessInstanceId()).isEqualTo(executionWithMessage.getProcessInstanceId());
+        assertThat(messageEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(messageEvent.getMessageName()).isEqualTo("messageName");
+        assertThat(messageEvent.getMessageData()).isNull();
 
         // A message received event is expected
-        assertTrue(listener.getEventsReceived().get(1) instanceof FlowableMessageEvent);
+        assertThat(listener.getEventsReceived().get(1)).isInstanceOf(FlowableMessageEvent.class);
         messageEvent = (FlowableMessageEvent) listener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.ACTIVITY_MESSAGE_CANCELLED, messageEvent.getType());
-        assertEquals("catchMessage", messageEvent.getActivityId());
-        assertEquals(executionWithMessage.getId(), messageEvent.getExecutionId());
-        assertEquals(executionWithMessage.getProcessInstanceId(), messageEvent.getProcessInstanceId());
-        assertEquals(processInstance.getProcessDefinitionId(), messageEvent.getProcessDefinitionId());
-        assertEquals("messageName", messageEvent.getMessageName());
-        assertNull(messageEvent.getMessageData());
+        assertThat(messageEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_MESSAGE_CANCELLED);
+        assertThat(messageEvent.getActivityId()).isEqualTo("catchMessage");
+        assertThat(messageEvent.getExecutionId()).isEqualTo(executionWithMessage.getId());
+        assertThat(messageEvent.getProcessInstanceId()).isEqualTo(executionWithMessage.getProcessInstanceId());
+        assertThat(messageEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(messageEvent.getMessageName()).isEqualTo("messageName");
+        assertThat(messageEvent.getMessageData()).isNull();
 
         assertDatabaseEventPresent(FlowableEngineEventType.ACTIVITY_MESSAGE_WAITING);
     }
@@ -450,30 +452,30 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
     @Deployment
     public void testActivityCompensationEvents() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("compensationProcess");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
 
         // Complete task, next a compensation event will be thrown
         taskService.complete(task.getId());
 
-        assertEquals(1, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(1);
 
         // A compensate-event is expected
-        assertTrue(listener.getEventsReceived().get(0) instanceof FlowableActivityEvent);
+        assertThat(listener.getEventsReceived().get(0)).isInstanceOf(FlowableActivityEvent.class);
         FlowableActivityEvent activityEvent = (FlowableActivityEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPENSATE, activityEvent.getType());
-        assertEquals("usertask", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPENSATE);
+        assertThat(activityEvent.getActivityId()).isEqualTo("usertask");
         // A new execution is created for the compensation-event, this should be visible in the event
-        assertFalse(processInstance.getId().equals(activityEvent.getExecutionId()));
-        assertEquals(processInstance.getProcessInstanceId(), activityEvent.getProcessInstanceId());
-        assertEquals(processInstance.getProcessDefinitionId(), activityEvent.getProcessDefinitionId());
+        assertThat(processInstance.getId()).isNotEqualTo(activityEvent.getExecutionId());
+        assertThat(activityEvent.getProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
+        assertThat(activityEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
 
         // Check if the process is still alive
         processInstance = runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).singleResult();
 
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         assertDatabaseEventPresent(FlowableEngineEventType.ACTIVITY_COMPENSATE);
     }
@@ -485,11 +487,11 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
     @Deployment
     public void testActivityErrorEvents() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("errorProcess");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         // Error-handling should have ended the process
         ProcessInstance afterErrorInstance = runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(afterErrorInstance);
+        assertThat(afterErrorInstance).isNull();
 
         FlowableErrorEvent errorEvent = null;
 
@@ -503,14 +505,14 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
             }
         }
 
-        assertNotNull(errorEvent);
-        assertEquals(FlowableEngineEventType.ACTIVITY_ERROR_RECEIVED, errorEvent.getType());
-        assertEquals("catchError", errorEvent.getActivityId());
-        assertEquals("myError", errorEvent.getErrorId());
-        assertEquals("123", errorEvent.getErrorCode());
-        assertEquals(processInstance.getId(), errorEvent.getProcessInstanceId());
-        assertEquals(processInstance.getProcessDefinitionId(), errorEvent.getProcessDefinitionId());
-        assertFalse(processInstance.getId().equals(errorEvent.getExecutionId()));
+        assertThat(errorEvent).isNotNull();
+        assertThat(errorEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_ERROR_RECEIVED);
+        assertThat(errorEvent.getActivityId()).isEqualTo("catchError");
+        assertThat(errorEvent.getErrorId()).isEqualTo("myError");
+        assertThat(errorEvent.getErrorCode()).isEqualTo("123");
+        assertThat(errorEvent.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(errorEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(processInstance.getId()).isNotEqualTo(errorEvent.getExecutionId());
     }
 
     /**
@@ -520,11 +522,11 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
     @Deployment
     public void testActivityErrorEventsFromBPMNError() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("errorProcess");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         // Error-handling should have ended the process
         ProcessInstance afterErrorInstance = runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(afterErrorInstance);
+        assertThat(afterErrorInstance).isNull();
 
         FlowableErrorEvent errorEvent = null;
 
@@ -538,14 +540,14 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
             }
         }
 
-        assertNotNull(errorEvent);
-        assertEquals(FlowableEngineEventType.ACTIVITY_ERROR_RECEIVED, errorEvent.getType());
-        assertEquals("catchError", errorEvent.getActivityId());
-        assertEquals("23", errorEvent.getErrorId());
-        assertEquals("23", errorEvent.getErrorCode());
-        assertEquals(processInstance.getId(), errorEvent.getProcessInstanceId());
-        assertEquals(processInstance.getProcessDefinitionId(), errorEvent.getProcessDefinitionId());
-        assertFalse(processInstance.getId().equals(errorEvent.getExecutionId()));
+        assertThat(errorEvent).isNotNull();
+        assertThat(errorEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_ERROR_RECEIVED);
+        assertThat(errorEvent.getActivityId()).isEqualTo("catchError");
+        assertThat(errorEvent.getErrorId()).isEqualTo("23");
+        assertThat(errorEvent.getErrorCode()).isEqualTo("23");
+        assertThat(errorEvent.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(errorEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(processInstance.getId()).isNotEqualTo(errorEvent.getExecutionId());
     }
 
     @Test
@@ -553,7 +555,7 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
     public void testActivityTimeOutEvent() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testJobEvents");
         Job theJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(theJob);
+        assertThat(theJob).isNotNull();
 
         // Force timer to fire
         Calendar tomorrow = Calendar.getInstance();
@@ -562,13 +564,13 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
         waitForJobExecutorToProcessAllJobs(2000, 1000);
 
         // Check timeout has been dispatched
-        assertEquals(1, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(1);
         FlowableEvent activitiEvent = listener.getEventsReceived().get(0);
-        assertEquals("ACTIVITY_CANCELLED event expected", FlowableEngineEventType.ACTIVITY_CANCELLED, activitiEvent.getType());
+        assertThat(activitiEvent.getType()).as("ACTIVITY_CANCELLED event expected").isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
         FlowableActivityCancelledEvent cancelledEvent = (FlowableActivityCancelledEvent) activitiEvent;
-        assertTrue("Boundary timer is the cause of the cancellation", cancelledEvent.getCause() instanceof BoundaryEvent);
+        assertThat(cancelledEvent.getCause()).isInstanceOf(BoundaryEvent.class).as("Boundary timer is the cause of the cancellation");
         BoundaryEvent boundaryEvent = (BoundaryEvent) cancelledEvent.getCause();
-        assertTrue("Boundary timer is the cause of the cancellation", boundaryEvent.getEventDefinitions().get(0) instanceof TimerEventDefinition);
+        assertThat(boundaryEvent.getEventDefinitions().get(0)).isInstanceOf(TimerEventDefinition.class).as("Boundary timer is the cause of the cancellation");
     }
 
     @Test
@@ -576,7 +578,7 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
     public void testActivityTimeOutEventInSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("timerOnNestedSubprocesses");
         Job theJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(theJob);
+        assertThat(theJob).isNotNull();
 
         // Force timer to fire
         Calendar timeToFire = Calendar.getInstance();
@@ -586,18 +588,21 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
         waitForJobExecutorToProcessAllJobs(2000, 200);
 
         // Check timeout-events have been dispatched
-        assertEquals(4, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(4);
         List<String> eventIdList = new ArrayList<>();
         for (FlowableEvent event : listener.getEventsReceived()) {
-            assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-            assertTrue("Boundary timer is the cause of the cancellation", ((FlowableActivityCancelledEvent) event).getCause() instanceof BoundaryEvent);
-            assertTrue("Boundary timer is the cause of the cancellation", ( (BoundaryEvent) ((FlowableActivityCancelledEvent) event).getCause()).getEventDefinitions().get(0) instanceof TimerEventDefinition);
+            assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+            assertThat(((FlowableActivityCancelledEvent) event).getCause()).isInstanceOf(BoundaryEvent.class)
+                    .as("Boundary timer is the cause of the cancellation");
+            assertThat(((BoundaryEvent) ((FlowableActivityCancelledEvent) event).getCause()).getEventDefinitions().get(0))
+                    .isInstanceOf(TimerEventDefinition.class)
+                    .as("Boundary timer is the cause of the cancellation");
             eventIdList.add(((FlowableActivityEventImpl) event).getActivityId());
         }
-        assertTrue(eventIdList.indexOf("innerTask1") >= 0);
-        assertTrue(eventIdList.indexOf("innerTask2") >= 0);
-        assertTrue(eventIdList.indexOf("subprocess") >= 0);
-        assertTrue(eventIdList.indexOf("innerSubprocess") >= 0);
+        assertThat(eventIdList.indexOf("innerTask1")).isGreaterThanOrEqualTo(0);
+        assertThat(eventIdList.indexOf("innerTask2")).isGreaterThanOrEqualTo(0);
+        assertThat(eventIdList.indexOf("subprocess")).isGreaterThanOrEqualTo(0);
+        assertThat(eventIdList.indexOf("innerSubprocess")).isGreaterThanOrEqualTo(0);
     }
 
     @Test
@@ -605,7 +610,7 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
     public void testActivityTimeOutEventInCallActivity() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("timerOnCallActivity");
         Job theJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(theJob);
+        assertThat(theJob).isNotNull();
 
         // Force timer to fire
         Calendar timeToFire = Calendar.getInstance();
@@ -615,19 +620,20 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
         waitForJobExecutorToProcessAllJobs(7000, 500);
 
         // Check timeout-events have been dispatched
-        assertEquals(4, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(4);
         List<String> eventIdList = new ArrayList<>();
         for (FlowableEvent event : listener.getEventsReceived()) {
-            assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-            assertTrue("Boundary timer is the cause of the cancellation", ((FlowableCancelledEvent)event).getCause() instanceof BoundaryEvent);
-            BoundaryEvent boundaryEvent = (BoundaryEvent) ((FlowableCancelledEvent)event).getCause();
-            assertTrue("Boundary timer is the cause of the cancellation", boundaryEvent.getEventDefinitions().get(0) instanceof TimerEventDefinition);
+            assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+            assertThat(((FlowableCancelledEvent) event).getCause()).isInstanceOf(BoundaryEvent.class).as("Boundary timer is the cause of the cancellation");
+            BoundaryEvent boundaryEvent = (BoundaryEvent) ((FlowableCancelledEvent) event).getCause();
+            assertThat(boundaryEvent.getEventDefinitions().get(0)).isInstanceOf(TimerEventDefinition.class)
+                    .as("Boundary timer is the cause of the cancellation");
             eventIdList.add(((FlowableActivityEventImpl) event).getActivityId());
         }
-        assertTrue(eventIdList.contains("innerTask1"));
-        assertTrue(eventIdList.contains("innerTask2"));
-        assertTrue(eventIdList.contains("callActivity"));
-        assertTrue(eventIdList.contains("innerSubprocess"));
+        assertThat(eventIdList.contains("innerTask1")).isTrue();
+        assertThat(eventIdList.contains("innerTask2")).isTrue();
+        assertThat(eventIdList.contains("callActivity")).isTrue();
+        assertThat(eventIdList.contains("innerSubprocess")).isTrue();
     }
 
     /**
@@ -637,47 +643,47 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
     @Deployment
     public void testActivityMessageBoundaryEventsOnUserTask() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("messageOnUserTaskProcess");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         Execution executionWithMessage = runtimeService.createExecutionQuery().messageEventSubscriptionName("message_1").singleResult();
-        assertNotNull(executionWithMessage);
+        assertThat(executionWithMessage).isNotNull();
 
         runtimeService.messageEventReceived("message_1", executionWithMessage.getId());
-        assertEquals(3, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(3);
 
         // First, a message waiting event is expected
-        assertTrue(listener.getEventsReceived().get(0) instanceof FlowableMessageEvent);
+        assertThat(listener.getEventsReceived().get(0)).isInstanceOf(FlowableMessageEvent.class);
         FlowableMessageEvent messageEvent = (FlowableMessageEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ACTIVITY_MESSAGE_WAITING, messageEvent.getType());
-        assertEquals("boundaryMessageEventCatching", messageEvent.getActivityId());
-        assertEquals(executionWithMessage.getId(), messageEvent.getExecutionId());
-        assertEquals(executionWithMessage.getProcessInstanceId(), messageEvent.getProcessInstanceId());
-        assertEquals(processInstance.getProcessDefinitionId(), messageEvent.getProcessDefinitionId());
-        assertEquals("message_1", messageEvent.getMessageName());
-        assertNull(messageEvent.getMessageData());
+        assertThat(messageEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_MESSAGE_WAITING);
+        assertThat(messageEvent.getActivityId()).isEqualTo("boundaryMessageEventCatching");
+        assertThat(messageEvent.getExecutionId()).isEqualTo(executionWithMessage.getId());
+        assertThat(messageEvent.getProcessInstanceId()).isEqualTo(executionWithMessage.getProcessInstanceId());
+        assertThat(messageEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(messageEvent.getMessageName()).isEqualTo("message_1");
+        assertThat(messageEvent.getMessageData()).isNull();
 
         // Second, a message received event is expected
-        assertTrue(listener.getEventsReceived().get(1) instanceof FlowableMessageEvent);
+        assertThat(listener.getEventsReceived().get(1)).isInstanceOf(FlowableMessageEvent.class);
         messageEvent = (FlowableMessageEvent) listener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.ACTIVITY_MESSAGE_RECEIVED, messageEvent.getType());
-        assertEquals("boundaryMessageEventCatching", messageEvent.getActivityId());
-        assertEquals(executionWithMessage.getId(), messageEvent.getExecutionId());
-        assertEquals(executionWithMessage.getProcessInstanceId(), messageEvent.getProcessInstanceId());
-        assertEquals(processInstance.getProcessDefinitionId(), messageEvent.getProcessDefinitionId());
-        assertEquals("message_1", messageEvent.getMessageName());
-        assertNull(messageEvent.getMessageData());
+        assertThat(messageEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_MESSAGE_RECEIVED);
+        assertThat(messageEvent.getActivityId()).isEqualTo("boundaryMessageEventCatching");
+        assertThat(messageEvent.getExecutionId()).isEqualTo(executionWithMessage.getId());
+        assertThat(messageEvent.getProcessInstanceId()).isEqualTo(executionWithMessage.getProcessInstanceId());
+        assertThat(messageEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(messageEvent.getMessageName()).isEqualTo("message_1");
+        assertThat(messageEvent.getMessageData()).isNull();
 
         // Next, an signal-event is expected, as a result of the message
-        assertTrue(listener.getEventsReceived().get(2) instanceof FlowableActivityCancelledEvent);
+        assertThat(listener.getEventsReceived().get(2)).isInstanceOf(FlowableActivityCancelledEvent.class);
         FlowableActivityCancelledEvent signalEvent = (FlowableActivityCancelledEvent) listener.getEventsReceived().get(2);
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, signalEvent.getType());
-        assertEquals("cloudformtask1", signalEvent.getActivityId());
-        assertEquals(executionWithMessage.getProcessInstanceId(), signalEvent.getProcessInstanceId());
-        assertEquals(processInstance.getProcessDefinitionId(), signalEvent.getProcessDefinitionId());
-        assertNotNull(signalEvent.getCause());
-        assertTrue(signalEvent.getCause() instanceof BoundaryEvent);
+        assertThat(signalEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(signalEvent.getActivityId()).isEqualTo("cloudformtask1");
+        assertThat(signalEvent.getProcessInstanceId()).isEqualTo(executionWithMessage.getProcessInstanceId());
+        assertThat(signalEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(signalEvent.getCause()).isNotNull();
+        assertThat(signalEvent.getCause()).isInstanceOf(BoundaryEvent.class);
         BoundaryEvent cause = (BoundaryEvent) signalEvent.getCause();
-        assertEquals("message_1", ((MessageEventDefinition) cause.getEventDefinitions().get(0)).getMessageRef());
+        assertThat(((MessageEventDefinition) cause.getEventDefinitions().get(0)).getMessageRef()).isEqualTo("message_1");
 
         assertDatabaseEventPresent(FlowableEngineEventType.ACTIVITY_MESSAGE_WAITING);
         assertDatabaseEventPresent(FlowableEngineEventType.ACTIVITY_MESSAGE_RECEIVED);
@@ -690,38 +696,38 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
     @Deployment(resources = "org/flowable/engine/test/api/event/ActivityEventsTest.testActivityMessageBoundaryEventsOnUserTask.bpmn20.xml")
     public void testActivityMessageBoundaryEventsOnUserTaskForCancel() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("messageOnUserTaskProcess");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         Execution executionWithMessage = runtimeService.createExecutionQuery().messageEventSubscriptionName("message_1").singleResult();
-        assertNotNull(executionWithMessage);
+        assertThat(executionWithMessage).isNotNull();
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("User Task", task.getName());
+        assertThat(task.getName()).isEqualTo("User Task");
         taskService.complete(task.getId());
 
-        assertEquals(2, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(2);
 
         // First, a message waiting event is expected
-        assertTrue(listener.getEventsReceived().get(0) instanceof FlowableMessageEvent);
+        assertThat(listener.getEventsReceived().get(0)).isInstanceOf(FlowableMessageEvent.class);
         FlowableMessageEvent messageEvent = (FlowableMessageEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ACTIVITY_MESSAGE_WAITING, messageEvent.getType());
-        assertEquals("boundaryMessageEventCatching", messageEvent.getActivityId());
-        assertEquals(executionWithMessage.getId(), messageEvent.getExecutionId());
-        assertEquals(executionWithMessage.getProcessInstanceId(), messageEvent.getProcessInstanceId());
-        assertEquals(processInstance.getProcessDefinitionId(), messageEvent.getProcessDefinitionId());
-        assertEquals("message_1", messageEvent.getMessageName());
-        assertNull(messageEvent.getMessageData());
+        assertThat(messageEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_MESSAGE_WAITING);
+        assertThat(messageEvent.getActivityId()).isEqualTo("boundaryMessageEventCatching");
+        assertThat(messageEvent.getExecutionId()).isEqualTo(executionWithMessage.getId());
+        assertThat(messageEvent.getProcessInstanceId()).isEqualTo(executionWithMessage.getProcessInstanceId());
+        assertThat(messageEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(messageEvent.getMessageName()).isEqualTo("message_1");
+        assertThat(messageEvent.getMessageData()).isNull();
 
         // Second, a message received event is expected
-        assertTrue(listener.getEventsReceived().get(1) instanceof FlowableMessageEvent);
+        assertThat(listener.getEventsReceived().get(1)).isInstanceOf(FlowableMessageEvent.class);
         messageEvent = (FlowableMessageEvent) listener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.ACTIVITY_MESSAGE_CANCELLED, messageEvent.getType());
-        assertEquals("boundaryMessageEventCatching", messageEvent.getActivityId());
-        assertEquals(executionWithMessage.getId(), messageEvent.getExecutionId());
-        assertEquals(executionWithMessage.getProcessInstanceId(), messageEvent.getProcessInstanceId());
-        assertEquals(processInstance.getProcessDefinitionId(), messageEvent.getProcessDefinitionId());
-        assertEquals("message_1", messageEvent.getMessageName());
-        assertNull(messageEvent.getMessageData());
+        assertThat(messageEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_MESSAGE_CANCELLED);
+        assertThat(messageEvent.getActivityId()).isEqualTo("boundaryMessageEventCatching");
+        assertThat(messageEvent.getExecutionId()).isEqualTo(executionWithMessage.getId());
+        assertThat(messageEvent.getProcessInstanceId()).isEqualTo(executionWithMessage.getProcessInstanceId());
+        assertThat(messageEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(messageEvent.getMessageName()).isEqualTo("message_1");
+        assertThat(messageEvent.getMessageData()).isNull();
 
         assertDatabaseEventPresent(FlowableEngineEventType.ACTIVITY_MESSAGE_WAITING);
     }
@@ -733,102 +739,102 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
     @Deployment
     public void testActivityMessageBoundaryEventsOnSubProcess() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("messageOnSubProcess");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         Execution executionWithMessage = runtimeService.createExecutionQuery().activityId("boundaryMessageEventCatching").singleResult();
-        assertNotNull(executionWithMessage);
+        assertThat(executionWithMessage).isNotNull();
 
         runtimeService.messageEventReceived("message_1", executionWithMessage.getId());
-        assertEquals(4, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(4);
 
         // First, a message waiting event is expected
-        assertTrue(listener.getEventsReceived().get(0) instanceof FlowableMessageEvent);
+        assertThat(listener.getEventsReceived().get(0)).isInstanceOf(FlowableMessageEvent.class);
         FlowableMessageEvent messageEvent = (FlowableMessageEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ACTIVITY_MESSAGE_WAITING, messageEvent.getType());
-        assertEquals("boundaryMessageEventCatching", messageEvent.getActivityId());
-        assertEquals(executionWithMessage.getId(), messageEvent.getExecutionId());
-        assertEquals(executionWithMessage.getProcessInstanceId(), messageEvent.getProcessInstanceId());
-        assertEquals(processInstance.getProcessDefinitionId(), messageEvent.getProcessDefinitionId());
-        assertEquals("message_1", messageEvent.getMessageName());
-        assertNull(messageEvent.getMessageData());
+        assertThat(messageEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_MESSAGE_WAITING);
+        assertThat(messageEvent.getActivityId()).isEqualTo("boundaryMessageEventCatching");
+        assertThat(messageEvent.getExecutionId()).isEqualTo(executionWithMessage.getId());
+        assertThat(messageEvent.getProcessInstanceId()).isEqualTo(executionWithMessage.getProcessInstanceId());
+        assertThat(messageEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(messageEvent.getMessageName()).isEqualTo("message_1");
+        assertThat(messageEvent.getMessageData()).isNull();
 
         // Second, a message received event is expected
-        assertTrue(listener.getEventsReceived().get(1) instanceof FlowableMessageEvent);
+        assertThat(listener.getEventsReceived().get(1)).isInstanceOf(FlowableMessageEvent.class);
         messageEvent = (FlowableMessageEvent) listener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.ACTIVITY_MESSAGE_RECEIVED, messageEvent.getType());
-        assertEquals("boundaryMessageEventCatching", messageEvent.getActivityId());
-        assertEquals(executionWithMessage.getId(), messageEvent.getExecutionId());
-        assertEquals(executionWithMessage.getProcessInstanceId(), messageEvent.getProcessInstanceId());
-        assertEquals(processInstance.getProcessDefinitionId(), messageEvent.getProcessDefinitionId());
-        assertEquals("message_1", messageEvent.getMessageName());
-        assertNull(messageEvent.getMessageData());
+        assertThat(messageEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_MESSAGE_RECEIVED);
+        assertThat(messageEvent.getActivityId()).isEqualTo("boundaryMessageEventCatching");
+        assertThat(messageEvent.getExecutionId()).isEqualTo(executionWithMessage.getId());
+        assertThat(messageEvent.getProcessInstanceId()).isEqualTo(executionWithMessage.getProcessInstanceId());
+        assertThat(messageEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(messageEvent.getMessageName()).isEqualTo("message_1");
+        assertThat(messageEvent.getMessageData()).isNull();
 
         // Next, an signal-event is expected, as a result of the message
 
-        assertTrue(listener.getEventsReceived().get(2) instanceof FlowableActivityCancelledEvent);
+        assertThat(listener.getEventsReceived().get(2)).isInstanceOf(FlowableActivityCancelledEvent.class);
         FlowableActivityCancelledEvent cancelEvent = (FlowableActivityCancelledEvent) listener.getEventsReceived().get(2);
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, cancelEvent.getType());
-        assertEquals("cloudformtask1", cancelEvent.getActivityId());
-        assertEquals(executionWithMessage.getProcessInstanceId(), cancelEvent.getProcessInstanceId());
-        assertEquals(processInstance.getProcessDefinitionId(), cancelEvent.getProcessDefinitionId());
-        assertNotNull(cancelEvent.getCause());
-        assertTrue(cancelEvent.getCause() instanceof BoundaryEvent);
+        assertThat(cancelEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(cancelEvent.getActivityId()).isEqualTo("cloudformtask1");
+        assertThat(cancelEvent.getProcessInstanceId()).isEqualTo(executionWithMessage.getProcessInstanceId());
+        assertThat(cancelEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(cancelEvent.getCause()).isNotNull();
+        assertThat(cancelEvent.getCause()).isInstanceOf(BoundaryEvent.class);
         BoundaryEvent cause = (BoundaryEvent) cancelEvent.getCause();
-        assertEquals("message_1", ((MessageEventDefinition) cause.getEventDefinitions().get(0)).getMessageRef());
-        
-        assertTrue(listener.getEventsReceived().get(3) instanceof FlowableActivityCancelledEvent);
+        assertThat(((MessageEventDefinition) cause.getEventDefinitions().get(0)).getMessageRef()).isEqualTo("message_1");
+
+        assertThat(listener.getEventsReceived().get(3)).isInstanceOf(FlowableActivityCancelledEvent.class);
         cancelEvent = (FlowableActivityCancelledEvent) listener.getEventsReceived().get(3);
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, cancelEvent.getType());
-        assertEquals("subProcess", cancelEvent.getActivityId());
-        assertEquals(executionWithMessage.getProcessInstanceId(), cancelEvent.getProcessInstanceId());
-        assertEquals(processInstance.getProcessDefinitionId(), cancelEvent.getProcessDefinitionId());
-        assertNotNull(cancelEvent.getCause());
-        assertTrue(cancelEvent.getCause() instanceof BoundaryEvent);
+        assertThat(cancelEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(cancelEvent.getActivityId()).isEqualTo("subProcess");
+        assertThat(cancelEvent.getProcessInstanceId()).isEqualTo(executionWithMessage.getProcessInstanceId());
+        assertThat(cancelEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(cancelEvent.getCause()).isNotNull();
+        assertThat(cancelEvent.getCause()).isInstanceOf(BoundaryEvent.class);
         cause = (BoundaryEvent) cancelEvent.getCause();
-        assertEquals("message_1", ((MessageEventDefinition) cause.getEventDefinitions().get(0)).getMessageRef());
+        assertThat(((MessageEventDefinition) cause.getEventDefinitions().get(0)).getMessageRef()).isEqualTo("message_1");
 
         assertDatabaseEventPresent(FlowableEngineEventType.ACTIVITY_MESSAGE_WAITING);
         assertDatabaseEventPresent(FlowableEngineEventType.ACTIVITY_MESSAGE_RECEIVED);
     }
 
-    /** 
+    /**
      * Test events related to message events, called from the API.
      */
     @Test
     @Deployment(resources = "org/flowable/engine/test/api/event/ActivityEventsTest.testActivityMessageBoundaryEventsOnSubProcess.bpmn20.xml")
     public void testActivityMessageBoundaryEventsOnSubProcessForCancel() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("messageOnSubProcess");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         Execution executionWithMessage = runtimeService.createExecutionQuery().activityId("boundaryMessageEventCatching").singleResult();
-        assertNotNull(executionWithMessage);
+        assertThat(executionWithMessage).isNotNull();
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         taskService.complete(task.getId());
 
-        assertEquals(2, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(2);
 
         // First, a message waiting event is expected
-        assertTrue(listener.getEventsReceived().get(0) instanceof FlowableMessageEvent);
+        assertThat(listener.getEventsReceived().get(0)).isInstanceOf(FlowableMessageEvent.class);
         FlowableMessageEvent messageEvent = (FlowableMessageEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ACTIVITY_MESSAGE_WAITING, messageEvent.getType());
-        assertEquals("boundaryMessageEventCatching", messageEvent.getActivityId());
-        assertEquals(executionWithMessage.getId(), messageEvent.getExecutionId());
-        assertEquals(executionWithMessage.getProcessInstanceId(), messageEvent.getProcessInstanceId());
-        assertEquals(processInstance.getProcessDefinitionId(), messageEvent.getProcessDefinitionId());
-        assertEquals("message_1", messageEvent.getMessageName());
-        assertNull(messageEvent.getMessageData());
+        assertThat(messageEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_MESSAGE_WAITING);
+        assertThat(messageEvent.getActivityId()).isEqualTo("boundaryMessageEventCatching");
+        assertThat(messageEvent.getExecutionId()).isEqualTo(executionWithMessage.getId());
+        assertThat(messageEvent.getProcessInstanceId()).isEqualTo(executionWithMessage.getProcessInstanceId());
+        assertThat(messageEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(messageEvent.getMessageName()).isEqualTo("message_1");
+        assertThat(messageEvent.getMessageData()).isNull();
 
         // Second, a message received event is expected
-        assertTrue(listener.getEventsReceived().get(1) instanceof FlowableMessageEvent);
+        assertThat(listener.getEventsReceived().get(1)).isInstanceOf(FlowableMessageEvent.class);
         messageEvent = (FlowableMessageEvent) listener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.ACTIVITY_MESSAGE_CANCELLED, messageEvent.getType());
-        assertEquals("boundaryMessageEventCatching", messageEvent.getActivityId());
-        assertEquals(executionWithMessage.getId(), messageEvent.getExecutionId());
-        assertEquals(executionWithMessage.getProcessInstanceId(), messageEvent.getProcessInstanceId());
-        assertEquals(processInstance.getProcessDefinitionId(), messageEvent.getProcessDefinitionId());
-        assertEquals("message_1", messageEvent.getMessageName());
-        assertNull(messageEvent.getMessageData());
+        assertThat(messageEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_MESSAGE_CANCELLED);
+        assertThat(messageEvent.getActivityId()).isEqualTo("boundaryMessageEventCatching");
+        assertThat(messageEvent.getExecutionId()).isEqualTo(executionWithMessage.getId());
+        assertThat(messageEvent.getProcessInstanceId()).isEqualTo(executionWithMessage.getProcessInstanceId());
+        assertThat(messageEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(messageEvent.getMessageName()).isEqualTo("message_1");
+        assertThat(messageEvent.getMessageData()).isNull();
 
         assertDatabaseEventPresent(FlowableEngineEventType.ACTIVITY_MESSAGE_WAITING);
     }
@@ -837,99 +843,102 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
     @Deployment
     public void testActivitySignalBoundaryEventsOnSubProcess() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("signalOnSubProcess");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         Execution executionWithSignal = runtimeService.createExecutionQuery().activityId("userTaskInsideProcess").singleResult();
-        assertNotNull(executionWithSignal);
+        assertThat(executionWithSignal).isNotNull();
 
         runtimeService.signalEventReceived("signalName");
-        assertEquals(4, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(4);
 
-        assertTrue(listener.getEventsReceived().get(0) instanceof FlowableSignalEventImpl);
+        assertThat(listener.getEventsReceived().get(0)).isInstanceOf(FlowableSignalEventImpl.class);
         FlowableSignalEventImpl signalEvent = (FlowableSignalEventImpl) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ACTIVITY_SIGNAL_WAITING, signalEvent.getType());
-        assertEquals("boundarySignalEventCatching", signalEvent.getActivityId());
-        assertEquals(executionWithSignal.getProcessInstanceId(), signalEvent.getProcessInstanceId());
-        assertEquals(processInstance.getProcessDefinitionId(), signalEvent.getProcessDefinitionId());
+        assertThat(signalEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_SIGNAL_WAITING);
+        assertThat(signalEvent.getActivityId()).isEqualTo("boundarySignalEventCatching");
+        assertThat(signalEvent.getProcessInstanceId()).isEqualTo(executionWithSignal.getProcessInstanceId());
+        assertThat(signalEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
 
-        assertTrue(listener.getEventsReceived().get(1) instanceof FlowableSignalEventImpl);
+        assertThat(listener.getEventsReceived().get(1)).isInstanceOf(FlowableSignalEventImpl.class);
         signalEvent = (FlowableSignalEventImpl) listener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.ACTIVITY_SIGNALED, signalEvent.getType());
-        assertEquals("boundarySignalEventCatching", signalEvent.getActivityId());
-        assertEquals(executionWithSignal.getProcessInstanceId(), signalEvent.getProcessInstanceId());
-        assertEquals(processInstance.getProcessDefinitionId(), signalEvent.getProcessDefinitionId());
+        assertThat(signalEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_SIGNALED);
+        assertThat(signalEvent.getActivityId()).isEqualTo("boundarySignalEventCatching");
+        assertThat(signalEvent.getProcessInstanceId()).isEqualTo(executionWithSignal.getProcessInstanceId());
+        assertThat(signalEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
 
-        assertTrue(listener.getEventsReceived().get(2) instanceof FlowableActivityCancelledEvent);
+        assertThat(listener.getEventsReceived().get(2)).isInstanceOf(FlowableActivityCancelledEvent.class);
         FlowableActivityCancelledEvent cancelEvent = (FlowableActivityCancelledEvent) listener.getEventsReceived().get(2);
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, cancelEvent.getType());
-        assertEquals("userTaskInsideProcess", cancelEvent.getActivityId());
-        assertEquals(executionWithSignal.getId(), cancelEvent.getExecutionId());
-        assertEquals(executionWithSignal.getProcessInstanceId(), cancelEvent.getProcessInstanceId());
-        assertEquals(processInstance.getProcessDefinitionId(), cancelEvent.getProcessDefinitionId());
-        assertNotNull(cancelEvent.getCause());
-        assertTrue(cancelEvent.getCause() instanceof BoundaryEvent);
+        assertThat(cancelEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(cancelEvent.getActivityId()).isEqualTo("userTaskInsideProcess");
+        assertThat(cancelEvent.getExecutionId()).isEqualTo(executionWithSignal.getId());
+        assertThat(cancelEvent.getProcessInstanceId()).isEqualTo(executionWithSignal.getProcessInstanceId());
+        assertThat(cancelEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(cancelEvent.getCause()).isNotNull();
+        assertThat(cancelEvent.getCause()).isInstanceOf(BoundaryEvent.class);
         BoundaryEvent cause = (BoundaryEvent) cancelEvent.getCause();
-        assertTrue(cause.getEventDefinitions().get(0) instanceof SignalEventDefinition);
+        assertThat(cause.getEventDefinitions().get(0)).isInstanceOf(SignalEventDefinition.class);
         SignalEventDefinition signalEventDefinition = ((SignalEventDefinition) cause.getEventDefinitions().get(0));
-        assertEquals("signal", signalEventDefinition.getSignalRef());
-        assertEquals("signalName", repositoryService.getBpmnModel(cancelEvent.getProcessDefinitionId()).getSignal(signalEventDefinition.getSignalRef()).getName());
-        
-        assertTrue(listener.getEventsReceived().get(3) instanceof FlowableActivityCancelledEvent);
+        assertThat(signalEventDefinition.getSignalRef()).isEqualTo("signal");
+        assertThat(repositoryService.getBpmnModel(cancelEvent.getProcessDefinitionId()).getSignal(signalEventDefinition.getSignalRef()).getName())
+                .isEqualTo("signalName");
+
+        assertThat(listener.getEventsReceived().get(3)).isInstanceOf(FlowableActivityCancelledEvent.class);
         cancelEvent = (FlowableActivityCancelledEvent) listener.getEventsReceived().get(3);
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, cancelEvent.getType());
-        assertEquals("subProcess", cancelEvent.getActivityId());
-        assertEquals(executionWithSignal.getProcessInstanceId(), cancelEvent.getProcessInstanceId());
-        assertEquals(processInstance.getProcessDefinitionId(), cancelEvent.getProcessDefinitionId());
-        assertNotNull(cancelEvent.getCause());
-        assertTrue(cancelEvent.getCause() instanceof BoundaryEvent);
+        assertThat(cancelEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(cancelEvent.getActivityId()).isEqualTo("subProcess");
+        assertThat(cancelEvent.getProcessInstanceId()).isEqualTo(executionWithSignal.getProcessInstanceId());
+        assertThat(cancelEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(cancelEvent.getCause()).isNotNull();
+        assertThat(cancelEvent.getCause()).isInstanceOf(BoundaryEvent.class);
         cause = (BoundaryEvent) cancelEvent.getCause();
-        assertTrue(cause.getEventDefinitions().get(0) instanceof SignalEventDefinition);
+        assertThat(cause.getEventDefinitions().get(0)).isInstanceOf(SignalEventDefinition.class);
         signalEventDefinition = ((SignalEventDefinition) cause.getEventDefinitions().get(0));
-        assertEquals("signal", signalEventDefinition.getSignalRef());
-        assertEquals("signalName", repositoryService.getBpmnModel(cancelEvent.getProcessDefinitionId()).getSignal(signalEventDefinition.getSignalRef()).getName());
+        assertThat(signalEventDefinition.getSignalRef()).isEqualTo("signal");
+        assertThat(repositoryService.getBpmnModel(cancelEvent.getProcessDefinitionId()).getSignal(signalEventDefinition.getSignalRef()).getName())
+                .isEqualTo("signalName");
     }
 
     @Test
     @Deployment
     public void testActivitySignalBoundaryEventsOnUserTask() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("signalOnUserTask");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         Execution executionWithSignal = runtimeService.createExecutionQuery().activityId("userTask").singleResult();
-        assertNotNull(executionWithSignal);
+        assertThat(executionWithSignal).isNotNull();
 
         runtimeService.signalEventReceived("signalName");
 
         // Next, an signal-event is expected, as a result of the message
-        assertEquals(3, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(3);
 
-        assertTrue(listener.getEventsReceived().get(0) instanceof FlowableSignalEventImpl);
+        assertThat(listener.getEventsReceived().get(0)).isInstanceOf(FlowableSignalEventImpl.class);
         FlowableSignalEventImpl signalEvent = (FlowableSignalEventImpl) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ACTIVITY_SIGNAL_WAITING, signalEvent.getType());
-        assertEquals("boundarySignalEventCatching", signalEvent.getActivityId());
-        assertEquals(executionWithSignal.getProcessInstanceId(), signalEvent.getProcessInstanceId());
-        assertEquals(processInstance.getProcessDefinitionId(), signalEvent.getProcessDefinitionId());
+        assertThat(signalEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_SIGNAL_WAITING);
+        assertThat(signalEvent.getActivityId()).isEqualTo("boundarySignalEventCatching");
+        assertThat(signalEvent.getProcessInstanceId()).isEqualTo(executionWithSignal.getProcessInstanceId());
+        assertThat(signalEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
 
-        assertTrue(listener.getEventsReceived().get(1) instanceof FlowableSignalEventImpl);
+        assertThat(listener.getEventsReceived().get(1)).isInstanceOf(FlowableSignalEventImpl.class);
         signalEvent = (FlowableSignalEventImpl) listener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.ACTIVITY_SIGNALED, signalEvent.getType());
-        assertEquals("boundarySignalEventCatching", signalEvent.getActivityId());
-        assertEquals(executionWithSignal.getProcessInstanceId(), signalEvent.getProcessInstanceId());
-        assertEquals(processInstance.getProcessDefinitionId(), signalEvent.getProcessDefinitionId());
+        assertThat(signalEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_SIGNALED);
+        assertThat(signalEvent.getActivityId()).isEqualTo("boundarySignalEventCatching");
+        assertThat(signalEvent.getProcessInstanceId()).isEqualTo(executionWithSignal.getProcessInstanceId());
+        assertThat(signalEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
 
-        assertTrue(listener.getEventsReceived().get(2) instanceof FlowableActivityCancelledEvent);
+        assertThat(listener.getEventsReceived().get(2)).isInstanceOf(FlowableActivityCancelledEvent.class);
         FlowableActivityCancelledEvent cancelEvent = (FlowableActivityCancelledEvent) listener.getEventsReceived().get(2);
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, cancelEvent.getType());
-        assertEquals("userTask", cancelEvent.getActivityId());
-        assertEquals(executionWithSignal.getProcessInstanceId(), cancelEvent.getProcessInstanceId());
-        assertEquals(processInstance.getProcessDefinitionId(), cancelEvent.getProcessDefinitionId());
-        assertNotNull(cancelEvent.getCause());
-        assertTrue(cancelEvent.getCause() instanceof BoundaryEvent);
+        assertThat(cancelEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(cancelEvent.getActivityId()).isEqualTo("userTask");
+        assertThat(cancelEvent.getProcessInstanceId()).isEqualTo(executionWithSignal.getProcessInstanceId());
+        assertThat(cancelEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(cancelEvent.getCause()).isNotNull();
+        assertThat(cancelEvent.getCause()).isInstanceOf(BoundaryEvent.class);
         BoundaryEvent cause = (BoundaryEvent) cancelEvent.getCause();
-        assertTrue(cause.getEventDefinitions().get(0) instanceof SignalEventDefinition);
+        assertThat(cause.getEventDefinitions().get(0)).isInstanceOf(SignalEventDefinition.class);
         SignalEventDefinition signalEventDefinition = ((SignalEventDefinition) cause.getEventDefinitions().get(0));
-        assertEquals("signal", signalEventDefinition.getSignalRef());
-        assertEquals("signalName", repositoryService.getBpmnModel(cancelEvent.getProcessDefinitionId()).getSignal(signalEventDefinition.getSignalRef()).getName());
+        assertThat(signalEventDefinition.getSignalRef()).isEqualTo("signal");
+        assertThat(repositoryService.getBpmnModel(cancelEvent.getProcessDefinitionId()).getSignal(signalEventDefinition.getSignalRef()).getName())
+                .isEqualTo("signalName");
     }
 
     protected void assertDatabaseEventPresent(FlowableEngineEventType eventType) {
@@ -941,7 +950,7 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
                 found = true;
             }
         }
-        assertTrue(found);
+        assertThat(found).isTrue();
     }
 
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ActivityEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ActivityEventsTest.java
@@ -566,11 +566,14 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
         // Check timeout has been dispatched
         assertThat(listener.getEventsReceived()).hasSize(1);
         FlowableEvent activitiEvent = listener.getEventsReceived().get(0);
-        assertThat(activitiEvent.getType()).as("ACTIVITY_CANCELLED event expected").isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(activitiEvent.getType()).as("ACTIVITY_CANCELLED event expected")
+                .isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
         FlowableActivityCancelledEvent cancelledEvent = (FlowableActivityCancelledEvent) activitiEvent;
-        assertThat(cancelledEvent.getCause()).isInstanceOf(BoundaryEvent.class).as("Boundary timer is the cause of the cancellation");
+        assertThat(cancelledEvent.getCause()).as("Boundary timer is the cause of the cancellation")
+                .isInstanceOf(BoundaryEvent.class);
         BoundaryEvent boundaryEvent = (BoundaryEvent) cancelledEvent.getCause();
-        assertThat(boundaryEvent.getEventDefinitions().get(0)).isInstanceOf(TimerEventDefinition.class).as("Boundary timer is the cause of the cancellation");
+        assertThat(boundaryEvent.getEventDefinitions().get(0)).as("Boundary timer is the cause of the cancellation")
+                .isInstanceOf(TimerEventDefinition.class);
     }
 
     @Test
@@ -592,11 +595,11 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
         List<String> eventIdList = new ArrayList<>();
         for (FlowableEvent event : listener.getEventsReceived()) {
             assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
-            assertThat(((FlowableActivityCancelledEvent) event).getCause()).isInstanceOf(BoundaryEvent.class)
-                    .as("Boundary timer is the cause of the cancellation");
+            assertThat(((FlowableActivityCancelledEvent) event).getCause()).as("Boundary timer is the cause of the cancellation")
+                    .isInstanceOf(BoundaryEvent.class);
             assertThat(((BoundaryEvent) ((FlowableActivityCancelledEvent) event).getCause()).getEventDefinitions().get(0))
-                    .isInstanceOf(TimerEventDefinition.class)
-                    .as("Boundary timer is the cause of the cancellation");
+                    .as("Boundary timer is the cause of the cancellation")
+                    .isInstanceOf(TimerEventDefinition.class);
             eventIdList.add(((FlowableActivityEventImpl) event).getActivityId());
         }
         assertThat(eventIdList.indexOf("innerTask1")).isGreaterThanOrEqualTo(0);
@@ -624,16 +627,15 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
         List<String> eventIdList = new ArrayList<>();
         for (FlowableEvent event : listener.getEventsReceived()) {
             assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
-            assertThat(((FlowableCancelledEvent) event).getCause()).isInstanceOf(BoundaryEvent.class).as("Boundary timer is the cause of the cancellation");
+            assertThat(((FlowableCancelledEvent) event).getCause()).as("Boundary timer is the cause of the cancellation")
+                    .isInstanceOf(BoundaryEvent.class);
             BoundaryEvent boundaryEvent = (BoundaryEvent) ((FlowableCancelledEvent) event).getCause();
-            assertThat(boundaryEvent.getEventDefinitions().get(0)).isInstanceOf(TimerEventDefinition.class)
-                    .as("Boundary timer is the cause of the cancellation");
+            assertThat(boundaryEvent.getEventDefinitions().get(0)).as("Boundary timer is the cause of the cancellation")
+                    .isInstanceOf(TimerEventDefinition.class);
             eventIdList.add(((FlowableActivityEventImpl) event).getActivityId());
         }
-        assertThat(eventIdList.contains("innerTask1")).isTrue();
-        assertThat(eventIdList.contains("innerTask2")).isTrue();
-        assertThat(eventIdList.contains("callActivity")).isTrue();
-        assertThat(eventIdList.contains("innerSubprocess")).isTrue();
+        assertThat(eventIdList)
+                .containsOnly("innerTask1", "innerTask2", "callActivity", "innerSubprocess");
     }
 
     /**

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/AttachmentEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/AttachmentEventsTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -11,6 +11,8 @@
  * limitations under the License.
  */
 package org.flowable.engine.test.api.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayInputStream;
 
@@ -30,7 +32,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for all {@link FlowableEvent}s related to attachments.
- * 
+ *
  * @author Frederik Heremans
  */
 public class AttachmentEventsTest extends PluggableFlowableTestCase {
@@ -48,44 +50,46 @@ public class AttachmentEventsTest extends PluggableFlowableTestCase {
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
             org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-            assertNotNull(task);
+            assertThat(task).isNotNull();
 
             // Create link-attachment
-            Attachment attachment = taskService.createAttachment("test", task.getId(), processInstance.getId(), "attachment name", "description", "http://flowable.org");
-            assertNull(attachment.getUserId());
-            assertEquals(2, listener.getEventsReceived().size());
+            Attachment attachment = taskService
+                    .createAttachment("test", task.getId(), processInstance.getId(), "attachment name", "description", "http://flowable.org");
+            assertThat(attachment.getUserId()).isNull();
+            assertThat(listener.getEventsReceived()).hasSize(2);
             FlowableEngineEntityEvent event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(0);
-            assertEquals(FlowableEngineEventType.ENTITY_CREATED, event.getType());
-            assertEquals(processInstance.getId(), event.getProcessInstanceId());
-            assertEquals(processInstance.getId(), event.getExecutionId());
-            assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
+            assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
+            assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+            assertThat(event.getExecutionId()).isEqualTo(processInstance.getId());
+            assertThat(event.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
             Attachment attachmentFromEvent = (Attachment) event.getEntity();
-            assertEquals(attachment.getId(), attachmentFromEvent.getId());
+            assertThat(attachmentFromEvent.getId()).isEqualTo(attachment.getId());
             event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(1);
-            assertEquals(FlowableEngineEventType.ENTITY_INITIALIZED, event.getType());
-            assertEquals(processInstance.getId(), event.getProcessInstanceId());
-            assertEquals(processInstance.getId(), event.getExecutionId());
-            assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
+            assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_INITIALIZED);
+            assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+            assertThat(event.getExecutionId()).isEqualTo(processInstance.getId());
+            assertThat(event.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
             attachmentFromEvent = (Attachment) event.getEntity();
-            assertEquals(attachment.getId(), attachmentFromEvent.getId());
+            assertThat(attachmentFromEvent.getId()).isEqualTo(attachment.getId());
             listener.clearEventsReceived();
 
             // Create binary attachment
             Authentication.setAuthenticatedUserId("testuser");
-            attachment = taskService.createAttachment("test", task.getId(), processInstance.getId(), "attachment name", "description", new ByteArrayInputStream("test".getBytes()));
-            assertNotNull(attachment.getUserId());
-            assertEquals("testuser", attachment.getUserId());
-            assertEquals(2, listener.getEventsReceived().size());
+            attachment = taskService.createAttachment("test", task.getId(), processInstance.getId(), "attachment name", "description",
+                    new ByteArrayInputStream("test".getBytes()));
+            assertThat(attachment.getUserId()).isNotNull();
+            assertThat(attachment.getUserId()).isEqualTo("testuser");
+            assertThat(listener.getEventsReceived()).hasSize(2);
             event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(0);
-            assertEquals(FlowableEngineEventType.ENTITY_CREATED, event.getType());
-            assertEquals(processInstance.getId(), event.getProcessInstanceId());
-            assertEquals(processInstance.getId(), event.getExecutionId());
-            assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
+            assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
+            assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+            assertThat(event.getExecutionId()).isEqualTo(processInstance.getId());
+            assertThat(event.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
             attachmentFromEvent = (Attachment) event.getEntity();
-            assertEquals(attachment.getId(), attachmentFromEvent.getId());
+            assertThat(attachmentFromEvent.getId()).isEqualTo(attachment.getId());
 
             event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(1);
-            assertEquals(FlowableEngineEventType.ENTITY_INITIALIZED, event.getType());
+            assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_INITIALIZED);
             listener.clearEventsReceived();
 
             // Update attachment
@@ -93,27 +97,27 @@ public class AttachmentEventsTest extends PluggableFlowableTestCase {
             attachment.setDescription("Description");
             taskService.saveAttachment(attachment);
 
-            assertEquals(1, listener.getEventsReceived().size());
+            assertThat(listener.getEventsReceived()).hasSize(1);
             event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(0);
-            assertEquals(FlowableEngineEventType.ENTITY_UPDATED, event.getType());
-            assertEquals(processInstance.getId(), event.getProcessInstanceId());
-            assertEquals(processInstance.getId(), event.getExecutionId());
-            assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
+            assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_UPDATED);
+            assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+            assertThat(event.getExecutionId()).isEqualTo(processInstance.getId());
+            assertThat(event.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
             attachmentFromEvent = (Attachment) event.getEntity();
-            assertEquals(attachment.getId(), attachmentFromEvent.getId());
-            assertEquals("Description", attachmentFromEvent.getDescription());
+            assertThat(attachmentFromEvent.getId()).isEqualTo(attachment.getId());
+            assertThat(attachmentFromEvent.getDescription()).isEqualTo("Description");
             listener.clearEventsReceived();
 
             // Finally, delete attachment
             taskService.deleteAttachment(attachment.getId());
-            assertEquals(1, listener.getEventsReceived().size());
+            assertThat(listener.getEventsReceived()).hasSize(1);
             event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(0);
-            assertEquals(FlowableEngineEventType.ENTITY_DELETED, event.getType());
-            assertEquals(processInstance.getId(), event.getProcessInstanceId());
-            assertEquals(processInstance.getId(), event.getExecutionId());
-            assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
+            assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_DELETED);
+            assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+            assertThat(event.getExecutionId()).isEqualTo(processInstance.getId());
+            assertThat(event.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
             attachmentFromEvent = (Attachment) event.getEntity();
-            assertEquals(attachment.getId(), attachmentFromEvent.getId());
+            assertThat(attachmentFromEvent.getId()).isEqualTo(attachment.getId());
         }
     }
 
@@ -127,35 +131,36 @@ public class AttachmentEventsTest extends PluggableFlowableTestCase {
             try {
                 task = taskService.newTask();
                 taskService.saveTask(task);
-                assertNotNull(task);
+                assertThat(task).isNotNull();
 
                 // Create link-attachment
                 Attachment attachment = taskService.createAttachment("test", task.getId(), null, "attachment name", "description", "http://flowable.org");
-                assertEquals(2, listener.getEventsReceived().size());
+                assertThat(listener.getEventsReceived()).hasSize(2);
                 FlowableEngineEntityEvent event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(0);
-                assertEquals(FlowableEngineEventType.ENTITY_CREATED, event.getType());
-                assertNull(event.getProcessInstanceId());
-                assertNull(event.getExecutionId());
-                assertNull(event.getProcessDefinitionId());
+                assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
+                assertThat(event.getProcessInstanceId()).isNull();
+                assertThat(event.getExecutionId()).isNull();
+                assertThat(event.getProcessDefinitionId()).isNull();
                 Attachment attachmentFromEvent = (Attachment) event.getEntity();
-                assertEquals(attachment.getId(), attachmentFromEvent.getId());
+                assertThat(attachmentFromEvent.getId()).isEqualTo(attachment.getId());
                 event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(1);
-                assertEquals(FlowableEngineEventType.ENTITY_INITIALIZED, event.getType());
+                assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_INITIALIZED);
                 listener.clearEventsReceived();
 
                 // Create binary attachment
-                attachment = taskService.createAttachment("test", task.getId(), null, "attachment name", "description", new ByteArrayInputStream("test".getBytes()));
-                assertEquals(2, listener.getEventsReceived().size());
+                attachment = taskService
+                        .createAttachment("test", task.getId(), null, "attachment name", "description", new ByteArrayInputStream("test".getBytes()));
+                assertThat(listener.getEventsReceived()).hasSize(2);
                 event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(0);
-                assertEquals(FlowableEngineEventType.ENTITY_CREATED, event.getType());
-                assertNull(event.getProcessInstanceId());
-                assertNull(event.getExecutionId());
-                assertNull(event.getProcessDefinitionId());
+                assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
+                assertThat(event.getProcessInstanceId()).isNull();
+                assertThat(event.getExecutionId()).isNull();
+                assertThat(event.getProcessDefinitionId()).isNull();
                 attachmentFromEvent = (Attachment) event.getEntity();
-                assertEquals(attachment.getId(), attachmentFromEvent.getId());
+                assertThat(attachmentFromEvent.getId()).isEqualTo(attachment.getId());
 
                 event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(1);
-                assertEquals(FlowableEngineEventType.ENTITY_INITIALIZED, event.getType());
+                assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_INITIALIZED);
                 listener.clearEventsReceived();
 
                 // Update attachment
@@ -163,27 +168,27 @@ public class AttachmentEventsTest extends PluggableFlowableTestCase {
                 attachment.setDescription("Description");
                 taskService.saveAttachment(attachment);
 
-                assertEquals(1, listener.getEventsReceived().size());
+                assertThat(listener.getEventsReceived()).hasSize(1);
                 event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(0);
-                assertEquals(FlowableEngineEventType.ENTITY_UPDATED, event.getType());
-                assertNull(event.getProcessInstanceId());
-                assertNull(event.getExecutionId());
-                assertNull(event.getProcessDefinitionId());
+                assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_UPDATED);
+                assertThat(event.getProcessInstanceId()).isNull();
+                assertThat(event.getExecutionId()).isNull();
+                assertThat(event.getProcessDefinitionId()).isNull();
                 attachmentFromEvent = (Attachment) event.getEntity();
-                assertEquals(attachment.getId(), attachmentFromEvent.getId());
-                assertEquals("Description", attachmentFromEvent.getDescription());
+                assertThat(attachmentFromEvent.getId()).isEqualTo(attachment.getId());
+                assertThat(attachmentFromEvent.getDescription()).isEqualTo("Description");
                 listener.clearEventsReceived();
 
                 // Finally, delete attachment
                 taskService.deleteAttachment(attachment.getId());
-                assertEquals(1, listener.getEventsReceived().size());
+                assertThat(listener.getEventsReceived()).hasSize(1);
                 event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(0);
-                assertEquals(FlowableEngineEventType.ENTITY_DELETED, event.getType());
-                assertNull(event.getProcessInstanceId());
-                assertNull(event.getExecutionId());
-                assertNull(event.getProcessDefinitionId());
+                assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_DELETED);
+                assertThat(event.getProcessInstanceId()).isNull();
+                assertThat(event.getExecutionId()).isNull();
+                assertThat(event.getProcessDefinitionId()).isNull();
                 attachmentFromEvent = (Attachment) event.getEntity();
-                assertEquals(attachment.getId(), attachmentFromEvent.getId());
+                assertThat(attachmentFromEvent.getId()).isEqualTo(attachment.getId());
 
             } finally {
                 if (task != null && task.getId() != null) {
@@ -200,7 +205,7 @@ public class AttachmentEventsTest extends PluggableFlowableTestCase {
             try {
                 task = taskService.newTask();
                 taskService.saveTask(task);
-                assertNotNull(task);
+                assertThat(task).isNotNull();
 
                 // Create link-attachment
                 Attachment attachment = taskService.createAttachment("test", task.getId(), null, "attachment name", "description", "http://flowable.org");
@@ -210,14 +215,14 @@ public class AttachmentEventsTest extends PluggableFlowableTestCase {
                 taskService.deleteTask(task.getId());
                 historyService.deleteHistoricTaskInstance(task.getId());
 
-                assertEquals(1, listener.getEventsReceived().size());
+                assertThat(listener.getEventsReceived()).hasSize(1);
                 FlowableEngineEntityEvent event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(0);
-                assertEquals(FlowableEngineEventType.ENTITY_DELETED, event.getType());
-                assertNull(event.getProcessInstanceId());
-                assertNull(event.getExecutionId());
-                assertNull(event.getProcessDefinitionId());
+                assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_DELETED);
+                assertThat(event.getProcessInstanceId()).isNull();
+                assertThat(event.getExecutionId()).isNull();
+                assertThat(event.getProcessDefinitionId()).isNull();
                 Attachment attachmentFromEvent = (Attachment) event.getEntity();
-                assertEquals(attachment.getId(), attachmentFromEvent.getId());
+                assertThat(attachmentFromEvent.getId()).isEqualTo(attachment.getId());
 
             } finally {
                 if (task != null && task.getId() != null) {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/CallActivityTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/CallActivityTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.api.event;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -88,180 +90,180 @@ public class CallActivityTest extends PluggableFlowableTestCase {
         processEngineConfiguration.getEventDispatcher().addEventListener(mylistener);
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("callActivity");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         // no task should be active in parent process
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(task);
+        assertThat(task).isNull();
 
         // only active task should be the one defined in the external subprocess
         task = taskService.createTaskQuery().active().singleResult();
-        assertNotNull(task);
-        assertEquals("User Task2 in External", task.getName());
+        assertThat(task).isNotNull();
+        assertThat(task.getName()).isEqualTo("User Task2 in External");
 
         ExecutionEntity subprocessInstance = (ExecutionEntity) runtimeService.createExecutionQuery()
                 .rootProcessInstanceId(processInstance.getId())
                 .onlySubProcessExecutions()
                 .singleResult();
-        assertNotNull(subprocessInstance);
+        assertThat(subprocessInstance).isNotNull();
 
-        assertEquals("Default name", runtimeService.getVariable(processInstance.getId(), "Name"));
-        assertEquals("Default name", runtimeService.getVariable(subprocessInstance.getId(), "FullName"));
+        assertThat(runtimeService.getVariable(processInstance.getId(), "Name")).isEqualTo("Default name");
+        assertThat(runtimeService.getVariable(subprocessInstance.getId(), "FullName")).isEqualTo("Default name");
 
         // set the variable in the subprocess to validate that the new value is returned from callActivity
         runtimeService.setVariable(subprocessInstance.getId(), "FullName", "Mary Smith");
-        assertEquals("Default name", runtimeService.getVariable(processInstance.getId(), "Name"));
-        assertEquals("Mary Smith", runtimeService.getVariable(subprocessInstance.getId(), "FullName"));
+        assertThat(runtimeService.getVariable(processInstance.getId(), "Name")).isEqualTo("Default name");
+        assertThat(runtimeService.getVariable(subprocessInstance.getId(), "FullName")).isEqualTo("Mary Smith");
 
         // complete user task so that external subprocess will flow to terminate end
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(task);
-        assertEquals("User Task1", task.getName());
+        assertThat(task).isNotNull();
+        assertThat(task.getName()).isEqualTo("User Task1");
 
         // validate that the variable was copied back when Call Activity finished
-        assertEquals("Mary Smith", runtimeService.getVariable(processInstance.getId(), "Name"));
+        assertThat(runtimeService.getVariable(processInstance.getId(), "Name")).isEqualTo("Mary Smith");
 
         // complete user task so that parent process will terminate normally
         taskService.complete(task.getId());
 
         FlowableEntityEvent entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ENTITY_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
         ExecutionEntity executionEntity = (ExecutionEntity) entityEvent.getEntity();
 
         // this is the root process so parent null
-        assertNull(executionEntity.getParentId());
+        assertThat(executionEntity.getParentId()).isNull();
         String processExecutionId = executionEntity.getId();
 
         entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.ENTITY_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
         executionEntity = (ExecutionEntity) entityEvent.getEntity();
-        assertNotNull(executionEntity.getParentId());
-        assertEquals(processExecutionId, executionEntity.getParentId());
+        assertThat(executionEntity.getParentId()).isNotNull();
+        assertThat(executionEntity.getParentId()).isEqualTo(processExecutionId);
 
         FlowableEvent flowableEvent = mylistener.getEventsReceived().get(2);
-        assertEquals(FlowableEngineEventType.PROCESS_STARTED, flowableEvent.getType());
+        assertThat(flowableEvent.getType()).isEqualTo(FlowableEngineEventType.PROCESS_STARTED);
 
         FlowableActivityEvent activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(3);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("startEvent", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityType()).isEqualTo("startEvent");
 
         activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(4);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("startEvent", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityType()).isEqualTo("startEvent");
 
         activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(5);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("callActivity1", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("callActivity1");
 
         entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(6);
-        assertEquals(FlowableEngineEventType.ENTITY_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
         executionEntity = (ExecutionEntity) entityEvent.getEntity();
-        assertNull(executionEntity.getParentId());
-        assertEquals(executionEntity.getId(), executionEntity.getProcessInstanceId());
+        assertThat(executionEntity.getParentId()).isNull();
+        assertThat(executionEntity.getProcessInstanceId()).isEqualTo(executionEntity.getId());
 
         // user task within the external subprocess
         entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(7);
-        assertEquals(FlowableEngineEventType.ENTITY_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
         executionEntity = (ExecutionEntity) entityEvent.getEntity();
-        assertEquals("calledtask1", executionEntity.getActivityId());
+        assertThat(executionEntity.getActivityId()).isEqualTo("calledtask1");
 
         // external subprocess
         flowableEvent = mylistener.getEventsReceived().get(8);
-        assertEquals(FlowableEngineEventType.PROCESS_STARTED, flowableEvent.getType());
+        assertThat(flowableEvent.getType()).isEqualTo(FlowableEngineEventType.PROCESS_STARTED);
 
         // start event in external subprocess
         activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(9);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("startEvent", activityEvent.getActivityType());
-        assertEquals("startevent2", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityType()).isEqualTo("startEvent");
+        assertThat(activityEvent.getActivityId()).isEqualTo("startevent2");
 
         activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(10);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("startEvent", activityEvent.getActivityType());
-        assertEquals("startevent2", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityType()).isEqualTo("startEvent");
+        assertThat(activityEvent.getActivityId()).isEqualTo("startevent2");
 
         // user task within external subprocess
         activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(11);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("calledtask1", activityEvent.getActivityId());
-        assertEquals("userTask", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("calledtask1");
+        assertThat(activityEvent.getActivityType()).isEqualTo("userTask");
 
         entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(12);
-        assertEquals(FlowableEngineEventType.TASK_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_CREATED);
         TaskEntity taskEntity = (TaskEntity) entityEvent.getEntity();
-        assertEquals("User Task2 in External", taskEntity.getName());
+        assertThat(taskEntity.getName()).isEqualTo("User Task2 in External");
 
         entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(13);
-        assertEquals(FlowableEngineEventType.TASK_COMPLETED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_COMPLETED);
         taskEntity = (TaskEntity) entityEvent.getEntity();
-        assertEquals("User Task2 in External", taskEntity.getName());
+        assertThat(taskEntity.getName()).isEqualTo("User Task2 in External");
 
         // user task within external subprocess
         activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(14);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("calledtask1", activityEvent.getActivityId());
-        assertEquals("userTask", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("calledtask1");
+        assertThat(activityEvent.getActivityType()).isEqualTo("userTask");
 
         // None event in external subprocess
         activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(15);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("noneevent2", activityEvent.getActivityId());
-        assertEquals("endEvent", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("noneevent2");
+        assertThat(activityEvent.getActivityType()).isEqualTo("endEvent");
 
         activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(16);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("noneevent2", activityEvent.getActivityId());
-        assertEquals("endEvent", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("noneevent2");
+        assertThat(activityEvent.getActivityType()).isEqualTo("endEvent");
 
         // the external subprocess
-        entityEvent = (FlowableEntityEvent)mylistener.getEventsReceived().get(17);
-        assertEquals(FlowableEngineEventType.PROCESS_COMPLETED, entityEvent.getType());
+        entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(17);
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.PROCESS_COMPLETED);
 
         // callActivity
         activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(18);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("callActivity", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityType()).isEqualTo("callActivity");
 
         // user task within parent process
         activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(19);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("task1", activityEvent.getActivityId());
-        assertEquals("userTask", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("task1");
+        assertThat(activityEvent.getActivityType()).isEqualTo("userTask");
 
         entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(20);
-        assertEquals(FlowableEngineEventType.TASK_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_CREATED);
         taskEntity = (TaskEntity) entityEvent.getEntity();
-        assertEquals("User Task1", taskEntity.getName());
+        assertThat(taskEntity.getName()).isEqualTo("User Task1");
 
         entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(21);
-        assertEquals(FlowableEngineEventType.TASK_COMPLETED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_COMPLETED);
         taskEntity = (TaskEntity) entityEvent.getEntity();
-        assertEquals("User Task1", taskEntity.getName());
+        assertThat(taskEntity.getName()).isEqualTo("User Task1");
 
         activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(22);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("task1", activityEvent.getActivityId());
-        assertEquals("userTask", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("task1");
+        assertThat(activityEvent.getActivityType()).isEqualTo("userTask");
 
         activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(23);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("noneevent1", activityEvent.getActivityId());
-        assertEquals("endEvent", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("noneevent1");
+        assertThat(activityEvent.getActivityType()).isEqualTo("endEvent");
 
         activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(24);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("noneevent1", activityEvent.getActivityId());
-        assertEquals("endEvent", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("noneevent1");
+        assertThat(activityEvent.getActivityType()).isEqualTo("endEvent");
 
         // the parent process
-        entityEvent = (FlowableEntityEvent)mylistener.getEventsReceived().get(25);
-        assertEquals(FlowableEngineEventType.PROCESS_COMPLETED, entityEvent.getType());
+        entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(25);
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.PROCESS_COMPLETED);
 
-        assertEquals(26, mylistener.getEventsReceived().size());
+        assertThat(mylistener.getEventsReceived()).hasSize(26);
     }
-    
+
     @Test
     @Deployment(resources = {
             "org/flowable/engine/test/api/event/CallActivityTest.testCallActivity.bpmn20.xml",
@@ -272,367 +274,369 @@ public class CallActivityTest extends PluggableFlowableTestCase {
         processEngineConfiguration.getEventDispatcher().addEventListener(mylistener);
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("callActivity");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         // no task should be active in parent process
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(task);
+        assertThat(task).isNull();
 
         // only active task should be the one defined in the external subprocess
         task = taskService.createTaskQuery().active().singleResult();
-        assertNotNull(task);
-        assertEquals("User Task2 in External", task.getName());
+        assertThat(task).isNotNull();
+        assertThat(task.getName()).isEqualTo("User Task2 in External");
 
         ExecutionEntity subprocessInstance = (ExecutionEntity) runtimeService.createExecutionQuery()
                 .rootProcessInstanceId(processInstance.getId())
                 .onlySubProcessExecutions()
                 .singleResult();
-        assertNotNull(subprocessInstance);
+        assertThat(subprocessInstance).isNotNull();
 
-        assertEquals("Default name", runtimeService.getVariable(processInstance.getId(), "Name"));
-        assertEquals("Default name", runtimeService.getVariable(subprocessInstance.getId(), "FullName"));
-        
-        runtimeService.deleteProcessInstance(processInstance.getId(), null);  
+        assertThat(runtimeService.getVariable(processInstance.getId(), "Name")).isEqualTo("Default name");
+        assertThat(runtimeService.getVariable(subprocessInstance.getId(), "FullName")).isEqualTo("Default name");
+
+        runtimeService.deleteProcessInstance(processInstance.getId(), null);
 
         FlowableEntityEvent entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ENTITY_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
         ExecutionEntity executionEntity = (ExecutionEntity) entityEvent.getEntity();
 
         // this is the root process so parent null
-        assertNull(executionEntity.getParentId());
+        assertThat(executionEntity.getParentId()).isNull();
         String processExecutionId = executionEntity.getId();
 
         entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.ENTITY_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
         executionEntity = (ExecutionEntity) entityEvent.getEntity();
-        assertNotNull(executionEntity.getParentId());
-        assertEquals(processExecutionId, executionEntity.getParentId());
+        assertThat(executionEntity.getParentId()).isNotNull();
+        assertThat(executionEntity.getParentId()).isEqualTo(processExecutionId);
 
         FlowableEvent flowableEvent = mylistener.getEventsReceived().get(2);
-        assertEquals(FlowableEngineEventType.PROCESS_STARTED, flowableEvent.getType());
+        assertThat(flowableEvent.getType()).isEqualTo(FlowableEngineEventType.PROCESS_STARTED);
 
         FlowableActivityEvent activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(3);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("startEvent", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityType()).isEqualTo("startEvent");
 
         activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(4);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("startEvent", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityType()).isEqualTo("startEvent");
 
         activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(5);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("callActivity1", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("callActivity1");
 
         entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(6);
-        assertEquals(FlowableEngineEventType.ENTITY_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
         executionEntity = (ExecutionEntity) entityEvent.getEntity();
-        assertNull(executionEntity.getParentId());
-        assertEquals(executionEntity.getId(), executionEntity.getProcessInstanceId());
+        assertThat(executionEntity.getParentId()).isNull();
+        assertThat(executionEntity.getProcessInstanceId()).isEqualTo(executionEntity.getId());
 
         // user task within the external subprocess
         entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(7);
-        assertEquals(FlowableEngineEventType.ENTITY_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
         executionEntity = (ExecutionEntity) entityEvent.getEntity();
-        assertEquals("calledtask1", executionEntity.getActivityId());
+        assertThat(executionEntity.getActivityId()).isEqualTo("calledtask1");
 
         // external subprocess
         flowableEvent = mylistener.getEventsReceived().get(8);
-        assertEquals(FlowableEngineEventType.PROCESS_STARTED, flowableEvent.getType());
+        assertThat(flowableEvent.getType()).isEqualTo(FlowableEngineEventType.PROCESS_STARTED);
 
         // start event in external subprocess
         activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(9);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("startEvent", activityEvent.getActivityType());
-        assertEquals("startevent2", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityType()).isEqualTo("startEvent");
+        assertThat(activityEvent.getActivityId()).isEqualTo("startevent2");
 
         activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(10);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("startEvent", activityEvent.getActivityType());
-        assertEquals("startevent2", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityType()).isEqualTo("startEvent");
+        assertThat(activityEvent.getActivityId()).isEqualTo("startevent2");
 
         // user task within external subprocess
         activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(11);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("calledtask1", activityEvent.getActivityId());
-        assertEquals("userTask", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("calledtask1");
+        assertThat(activityEvent.getActivityType()).isEqualTo("userTask");
 
         entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(12);
-        assertEquals(FlowableEngineEventType.TASK_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_CREATED);
         TaskEntity taskEntity = (TaskEntity) entityEvent.getEntity();
-        assertEquals("User Task2 in External", taskEntity.getName());
+        assertThat(taskEntity.getName()).isEqualTo("User Task2 in External");
 
         // user task within external subprocess cancelled
         FlowableActivityCancelledEvent activityCancelledEvent = (FlowableActivityCancelledEvent) mylistener.getEventsReceived().get(13);
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, activityCancelledEvent.getType());       
-        assertEquals("User Task2 in External", activityCancelledEvent.getActivityName());
-        assertEquals("userTask", activityCancelledEvent.getActivityType());
-   
+        assertThat(activityCancelledEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(activityCancelledEvent.getActivityName()).isEqualTo("User Task2 in External");
+        assertThat(activityCancelledEvent.getActivityType()).isEqualTo("userTask");
+
         // external subprocess cancelled
         FlowableCancelledEvent processCancelledEvent = (FlowableCancelledEvent) mylistener.getEventsReceived().get(14);
-        assertEquals(FlowableEngineEventType.PROCESS_CANCELLED, processCancelledEvent.getType());       
-        assertEquals(subprocessInstance.getId(), processCancelledEvent.getProcessInstanceId());
-        
+        assertThat(processCancelledEvent.getType()).isEqualTo(FlowableEngineEventType.PROCESS_CANCELLED);
+        assertThat(processCancelledEvent.getProcessInstanceId()).isEqualTo(subprocessInstance.getId());
+
         // expecting cancelled event for Call Activity
         activityCancelledEvent = (FlowableActivityCancelledEvent) mylistener.getEventsReceived().get(15);
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, activityCancelledEvent.getType());       
-        assertEquals("callActivity", activityCancelledEvent.getActivityType());
-        
+        assertThat(activityCancelledEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(activityCancelledEvent.getActivityType()).isEqualTo("callActivity");
+
         // parent process cancelled
         processCancelledEvent = (FlowableCancelledEvent) mylistener.getEventsReceived().get(16);
-        assertEquals(FlowableEngineEventType.PROCESS_CANCELLED, processCancelledEvent.getType());       
-        assertEquals(processInstance.getId(), processCancelledEvent.getProcessInstanceId());
+        assertThat(processCancelledEvent.getType()).isEqualTo(FlowableEngineEventType.PROCESS_CANCELLED);
+        assertThat(processCancelledEvent.getProcessInstanceId()).isEqualTo(processInstance.getId());
 
-        assertEquals(17, mylistener.getEventsReceived().size());
+        assertThat(mylistener.getEventsReceived()).hasSize(17);
     }
 
     @Test
     @Deployment(resources = {
             "org/flowable/engine/test/api/event/CallActivityTest.testCallActivityTerminateEnd.bpmn20.xml",
             "org/flowable/engine/test/api/event/CallActivityTest.testCalledActivityTerminateEnd.bpmn20.xml" })
-    public void  testCallActivityCalledHasTerminateEndEvent() throws Exception {
+    public void testCallActivityCalledHasTerminateEndEvent() throws Exception {
 
         CallActivityEventListener mylistener = new CallActivityEventListener();
         processEngineConfiguration.getEventDispatcher().addEventListener(mylistener);
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("callActivityTerminateEnd");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         // no task should be active in parent process
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(task);
+        assertThat(task).isNull();
 
         // only active task should be the one defined in the external subprocess
         task = taskService.createTaskQuery().active().singleResult();
-        assertNotNull(task);
-        assertEquals("User Task2 in External with Terminate End Event", task.getName());
+        assertThat(task).isNotNull();
+        assertThat(task.getName()).isEqualTo("User Task2 in External with Terminate End Event");
 
         ExecutionEntity subprocessInstance = (ExecutionEntity) runtimeService.createExecutionQuery()
                 .rootProcessInstanceId(processInstance.getId())
                 .onlySubProcessExecutions()
                 .singleResult();
-        assertNotNull(subprocessInstance);
+        assertThat(subprocessInstance).isNotNull();
 
-        assertEquals("Default name", runtimeService.getVariable(processInstance.getId(), "Name"));
-        assertEquals("Default name", runtimeService.getVariable(subprocessInstance.getId(), "FullName"));
+        assertThat(runtimeService.getVariable(processInstance.getId(), "Name")).isEqualTo("Default name");
+        assertThat(runtimeService.getVariable(subprocessInstance.getId(), "FullName")).isEqualTo("Default name");
 
         // set the variable in the subprocess to validate that the new value is returned from callActivity
         runtimeService.setVariable(subprocessInstance.getId(), "FullName", "Mary Smith");
-        assertEquals("Default name", runtimeService.getVariable(processInstance.getId(), "Name"));
-        assertEquals("Mary Smith", runtimeService.getVariable(subprocessInstance.getId(), "FullName"));
+        assertThat(runtimeService.getVariable(processInstance.getId(), "Name")).isEqualTo("Default name");
+        assertThat(runtimeService.getVariable(subprocessInstance.getId(), "FullName")).isEqualTo("Mary Smith");
 
         // complete user task so that external subprocess will flow to terminate end
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(task);
-        assertEquals("User Task1 in Parent", task.getName());
+        assertThat(task).isNotNull();
+        assertThat(task.getName()).isEqualTo("User Task1 in Parent");
 
         // validate that the variable was copied back when Call Activity finished
-        assertEquals("Mary Smith", runtimeService.getVariable(processInstance.getId(), "Name"));
+        assertThat("Mary Smith").isEqualTo(runtimeService.getVariable(processInstance.getId(), "Name"));
 
         // complete user task so that parent process will terminate normally
         taskService.complete(task.getId());
 
         FlowableEntityEvent entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ENTITY_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
         ExecutionEntity executionEntity = (ExecutionEntity) entityEvent.getEntity();
 
         // this is the root process so parent null
-        assertNull(executionEntity.getParentId());
+        assertThat(executionEntity.getParentId()).isNull();
         String processExecutionId = executionEntity.getId();
 
-        int idx=1;
+        int idx = 1;
         entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ENTITY_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
         executionEntity = (ExecutionEntity) entityEvent.getEntity();
-        assertNotNull(executionEntity.getParentId());
-        assertEquals(processExecutionId, executionEntity.getParentId());
+        assertThat(executionEntity.getParentId()).isNotNull();
+        assertThat(executionEntity.getParentId()).isEqualTo(processExecutionId);
 
         FlowableEvent flowableEvent = mylistener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.PROCESS_STARTED, flowableEvent.getType());
+        assertThat(flowableEvent.getType()).isEqualTo(FlowableEngineEventType.PROCESS_STARTED);
 
         FlowableActivityEvent activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("startEvent", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityType()).isEqualTo("startEvent");
 
         activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("startEvent", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityType()).isEqualTo("startEvent");
 
         activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("callActivityId1", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("callActivityId1");
 
         entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ENTITY_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
         executionEntity = (ExecutionEntity) entityEvent.getEntity();
-        assertNull(executionEntity.getParentId());
-        assertEquals(executionEntity.getId(), executionEntity.getProcessInstanceId());
+        assertThat(executionEntity.getParentId()).isNull();
+        assertThat(executionEntity.getProcessInstanceId()).isEqualTo(executionEntity.getId());
 
         // user task within the external subprocess
         entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ENTITY_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
         executionEntity = (ExecutionEntity) entityEvent.getEntity();
-        assertEquals("calledtask1", executionEntity.getActivityId());
+        assertThat(executionEntity.getActivityId()).isEqualTo("calledtask1");
 
         // external subprocess
         flowableEvent = mylistener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.PROCESS_STARTED, flowableEvent.getType());
+        assertThat(flowableEvent.getType()).isEqualTo(FlowableEngineEventType.PROCESS_STARTED);
         executionEntity = (ExecutionEntity) ((FlowableProcessStartedEvent) flowableEvent).getEntity();
-        assertEquals(subprocessInstance.getId(), executionEntity.getParentId());
+        assertThat(executionEntity.getParentId()).isEqualTo(subprocessInstance.getId());
 
         // start event in external subprocess
         activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("startEvent", activityEvent.getActivityType());
-        assertEquals("startevent2", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityType()).isEqualTo("startEvent");
+        assertThat(activityEvent.getActivityId()).isEqualTo("startevent2");
 
         activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("startEvent", activityEvent.getActivityType());
-        assertEquals("startevent2", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityType()).isEqualTo("startEvent");
+        assertThat(activityEvent.getActivityId()).isEqualTo("startevent2");
 
         // user task within external subprocess
         activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("calledtask1", activityEvent.getActivityId());
-        assertEquals("userTask", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("calledtask1");
+        assertThat(activityEvent.getActivityType()).isEqualTo("userTask");
 
         entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.TASK_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_CREATED);
         TaskEntity taskEntity = (TaskEntity) entityEvent.getEntity();
-        assertEquals("User Task2 in External with Terminate End Event", taskEntity.getName());
+        assertThat(taskEntity.getName()).isEqualTo("User Task2 in External with Terminate End Event");
 
         entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.TASK_COMPLETED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_COMPLETED);
         taskEntity = (TaskEntity) entityEvent.getEntity();
-        assertEquals("User Task2 in External with Terminate End Event", taskEntity.getName());
+        assertThat(taskEntity.getName()).isEqualTo("User Task2 in External with Terminate End Event");
 
         // user task within external subprocess
         activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("calledtask1", activityEvent.getActivityId());
-        assertEquals("userTask", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("calledtask1");
+        assertThat(activityEvent.getActivityType()).isEqualTo("userTask");
 
         // None event in external subprocess
         activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("terminateEnd2", activityEvent.getActivityId());
-        assertEquals("endEvent", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("terminateEnd2");
+        assertThat(activityEvent.getActivityType()).isEqualTo("endEvent");
 
         // PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT instead of PROCESS_COMPLETED
         // because external subprocess defined with terminate end event
-        entityEvent = (FlowableEntityEvent)mylistener.getEventsReceived().get(idx++);
-        assertEquals(subprocessInstance.getId(), ((FlowableEngineEntityEvent)entityEvent).getExecutionId());
-        assertEquals(FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT, entityEvent.getType());
+        entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(idx++);
+        assertThat(((FlowableEngineEntityEvent) entityEvent).getExecutionId()).isEqualTo(subprocessInstance.getId());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT);
 
         //the external subprocess (callActivity)
         activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("callActivity", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityType()).isEqualTo("callActivity");
 
         // user task within parent process
         activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("task1", activityEvent.getActivityId());
-        assertEquals("userTask", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("task1");
+        assertThat(activityEvent.getActivityType()).isEqualTo("userTask");
 
         entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.TASK_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_CREATED);
         taskEntity = (TaskEntity) entityEvent.getEntity();
-        assertEquals("User Task1 in Parent", taskEntity.getName());
+        assertThat(taskEntity.getName()).isEqualTo("User Task1 in Parent");
 
         entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.TASK_COMPLETED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_COMPLETED);
         taskEntity = (TaskEntity) entityEvent.getEntity();
-        assertEquals("User Task1 in Parent", taskEntity.getName());
+        assertThat(taskEntity.getName()).isEqualTo("User Task1 in Parent");
 
         activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("task1", activityEvent.getActivityId());
-        assertEquals("userTask", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("task1");
+        assertThat(activityEvent.getActivityType()).isEqualTo("userTask");
 
         activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("noneevent1", activityEvent.getActivityId());
-        assertEquals("endEvent", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("noneevent1");
+        assertThat(activityEvent.getActivityType()).isEqualTo("endEvent");
 
         activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("noneevent1", activityEvent.getActivityId());
-        assertEquals("endEvent", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("noneevent1");
+        assertThat(activityEvent.getActivityType()).isEqualTo("endEvent");
 
         // the parent process
-        entityEvent = (FlowableEntityEvent)mylistener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.PROCESS_COMPLETED, entityEvent.getType());
+        entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(idx++);
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.PROCESS_COMPLETED);
 
-        assertEquals(idx, mylistener.getEventsReceived().size());
+        assertThat(mylistener.getEventsReceived()).hasSize(idx);
     }
-    
+
     @Test
     @Deployment(resources = {
             "org/flowable/engine/test/api/event/CallActivityTest.testCallActivity.bpmn20.xml",
             "org/flowable/engine/test/api/event/CallActivityTest.testCalledActivity.bpmn20.xml" })
     public void testDeleteParentProcessWithCallActivity() throws Exception {
-        
+
         CallActivityEventListener mylistener = new CallActivityEventListener();
         processEngineConfiguration.getEventDispatcher().addEventListener(mylistener);
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("callActivity");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         // no task should be active in parent process
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(task);
+        assertThat(task).isNull();
 
         // only active task should be the one defined in the external subprocess
         task = taskService.createTaskQuery().active().singleResult();
-        assertNotNull(task);
-        assertEquals("User Task2 in External", task.getName());
+        assertThat(task).isNotNull();
+        assertThat(task.getName()).isEqualTo("User Task2 in External");
 
         ExecutionEntity subprocessInstance = (ExecutionEntity) runtimeService.createExecutionQuery()
                 .rootProcessInstanceId(processInstance.getId())
                 .onlySubProcessExecutions()
                 .singleResult();
-        assertNotNull(subprocessInstance);
-        
+        assertThat(subprocessInstance).isNotNull();
+
         runtimeService.deleteProcessInstance(processInstance.getId(), null);
-        
+
         List<FlowableEvent> entityEvents = mylistener.getEventsReceived();
         int lastIndex = entityEvents.size() - 1;
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, entityEvents.get(lastIndex - 3).getType());
-        assertEquals(FlowableEngineEventType.PROCESS_CANCELLED, entityEvents.get(lastIndex - 2).getType());
+        assertThat(entityEvents.get(lastIndex - 3).getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(entityEvents.get(lastIndex - 2).getType()).isEqualTo(FlowableEngineEventType.PROCESS_CANCELLED);
         FlowableCancelledEvent subProcessCancelledEvent = (FlowableCancelledEvent) entityEvents.get(lastIndex - 2);
-        assertEquals(subprocessInstance.getId(), subProcessCancelledEvent.getProcessInstanceId());
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, entityEvents.get(lastIndex - 1).getType());
-        assertEquals(FlowableEngineEventType.PROCESS_CANCELLED, entityEvents.get(lastIndex).getType());
+        assertThat(subProcessCancelledEvent.getProcessInstanceId()).isEqualTo(subprocessInstance.getId());
+        assertThat(entityEvents.get(lastIndex - 1).getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(entityEvents.get(lastIndex).getType()).isEqualTo(FlowableEngineEventType.PROCESS_CANCELLED);
         FlowableCancelledEvent processCancelledEvent = (FlowableCancelledEvent) entityEvents.get(lastIndex);
-        assertEquals(processInstance.getId(), processCancelledEvent.getProcessInstanceId());
-        
+        assertThat(processCancelledEvent.getProcessInstanceId()).isEqualTo(processInstance.getId());
+
         System.out.println("the end");
     }
-    
+
     @Test
     @Deployment(resources = {
             "org/flowable/engine/test/api/event/CallActivityTest.testCallActivityProcessInstanceName.bpmn20.xml",
             "org/flowable/engine/test/api/event/CallActivityTest.testCalledActivity.bpmn20.xml"
     })
     public void testCallActivityProcessInstanceName() {
-        runtimeService.startProcessInstanceByKey("testCallActivityProcessInstanceName", 
+        runtimeService.startProcessInstanceByKey("testCallActivityProcessInstanceName",
                 CollectionUtil.singletonMap("theCollection", Arrays.asList("A", "B", "C", "D")));
-        
+
         List<ProcessInstance> childProcessInstances = runtimeService.createProcessInstanceQuery().list().stream()
-            .filter(processInstance -> (processInstance.getSuperExecutionId() != null))
-            .sorted((p1, p2) -> p1.getName().compareTo(p2.getName()))
-            .collect(Collectors.toList());
-        
-        assertEquals(4, childProcessInstances.size());
-        assertEquals("Process instance A", childProcessInstances.get(0).getName());
-        assertEquals("Process instance B", childProcessInstances.get(1).getName());
-        assertEquals("Process instance C", childProcessInstances.get(2).getName());
-        assertEquals("Process instance D", childProcessInstances.get(3).getName());
+                .filter(processInstance -> (processInstance.getSuperExecutionId() != null))
+                .sorted((p1, p2) -> p1.getName().compareTo(p2.getName()))
+                .collect(Collectors.toList());
+
+        assertThat(childProcessInstances)
+                .extracting(ProcessInstance::getName)
+                .containsExactly(
+                        "Process instance A",
+                        "Process instance B",
+                        "Process instance C",
+                        "Process instance D")
+        ;
     }
-    
 
     @Test
     @Deployment(resources = {
@@ -641,55 +645,59 @@ public class CallActivityTest extends PluggableFlowableTestCase {
     })
     public void testCallActivityAsyncComplete() {
         runtimeService.startProcessInstanceByKey("testAsyncComplete");
-        
+
         // 1 async service task
         List<Job> jobs = managementService.createJobQuery().list();
-        assertEquals(1, jobs.size());
+        assertThat(jobs).hasSize(1);
         jobs.forEach(job -> managementService.executeJob(job.getId()));
-        
+
         // 5 async multi instance call activities after start
         jobs = managementService.createJobQuery().list();
-        assertEquals(5, jobs.size());
+        assertThat(jobs).hasSize(5);
         for (Job job : jobs) {
-            ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().processDefinitionId(job.getProcessDefinitionId()).singleResult();
-            assertEquals("testAsyncComplete", processDefinition.getKey());
+            ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().processDefinitionId(job.getProcessDefinitionId())
+                    .singleResult();
+            assertThat(processDefinition.getKey()).isEqualTo("testAsyncComplete");
         }
         jobs.forEach(job -> managementService.executeJob(job.getId()));
-        
+
         // 1 job for each step1 in subprocess, so 5 in total
         jobs = managementService.createJobQuery().list();
-        assertEquals(5, jobs.size());
+        assertThat(jobs).hasSize(5);
         for (Job job : jobs) {
-            ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().processDefinitionId(job.getProcessDefinitionId()).singleResult();
-            assertEquals("subProcess", processDefinition.getKey());
+            ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().processDefinitionId(job.getProcessDefinitionId())
+                    .singleResult();
+            assertThat(processDefinition.getKey()).isEqualTo("subProcess");
         }
         jobs.forEach(job -> managementService.executeJob(job.getId()));
 
         // Step 2
         jobs = managementService.createJobQuery().list();
-        assertEquals(5, jobs.size());
+        assertThat(jobs).hasSize(5);
         jobs.forEach(job -> managementService.executeJob(job.getId()));
-        
+
         // Step 3 will trigger the async complete
         jobs = managementService.createJobQuery().list();
-        assertEquals(5, jobs.size());
+        assertThat(jobs).hasSize(5);
         jobs.forEach(job -> managementService.executeJob(job.getId()));
-        
+
         // Async complete
         jobs = managementService.createJobQuery().list();
-        assertEquals(5, jobs.size());
+        assertThat(jobs).hasSize(5);
         for (Job job : jobs) {
-            ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().processDefinitionId(job.getProcessDefinitionId()).singleResult();
-            assertEquals("subProcess", processDefinition.getKey()); // context is the subprocess, as the EndExecution will be scheduled for that process definition
-            
-            assertEquals(AsyncCompleteCallActivityJobHandler.TYPE, job.getJobHandlerType());
+            ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().processDefinitionId(job.getProcessDefinitionId())
+                    .singleResult();
+            assertThat(processDefinition.getKey())
+                    .isEqualTo("subProcess"); // context is the subprocess, as the EndExecution will be scheduled for that process definition
+
+            assertThat(job.getJobHandlerType()).isEqualTo(AsyncCompleteCallActivityJobHandler.TYPE);
         }
-        
+
         // Completing ends the process instance
         jobs.forEach(job -> managementService.executeJob(job.getId()));
-        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(0);
     }
-    
+
     // Same as testCallActivityAsyncComplete, but now using the real job executor instead of fetching and executing jobs manually
     @Test
     @Deployment(resources = {
@@ -700,46 +708,46 @@ public class CallActivityTest extends PluggableFlowableTestCase {
     public void testCallActivityAsyncCompleteRealExecutor() {
         runtimeService.startProcessInstanceByKey("testAsyncComplete");
         waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(20000L, 200L);
-        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(0);
     }
 
     @Test
     @Deployment(resources = {
-        "org/flowable/engine/test/api/event/CallActivityTest.testCallActivityWithEventSubprocessParent.bpmn20.xml",
-        "org/flowable/engine/test/api/event/CallActivityTest.testCallActivityWithEventSubprocess.bpmn20.xml"
+            "org/flowable/engine/test/api/event/CallActivityTest.testCallActivityWithEventSubprocessParent.bpmn20.xml",
+            "org/flowable/engine/test/api/event/CallActivityTest.testCallActivityWithEventSubprocess.bpmn20.xml"
     })
     public void testCallActivityWithEventSubprocess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testWithEventSubprocessParent");
         Task task = taskService.createTaskQuery().singleResult();
-        assertEquals("One", task.getName());
+        assertThat(task.getName()).isEqualTo("One");
 
         // Completing the task should trigger the event subprocess
         taskService.complete(task.getId());
         Task subOneTask = taskService.createTaskQuery().taskName("sub one").singleResult();
-        assertNotNull(subOneTask);
+        assertThat(subOneTask).isNotNull();
         taskService.complete(subOneTask.getId());
 
         // Complete the last task
         task = taskService.createTaskQuery().singleResult();
-        assertEquals("Two", task.getName());
+        assertThat(task.getName()).isEqualTo("Two");
         taskService.complete(task.getId());
         assertProcessEnded(processInstance.getId());
     }
 
     @Test
     @Deployment(resources = {
-        "org/flowable/engine/test/api/event/CallActivityTest.testCallActivityWithEventSubprocessParent.bpmn20.xml",
-        "org/flowable/engine/test/api/event/CallActivityTest.testCallActivityWithEventSubprocessInterrupting.bpmn20.xml"
+            "org/flowable/engine/test/api/event/CallActivityTest.testCallActivityWithEventSubprocessParent.bpmn20.xml",
+            "org/flowable/engine/test/api/event/CallActivityTest.testCallActivityWithEventSubprocessInterrupting.bpmn20.xml"
     })
     public void testCallActivityWithEventSubprocessInterrupting() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testWithEventSubprocessParent");
         Task task = taskService.createTaskQuery().singleResult();
-        assertEquals("One", task.getName());
+        assertThat(task.getName()).isEqualTo("One");
 
         // Completing the task should trigger the event subprocess. This interupts the main flow.
         taskService.complete(task.getId());
         Task subOneTask = taskService.createTaskQuery().taskName("sub one").singleResult();
-        assertNotNull(subOneTask);
+        assertThat(subOneTask).isNotNull();
         taskService.complete(subOneTask.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -751,7 +759,6 @@ public class CallActivityTest extends PluggableFlowableTestCase {
 
         public CallActivityEventListener() {
             eventsReceived = new ArrayList<>();
-
         }
 
         public List<FlowableEvent> getEventsReceived() {
@@ -766,25 +773,25 @@ public class CallActivityTest extends PluggableFlowableTestCase {
         public void onEvent(FlowableEvent event) {
             FlowableEngineEventType engineEventType = (FlowableEngineEventType) event.getType();
             switch (engineEventType) {
-            case ENTITY_CREATED:
-                FlowableEntityEvent entityEvent = (FlowableEntityEvent) event;
-                if (entityEvent.getEntity() instanceof ExecutionEntity) {
+                case ENTITY_CREATED:
+                    FlowableEntityEvent entityEvent = (FlowableEntityEvent) event;
+                    if (entityEvent.getEntity() instanceof ExecutionEntity) {
+                        eventsReceived.add(event);
+                    }
+                    break;
+                case ACTIVITY_STARTED:
+                case ACTIVITY_COMPLETED:
+                case ACTIVITY_CANCELLED:
+                case TASK_CREATED:
+                case TASK_COMPLETED:
+                case PROCESS_STARTED:
+                case PROCESS_COMPLETED:
+                case PROCESS_CANCELLED:
+                case PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT:
                     eventsReceived.add(event);
-                }
-                break;
-            case ACTIVITY_STARTED:
-            case ACTIVITY_COMPLETED:
-            case ACTIVITY_CANCELLED:
-            case TASK_CREATED:
-            case TASK_COMPLETED:
-            case PROCESS_STARTED:
-            case PROCESS_COMPLETED:
-            case PROCESS_CANCELLED:
-            case PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT:
-                eventsReceived.add(event);
-                break;
-            default:
-                break;
+                    break;
+                default:
+                    break;
 
             }
         }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/CancelCallActivityTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/CancelCallActivityTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -11,6 +11,8 @@
  * limitations under the License.
  */
 package org.flowable.engine.test.api.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -83,118 +85,118 @@ public class CancelCallActivityTest extends PluggableFlowableTestCase {
         processEngineConfiguration.getEventDispatcher().addEventListener(mylistener);
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("messageOnCallActivity");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         Execution executionWithMessage = runtimeService.createExecutionQuery().activityId("cancelBoundaryEvent").singleResult();
-        assertNotNull(executionWithMessage);
+        assertThat(executionWithMessage).isNotNull();
 
         runtimeService.messageEventReceived("cancel", executionWithMessage.getId());
 
         FlowableEntityEvent entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ENTITY_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
         ExecutionEntity executionEntity = (ExecutionEntity) entityEvent.getEntity();
 
         // this is the root process so parent null
-        assertNull(executionEntity.getParentId());
+        assertThat(executionEntity.getParentId()).isNull();
         String processExecutionId = executionEntity.getId();
 
         // this is callActivity
         entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.ENTITY_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
         executionEntity = (ExecutionEntity) entityEvent.getEntity();
-        assertNotNull(executionEntity.getParentId());
-        assertEquals(processExecutionId, executionEntity.getParentId());
+        assertThat(executionEntity.getParentId()).isNotNull();
+        assertThat(executionEntity.getParentId()).isEqualTo(processExecutionId);
 
         FlowableEvent activitiEvent = mylistener.getEventsReceived().get(2);
-        assertEquals(FlowableEngineEventType.PROCESS_STARTED, activitiEvent.getType());
+        assertThat(activitiEvent.getType()).isEqualTo(FlowableEngineEventType.PROCESS_STARTED);
 
         FlowableActivityEvent activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(3);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("startEvent", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityType()).isEqualTo("startEvent");
 
         activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(4);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("startEvent", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityType()).isEqualTo("startEvent");
 
         entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(5);
-        assertEquals(FlowableEngineEventType.ENTITY_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
         executionEntity = (ExecutionEntity) entityEvent.getEntity();
-        assertEquals("cancelBoundaryEvent", executionEntity.getActivityId());
+        assertThat(executionEntity.getActivityId()).isEqualTo("cancelBoundaryEvent");
 
         activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(6);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("callActivity1", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("callActivity1");
 
         // this is external subprocess. Workflow uses the ENTITY_CREATED event to determine when to send our event.
         entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(7);
-        assertEquals(FlowableEngineEventType.ENTITY_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
         executionEntity = (ExecutionEntity) entityEvent.getEntity();
-        assertNull(executionEntity.getParentId());
-        assertEquals(executionEntity.getId(), executionEntity.getProcessInstanceId());
+        assertThat(executionEntity.getParentId()).isNull();
+        assertThat(executionEntity.getProcessInstanceId()).isEqualTo(executionEntity.getId());
 
         // this is the task within the external subprocess
         entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(8);
-        assertEquals(FlowableEngineEventType.ENTITY_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
         executionEntity = (ExecutionEntity) entityEvent.getEntity();
-        assertEquals("calledtask1", executionEntity.getActivityId());
+        assertThat(executionEntity.getActivityId()).isEqualTo("calledtask1");
 
         // start event in external subprocess
         activitiEvent = mylistener.getEventsReceived().get(9);
-        assertEquals(FlowableEngineEventType.PROCESS_STARTED, activitiEvent.getType());
+        assertThat(activitiEvent.getType()).isEqualTo(FlowableEngineEventType.PROCESS_STARTED);
 
         activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(10);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("startEvent", activityEvent.getActivityType());
-        assertEquals("startevent2", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityType()).isEqualTo("startEvent");
+        assertThat(activityEvent.getActivityId()).isEqualTo("startevent2");
 
         // start event in external subprocess
         activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(11);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("startEvent", activityEvent.getActivityType());
-        assertEquals("startevent2", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityType()).isEqualTo("startEvent");
+        assertThat(activityEvent.getActivityId()).isEqualTo("startevent2");
 
         // this is user task within external subprocess
         activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(12);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("calledtask1", activityEvent.getActivityId());
-        assertEquals("userTask", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("calledtask1");
+        assertThat(activityEvent.getActivityType()).isEqualTo("userTask");
 
         entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(13);
-        assertEquals(FlowableEngineEventType.TASK_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_CREATED);
         TaskEntity taskEntity = (TaskEntity) entityEvent.getEntity();
-        assertEquals("User Task2 in External", taskEntity.getName());
+        assertThat(taskEntity.getName()).isEqualTo("User Task2 in External");
 
         FlowableActivityCancelledEvent taskCancelledEvent = (FlowableActivityCancelledEvent) mylistener.getEventsReceived().get(14);
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, taskCancelledEvent.getType());
-        assertEquals(taskEntity.getName(), taskCancelledEvent.getActivityName());
-        assertEquals("userTask", taskCancelledEvent.getActivityType());
+        assertThat(taskCancelledEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(taskCancelledEvent.getActivityName()).isEqualTo(taskEntity.getName());
+        assertThat(taskCancelledEvent.getActivityType()).isEqualTo("userTask");
 
         FlowableCancelledEvent processCancelledEvent = (FlowableCancelledEvent) mylistener.getEventsReceived().get(15);
-        assertEquals(FlowableEngineEventType.PROCESS_CANCELLED, processCancelledEvent.getType());
-        assertEquals(processCancelledEvent.getProcessInstanceId(), processCancelledEvent.getExecutionId());
-        
+        assertThat(processCancelledEvent.getType()).isEqualTo(FlowableEngineEventType.PROCESS_CANCELLED);
+        assertThat(processCancelledEvent.getExecutionId()).isEqualTo(processCancelledEvent.getProcessInstanceId());
+
         activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(16);
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, activityEvent.getType());
-        assertEquals("callActivity", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(activityEvent.getActivityType()).isEqualTo("callActivity");
 
         activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(17);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("boundaryEvent", activityEvent.getActivityType());
-        assertEquals("cancelBoundaryEvent", activityEvent.getActivityId());
-        assertEquals(executionWithMessage.getId(), activityEvent.getExecutionId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityType()).isEqualTo("boundaryEvent");
+        assertThat(activityEvent.getActivityId()).isEqualTo("cancelBoundaryEvent");
+        assertThat(activityEvent.getExecutionId()).isEqualTo(executionWithMessage.getId());
 
         // task in the main definition
         activityEvent = (FlowableActivityEvent) mylistener.getEventsReceived().get(18);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("task1", activityEvent.getActivityId());
-        assertEquals("userTask", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("task1");
+        assertThat(activityEvent.getActivityType()).isEqualTo("userTask");
 
         entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(19);
-        assertEquals(FlowableEngineEventType.TASK_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_CREATED);
         taskEntity = (TaskEntity) entityEvent.getEntity();
-        assertEquals("User Task1", taskEntity.getName());
+        assertThat(taskEntity.getName()).isEqualTo("User Task1");
 
-        assertEquals(20, mylistener.getEventsReceived().size());
+        assertThat(mylistener.getEventsReceived()).hasSize(20);
     }
 
     class CallActivityEventListener extends AbstractFlowableEngineEventListener {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/CancelUserTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/CancelUserTaskTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.api.event;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -63,7 +65,7 @@ public class CancelUserTaskTest extends PluggableFlowableTestCase {
     @Deployment(resources = { "org/flowable/engine/test/api/event/CancelUserTaskEventsTest.bpmn20.xml" })
     public void testUserTaskCancelledWhenFlowToTerminateEnd() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("cancelUserTaskEvents");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         Execution task1Execution = runtimeService.createExecutionQuery().activityId("task1").singleResult();
         Execution task2Execution = runtimeService.createExecutionQuery().activityId("task2").singleResult();
@@ -71,38 +73,38 @@ public class CancelUserTaskTest extends PluggableFlowableTestCase {
 
         int idx = 0;
         FlowableEvent flowableEvent = testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.PROCESS_STARTED, flowableEvent.getType());
+        assertThat(flowableEvent.getType()).isEqualTo(FlowableEngineEventType.PROCESS_STARTED);
         ExecutionEntity executionEntity = (ExecutionEntity) ((FlowableProcessStartedEvent) flowableEvent).getEntity();
-        assertEquals(processInstance.getId(), executionEntity.getProcessInstanceId());
+        assertThat(executionEntity.getProcessInstanceId()).isEqualTo(processInstance.getId());
 
         FlowableActivityEvent activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("startEvent", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityType()).isEqualTo("startEvent");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("startEvent", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityType()).isEqualTo("startEvent");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("task1", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("task1");
 
         FlowableEntityEvent entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.TASK_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_CREATED);
         TaskEntity taskEntity = (TaskEntity) entityEvent.getEntity();
-        assertEquals("User Task1", taskEntity.getName());
+        assertThat(taskEntity.getName()).isEqualTo("User Task1");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("task2", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("task2");
 
         entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.TASK_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_CREATED);
         taskEntity = (TaskEntity) entityEvent.getEntity();
-        assertEquals("User Task2", taskEntity.getName());
+        assertThat(taskEntity.getName()).isEqualTo("User Task2");
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
         Task userTask1 = null;
         for (Task task : tasks) {
             if ("User Task1".equals(task.getName())) {
@@ -110,51 +112,51 @@ public class CancelUserTaskTest extends PluggableFlowableTestCase {
                 break;
             }
         }
-        assertNotNull(userTask1);
+        assertThat(userTask1).isNotNull();
 
         // complete task1 so we flow to terminate end
         taskService.complete(userTask1.getId());
 
         entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.TASK_COMPLETED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_COMPLETED);
         taskEntity = (TaskEntity) entityEvent.getEntity();
-        assertEquals("User Task1", taskEntity.getName());
+        assertThat(taskEntity.getName()).isEqualTo("User Task1");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("task1", activityEvent.getActivityId());
-        assertEquals(task1Execution.getId(), activityEvent.getExecutionId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("task1");
+        assertThat(activityEvent.getExecutionId()).isEqualTo(task1Execution.getId());
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("endEvent", activityEvent.getActivityType());
-        assertEquals("endEvent1", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityType()).isEqualTo("endEvent");
+        assertThat(activityEvent.getActivityId()).isEqualTo("endEvent1");
 
         for (int i = 0; i < 2; i++) {
             activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-            assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, activityEvent.getType());
+            assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
             FlowableActivityCancelledEvent cancelledEvent = (FlowableActivityCancelledEvent) activityEvent;
 
             if ("task2".equals(cancelledEvent.getActivityId())) {
-                assertEquals("task2", cancelledEvent.getActivityId());
-                assertEquals("userTask", cancelledEvent.getActivityType());
-                assertEquals("User Task2", cancelledEvent.getActivityName());
-                assertEquals(task2Execution.getId(), cancelledEvent.getExecutionId());
+                assertThat(cancelledEvent.getActivityId()).isEqualTo("task2");
+                assertThat(cancelledEvent.getActivityType()).isEqualTo("userTask");
+                assertThat(cancelledEvent.getActivityName()).isEqualTo("User Task2");
+                assertThat(cancelledEvent.getExecutionId()).isEqualTo(task2Execution.getId());
 
             } else if ("cancelBoundaryEvent1".equals(cancelledEvent.getActivityId())) {
-                assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, activityEvent.getType());
+                assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
                 cancelledEvent = (FlowableActivityCancelledEvent) activityEvent;
-                assertEquals("cancelBoundaryEvent1", cancelledEvent.getActivityId());
-                assertEquals(boundaryExecution.getId(), cancelledEvent.getExecutionId());
+                assertThat(cancelledEvent.getActivityId()).isEqualTo("cancelBoundaryEvent1");
+                assertThat(cancelledEvent.getExecutionId()).isEqualTo(boundaryExecution.getId());
             }
         }
 
         entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
 
-        assertEquals(FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT);
 
-        assertEquals(13, idx);
-        assertEquals(13, testListener.getEventsReceived().size());
+        assertThat(idx).isEqualTo(13);
+        assertThat(testListener.getEventsReceived()).hasSize(13);
     }
 
     /**
@@ -164,7 +166,7 @@ public class CancelUserTaskTest extends PluggableFlowableTestCase {
     @Deployment(resources = { "org/flowable/engine/test/api/event/CancelUserTaskEventsTest.bpmn20.xml" })
     public void testUserTaskCancelledByMessageBoundaryEvent() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("cancelUserTaskEvents");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         Execution task1Execution = runtimeService.createExecutionQuery().activityId("task1").singleResult();
         Execution task2Execution = runtimeService.createExecutionQuery().activityId("task2").singleResult();
@@ -172,72 +174,71 @@ public class CancelUserTaskTest extends PluggableFlowableTestCase {
 
         int idx = 0;
         FlowableEvent flowableEvent = testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.PROCESS_STARTED, flowableEvent.getType());
+        assertThat(flowableEvent.getType()).isEqualTo(FlowableEngineEventType.PROCESS_STARTED);
         ExecutionEntity executionEntity = (ExecutionEntity) ((FlowableProcessStartedEvent) flowableEvent).getEntity();
-        assertEquals(processInstance.getId(), executionEntity.getProcessInstanceId());
+        assertThat(executionEntity.getProcessInstanceId()).isEqualTo(processInstance.getId());
 
         FlowableActivityEvent activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("startEvent", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityType()).isEqualTo("startEvent");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("startEvent", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityType()).isEqualTo("startEvent");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("task1", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("task1");
 
         FlowableEntityEvent entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.TASK_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_CREATED);
         TaskEntity taskEntity = (TaskEntity) entityEvent.getEntity();
-        assertEquals("User Task1", taskEntity.getName());
+        assertThat(taskEntity.getName()).isEqualTo("User Task1");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("task2", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("task2");
 
         entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.TASK_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_CREATED);
         taskEntity = (TaskEntity) entityEvent.getEntity();
-        assertEquals("User Task2", taskEntity.getName());
+        assertThat(taskEntity.getName()).isEqualTo("User Task2");
 
-        Execution cancelMessageExecution = runtimeService.createExecutionQuery().messageEventSubscriptionName("cancel")
-                .singleResult();
-        assertNotNull(cancelMessageExecution);
-        assertEquals("cancelBoundaryEvent1", cancelMessageExecution.getActivityId());
+        Execution cancelMessageExecution = runtimeService.createExecutionQuery().messageEventSubscriptionName("cancel").singleResult();
+        assertThat(cancelMessageExecution).isNotNull();
+        assertThat(cancelMessageExecution.getActivityId()).isEqualTo("cancelBoundaryEvent1");
 
         // cancel the user task (task2)
         runtimeService.messageEventReceived("cancel", cancelMessageExecution.getId());
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, activityEvent.getType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
         FlowableActivityCancelledEvent cancelledEvent = (FlowableActivityCancelledEvent) activityEvent;
-        assertEquals("task2", cancelledEvent.getActivityId());
-        assertEquals("userTask", cancelledEvent.getActivityType());
-        assertEquals("User Task2", cancelledEvent.getActivityName());
-        assertEquals(task2Execution.getId(), cancelledEvent.getExecutionId());
+        assertThat(cancelledEvent.getActivityId()).isEqualTo("task2");
+        assertThat(cancelledEvent.getActivityType()).isEqualTo("userTask");
+        assertThat(cancelledEvent.getActivityName()).isEqualTo("User Task2");
+        assertThat(cancelledEvent.getExecutionId()).isEqualTo(task2Execution.getId());
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("cancelBoundaryEvent1", activityEvent.getActivityId());
-        assertEquals("boundaryEvent", activityEvent.getActivityType());
-        assertEquals(boundaryExecution.getId(), activityEvent.getExecutionId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("cancelBoundaryEvent1");
+        assertThat(activityEvent.getActivityType()).isEqualTo("boundaryEvent");
+        assertThat(activityEvent.getExecutionId()).isEqualTo(boundaryExecution.getId());
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("endEvent1", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("endEvent1");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, activityEvent.getType());
-        assertEquals("task1", activityEvent.getActivityId());
-        assertEquals(task1Execution.getId(), activityEvent.getExecutionId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("task1");
+        assertThat(activityEvent.getExecutionId()).isEqualTo(task1Execution.getId());
 
         entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT);
 
-        assertEquals(12, idx);
-        assertEquals(12, testListener.getEventsReceived().size());
+        assertThat(idx).isEqualTo(12);
+        assertThat(testListener.getEventsReceived()).hasSize(12);
     }
 
     class UserActivityEventListener extends AbstractFlowableEngineEventListener {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/CommentEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/CommentEventsTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -11,6 +11,8 @@
  * limitations under the License.
  */
 package org.flowable.engine.test.api.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.common.engine.api.delegate.event.FlowableEngineEntityEvent;
 import org.flowable.common.engine.api.delegate.event.FlowableEngineEventType;
@@ -27,7 +29,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for all {@link FlowableEvent}s related to comments.
- * 
+ *
  * @author Frederik Heremans
  */
 public class CommentEventsTest extends PluggableFlowableTestCase {
@@ -44,33 +46,33 @@ public class CommentEventsTest extends PluggableFlowableTestCase {
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
             org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-            assertNotNull(task);
+            assertThat(task).isNotNull();
 
             // Create link-comment
             Comment comment = taskService.addComment(task.getId(), task.getProcessInstanceId(), "comment");
-            assertEquals(2, listener.getEventsReceived().size());
+            assertThat(listener.getEventsReceived()).hasSize(2);
             FlowableEngineEntityEvent event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(0);
-            assertEquals(FlowableEngineEventType.ENTITY_CREATED, event.getType());
-            assertEquals(processInstance.getId(), event.getProcessInstanceId());
-            assertEquals(processInstance.getId(), event.getExecutionId());
-            assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
+            assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
+            assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+            assertThat(event.getExecutionId()).isEqualTo(processInstance.getId());
+            assertThat(event.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
             Comment commentFromEvent = (Comment) event.getEntity();
-            assertEquals(comment.getId(), commentFromEvent.getId());
+            assertThat(commentFromEvent.getId()).isEqualTo(comment.getId());
 
             event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(1);
-            assertEquals(FlowableEngineEventType.ENTITY_INITIALIZED, event.getType());
+            assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_INITIALIZED);
             listener.clearEventsReceived();
 
             // Finally, delete comment
             taskService.deleteComment(comment.getId());
-            assertEquals(1, listener.getEventsReceived().size());
+            assertThat(listener.getEventsReceived()).hasSize(1);
             event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(0);
-            assertEquals(FlowableEngineEventType.ENTITY_DELETED, event.getType());
-            assertEquals(processInstance.getId(), event.getProcessInstanceId());
-            assertEquals(processInstance.getId(), event.getExecutionId());
-            assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
+            assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_DELETED);
+            assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+            assertThat(event.getExecutionId()).isEqualTo(processInstance.getId());
+            assertThat(event.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
             commentFromEvent = (Comment) event.getEntity();
-            assertEquals(comment.getId(), commentFromEvent.getId());
+            assertThat(commentFromEvent.getId()).isEqualTo(comment.getId());
         }
     }
 
@@ -81,33 +83,33 @@ public class CommentEventsTest extends PluggableFlowableTestCase {
             try {
                 task = taskService.newTask();
                 taskService.saveTask(task);
-                assertNotNull(task);
+                assertThat(task).isNotNull();
 
                 // Create link-comment
                 Comment comment = taskService.addComment(task.getId(), null, "comment");
-                assertEquals(2, listener.getEventsReceived().size());
+                assertThat(listener.getEventsReceived()).hasSize(2);
                 FlowableEngineEntityEvent event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(0);
-                assertEquals(FlowableEngineEventType.ENTITY_CREATED, event.getType());
-                assertNull(event.getProcessInstanceId());
-                assertNull(event.getExecutionId());
-                assertNull(event.getProcessDefinitionId());
+                assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
+                assertThat(event.getProcessInstanceId()).isNull();
+                assertThat(event.getExecutionId()).isNull();
+                assertThat(event.getProcessDefinitionId()).isNull();
                 Comment commentFromEvent = (Comment) event.getEntity();
-                assertEquals(comment.getId(), commentFromEvent.getId());
+                assertThat(commentFromEvent.getId()).isEqualTo(comment.getId());
 
                 event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(1);
-                assertEquals(FlowableEngineEventType.ENTITY_INITIALIZED, event.getType());
+                assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_INITIALIZED);
                 listener.clearEventsReceived();
 
                 // Finally, delete comment
                 taskService.deleteComment(comment.getId());
-                assertEquals(1, listener.getEventsReceived().size());
+                assertThat(listener.getEventsReceived()).hasSize(1);
                 event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(0);
-                assertEquals(FlowableEngineEventType.ENTITY_DELETED, event.getType());
-                assertNull(event.getProcessInstanceId());
-                assertNull(event.getExecutionId());
-                assertNull(event.getProcessDefinitionId());
+                assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_DELETED);
+                assertThat(event.getProcessInstanceId()).isNull();
+                assertThat(event.getExecutionId()).isNull();
+                assertThat(event.getProcessDefinitionId()).isNull();
                 commentFromEvent = (Comment) event.getEntity();
-                assertEquals(comment.getId(), commentFromEvent.getId());
+                assertThat(commentFromEvent.getId()).isEqualTo(comment.getId());
 
             } finally {
                 if (task != null && task.getId() != null) {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/DatabaseEventLoggerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/DatabaseEventLoggerTest.java
@@ -109,9 +109,13 @@ public class DatabaseEventLoggerTest extends PluggableFlowableTestCase {
                 Map<String, Object> data = objectMapper.readValue(entry.getData(), new TypeReference<HashMap<String, Object>>() {
 
                 });
-                assertThat(data.get(Fields.PROCESS_DEFINITION_ID)).isNotNull();
-                assertThat(data.get(Fields.PROCESS_INSTANCE_ID)).isNotNull();
-                assertThat(data.get(Fields.VALUE_STRING)).isNotNull();
+                assertThat(data)
+                        .containsKeys(
+                                Fields.PROCESS_DEFINITION_ID,
+                                Fields.PROCESS_INSTANCE_ID,
+                                Fields.VALUE_STRING,
+                                Fields.TENANT_ID
+                        );
                 assertThat(data.get(Fields.TENANT_ID)).isEqualTo(testTenant);
             }
 
@@ -129,9 +133,12 @@ public class DatabaseEventLoggerTest extends PluggableFlowableTestCase {
                 Map<String, Object> data = objectMapper.readValue(entry.getData(), new TypeReference<HashMap<String, Object>>() {
 
                 });
-                assertThat(data.get(Fields.ID)).isNotNull();
-                assertThat(data.get(Fields.PROCESS_DEFINITION_ID)).isNotNull();
-                assertThat(data.get(Fields.TENANT_ID)).isNotNull();
+                assertThat(data)
+                        .containsKeys(
+                                Fields.ID,
+                                Fields.PROCESS_DEFINITION_ID,
+                                Fields.TENANT_ID
+                        );
                 assertThat(data.get(Fields.TENANT_ID)).isEqualTo(testTenant);
 
                 Map<String, Object> variableMap = (Map<String, Object>) data.get(Fields.VARIABLES);
@@ -155,11 +162,15 @@ public class DatabaseEventLoggerTest extends PluggableFlowableTestCase {
                 Map<String, Object> data = objectMapper.readValue(entry.getData(), new TypeReference<HashMap<String, Object>>() {
 
                 });
-                assertThat(data.get(Fields.ACTIVITY_ID)).isNotNull();
-                assertThat(data.get(Fields.PROCESS_DEFINITION_ID)).isNotNull();
-                assertThat(data.get(Fields.PROCESS_INSTANCE_ID)).isNotNull();
-                assertThat(data.get(Fields.EXECUTION_ID)).isNotNull();
-                assertThat(data.get(Fields.ACTIVITY_TYPE)).isNotNull();
+                assertThat(data)
+                        .containsKeys(
+                                Fields.ACTIVITY_ID,
+                                Fields.PROCESS_DEFINITION_ID,
+                                Fields.PROCESS_INSTANCE_ID,
+                                Fields.EXECUTION_ID,
+                                Fields.ACTIVITY_TYPE,
+                                Fields.TENANT_ID
+                        );
                 assertThat(data.get(Fields.TENANT_ID)).isEqualTo(testTenant);
             }
 
@@ -177,14 +188,17 @@ public class DatabaseEventLoggerTest extends PluggableFlowableTestCase {
                 Map<String, Object> data = objectMapper.readValue(entry.getData(), new TypeReference<HashMap<String, Object>>() {
 
                 });
-                assertThat(data.get(Fields.ACTIVITY_ID)).isNotNull();
+                assertThat(data)
+                        .containsKeys(
+                                Fields.ACTIVITY_ID,
+                                Fields.PROCESS_DEFINITION_ID,
+                                Fields.PROCESS_INSTANCE_ID,
+                                Fields.EXECUTION_ID,
+                                Fields.ACTIVITY_TYPE,
+                                Fields.TENANT_ID
+                        );
                 assertThat(data.get(Fields.ACTIVITY_ID)).isEqualTo("startEvent1");
-                assertThat(data.get(Fields.PROCESS_DEFINITION_ID)).isNotNull();
-                assertThat(data.get(Fields.PROCESS_INSTANCE_ID)).isNotNull();
-                assertThat(data.get(Fields.EXECUTION_ID)).isNotNull();
-                assertThat(data.get(Fields.ACTIVITY_TYPE)).isNotNull();
                 assertThat(data.get(Fields.TENANT_ID)).isEqualTo(testTenant);
-
             }
 
             // Sequence flow taken
@@ -200,10 +214,14 @@ public class DatabaseEventLoggerTest extends PluggableFlowableTestCase {
                 Map<String, Object> data = objectMapper.readValue(entry.getData(), new TypeReference<HashMap<String, Object>>() {
 
                 });
-                assertThat(data.get(Fields.ID)).isNotNull();
-                assertThat(data.get(Fields.SOURCE_ACTIVITY_ID)).isNotNull();
-                assertThat(data.get(Fields.SOURCE_ACTIVITY_NAME)).isNotNull();
-                assertThat(data.get(Fields.SOURCE_ACTIVITY_TYPE)).isNotNull();
+                assertThat(data)
+                        .containsKeys(
+                                Fields.ID,
+                                Fields.SOURCE_ACTIVITY_ID,
+                                Fields.SOURCE_ACTIVITY_TYPE,
+                                Fields.SOURCE_ACTIVITY_TYPE,
+                                Fields.TENANT_ID
+                        );
                 assertThat(data.get(Fields.TENANT_ID)).isEqualTo(testTenant);
             }
 
@@ -221,13 +239,15 @@ public class DatabaseEventLoggerTest extends PluggableFlowableTestCase {
                 Map<String, Object> data = objectMapper.readValue(entry.getData(), new TypeReference<HashMap<String, Object>>() {
 
                 });
-                assertThat(data.get(Fields.ACTIVITY_ID)).isNotNull();
-                assertThat(data.get(Fields.PROCESS_DEFINITION_ID)).isNotNull();
-                assertThat(data.get(Fields.PROCESS_INSTANCE_ID)).isNotNull();
-                assertThat(data.get(Fields.EXECUTION_ID)).isNotNull();
-                assertThat(data.get(Fields.ACTIVITY_TYPE)).isNotNull();
-                assertThat(data.get(Fields.TENANT_ID)).isEqualTo(testTenant);
-
+                assertThat(data)
+                        .containsKeys(
+                                Fields.ACTIVITY_ID,
+                                Fields.PROCESS_DEFINITION_ID,
+                                Fields.PROCESS_INSTANCE_ID,
+                                Fields.EXECUTION_ID,
+                                Fields.ACTIVITY_TYPE,
+                                Fields.TENANT_ID
+                        );
             }
 
             // Tasks
@@ -244,21 +264,26 @@ public class DatabaseEventLoggerTest extends PluggableFlowableTestCase {
                 Map<String, Object> data = objectMapper.readValue(entry.getData(), new TypeReference<HashMap<String, Object>>() {
 
                 });
-                assertThat(data.get(Fields.ID)).isNotNull();
-                assertThat(data.get(Fields.NAME)).isNotNull();
-                assertThat(data.get(Fields.ASSIGNEE)).isNotNull();
-                assertThat(data.get(Fields.CREATE_TIME)).isNotNull();
-                assertThat(data.get(Fields.PRIORITY)).isNotNull();
-                assertThat(data.get(Fields.PROCESS_DEFINITION_ID)).isNotNull();
-                assertThat(data.get(Fields.EXECUTION_ID)).isNotNull();
-                assertThat(data.get(Fields.TENANT_ID)).isNotNull();
-
-                assertThat(data.containsKey(Fields.DESCRIPTION)).isFalse();
-                assertThat(data.containsKey(Fields.CATEGORY)).isFalse();
-                assertThat(data.containsKey(Fields.OWNER)).isFalse();
-                assertThat(data.containsKey(Fields.DUE_DATE)).isFalse();
-                assertThat(data.containsKey(Fields.FORM_KEY)).isFalse();
-                assertThat(data.containsKey(Fields.USER_ID)).isFalse();
+                assertThat(data)
+                        .containsKeys(
+                                Fields.ID,
+                                Fields.NAME,
+                                Fields.ASSIGNEE,
+                                Fields.CREATE_TIME,
+                                Fields.PRIORITY,
+                                Fields.PROCESS_DEFINITION_ID,
+                                Fields.EXECUTION_ID,
+                                Fields.TENANT_ID
+                        );
+                assertThat(data)
+                        .doesNotContainKeys(
+                                Fields.DESCRIPTION,
+                                Fields.CATEGORY,
+                                Fields.OWNER,
+                                Fields.DUE_DATE,
+                                Fields.FORM_KEY,
+                                Fields.USER_ID
+                        );
 
                 assertThat(data.get(Fields.TENANT_ID)).isEqualTo(testTenant);
 
@@ -277,24 +302,28 @@ public class DatabaseEventLoggerTest extends PluggableFlowableTestCase {
                 Map<String, Object> data = objectMapper.readValue(entry.getData(), new TypeReference<HashMap<String, Object>>() {
 
                 });
-                assertThat(data.get(Fields.ID)).isNotNull();
-                assertThat(data.get(Fields.NAME)).isNotNull();
-                assertThat(data.get(Fields.ASSIGNEE)).isNotNull();
-                assertThat(data.get(Fields.CREATE_TIME)).isNotNull();
-                assertThat(data.get(Fields.PRIORITY)).isNotNull();
-                assertThat(data.get(Fields.PROCESS_DEFINITION_ID)).isNotNull();
-                assertThat(data.get(Fields.EXECUTION_ID)).isNotNull();
-                assertThat(data.get(Fields.TENANT_ID)).isNotNull();
-
-                assertThat(data.containsKey(Fields.DESCRIPTION)).isFalse();
-                assertThat(data.containsKey(Fields.CATEGORY)).isFalse();
-                assertThat(data.containsKey(Fields.OWNER)).isFalse();
-                assertThat(data.containsKey(Fields.DUE_DATE)).isFalse();
-                assertThat(data.containsKey(Fields.FORM_KEY)).isFalse();
-                assertThat(data.containsKey(Fields.USER_ID)).isFalse();
+                assertThat(data)
+                        .containsKeys(
+                                Fields.ID,
+                                Fields.NAME,
+                                Fields.ASSIGNEE,
+                                Fields.CREATE_TIME,
+                                Fields.PRIORITY,
+                                Fields.PROCESS_DEFINITION_ID,
+                                Fields.EXECUTION_ID,
+                                Fields.TENANT_ID
+                        );
+                assertThat(data)
+                        .doesNotContainKeys(
+                                Fields.DESCRIPTION,
+                                Fields.CATEGORY,
+                                Fields.OWNER,
+                                Fields.DUE_DATE,
+                                Fields.FORM_KEY,
+                                Fields.USER_ID
+                        );
 
                 assertThat(data.get(Fields.TENANT_ID)).isEqualTo(testTenant);
-
             }
 
             lastLogNr = entry.getLogNumber();
@@ -329,25 +358,31 @@ public class DatabaseEventLoggerTest extends PluggableFlowableTestCase {
                 Map<String, Object> data = objectMapper.readValue(entry.getData(), new TypeReference<HashMap<String, Object>>() {
 
                 });
-                assertThat(data.get(Fields.ID)).isNotNull();
-                assertThat(data.get(Fields.NAME)).isNotNull();
-                assertThat(data.get(Fields.ASSIGNEE)).isNotNull();
-                assertThat(data.get(Fields.CREATE_TIME)).isNotNull();
-                assertThat(data.get(Fields.PRIORITY)).isNotNull();
-                assertThat(data.get(Fields.PROCESS_DEFINITION_ID)).isNotNull();
-                assertThat(data.get(Fields.EXECUTION_ID)).isNotNull();
-                assertThat(data.get(Fields.TENANT_ID)).isNotNull();
-                assertThat(data.get(Fields.USER_ID)).isNotNull();
+                assertThat(data)
+                        .containsKeys(
+                                Fields.ID,
+                                Fields.NAME,
+                                Fields.ASSIGNEE,
+                                Fields.CREATE_TIME,
+                                Fields.PRIORITY,
+                                Fields.PROCESS_DEFINITION_ID,
+                                Fields.EXECUTION_ID,
+                                Fields.TENANT_ID,
+                                Fields.USER_ID
+                        );
 
                 Map<String, Object> variableMap = (Map<String, Object>) data.get(Fields.VARIABLES);
                 assertThat(variableMap).hasSize(1);
                 assertThat(variableMap.get("test")).isEqualTo("test");
 
-                assertThat(data.containsKey(Fields.DESCRIPTION)).isFalse();
-                assertThat(data.containsKey(Fields.CATEGORY)).isFalse();
-                assertThat(data.containsKey(Fields.OWNER)).isFalse();
-                assertThat(data.containsKey(Fields.DUE_DATE)).isFalse();
-                assertThat(data.containsKey(Fields.FORM_KEY)).isFalse();
+                assertThat(data)
+                        .doesNotContainKeys(
+                                Fields.DESCRIPTION,
+                                Fields.CATEGORY,
+                                Fields.OWNER,
+                                Fields.DUE_DATE,
+                                Fields.FORM_KEY
+                        );
 
                 assertThat(data.get(Fields.TENANT_ID)).isEqualTo(testTenant);
 
@@ -366,12 +401,16 @@ public class DatabaseEventLoggerTest extends PluggableFlowableTestCase {
                 Map<String, Object> data = objectMapper.readValue(entry.getData(), new TypeReference<HashMap<String, Object>>() {
 
                 });
-                assertThat(data.get(Fields.ACTIVITY_ID)).isNotNull();
-                assertThat(data.get(Fields.PROCESS_DEFINITION_ID)).isNotNull();
-                assertThat(data.get(Fields.PROCESS_INSTANCE_ID)).isNotNull();
-                assertThat(data.get(Fields.EXECUTION_ID)).isNotNull();
-                assertThat(data.get(Fields.ACTIVITY_TYPE)).isNotNull();
-                assertThat(data.get(Fields.BEHAVIOR_CLASS)).isNotNull();
+                assertThat(data)
+                        .containsKeys(
+                                Fields.ACTIVITY_ID,
+                                Fields.PROCESS_DEFINITION_ID,
+                                Fields.PROCESS_INSTANCE_ID,
+                                Fields.EXECUTION_ID,
+                                Fields.ACTIVITY_TYPE,
+                                Fields.TENANT_ID,
+                                Fields.BEHAVIOR_CLASS
+                        );
 
                 assertThat(data.get(Fields.TENANT_ID)).isEqualTo(testTenant);
 
@@ -400,13 +439,16 @@ public class DatabaseEventLoggerTest extends PluggableFlowableTestCase {
                 Map<String, Object> data = objectMapper.readValue(entry.getData(), new TypeReference<HashMap<String, Object>>() {
 
                 });
-                assertThat(data.get(Fields.ID)).isNotNull();
-                assertThat(data.get(Fields.SOURCE_ACTIVITY_ID)).isNotNull();
-                assertThat(data.get(Fields.SOURCE_ACTIVITY_TYPE)).isNotNull();
-                assertThat(data.get(Fields.SOURCE_ACTIVITY_BEHAVIOR_CLASS)).isNotNull();
-                assertThat(data.get(Fields.TARGET_ACTIVITY_ID)).isNotNull();
-                assertThat(data.get(Fields.TARGET_ACTIVITY_TYPE)).isNotNull();
-                assertThat(data.get(Fields.TARGET_ACTIVITY_BEHAVIOR_CLASS)).isNotNull();
+                assertThat(data)
+                        .containsKeys(
+                                Fields.ID,
+                                Fields.SOURCE_ACTIVITY_ID,
+                                Fields.SOURCE_ACTIVITY_TYPE,
+                                Fields.SOURCE_ACTIVITY_BEHAVIOR_CLASS,
+                                Fields.TARGET_ACTIVITY_ID,
+                                Fields.TARGET_ACTIVITY_TYPE,
+                                Fields.TARGET_ACTIVITY_BEHAVIOR_CLASS
+                        );
 
                 assertThat(data.get(Fields.TENANT_ID)).isEqualTo(testTenant);
             }
@@ -433,12 +475,17 @@ public class DatabaseEventLoggerTest extends PluggableFlowableTestCase {
                 Map<String, Object> data = objectMapper.readValue(entry.getData(), new TypeReference<HashMap<String, Object>>() {
 
                 });
-                assertThat(data.get(Fields.ID)).isNotNull();
-                assertThat(data.get(Fields.PROCESS_DEFINITION_ID)).isNotNull();
-                assertThat(data.get(Fields.TENANT_ID)).isNotNull();
-
-                assertThat(data.containsKey(Fields.NAME)).isFalse();
-                assertThat(data.containsKey(Fields.BUSINESS_KEY)).isFalse();
+                assertThat(data)
+                        .containsKeys(
+                                Fields.ID,
+                                Fields.PROCESS_DEFINITION_ID,
+                                Fields.TENANT_ID
+                        );
+                assertThat(data)
+                        .doesNotContainKeys(
+                                Fields.NAME,
+                                Fields.BUSINESS_KEY
+                        );
 
                 assertThat(data.get(Fields.TENANT_ID)).isEqualTo(testTenant);
             }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/DatabaseEventLoggerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/DatabaseEventLoggerTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.api.event;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -88,7 +90,7 @@ public class DatabaseEventLoggerTest extends PluggableFlowableTestCase {
             }
         }
 
-        assertEquals(15, eventLogEntries.size());
+        assertThat(eventLogEntries).hasSize(15);
 
         long lastLogNr = -1;
         for (int i = 0; i < eventLogEntries.size(); i++) {
@@ -97,193 +99,201 @@ public class DatabaseEventLoggerTest extends PluggableFlowableTestCase {
 
             if (i == 0) {
 
-                assertNotNull(entry.getType());
-                assertEquals(FlowableEngineEventType.VARIABLE_CREATED.name(), entry.getType());
-                assertNotNull(entry.getProcessDefinitionId());
-                assertNotNull(entry.getProcessInstanceId());
-                assertNotNull(entry.getTimeStamp());
-                assertNull(entry.getTaskId());
+                assertThat(entry.getType()).isNotNull();
+                assertThat(entry.getType()).isEqualTo(FlowableEngineEventType.VARIABLE_CREATED.name());
+                assertThat(entry.getProcessDefinitionId()).isNotNull();
+                assertThat(entry.getProcessInstanceId()).isNotNull();
+                assertThat(entry.getTimeStamp()).isNotNull();
+                assertThat(entry.getTaskId()).isNull();
 
                 Map<String, Object> data = objectMapper.readValue(entry.getData(), new TypeReference<HashMap<String, Object>>() {
+
                 });
-                assertNotNull(data.get(Fields.PROCESS_DEFINITION_ID));
-                assertNotNull(data.get(Fields.PROCESS_INSTANCE_ID));
-                assertNotNull(data.get(Fields.VALUE_STRING));
-                assertEquals(testTenant, data.get(Fields.TENANT_ID));
+                assertThat(data.get(Fields.PROCESS_DEFINITION_ID)).isNotNull();
+                assertThat(data.get(Fields.PROCESS_INSTANCE_ID)).isNotNull();
+                assertThat(data.get(Fields.VALUE_STRING)).isNotNull();
+                assertThat(data.get(Fields.TENANT_ID)).isEqualTo(testTenant);
             }
 
             // process instance start
             if (i == 1) {
 
-                assertNotNull(entry.getType());
-                assertEquals("PROCESSINSTANCE_START", entry.getType());
-                assertNotNull(entry.getProcessDefinitionId());
-                assertNotNull(entry.getProcessInstanceId());
-                assertNotNull(entry.getTimeStamp());
-                assertNull(entry.getExecutionId());
-                assertNull(entry.getTaskId());
+                assertThat(entry.getType()).isNotNull();
+                assertThat(entry.getType()).isEqualTo("PROCESSINSTANCE_START");
+                assertThat(entry.getProcessDefinitionId()).isNotNull();
+                assertThat(entry.getProcessInstanceId()).isNotNull();
+                assertThat(entry.getTimeStamp()).isNotNull();
+                assertThat(entry.getExecutionId()).isNull();
+                assertThat(entry.getTaskId()).isNull();
 
                 Map<String, Object> data = objectMapper.readValue(entry.getData(), new TypeReference<HashMap<String, Object>>() {
+
                 });
-                assertNotNull(data.get(Fields.ID));
-                assertNotNull(data.get(Fields.PROCESS_DEFINITION_ID));
-                assertNotNull(data.get(Fields.TENANT_ID));
-                assertEquals(testTenant, data.get(Fields.TENANT_ID));
+                assertThat(data.get(Fields.ID)).isNotNull();
+                assertThat(data.get(Fields.PROCESS_DEFINITION_ID)).isNotNull();
+                assertThat(data.get(Fields.TENANT_ID)).isNotNull();
+                assertThat(data.get(Fields.TENANT_ID)).isEqualTo(testTenant);
 
                 Map<String, Object> variableMap = (Map<String, Object>) data.get(Fields.VARIABLES);
-                assertEquals(1, variableMap.size());
-                assertEquals("helloWorld", variableMap.get("testVar"));
+                assertThat(variableMap).hasSize(1);
+                assertThat(variableMap.get("testVar")).isEqualTo("helloWorld");
 
-                assertFalse(data.containsKey(Fields.NAME));
-                assertFalse(data.containsKey(Fields.BUSINESS_KEY));
+                assertThat(data.containsKey(Fields.NAME)).isFalse();
+                assertThat(data.containsKey(Fields.BUSINESS_KEY)).isFalse();
             }
 
             // Activity started
             if (i == 2 || i == 5 || i == 8 || i == 12) {
-                assertNotNull(entry.getType());
-                assertEquals(FlowableEngineEventType.ACTIVITY_STARTED.name(), entry.getType());
-                assertNotNull(entry.getProcessDefinitionId());
-                assertNotNull(entry.getProcessInstanceId());
-                assertNotNull(entry.getTimeStamp());
-                assertNotNull(entry.getExecutionId());
-                assertNull(entry.getTaskId());
+                assertThat(entry.getType()).isNotNull();
+                assertThat(entry.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED.name());
+                assertThat(entry.getProcessDefinitionId()).isNotNull();
+                assertThat(entry.getProcessInstanceId()).isNotNull();
+                assertThat(entry.getTimeStamp()).isNotNull();
+                assertThat(entry.getExecutionId()).isNotNull();
+                assertThat(entry.getTaskId()).isNull();
 
                 Map<String, Object> data = objectMapper.readValue(entry.getData(), new TypeReference<HashMap<String, Object>>() {
+
                 });
-                assertNotNull(data.get(Fields.ACTIVITY_ID));
-                assertNotNull(data.get(Fields.PROCESS_DEFINITION_ID));
-                assertNotNull(data.get(Fields.PROCESS_INSTANCE_ID));
-                assertNotNull(data.get(Fields.EXECUTION_ID));
-                assertNotNull(data.get(Fields.ACTIVITY_TYPE));
-                assertEquals(testTenant, data.get(Fields.TENANT_ID));
+                assertThat(data.get(Fields.ACTIVITY_ID)).isNotNull();
+                assertThat(data.get(Fields.PROCESS_DEFINITION_ID)).isNotNull();
+                assertThat(data.get(Fields.PROCESS_INSTANCE_ID)).isNotNull();
+                assertThat(data.get(Fields.EXECUTION_ID)).isNotNull();
+                assertThat(data.get(Fields.ACTIVITY_TYPE)).isNotNull();
+                assertThat(data.get(Fields.TENANT_ID)).isEqualTo(testTenant);
             }
 
             // Leaving start
             if (i == 3) {
 
-                assertNotNull(entry.getType());
-                assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED.name(), entry.getType());
-                assertNotNull(entry.getProcessDefinitionId());
-                assertNotNull(entry.getProcessInstanceId());
-                assertNotNull(entry.getTimeStamp());
-                assertNotNull(entry.getExecutionId());
-                assertNull(entry.getTaskId());
+                assertThat(entry.getType()).isNotNull();
+                assertThat(entry.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED.name());
+                assertThat(entry.getProcessDefinitionId()).isNotNull();
+                assertThat(entry.getProcessInstanceId()).isNotNull();
+                assertThat(entry.getTimeStamp()).isNotNull();
+                assertThat(entry.getExecutionId()).isNotNull();
+                assertThat(entry.getTaskId()).isNull();
 
                 Map<String, Object> data = objectMapper.readValue(entry.getData(), new TypeReference<HashMap<String, Object>>() {
+
                 });
-                assertNotNull(data.get(Fields.ACTIVITY_ID));
-                assertEquals("startEvent1", data.get(Fields.ACTIVITY_ID));
-                assertNotNull(data.get(Fields.PROCESS_DEFINITION_ID));
-                assertNotNull(data.get(Fields.PROCESS_INSTANCE_ID));
-                assertNotNull(data.get(Fields.EXECUTION_ID));
-                assertNotNull(data.get(Fields.ACTIVITY_TYPE));
-                assertEquals(testTenant, data.get(Fields.TENANT_ID));
+                assertThat(data.get(Fields.ACTIVITY_ID)).isNotNull();
+                assertThat(data.get(Fields.ACTIVITY_ID)).isEqualTo("startEvent1");
+                assertThat(data.get(Fields.PROCESS_DEFINITION_ID)).isNotNull();
+                assertThat(data.get(Fields.PROCESS_INSTANCE_ID)).isNotNull();
+                assertThat(data.get(Fields.EXECUTION_ID)).isNotNull();
+                assertThat(data.get(Fields.ACTIVITY_TYPE)).isNotNull();
+                assertThat(data.get(Fields.TENANT_ID)).isEqualTo(testTenant);
 
             }
 
             // Sequence flow taken
             if (i == 4 || i == 7 || i == 11) {
-                assertNotNull(entry.getType());
-                assertEquals(FlowableEngineEventType.SEQUENCEFLOW_TAKEN.name(), entry.getType());
-                assertNotNull(entry.getProcessDefinitionId());
-                assertNotNull(entry.getProcessInstanceId());
-                assertNotNull(entry.getTimeStamp());
-                assertNotNull(entry.getExecutionId());
-                assertNull(entry.getTaskId());
+                assertThat(entry.getType()).isNotNull();
+                assertThat(entry.getType()).isEqualTo(FlowableEngineEventType.SEQUENCEFLOW_TAKEN.name());
+                assertThat(entry.getProcessDefinitionId()).isNotNull();
+                assertThat(entry.getProcessInstanceId()).isNotNull();
+                assertThat(entry.getTimeStamp()).isNotNull();
+                assertThat(entry.getExecutionId()).isNotNull();
+                assertThat(entry.getTaskId()).isNull();
 
                 Map<String, Object> data = objectMapper.readValue(entry.getData(), new TypeReference<HashMap<String, Object>>() {
+
                 });
-                assertNotNull(data.get(Fields.ID));
-                assertNotNull(data.get(Fields.SOURCE_ACTIVITY_ID));
-                assertNotNull(data.get(Fields.SOURCE_ACTIVITY_NAME));
-                assertNotNull(data.get(Fields.SOURCE_ACTIVITY_TYPE));
-                assertEquals(testTenant, data.get(Fields.TENANT_ID));
+                assertThat(data.get(Fields.ID)).isNotNull();
+                assertThat(data.get(Fields.SOURCE_ACTIVITY_ID)).isNotNull();
+                assertThat(data.get(Fields.SOURCE_ACTIVITY_NAME)).isNotNull();
+                assertThat(data.get(Fields.SOURCE_ACTIVITY_TYPE)).isNotNull();
+                assertThat(data.get(Fields.TENANT_ID)).isEqualTo(testTenant);
             }
 
             // Leaving parallel gateway
             if (i == 6) {
 
-                assertNotNull(entry.getType());
-                assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED.name(), entry.getType());
-                assertNotNull(entry.getProcessDefinitionId());
-                assertNotNull(entry.getProcessInstanceId());
-                assertNotNull(entry.getTimeStamp());
-                assertNotNull(entry.getExecutionId());
-                assertNull(entry.getTaskId());
+                assertThat(entry.getType()).isNotNull();
+                assertThat(entry.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED.name());
+                assertThat(entry.getProcessDefinitionId()).isNotNull();
+                assertThat(entry.getProcessInstanceId()).isNotNull();
+                assertThat(entry.getTimeStamp()).isNotNull();
+                assertThat(entry.getExecutionId()).isNotNull();
+                assertThat(entry.getTaskId()).isNull();
 
                 Map<String, Object> data = objectMapper.readValue(entry.getData(), new TypeReference<HashMap<String, Object>>() {
+
                 });
-                assertNotNull(data.get(Fields.ACTIVITY_ID));
-                assertNotNull(data.get(Fields.PROCESS_DEFINITION_ID));
-                assertNotNull(data.get(Fields.PROCESS_INSTANCE_ID));
-                assertNotNull(data.get(Fields.EXECUTION_ID));
-                assertNotNull(data.get(Fields.ACTIVITY_TYPE));
-                assertEquals(testTenant, data.get(Fields.TENANT_ID));
+                assertThat(data.get(Fields.ACTIVITY_ID)).isNotNull();
+                assertThat(data.get(Fields.PROCESS_DEFINITION_ID)).isNotNull();
+                assertThat(data.get(Fields.PROCESS_INSTANCE_ID)).isNotNull();
+                assertThat(data.get(Fields.EXECUTION_ID)).isNotNull();
+                assertThat(data.get(Fields.ACTIVITY_TYPE)).isNotNull();
+                assertThat(data.get(Fields.TENANT_ID)).isEqualTo(testTenant);
 
             }
 
             // Tasks
             if (i == 10 || i == 14) {
 
-                assertNotNull(entry.getType());
-                assertEquals(FlowableEngineEventType.TASK_CREATED.name(), entry.getType());
-                assertNotNull(entry.getTimeStamp());
-                assertNotNull(entry.getProcessDefinitionId());
-                assertNotNull(entry.getProcessInstanceId());
-                assertNotNull(entry.getExecutionId());
-                assertNotNull(entry.getTaskId());
+                assertThat(entry.getType()).isNotNull();
+                assertThat(entry.getType()).isEqualTo(FlowableEngineEventType.TASK_CREATED.name());
+                assertThat(entry.getTimeStamp()).isNotNull();
+                assertThat(entry.getProcessDefinitionId()).isNotNull();
+                assertThat(entry.getProcessInstanceId()).isNotNull();
+                assertThat(entry.getExecutionId()).isNotNull();
+                assertThat(entry.getTaskId()).isNotNull();
 
                 Map<String, Object> data = objectMapper.readValue(entry.getData(), new TypeReference<HashMap<String, Object>>() {
+
                 });
-                assertNotNull(data.get(Fields.ID));
-                assertNotNull(data.get(Fields.NAME));
-                assertNotNull(data.get(Fields.ASSIGNEE));
-                assertNotNull(data.get(Fields.CREATE_TIME));
-                assertNotNull(data.get(Fields.PRIORITY));
-                assertNotNull(data.get(Fields.PROCESS_DEFINITION_ID));
-                assertNotNull(data.get(Fields.EXECUTION_ID));
-                assertNotNull(data.get(Fields.TENANT_ID));
+                assertThat(data.get(Fields.ID)).isNotNull();
+                assertThat(data.get(Fields.NAME)).isNotNull();
+                assertThat(data.get(Fields.ASSIGNEE)).isNotNull();
+                assertThat(data.get(Fields.CREATE_TIME)).isNotNull();
+                assertThat(data.get(Fields.PRIORITY)).isNotNull();
+                assertThat(data.get(Fields.PROCESS_DEFINITION_ID)).isNotNull();
+                assertThat(data.get(Fields.EXECUTION_ID)).isNotNull();
+                assertThat(data.get(Fields.TENANT_ID)).isNotNull();
 
-                assertFalse(data.containsKey(Fields.DESCRIPTION));
-                assertFalse(data.containsKey(Fields.CATEGORY));
-                assertFalse(data.containsKey(Fields.OWNER));
-                assertFalse(data.containsKey(Fields.DUE_DATE));
-                assertFalse(data.containsKey(Fields.FORM_KEY));
-                assertFalse(data.containsKey(Fields.USER_ID));
+                assertThat(data.containsKey(Fields.DESCRIPTION)).isFalse();
+                assertThat(data.containsKey(Fields.CATEGORY)).isFalse();
+                assertThat(data.containsKey(Fields.OWNER)).isFalse();
+                assertThat(data.containsKey(Fields.DUE_DATE)).isFalse();
+                assertThat(data.containsKey(Fields.FORM_KEY)).isFalse();
+                assertThat(data.containsKey(Fields.USER_ID)).isFalse();
 
-                assertEquals(testTenant, data.get(Fields.TENANT_ID));
+                assertThat(data.get(Fields.TENANT_ID)).isEqualTo(testTenant);
 
             }
 
             if (i == 9 || i == 13) {
 
-                assertNotNull(entry.getType());
-                assertEquals(FlowableEngineEventType.TASK_ASSIGNED.name(), entry.getType());
-                assertNotNull(entry.getTimeStamp());
-                assertNotNull(entry.getProcessDefinitionId());
-                assertNotNull(entry.getProcessInstanceId());
-                assertNotNull(entry.getExecutionId());
-                assertNotNull(entry.getTaskId());
+                assertThat(entry.getType()).isNotNull();
+                assertThat(entry.getType()).isEqualTo(FlowableEngineEventType.TASK_ASSIGNED.name());
+                assertThat(entry.getTimeStamp()).isNotNull();
+                assertThat(entry.getProcessDefinitionId()).isNotNull();
+                assertThat(entry.getProcessInstanceId()).isNotNull();
+                assertThat(entry.getExecutionId()).isNotNull();
+                assertThat(entry.getTaskId()).isNotNull();
 
                 Map<String, Object> data = objectMapper.readValue(entry.getData(), new TypeReference<HashMap<String, Object>>() {
+
                 });
-                assertNotNull(data.get(Fields.ID));
-                assertNotNull(data.get(Fields.NAME));
-                assertNotNull(data.get(Fields.ASSIGNEE));
-                assertNotNull(data.get(Fields.CREATE_TIME));
-                assertNotNull(data.get(Fields.PRIORITY));
-                assertNotNull(data.get(Fields.PROCESS_DEFINITION_ID));
-                assertNotNull(data.get(Fields.EXECUTION_ID));
-                assertNotNull(data.get(Fields.TENANT_ID));
+                assertThat(data.get(Fields.ID)).isNotNull();
+                assertThat(data.get(Fields.NAME)).isNotNull();
+                assertThat(data.get(Fields.ASSIGNEE)).isNotNull();
+                assertThat(data.get(Fields.CREATE_TIME)).isNotNull();
+                assertThat(data.get(Fields.PRIORITY)).isNotNull();
+                assertThat(data.get(Fields.PROCESS_DEFINITION_ID)).isNotNull();
+                assertThat(data.get(Fields.EXECUTION_ID)).isNotNull();
+                assertThat(data.get(Fields.TENANT_ID)).isNotNull();
 
-                assertFalse(data.containsKey(Fields.DESCRIPTION));
-                assertFalse(data.containsKey(Fields.CATEGORY));
-                assertFalse(data.containsKey(Fields.OWNER));
-                assertFalse(data.containsKey(Fields.DUE_DATE));
-                assertFalse(data.containsKey(Fields.FORM_KEY));
-                assertFalse(data.containsKey(Fields.USER_ID));
+                assertThat(data.containsKey(Fields.DESCRIPTION)).isFalse();
+                assertThat(data.containsKey(Fields.CATEGORY)).isFalse();
+                assertThat(data.containsKey(Fields.OWNER)).isFalse();
+                assertThat(data.containsKey(Fields.DUE_DATE)).isFalse();
+                assertThat(data.containsKey(Fields.FORM_KEY)).isFalse();
+                assertThat(data.containsKey(Fields.USER_ID)).isFalse();
 
-                assertEquals(testTenant, data.get(Fields.TENANT_ID));
+                assertThat(data.get(Fields.TENANT_ID)).isEqualTo(testTenant);
 
             }
 
@@ -301,7 +311,7 @@ public class DatabaseEventLoggerTest extends PluggableFlowableTestCase {
 
         // Verify events
         eventLogEntries = managementService.getEventLogEntries(lastLogNr, 100L);
-        assertEquals(17, eventLogEntries.size());
+        assertThat(eventLogEntries).hasSize(17);
 
         for (int i = 0; i < eventLogEntries.size(); i++) {
 
@@ -309,124 +319,128 @@ public class DatabaseEventLoggerTest extends PluggableFlowableTestCase {
 
             // org.flowable.task.service.Task completion
             if (i == 1 || i == 6) {
-                assertNotNull(entry.getType());
-                assertEquals(FlowableEngineEventType.TASK_COMPLETED.name(), entry.getType());
-                assertNotNull(entry.getProcessDefinitionId());
-                assertNotNull(entry.getProcessInstanceId());
-                assertNotNull(entry.getExecutionId());
-                assertNotNull(entry.getTaskId());
+                assertThat(entry.getType()).isNotNull();
+                assertThat(entry.getType()).isEqualTo(FlowableEngineEventType.TASK_COMPLETED.name());
+                assertThat(entry.getProcessDefinitionId()).isNotNull();
+                assertThat(entry.getProcessInstanceId()).isNotNull();
+                assertThat(entry.getExecutionId()).isNotNull();
+                assertThat(entry.getTaskId()).isNotNull();
 
                 Map<String, Object> data = objectMapper.readValue(entry.getData(), new TypeReference<HashMap<String, Object>>() {
+
                 });
-                assertNotNull(data.get(Fields.ID));
-                assertNotNull(data.get(Fields.NAME));
-                assertNotNull(data.get(Fields.ASSIGNEE));
-                assertNotNull(data.get(Fields.CREATE_TIME));
-                assertNotNull(data.get(Fields.PRIORITY));
-                assertNotNull(data.get(Fields.PROCESS_DEFINITION_ID));
-                assertNotNull(data.get(Fields.EXECUTION_ID));
-                assertNotNull(data.get(Fields.TENANT_ID));
-                assertNotNull(data.get(Fields.USER_ID));
+                assertThat(data.get(Fields.ID)).isNotNull();
+                assertThat(data.get(Fields.NAME)).isNotNull();
+                assertThat(data.get(Fields.ASSIGNEE)).isNotNull();
+                assertThat(data.get(Fields.CREATE_TIME)).isNotNull();
+                assertThat(data.get(Fields.PRIORITY)).isNotNull();
+                assertThat(data.get(Fields.PROCESS_DEFINITION_ID)).isNotNull();
+                assertThat(data.get(Fields.EXECUTION_ID)).isNotNull();
+                assertThat(data.get(Fields.TENANT_ID)).isNotNull();
+                assertThat(data.get(Fields.USER_ID)).isNotNull();
 
                 Map<String, Object> variableMap = (Map<String, Object>) data.get(Fields.VARIABLES);
-                assertEquals(1, variableMap.size());
-                assertEquals("test", variableMap.get("test"));
+                assertThat(variableMap).hasSize(1);
+                assertThat(variableMap.get("test")).isEqualTo("test");
 
-                assertFalse(data.containsKey(Fields.DESCRIPTION));
-                assertFalse(data.containsKey(Fields.CATEGORY));
-                assertFalse(data.containsKey(Fields.OWNER));
-                assertFalse(data.containsKey(Fields.DUE_DATE));
-                assertFalse(data.containsKey(Fields.FORM_KEY));
+                assertThat(data.containsKey(Fields.DESCRIPTION)).isFalse();
+                assertThat(data.containsKey(Fields.CATEGORY)).isFalse();
+                assertThat(data.containsKey(Fields.OWNER)).isFalse();
+                assertThat(data.containsKey(Fields.DUE_DATE)).isFalse();
+                assertThat(data.containsKey(Fields.FORM_KEY)).isFalse();
 
-                assertEquals(testTenant, data.get(Fields.TENANT_ID));
+                assertThat(data.get(Fields.TENANT_ID)).isEqualTo(testTenant);
 
             }
 
             // Activity Completed
             if (i == 2 || i == 7 || i == 10 || i == 13) {
-                assertNotNull(entry.getType());
-                assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED.name(), entry.getType());
-                assertNotNull(entry.getProcessDefinitionId());
-                assertNotNull(entry.getProcessInstanceId());
-                assertNotNull(entry.getTimeStamp());
-                assertNotNull(entry.getExecutionId());
-                assertNull(entry.getTaskId());
+                assertThat(entry.getType()).isNotNull();
+                assertThat(entry.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED.name());
+                assertThat(entry.getProcessDefinitionId()).isNotNull();
+                assertThat(entry.getProcessInstanceId()).isNotNull();
+                assertThat(entry.getTimeStamp()).isNotNull();
+                assertThat(entry.getExecutionId()).isNotNull();
+                assertThat(entry.getTaskId()).isNull();
 
                 Map<String, Object> data = objectMapper.readValue(entry.getData(), new TypeReference<HashMap<String, Object>>() {
-                });
-                assertNotNull(data.get(Fields.ACTIVITY_ID));
-                assertNotNull(data.get(Fields.PROCESS_DEFINITION_ID));
-                assertNotNull(data.get(Fields.PROCESS_INSTANCE_ID));
-                assertNotNull(data.get(Fields.EXECUTION_ID));
-                assertNotNull(data.get(Fields.ACTIVITY_TYPE));
-                assertNotNull(data.get(Fields.BEHAVIOR_CLASS));
 
-                assertEquals(testTenant, data.get(Fields.TENANT_ID));
+                });
+                assertThat(data.get(Fields.ACTIVITY_ID)).isNotNull();
+                assertThat(data.get(Fields.PROCESS_DEFINITION_ID)).isNotNull();
+                assertThat(data.get(Fields.PROCESS_INSTANCE_ID)).isNotNull();
+                assertThat(data.get(Fields.EXECUTION_ID)).isNotNull();
+                assertThat(data.get(Fields.ACTIVITY_TYPE)).isNotNull();
+                assertThat(data.get(Fields.BEHAVIOR_CLASS)).isNotNull();
+
+                assertThat(data.get(Fields.TENANT_ID)).isEqualTo(testTenant);
 
                 if (i == 2) {
-                    assertEquals("userTask", data.get(Fields.ACTIVITY_TYPE));
+                    assertThat(data.get(Fields.ACTIVITY_TYPE)).isEqualTo("userTask");
                 } else if (i == 7) {
-                    assertEquals("userTask", data.get(Fields.ACTIVITY_TYPE));
+                    assertThat(data.get(Fields.ACTIVITY_TYPE)).isEqualTo("userTask");
                 } else if (i == 10) {
-                    assertEquals("parallelGateway", data.get(Fields.ACTIVITY_TYPE));
+                    assertThat(data.get(Fields.ACTIVITY_TYPE)).isEqualTo("parallelGateway");
                 } else if (i == 13) {
-                    assertEquals("endEvent", data.get(Fields.ACTIVITY_TYPE));
+                    assertThat(data.get(Fields.ACTIVITY_TYPE)).isEqualTo("endEvent");
                 }
 
             }
 
             // Sequence flow taken
             if (i == 3 || i == 8 || i == 11) {
-                assertNotNull(entry.getType());
-                assertEquals(entry.getType(), FlowableEngineEventType.SEQUENCEFLOW_TAKEN.name());
-                assertNotNull(entry.getProcessDefinitionId());
-                assertNotNull(entry.getProcessInstanceId());
-                assertNotNull(entry.getTimeStamp());
-                assertNotNull(entry.getExecutionId());
-                assertNull(entry.getTaskId());
+                assertThat(entry.getType()).isNotNull();
+                assertThat(FlowableEngineEventType.SEQUENCEFLOW_TAKEN.name()).isEqualTo(entry.getType());
+                assertThat(entry.getProcessDefinitionId()).isNotNull();
+                assertThat(entry.getProcessInstanceId()).isNotNull();
+                assertThat(entry.getTimeStamp()).isNotNull();
+                assertThat(entry.getExecutionId()).isNotNull();
+                assertThat(entry.getTaskId()).isNull();
 
                 Map<String, Object> data = objectMapper.readValue(entry.getData(), new TypeReference<HashMap<String, Object>>() {
-                });
-                assertNotNull(data.get(Fields.ID));
-                assertNotNull(data.get(Fields.SOURCE_ACTIVITY_ID));
-                assertNotNull(data.get(Fields.SOURCE_ACTIVITY_TYPE));
-                assertNotNull(data.get(Fields.SOURCE_ACTIVITY_BEHAVIOR_CLASS));
-                assertNotNull(data.get(Fields.TARGET_ACTIVITY_ID));
-                assertNotNull(data.get(Fields.TARGET_ACTIVITY_TYPE));
-                assertNotNull(data.get(Fields.TARGET_ACTIVITY_BEHAVIOR_CLASS));
 
-                assertEquals(testTenant, data.get(Fields.TENANT_ID));
+                });
+                assertThat(data.get(Fields.ID)).isNotNull();
+                assertThat(data.get(Fields.SOURCE_ACTIVITY_ID)).isNotNull();
+                assertThat(data.get(Fields.SOURCE_ACTIVITY_TYPE)).isNotNull();
+                assertThat(data.get(Fields.SOURCE_ACTIVITY_BEHAVIOR_CLASS)).isNotNull();
+                assertThat(data.get(Fields.TARGET_ACTIVITY_ID)).isNotNull();
+                assertThat(data.get(Fields.TARGET_ACTIVITY_TYPE)).isNotNull();
+                assertThat(data.get(Fields.TARGET_ACTIVITY_BEHAVIOR_CLASS)).isNotNull();
+
+                assertThat(data.get(Fields.TENANT_ID)).isEqualTo(testTenant);
             }
 
             if (i == 14 || i == 15) {
-                assertNotNull(entry.getType());
-                assertEquals("VARIABLE_DELETED", entry.getType());
-                assertNotNull(entry.getProcessDefinitionId());
-                assertNotNull(entry.getProcessInstanceId());
-                assertNotNull(entry.getTimeStamp());
-                assertNotNull(entry.getExecutionId());
-                assertNull(entry.getTaskId());
+                assertThat(entry.getType()).isNotNull();
+                assertThat(entry.getType()).isEqualTo("VARIABLE_DELETED");
+                assertThat(entry.getProcessDefinitionId()).isNotNull();
+                assertThat(entry.getProcessInstanceId()).isNotNull();
+                assertThat(entry.getTimeStamp()).isNotNull();
+                assertThat(entry.getExecutionId()).isNotNull();
+                assertThat(entry.getTaskId()).isNull();
             }
 
             if (i == 16) {
-                assertNotNull(entry.getType());
-                assertEquals("PROCESSINSTANCE_END", entry.getType());
-                assertNotNull(entry.getProcessDefinitionId());
-                assertNotNull(entry.getProcessInstanceId());
-                assertNotNull(entry.getTimeStamp());
-                assertNull(entry.getExecutionId());
-                assertNull(entry.getTaskId());
+                assertThat(entry.getType()).isNotNull();
+                assertThat(entry.getType()).isEqualTo("PROCESSINSTANCE_END");
+                assertThat(entry.getProcessDefinitionId()).isNotNull();
+                assertThat(entry.getProcessInstanceId()).isNotNull();
+                assertThat(entry.getTimeStamp()).isNotNull();
+                assertThat(entry.getExecutionId()).isNull();
+                assertThat(entry.getTaskId()).isNull();
 
                 Map<String, Object> data = objectMapper.readValue(entry.getData(), new TypeReference<HashMap<String, Object>>() {
+
                 });
-                assertNotNull(data.get(Fields.ID));
-                assertNotNull(data.get(Fields.PROCESS_DEFINITION_ID));
-                assertNotNull(data.get(Fields.TENANT_ID));
+                assertThat(data.get(Fields.ID)).isNotNull();
+                assertThat(data.get(Fields.PROCESS_DEFINITION_ID)).isNotNull();
+                assertThat(data.get(Fields.TENANT_ID)).isNotNull();
 
-                assertFalse(data.containsKey(Fields.NAME));
-                assertFalse(data.containsKey(Fields.BUSINESS_KEY));
+                assertThat(data.containsKey(Fields.NAME)).isFalse();
+                assertThat(data.containsKey(Fields.BUSINESS_KEY)).isFalse();
 
-                assertEquals(testTenant, data.get(Fields.TENANT_ID));
+                assertThat(data.get(Fields.TENANT_ID)).isEqualTo(testTenant);
             }
         }
 
@@ -442,10 +456,12 @@ public class DatabaseEventLoggerTest extends PluggableFlowableTestCase {
     @Test
     public void testDatabaseEventsNoTenant() throws IOException {
 
-        String deploymentId = repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/api/event/DatabaseEventLoggerProcess.bpmn20.xml").deploy().getId();
+        String deploymentId = repositoryService.createDeployment()
+                .addClasspathResource("org/flowable/engine/test/api/event/DatabaseEventLoggerProcess.bpmn20.xml").deploy().getId();
 
         // Run process to gather data
-        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("DatabaseEventLoggerProcess", CollectionUtil.singletonMap("testVar", "helloWorld"));
+        ProcessInstance processInstance = runtimeService
+                .startProcessInstanceByKey("DatabaseEventLoggerProcess", CollectionUtil.singletonMap("testVar", "helloWorld"));
 
         // Verify event log entries
         List<EventLogEntry> eventLogEntries = managementService.getEventLogEntries(null, null);
@@ -459,72 +475,80 @@ public class DatabaseEventLoggerTest extends PluggableFlowableTestCase {
             }
         }
 
-        assertEquals(15, eventLogEntries.size());
+        assertThat(eventLogEntries).hasSize(15);
 
         for (int i = 0; i < eventLogEntries.size(); i++) {
 
             EventLogEntry entry = eventLogEntries.get(i);
 
             if (i == 0) {
-                assertEquals(entry.getType(), FlowableEngineEventType.VARIABLE_CREATED.name());
+                assertThat(FlowableEngineEventType.VARIABLE_CREATED.name()).isEqualTo(entry.getType());
                 Map<String, Object> data = objectMapper.readValue(entry.getData(), new TypeReference<HashMap<String, Object>>() {
+
                 });
-                assertNull(data.get(Fields.TENANT_ID));
+                assertThat(data.get(Fields.TENANT_ID)).isNull();
             }
 
             // process instance start
             if (i == 1) {
-                assertEquals("PROCESSINSTANCE_START", entry.getType());
+                assertThat(entry.getType()).isEqualTo("PROCESSINSTANCE_START");
                 Map<String, Object> data = objectMapper.readValue(entry.getData(), new TypeReference<HashMap<String, Object>>() {
+
                 });
-                assertNull(data.get(Fields.TENANT_ID));
+                assertThat(data.get(Fields.TENANT_ID)).isNull();
             }
 
             // Activity started
             if (i == 2 || i == 5 || i == 8 || i == 12) {
-                assertEquals(entry.getType(), FlowableEngineEventType.ACTIVITY_STARTED.name());
+                assertThat(FlowableEngineEventType.ACTIVITY_STARTED.name()).isEqualTo(entry.getType());
                 Map<String, Object> data = objectMapper.readValue(entry.getData(), new TypeReference<HashMap<String, Object>>() {
+
                 });
-                assertNull(data.get(Fields.TENANT_ID));
+                assertThat(data.get(Fields.TENANT_ID)).isNull();
             }
 
             // Leaving start
             if (i == 3) {
-                assertEquals(entry.getType(), FlowableEngineEventType.ACTIVITY_COMPLETED.name());
+                assertThat(FlowableEngineEventType.ACTIVITY_COMPLETED.name()).isEqualTo(entry.getType());
                 Map<String, Object> data = objectMapper.readValue(entry.getData(), new TypeReference<HashMap<String, Object>>() {
+
                 });
-                assertNull(data.get(Fields.TENANT_ID));
+                assertThat(data.get(Fields.TENANT_ID)).isNull();
             }
 
             // Sequence flow taken
             if (i == 4 || i == 7 || i == 11) {
-                assertEquals(entry.getType(), FlowableEngineEventType.SEQUENCEFLOW_TAKEN.name());
+                assertThat(FlowableEngineEventType.SEQUENCEFLOW_TAKEN.name()).isEqualTo(entry.getType());
                 Map<String, Object> data = objectMapper.readValue(entry.getData(), new TypeReference<HashMap<String, Object>>() {
+
                 });
-                assertNull(data.get(Fields.TENANT_ID));
+                assertThat(data.get(Fields.TENANT_ID)).isNull();
             }
 
             // Leaving parallel gateway
             if (i == 6) {
-                assertEquals(entry.getType(), FlowableEngineEventType.ACTIVITY_COMPLETED.name());
+                assertThat(FlowableEngineEventType.ACTIVITY_COMPLETED.name()).isEqualTo(entry.getType());
                 Map<String, Object> data = objectMapper.readValue(entry.getData(), new TypeReference<HashMap<String, Object>>() {
+
                 });
-                assertNull(data.get(Fields.TENANT_ID));
+                assertThat(data.get(Fields.TENANT_ID)).isNull();
             }
 
             // Tasks
             if (i == 10 || i == 14) {
-                assertEquals(entry.getType(), FlowableEngineEventType.TASK_CREATED.name());
+                assertThat(FlowableEngineEventType.TASK_CREATED.name()).isEqualTo(entry.getType());
                 Map<String, Object> data = objectMapper.readValue(entry.getData(), new TypeReference<HashMap<String, Object>>() {
+
                 });
-                assertNull(data.get(Fields.TENANT_ID));
+                assertThat(data.get(Fields.TENANT_ID)).isNull();
             }
 
             if (i == 9 || i == 13) {
-                assertEquals(entry.getType(), FlowableEngineEventType.TASK_ASSIGNED.name());
+                assertThat(FlowableEngineEventType.TASK_ASSIGNED.name()).isEqualTo(entry.getType());
                 Map<String, Object> data = objectMapper.readValue(entry.getData(), new TypeReference<HashMap<String, Object>>() {
+
                 });
-                assertNull(data.get(Fields.TENANT_ID));
+                assertThat(data.get(Fields.TENANT_ID)).isNull();
             }
 
         }
@@ -547,14 +571,15 @@ public class DatabaseEventLoggerTest extends PluggableFlowableTestCase {
         taskService.saveTask(task);
 
         List<EventLogEntry> events = managementService.getEventLogEntries(null, null);
-        assertEquals(2, events.size());
-        assertEquals("TASK_ASSIGNED", events.get(0).getType());
-        assertEquals("TASK_CREATED", events.get(1).getType());
+        assertThat(events).hasSize(2);
+        assertThat(events.get(0).getType()).isEqualTo("TASK_ASSIGNED");
+        assertThat(events.get(1).getType()).isEqualTo("TASK_CREATED");
 
         for (EventLogEntry eventLogEntry : events) {
             Map<String, Object> data = objectMapper.readValue(eventLogEntry.getData(), new TypeReference<HashMap<String, Object>>() {
+
             });
-            assertEquals("myTenant", data.get(Fields.TENANT_ID));
+            assertThat(data.get(Fields.TENANT_ID)).isEqualTo("myTenant");
         }
 
         // Cleanup

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/DeploymentEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/DeploymentEventsTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -11,6 +11,8 @@
  * limitations under the License.
  */
 package org.flowable.engine.test.api.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.common.engine.api.delegate.event.FlowableEngineEventType;
 import org.flowable.common.engine.api.delegate.event.FlowableEntityEvent;
@@ -23,7 +25,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for all {@link FlowableEvent}s related to deployments.
- * 
+ *
  * @author Frederik Heremans
  */
 public class DeploymentEventsTest extends PluggableFlowableTestCase {
@@ -39,42 +41,42 @@ public class DeploymentEventsTest extends PluggableFlowableTestCase {
         try {
             listener.clearEventsReceived();
             deployment = repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml").deploy();
-            assertNotNull(deployment);
+            assertThat(deployment).isNotNull();
 
             // Check create-event
-            assertEquals(2, listener.getEventsReceived().size());
-            assertTrue(listener.getEventsReceived().get(0) instanceof FlowableEntityEvent);
+            assertThat(listener.getEventsReceived()).hasSize(2);
+            assertThat(listener.getEventsReceived().get(0)).isInstanceOf(FlowableEntityEvent.class);
 
             FlowableEntityEvent event = (FlowableEntityEvent) listener.getEventsReceived().get(0);
-            assertEquals(FlowableEngineEventType.ENTITY_CREATED, event.getType());
-            assertEquals(deployment.getId(), ((Deployment) event.getEntity()).getId());
+            assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
+            assertThat(((Deployment) event.getEntity()).getId()).isEqualTo(deployment.getId());
 
-            assertTrue(listener.getEventsReceived().get(1) instanceof FlowableEntityEvent);
+            assertThat(listener.getEventsReceived().get(1)).isInstanceOf(FlowableEntityEvent.class);
             event = (FlowableEntityEvent) listener.getEventsReceived().get(1);
-            assertEquals(FlowableEngineEventType.ENTITY_INITIALIZED, event.getType());
-            assertEquals(deployment.getId(), ((Deployment) event.getEntity()).getId());
+            assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_INITIALIZED);
+            assertThat(((Deployment) event.getEntity()).getId()).isEqualTo(deployment.getId());
 
             listener.clearEventsReceived();
 
             // Check update event when category is updated
             repositoryService.setDeploymentCategory(deployment.getId(), "test");
-            assertEquals(1, listener.getEventsReceived().size());
-            assertTrue(listener.getEventsReceived().get(0) instanceof FlowableEntityEvent);
+            assertThat(listener.getEventsReceived()).hasSize(1);
+            assertThat(listener.getEventsReceived().get(0)).isInstanceOf(FlowableEntityEvent.class);
 
             event = (FlowableEntityEvent) listener.getEventsReceived().get(0);
-            assertEquals(FlowableEngineEventType.ENTITY_UPDATED, event.getType());
-            assertEquals(deployment.getId(), ((Deployment) event.getEntity()).getId());
-            assertEquals("test", ((Deployment) event.getEntity()).getCategory());
+            assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_UPDATED);
+            assertThat(((Deployment) event.getEntity()).getId()).isEqualTo(deployment.getId());
+            assertThat(((Deployment) event.getEntity()).getCategory()).isEqualTo("test");
             listener.clearEventsReceived();
 
             // Check delete event when category is updated
             repositoryService.deleteDeployment(deployment.getId(), true);
-            assertEquals(1, listener.getEventsReceived().size());
-            assertTrue(listener.getEventsReceived().get(0) instanceof FlowableEntityEvent);
+            assertThat(listener.getEventsReceived()).hasSize(1);
+            assertThat(listener.getEventsReceived().get(0)).isInstanceOf(FlowableEntityEvent.class);
 
             event = (FlowableEntityEvent) listener.getEventsReceived().get(0);
-            assertEquals(FlowableEngineEventType.ENTITY_DELETED, event.getType());
-            assertEquals(deployment.getId(), ((Deployment) event.getEntity()).getId());
+            assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_DELETED);
+            assertThat(((Deployment) event.getEntity()).getId()).isEqualTo(deployment.getId());
             listener.clearEventsReceived();
 
         } finally {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ErrorThrowingEventListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ErrorThrowingEventListenerTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -11,6 +11,8 @@
  * limitations under the License.
  */
 package org.flowable.engine.test.api.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.common.engine.api.delegate.event.FlowableEngineEventType;
 import org.flowable.common.engine.api.delegate.event.FlowableEvent;
@@ -23,7 +25,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for all {@link FlowableEventListener}s that throws an error BPMN event when an {@link FlowableEvent} has been dispatched.
- * 
+ *
  * @author Frederik Heremans
  */
 public class ErrorThrowingEventListenerTest extends PluggableFlowableTestCase {
@@ -38,18 +40,19 @@ public class ErrorThrowingEventListenerTest extends PluggableFlowableTestCase {
             processEngineConfiguration.getEventDispatcher().addEventListener(listener, FlowableEngineEventType.TASK_ASSIGNED);
 
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testError");
-            assertNotNull(processInstance);
+            assertThat(processInstance).isNotNull();
 
             // Fetch the task and assign it. Should cause error-event to be dispatched
-            org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("userTask").singleResult();
-            assertNotNull(task);
+            org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("userTask")
+                    .singleResult();
+            assertThat(task).isNotNull();
             taskService.setAssignee(task.getId(), "kermit");
 
             // Error-handling should have been called, and "escalate" task
             // should be available instead of original one
             task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("escalatedTask").singleResult();
-            assertNotNull(task);
-            
+            assertThat(task).isNotNull();
+
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         } finally {
@@ -61,19 +64,19 @@ public class ErrorThrowingEventListenerTest extends PluggableFlowableTestCase {
     @Deployment
     public void testThrowErrorDefinedInProcessDefinition() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testError");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         // Fetch the task and assign it. Should cause error-event to be
         // dispatched
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("userTask").singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         taskService.setAssignee(task.getId(), "kermit");
 
         // Error-handling should have been called, and "escalate" task should be
         // available instead of original one
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("escalatedTask").singleResult();
-        assertNotNull(task);
-        
+        assertThat(task).isNotNull();
+
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
     }
 
@@ -88,35 +91,36 @@ public class ErrorThrowingEventListenerTest extends PluggableFlowableTestCase {
             processEngineConfiguration.getEventDispatcher().addEventListener(listener, FlowableEngineEventType.TASK_ASSIGNED);
 
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testError");
-            assertNotNull(processInstance);
+            assertThat(processInstance).isNotNull();
 
             // Fetch the task and assign it. Should cause error-event to be
             // dispatched
-            org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("userTask").singleResult();
-            assertNotNull(task);
+            org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("userTask")
+                    .singleResult();
+            assertThat(task).isNotNull();
             taskService.setAssignee(task.getId(), "kermit");
 
             // Error-handling should have been called, and "escalate" task
             // should be available instead of original one
             task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("escalatedTask").singleResult();
-            assertNotNull(task);
+            assertThat(task).isNotNull();
 
             // Try with a different error-code, resulting in a different task being created
             listener.setErrorCode("456");
 
             processInstance = runtimeService.startProcessInstanceByKey("testError");
-            assertNotNull(processInstance);
+            assertThat(processInstance).isNotNull();
 
             // Fetch the task and assign it. Should cause error-event to be dispatched
             task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("userTask").singleResult();
-            assertNotNull(task);
+            assertThat(task).isNotNull();
             taskService.setAssignee(task.getId(), "kermit");
 
             task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("escalatedTask2").singleResult();
-            assertNotNull(task);
-            
+            assertThat(task).isNotNull();
+
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
-            
+
         } finally {
             processEngineConfiguration.getEventDispatcher().removeEventListener(listener);
         }
@@ -126,18 +130,18 @@ public class ErrorThrowingEventListenerTest extends PluggableFlowableTestCase {
     @Deployment
     public void testThrowErrorWithErrorcodeDefinedInProcessDefinition() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testError");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         // Fetch the task and assign it. Should cause error-event to be dispatched
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("userTask").singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         taskService.setAssignee(task.getId(), "kermit");
 
         // Error-handling should have been called, and "escalate" task should be
         // available instead of original one
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("escalatedTask").singleResult();
-        assertNotNull(task);
-        
+        assertThat(task).isNotNull();
+
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ExecutionEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ExecutionEventsTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -11,6 +11,8 @@
  * limitations under the License.
  */
 package org.flowable.engine.test.api.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.common.engine.api.delegate.event.FlowableEngineEventType;
 import org.flowable.common.engine.api.delegate.event.FlowableEntityEvent;
@@ -25,7 +27,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for all {@link FlowableEvent}s related to executions.
- * 
+ *
  * @author Frederik Heremans
  */
 public class ExecutionEventsTest extends PluggableFlowableTestCase {
@@ -40,53 +42,53 @@ public class ExecutionEventsTest extends PluggableFlowableTestCase {
     public void testExecutionEvents() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         // Check create-event
-        assertEquals(6, listener.getEventsReceived().size());
-        assertTrue(listener.getEventsReceived().get(0) instanceof FlowableEntityEvent);
+        assertThat(listener.getEventsReceived()).hasSize(6);
+        assertThat(listener.getEventsReceived().get(0)).isInstanceOf(FlowableEntityEvent.class);
 
         FlowableEntityEvent event = (FlowableEntityEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ENTITY_CREATED, event.getType());
-        assertEquals(processInstance.getId(), ((Execution) event.getEntity()).getProcessInstanceId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
+        assertThat(((Execution) event.getEntity()).getProcessInstanceId()).isEqualTo(processInstance.getId());
 
         event = (FlowableEntityEvent) listener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.PROCESS_CREATED, event.getType());
-        assertEquals(processInstance.getId(), ((Execution) event.getEntity()).getProcessInstanceId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.PROCESS_CREATED);
+        assertThat(((Execution) event.getEntity()).getProcessInstanceId()).isEqualTo(processInstance.getId());
 
         event = (FlowableEntityEvent) listener.getEventsReceived().get(2);
-        assertEquals(FlowableEngineEventType.ENTITY_INITIALIZED, event.getType());
-        assertEquals(processInstance.getId(), ((Execution) event.getEntity()).getProcessInstanceId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_INITIALIZED);
+        assertThat(((Execution) event.getEntity()).getProcessInstanceId()).isEqualTo(processInstance.getId());
 
         event = (FlowableEntityEvent) listener.getEventsReceived().get(3);
-        assertEquals(FlowableEngineEventType.ENTITY_CREATED, event.getType());
-        assertEquals(processInstance.getId(), ((Execution) event.getEntity()).getProcessInstanceId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
+        assertThat(((Execution) event.getEntity()).getProcessInstanceId()).isEqualTo(processInstance.getId());
 
         event = (FlowableEntityEvent) listener.getEventsReceived().get(4);
-        assertEquals(FlowableEngineEventType.ENTITY_INITIALIZED, event.getType());
-        assertEquals(processInstance.getId(), ((Execution) event.getEntity()).getProcessInstanceId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_INITIALIZED);
+        assertThat(((Execution) event.getEntity()).getProcessInstanceId()).isEqualTo(processInstance.getId());
         listener.clearEventsReceived();
 
         // Check update event when suspended/activated
         runtimeService.suspendProcessInstanceById(processInstance.getId());
         runtimeService.activateProcessInstanceById(processInstance.getId());
 
-        assertEquals(4, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(4);
         event = (FlowableEntityEvent) listener.getEventsReceived().get(0);
-        assertEquals(processInstance.getId(), ((Execution) event.getEntity()).getProcessInstanceId());
-        assertEquals(FlowableEngineEventType.ENTITY_SUSPENDED, event.getType());
+        assertThat(((Execution) event.getEntity()).getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_SUSPENDED);
 
         event = (FlowableEntityEvent) listener.getEventsReceived().get(1);
-        assertEquals(processInstance.getId(), ((Execution) event.getEntity()).getProcessInstanceId());
-        assertEquals(FlowableEngineEventType.ENTITY_SUSPENDED, event.getType());
+        assertThat(((Execution) event.getEntity()).getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_SUSPENDED);
 
         event = (FlowableEntityEvent) listener.getEventsReceived().get(2);
-        assertEquals(FlowableEngineEventType.ENTITY_ACTIVATED, event.getType());
-        assertEquals(processInstance.getId(), ((Execution) event.getEntity()).getProcessInstanceId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_ACTIVATED);
+        assertThat(((Execution) event.getEntity()).getProcessInstanceId()).isEqualTo(processInstance.getId());
 
         event = (FlowableEntityEvent) listener.getEventsReceived().get(3);
-        assertEquals(FlowableEngineEventType.ENTITY_ACTIVATED, event.getType());
-        assertEquals(processInstance.getId(), ((Execution) event.getEntity()).getProcessInstanceId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_ACTIVATED);
+        assertThat(((Execution) event.getEntity()).getProcessInstanceId()).isEqualTo(processInstance.getId());
 
         listener.clearEventsReceived();
 
@@ -95,39 +97,39 @@ public class ExecutionEventsTest extends PluggableFlowableTestCase {
         repositoryService.suspendProcessDefinitionById(processInstance.getProcessDefinitionId(), true, null);
         repositoryService.activateProcessDefinitionById(processInstance.getProcessDefinitionId(), true, null);
 
-        assertEquals(4, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(4);
 
         event = (FlowableEntityEvent) listener.getEventsReceived().get(0);
-        assertEquals(processInstance.getId(), ((Execution) event.getEntity()).getProcessInstanceId());
-        assertEquals(FlowableEngineEventType.ENTITY_SUSPENDED, event.getType());
+        assertThat(((Execution) event.getEntity()).getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_SUSPENDED);
 
         event = (FlowableEntityEvent) listener.getEventsReceived().get(1);
-        assertEquals(processInstance.getId(), ((Execution) event.getEntity()).getProcessInstanceId());
-        assertEquals(FlowableEngineEventType.ENTITY_SUSPENDED, event.getType());
+        assertThat(((Execution) event.getEntity()).getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_SUSPENDED);
 
         event = (FlowableEntityEvent) listener.getEventsReceived().get(2);
-        assertEquals(FlowableEngineEventType.ENTITY_ACTIVATED, event.getType());
-        assertEquals(processInstance.getId(), ((Execution) event.getEntity()).getProcessInstanceId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_ACTIVATED);
+        assertThat(((Execution) event.getEntity()).getProcessInstanceId()).isEqualTo(processInstance.getId());
 
         event = (FlowableEntityEvent) listener.getEventsReceived().get(3);
-        assertEquals(FlowableEngineEventType.ENTITY_ACTIVATED, event.getType());
-        assertEquals(processInstance.getId(), ((Execution) event.getEntity()).getProcessInstanceId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_ACTIVATED);
+        assertThat(((Execution) event.getEntity()).getProcessInstanceId()).isEqualTo(processInstance.getId());
 
         listener.clearEventsReceived();
 
         // Check update-event when business-key is updated
         runtimeService.updateBusinessKey(processInstance.getId(), "thekey");
-        assertEquals(1, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(1);
         event = (FlowableEntityEvent) listener.getEventsReceived().get(0);
-        assertEquals(processInstance.getId(), ((Execution) event.getEntity()).getId());
-        assertEquals(FlowableEngineEventType.ENTITY_UPDATED, event.getType());
+        assertThat(((Execution) event.getEntity()).getId()).isEqualTo(processInstance.getId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_UPDATED);
         listener.clearEventsReceived();
 
         runtimeService.deleteProcessInstance(processInstance.getId(), "Testing events");
 
         event = (FlowableEntityEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ENTITY_DELETED, event.getType());
-        assertEquals(processInstance.getId(), ((Execution) event.getEntity()).getProcessInstanceId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_DELETED);
+        assertThat(((Execution) event.getEntity()).getProcessInstanceId()).isEqualTo(processInstance.getId());
         listener.clearEventsReceived();
     }
 


### PR DESCRIPTION
Working on the `org.flowable.engine.test.api.event` package.

Continuing quest to use only a single style in each file and in the module.

