### PR TITLE
Use assertj fluent style in flowable-engine.  Part 2

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/FlowableEventDispatcherTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/FlowableEventDispatcherTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,8 +18,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import org.flowable.common.engine.api.FlowableIllegalArgumentException;
 import org.flowable.common.engine.api.delegate.event.FlowableEngineEventType;
 import org.flowable.common.engine.api.delegate.event.FlowableEventDispatcher;
-import org.flowable.common.engine.impl.event.FlowableEventDispatcherImpl;
 import org.flowable.common.engine.impl.event.FlowableEngineEventImpl;
+import org.flowable.common.engine.impl.event.FlowableEventDispatcherImpl;
 import org.flowable.common.engine.impl.interceptor.EngineConfigurationConstants;
 import org.flowable.engine.delegate.event.BaseEntityEventListener;
 import org.flowable.engine.delegate.event.impl.FlowableEntityEventImpl;
@@ -32,7 +32,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * 
  * @author Frederik Heremans
  */
 public class FlowableEventDispatcherTest extends PluggableFlowableTestCase {
@@ -56,17 +55,20 @@ public class FlowableEventDispatcherTest extends PluggableFlowableTestCase {
         // Add event-listener to dispatcher
         dispatcher.addEventListener(newListener);
 
-        TaskServiceConfiguration taskServiceConfiguration = (TaskServiceConfiguration) processEngineConfiguration.getServiceConfigurations().get(EngineConfigurationConstants.KEY_TASK_SERVICE_CONFIG);
-        FlowableEntityEventImpl event1 = new FlowableEntityEventImpl(taskServiceConfiguration.getTaskEntityManager().create(), FlowableEngineEventType.ENTITY_CREATED);
-        FlowableEntityEventImpl event2 = new FlowableEntityEventImpl(taskServiceConfiguration.getTaskEntityManager().create(), FlowableEngineEventType.ENTITY_CREATED);
+        TaskServiceConfiguration taskServiceConfiguration = (TaskServiceConfiguration) processEngineConfiguration.getServiceConfigurations()
+                .get(EngineConfigurationConstants.KEY_TASK_SERVICE_CONFIG);
+        FlowableEntityEventImpl event1 = new FlowableEntityEventImpl(taskServiceConfiguration.getTaskEntityManager().create(),
+                FlowableEngineEventType.ENTITY_CREATED);
+        FlowableEntityEventImpl event2 = new FlowableEntityEventImpl(taskServiceConfiguration.getTaskEntityManager().create(),
+                FlowableEngineEventType.ENTITY_CREATED);
 
         // Dispatch events
         dispatcher.dispatchEvent(event1);
         dispatcher.dispatchEvent(event2);
 
-        assertEquals(2, newListener.getEventsReceived().size());
-        assertEquals(event1, newListener.getEventsReceived().get(0));
-        assertEquals(event2, newListener.getEventsReceived().get(1));
+        assertThat(newListener.getEventsReceived()).hasSize(2);
+        assertThat(newListener.getEventsReceived().get(0)).isEqualTo(event1);
+        assertThat(newListener.getEventsReceived().get(1)).isEqualTo(event2);
 
         // Remove listener and dispatch events again, listener should not be
         // invoked
@@ -75,7 +77,7 @@ public class FlowableEventDispatcherTest extends PluggableFlowableTestCase {
         dispatcher.dispatchEvent(event1);
         dispatcher.dispatchEvent(event2);
 
-        assertTrue(newListener.getEventsReceived().isEmpty());
+        assertThat(newListener.getEventsReceived()).isEmpty();
     }
 
     /**
@@ -89,19 +91,23 @@ public class FlowableEventDispatcherTest extends PluggableFlowableTestCase {
         // Add event-listener to dispatcher
         dispatcher.addEventListener(newListener, FlowableEngineEventType.ENTITY_CREATED, FlowableEngineEventType.ENTITY_DELETED);
 
-        TaskServiceConfiguration taskServiceConfiguration = (TaskServiceConfiguration) processEngineConfiguration.getServiceConfigurations().get(EngineConfigurationConstants.KEY_TASK_SERVICE_CONFIG);
-        FlowableEntityEventImpl event1 = new FlowableEntityEventImpl(taskServiceConfiguration.getTaskEntityManager().create(), FlowableEngineEventType.ENTITY_CREATED);
-        FlowableEntityEventImpl event2 = new FlowableEntityEventImpl(taskServiceConfiguration.getTaskEntityManager().create(), FlowableEngineEventType.ENTITY_DELETED);
-        FlowableEntityEventImpl event3 = new FlowableEntityEventImpl(taskServiceConfiguration.getTaskEntityManager().create(), FlowableEngineEventType.ENTITY_UPDATED);
+        TaskServiceConfiguration taskServiceConfiguration = (TaskServiceConfiguration) processEngineConfiguration.getServiceConfigurations()
+                .get(EngineConfigurationConstants.KEY_TASK_SERVICE_CONFIG);
+        FlowableEntityEventImpl event1 = new FlowableEntityEventImpl(taskServiceConfiguration.getTaskEntityManager().create(),
+                FlowableEngineEventType.ENTITY_CREATED);
+        FlowableEntityEventImpl event2 = new FlowableEntityEventImpl(taskServiceConfiguration.getTaskEntityManager().create(),
+                FlowableEngineEventType.ENTITY_DELETED);
+        FlowableEntityEventImpl event3 = new FlowableEntityEventImpl(taskServiceConfiguration.getTaskEntityManager().create(),
+                FlowableEngineEventType.ENTITY_UPDATED);
 
         // Dispatch events, only 2 out of 3 should have entered the listener
         dispatcher.dispatchEvent(event1);
         dispatcher.dispatchEvent(event2);
         dispatcher.dispatchEvent(event3);
 
-        assertEquals(2, newListener.getEventsReceived().size());
-        assertEquals(event1, newListener.getEventsReceived().get(0));
-        assertEquals(event2, newListener.getEventsReceived().get(1));
+        assertThat(newListener.getEventsReceived()).hasSize(2);
+        assertThat(newListener.getEventsReceived().get(0)).isEqualTo(event1);
+        assertThat(newListener.getEventsReceived().get(1)).isEqualTo(event2);
 
         // Remove listener and dispatch events again, listener should not be
         // invoked
@@ -110,7 +116,7 @@ public class FlowableEventDispatcherTest extends PluggableFlowableTestCase {
         dispatcher.dispatchEvent(event1);
         dispatcher.dispatchEvent(event2);
 
-        assertTrue(newListener.getEventsReceived().isEmpty());
+        assertThat(newListener.getEventsReceived()).isEmpty();
     }
 
     /**
@@ -125,15 +131,18 @@ public class FlowableEventDispatcherTest extends PluggableFlowableTestCase {
         // Add event-listener to dispatcher
         dispatcher.addEventListener(newListener, (FlowableEngineEventType) null);
 
-        TaskServiceConfiguration taskServiceConfiguration = (TaskServiceConfiguration) processEngineConfiguration.getServiceConfigurations().get(EngineConfigurationConstants.KEY_TASK_SERVICE_CONFIG);
-        FlowableEntityEventImpl event1 = new FlowableEntityEventImpl(taskServiceConfiguration.getTaskEntityManager().create(), FlowableEngineEventType.ENTITY_CREATED);
-        FlowableEntityEventImpl event2 = new FlowableEntityEventImpl(taskServiceConfiguration.getTaskEntityManager().create(), FlowableEngineEventType.ENTITY_DELETED);
+        TaskServiceConfiguration taskServiceConfiguration = (TaskServiceConfiguration) processEngineConfiguration.getServiceConfigurations()
+                .get(EngineConfigurationConstants.KEY_TASK_SERVICE_CONFIG);
+        FlowableEntityEventImpl event1 = new FlowableEntityEventImpl(taskServiceConfiguration.getTaskEntityManager().create(),
+                FlowableEngineEventType.ENTITY_CREATED);
+        FlowableEntityEventImpl event2 = new FlowableEntityEventImpl(taskServiceConfiguration.getTaskEntityManager().create(),
+                FlowableEngineEventType.ENTITY_DELETED);
 
         // Dispatch events, all should have entered the listener
         dispatcher.dispatchEvent(event1);
         dispatcher.dispatchEvent(event2);
 
-        assertTrue(newListener.getEventsReceived().isEmpty());
+        assertThat(newListener.getEventsReceived()).isEmpty();
     }
 
     /**
@@ -145,43 +154,48 @@ public class FlowableEventDispatcherTest extends PluggableFlowableTestCase {
 
         dispatcher.addEventListener(listener);
 
-        TaskServiceConfiguration taskServiceConfiguration = (TaskServiceConfiguration) processEngineConfiguration.getServiceConfigurations().get(EngineConfigurationConstants.KEY_TASK_SERVICE_CONFIG);
-        FlowableEntityEventImpl createEvent = new FlowableEntityEventImpl(taskServiceConfiguration.getTaskEntityManager().create(), FlowableEngineEventType.ENTITY_CREATED);
-        FlowableEntityEventImpl deleteEvent = new FlowableEntityEventImpl(taskServiceConfiguration.getTaskEntityManager().create(), FlowableEngineEventType.ENTITY_DELETED);
-        FlowableEntityEventImpl updateEvent = new FlowableEntityEventImpl(taskServiceConfiguration.getTaskEntityManager().create(), FlowableEngineEventType.ENTITY_UPDATED);
-        FlowableEntityEventImpl otherEvent = new FlowableEntityEventImpl(taskServiceConfiguration.getTaskEntityManager().create(), FlowableEngineEventType.CUSTOM);
+        TaskServiceConfiguration taskServiceConfiguration = (TaskServiceConfiguration) processEngineConfiguration.getServiceConfigurations()
+                .get(EngineConfigurationConstants.KEY_TASK_SERVICE_CONFIG);
+        FlowableEntityEventImpl createEvent = new FlowableEntityEventImpl(taskServiceConfiguration.getTaskEntityManager().create(),
+                FlowableEngineEventType.ENTITY_CREATED);
+        FlowableEntityEventImpl deleteEvent = new FlowableEntityEventImpl(taskServiceConfiguration.getTaskEntityManager().create(),
+                FlowableEngineEventType.ENTITY_DELETED);
+        FlowableEntityEventImpl updateEvent = new FlowableEntityEventImpl(taskServiceConfiguration.getTaskEntityManager().create(),
+                FlowableEngineEventType.ENTITY_UPDATED);
+        FlowableEntityEventImpl otherEvent = new FlowableEntityEventImpl(taskServiceConfiguration.getTaskEntityManager().create(),
+                FlowableEngineEventType.CUSTOM);
 
         // Dispatch create event
         dispatcher.dispatchEvent(createEvent);
-        assertTrue(listener.isCreateReceived());
-        assertFalse(listener.isUpdateReceived());
-        assertFalse(listener.isCustomReceived());
-        assertFalse(listener.isInitializeReceived());
-        assertFalse(listener.isDeleteReceived());
+        assertThat(listener.isCreateReceived()).isTrue();
+        assertThat(listener.isUpdateReceived()).isFalse();
+        assertThat(listener.isCustomReceived()).isFalse();
+        assertThat(listener.isInitializeReceived()).isFalse();
+        assertThat(listener.isDeleteReceived()).isFalse();
         listener.reset();
 
         // Dispatch update event
         dispatcher.dispatchEvent(updateEvent);
-        assertTrue(listener.isUpdateReceived());
-        assertFalse(listener.isCreateReceived());
-        assertFalse(listener.isCustomReceived());
-        assertFalse(listener.isDeleteReceived());
+        assertThat(listener.isUpdateReceived()).isTrue();
+        assertThat(listener.isCreateReceived()).isFalse();
+        assertThat(listener.isCustomReceived()).isFalse();
+        assertThat(listener.isDeleteReceived()).isFalse();
         listener.reset();
 
         // Dispatch delete event
         dispatcher.dispatchEvent(deleteEvent);
-        assertTrue(listener.isDeleteReceived());
-        assertFalse(listener.isCreateReceived());
-        assertFalse(listener.isCustomReceived());
-        assertFalse(listener.isUpdateReceived());
+        assertThat(listener.isDeleteReceived()).isTrue();
+        assertThat(listener.isCreateReceived()).isFalse();
+        assertThat(listener.isCustomReceived()).isFalse();
+        assertThat(listener.isUpdateReceived()).isFalse();
         listener.reset();
 
         // Dispatch other event
         dispatcher.dispatchEvent(otherEvent);
-        assertTrue(listener.isCustomReceived());
-        assertFalse(listener.isCreateReceived());
-        assertFalse(listener.isUpdateReceived());
-        assertFalse(listener.isDeleteReceived());
+        assertThat(listener.isCustomReceived()).isTrue();
+        assertThat(listener.isCreateReceived()).isFalse();
+        assertThat(listener.isUpdateReceived()).isFalse();
+        assertThat(listener.isDeleteReceived()).isFalse();
         listener.reset();
 
         // Test typed entity-listener
@@ -191,14 +205,14 @@ public class FlowableEventDispatcherTest extends PluggableFlowableTestCase {
         dispatcher.addEventListener(listener);
         dispatcher.dispatchEvent(createEvent);
 
-        assertTrue(listener.isCreateReceived());
+        assertThat(listener.isCreateReceived()).isTrue();
         listener.reset();
 
         // Dispatch event for a execution, should NOT be received
         FlowableEntityEventImpl createEventForExecution = new FlowableEntityEventImpl(new ExecutionEntityImpl(), FlowableEngineEventType.ENTITY_CREATED);
 
         dispatcher.dispatchEvent(createEventForExecution);
-        assertFalse(listener.isCreateReceived());
+        assertThat(listener.isCreateReceived()).isFalse();
     }
 
     /**
@@ -216,7 +230,7 @@ public class FlowableEventDispatcherTest extends PluggableFlowableTestCase {
         FlowableEngineEventImpl event = new FlowableProcessEventImpl(FlowableEngineEventType.ENTITY_CREATED);
         try {
             dispatcher.dispatchEvent(event);
-            assertEquals(1, secondListener.getEventsReceived().size());
+            assertThat(secondListener.getEventsReceived()).hasSize(1);
         } catch (Throwable t) {
             fail("No exception expected");
         }
@@ -232,8 +246,8 @@ public class FlowableEventDispatcherTest extends PluggableFlowableTestCase {
         dispatcher.addEventListener(secondListener);
 
         assertThatThrownBy(() -> dispatcher.dispatchEvent(event))
-            .isExactlyInstanceOf(RuntimeException.class)
-            .hasMessage("Test exception");
+                .isExactlyInstanceOf(RuntimeException.class)
+                .hasMessage("Test exception");
 
         // Second listener should NOT have been called
         assertThat(secondListener.getEventsReceived()).isEmpty();
@@ -247,41 +261,37 @@ public class FlowableEventDispatcherTest extends PluggableFlowableTestCase {
     public void testActivitiEventTypeParsing() throws Exception {
         // Check with empty null
         FlowableEngineEventType[] types = FlowableEngineEventType.getTypesFromString(null);
-        assertNotNull(types);
-        assertEquals(0, types.length);
+        assertThat(types).isNotNull();
+        assertThat(types.length).isEqualTo(0);
 
         // Check with empty string
         types = FlowableEngineEventType.getTypesFromString("");
-        assertNotNull(types);
-        assertEquals(0, types.length);
+        assertThat(types).isNotNull();
+        assertThat(types.length).isEqualTo(0);
 
         // Single value
         types = FlowableEngineEventType.getTypesFromString("ENTITY_CREATED");
-        assertNotNull(types);
-        assertEquals(1, types.length);
-        assertEquals(FlowableEngineEventType.ENTITY_CREATED, types[0]);
+        assertThat(types).isNotNull();
+        assertThat(types.length).isEqualTo(1);
+        assertThat(types[0]).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
 
         // Multiple value
         types = FlowableEngineEventType.getTypesFromString("ENTITY_CREATED,ENTITY_DELETED");
-        assertNotNull(types);
-        assertEquals(2, types.length);
-        assertEquals(FlowableEngineEventType.ENTITY_CREATED, types[0]);
-        assertEquals(FlowableEngineEventType.ENTITY_DELETED, types[1]);
+        assertThat(types).isNotNull();
+        assertThat(types.length).isEqualTo(2);
+        assertThat(types[0]).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
+        assertThat(types[1]).isEqualTo(FlowableEngineEventType.ENTITY_DELETED);
 
         // Additional separators should be ignored
         types = FlowableEngineEventType.getTypesFromString(",ENTITY_CREATED,,ENTITY_DELETED,,,");
-        assertNotNull(types);
-        assertEquals(2, types.length);
-        assertEquals(FlowableEngineEventType.ENTITY_CREATED, types[0]);
-        assertEquals(FlowableEngineEventType.ENTITY_DELETED, types[1]);
+        assertThat(types).isNotNull();
+        assertThat(types.length).isEqualTo(2);
+        assertThat(types[0]).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
+        assertThat(types[1]).isEqualTo(FlowableEngineEventType.ENTITY_DELETED);
 
         // Invalid type name
-        try {
-            FlowableEngineEventType.getTypesFromString("WHOOPS,ENTITY_DELETED");
-            fail("Exception expected");
-        } catch (FlowableIllegalArgumentException expected) {
-            // Expected exception
-            assertEquals("Invalid event-type: WHOOPS", expected.getMessage());
-        }
+        assertThatThrownBy(() -> FlowableEngineEventType.getTypesFromString("WHOOPS,ENTITY_DELETED"))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage("Invalid event-type: WHOOPS");
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/FlowableProcessTerminatedEventImplTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/FlowableProcessTerminatedEventImplTest.java
@@ -12,12 +12,10 @@
  */
 package org.flowable.engine.test.api.event;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
+import org.flowable.common.engine.api.FlowableException;
 import org.flowable.engine.delegate.event.impl.FlowableProcessTerminatedEventImpl;
 import org.flowable.engine.impl.persistence.entity.ExecutionEntity;
 import org.junit.jupiter.api.Test;
@@ -35,13 +33,8 @@ public class FlowableProcessTerminatedEventImplTest {
         when(execution.isProcessInstanceType()).thenReturn(false);
 
         // Act
-        try {
-            new FlowableProcessTerminatedEventImpl(execution, null);
-            fail("Expected exception was not thrown.");
-        } catch(Exception e) {
-            // Assert
-            assertThat(e, instanceOf(RuntimeException.class));
-            assertThat(e.getMessage(), containsString("is not a processInstance"));
-        }
+        assertThatThrownBy(() -> new FlowableProcessTerminatedEventImpl(execution, null))
+                .isExactlyInstanceOf(FlowableException.class)
+                .hasMessageContaining("is not a processInstance");
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/GroupEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/GroupEventsTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -11,6 +11,8 @@
  * limitations under the License.
  */
 package org.flowable.engine.test.api.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.common.engine.api.delegate.event.FlowableEntityEvent;
 import org.flowable.common.engine.api.delegate.event.FlowableEvent;
@@ -25,7 +27,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for all {@link FlowableEvent}s related to groups.
- * 
+ *
  * @author Frederik Heremans
  */
 public class GroupEventsTest extends PluggableFlowableTestCase {
@@ -44,38 +46,38 @@ public class GroupEventsTest extends PluggableFlowableTestCase {
             group.setType("type");
             identityService.saveGroup(group);
 
-            assertEquals(2, listener.getEventsReceived().size());
+            assertThat(listener.getEventsReceived()).hasSize(2);
             FlowableEntityEvent event = (FlowableEntityEvent) listener.getEventsReceived().get(0);
-            assertEquals(FlowableIdmEventType.ENTITY_CREATED, event.getType());
-            assertTrue(event.getEntity() instanceof Group);
+            assertThat(event.getType()).isEqualTo(FlowableIdmEventType.ENTITY_CREATED);
+            assertThat(event.getEntity()).isInstanceOf(Group.class);
             Group groupFromEvent = (Group) event.getEntity();
-            assertEquals("fred", groupFromEvent.getId());
+            assertThat(groupFromEvent.getId()).isEqualTo("fred");
 
             event = (FlowableEntityEvent) listener.getEventsReceived().get(1);
-            assertEquals(FlowableIdmEventType.ENTITY_INITIALIZED, event.getType());
+            assertThat(event.getType()).isEqualTo(FlowableIdmEventType.ENTITY_INITIALIZED);
             listener.clearEventsReceived();
 
             // Update Group
             group.setName("Another name");
             identityService.saveGroup(group);
-            assertEquals(1, listener.getEventsReceived().size());
+            assertThat(listener.getEventsReceived()).hasSize(1);
             event = (FlowableEntityEvent) listener.getEventsReceived().get(0);
-            assertEquals(FlowableIdmEventType.ENTITY_UPDATED, event.getType());
-            assertTrue(event.getEntity() instanceof Group);
+            assertThat(event.getType()).isEqualTo(FlowableIdmEventType.ENTITY_UPDATED);
+            assertThat(event.getEntity()).isInstanceOf(Group.class);
             groupFromEvent = (Group) event.getEntity();
-            assertEquals("fred", groupFromEvent.getId());
-            assertEquals("Another name", groupFromEvent.getName());
+            assertThat(groupFromEvent.getId()).isEqualTo("fred");
+            assertThat(groupFromEvent.getName()).isEqualTo("Another name");
             listener.clearEventsReceived();
 
             // Delete Group
             identityService.deleteGroup(group.getId());
 
-            assertEquals(1, listener.getEventsReceived().size());
+            assertThat(listener.getEventsReceived()).hasSize(1);
             event = (FlowableEntityEvent) listener.getEventsReceived().get(0);
-            assertEquals(FlowableIdmEventType.ENTITY_DELETED, event.getType());
-            assertTrue(event.getEntity() instanceof Group);
+            assertThat(event.getType()).isEqualTo(FlowableIdmEventType.ENTITY_DELETED);
+            assertThat(event.getEntity()).isInstanceOf(Group.class);
             groupFromEvent = (Group) event.getEntity();
-            assertEquals("fred", groupFromEvent.getId());
+            assertThat(groupFromEvent.getId()).isEqualTo("fred");
             listener.clearEventsReceived();
 
         } finally {
@@ -105,22 +107,22 @@ public class GroupEventsTest extends PluggableFlowableTestCase {
             // Add membership
             membershipListener.clearEventsReceived();
             identityService.createMembership("kermit", "sales");
-            assertEquals(1, membershipListener.getEventsReceived().size());
-            assertTrue(membershipListener.getEventsReceived().get(0) instanceof FlowableIdmMembershipEvent);
+            assertThat(membershipListener.getEventsReceived()).hasSize(1);
+            assertThat(membershipListener.getEventsReceived().get(0)).isInstanceOf(FlowableIdmMembershipEvent.class);
             FlowableIdmMembershipEvent event = (FlowableIdmMembershipEvent) membershipListener.getEventsReceived().get(0);
-            assertEquals(FlowableIdmEventType.MEMBERSHIP_CREATED, event.getType());
-            assertEquals("sales", event.getGroupId());
-            assertEquals("kermit", event.getUserId());
+            assertThat(event.getType()).isEqualTo(FlowableIdmEventType.MEMBERSHIP_CREATED);
+            assertThat(event.getGroupId()).isEqualTo("sales");
+            assertThat(event.getUserId()).isEqualTo("kermit");
             membershipListener.clearEventsReceived();
 
             // Delete membership
             identityService.deleteMembership("kermit", "sales");
-            assertEquals(1, membershipListener.getEventsReceived().size());
-            assertTrue(membershipListener.getEventsReceived().get(0) instanceof FlowableIdmMembershipEvent);
+            assertThat(membershipListener.getEventsReceived()).hasSize(1);
+            assertThat(membershipListener.getEventsReceived().get(0)).isInstanceOf(FlowableIdmMembershipEvent.class);
             event = (FlowableIdmMembershipEvent) membershipListener.getEventsReceived().get(0);
-            assertEquals(FlowableIdmEventType.MEMBERSHIP_DELETED, event.getType());
-            assertEquals("sales", event.getGroupId());
-            assertEquals("kermit", event.getUserId());
+            assertThat(event.getType()).isEqualTo(FlowableIdmEventType.MEMBERSHIP_DELETED);
+            assertThat(event.getGroupId()).isEqualTo("sales");
+            assertThat(event.getUserId()).isEqualTo("kermit");
             membershipListener.clearEventsReceived();
 
             // Deleting group will dispatch an event, informing ALL memberships are deleted
@@ -128,12 +130,12 @@ public class GroupEventsTest extends PluggableFlowableTestCase {
             membershipListener.clearEventsReceived();
             identityService.deleteGroup(group.getId());
 
-            assertEquals(2, membershipListener.getEventsReceived().size());
-            assertTrue(membershipListener.getEventsReceived().get(0) instanceof FlowableIdmMembershipEvent);
+            assertThat(membershipListener.getEventsReceived()).hasSize(2);
+            assertThat(membershipListener.getEventsReceived().get(0)).isInstanceOf(FlowableIdmMembershipEvent.class);
             event = (FlowableIdmMembershipEvent) membershipListener.getEventsReceived().get(0);
-            assertEquals(FlowableIdmEventType.MEMBERSHIPS_DELETED, event.getType());
-            assertEquals("sales", event.getGroupId());
-            assertNull(event.getUserId());
+            assertThat(event.getType()).isEqualTo(FlowableIdmEventType.MEMBERSHIPS_DELETED);
+            assertThat(event.getGroupId()).isEqualTo("sales");
+            assertThat(event.getUserId()).isNull();
             membershipListener.clearEventsReceived();
         } finally {
             processEngineConfiguration.getEventDispatcher().removeEventListener(membershipListener);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/HistoricActivityEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/HistoricActivityEventsTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -11,6 +11,8 @@
  * limitations under the License.
  */
 package org.flowable.engine.test.api.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
@@ -29,7 +31,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for all {@link FlowableEvent}s related to activities.
- * 
+ *
  * @author Frederik Heremans
  * @author Joram Barrez
  */
@@ -62,16 +64,16 @@ public class HistoricActivityEventsTest extends PluggableFlowableTestCase {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
 
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("TestActivityEvents");
-            assertNotNull(processInstance);
+            assertThat(processInstance).isNotNull();
 
             for (int i = 0; i < 2; i++) {
                 taskService.complete(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getId());
             }
 
             List<FlowableEvent> events = listener.getEventsReceived();
-            
+
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
-            
+
             int processInstanceCreated = 0;
             int mainStartActivityStarted = 0;
             int mainStartActivityEnded = 0;
@@ -93,85 +95,85 @@ public class HistoricActivityEventsTest extends PluggableFlowableTestCase {
             for (FlowableEvent flowableEvent : events) {
                 if (FlowableEngineEventType.HISTORIC_PROCESS_INSTANCE_CREATED == flowableEvent.getType()) {
                     processInstanceCreated++;
-                
+
                 } else if (FlowableEngineEventType.HISTORIC_ACTIVITY_INSTANCE_CREATED == flowableEvent.getType()) {
                     FlowableEntityEvent flowableEntityEvent = (FlowableEntityEvent) flowableEvent;
                     HistoricActivityInstance historicActivityInstance = (HistoricActivityInstance) flowableEntityEvent.getEntity();
                     if ("mainStart".equals(historicActivityInstance.getActivityId())) {
                         mainStartActivityStarted++;
-                        
+
                     } else if ("subProcess".equals(historicActivityInstance.getActivityId())) {
                         subProcessActivityStarted++;
-                    
+
                     } else if ("subProcessStart".equals(historicActivityInstance.getActivityId())) {
                         subProcessStartActivityStarted++;
-                    
+
                     } else if ("a".equals(historicActivityInstance.getActivityId())) {
                         aActivityStarted++;
-                    
+
                     } else if ("b".equals(historicActivityInstance.getActivityId())) {
                         bActivityStarted++;
-                    
+
                     } else if ("subprocessEnd".equals(historicActivityInstance.getActivityId())) {
                         subProcessEndActivityStarted++;
-                        
+
                     } else if ("mainEnd".equals(historicActivityInstance.getActivityId())) {
                         mainEndActivityStarted++;
                     }
-                    
+
                 } else if (FlowableEngineEventType.HISTORIC_ACTIVITY_INSTANCE_ENDED == flowableEvent.getType()) {
                     FlowableEntityEvent flowableEntityEvent = (FlowableEntityEvent) flowableEvent;
                     HistoricActivityInstance historicActivityInstance = (HistoricActivityInstance) flowableEntityEvent.getEntity();
                     if ("mainStart".equals(historicActivityInstance.getActivityId())) {
-                        assertNotNull(historicActivityInstance.getEndTime());
+                        assertThat(historicActivityInstance.getEndTime()).isNotNull();
                         mainStartActivityEnded++;
-                    
+
                     } else if ("subProcess".equals(historicActivityInstance.getActivityId())) {
-                        assertNotNull(historicActivityInstance.getEndTime());
+                        assertThat(historicActivityInstance.getEndTime()).isNotNull();
                         subProcessActivityEnded++;
-                    
+
                     } else if ("subProcessStart".equals(historicActivityInstance.getActivityId())) {
-                        assertNotNull(historicActivityInstance.getEndTime());
+                        assertThat(historicActivityInstance.getEndTime()).isNotNull();
                         subProcessStartActivityEnded++;
-                    
+
                     } else if ("a".equals(historicActivityInstance.getActivityId())) {
-                        assertNotNull(historicActivityInstance.getEndTime());
+                        assertThat(historicActivityInstance.getEndTime()).isNotNull();
                         aActivityEnded++;
-                    
+
                     } else if ("b".equals(historicActivityInstance.getActivityId())) {
-                        assertNotNull(historicActivityInstance.getEndTime());
+                        assertThat(historicActivityInstance.getEndTime()).isNotNull();
                         bActivityEnded++;
-                    
+
                     } else if ("subprocessEnd".equals(historicActivityInstance.getActivityId())) {
-                        assertNotNull(historicActivityInstance.getEndTime());
+                        assertThat(historicActivityInstance.getEndTime()).isNotNull();
                         subProcessEndActivityEnded++;
-                    
+
                     } else if ("mainEnd".equals(historicActivityInstance.getActivityId())) {
-                        assertNotNull(historicActivityInstance.getEndTime());
+                        assertThat(historicActivityInstance.getEndTime()).isNotNull();
                         mainEndActivityEnded++;
                     }
-                    
+
                 } else if (FlowableEngineEventType.HISTORIC_PROCESS_INSTANCE_ENDED == flowableEvent.getType()) {
                     processInstanceEnded++;
                 }
             }
-            
-            assertEquals(1, processInstanceCreated);
-            assertEquals(1, mainStartActivityStarted);
-            assertEquals(1, mainStartActivityEnded);
-            assertEquals(1, subProcessActivityStarted);
-            assertEquals(1, subProcessActivityEnded);
-            assertEquals(1, subProcessStartActivityStarted);
-            assertEquals(1, subProcessStartActivityEnded);
-            assertEquals(1, aActivityStarted);
-            assertEquals(1, aActivityEnded);
-            assertEquals(1, bActivityStarted);
-            assertEquals(1, bActivityEnded);
-            assertEquals(1, subProcessEndActivityStarted);
-            assertEquals(1, subProcessEndActivityEnded);
-            assertEquals(1, mainEndActivityStarted);
-            assertEquals(1, mainEndActivityEnded);
-            assertEquals(1, processInstanceEnded);
+
+            assertThat(processInstanceCreated).isEqualTo(1);
+            assertThat(mainStartActivityStarted).isEqualTo(1);
+            assertThat(mainStartActivityEnded).isEqualTo(1);
+            assertThat(subProcessActivityStarted).isEqualTo(1);
+            assertThat(subProcessActivityEnded).isEqualTo(1);
+            assertThat(subProcessStartActivityStarted).isEqualTo(1);
+            assertThat(subProcessStartActivityEnded).isEqualTo(1);
+            assertThat(aActivityStarted).isEqualTo(1);
+            assertThat(aActivityEnded).isEqualTo(1);
+            assertThat(bActivityStarted).isEqualTo(1);
+            assertThat(bActivityEnded).isEqualTo(1);
+            assertThat(subProcessEndActivityStarted).isEqualTo(1);
+            assertThat(subProcessEndActivityEnded).isEqualTo(1);
+            assertThat(mainEndActivityStarted).isEqualTo(1);
+            assertThat(mainEndActivityEnded).isEqualTo(1);
+            assertThat(processInstanceEnded).isEqualTo(1);
         }
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/IdentityLinkEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/IdentityLinkEventsTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -11,6 +11,8 @@
  * limitations under the License.
  */
 package org.flowable.engine.test.api.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.common.engine.api.delegate.event.FlowableEngineEventType;
 import org.flowable.common.engine.api.delegate.event.FlowableEntityEvent;
@@ -26,7 +28,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for all {@link FlowableEvent}s related to process definitions.
- * 
+ *
  * @author Frederik Heremans
  */
 public class IdentityLinkEventsTest extends PluggableFlowableTestCase {
@@ -41,43 +43,43 @@ public class IdentityLinkEventsTest extends PluggableFlowableTestCase {
     public void testProcessDefinitionIdentityLinkEvents() throws Exception {
         ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().processDefinitionKey("oneTaskProcess").singleResult();
 
-        assertNotNull(processDefinition);
+        assertThat(processDefinition).isNotNull();
 
         // Add candidate user and group
         repositoryService.addCandidateStarterUser(processDefinition.getId(), "kermit");
         repositoryService.addCandidateStarterGroup(processDefinition.getId(), "sales");
-        assertEquals(4, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(4);
 
         FlowableEntityEvent event = (FlowableEntityEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ENTITY_CREATED, event.getType());
-        assertTrue(event.getEntity() instanceof IdentityLink);
-        assertEquals(processDefinition.getId(), ((IdentityLink) event.getEntity()).getProcessDefinitionId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
+        assertThat(event.getEntity()).isInstanceOf(IdentityLink.class);
+        assertThat(((IdentityLink) event.getEntity()).getProcessDefinitionId()).isEqualTo(processDefinition.getId());
 
         event = (FlowableEntityEvent) listener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.ENTITY_INITIALIZED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_INITIALIZED);
 
         event = (FlowableEntityEvent) listener.getEventsReceived().get(2);
-        assertEquals(FlowableEngineEventType.ENTITY_CREATED, event.getType());
-        assertTrue(event.getEntity() instanceof IdentityLink);
-        assertEquals(processDefinition.getId(), ((IdentityLink) event.getEntity()).getProcessDefinitionId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
+        assertThat(event.getEntity()).isInstanceOf(IdentityLink.class);
+        assertThat(((IdentityLink) event.getEntity()).getProcessDefinitionId()).isEqualTo(processDefinition.getId());
 
         event = (FlowableEntityEvent) listener.getEventsReceived().get(3);
-        assertEquals(FlowableEngineEventType.ENTITY_INITIALIZED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_INITIALIZED);
         listener.clearEventsReceived();
 
         // Delete identity links
         repositoryService.deleteCandidateStarterUser(processDefinition.getId(), "kermit");
         repositoryService.deleteCandidateStarterGroup(processDefinition.getId(), "sales");
-        assertEquals(2, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(2);
         event = (FlowableEntityEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ENTITY_DELETED, event.getType());
-        assertTrue(event.getEntity() instanceof IdentityLink);
-        assertEquals(processDefinition.getId(), ((IdentityLink) event.getEntity()).getProcessDefinitionId());
-        
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_DELETED);
+        assertThat(event.getEntity()).isInstanceOf(IdentityLink.class);
+        assertThat(((IdentityLink) event.getEntity()).getProcessDefinitionId()).isEqualTo(processDefinition.getId());
+
         event = (FlowableEntityEvent) listener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.ENTITY_DELETED, event.getType());
-        assertTrue(event.getEntity() instanceof IdentityLink);
-        assertEquals(processDefinition.getId(), ((IdentityLink) event.getEntity()).getProcessDefinitionId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_DELETED);
+        assertThat(event.getEntity()).isInstanceOf(IdentityLink.class);
+        assertThat(((IdentityLink) event.getEntity()).getProcessDefinitionId()).isEqualTo(processDefinition.getId());
     }
 
     /**
@@ -90,32 +92,32 @@ public class IdentityLinkEventsTest extends PluggableFlowableTestCase {
 
         // Add identity link
         runtimeService.addUserIdentityLink(processInstance.getId(), "kermit", "test");
-        assertEquals(2, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(2);
 
         FlowableEntityEvent event = (FlowableEntityEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ENTITY_CREATED, event.getType());
-        assertTrue(event.getEntity() instanceof IdentityLink);
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
+        assertThat(event.getEntity()).isInstanceOf(IdentityLink.class);
         IdentityLink link = (IdentityLink) event.getEntity();
-        assertEquals(processInstance.getId(), link.getProcessInstanceId());
-        assertEquals("kermit", link.getUserId());
-        assertEquals("test", link.getType());
+        assertThat(link.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(link.getUserId()).isEqualTo("kermit");
+        assertThat(link.getType()).isEqualTo("test");
 
         event = (FlowableEntityEvent) listener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.ENTITY_INITIALIZED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_INITIALIZED);
 
         listener.clearEventsReceived();
 
         // Deleting process should delete identity link
         runtimeService.deleteProcessInstance(processInstance.getId(), "test");
-        assertEquals(1, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(1);
 
         event = (FlowableEntityEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ENTITY_DELETED, event.getType());
-        assertTrue(event.getEntity() instanceof IdentityLink);
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_DELETED);
+        assertThat(event.getEntity()).isInstanceOf(IdentityLink.class);
         link = (IdentityLink) event.getEntity();
-        assertEquals("kermit", link.getUserId());
-        assertEquals("test", link.getType());
-        
+        assertThat(link.getUserId()).isEqualTo("kermit");
+        assertThat(link.getType()).isEqualTo("test");
+
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
     }
 
@@ -128,7 +130,7 @@ public class IdentityLinkEventsTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
 
         // Add identity link
         taskService.addCandidateUser(task.getId(), "kermit");
@@ -136,47 +138,47 @@ public class IdentityLinkEventsTest extends PluggableFlowableTestCase {
 
         // Three events are received, since the user link on the task also
         // creates an involvement in the process
-        assertEquals(6, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(6);
 
         FlowableEntityEvent event = (FlowableEntityEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ENTITY_CREATED, event.getType());
-        assertTrue(event.getEntity() instanceof IdentityLink);
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
+        assertThat(event.getEntity()).isInstanceOf(IdentityLink.class);
         IdentityLink link = (IdentityLink) event.getEntity();
-        assertEquals("kermit", link.getUserId());
-        assertEquals("candidate", link.getType());
-        assertEquals(task.getId(), link.getTaskId());
+        assertThat(link.getUserId()).isEqualTo("kermit");
+        assertThat(link.getType()).isEqualTo("candidate");
+        assertThat(link.getTaskId()).isEqualTo(task.getId());
 
         event = (FlowableEntityEvent) listener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.ENTITY_INITIALIZED, event.getType());
-        assertEquals("kermit", link.getUserId());
-        assertEquals("candidate", link.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_INITIALIZED);
+        assertThat(link.getUserId()).isEqualTo("kermit");
+        assertThat(link.getType()).isEqualTo("candidate");
 
         event = (FlowableEntityEvent) listener.getEventsReceived().get(4);
-        assertEquals(FlowableEngineEventType.ENTITY_CREATED, event.getType());
-        assertTrue(event.getEntity() instanceof IdentityLink);
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
+        assertThat(event.getEntity()).isInstanceOf(IdentityLink.class);
         link = (IdentityLink) event.getEntity();
-        assertEquals("sales", link.getGroupId());
-        assertEquals("candidate", link.getType());
-        assertEquals(task.getId(), link.getTaskId());
-        
+        assertThat(link.getGroupId()).isEqualTo("sales");
+        assertThat(link.getType()).isEqualTo("candidate");
+        assertThat(link.getTaskId()).isEqualTo(task.getId());
+
         event = (FlowableEntityEvent) listener.getEventsReceived().get(5);
-        assertEquals(FlowableEngineEventType.ENTITY_INITIALIZED, event.getType());
-        assertEquals("sales", link.getGroupId());
-        assertEquals("candidate", link.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_INITIALIZED);
+        assertThat(link.getGroupId()).isEqualTo("sales");
+        assertThat(link.getType()).isEqualTo("candidate");
 
         listener.clearEventsReceived();
 
         // Deleting process should delete identity link
         runtimeService.deleteProcessInstance(processInstance.getId(), "test");
-        assertEquals(3, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(3);
 
         event = (FlowableEntityEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ENTITY_DELETED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_DELETED);
         event = (FlowableEntityEvent) listener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.ENTITY_DELETED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_DELETED);
         event = (FlowableEntityEvent) listener.getEventsReceived().get(2);
-        assertEquals(FlowableEngineEventType.ENTITY_DELETED, event.getType());
-        
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_DELETED);
+
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
     }
 
@@ -190,22 +192,22 @@ public class IdentityLinkEventsTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
 
         // Add identity link
         taskService.addCandidateUser(task.getId(), "kermit");
         taskService.addCandidateGroup(task.getId(), "sales");
 
         // Three events are received, since the user link on the task also creates an involvement in the process. See previous test
-        assertEquals(6, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(6);
 
         listener.clearEventsReceived();
         taskService.deleteCandidateUser(task.getId(), "kermit");
-        assertEquals(1, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(1);
 
         listener.clearEventsReceived();
         taskService.deleteCandidateGroup(task.getId(), "sales");
-        assertEquals(1, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(1);
     }
 
     @BeforeEach

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/JobEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/JobEventsTest.java
@@ -385,7 +385,8 @@ public class JobEventsTest extends PluggableFlowableTestCase {
                 timerCancelledCount++;
             }
         }
-        assertThat(expectedCount).isEqualTo(timerCancelledCount).as(eventType.name() + " event was expected " + expectedCount + " times.");
+        assertThat(expectedCount).as(eventType.name() + " event was expected " + expectedCount + " times.")
+                .isEqualTo(timerCancelledCount);
     }
 
     private List<FlowableEngineEvent> filterEvents(FlowableEngineEventType eventType) {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/JobEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/JobEventsTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,6 +12,9 @@
  */
 package org.flowable.engine.test.api.event;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -19,6 +22,7 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
 
+import org.flowable.common.engine.api.FlowableException;
 import org.flowable.common.engine.api.delegate.event.FlowableEngineEvent;
 import org.flowable.common.engine.api.delegate.event.FlowableEngineEventType;
 import org.flowable.common.engine.api.delegate.event.FlowableEntityEvent;
@@ -36,7 +40,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for all {@link FlowableEvent}s related to jobs.
- * 
+ *
  * @author Frederik Heremans
  */
 public class JobEventsTest extends PluggableFlowableTestCase {
@@ -52,31 +56,31 @@ public class JobEventsTest extends PluggableFlowableTestCase {
     public void testJobEntityEvents() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testJobEvents");
         Job theJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(theJob);
+        assertThat(theJob).isNotNull();
 
         // Check if create-event has been dispatched
-        assertEquals(3, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(3);
         FlowableEngineEvent event = (FlowableEngineEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ENTITY_CREATED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
         checkEventContext(event, theJob);
 
         event = (FlowableEngineEvent) listener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.ENTITY_INITIALIZED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_INITIALIZED);
         checkEventContext(event, theJob);
 
         event = (FlowableEngineEvent) listener.getEventsReceived().get(2);
-        assertEquals(FlowableEngineEventType.TIMER_SCHEDULED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.TIMER_SCHEDULED);
         checkEventContext(event, theJob);
 
         listener.clearEventsReceived();
 
         // Update the job-entity. Check if update event is dispatched with update job entity
         managementService.setTimerJobRetries(theJob.getId(), 5);
-        assertEquals(1, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(1);
         event = (FlowableEngineEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ENTITY_UPDATED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_UPDATED);
         Job updatedJob = (Job) ((FlowableEntityEvent) event).getEntity();
-        assertEquals(5, updatedJob.getRetries());
+        assertThat(updatedJob.getRetries()).isEqualTo(5);
         checkEventContext(event, theJob);
 
         checkEventCount(0, FlowableEngineEventType.TIMER_SCHEDULED);
@@ -91,29 +95,29 @@ public class JobEventsTest extends PluggableFlowableTestCase {
         managementService.executeJob(jobId);
 
         // Check delete-event has been dispatched
-        assertEquals(6, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(6);
 
         event = (FlowableEngineEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ENTITY_CREATED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
         checkEventContext(event, theJob);
 
         event = (FlowableEngineEvent) listener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.ENTITY_INITIALIZED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_INITIALIZED);
         checkEventContext(event, theJob);
 
         // First, a timer fired event has been dispatched
         event = (FlowableEngineEvent) listener.getEventsReceived().get(3);
-        assertEquals(FlowableEngineEventType.TIMER_FIRED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.TIMER_FIRED);
         checkEventContext(event, theJob);
 
         // Next, a delete event has been dispatched
         event = (FlowableEngineEvent) listener.getEventsReceived().get(4);
-        assertEquals(FlowableEngineEventType.ENTITY_DELETED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_DELETED);
         checkEventContext(event, theJob);
 
         // Finally, a complete event has been dispatched
         event = (FlowableEngineEvent) listener.getEventsReceived().get(5);
-        assertEquals(FlowableEngineEventType.JOB_EXECUTION_SUCCESS, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.JOB_EXECUTION_SUCCESS);
         checkEventContext(event, theJob);
 
         checkEventCount(0, FlowableEngineEventType.TIMER_SCHEDULED);
@@ -127,20 +131,20 @@ public class JobEventsTest extends PluggableFlowableTestCase {
     public void testJobEntityEventsForRescheduleTimer() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testJobEventsForReschedule");
         Job originalTimerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(originalTimerJob);
+        assertThat(originalTimerJob).isNotNull();
 
         // Check if create-event has been dispatched
-        assertEquals(3, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(3);
         FlowableEngineEvent event = (FlowableEngineEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ENTITY_CREATED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
         checkEventContext(event, originalTimerJob);
 
         event = (FlowableEngineEvent) listener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.ENTITY_INITIALIZED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_INITIALIZED);
         checkEventContext(event, originalTimerJob);
 
         event = (FlowableEngineEvent) listener.getEventsReceived().get(2);
-        assertEquals(FlowableEngineEventType.TIMER_SCHEDULED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.TIMER_SCHEDULED);
         checkEventContext(event, originalTimerJob);
 
         listener.clearEventsReceived();
@@ -149,12 +153,12 @@ public class JobEventsTest extends PluggableFlowableTestCase {
         managementService.rescheduleTimeDurationJob(originalTimerJob.getId(), "PT2H");
 
         Job rescheduledJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(rescheduledJob);
-        assertNotSame(originalTimerJob.getId(), rescheduledJob.getId());
+        assertThat(rescheduledJob).isNotNull();
+        assertThat(rescheduledJob.getId()).isNotSameAs(originalTimerJob.getId());
 
-        assertEquals(5, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(5);
         event = (FlowableEngineEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ENTITY_DELETED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_DELETED);
         checkEventContext(event, originalTimerJob);
 
         Job deletedJob = (Job) ((FlowableEntityEvent) event).getEntity();
@@ -162,25 +166,25 @@ public class JobEventsTest extends PluggableFlowableTestCase {
 
         event = (FlowableEngineEvent) listener.getEventsReceived().get(1);
         Job newJob = (Job) ((FlowableEntityEvent) event).getEntity();
-        assertEquals(FlowableEngineEventType.ENTITY_CREATED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
         checkEventContext(event, newJob);
         checkEventContext(event, rescheduledJob);
-        assertEquals(newJob.getId(), rescheduledJob.getId());
+        assertThat(rescheduledJob.getId()).isEqualTo(newJob.getId());
 
         event = (FlowableEngineEvent) listener.getEventsReceived().get(2);
-        assertEquals(FlowableEngineEventType.ENTITY_INITIALIZED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_INITIALIZED);
         newJob = (Job) ((FlowableEntityEvent) event).getEntity();
         checkEventContext(event, newJob);
 
         event = (FlowableEngineEvent) listener.getEventsReceived().get(3);
-        assertEquals(FlowableEngineEventType.JOB_RESCHEDULED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.JOB_RESCHEDULED);
         Job newTimerJob = (Job) ((FlowableEntityEvent) event).getEntity();
         checkEventContext(event, rescheduledJob);
-        assertEquals(rescheduledJob.getId(), newTimerJob.getId());
-        assertEquals(simpleDateFormat.format(rescheduledJob.getDuedate()), simpleDateFormat.format(newTimerJob.getDuedate()));
+        assertThat(newTimerJob.getId()).isEqualTo(rescheduledJob.getId());
+        assertThat(simpleDateFormat.format(newTimerJob.getDuedate())).isEqualTo(simpleDateFormat.format(rescheduledJob.getDuedate()));
 
         event = (FlowableEngineEvent) listener.getEventsReceived().get(4);
-        assertEquals(FlowableEngineEventType.TIMER_SCHEDULED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.TIMER_SCHEDULED);
         newJob = (Job) ((FlowableEntityEvent) event).getEntity();
         checkEventContext(event, newJob);
 
@@ -194,29 +198,29 @@ public class JobEventsTest extends PluggableFlowableTestCase {
         managementService.executeJob(rescheduledJob.getId());
 
         // Check delete-event has been dispatched
-        assertEquals(6, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(6);
 
         event = (FlowableEngineEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ENTITY_CREATED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
         checkEventContext(event, rescheduledJob);
 
         event = (FlowableEngineEvent) listener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.ENTITY_INITIALIZED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_INITIALIZED);
         checkEventContext(event, rescheduledJob);
 
         // First, a timer fired event has been dispatched
         event = (FlowableEngineEvent) listener.getEventsReceived().get(3);
-        assertEquals(FlowableEngineEventType.TIMER_FIRED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.TIMER_FIRED);
         checkEventContext(event, rescheduledJob);
 
         // Next, a delete event has been dispatched
         event = (FlowableEngineEvent) listener.getEventsReceived().get(4);
-        assertEquals(FlowableEngineEventType.ENTITY_DELETED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_DELETED);
         checkEventContext(event, rescheduledJob);
 
         // Finally, a complete event has been dispatched
         event = (FlowableEngineEvent) listener.getEventsReceived().get(5);
-        assertEquals(FlowableEngineEventType.JOB_EXECUTION_SUCCESS, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.JOB_EXECUTION_SUCCESS);
         checkEventContext(event, rescheduledJob);
 
         checkEventCount(0, FlowableEngineEventType.TIMER_SCHEDULED);
@@ -241,28 +245,28 @@ public class JobEventsTest extends PluggableFlowableTestCase {
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testRepetitionJobEvents");
         Job theJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(theJob);
+        assertThat(theJob).isNotNull();
 
         // Check if create-event has been dispatched
-        assertEquals(3, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(3);
         FlowableEngineEvent event = (FlowableEngineEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ENTITY_CREATED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
         checkEventContext(event, theJob);
 
         event = (FlowableEngineEvent) listener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.ENTITY_INITIALIZED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_INITIALIZED);
         checkEventContext(event, theJob);
 
         event = (FlowableEngineEvent) listener.getEventsReceived().get(2);
-        assertEquals(FlowableEngineEventType.TIMER_SCHEDULED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.TIMER_SCHEDULED);
         checkEventContext(event, theJob);
 
         listener.clearEventsReceived();
 
         // no timer jobs will be fired
         waitForJobExecutorToProcessAllJobs(2000, 200);
-        assertEquals(0, listener.getEventsReceived().size());
-        assertEquals(1, managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(listener.getEventsReceived()).isEmpty();
+        assertThat(managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(1);
         Job firstTimerInstance = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
 
         nowCalendar.add(Calendar.HOUR, 1);
@@ -273,9 +277,9 @@ public class JobEventsTest extends PluggableFlowableTestCase {
         waitForJobExecutorToProcessAllJobs(2000, 200);
 
         // a new timer should be created with the repeat
-        assertEquals(1, managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(1);
         Job secondTimerInstance = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotSame(firstTimerInstance.getId(), secondTimerInstance.getId());
+        assertThat(secondTimerInstance.getId()).isNotSameAs(firstTimerInstance.getId());
 
         checkEventCount(1, FlowableEngineEventType.TIMER_FIRED);
         checkEventContext(filterEvents(FlowableEngineEventType.TIMER_FIRED).get(0), firstTimerInstance);
@@ -290,14 +294,14 @@ public class JobEventsTest extends PluggableFlowableTestCase {
 
         // the second timer job will be fired and no jobs should be remaining
         waitForJobExecutorToProcessAllJobs(2000, 200);
-        assertEquals(0, managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0);
 
         nowCalendar.add(Calendar.HOUR, 1);
         nowCalendar.add(Calendar.MINUTE, 5);
         testClock.setCurrentTime(nowCalendar.getTime());
         waitForJobExecutorToProcessAllJobs(2000, 200);
 
-        assertEquals(0, managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0);
 
         checkEventCount(1, FlowableEngineEventType.TIMER_FIRED);
         checkEventContext(filterEvents(FlowableEngineEventType.TIMER_FIRED).get(0), secondTimerInstance);
@@ -345,12 +349,14 @@ public class JobEventsTest extends PluggableFlowableTestCase {
     @Test
     public void testJobCanceledAndTimerStartEventOnProcessRedeploy() throws Exception {
         // GIVEN deploy process definition
-        String deployment1 = repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/api/event/JobEventsTest.testTimerFiredForTimerStart.bpmn20.xml").deploy().getId();
+        String deployment1 = repositoryService.createDeployment()
+                .addClasspathResource("org/flowable/engine/test/api/event/JobEventsTest.testTimerFiredForTimerStart.bpmn20.xml").deploy().getId();
         checkEventCount(1, FlowableEngineEventType.TIMER_SCHEDULED);
         listener.clearEventsReceived();
 
         // WHEN
-        String deployment2 = repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/api/event/JobEventsTest.testTimerFiredForTimerStart.bpmn20.xml").deploy().getId();
+        String deployment2 = repositoryService.createDeployment()
+                .addClasspathResource("org/flowable/engine/test/api/event/JobEventsTest.testTimerFiredForTimerStart.bpmn20.xml").deploy().getId();
 
         // THEN
         checkEventCount(1, FlowableEngineEventType.JOB_CANCELED);
@@ -379,7 +385,7 @@ public class JobEventsTest extends PluggableFlowableTestCase {
                 timerCancelledCount++;
             }
         }
-        assertEquals(eventType.name() + " event was expected " + expectedCount + " times.", expectedCount, timerCancelledCount);
+        assertThat(expectedCount).isEqualTo(timerCancelledCount).as(eventType.name() + " event was expected " + expectedCount + " times.");
     }
 
     private List<FlowableEngineEvent> filterEvents(FlowableEngineEventType eventType) {
@@ -408,18 +414,18 @@ public class JobEventsTest extends PluggableFlowableTestCase {
         waitForJobExecutorToProcessAllJobs(2000, 100);
 
         // Check Timer fired event has been dispatched
-        assertEquals(6, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(6);
 
         // timer entity created first
-        assertEquals(FlowableEngineEventType.ENTITY_CREATED, listener.getEventsReceived().get(0).getType());
+        assertThat(listener.getEventsReceived().get(0).getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
         // timer entity initialized
-        assertEquals(FlowableEngineEventType.ENTITY_INITIALIZED, listener.getEventsReceived().get(1).getType());
+        assertThat(listener.getEventsReceived().get(1).getType()).isEqualTo(FlowableEngineEventType.ENTITY_INITIALIZED);
         // timer entity deleted
-        assertEquals(FlowableEngineEventType.ENTITY_DELETED, listener.getEventsReceived().get(2).getType());
+        assertThat(listener.getEventsReceived().get(2).getType()).isEqualTo(FlowableEngineEventType.ENTITY_DELETED);
         // job fired
-        assertEquals(FlowableEngineEventType.TIMER_FIRED, listener.getEventsReceived().get(3).getType());
+        assertThat(listener.getEventsReceived().get(3).getType()).isEqualTo(FlowableEngineEventType.TIMER_FIRED);
         // job executed successfully
-        assertEquals(FlowableEngineEventType.JOB_EXECUTION_SUCCESS, listener.getEventsReceived().get(5).getType());
+        assertThat(listener.getEventsReceived().get(5).getType()).isEqualTo(FlowableEngineEventType.JOB_EXECUTION_SUCCESS);
 
         checkEventCount(0, FlowableEngineEventType.JOB_CANCELED);
     }
@@ -451,7 +457,7 @@ public class JobEventsTest extends PluggableFlowableTestCase {
     public void testJobEntityEventsException() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testJobEvents");
         Job theJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(theJob);
+        assertThat(theJob).isNotNull();
 
         // Set retries to 1, to prevent multiple chains of events being thrown
         managementService.setTimerJobRetries(theJob.getId(), 1);
@@ -465,58 +471,54 @@ public class JobEventsTest extends PluggableFlowableTestCase {
 
         listener.clearEventsReceived();
 
-        try {
-            managementService.executeJob(executableJob.getId());
-            fail("Expected exception");
-        } catch (Exception e) {
-            // exception expected
-        }
+        assertThatThrownBy(() -> managementService.executeJob(executableJob.getId()))
+                .isInstanceOf(FlowableException.class);
 
         theJob = managementService.createDeadLetterJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(theJob);
-        assertEquals("timer", theJob.getElementId());
-        assertEquals("Timer", theJob.getElementName());
+        assertThat(theJob).isNotNull();
+        assertThat(theJob.getElementId()).isEqualTo("timer");
+        assertThat(theJob.getElementName()).isEqualTo("Timer");
 
         // Check delete-event has been dispatched
-        assertEquals(8, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(8);
 
         // First, the timer was fired
         FlowableEngineEvent event = (FlowableEngineEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.TIMER_FIRED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.TIMER_FIRED);
         checkEventContext(event, theJob);
 
         // Second, the job-entity was deleted, as the job was executed
         event = (FlowableEngineEvent) listener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.ENTITY_DELETED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_DELETED);
         checkEventContext(event, theJob);
 
         // Next, a job failed event is dispatched
         event = (FlowableEngineEvent) listener.getEventsReceived().get(2);
-        assertEquals(FlowableEngineEventType.JOB_EXECUTION_FAILURE, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.JOB_EXECUTION_FAILURE);
         checkEventContext(event, theJob);
 
         // Finally, an timer create event is received and the job count is decremented
         event = (FlowableEngineEvent) listener.getEventsReceived().get(3);
-        assertEquals(FlowableEngineEventType.ENTITY_CREATED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
         checkEventContext(event, theJob);
 
         event = (FlowableEngineEvent) listener.getEventsReceived().get(4);
-        assertEquals(FlowableEngineEventType.ENTITY_INITIALIZED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_INITIALIZED);
         checkEventContext(event, theJob);
 
         // original job is deleted
         event = (FlowableEngineEvent) listener.getEventsReceived().get(5);
-        assertEquals(FlowableEngineEventType.ENTITY_DELETED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_DELETED);
         checkEventContext(event, theJob);
 
         // timer job updated
         event = (FlowableEngineEvent) listener.getEventsReceived().get(6);
-        assertEquals(FlowableEngineEventType.ENTITY_UPDATED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_UPDATED);
         checkEventContext(event, theJob);
 
         event = (FlowableEngineEvent) listener.getEventsReceived().get(7);
-        assertEquals(FlowableEngineEventType.JOB_RETRIES_DECREMENTED, event.getType());
-        assertEquals(0, ((Job) ((FlowableEntityEvent) event).getEntity()).getRetries());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.JOB_RETRIES_DECREMENTED);
+        assertThat(((Job) ((FlowableEntityEvent) event).getEntity()).getRetries()).isEqualTo(0);
         checkEventContext(event, theJob);
     }
 
@@ -536,7 +538,7 @@ public class JobEventsTest extends PluggableFlowableTestCase {
         listener.clearEventsReceived();
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("Inside Task", task.getName());
+        assertThat(task.getName()).isEqualTo("Inside Task");
 
         // Force timer to trigger so that subprocess will flow to terminate end event
         Calendar later = Calendar.getInstance();
@@ -564,7 +566,7 @@ public class JobEventsTest extends PluggableFlowableTestCase {
         }
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("Outside Task", task.getName());
+        assertThat(task.getName()).isEqualTo("Outside Task");
 
         taskService.complete(task.getId());
 
@@ -574,14 +576,14 @@ public class JobEventsTest extends PluggableFlowableTestCase {
     }
 
     protected void checkEventContext(FlowableEngineEvent event, Job entity) {
-        assertEquals(entity.getProcessInstanceId(), event.getProcessInstanceId());
-        assertEquals(entity.getProcessDefinitionId(), event.getProcessDefinitionId());
-        assertNotNull(event.getExecutionId());
+        assertThat(event.getProcessInstanceId()).isEqualTo(entity.getProcessInstanceId());
+        assertThat(event.getProcessDefinitionId()).isEqualTo(entity.getProcessDefinitionId());
+        assertThat(event.getExecutionId()).isNotNull();
 
-        assertTrue(event instanceof FlowableEntityEvent);
+        assertThat(event).isInstanceOf(FlowableEntityEvent.class);
         FlowableEntityEvent entityEvent = (FlowableEntityEvent) event;
-        assertTrue(entityEvent.getEntity() instanceof Job);
-        assertEquals(entity.getId(), ((Job) entityEvent.getEntity()).getId());
+        assertThat(entityEvent.getEntity()).isInstanceOf(Job.class);
+        assertThat(((Job) entityEvent.getEntity()).getId()).isEqualTo(entity.getId());
     }
 
     @BeforeEach

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/MessageThrowingEventListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/MessageThrowingEventListenerTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -11,6 +11,8 @@
  * limitations under the License.
  */
 package org.flowable.engine.test.api.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.common.engine.api.delegate.event.FlowableEngineEventType;
 import org.flowable.common.engine.api.delegate.event.FlowableEvent;
@@ -23,7 +25,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for all {@link FlowableEventListener}s that throw a message BPMN event when an {@link FlowableEvent} has been dispatched.
- * 
+ *
  * @author Tijs Rademakers
  */
 public class MessageThrowingEventListenerTest extends PluggableFlowableTestCase {
@@ -39,22 +41,22 @@ public class MessageThrowingEventListenerTest extends PluggableFlowableTestCase 
             processEngineConfiguration.getEventDispatcher().addEventListener(listener, FlowableEngineEventType.TASK_ASSIGNED);
 
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testMessage");
-            assertNotNull(processInstance);
+            assertThat(processInstance).isNotNull();
 
             // Fetch the task and reassign it to trigger the event-listener
             org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-            assertNotNull(task);
+            assertThat(task).isNotNull();
             taskService.setAssignee(task.getId(), "kermit");
 
             // Boundary-event should have been messaged and a new task should be
-            // available, on top of the already
-            // existing one, since the cancelActivity='false'
+            // available, on top of the already existing one, since the cancelActivity='false'
             task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("subTask").singleResult();
-            assertNotNull(task);
-            assertEquals("kermit", task.getAssignee());
+            assertThat(task).isNotNull();
+            assertThat(task.getAssignee()).isEqualTo("kermit");
 
-            org.flowable.task.api.Task boundaryTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("boundaryTask").singleResult();
-            assertNotNull(boundaryTask);
+            org.flowable.task.api.Task boundaryTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("boundaryTask")
+                    .singleResult();
+            assertThat(boundaryTask).isNotNull();
 
         } finally {
             processEngineConfiguration.getEventDispatcher().removeEventListener(listener);
@@ -65,21 +67,22 @@ public class MessageThrowingEventListenerTest extends PluggableFlowableTestCase 
     @Deployment
     public void testThrowMessageDefinedInProcessDefinition() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testMessage");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         // Fetch the task and re-assign it to trigger the event-listener
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         taskService.setAssignee(task.getId(), "kermit");
 
         // Boundary-event should have been messaged and a new task should be available, on top of the already
         // existing one, since the cancelActivity='false'
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("subTask").singleResult();
-        assertNotNull(task);
-        assertEquals("kermit", task.getAssignee());
+        assertThat(task).isNotNull();
+        assertThat(task.getAssignee()).isEqualTo("kermit");
 
-        org.flowable.task.api.Task boundaryTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("boundaryTask").singleResult();
-        assertNotNull(boundaryTask);
+        org.flowable.task.api.Task boundaryTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("boundaryTask")
+                .singleResult();
+        assertThat(boundaryTask).isNotNull();
     }
 
     @Test
@@ -93,23 +96,24 @@ public class MessageThrowingEventListenerTest extends PluggableFlowableTestCase 
             processEngineConfiguration.getEventDispatcher().addEventListener(listener, FlowableEngineEventType.TASK_ASSIGNED);
 
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testMessage");
-            assertNotNull(processInstance);
+            assertThat(processInstance).isNotNull();
 
             // Fetch the task and reassign it to trigger the event-listener
             org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-            assertNotNull(task);
+            assertThat(task).isNotNull();
             taskService.setAssignee(task.getId(), "kermit");
 
             // Boundary-event should have been messaged and a new task should be
             // available, the already existing one should be removed, since the cancelActivity='true'
             task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("subTask").singleResult();
-            assertNull(task);
+            assertThat(task).isNull();
 
-            org.flowable.task.api.Task boundaryTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("boundaryTask").singleResult();
-            assertNotNull(boundaryTask);
-            
+            org.flowable.task.api.Task boundaryTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("boundaryTask")
+                    .singleResult();
+            assertThat(boundaryTask).isNotNull();
+
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
-            
+
         } finally {
             processEngineConfiguration.getEventDispatcher().removeEventListener(listener);
         }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ModelEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ModelEventsTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -11,6 +11,8 @@
  * limitations under the License.
  */
 package org.flowable.engine.test.api.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.common.engine.api.delegate.event.FlowableEngineEventType;
 import org.flowable.common.engine.api.delegate.event.FlowableEntityEvent;
@@ -23,7 +25,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for all {@link FlowableEvent}s related to models.
- * 
+ *
  * @author Frederik Heremans
  */
 public class ModelEventsTest extends PluggableFlowableTestCase {
@@ -43,36 +45,40 @@ public class ModelEventsTest extends PluggableFlowableTestCase {
             repositoryService.saveModel(model);
 
             // Check create event
-            assertEquals(2, listener.getEventsReceived().size());
-            assertEquals(FlowableEngineEventType.ENTITY_CREATED, listener.getEventsReceived().get(0).getType());
-            assertEquals(model.getId(), ((Model) ((FlowableEntityEvent) listener.getEventsReceived().get(0)).getEntity()).getId());
+            assertThat(listener.getEventsReceived()).hasSize(2);
+            assertThat(listener.getEventsReceived().get(0).getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
+            assertThat(((Model) ((FlowableEntityEvent) listener.getEventsReceived().get(0)).getEntity()).getId()).isEqualTo(model.getId());
 
-            assertEquals(FlowableEngineEventType.ENTITY_INITIALIZED, listener.getEventsReceived().get(1).getType());
-            assertEquals(model.getId(), ((Model) ((FlowableEntityEvent) listener.getEventsReceived().get(1)).getEntity()).getId());
+            assertThat(listener.getEventsReceived().get(1).getType()).isEqualTo(FlowableEngineEventType.ENTITY_INITIALIZED);
+            assertThat(((Model) ((FlowableEntityEvent) listener.getEventsReceived().get(1)).getEntity()).getId()).isEqualTo(model.getId());
             listener.clearEventsReceived();
 
             // Update model
             model = repositoryService.getModel(model.getId());
             model.setName("Updated");
             repositoryService.saveModel(model);
-            assertEquals(1, listener.getEventsReceived().size());
-            assertEquals(FlowableEngineEventType.ENTITY_UPDATED, listener.getEventsReceived().get(0).getType());
-            assertEquals(model.getId(), ((Model) ((FlowableEntityEvent) listener.getEventsReceived().get(0)).getEntity()).getId());
+            assertThat(listener.getEventsReceived())
+                    .extracting(FlowableEvent::getType)
+                    .containsExactly(FlowableEngineEventType.ENTITY_UPDATED);
+            assertThat(((Model) ((FlowableEntityEvent) listener.getEventsReceived().get(0)).getEntity()).getId()).isEqualTo(model.getId());
             listener.clearEventsReceived();
 
             // Test additional update-methods (source and extra-source)
             repositoryService.addModelEditorSource(model.getId(), "test".getBytes());
             repositoryService.addModelEditorSourceExtra(model.getId(), "test extra".getBytes());
-            assertEquals(2, listener.getEventsReceived().size());
-            assertEquals(FlowableEngineEventType.ENTITY_UPDATED, listener.getEventsReceived().get(0).getType());
-            assertEquals(FlowableEngineEventType.ENTITY_UPDATED, listener.getEventsReceived().get(1).getType());
+            assertThat(listener.getEventsReceived())
+                    .extracting(FlowableEvent::getType)
+                    .containsExactly(
+                            FlowableEngineEventType.ENTITY_UPDATED,
+                            FlowableEngineEventType.ENTITY_UPDATED);
             listener.clearEventsReceived();
 
             // Delete model events
             repositoryService.deleteModel(model.getId());
-            assertEquals(1, listener.getEventsReceived().size());
-            assertEquals(FlowableEngineEventType.ENTITY_DELETED, listener.getEventsReceived().get(0).getType());
-            assertEquals(model.getId(), ((Model) ((FlowableEntityEvent) listener.getEventsReceived().get(0)).getEntity()).getId());
+            assertThat(listener.getEventsReceived())
+                    .extracting(FlowableEvent::getType)
+                    .containsExactly(FlowableEngineEventType.ENTITY_DELETED);
+            assertThat(((Model) ((FlowableEntityEvent) listener.getEventsReceived().get(0)).getEntity()).getId()).isEqualTo(model.getId());
             listener.clearEventsReceived();
 
         } finally {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -11,6 +11,8 @@
  * limitations under the License.
  */
 package org.flowable.engine.test.api.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -66,81 +68,80 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
      * Multi-instance user task cancelled by terminate end event.
      */
     @Test
-    @Deployment(resources = {"org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.bpmn20.xml"})
+    @Deployment(resources = { "org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.bpmn20.xml" })
     public void testMultiInstanceCancelledWhenFlowToTerminateEnd() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("multiInstanceUserTaskEvents");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         Execution task1Execution = runtimeService.createExecutionQuery().activityId("task1").singleResult();
         Execution boundaryExecution = runtimeService.createExecutionQuery().activityId("cancelBoundaryEvent1").singleResult();
         List<Execution> multiExecutions = runtimeService.createExecutionQuery().activityId("task2").list();
-        assertEquals(2, multiExecutions.size());
+        assertThat(multiExecutions).hasSize(2);
         String multiExecutionId1 = multiExecutions.get(0).getId();
         String multiExecutionId2 = multiExecutions.get(1).getId();
         String rootMultiExecutionId = null;
 
         List<Execution> executions = runtimeService.createExecutionQuery().parentId(processInstance.getId()).list();
-        for (Execution execution: executions)
-        {
-            if (((ExecutionEntity)execution).isMultiInstanceRoot()) {
+        for (Execution execution : executions) {
+            if (((ExecutionEntity) execution).isMultiInstanceRoot()) {
                 rootMultiExecutionId = execution.getId();
                 break;
             }
         }
-        assertNotNull(rootMultiExecutionId);
-        assertNotSame(rootMultiExecutionId, multiExecutionId1);
-        assertNotSame(rootMultiExecutionId, multiExecutionId2);
-        assertNotSame(rootMultiExecutionId, boundaryExecution);
+        assertThat(rootMultiExecutionId).isNotNull();
+        assertThat(multiExecutionId1).isNotSameAs(rootMultiExecutionId);
+        assertThat(multiExecutionId2).isNotSameAs(rootMultiExecutionId);
+        assertThat(boundaryExecution).isNotSameAs(rootMultiExecutionId);
 
         int idx = 0;
         FlowableEvent flowableEvent = testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.PROCESS_STARTED, flowableEvent.getType());
+        assertThat(flowableEvent.getType()).isEqualTo(FlowableEngineEventType.PROCESS_STARTED);
         ExecutionEntity executionEntity = (ExecutionEntity) ((FlowableProcessStartedEvent) flowableEvent).getEntity();
-        assertEquals(processInstance.getId(), executionEntity.getProcessInstanceId());
+        assertThat(executionEntity.getProcessInstanceId()).isEqualTo(processInstance.getId());
 
         FlowableActivityEvent activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("startEvent", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityType()).isEqualTo("startEvent");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("startEvent", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityType()).isEqualTo("startEvent");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("task1", activityEvent.getActivityId());
-        assertEquals(task1Execution.getId(), activityEvent.getExecutionId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("task1");
+        assertThat(activityEvent.getExecutionId()).isEqualTo(task1Execution.getId());
 
         FlowableEntityEvent entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.TASK_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_CREATED);
         TaskEntity taskEntity = (TaskEntity) entityEvent.getEntity();
-        assertEquals("User Task1", taskEntity.getName());
+        assertThat(taskEntity.getName()).isEqualTo("User Task1");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.MULTI_INSTANCE_ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("task2", activityEvent.getActivityId());
-        assertEquals(rootMultiExecutionId, activityEvent.getExecutionId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.MULTI_INSTANCE_ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("task2");
+        assertThat(activityEvent.getExecutionId()).isEqualTo(rootMultiExecutionId);
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("task2", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("task2");
 
         entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.TASK_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_CREATED);
         taskEntity = (TaskEntity) entityEvent.getEntity();
-        assertEquals("Multi User Task-0", taskEntity.getName());
+        assertThat(taskEntity.getName()).isEqualTo("Multi User Task-0");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("task2", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("task2");
 
         entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.TASK_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_CREATED);
         taskEntity = (TaskEntity) entityEvent.getEntity();
-        assertEquals("Multi User Task-1", taskEntity.getName());
+        assertThat(taskEntity.getName()).isEqualTo("Multi User Task-1");
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(3, tasks.size());
+        assertThat(tasks).hasSize(3);
         org.flowable.task.api.Task userTask1 = null;
         for (org.flowable.task.api.Task task : tasks) {
             if ("User Task1".equals(task.getName())) {
@@ -148,25 +149,25 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
                 break;
             }
         }
-        assertNotNull(userTask1);
+        assertThat(userTask1).isNotNull();
 
         // complete task1 so we flow to terminate end
         taskService.complete(userTask1.getId());
 
         entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.TASK_COMPLETED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_COMPLETED);
         taskEntity = (TaskEntity) entityEvent.getEntity();
-        assertEquals("User Task1", taskEntity.getName());
+        assertThat(taskEntity.getName()).isEqualTo("User Task1");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("task1", activityEvent.getActivityId());
-        assertEquals(task1Execution.getId(), activityEvent.getExecutionId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("task1");
+        assertThat(activityEvent.getExecutionId()).isEqualTo(task1Execution.getId());
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("endEvent", activityEvent.getActivityType());
-        assertEquals("endEvent1", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityType()).isEqualTo("endEvent");
+        assertThat(activityEvent.getActivityId()).isEqualTo("endEvent1");
 
         boolean foundMultiExec1 = false;
         boolean foundMultiExec2 = false;
@@ -179,263 +180,259 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
             FlowableActivityCancelledEvent cancelledEvent = (FlowableActivityCancelledEvent) activityEvent;
 
             if ("task2".equals(cancelledEvent.getActivityId())) {
-                assertEquals("task2", cancelledEvent.getActivityId());
-                assertEquals("userTask", cancelledEvent.getActivityType());
-                assertEquals("Multi User Task-${loopCounter}", cancelledEvent.getActivityName());
+                assertThat(cancelledEvent.getActivityId()).isEqualTo("task2");
+                assertThat(cancelledEvent.getActivityType()).isEqualTo("userTask");
+                assertThat(cancelledEvent.getActivityName()).isEqualTo("Multi User Task-${loopCounter}");
                 String eventExecutionId = activityEvent.getExecutionId();
                 if (multiExecutionId1.equals(eventExecutionId)) {
-                    assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, activityEvent.getType());
+                    assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
                     foundMultiExec1 = true;
-                }
-                else if (multiExecutionId2.equals(eventExecutionId)) {
-                    assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, activityEvent.getType());
+                } else if (multiExecutionId2.equals(eventExecutionId)) {
+                    assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
                     foundMultiExec2 = true;
-                }
-                else if (rootMultiExecutionId.equals(eventExecutionId)) {
-                    assertEquals(FlowableEngineEventType.MULTI_INSTANCE_ACTIVITY_CANCELLED, activityEvent.getType());
+                } else if (rootMultiExecutionId.equals(eventExecutionId)) {
+                    assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.MULTI_INSTANCE_ACTIVITY_CANCELLED);
                     foundRootExec = true;
                 }
             } else if ("cancelBoundaryEvent1".equals(cancelledEvent.getActivityId())) {
-                assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, activityEvent.getType());
+                assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
                 cancelledEvent = (FlowableActivityCancelledEvent) activityEvent;
-                assertEquals("cancelBoundaryEvent1", cancelledEvent.getActivityId());
-                assertEquals(boundaryExecution.getId(), activityEvent.getExecutionId());
+                assertThat(cancelledEvent.getActivityId()).isEqualTo("cancelBoundaryEvent1");
+                assertThat(activityEvent.getExecutionId()).isEqualTo(boundaryExecution.getId());
                 foundBoundaryExec = true;
             }
         }
 
-        assert(foundMultiExec1);
-        assert(foundMultiExec2);
-        assert(foundRootExec);
-        assert(foundBoundaryExec);
+        assert (foundMultiExec1);
+        assert (foundMultiExec2);
+        assert (foundRootExec);
+        assert (foundBoundaryExec);
 
         entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
 
-        assertEquals(FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT);
 
-        assertEquals(18, idx);
-        assertEquals(18, testListener.getEventsReceived().size());
+        assertThat(idx).isEqualTo(18);
+        assertThat(testListener.getEventsReceived()).hasSize(18);
     }
 
     /**
      * Multi-instance user task cancelled by terminate end event.
      */
     @Test
-    @Deployment(resources = {"org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.testMultiInstanceCompleteCondition.bpmn20.xml"})
+    @Deployment(resources = { "org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.testMultiInstanceCompleteCondition.bpmn20.xml" })
     public void testMultiInstanceCompleteCondition() throws Exception {
-        Map<String,Object> variables = new HashMap<>();
+        Map<String, Object> variables = new HashMap<>();
         variables.put("percentageCompleted", Float.valueOf(.5f));
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("multiInstanceUserTaskEvents", variables);
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         //Execution task1Execution = runtimeService.createExecutionQuery().activityId("task1").singleResult();
 
         List<Execution> multiExecutions = runtimeService.createExecutionQuery().activityId("task").list();
-        assertEquals(2, multiExecutions.size());
+        assertThat(multiExecutions).hasSize(2);
         String multiExecutionId1 = multiExecutions.get(0).getId();
         String multiExecutionId2 = multiExecutions.get(1).getId();
         String rootMultiExecutionId = null;
 
         List<Execution> executions = runtimeService.createExecutionQuery().parentId(processInstance.getId()).list();
-        for (Execution execution: executions)
-        {
-            if (((ExecutionEntity)execution).isMultiInstanceRoot()) {
+        for (Execution execution : executions) {
+            if (((ExecutionEntity) execution).isMultiInstanceRoot()) {
                 rootMultiExecutionId = execution.getId();
                 break;
             }
         }
-        assertNotNull(rootMultiExecutionId);
-        assertNotSame(rootMultiExecutionId, multiExecutionId1);
-        assertNotSame(rootMultiExecutionId, multiExecutionId2);
+        assertThat(rootMultiExecutionId).isNotNull();
+        assertThat(multiExecutionId1).isNotSameAs(rootMultiExecutionId);
+        assertThat(multiExecutionId2).isNotSameAs(rootMultiExecutionId);
 
         int idx = 0;
         FlowableEvent flowableEvent = testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.PROCESS_STARTED, flowableEvent.getType());
+        assertThat(flowableEvent.getType()).isEqualTo(FlowableEngineEventType.PROCESS_STARTED);
         ExecutionEntity executionEntity = (ExecutionEntity) ((FlowableProcessStartedEvent) flowableEvent).getEntity();
-        assertEquals(processInstance.getId(), executionEntity.getProcessInstanceId());
+        assertThat(executionEntity.getProcessInstanceId()).isEqualTo(processInstance.getId());
 
         FlowableActivityEvent activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("start", activityEvent.getActivityName());
-        assertEquals("startEvent", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityName()).isEqualTo("start");
+        assertThat(activityEvent.getActivityType()).isEqualTo("startEvent");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("start", activityEvent.getActivityName());
-        assertEquals("startEvent", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityName()).isEqualTo("start");
+        assertThat(activityEvent.getActivityType()).isEqualTo("startEvent");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.MULTI_INSTANCE_ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("Multi User Task-${loopCounter}", activityEvent.getActivityName());
-        assertEquals("task", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.MULTI_INSTANCE_ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityName()).isEqualTo("Multi User Task-${loopCounter}");
+        assertThat(activityEvent.getActivityId()).isEqualTo("task");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("Multi User Task-${loopCounter}", activityEvent.getActivityName());
-        assertEquals("task", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityName()).isEqualTo("Multi User Task-${loopCounter}");
+        assertThat(activityEvent.getActivityId()).isEqualTo("task");
 
         FlowableEntityEvent entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.TASK_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_CREATED);
         TaskEntity taskEntity = (TaskEntity) entityEvent.getEntity();
-        assertEquals("Multi User Task-0", taskEntity.getName());
+        assertThat(taskEntity.getName()).isEqualTo("Multi User Task-0");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("task", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("task");
 
         entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.TASK_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_CREATED);
         taskEntity = (TaskEntity) entityEvent.getEntity();
-        assertEquals("Multi User Task-1", taskEntity.getName());
+        assertThat(taskEntity.getName()).isEqualTo("Multi User Task-1");
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
         org.flowable.task.api.Task task0 = tasks.get(0);
 
         taskService.complete(task0.getId());
 
         entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.TASK_COMPLETED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_COMPLETED);
         taskEntity = (TaskEntity) entityEvent.getEntity();
-        assertEquals(task0.getId(), taskEntity.getId());
+        assertThat(taskEntity.getId()).isEqualTo(task0.getId());
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.MULTI_INSTANCE_ACTIVITY_COMPLETED_WITH_CONDITION, activityEvent.getType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.MULTI_INSTANCE_ACTIVITY_COMPLETED_WITH_CONDITION);
 
-        assertEquals("task", activityEvent.getActivityId());
-        assertEquals(2, ((FlowableMultiInstanceActivityCompletedEvent)activityEvent).getNumberOfInstances());
-        assertEquals(1, ((FlowableMultiInstanceActivityCompletedEvent)activityEvent).getNumberOfActiveInstances());
-        assertEquals(1, ((FlowableMultiInstanceActivityCompletedEvent)activityEvent).getNumberOfCompletedInstances());
-        assertEquals(false, ((FlowableMultiInstanceActivityCompletedEvent)activityEvent).isSequential());
-
-        activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, activityEvent.getType());
-        assertEquals("task", activityEvent.getActivityId());
+        assertThat(activityEvent.getActivityId()).isEqualTo("task");
+        assertThat(((FlowableMultiInstanceActivityCompletedEvent) activityEvent).getNumberOfInstances()).isEqualTo(2);
+        assertThat(((FlowableMultiInstanceActivityCompletedEvent) activityEvent).getNumberOfActiveInstances()).isEqualTo(1);
+        assertThat(((FlowableMultiInstanceActivityCompletedEvent) activityEvent).getNumberOfCompletedInstances()).isEqualTo(1);
+        assertThat(((FlowableMultiInstanceActivityCompletedEvent) activityEvent).isSequential()).isEqualTo(false);
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("endEvent", activityEvent.getActivityType());
-        assertEquals("endEvent1", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("task");
+
+        activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityType()).isEqualTo("endEvent");
+        assertThat(activityEvent.getActivityId()).isEqualTo("endEvent1");
 
         entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT);
     }
 
     /**
      * Multi-instance user task cancelled by terminate end event.
      */
     @Test
-    @Deployment(resources = {"org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.testMultiInstanceCompleteCondition.bpmn20.xml"})
+    @Deployment(resources = { "org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.testMultiInstanceCompleteCondition.bpmn20.xml" })
     public void testMultiInstanceComplete() throws Exception {
-        Map<String,Object> variables = new HashMap<>();
+        Map<String, Object> variables = new HashMap<>();
         variables.put("percentageCompleted", Float.valueOf(2));
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("multiInstanceUserTaskEvents", variables);
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         //Execution task1Execution = runtimeService.createExecutionQuery().activityId("task1").singleResult();
 
         List<Execution> multiExecutions = runtimeService.createExecutionQuery().activityId("task").list();
-        assertEquals(2, multiExecutions.size());
+        assertThat(multiExecutions).hasSize(2);
         String multiExecutionId1 = multiExecutions.get(0).getId();
         String multiExecutionId2 = multiExecutions.get(1).getId();
         String rootMultiExecutionId = null;
 
         List<Execution> executions = runtimeService.createExecutionQuery().parentId(processInstance.getId()).list();
-        for (Execution execution: executions)
-        {
-            if (((ExecutionEntity)execution).isMultiInstanceRoot()) {
+        for (Execution execution : executions) {
+            if (((ExecutionEntity) execution).isMultiInstanceRoot()) {
                 rootMultiExecutionId = execution.getId();
                 break;
             }
         }
-        assertNotNull(rootMultiExecutionId);
-        assertNotSame(rootMultiExecutionId, multiExecutionId1);
-        assertNotSame(rootMultiExecutionId, multiExecutionId2);
+        assertThat(rootMultiExecutionId).isNotNull();
+        assertThat(multiExecutionId1).isNotSameAs(rootMultiExecutionId);
+        assertThat(multiExecutionId2).isNotSameAs(rootMultiExecutionId);
 
         int idx = 0;
         FlowableEvent flowableEvent = testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.PROCESS_STARTED, flowableEvent.getType());
+        assertThat(flowableEvent.getType()).isEqualTo(FlowableEngineEventType.PROCESS_STARTED);
         ExecutionEntity executionEntity = (ExecutionEntity) ((FlowableProcessStartedEvent) flowableEvent).getEntity();
-        assertEquals(processInstance.getId(), executionEntity.getProcessInstanceId());
+        assertThat(executionEntity.getProcessInstanceId()).isEqualTo(processInstance.getId());
 
         FlowableActivityEvent activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("start", activityEvent.getActivityName());
-        assertEquals("startEvent", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityName()).isEqualTo("start");
+        assertThat(activityEvent.getActivityType()).isEqualTo("startEvent");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("start", activityEvent.getActivityName());
-        assertEquals("startEvent", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityName()).isEqualTo("start");
+        assertThat(activityEvent.getActivityType()).isEqualTo("startEvent");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.MULTI_INSTANCE_ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("Multi User Task-${loopCounter}", activityEvent.getActivityName());
-        assertEquals("task", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.MULTI_INSTANCE_ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityName()).isEqualTo("Multi User Task-${loopCounter}");
+        assertThat(activityEvent.getActivityId()).isEqualTo("task");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("Multi User Task-${loopCounter}", activityEvent.getActivityName());
-        assertEquals("task", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityName()).isEqualTo("Multi User Task-${loopCounter}");
+        assertThat(activityEvent.getActivityId()).isEqualTo("task");
 
         FlowableEntityEvent entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.TASK_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_CREATED);
         TaskEntity taskEntity = (TaskEntity) entityEvent.getEntity();
-        assertEquals("Multi User Task-0", taskEntity.getName());
+        assertThat(taskEntity.getName()).isEqualTo("Multi User Task-0");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("task", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("task");
 
         entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.TASK_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_CREATED);
         taskEntity = (TaskEntity) entityEvent.getEntity();
-        assertEquals("Multi User Task-1", taskEntity.getName());
+        assertThat(taskEntity.getName()).isEqualTo("Multi User Task-1");
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
         org.flowable.task.api.Task task0 = tasks.get(0);
         org.flowable.task.api.Task task1 = tasks.get(1);
 
-        multiExecutions = runtimeService.createExecutionQuery().activityId("task").list() ;
-        assertEquals(2, multiExecutions.size());
+        multiExecutions = runtimeService.createExecutionQuery().activityId("task").list();
+        assertThat(multiExecutions).hasSize(2);
 
         taskService.complete(task0.getId());
 
-        multiExecutions = runtimeService.createExecutionQuery().activityId("task").list() ;
-        assertEquals(1, multiExecutions.size());
+        multiExecutions = runtimeService.createExecutionQuery().activityId("task").list();
+        assertThat(multiExecutions).hasSize(1);
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(1, tasks.size());
+        assertThat(tasks).hasSize(1);
 
         entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.TASK_COMPLETED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_COMPLETED);
         taskEntity = (TaskEntity) entityEvent.getEntity();
-        assertEquals(task0.getId(), taskEntity.getId());
+        assertThat(taskEntity.getId()).isEqualTo(task0.getId());
 
         taskService.complete(task1.getId());
 
         entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.TASK_COMPLETED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_COMPLETED);
         taskEntity = (TaskEntity) entityEvent.getEntity();
-        assertEquals(task1.getId(), taskEntity.getId());
+        assertThat(taskEntity.getId()).isEqualTo(task1.getId());
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.MULTI_INSTANCE_ACTIVITY_COMPLETED, activityEvent.getType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.MULTI_INSTANCE_ACTIVITY_COMPLETED);
 
-        assertEquals("task", activityEvent.getActivityId());
-        assertEquals(2, ((FlowableMultiInstanceActivityCompletedEvent)activityEvent).getNumberOfInstances());
-        assertEquals(0, ((FlowableMultiInstanceActivityCompletedEvent)activityEvent).getNumberOfActiveInstances());
-        assertEquals(2, ((FlowableMultiInstanceActivityCompletedEvent)activityEvent).getNumberOfCompletedInstances());
-        assertEquals(false, ((FlowableMultiInstanceActivityCompletedEvent)activityEvent).isSequential());
+        assertThat(activityEvent.getActivityId()).isEqualTo("task");
+        assertThat(((FlowableMultiInstanceActivityCompletedEvent) activityEvent).getNumberOfInstances()).isEqualTo(2);
+        assertThat(((FlowableMultiInstanceActivityCompletedEvent) activityEvent).getNumberOfActiveInstances()).isEqualTo(0);
+        assertThat(((FlowableMultiInstanceActivityCompletedEvent) activityEvent).getNumberOfCompletedInstances()).isEqualTo(2);
+        assertThat(((FlowableMultiInstanceActivityCompletedEvent) activityEvent).isSequential()).isEqualTo(false);
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("endEvent", activityEvent.getActivityType());
-        assertEquals("endEvent1", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityType()).isEqualTo("endEvent");
+        assertThat(activityEvent.getActivityId()).isEqualTo("endEvent1");
 
         entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT);
     }
 
     /**
@@ -443,81 +440,80 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
      * multi-instance user task.
      */
     @Test
-    @Deployment(resources = {"org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.bpmn20.xml"})
+    @Deployment(resources = { "org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.bpmn20.xml" })
     public void testMultiInstanceCancelledByMessageBoundaryEvent() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("multiInstanceUserTaskEvents");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         Execution task1Execution = runtimeService.createExecutionQuery().activityId("task1").singleResult();
         Execution boundaryExecution = runtimeService.createExecutionQuery().activityId("cancelBoundaryEvent1").singleResult();
         List<Execution> multiExecutions = runtimeService.createExecutionQuery().activityId("task2").list();
-        assertEquals(2, multiExecutions.size());
+        assertThat(multiExecutions).hasSize(2);
         String multiExecutionId1 = multiExecutions.get(0).getId();
         String multiExecutionId2 = multiExecutions.get(1).getId();
         String rootMultiExecutionId = null;
 
         List<Execution> executions = runtimeService.createExecutionQuery().parentId(processInstance.getId()).list();
-        for (Execution execution: executions)
-        {
-            if (((ExecutionEntity)execution).isMultiInstanceRoot()) {
+        for (Execution execution : executions) {
+            if (((ExecutionEntity) execution).isMultiInstanceRoot()) {
                 rootMultiExecutionId = execution.getId();
                 break;
             }
         }
-        assertNotNull(rootMultiExecutionId);
-        assertNotSame(rootMultiExecutionId, multiExecutionId1);
-        assertNotSame(rootMultiExecutionId, multiExecutionId2);
-        assertNotSame(rootMultiExecutionId, boundaryExecution);
+        assertThat(rootMultiExecutionId).isNotNull();
+        assertThat(multiExecutionId1).isNotSameAs(rootMultiExecutionId);
+        assertThat(multiExecutionId2).isNotSameAs(rootMultiExecutionId);
+        assertThat(boundaryExecution).isNotSameAs(rootMultiExecutionId);
 
         int idx = 0;
         FlowableEvent flowableEvent = testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.PROCESS_STARTED, flowableEvent.getType());
+        assertThat(flowableEvent.getType()).isEqualTo(FlowableEngineEventType.PROCESS_STARTED);
         ExecutionEntity executionEntity = (ExecutionEntity) ((FlowableProcessStartedEvent) flowableEvent).getEntity();
-        assertEquals(processInstance.getId(), executionEntity.getProcessInstanceId());
+        assertThat(executionEntity.getProcessInstanceId()).isEqualTo(processInstance.getId());
 
         FlowableActivityEvent activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("startEvent", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityType()).isEqualTo("startEvent");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("startEvent", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityType()).isEqualTo("startEvent");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("task1", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("task1");
 
         FlowableEntityEvent entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.TASK_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_CREATED);
         TaskEntity taskEntity = (TaskEntity) entityEvent.getEntity();
-        assertEquals("User Task1", taskEntity.getName());
+        assertThat(taskEntity.getName()).isEqualTo("User Task1");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.MULTI_INSTANCE_ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("task2", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.MULTI_INSTANCE_ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("task2");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("task2", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("task2");
 
         entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.TASK_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_CREATED);
         taskEntity = (TaskEntity) entityEvent.getEntity();
-        assertEquals("Multi User Task-0", taskEntity.getName());
+        assertThat(taskEntity.getName()).isEqualTo("Multi User Task-0");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("task2", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("task2");
 
         entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.TASK_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_CREATED);
         taskEntity = (TaskEntity) entityEvent.getEntity();
-        assertEquals("Multi User Task-1", taskEntity.getName());
+        assertThat(taskEntity.getName()).isEqualTo("Multi User Task-1");
 
         Execution cancelMessageExecution = runtimeService.createExecutionQuery().messageEventSubscriptionName("cancel")
                 .singleResult();
-        assertNotNull(cancelMessageExecution);
-        assertEquals("cancelBoundaryEvent1", cancelMessageExecution.getActivityId());
+        assertThat(cancelMessageExecution).isNotNull();
+        assertThat(cancelMessageExecution.getActivityId()).isEqualTo("cancelBoundaryEvent1");
 
         // cancel the multi-instance user task
         runtimeService.messageEventReceived("cancel", cancelMessageExecution.getId());
@@ -527,63 +523,59 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
 
         // cancelled event for one of the multi-instance user task instances
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, activityEvent.getType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
         FlowableActivityCancelledEvent cancelledEvent = (FlowableActivityCancelledEvent) activityEvent;
-        assertEquals("task2", cancelledEvent.getActivityId());
-        assertEquals("userTask", cancelledEvent.getActivityType());
-        assertEquals("Multi User Task-${loopCounter}", cancelledEvent.getActivityName());
+        assertThat(cancelledEvent.getActivityId()).isEqualTo("task2");
+        assertThat(cancelledEvent.getActivityType()).isEqualTo("userTask");
+        assertThat(cancelledEvent.getActivityName()).isEqualTo("Multi User Task-${loopCounter}");
         if (multiExecutionId2.equals(activityEvent.getExecutionId())) {
-            foundMultiExec2 = true;            
-        }
-        else if (multiExecutionId1.equals(activityEvent.getExecutionId())) {
-            foundMultiExec1 = true;            
-        }
-        else {
+            foundMultiExec2 = true;
+        } else if (multiExecutionId1.equals(activityEvent.getExecutionId())) {
+            foundMultiExec1 = true;
+        } else {
             fail("Unexpected execution id " + activityEvent.getExecutionId());
-        }       
+        }
 
         // cancelled event for one of the multi-instance user task instances
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, activityEvent.getType());
-        assertEquals("task2", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("task2");
         if (multiExecutionId2.equals(activityEvent.getExecutionId())) {
-            foundMultiExec2 = true;            
-        }
-        else if (multiExecutionId1.equals(activityEvent.getExecutionId())) {
-            foundMultiExec1 = true;            
-        }
-        else {
+            foundMultiExec2 = true;
+        } else if (multiExecutionId1.equals(activityEvent.getExecutionId())) {
+            foundMultiExec1 = true;
+        } else {
             fail("Unexpected execution id " + activityEvent.getExecutionId());
         }
 
-        assertTrue(foundMultiExec1);
-        assertTrue(foundMultiExec2);
+        assertThat(foundMultiExec1).isTrue();
+        assertThat(foundMultiExec2).isTrue();
 
         // cancelled event for the root of the multi-instance user task
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, activityEvent.getType());
-        assertEquals("task2", activityEvent.getActivityId());
-        assertEquals(rootMultiExecutionId, activityEvent.getExecutionId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("task2");
+        assertThat(activityEvent.getExecutionId()).isEqualTo(rootMultiExecutionId);
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("cancelBoundaryEvent1", activityEvent.getActivityId());
-        assertEquals(boundaryExecution.getId(), activityEvent.getExecutionId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("cancelBoundaryEvent1");
+        assertThat(activityEvent.getExecutionId()).isEqualTo(boundaryExecution.getId());
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("endEvent1", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("endEvent1");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, activityEvent.getType());
-        assertEquals("task1", activityEvent.getActivityId());
-        assertEquals(task1Execution.getId(), activityEvent.getExecutionId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("task1");
+        assertThat(activityEvent.getExecutionId()).isEqualTo(task1Execution.getId());
 
         entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT);
 
-        assertEquals(17, idx);
-        assertEquals(17, testListener.getEventsReceived().size());
+        assertThat(idx).isEqualTo(17);
+        assertThat(testListener.getEventsReceived()).hasSize(17);
     }
 
     /**
@@ -593,144 +585,143 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
     @Test
     @Deployment(resources = {
             "org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.testCallActivityTerminateEnd.bpmn20.xml",
-            "org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.testCalledActivityTerminateEnd.bpmn20.xml"})
+            "org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.testCalledActivityTerminateEnd.bpmn20.xml" })
     public void testMultiInstanceInCallActivityCancelledByMessageBoundaryEvent() throws Exception {
         ProcessInstance processInstance = runtimeService
                 .startProcessInstanceByKey("multiInstanceCallActivityTerminateEnd");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         ExecutionEntity subprocessInstance = (ExecutionEntity) runtimeService.createExecutionQuery()
                 .rootProcessInstanceId(processInstance.getId()).onlySubProcessExecutions().singleResult();
-        assertNotNull(subprocessInstance);
+        assertThat(subprocessInstance).isNotNull();
 
         int idx = 0;
         FlowableEvent flowableEvent = testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.PROCESS_STARTED, flowableEvent.getType());
+        assertThat(flowableEvent.getType()).isEqualTo(FlowableEngineEventType.PROCESS_STARTED);
         ExecutionEntity executionEntity = (ExecutionEntity) ((FlowableProcessStartedEvent) flowableEvent).getEntity();
-        assertEquals(processInstance.getId(), executionEntity.getProcessInstanceId());
+        assertThat(executionEntity.getProcessInstanceId()).isEqualTo(processInstance.getId());
 
         FlowableActivityEvent activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("startEvent", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityType()).isEqualTo("startEvent");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("startEvent", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityType()).isEqualTo("startEvent");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("callActivityId1", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("callActivityId1");
 
         // external subprocess
         flowableEvent = testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.PROCESS_STARTED, flowableEvent.getType());
+        assertThat(flowableEvent.getType()).isEqualTo(FlowableEngineEventType.PROCESS_STARTED);
         executionEntity = (ExecutionEntity) ((FlowableProcessStartedEvent) flowableEvent).getEntity();
-        assertEquals(subprocessInstance.getId(), executionEntity.getParentId());
+        assertThat(executionEntity.getParentId()).isEqualTo(subprocessInstance.getId());
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("task1", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("task1");
 
         FlowableEntityEvent entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.TASK_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_CREATED);
         TaskEntity taskEntity = (TaskEntity) entityEvent.getEntity();
-        assertEquals("User Task1 in Parent", taskEntity.getName());
+        assertThat(taskEntity.getName()).isEqualTo("User Task1 in Parent");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("startevent2", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("startevent2");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("startevent2", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("startevent2");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.MULTI_INSTANCE_ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("calledtask1", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.MULTI_INSTANCE_ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("calledtask1");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("calledtask1", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("calledtask1");
 
         entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.TASK_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_CREATED);
         taskEntity = (TaskEntity) entityEvent.getEntity();
-        assertEquals("Multi User Task-0", taskEntity.getName());
+        assertThat(taskEntity.getName()).isEqualTo("Multi User Task-0");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("calledtask1", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("calledtask1");
 
         entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.TASK_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_CREATED);
         taskEntity = (TaskEntity) entityEvent.getEntity();
-        assertEquals("Multi User Task-1", taskEntity.getName());
+        assertThat(taskEntity.getName()).isEqualTo("Multi User Task-1");
 
-        assertEquals(testListener.getEventsReceived().size(), idx);
+        assertThat(testListener.getEventsReceived()).hasSize(idx);
         testListener.clearEventsReceived();
 
         idx = 0;
         Execution cancelMessageExecution = runtimeService.createExecutionQuery().messageEventSubscriptionName("cancel")
                 .singleResult();
-        assertNotNull(cancelMessageExecution);
-        assertEquals("cancelBoundaryEvent1", cancelMessageExecution.getActivityId());
+        assertThat(cancelMessageExecution).isNotNull();
+        assertThat(cancelMessageExecution.getActivityId()).isEqualTo("cancelBoundaryEvent1");
 
         // cancel the multi-instance user task
         runtimeService.messageEventReceived("cancel", cancelMessageExecution.getId());
 
         // cancelled event for one of the multi-instance user task instances
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, activityEvent.getType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
         FlowableActivityCancelledEvent cancelledEvent = (FlowableActivityCancelledEvent) activityEvent;
-        assertEquals("calledtask1", cancelledEvent.getActivityId());
-        assertEquals("userTask", cancelledEvent.getActivityType());
-        assertEquals("Multi User Task-${loopCounter}", cancelledEvent.getActivityName());
+        assertThat(cancelledEvent.getActivityId()).isEqualTo("calledtask1");
+        assertThat(cancelledEvent.getActivityType()).isEqualTo("userTask");
+        assertThat(cancelledEvent.getActivityName()).isEqualTo("Multi User Task-${loopCounter}");
 
         // cancelled event for one of the multi-instance user task instances
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, activityEvent.getType());
-        assertEquals("calledtask1", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("calledtask1");
 
         // cancelled event for the root of the multi-instance user task
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, activityEvent.getType());
-        assertEquals("calledtask1", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("calledtask1");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("cancelBoundaryEvent1", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("cancelBoundaryEvent1");
 
         // end event in external call activity
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("terminateEnd2", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("terminateEnd2");
 
         entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT);
         executionEntity = (ExecutionEntity) entityEvent.getEntity();
-        assertEquals(subprocessInstance.getId(), executionEntity.getId());
+        assertThat(executionEntity.getId()).isEqualTo(subprocessInstance.getId());
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("callActivityId1", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("callActivityId1");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("endevent1", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("endevent1");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, activityEvent.getType());
-        assertEquals("task1", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("task1");
 
         entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT);
         executionEntity = (ExecutionEntity) entityEvent.getEntity();
-        assertEquals(processInstance.getId(), executionEntity.getId());
+        assertThat(executionEntity.getId()).isEqualTo(processInstance.getId());
 
-        assertEquals(10, idx);
-        assertEquals(10, testListener.getEventsReceived().size());
+        assertThat(idx).isEqualTo(10);
+        assertThat(testListener.getEventsReceived()).hasSize(10);
     }
-
 
     /**
      * Multi-instance user task defined in external subprocess. The external subprocess and
@@ -739,111 +730,111 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
     @Test
     @Deployment(resources = {
             "org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.testCallActivityTerminateEnd.bpmn20.xml",
-            "org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.testCalledActivityTerminateEnd.bpmn20.xml"})
+            "org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.testCalledActivityTerminateEnd.bpmn20.xml" })
     public void testMultiInstanceInCallActivityCancelledWhenFlowToTerminateEnd() throws Exception {
         ProcessInstance processInstance = runtimeService
                 .startProcessInstanceByKey("multiInstanceCallActivityTerminateEnd");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         ExecutionEntity subprocessInstance = (ExecutionEntity) runtimeService.createExecutionQuery()
                 .rootProcessInstanceId(processInstance.getId()).onlySubProcessExecutions().singleResult();
-        assertNotNull(subprocessInstance);
+        assertThat(subprocessInstance).isNotNull();
 
         int idx = 0;
         FlowableEvent flowableEvent = testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.PROCESS_STARTED, flowableEvent.getType());
+        assertThat(flowableEvent.getType()).isEqualTo(FlowableEngineEventType.PROCESS_STARTED);
         ExecutionEntity executionEntity = (ExecutionEntity) ((FlowableProcessStartedEvent) flowableEvent).getEntity();
-        assertEquals(processInstance.getId(), executionEntity.getProcessInstanceId());
+        assertThat(executionEntity.getProcessInstanceId()).isEqualTo(processInstance.getId());
 
         FlowableActivityEvent activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("startEvent", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityType()).isEqualTo("startEvent");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("startEvent", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityType()).isEqualTo("startEvent");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("callActivityId1", activityEvent.getActivityId());
-        assertEquals("callActivity", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("callActivityId1");
+        assertThat(activityEvent.getActivityType()).isEqualTo("callActivity");
 
         // external subprocess
         flowableEvent = testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.PROCESS_STARTED, flowableEvent.getType());
+        assertThat(flowableEvent.getType()).isEqualTo(FlowableEngineEventType.PROCESS_STARTED);
         executionEntity = (ExecutionEntity) ((FlowableProcessStartedEvent) flowableEvent).getEntity();
-        assertEquals(subprocessInstance.getId(), executionEntity.getParentId());
+        assertThat(executionEntity.getParentId()).isEqualTo(subprocessInstance.getId());
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("task1", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("task1");
 
         FlowableEntityEvent entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.TASK_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_CREATED);
         TaskEntity taskEntity = (TaskEntity) entityEvent.getEntity();
-        assertEquals("User Task1 in Parent", taskEntity.getName());
+        assertThat(taskEntity.getName()).isEqualTo("User Task1 in Parent");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("startevent2", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("startevent2");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("startevent2", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("startevent2");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.MULTI_INSTANCE_ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("calledtask1", activityEvent.getActivityId());
-        assertEquals("userTask", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.MULTI_INSTANCE_ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("calledtask1");
+        assertThat(activityEvent.getActivityType()).isEqualTo("userTask");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("calledtask1", activityEvent.getActivityId());
-        assertEquals("userTask", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("calledtask1");
+        assertThat(activityEvent.getActivityType()).isEqualTo("userTask");
 
         entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.TASK_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_CREATED);
         taskEntity = (TaskEntity) entityEvent.getEntity();
-        assertEquals("Multi User Task-0", taskEntity.getName());
+        assertThat(taskEntity.getName()).isEqualTo("Multi User Task-0");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("calledtask1", activityEvent.getActivityId());
-        assertEquals("userTask", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("calledtask1");
+        assertThat(activityEvent.getActivityType()).isEqualTo("userTask");
 
         entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.TASK_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_CREATED);
         taskEntity = (TaskEntity) entityEvent.getEntity();
-        assertEquals("Multi User Task-1", taskEntity.getName());
+        assertThat(taskEntity.getName()).isEqualTo("Multi User Task-1");
 
-        assertEquals(testListener.getEventsReceived().size(), idx);
+        assertThat(testListener.getEventsReceived()).hasSize(idx);
         testListener.clearEventsReceived();
 
         testListener.getEventsReceived().clear();
         idx = 0;
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(1, tasks.size());
+        assertThat(tasks).hasSize(1);
         org.flowable.task.api.Task userTask1 = tasks.get(0);
-        assertEquals("User Task1 in Parent", userTask1.getName());
+        assertThat(userTask1.getName()).isEqualTo("User Task1 in Parent");
 
         // complete task1 in parent so we flow to terminate end
         taskService.complete(userTask1.getId());
 
         entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.TASK_COMPLETED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_COMPLETED);
         taskEntity = (TaskEntity) entityEvent.getEntity();
-        assertEquals("User Task1 in Parent", taskEntity.getName());
+        assertThat(taskEntity.getName()).isEqualTo("User Task1 in Parent");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("task1", activityEvent.getActivityId());
-        assertEquals("userTask", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("task1");
+        assertThat(activityEvent.getActivityType()).isEqualTo("userTask");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("endevent1", activityEvent.getActivityId());
-        assertEquals("endEvent", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("endevent1");
+        assertThat(activityEvent.getActivityType()).isEqualTo("endEvent");
 
         // we now should see cancelled event for the root of the multi-instance,
         // for each instance, and for the boundary event.  They have the same creation
@@ -853,24 +844,23 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
         for (int i = 0; i < 4; i++) {
             activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
             if ("cancelBoundaryEvent1".equals(activityEvent.getActivityId())) {
-                assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, activityEvent.getType());
+                assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
                 foundBoundary = true;
-                assertEquals("cancelBoundaryEvent1", activityEvent.getActivityId());
-                assertEquals("boundaryEvent", activityEvent.getActivityType());
+                assertThat(activityEvent.getActivityId()).isEqualTo("cancelBoundaryEvent1");
+                assertThat(activityEvent.getActivityType()).isEqualTo("boundaryEvent");
             } else if ("calledtask1".equals(activityEvent.getActivityId())) {
                 // cancelled event for one of the multi-instance user task instances or the root
-                if(FlowableEngineEventType.ACTIVITY_CANCELLED.equals(activityEvent.getType())) {
+                if (FlowableEngineEventType.ACTIVITY_CANCELLED.equals(activityEvent.getType())) {
                     FlowableActivityCancelledEvent cancelledEvent = (FlowableActivityCancelledEvent) activityEvent;
-                    assertEquals("calledtask1", cancelledEvent.getActivityId());
-                    assertEquals("userTask", cancelledEvent.getActivityType());
-                    assertEquals("Multi User Task-${loopCounter}", cancelledEvent.getActivityName());
-                }
-                else {
-                    assertEquals(FlowableEngineEventType.MULTI_INSTANCE_ACTIVITY_CANCELLED, activityEvent.getType());
+                    assertThat(cancelledEvent.getActivityId()).isEqualTo("calledtask1");
+                    assertThat(cancelledEvent.getActivityType()).isEqualTo("userTask");
+                    assertThat(cancelledEvent.getActivityName()).isEqualTo("Multi User Task-${loopCounter}");
+                } else {
+                    assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.MULTI_INSTANCE_ACTIVITY_CANCELLED);
                     FlowableMultiInstanceActivityCancelledEvent cancelledEvent = (FlowableMultiInstanceActivityCancelledEvent) activityEvent;
-                    assertEquals("calledtask1", cancelledEvent.getActivityId());
-                    assertEquals("userTask", cancelledEvent.getActivityType());
-                    assertEquals("Multi User Task-${loopCounter}", cancelledEvent.getActivityName());
+                    assertThat(cancelledEvent.getActivityId()).isEqualTo("calledtask1");
+                    assertThat(cancelledEvent.getActivityType()).isEqualTo("userTask");
+                    assertThat(cancelledEvent.getActivityName()).isEqualTo("Multi User Task-${loopCounter}");
                 }
 
                 multiCount++;
@@ -878,110 +868,110 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
                 fail("Unknown activity id " + activityEvent.getActivityId());
             }
         }
-        assertTrue(foundBoundary);
-        assertEquals(3, multiCount);
+        assertThat(foundBoundary).isTrue();
+        assertThat(multiCount).isEqualTo(3);
 
         // external subprocess cancelled
         FlowableCancelledEvent processCancelledEvent = (FlowableCancelledEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.PROCESS_CANCELLED, processCancelledEvent.getType());
-        assertEquals(subprocessInstance.getId(), processCancelledEvent.getExecutionId());
+        assertThat(processCancelledEvent.getType()).isEqualTo(FlowableEngineEventType.PROCESS_CANCELLED);
+        assertThat(processCancelledEvent.getExecutionId()).isEqualTo(subprocessInstance.getId());
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, activityEvent.getType());
-        assertEquals("callActivityId1", activityEvent.getActivityId());
-        assertEquals("callActivity", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("callActivityId1");
+        assertThat(activityEvent.getActivityType()).isEqualTo("callActivity");
 
         entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT);
         executionEntity = (ExecutionEntity) entityEvent.getEntity();
-        assertEquals(processInstance.getId(), executionEntity.getId());
+        assertThat(executionEntity.getId()).isEqualTo(processInstance.getId());
 
-        assertEquals(10, idx);
-        assertEquals(idx, testListener.getEventsReceived().size());
+        assertThat(idx).isEqualTo(10);
+        assertThat(testListener.getEventsReceived()).hasSize(idx);
     }
 
     @Test
     @Deployment(resources = {
-            "org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.testEmbeddedSubprocess.bpmn20.xml"})
+            "org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.testEmbeddedSubprocess.bpmn20.xml" })
     public void testMultiInstanceInSubprocessCancelledWhenFlowToTerminateEnd() throws Exception {
         ProcessInstance processInstance = runtimeService
                 .startProcessInstanceByKey("multiInstanceEmbeddedSubprocess");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         ExecutionEntity subprocessInstance = (ExecutionEntity) runtimeService.createExecutionQuery()
                 .rootProcessInstanceId(processInstance.getId()).onlySubProcessExecutions().singleResult();
-        assertNotNull(subprocessInstance);
+        assertThat(subprocessInstance).isNotNull();
 
         int idx = 0;
         FlowableEvent flowableEvent = testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.PROCESS_STARTED, flowableEvent.getType());
+        assertThat(flowableEvent.getType()).isEqualTo(FlowableEngineEventType.PROCESS_STARTED);
         ExecutionEntity executionEntity = (ExecutionEntity) ((FlowableProcessStartedEvent) flowableEvent).getEntity();
-        assertEquals(processInstance.getId(), executionEntity.getProcessInstanceId());
+        assertThat(executionEntity.getProcessInstanceId()).isEqualTo(processInstance.getId());
 
         FlowableActivityEvent activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("startEvent", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityType()).isEqualTo("startEvent");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("startEvent", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityType()).isEqualTo("startEvent");
 
         // embedded subprocess
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("subprocess1", activityEvent.getActivityId());
-        assertEquals("subProcess", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("subprocess1");
+        assertThat(activityEvent.getActivityType()).isEqualTo("subProcess");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("task1", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("task1");
 
         FlowableEntityEvent entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.TASK_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_CREATED);
         TaskEntity taskEntity = (TaskEntity) entityEvent.getEntity();
-        assertEquals("User Task1 in Parent", taskEntity.getName());
+        assertThat(taskEntity.getName()).isEqualTo("User Task1 in Parent");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("startevent2", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("startevent2");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("startevent2", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("startevent2");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.MULTI_INSTANCE_ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("task2", activityEvent.getActivityId());
-        assertEquals("userTask", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.MULTI_INSTANCE_ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("task2");
+        assertThat(activityEvent.getActivityType()).isEqualTo("userTask");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("task2", activityEvent.getActivityId());
-        assertEquals("userTask", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("task2");
+        assertThat(activityEvent.getActivityType()).isEqualTo("userTask");
 
         entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.TASK_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_CREATED);
         taskEntity = (TaskEntity) entityEvent.getEntity();
-        assertEquals("Multi User Task-0", taskEntity.getName());
+        assertThat(taskEntity.getName()).isEqualTo("Multi User Task-0");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("task2", activityEvent.getActivityId());
-        assertEquals("userTask", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("task2");
+        assertThat(activityEvent.getActivityType()).isEqualTo("userTask");
 
         entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.TASK_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_CREATED);
         taskEntity = (TaskEntity) entityEvent.getEntity();
-        assertEquals("Multi User Task-1", taskEntity.getName());
+        assertThat(taskEntity.getName()).isEqualTo("Multi User Task-1");
 
-        assertEquals(testListener.getEventsReceived().size(), idx);
+        assertThat(testListener.getEventsReceived()).hasSize(idx);
         testListener.clearEventsReceived();
 
         testListener.getEventsReceived().clear();
         idx = 0;
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(3, tasks.size());
+        assertThat(tasks).hasSize(3);
         org.flowable.task.api.Task userTask1 = null;
         for (org.flowable.task.api.Task t : tasks) {
             if ("User Task1 in Parent".equals(t.getName())) {
@@ -989,159 +979,158 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
                 break;
             }
         }
-        assertNotNull(userTask1);
+        assertThat(userTask1).isNotNull();
 
         // complete task1 so we flow to terminate end
         taskService.complete(userTask1.getId());
 
         entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.TASK_COMPLETED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_COMPLETED);
         taskEntity = (TaskEntity) entityEvent.getEntity();
-        assertEquals("User Task1 in Parent", taskEntity.getName());
+        assertThat(taskEntity.getName()).isEqualTo("User Task1 in Parent");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("task1", activityEvent.getActivityId());
-        assertEquals("userTask", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("task1");
+        assertThat(activityEvent.getActivityType()).isEqualTo("userTask");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("endevent1", activityEvent.getActivityId());
-        assertEquals("endEvent", activityEvent.getActivityType());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("endevent1");
+        assertThat(activityEvent.getActivityType()).isEqualTo("endEvent");
 
         int miEventCount = 0;
         for (int i = 0; i < 4; i++) {
 
             activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
             if ("cancelBoundaryEvent1".equals(activityEvent.getActivityId())) {
-                assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, activityEvent.getType());
-                assertEquals("cancelBoundaryEvent1", activityEvent.getActivityId());
-                assertEquals("boundaryEvent", activityEvent.getActivityType());
+                assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+                assertThat(activityEvent.getActivityId()).isEqualTo("cancelBoundaryEvent1");
+                assertThat(activityEvent.getActivityType()).isEqualTo("boundaryEvent");
 
             } else if ("task2".equals(activityEvent.getActivityId())) {
                 // cancelled event for one of the multi-instance user task instances
-                if(FlowableEngineEventType.ACTIVITY_CANCELLED.equals(activityEvent.getType())) {
+                if (FlowableEngineEventType.ACTIVITY_CANCELLED.equals(activityEvent.getType())) {
                     FlowableActivityCancelledEvent cancelledEvent = (FlowableActivityCancelledEvent) activityEvent;
-                    assertEquals("task2", cancelledEvent.getActivityId());
-                    assertEquals("userTask", cancelledEvent.getActivityType());
-                    assertEquals("Multi User Task-${loopCounter}", cancelledEvent.getActivityName());
-                }
-                else {
-                    assertEquals(FlowableEngineEventType.MULTI_INSTANCE_ACTIVITY_CANCELLED, activityEvent.getType());
+                    assertThat(cancelledEvent.getActivityId()).isEqualTo("task2");
+                    assertThat(cancelledEvent.getActivityType()).isEqualTo("userTask");
+                    assertThat(cancelledEvent.getActivityName()).isEqualTo("Multi User Task-${loopCounter}");
+                } else {
+                    assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.MULTI_INSTANCE_ACTIVITY_CANCELLED);
                     FlowableMultiInstanceActivityCancelledEvent cancelledEvent = (FlowableMultiInstanceActivityCancelledEvent) activityEvent;
-                    assertEquals("task2", cancelledEvent.getActivityId());
-                    assertEquals("userTask", cancelledEvent.getActivityType());
-                    assertEquals("Multi User Task-${loopCounter}", cancelledEvent.getActivityName());
+                    assertThat(cancelledEvent.getActivityId()).isEqualTo("task2");
+                    assertThat(cancelledEvent.getActivityType()).isEqualTo("userTask");
+                    assertThat(cancelledEvent.getActivityName()).isEqualTo("Multi User Task-${loopCounter}");
                 }
                 miEventCount++;
 
             } else if ("subprocess1".equals(activityEvent.getActivityId())) {
-                assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, activityEvent.getType());
-                assertEquals("subProcess", activityEvent.getActivityType());
-                
+                assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+                assertThat(activityEvent.getActivityType()).isEqualTo("subProcess");
+
             } else {
                 fail("Unknown activity id " + activityEvent.getActivityId());
-                
+
             }
 
         }
-        assertEquals(3, miEventCount);
+        assertThat(miEventCount).isEqualTo(3);
 
         // embedded subprocess cancelled
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
         FlowableCancelledEvent processCancelledEvent = (FlowableCancelledEvent) activityEvent;
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, processCancelledEvent.getType());
-        assertEquals(subprocessInstance.getId(), processCancelledEvent.getExecutionId());
-        assertEquals("subProcess", activityEvent.getActivityType());
+        assertThat(processCancelledEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(processCancelledEvent.getExecutionId()).isEqualTo(subprocessInstance.getId());
+        assertThat(activityEvent.getActivityType()).isEqualTo("subProcess");
 
         entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT);
         executionEntity = (ExecutionEntity) entityEvent.getEntity();
-        assertEquals(processInstance.getId(), executionEntity.getId());
+        assertThat(executionEntity.getId()).isEqualTo(processInstance.getId());
 
-        assertEquals(9, idx);
-        assertEquals(idx, testListener.getEventsReceived().size());
+        assertThat(idx).isEqualTo(9);
+        assertThat(testListener.getEventsReceived()).hasSize(idx);
     }
 
     @Test
     @Deployment(resources = {
-            "org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.testMultiInstanceSequentialUserTaskEventsWithNormalCompletion.bpmn20.xml"})
+            "org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.testMultiInstanceSequentialUserTaskEventsWithNormalCompletion.bpmn20.xml" })
     public void testMultiInstanceSequentialUserTaskEventsWithNormalCompletion() {
         ProcessInstance processInstance = runtimeService
                 .startProcessInstanceByKey("ID_b8a6875f-6c4b-4864-b369-af6e69c612a5");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
         String processId = processInstance.getProcessInstanceId();
         int idx = 0;
 
         FlowableProcessStartedEvent startEvent = (FlowableProcessStartedEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.PROCESS_STARTED, startEvent.getType());
+        assertThat(startEvent.getType()).isEqualTo(FlowableEngineEventType.PROCESS_STARTED);
 
         FlowableActivityEvent activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("startevent1", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("startevent1");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("startevent1", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("startevent1");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.MULTI_INSTANCE_ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("usertask1", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.MULTI_INSTANCE_ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("usertask1");
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("usertask1", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("usertask1");
 
         FlowableEntityEvent entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.TASK_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_CREATED);
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processId).includeIdentityLinks().list();
-        assertEquals(1, tasks.size());
-        Task task0  = tasks.get(0);
-        assertEquals("Task A-0", task0.getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("Task A-0");
 
-        taskService.complete(task0.getId());
+        taskService.complete(tasks.get(0).getId());
 
         entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.TASK_COMPLETED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_COMPLETED);
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("usertask1", activityEvent.getActivityId());
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("usertask1");
 
         entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.TASK_CREATED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_CREATED);
 
         tasks = taskService.createTaskQuery().processInstanceId(processId).includeIdentityLinks().list();
-        assertEquals(1, tasks.size());
-        Task task1 = tasks.get(0);
-        assertEquals("Task A-1", task1.getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("Task A-1");
 
-        taskService.complete(task1.getId());
+        taskService.complete(tasks.get(0).getId());
 
-        assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(processId).list().size());
-
-        entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.TASK_COMPLETED, entityEvent.getType());
-
-        activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.MULTI_INSTANCE_ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("usertask1", activityEvent.getActivityId());
-
-        activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, activityEvent.getType());
-        assertEquals("cancelBoundaryEvent", activityEvent.getActivityId());
-
-        activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, activityEvent.getType());
-        assertEquals("endevent1", activityEvent.getActivityId());
-
-        activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.ACTIVITY_COMPLETED, activityEvent.getType());
-        assertEquals("endevent1", activityEvent.getActivityId());
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processId).list()).isEmpty();
 
         entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
-        assertEquals(FlowableEngineEventType.PROCESS_COMPLETED, entityEvent.getType());
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_COMPLETED);
+
+        activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.MULTI_INSTANCE_ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("usertask1");
+
+        activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("cancelBoundaryEvent");
+
+        activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("endevent1");
+
+        activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
+        assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED);
+        assertThat(activityEvent.getActivityId()).isEqualTo("endevent1");
+
+        entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
+        assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.PROCESS_COMPLETED);
     }
 
     class MultiInstanceUserActivityEventListener extends AbstractFlowableEngineEventListener {
@@ -1150,19 +1139,19 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
 
         public MultiInstanceUserActivityEventListener() {
             super(new HashSet<>(Arrays.asList(
-                FlowableEngineEventType.ACTIVITY_STARTED,
-                FlowableEngineEventType.ACTIVITY_COMPLETED,
-                FlowableEngineEventType.ACTIVITY_CANCELLED,
-                FlowableEngineEventType.MULTI_INSTANCE_ACTIVITY_STARTED,
-                FlowableEngineEventType.MULTI_INSTANCE_ACTIVITY_COMPLETED,
+                    FlowableEngineEventType.ACTIVITY_STARTED,
+                    FlowableEngineEventType.ACTIVITY_COMPLETED,
+                    FlowableEngineEventType.ACTIVITY_CANCELLED,
+                    FlowableEngineEventType.MULTI_INSTANCE_ACTIVITY_STARTED,
+                    FlowableEngineEventType.MULTI_INSTANCE_ACTIVITY_COMPLETED,
                     FlowableEngineEventType.MULTI_INSTANCE_ACTIVITY_COMPLETED_WITH_CONDITION,
-                FlowableEngineEventType.MULTI_INSTANCE_ACTIVITY_CANCELLED,
-                FlowableEngineEventType.TASK_CREATED,
-                FlowableEngineEventType.TASK_COMPLETED,
-                FlowableEngineEventType.PROCESS_STARTED,
-                FlowableEngineEventType.PROCESS_COMPLETED,
-                FlowableEngineEventType.PROCESS_CANCELLED,
-                FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT
+                    FlowableEngineEventType.MULTI_INSTANCE_ACTIVITY_CANCELLED,
+                    FlowableEngineEventType.TASK_CREATED,
+                    FlowableEngineEventType.TASK_COMPLETED,
+                    FlowableEngineEventType.PROCESS_STARTED,
+                    FlowableEngineEventType.PROCESS_COMPLETED,
+                    FlowableEngineEventType.PROCESS_CANCELLED,
+                    FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT
             )));
             eventsReceived = new ArrayList<>();
         }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.java
@@ -203,10 +203,10 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
             }
         }
 
-        assert (foundMultiExec1);
-        assert (foundMultiExec2);
-        assert (foundRootExec);
-        assert (foundBoundaryExec);
+        assertThat(foundMultiExec1).isTrue();
+        assertThat(foundMultiExec2).isTrue();
+        assertThat(foundRootExec).isTrue();
+        assertThat(foundBoundaryExec).isTrue();
 
         entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ProcessDefinitionEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ProcessDefinitionEventsTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.api.event;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.flowable.common.engine.api.delegate.event.FlowableEngineEventType;
 import org.flowable.common.engine.api.delegate.event.FlowableEntityEvent;
 import org.flowable.common.engine.api.delegate.event.FlowableEvent;
@@ -40,54 +42,54 @@ public class ProcessDefinitionEventsTest extends PluggableFlowableTestCase {
         repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml").deploy();
         ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().processDefinitionKey("oneTaskProcess").singleResult();
 
-        assertNotNull(processDefinition);
+        assertThat(processDefinition).isNotNull();
 
         // Check create-event
-        assertEquals(2, listener.getEventsReceived().size());
-        assertTrue(listener.getEventsReceived().get(0) instanceof FlowableEntityEvent);
+        assertThat(listener.getEventsReceived()).hasSize(2);
+        assertThat(listener.getEventsReceived().get(0)).isInstanceOf(FlowableEntityEvent.class);
 
         FlowableEntityEvent event = (FlowableEntityEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ENTITY_CREATED, event.getType());
-        assertEquals(processDefinition.getId(), ((ProcessDefinition) event.getEntity()).getId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
+        assertThat(((ProcessDefinition) event.getEntity()).getId()).isEqualTo(processDefinition.getId());
 
         event = (FlowableEntityEvent) listener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.ENTITY_INITIALIZED, event.getType());
-        assertEquals(processDefinition.getId(), ((ProcessDefinition) event.getEntity()).getId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_INITIALIZED);
+        assertThat(((ProcessDefinition) event.getEntity()).getId()).isEqualTo(processDefinition.getId());
         listener.clearEventsReceived();
 
         // Check update event when category is updated
         repositoryService.setProcessDefinitionCategory(processDefinition.getId(), "test");
-        assertEquals(1, listener.getEventsReceived().size());
-        assertTrue(listener.getEventsReceived().get(0) instanceof FlowableEntityEvent);
+        assertThat(listener.getEventsReceived()).hasSize(1);
+        assertThat(listener.getEventsReceived().get(0)).isInstanceOf(FlowableEntityEvent.class);
 
         event = (FlowableEntityEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ENTITY_UPDATED, event.getType());
-        assertEquals(processDefinition.getId(), ((ProcessDefinition) event.getEntity()).getId());
-        assertEquals("test", ((ProcessDefinition) event.getEntity()).getCategory());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_UPDATED);
+        assertThat(((ProcessDefinition) event.getEntity()).getId()).isEqualTo(processDefinition.getId());
+        assertThat(((ProcessDefinition) event.getEntity()).getCategory()).isEqualTo("test");
         listener.clearEventsReceived();
 
         // Check update event when suspended/activated
         repositoryService.suspendProcessDefinitionById(processDefinition.getId());
         repositoryService.activateProcessDefinitionById(processDefinition.getId());
 
-        assertEquals(2, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(2);
         event = (FlowableEntityEvent) listener.getEventsReceived().get(0);
-        assertEquals(processDefinition.getId(), ((ProcessDefinition) event.getEntity()).getId());
-        assertEquals(FlowableEngineEventType.ENTITY_SUSPENDED, event.getType());
+        assertThat(((ProcessDefinition) event.getEntity()).getId()).isEqualTo(processDefinition.getId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_SUSPENDED);
         event = (FlowableEntityEvent) listener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.ENTITY_ACTIVATED, event.getType());
-        assertEquals(processDefinition.getId(), ((ProcessDefinition) event.getEntity()).getId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_ACTIVATED);
+        assertThat(((ProcessDefinition) event.getEntity()).getId()).isEqualTo(processDefinition.getId());
         listener.clearEventsReceived();
 
         // Check delete event when category is updated
         repositoryService.deleteDeployment(processDefinition.getDeploymentId(), true);
 
-        assertEquals(1, listener.getEventsReceived().size());
-        assertTrue(listener.getEventsReceived().get(0) instanceof FlowableEntityEvent);
+        assertThat(listener.getEventsReceived()).hasSize(1);
+        assertThat(listener.getEventsReceived().get(0)).isInstanceOf(FlowableEntityEvent.class);
 
         event = (FlowableEntityEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ENTITY_DELETED, event.getType());
-        assertEquals(processDefinition.getId(), ((ProcessDefinition) event.getEntity()).getId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_DELETED);
+        assertThat(((ProcessDefinition) event.getEntity()).getId()).isEqualTo(processDefinition.getId());
         listener.clearEventsReceived();
     }
 
@@ -99,11 +101,12 @@ public class ProcessDefinitionEventsTest extends PluggableFlowableTestCase {
     @Test
     public void testTimerStartEventDeployment() {
         deploymentIdsForAutoCleanup
-            .add(repositoryService.createDeployment()
-                .addClasspathResource("org/flowable/engine/test/bpmn/event/timer/StartTimerEventTest.testDurationStartTimerEvent.bpmn20.xml")
-                .deploy()
-                .getId());
-        ProcessDefinitionEntity processDefinition = (ProcessDefinitionEntity) repositoryService.createProcessDefinitionQuery().processDefinitionKey("startTimerEventExample").singleResult();
+                .add(repositoryService.createDeployment()
+                        .addClasspathResource("org/flowable/engine/test/bpmn/event/timer/StartTimerEventTest.testDurationStartTimerEvent.bpmn20.xml")
+                        .deploy()
+                        .getId());
+        ProcessDefinitionEntity processDefinition = (ProcessDefinitionEntity) repositoryService.createProcessDefinitionQuery()
+                .processDefinitionKey("startTimerEventExample").singleResult();
         FlowableEntityEvent processDefinitionCreated = FlowableEventBuilder.createEntityEvent(FlowableEngineEventType.ENTITY_CREATED, processDefinition);
 
         TimerJobEntity timer = (TimerJobEntity) managementService.createTimerJobQuery().singleResult();
@@ -116,23 +119,23 @@ public class ProcessDefinitionEventsTest extends PluggableFlowableTestCase {
         int beforeIndex = 0;
         int afterIndex = 0;
         for (int index = 0; index < listener.getEventsReceived().size(); index++) {
-            FlowableEvent activitiEvent = listener.getEventsReceived().get(index);
+            FlowableEvent flowableEvent = listener.getEventsReceived().get(index);
 
-            if (isEqual(before, activitiEvent))
+            if (isEqual(before, flowableEvent))
                 beforeIndex = index;
-            if (isEqual(after, activitiEvent))
+            if (isEqual(after, flowableEvent))
                 afterIndex = index;
         }
-        assertTrue(beforeIndex < afterIndex);
+        assertThat(beforeIndex).isLessThan(afterIndex);
     }
 
     /**
      * equals is not implemented.
      */
-    private boolean isEqual(FlowableEntityEvent event1, FlowableEvent activitiEvent) {
-        if (activitiEvent instanceof FlowableEntityEvent && event1.getType().equals(activitiEvent.getType())) {
-            FlowableEntityEvent activitiEntityEvent = (FlowableEntityEvent) activitiEvent;
-            if (activitiEntityEvent.getEntity().getClass().equals(event1.getEntity().getClass())) {
+    private boolean isEqual(FlowableEntityEvent event1, FlowableEvent flowableEvent) {
+        if (flowableEvent instanceof FlowableEntityEvent && event1.getType().equals(flowableEvent.getType())) {
+            FlowableEntityEvent flowableEntityEvent = (FlowableEntityEvent) flowableEvent;
+            if (flowableEntityEvent.getEntity().getClass().equals(event1.getEntity().getClass())) {
                 return true;
             }
         }
@@ -157,6 +160,7 @@ public class ProcessDefinitionEventsTest extends PluggableFlowableTestCase {
     }
 
     private static class ProcessDefinitionEventsListener extends TestMultipleFlowableEventListener {
+
         @Override
         public void onEvent(FlowableEvent event) {
             super.onEvent(event);
@@ -168,7 +172,6 @@ public class ProcessDefinitionEventsTest extends PluggableFlowableTestCase {
                         if (entity instanceof ProcessDefinitionEntity) {
                             // It is necessary to have process already present on the ProcessDefinitionEntity CREATE event
                             ProcessDefinitionUtil.getProcess(((ProcessDefinitionEntity) entity).getId());
-
                         }
                     default:
                         break;


### PR DESCRIPTION
Working on the `org.flowable.engine.test.api.event` package.

Continuing quest to use only a single style in each file and in the module.

