### PR TITLE
Use assertj fluent style in flowable-engine.  Part 3

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ProcessDefinitionScopedEventListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ProcessDefinitionScopedEventListenerTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -11,6 +11,8 @@
  * limitations under the License.
  */
 package org.flowable.engine.test.api.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
 
@@ -25,7 +27,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test for event-listeners that are registered on a process-definition scope, rather than on the global engine-wide scope.
- * 
+ *
  * @author Frederik Heremans
  */
 public class ProcessDefinitionScopedEventListenerTest extends PluggableFlowableTestCase {
@@ -39,29 +41,31 @@ public class ProcessDefinitionScopedEventListenerTest extends PluggableFlowableT
     @Test
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml", "org/flowable/engine/test/api/event/simpleProcess.bpmn20.xml" })
     public void testProcessDefinitionScopedListener(@DeploymentId String deploymentIdFromDeploymentAnnotation) throws Exception {
-        ProcessDefinition firstDefinition = repositoryService.createProcessDefinitionQuery().deploymentId(deploymentIdFromDeploymentAnnotation).processDefinitionKey("oneTaskProcess").singleResult();
-        assertNotNull(firstDefinition);
+        ProcessDefinition firstDefinition = repositoryService.createProcessDefinitionQuery().deploymentId(deploymentIdFromDeploymentAnnotation)
+                .processDefinitionKey("oneTaskProcess").singleResult();
+        assertThat(firstDefinition).isNotNull();
 
-        ProcessDefinition secondDefinition = repositoryService.createProcessDefinitionQuery().deploymentId(deploymentIdFromDeploymentAnnotation).processDefinitionKey("simpleProcess").singleResult();
-        assertNotNull(firstDefinition);
+        ProcessDefinition secondDefinition = repositoryService.createProcessDefinitionQuery().deploymentId(deploymentIdFromDeploymentAnnotation)
+                .processDefinitionKey("simpleProcess").singleResult();
+        assertThat(firstDefinition).isNotNull();
 
         // Fetch a reference to the process definition entity to add the listener
         TestFlowableEventListener listener = new TestFlowableEventListener();
         BpmnModel bpmnModel = repositoryService.getBpmnModel(firstDefinition.getId());
-        assertNotNull(bpmnModel);
+        assertThat(bpmnModel).isNotNull();
 
         ((FlowableEventSupport) bpmnModel.getEventSupport()).addEventListener(listener);
 
         // Start a process for the first definition, events should be received
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(firstDefinition.getId());
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
-        assertFalse(listener.getEventsReceived().isEmpty());
+        assertThat(listener.getEventsReceived()).isNotEmpty();
         listener.clearEventsReceived();
 
         // Start an instance of the other definition
         ProcessInstance otherInstance = runtimeService.startProcessInstanceById(secondDefinition.getId());
-        assertNotNull(otherInstance);
-        assertTrue(listener.getEventsReceived().isEmpty());
+        assertThat(otherInstance).isNotNull();
+        assertThat(listener.getEventsReceived()).isEmpty();
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ProcessInstanceEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ProcessInstanceEventsTest.java
@@ -12,10 +12,7 @@
  */
 package org.flowable.engine.test.api.event;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertNotEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -58,7 +55,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
     public void testProcessInstanceEvents() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         // Check create-event
         assertProcessStartedEvents(processInstance);
@@ -72,37 +69,37 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
         runtimeService.suspendProcessInstanceById(processInstance.getId());
         runtimeService.activateProcessInstanceById(processInstance.getId());
 
-        assertEquals(4, listener.getEventsReceived().size());
-        assertEquals(4, FilteredStaticTestFlowableEventListener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(4);
+        assertThat(FilteredStaticTestFlowableEventListener.getEventsReceived()).hasSize(4);
 
         event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(0);
-        assertEquals(processInstance.getId(), ((ProcessInstance) event.getEntity()).getId());
-        assertEquals(FlowableEngineEventType.ENTITY_SUSPENDED, event.getType());
-        assertEquals(processInstance.getId(), event.getProcessInstanceId());
-        assertEquals(processInstance.getId(), event.getExecutionId());
-        assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
+        assertThat(((ProcessInstance) event.getEntity()).getId()).isEqualTo(processInstance.getId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_SUSPENDED);
+        assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(event.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(event.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
         assertEventsEqual(event, FilteredStaticTestFlowableEventListener.getEventsReceived().get(0));
 
         event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.ENTITY_SUSPENDED, event.getType());
-        assertEquals(processInstance.getId(), event.getProcessInstanceId());
-        assertNotEquals(processInstance.getId(), event.getExecutionId());
-        assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_SUSPENDED);
+        assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(processInstance.getId()).isNotEqualTo(event.getExecutionId());
+        assertThat(event.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
         assertEventsEqual(event, FilteredStaticTestFlowableEventListener.getEventsReceived().get(1));
 
         event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(2);
-        assertEquals(FlowableEngineEventType.ENTITY_ACTIVATED, event.getType());
-        assertEquals(processInstance.getId(), ((ProcessInstance) event.getEntity()).getId());
-        assertEquals(processInstance.getId(), event.getProcessInstanceId());
-        assertEquals(processInstance.getId(), event.getExecutionId());
-        assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_ACTIVATED);
+        assertThat(((ProcessInstance) event.getEntity()).getId()).isEqualTo(processInstance.getId());
+        assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(event.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(event.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
         assertEventsEqual(event, FilteredStaticTestFlowableEventListener.getEventsReceived().get(2));
 
         event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(3);
-        assertEquals(FlowableEngineEventType.ENTITY_ACTIVATED, event.getType());
-        assertEquals(processInstance.getId(), event.getProcessInstanceId());
-        assertNotEquals(processInstance.getId(), event.getExecutionId());
-        assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_ACTIVATED);
+        assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(processInstance.getId()).isNotEqualTo(event.getExecutionId());
+        assertThat(event.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
         assertEventsEqual(event, FilteredStaticTestFlowableEventListener.getEventsReceived().get(3));
 
         listener.clearEventsReceived();
@@ -113,37 +110,37 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
         repositoryService.suspendProcessDefinitionById(processInstance.getProcessDefinitionId(), true, null);
         repositoryService.activateProcessDefinitionById(processInstance.getProcessDefinitionId(), true, null);
 
-        assertEquals(4, listener.getEventsReceived().size());
-        assertEquals(4, FilteredStaticTestFlowableEventListener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(4);
+        assertThat(FilteredStaticTestFlowableEventListener.getEventsReceived()).hasSize(4);
 
         event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(0);
-        assertEquals(processInstance.getId(), ((ProcessInstance) event.getEntity()).getId());
-        assertEquals(FlowableEngineEventType.ENTITY_SUSPENDED, event.getType());
-        assertEquals(processInstance.getId(), event.getProcessInstanceId());
-        assertEquals(processInstance.getId(), event.getExecutionId());
-        assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
+        assertThat(((ProcessInstance) event.getEntity()).getId()).isEqualTo(processInstance.getId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_SUSPENDED);
+        assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(event.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(event.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
         assertEventsEqual(event, FilteredStaticTestFlowableEventListener.getEventsReceived().get(0));
 
         event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.ENTITY_SUSPENDED, event.getType());
-        assertEquals(processInstance.getId(), event.getProcessInstanceId());
-        assertNotEquals(processInstance.getId(), event.getExecutionId());
-        assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_SUSPENDED);
+        assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(processInstance.getId()).isNotEqualTo(event.getExecutionId());
+        assertThat(event.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
         assertEventsEqual(event, FilteredStaticTestFlowableEventListener.getEventsReceived().get(1));
 
         event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(2);
-        assertEquals(FlowableEngineEventType.ENTITY_ACTIVATED, event.getType());
-        assertEquals(processInstance.getId(), ((ProcessInstance) event.getEntity()).getId());
-        assertEquals(processInstance.getId(), event.getProcessInstanceId());
-        assertEquals(processInstance.getId(), event.getExecutionId());
-        assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_ACTIVATED);
+        assertThat(((ProcessInstance) event.getEntity()).getId()).isEqualTo(processInstance.getId());
+        assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(event.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(event.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
         assertEventsEqual(event, FilteredStaticTestFlowableEventListener.getEventsReceived().get(2));
 
         event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(3);
-        assertEquals(FlowableEngineEventType.ENTITY_ACTIVATED, event.getType());
-        assertEquals(processInstance.getId(), event.getProcessInstanceId());
-        assertNotEquals(processInstance.getId(), event.getExecutionId());
-        assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_ACTIVATED);
+        assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(processInstance.getId()).isNotEqualTo(event.getExecutionId());
+        assertThat(event.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
         assertEventsEqual(event, FilteredStaticTestFlowableEventListener.getEventsReceived().get(3));
 
         listener.clearEventsReceived();
@@ -151,15 +148,15 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
 
         // Check update-event when business-key is updated
         runtimeService.updateBusinessKey(processInstance.getId(), "thekey");
-        assertEquals(1, listener.getEventsReceived().size());
-        assertEquals(1, FilteredStaticTestFlowableEventListener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(1);
+        assertThat(FilteredStaticTestFlowableEventListener.getEventsReceived()).hasSize(1);
 
         event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(0);
-        assertEquals(processInstance.getId(), ((ProcessInstance) event.getEntity()).getId());
-        assertEquals(FlowableEngineEventType.ENTITY_UPDATED, event.getType());
-        assertEquals(processInstance.getId(), event.getProcessInstanceId());
-        assertEquals(processInstance.getId(), event.getExecutionId());
-        assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
+        assertThat(((ProcessInstance) event.getEntity()).getId()).isEqualTo(processInstance.getId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_UPDATED);
+        assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(event.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(event.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
         assertEventsEqual(event, FilteredStaticTestFlowableEventListener.getEventsReceived().get(0));
         listener.clearEventsReceived();
         FilteredStaticTestFlowableEventListener.clearEventsReceived();
@@ -167,67 +164,67 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
         runtimeService.deleteProcessInstance(processInstance.getId(), "Testing events");
 
         List<FlowableEvent> processCancelledEvents = listener.filterEvents(FlowableEngineEventType.PROCESS_CANCELLED);
-        assertEquals(1, processCancelledEvents.size());
+        assertThat(processCancelledEvents).hasSize(1);
         FlowableCancelledEvent cancelledEvent = (FlowableCancelledEvent) processCancelledEvents.get(0);
-        assertEquals(FlowableEngineEventType.PROCESS_CANCELLED, cancelledEvent.getType());
-        assertEquals(processInstance.getId(), cancelledEvent.getProcessInstanceId());
-        assertEquals(processInstance.getId(), cancelledEvent.getExecutionId());
+        assertThat(cancelledEvent.getType()).isEqualTo(FlowableEngineEventType.PROCESS_CANCELLED);
+        assertThat(cancelledEvent.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(cancelledEvent.getExecutionId()).isEqualTo(processInstance.getId());
         assertEventsEqual(cancelledEvent, FilteredStaticTestFlowableEventListener.filterEvents(FlowableEngineEventType.PROCESS_CANCELLED).get(0));
         listener.clearEventsReceived();
         FilteredStaticTestFlowableEventListener.clearEventsReceived();
     }
 
     protected void assertProcessStartedEvents(ProcessInstance processInstance) {
-        assertEquals(6, listener.getEventsReceived().size());
-        assertEquals(6, FilteredStaticTestFlowableEventListener.getEventsReceived().size());
-        assertTrue(listener.getEventsReceived().get(0) instanceof FlowableEngineEntityEvent);
+        assertThat(listener.getEventsReceived()).hasSize(6);
+        assertThat(FilteredStaticTestFlowableEventListener.getEventsReceived()).hasSize(6);
+        assertThat(listener.getEventsReceived().get(0) instanceof FlowableEngineEntityEvent).isTrue();
 
         // process instance create event
         FlowableEngineEntityEvent event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ENTITY_CREATED, event.getType());
-        assertEquals(processInstance.getId(), ((ProcessInstance) event.getEntity()).getId());
-        assertEquals(processInstance.getId(), event.getProcessInstanceId());
-        assertEquals(processInstance.getId(), event.getExecutionId());
-        assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
+        assertThat(((ProcessInstance) event.getEntity()).getId()).isEqualTo(processInstance.getId());
+        assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(event.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(event.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
         assertEventsEqual(event, FilteredStaticTestFlowableEventListener.getEventsReceived().get(0));
 
         event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.PROCESS_CREATED, event.getType());
-        assertEquals(processInstance.getId(), event.getProcessInstanceId());
-        assertEquals(processInstance.getId(), event.getExecutionId());
-        assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.PROCESS_CREATED);
+        assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(event.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(event.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
         assertEventsEqual(event, FilteredStaticTestFlowableEventListener.getEventsReceived().get(1));
 
         event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(2);
-        assertEquals(FlowableEngineEventType.ENTITY_INITIALIZED, event.getType());
-        assertEquals(processInstance.getId(), event.getProcessInstanceId());
-        assertEquals(processInstance.getId(), event.getExecutionId());
-        assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_INITIALIZED);
+        assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(event.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(event.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
         assertEventsEqual(event, FilteredStaticTestFlowableEventListener.getEventsReceived().get(2));
 
         // start event create event
         event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(3);
-        assertEquals(FlowableEngineEventType.ENTITY_CREATED, event.getType());
-        assertEquals(processInstance.getId(), event.getProcessInstanceId());
-        assertNotEquals(processInstance.getId(), event.getExecutionId());
-        assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
+        assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(processInstance.getId()).isNotEqualTo(event.getExecutionId());
+        assertThat(event.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
         assertEventsEqual(event, FilteredStaticTestFlowableEventListener.getEventsReceived().get(3));
 
         // start event create initialized
         event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(4);
-        assertEquals(FlowableEngineEventType.ENTITY_INITIALIZED, event.getType());
-        assertEquals(processInstance.getId(), event.getProcessInstanceId());
-        assertNotEquals(processInstance.getId(), event.getExecutionId());
-        assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_INITIALIZED);
+        assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(processInstance.getId()).isNotEqualTo(event.getExecutionId());
+        assertThat(event.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
         assertEventsEqual(event, FilteredStaticTestFlowableEventListener.getEventsReceived().get(4));
 
         event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(5);
-        assertEquals(FlowableEngineEventType.PROCESS_STARTED, event.getType());
-        assertEquals(processInstance.getId(), event.getProcessInstanceId());
-        assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
-        assertTrue(event instanceof FlowableProcessStartedEvent);
-        assertNull(((FlowableProcessStartedEvent) event).getNestedProcessDefinitionId());
-        assertNull(((FlowableProcessStartedEvent) event).getNestedProcessInstanceId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.PROCESS_STARTED);
+        assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(event.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(event instanceof FlowableProcessStartedEvent).isTrue();
+        assertThat(((FlowableProcessStartedEvent) event).getNestedProcessDefinitionId()).isNull();
+        assertThat(((FlowableProcessStartedEvent) event).getNestedProcessInstanceId()).isNull();
         assertEventsEqual(event, FilteredStaticTestFlowableEventListener.getEventsReceived().get(5));
     }
 
@@ -235,105 +232,106 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
      * Test create, update and delete events of process instances.
      */
     @Test
-    @Deployment(resources = {"org/flowable/engine/test/api/runtime/nestedSubProcess.bpmn20.xml", "org/flowable/engine/test/api/runtime/subProcess.bpmn20.xml"})
+    @Deployment(resources = { "org/flowable/engine/test/api/runtime/nestedSubProcess.bpmn20.xml",
+            "org/flowable/engine/test/api/runtime/subProcess.bpmn20.xml" })
     public void testSubProcessInstanceEvents() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("nestedSimpleSubProcess");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
         String processDefinitionId = processInstance.getProcessDefinitionId();
 
         // Check create-event one main process the second one Scope execution, and the third one subprocess
-        assertEquals(12, listener.getEventsReceived().size());
-        assertTrue(listener.getEventsReceived().get(0) instanceof FlowableEngineEntityEvent);
+        assertThat(listener.getEventsReceived()).hasSize(12);
+        assertThat(listener.getEventsReceived().get(0) instanceof FlowableEngineEntityEvent).isTrue();
 
         // process instance created event
         FlowableEngineEntityEvent event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ENTITY_CREATED, event.getType());
-        assertEquals(processInstance.getId(), ((ProcessInstance) event.getEntity()).getId());
-        assertEquals(processInstance.getId(), event.getProcessInstanceId());
-        assertEquals(processInstance.getId(), event.getExecutionId());
-        assertEquals(processDefinitionId, event.getProcessDefinitionId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
+        assertThat(((ProcessInstance) event.getEntity()).getId()).isEqualTo(processInstance.getId());
+        assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(event.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(event.getProcessDefinitionId()).isEqualTo(processDefinitionId);
 
         event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(1);
         String processExecutionId = event.getExecutionId();
-        assertEquals(FlowableEngineEventType.PROCESS_CREATED, event.getType());
-        assertEquals(processInstance.getId(), event.getProcessInstanceId());
-        assertEquals(processInstance.getId(), processExecutionId);
-        assertEquals(processDefinitionId, event.getProcessDefinitionId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.PROCESS_CREATED);
+        assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(processExecutionId).isEqualTo(processInstance.getId());
+        assertThat(event.getProcessDefinitionId()).isEqualTo(processDefinitionId);
 
         event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(2);
         processExecutionId = event.getExecutionId();
-        assertEquals(FlowableEngineEventType.ENTITY_INITIALIZED, event.getType());
-        assertEquals(processInstance.getId(), event.getProcessInstanceId());
-        assertEquals(processInstance.getId(), processExecutionId);
-        assertEquals(processDefinitionId, event.getProcessDefinitionId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_INITIALIZED);
+        assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(processExecutionId).isEqualTo(processInstance.getId());
+        assertThat(event.getProcessDefinitionId()).isEqualTo(processDefinitionId);
 
         // start event created event
         event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(3);
         processExecutionId = event.getExecutionId();
-        assertEquals(FlowableEngineEventType.ENTITY_CREATED, event.getType());
-        assertEquals(processInstance.getId(), event.getProcessInstanceId());
-        assertNotEquals(processInstance.getId(), processExecutionId);
-        assertEquals(processDefinitionId, event.getProcessDefinitionId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
+        assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(processInstance.getId()).isNotEqualTo(processExecutionId);
+        assertThat(event.getProcessDefinitionId()).isEqualTo(processDefinitionId);
 
         // start event initialized event
         event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(4);
-        assertEquals(FlowableEngineEventType.ENTITY_INITIALIZED, event.getType());
-        assertEquals(processInstance.getId(), event.getProcessInstanceId());
-        assertNotEquals(processInstance.getId(), ((ExecutionEntity) event.getEntity()).getId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_INITIALIZED);
+        assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(processInstance.getId()).isNotEqualTo(((ExecutionEntity) event.getEntity()).getId());
 
         // Process start
         event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(5);
-        assertEquals(FlowableEngineEventType.PROCESS_STARTED, event.getType());
-        assertEquals(processInstance.getId(), event.getProcessInstanceId());
-        assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
-        assertTrue(event instanceof FlowableProcessStartedEvent);
-        assertNull(((FlowableProcessStartedEvent) event).getNestedProcessDefinitionId());
-        assertNull(((FlowableProcessStartedEvent) event).getNestedProcessInstanceId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.PROCESS_STARTED);
+        assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(event.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(event instanceof FlowableProcessStartedEvent).isTrue();
+        assertThat(((FlowableProcessStartedEvent) event).getNestedProcessDefinitionId()).isNull();
+        assertThat(((FlowableProcessStartedEvent) event).getNestedProcessInstanceId()).isNull();
 
         // sub process instance created event
         event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(6);
-        assertEquals(FlowableEngineEventType.ENTITY_CREATED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
         ExecutionEntity subProcessEntity = (ExecutionEntity) event.getEntity();
-        assertEquals(processExecutionId, subProcessEntity.getSuperExecutionId());
+        assertThat(subProcessEntity.getSuperExecutionId()).isEqualTo(processExecutionId);
         String subProcessInstanceId = subProcessEntity.getProcessInstanceId();
 
         event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(7);
-        assertEquals(FlowableEngineEventType.PROCESS_CREATED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.PROCESS_CREATED);
         subProcessEntity = (ExecutionEntity) event.getEntity();
-        assertEquals(processExecutionId, subProcessEntity.getSuperExecutionId());
-        
+        assertThat(subProcessEntity.getSuperExecutionId()).isEqualTo(processExecutionId);
+
         // sub process instance initialized event
         event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(8);
-        assertEquals(FlowableEngineEventType.ENTITY_INITIALIZED, event.getType());
-        assertEquals(subProcessInstanceId, event.getExecutionId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_INITIALIZED);
+        assertThat(event.getExecutionId()).isEqualTo(subProcessInstanceId);
         String subProcessDefinitionId = ((ExecutionEntity) event.getEntity()).getProcessDefinitionId();
-        assertNotNull(subProcessDefinitionId);
+        assertThat(subProcessDefinitionId).isNotNull();
 
         // sub process instance child execution created event
         event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(9);
-        assertEquals(FlowableEngineEventType.ENTITY_CREATED, event.getType());
-        assertEquals(subProcessInstanceId, event.getProcessInstanceId());
-        assertNotEquals(subProcessInstanceId, event.getExecutionId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
+        assertThat(event.getProcessInstanceId()).isEqualTo(subProcessInstanceId);
+        assertThat(subProcessInstanceId).isNotEqualTo(event.getExecutionId());
         subProcessDefinitionId = ((ExecutionEntity) event.getEntity()).getProcessDefinitionId();
-        assertNotNull(subProcessDefinitionId);
+        assertThat(subProcessDefinitionId).isNotNull();
         ProcessDefinition subProcessDefinition = repositoryService.getProcessDefinition(subProcessDefinitionId);
-        assertEquals("simpleSubProcess", subProcessDefinition.getKey());
+        assertThat(subProcessDefinition.getKey()).isEqualTo("simpleSubProcess");
 
         // sub process instance child execution initialized event
         event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(10);
-        assertEquals(FlowableEngineEventType.ENTITY_INITIALIZED, event.getType());
-        assertEquals(subProcessInstanceId, event.getProcessInstanceId());
-        assertNotEquals(subProcessInstanceId, event.getExecutionId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_INITIALIZED);
+        assertThat(event.getProcessInstanceId()).isEqualTo(subProcessInstanceId);
+        assertThat(subProcessInstanceId).isNotEqualTo(event.getExecutionId());
         subProcessDefinitionId = ((ExecutionEntity) event.getEntity()).getProcessDefinitionId();
-        assertNotNull(subProcessDefinitionId);
+        assertThat(subProcessDefinitionId).isNotNull();
 
         event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(11);
-        assertEquals(FlowableEngineEventType.PROCESS_STARTED, event.getType());
-        assertEquals(subProcessInstanceId, event.getProcessInstanceId());
-        assertEquals(subProcessDefinitionId, event.getProcessDefinitionId());
-        assertTrue(event instanceof FlowableProcessStartedEvent);
-        assertEquals(processDefinitionId, ((FlowableProcessStartedEvent) event).getNestedProcessDefinitionId());
-        assertEquals(processInstance.getId(), ((FlowableProcessStartedEvent) event).getNestedProcessInstanceId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.PROCESS_STARTED);
+        assertThat(event.getProcessInstanceId()).isEqualTo(subProcessInstanceId);
+        assertThat(event.getProcessDefinitionId()).isEqualTo(subProcessDefinitionId);
+        assertThat(event instanceof FlowableProcessStartedEvent).isTrue();
+        assertThat(((FlowableProcessStartedEvent) event).getNestedProcessDefinitionId()).isEqualTo(processDefinitionId);
+        assertThat(((FlowableProcessStartedEvent) event).getNestedProcessInstanceId()).isEqualTo(processInstance.getId());
 
         listener.clearEventsReceived();
     }
@@ -342,7 +340,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
      * Test process with signals start.
      */
     @Test
-    @Deployment(resources = {"org/flowable/engine/test/bpmn/event/signal/SignalEventTest.testSignalWithGlobalScope.bpmn20.xml"})
+    @Deployment(resources = { "org/flowable/engine/test/bpmn/event/signal/SignalEventTest.testSignalWithGlobalScope.bpmn20.xml" })
     public void testSignalProcessInstanceStart() throws Exception {
         this.runtimeService.startProcessInstanceByKey("processWithSignalCatch");
         listener.clearEventsReceived();
@@ -355,24 +353,24 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
      * Test Start->End process on PROCESS_COMPLETED event
      */
     @Test
-    @Deployment(resources = {"org/flowable/engine/test/api/event/ProcessInstanceEventsTest.noneTaskProcess.bpmn20.xml"})
+    @Deployment(resources = { "org/flowable/engine/test/api/event/ProcessInstanceEventsTest.noneTaskProcess.bpmn20.xml" })
     public void testProcessCompleted_StartEnd() throws Exception {
         this.runtimeService.startProcessInstanceByKey("noneTaskProcess");
 
-        assertEquals("ActivitiEventType.PROCESS_COMPLETED was expected 1 time.", 1, listener.filterEvents(FlowableEngineEventType.PROCESS_COMPLETED).size());
+        assertThat(listener.filterEvents(FlowableEngineEventType.PROCESS_COMPLETED)).as("ActivitiEventType.PROCESS_COMPLETED was expected 1 time.").hasSize(1);
     }
 
     /**
      * Test Start->User org.flowable.task.service.Task process on PROCESS_COMPLETED event
      */
     @Test
-    @Deployment(resources = {"org/flowable/engine/test/api/event/ProcessInstanceEventsTest.noEndProcess.bpmn20.xml"})
+    @Deployment(resources = { "org/flowable/engine/test/api/event/ProcessInstanceEventsTest.noEndProcess.bpmn20.xml" })
     public void testProcessCompleted_NoEnd() throws Exception {
         ProcessInstance noEndProcess = this.runtimeService.startProcessInstanceByKey("noEndProcess");
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(noEndProcess.getId()).singleResult();
         taskService.complete(task.getId());
 
-        assertEquals("ActivitiEventType.PROCESS_COMPLETED was expected 1 time.", 1, listener.filterEvents(FlowableEngineEventType.PROCESS_COMPLETED).size());
+        assertThat(listener.filterEvents(FlowableEngineEventType.PROCESS_COMPLETED)).as("ActivitiEventType.PROCESS_COMPLETED was expected 1 time.").hasSize(1);
     }
 
     /**
@@ -381,11 +379,11 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
      * process on PROCESS_COMPLETED event
      */
     @Test
-    @Deployment(resources = {"org/flowable/engine/test/api/event/ProcessInstanceEventsTest.parallelGatewayNoEndProcess.bpmn20.xml"})
+    @Deployment(resources = { "org/flowable/engine/test/api/event/ProcessInstanceEventsTest.parallelGatewayNoEndProcess.bpmn20.xml" })
     public void testProcessCompleted_ParallelGatewayNoEnd() throws Exception {
         this.runtimeService.startProcessInstanceByKey("noEndProcess");
 
-        assertEquals("ActivitiEventType.PROCESS_COMPLETED was expected 1 time.", 1, listener.filterEvents(FlowableEngineEventType.PROCESS_COMPLETED).size());
+        assertThat(listener.filterEvents(FlowableEngineEventType.PROCESS_COMPLETED)).as("ActivitiEventType.PROCESS_COMPLETED was expected 1 time.").hasSize(1);
     }
 
     /**
@@ -394,122 +392,138 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
      * process on PROCESS_COMPLETED event
      */
     @Test
-    @Deployment(resources = {"org/flowable/engine/test/api/event/ProcessInstanceEventsTest.parallelGatewayTwoEndsProcess.bpmn20.xml"})
+    @Deployment(resources = { "org/flowable/engine/test/api/event/ProcessInstanceEventsTest.parallelGatewayTwoEndsProcess.bpmn20.xml" })
     public void testProcessCompleted_ParallelGatewayTwoEnds() throws Exception {
         this.runtimeService.startProcessInstanceByKey("noEndProcess");
 
         List<FlowableEvent> events = listener.filterEvents(FlowableEngineEventType.PROCESS_COMPLETED);
-        assertEquals("ActivitiEventType.PROCESS_COMPLETED was expected 1 time.", 1, events.size());
+        assertThat(events).as("ActivitiEventType.PROCESS_COMPLETED was expected 1 time.").hasSize(1);
     }
 
     @Test
     @Deployment(resources = {
             "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateInCallActivityMulitInstance.bpmn",
-            "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.subProcessTerminateTerminateAll.bpmn20.xml"})
+            "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.subProcessTerminateTerminateAll.bpmn20.xml" })
     public void testProcessCompleted_TerminateInCallActivityMultiInstanceTerminateAll() throws Exception {
         runtimeService.startProcessInstanceByKey("terminateEndEventExample");
 
         List<FlowableEvent> events = listener.filterEvents(FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT);
-        assertEquals("FlowableEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT was expected 6 times.", 6, events.size());
+        assertThat(events).as("FlowableEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT was expected 6 times.").hasSize(6);
     }
 
     @Test
-    @Deployment(resources = {"org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
+    @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testProcessInstanceCancelledEvents_cancel() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
         listener.clearEventsReceived();
 
         runtimeService.deleteProcessInstance(processInstance.getId(), "delete_test");
 
         List<FlowableEvent> processCancelledEvents = listener.filterEvents(FlowableEngineEventType.PROCESS_CANCELLED);
-        assertEquals("ActivitiEventType.PROCESS_CANCELLED was expected 1 time.", 1, processCancelledEvents.size());
+        assertThat(processCancelledEvents).as("ActivitiEventType.PROCESS_CANCELLED was expected 1 time.").hasSize(1);
         FlowableCancelledEvent processCancelledEvent = (FlowableCancelledEvent) processCancelledEvents.get(0);
-        assertTrue("The cause has to be the same as deleteProcessInstance method call", FlowableCancelledEvent.class.isAssignableFrom(processCancelledEvent.getClass()));
-        assertEquals("The process instance has to be the same as in deleteProcessInstance method call", processInstance.getId(), processCancelledEvent.getProcessInstanceId());
-        assertEquals("The execution instance has to be the same as in deleteProcessInstance method call", processInstance.getId(), processCancelledEvent.getExecutionId());
-        assertEquals("The cause has to be the same as in deleteProcessInstance method call", "delete_test", processCancelledEvent.getCause());
+        assertThat(FlowableCancelledEvent.class.isAssignableFrom(processCancelledEvent.getClass()))
+                .as("The cause has to be the same as deleteProcessInstance method call").isTrue();
+        assertThat(processCancelledEvent.getProcessInstanceId()).as("The process instance has to be the same as in deleteProcessInstance method call")
+                .isEqualTo(processInstance.getId());
+        assertThat(processCancelledEvent.getExecutionId()).as("The execution instance has to be the same as in deleteProcessInstance method call")
+                .isEqualTo(processInstance.getId());
+        assertThat(processCancelledEvent.getCause()).as("The cause has to be the same as in deleteProcessInstance method call").isEqualTo("delete_test");
 
         List<FlowableEvent> taskCancelledEvents = listener.filterEvents(FlowableEngineEventType.ACTIVITY_CANCELLED);
-        assertEquals("ActivitiEventType.ACTIVITY_CANCELLED was expected 1 time.", 1, taskCancelledEvents.size());
+        assertThat(taskCancelledEvents).as("ActivitiEventType.ACTIVITY_CANCELLED was expected 1 time.").hasSize(1);
         FlowableActivityCancelledEvent activityCancelledEvent = (FlowableActivityCancelledEvent) taskCancelledEvents.get(0);
-        assertTrue("The cause has to be the same as deleteProcessInstance method call", FlowableActivityCancelledEvent.class.isAssignableFrom(activityCancelledEvent.getClass()));
-        assertEquals("The process instance has to be the same as in deleteProcessInstance method call", processInstance.getId(), activityCancelledEvent.getProcessInstanceId());
-        assertEquals("The cause has to be the same as in deleteProcessInstance method call", "delete_test", activityCancelledEvent.getCause());
+        assertThat(FlowableActivityCancelledEvent.class.isAssignableFrom(activityCancelledEvent.getClass()))
+                .as("The cause has to be the same as deleteProcessInstance method call").isTrue();
+        assertThat(activityCancelledEvent.getProcessInstanceId()).as("The process instance has to be the same as in deleteProcessInstance method call")
+                .isEqualTo(processInstance.getId());
+        assertThat(activityCancelledEvent.getCause()).as("The cause has to be the same as in deleteProcessInstance method call").isEqualTo("delete_test");
 
         listener.clearEventsReceived();
     }
 
     @Test
-    @Deployment(resources = {"org/flowable/engine/test/api/runtime/nestedSubProcess.bpmn20.xml", "org/flowable/engine/test/api/runtime/subProcess.bpmn20.xml"})
+    @Deployment(resources = { "org/flowable/engine/test/api/runtime/nestedSubProcess.bpmn20.xml",
+            "org/flowable/engine/test/api/runtime/subProcess.bpmn20.xml" })
     public void testProcessInstanceCancelledEvents_cancelProcessHierarchy() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("nestedSimpleSubProcess");
         ProcessInstance subProcess = runtimeService.createProcessInstanceQuery().superProcessInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
         listener.clearEventsReceived();
 
         runtimeService.deleteProcessInstance(processInstance.getId(), "delete_test");
 
         List<FlowableEvent> processCancelledEvents = listener.filterEvents(FlowableEngineEventType.PROCESS_CANCELLED);
-        assertEquals("ActivitiEventType.PROCESS_CANCELLED was expected 2 times.", 2, processCancelledEvents.size());
+        assertThat(processCancelledEvents).as("ActivitiEventType.PROCESS_CANCELLED was expected 2 times.").hasSize(2);
         FlowableCancelledEvent processCancelledEvent = (FlowableCancelledEvent) processCancelledEvents.get(0);
-        assertTrue("The cause has to be the same as deleteProcessInstance method call", FlowableCancelledEvent.class.isAssignableFrom(processCancelledEvent.getClass()));
-        assertEquals("The process instance has to be the same as in deleteProcessInstance method call", subProcess.getId(), processCancelledEvent.getProcessInstanceId());
-        assertEquals("The execution instance has to be the same as in deleteProcessInstance method call", subProcess.getId(), processCancelledEvent.getExecutionId());
-        assertEquals("The cause has to be the same as in deleteProcessInstance method call", "delete_test", processCancelledEvent.getCause());
+        assertThat(FlowableCancelledEvent.class.isAssignableFrom(processCancelledEvent.getClass()))
+                .as("The cause has to be the same as deleteProcessInstance method call").isTrue();
+        assertThat(processCancelledEvent.getProcessInstanceId()).as("The process instance has to be the same as in deleteProcessInstance method call")
+                .isEqualTo(subProcess.getId());
+        assertThat(processCancelledEvent.getExecutionId()).as("The execution instance has to be the same as in deleteProcessInstance method call")
+                .isEqualTo(subProcess.getId());
+        assertThat(processCancelledEvent.getCause()).as("The cause has to be the same as in deleteProcessInstance method call").isEqualTo("delete_test");
 
         processCancelledEvent = (FlowableCancelledEvent) processCancelledEvents.get(1);
-        assertTrue("The cause has to be the same as deleteProcessInstance method call", FlowableCancelledEvent.class.isAssignableFrom(processCancelledEvent.getClass()));
-        assertEquals("The process instance has to be the same as in deleteProcessInstance method call", processInstance.getId(), processCancelledEvent.getProcessInstanceId());
-        assertEquals("The execution instance has to be the same as in deleteProcessInstance method call", processInstance.getId(), processCancelledEvent.getExecutionId());
-        assertEquals("The cause has to be the same as in deleteProcessInstance method call", "delete_test", processCancelledEvent.getCause());
+        assertThat(FlowableCancelledEvent.class.isAssignableFrom(processCancelledEvent.getClass()))
+                .as("The cause has to be the same as deleteProcessInstance method call").isTrue();
+        assertThat(processCancelledEvent.getProcessInstanceId()).as("The process instance has to be the same as in deleteProcessInstance method call")
+                .isEqualTo(processInstance.getId());
+        assertThat(processCancelledEvent.getExecutionId()).as("The execution instance has to be the same as in deleteProcessInstance method call")
+                .isEqualTo(processInstance.getId());
+        assertThat(processCancelledEvent.getCause()).as("The cause has to be the same as in deleteProcessInstance method call").isEqualTo("delete_test");
 
-        assertEquals("No task can be active for deleted process.", 0, this.taskService.createTaskQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(this.taskService.createTaskQuery().processInstanceId(processInstance.getId()).count()).as("No task can be active for deleted process.")
+                .isEqualTo(0);
 
         List<FlowableEvent> taskCancelledEvents = listener.filterEvents(FlowableEngineEventType.ACTIVITY_CANCELLED);
-        assertEquals("ActivitiEventType.ACTIVITY_CANCELLED was expected 2 times.", 2, taskCancelledEvents.size());
+        assertThat(taskCancelledEvents).as("ActivitiEventType.ACTIVITY_CANCELLED was expected 2 times.").hasSize(2);
 
         FlowableActivityCancelledEvent activityCancelledEvent = (FlowableActivityCancelledEvent) taskCancelledEvents.get(0);
-        assertTrue("The cause has to be the same as deleteProcessInstance method call", FlowableActivityCancelledEvent.class.isAssignableFrom(activityCancelledEvent.getClass()));
-        assertEquals("The process instance has to point to the subprocess", subProcess.getId(), activityCancelledEvent.getProcessInstanceId());
-        assertEquals("The cause has to be the same as in deleteProcessInstance method call", "delete_test", activityCancelledEvent.getCause());
+        assertThat(FlowableActivityCancelledEvent.class.isAssignableFrom(activityCancelledEvent.getClass()))
+                .as("The cause has to be the same as deleteProcessInstance method call").isTrue();
+        assertThat(activityCancelledEvent.getProcessInstanceId()).as("The process instance has to point to the subprocess").isEqualTo(subProcess.getId());
+        assertThat(activityCancelledEvent.getCause()).as("The cause has to be the same as in deleteProcessInstance method call").isEqualTo("delete_test");
 
         activityCancelledEvent = (FlowableActivityCancelledEvent) taskCancelledEvents.get(1);
-        assertTrue("The cause has to be the same as deleteProcessInstance method call", FlowableActivityCancelledEvent.class.isAssignableFrom(activityCancelledEvent.getClass()));
-        assertEquals("The process instance has to point to the main process", processInstance.getId(), activityCancelledEvent.getProcessInstanceId());
-        assertEquals("expect callActivity type", "callActivity", activityCancelledEvent.getActivityType());
-        assertEquals("The cause has to be the same as in deleteProcessInstance method call", "delete_test", activityCancelledEvent.getCause());
+        assertThat(FlowableActivityCancelledEvent.class.isAssignableFrom(activityCancelledEvent.getClass()))
+                .as("The cause has to be the same as deleteProcessInstance method call").isTrue();
+        assertThat(activityCancelledEvent.getProcessInstanceId()).as("The process instance has to point to the main process")
+                .isEqualTo(processInstance.getId());
+        assertThat(activityCancelledEvent.getActivityType()).as("expect callActivity type").isEqualTo("callActivity");
+        assertThat(activityCancelledEvent.getCause()).as("The cause has to be the same as in deleteProcessInstance method call").isEqualTo("delete_test");
 
         listener.clearEventsReceived();
     }
 
     @Test
-    @Deployment(resources = {"org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
+    @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testProcessInstanceCancelledEvents_complete() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         taskService.complete(task.getId());
 
         List<FlowableEvent> processCancelledEvents = listener.filterEvents(FlowableEngineEventType.PROCESS_CANCELLED);
-        assertEquals("There should be no FlowableEventType.PROCESS_CANCELLED event after process complete.", 0, processCancelledEvents.size());
+        assertThat(processCancelledEvents).as("There should be no FlowableEventType.PROCESS_CANCELLED event after process complete.").isEmpty();
         List<FlowableEvent> taskCancelledEvents = listener.filterEvents(FlowableEngineEventType.ACTIVITY_CANCELLED);
-        assertEquals("There should be no FlowableEventType.ACTIVITY_CANCELLED event.", 0, taskCancelledEvents.size());
+        assertThat(taskCancelledEvents).as("There should be no FlowableEventType.ACTIVITY_CANCELLED event.").isEmpty();
 
     }
 
     @Test
-    @Deployment(resources = {"org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
+    @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testProcessInstanceTerminatedEvents_complete() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         taskService.complete(task.getId());
 
         List<FlowableEvent> processTerminatedEvents = listener.filterEvents(FlowableEngineEventType.PROCESS_CANCELLED);
-        assertEquals("There should be no FlowableEventType.PROCESS_TERMINATED event after process complete.", 0, processTerminatedEvents.size());
+        assertThat(processTerminatedEvents).as("There should be no FlowableEventType.PROCESS_TERMINATED event after process complete.").isEmpty();
     }
 
     @Test
@@ -518,35 +532,37 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
 
         long executionEntities = runtimeService.createExecutionQuery().processInstanceId(pi.getId()).count();
-        assertEquals(3, executionEntities);
+        assertThat(executionEntities).isEqualTo(3);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preTerminateTask").singleResult();
         taskService.complete(task.getId());
 
         List<FlowableEvent> processTerminatedEvents = listener.filterEvents(FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT);
-        assertEquals("There should be exactly one FlowableEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT event after the task complete.", 1,
-                processTerminatedEvents.size());
+        assertThat(processTerminatedEvents).hasSize(1)
+                .as("There should be exactly one FlowableEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT event after the task complete.");
         FlowableEngineEntityEvent processCompletedEvent = (FlowableEngineEntityEvent) processTerminatedEvents.get(0);
-        assertThat(processCompletedEvent.getProcessInstanceId(), is(pi.getProcessInstanceId()));
+        assertThat(processCompletedEvent.getProcessInstanceId()).isEqualTo(pi.getProcessInstanceId());
 
         List<FlowableEvent> activityTerminatedEvents = listener.filterEvents(FlowableEngineEventType.ACTIVITY_CANCELLED);
-        assertThat("There should be exactly two FlowableEventType.ACTIVITY_CANCELLED event after the task complete.", activityTerminatedEvents.size(), is(1));
+        assertThat(activityTerminatedEvents).hasSize(1)
+                .as("There should be exactly two FlowableEventType.ACTIVITY_CANCELLED event after the task complete.");
 
         for (FlowableEvent event : activityTerminatedEvents) {
 
             FlowableActivityCancelledEventImpl activityEvent = (FlowableActivityCancelledEventImpl) event;
             if (activityEvent.getActivityId().equals("preNormalTerminateTask")) {
-                assertThat("The user task must be terminated", activityEvent.getActivityId(), is("preNormalTerminateTask"));
-                assertThat("The cause must be terminate end event", ((FlowNode) activityEvent.getCause()).getId(), is("EndEvent_2"));
+                assertThat(activityEvent.getActivityId()).isEqualTo("preNormalTerminateTask")
+                        .as("The user task must be terminated");
+                assertThat(((FlowNode) activityEvent.getCause()).getId()).isEqualTo("EndEvent_2")
+                        .as("The cause must be terminate end event");
             }
-
         }
 
     }
 
     @Test
-    @Deployment(resources = {"org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateInCallActivity.bpmn",
-            "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.subProcessTerminate.bpmn"})
+    @Deployment(resources = { "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateInCallActivity.bpmn",
+            "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.subProcessTerminate.bpmn" })
     public void testProcessInstanceTerminatedEvents_callActivity() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
 
@@ -555,16 +571,16 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
 
         assertProcessEnded(pi.getId());
         List<FlowableEvent> processTerminatedEvents = listener.filterEvents(FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT);
-        assertEquals("There should be exactly one FlowableEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT event after the task complete.", 1,
-                processTerminatedEvents.size());
+        assertThat(processTerminatedEvents).hasSize(1)
+                .as("There should be exactly one FlowableEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT event after the task complete.");
         FlowableEngineEntityEvent processCompletedEvent = (FlowableEngineEntityEvent) processTerminatedEvents.get(0);
-        assertNotEquals(pi.getProcessInstanceId(), processCompletedEvent.getProcessInstanceId());
-        assertThat(processCompletedEvent.getProcessDefinitionId(), containsString("terminateEndEventSubprocessExample"));
+        assertThat(pi.getProcessInstanceId()).isNotEqualTo(processCompletedEvent.getProcessInstanceId());
+        assertThat(processCompletedEvent.getProcessDefinitionId()).contains("terminateEndEventSubprocessExample");
 
     }
 
     @Test
-    @Deployment(resources = {"org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateInSubProcessWithBoundaryTerminateAll.bpmn20.xml"})
+    @Deployment(resources = { "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateInSubProcessWithBoundaryTerminateAll.bpmn20.xml" })
     public void testTerminateAllInSubProcess() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventWithBoundary");
 
@@ -573,16 +589,16 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
 
         assertProcessEnded(pi.getId());
         List<FlowableEvent> processTerminatedEvents = listener.filterEvents(FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT);
-        assertEquals("There should be exactly one FlowableEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT event after the task complete.", 1,
-                processTerminatedEvents.size());
+        assertThat(processTerminatedEvents).hasSize(1)
+                .as("There should be exactly one FlowableEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT event after the task complete.");
         FlowableEngineEntityEvent processCompletedEvent = (FlowableEngineEntityEvent) processTerminatedEvents.get(0);
-        assertEquals(pi.getProcessInstanceId(), processCompletedEvent.getProcessInstanceId());
+        assertThat(processCompletedEvent.getProcessInstanceId()).isEqualTo(pi.getProcessInstanceId());
 
     }
 
     @Test
-    @Deployment(resources = {"org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateInParentProcess.bpmn",
-            "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
+    @Deployment(resources = { "org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.testTerminateInParentProcess.bpmn",
+            "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testProcessInstanceTerminatedEvents_terminateInParentProcess() throws Exception {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateParentProcess");
 
@@ -592,14 +608,14 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
 
         assertProcessEnded(pi.getId());
         List<FlowableEvent> processTerminatedEvents = listener.filterEvents(FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT);
-        assertEquals("There should be exactly one FlowableEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT events after the task complete.", 1,
-                processTerminatedEvents.size());
+        assertThat(processTerminatedEvents).hasSize(1)
+                .as("There should be exactly one FlowableEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT event after the task complete.");
         FlowableEngineEntityEvent processCompletedEvent = (FlowableEngineEntityEvent) processTerminatedEvents.get(0);
-        assertThat(processCompletedEvent.getProcessInstanceId(), is(pi.getProcessInstanceId()));
-        assertThat(processCompletedEvent.getProcessDefinitionId(), containsString("terminateParentProcess"));
+        assertThat(processCompletedEvent.getProcessInstanceId()).isEqualTo(pi.getProcessInstanceId());
+        assertThat(processCompletedEvent.getProcessDefinitionId()).contains("terminateParentProcess");
 
         List<FlowableEvent> activityTerminatedEvents = listener.filterEvents(FlowableEngineEventType.ACTIVITY_CANCELLED);
-        assertThat("Two activities must be cancelled.", activityTerminatedEvents.size(), is(2));
+        assertThat(activityTerminatedEvents).hasSize(2).as("Two activities must be cancelled.");
 
         for (FlowableEvent event : activityTerminatedEvents) {
 
@@ -607,13 +623,13 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
 
             if (activityEvent.getActivityId().equals("theTask")) {
 
-                assertThat("The user task must be terminated in the called sub process.", activityEvent.getActivityId(), is("theTask"));
-                assertThat("The cause must be terminate end event", ((FlowNode) activityEvent.getCause()).getId(), is("EndEvent_3"));
+                assertThat(activityEvent.getActivityId()).isEqualTo("theTask").as("The user task must be terminated in the called sub process.");
+                assertThat(((FlowNode) activityEvent.getCause()).getId()).isEqualTo("EndEvent_3").as("The cause must be terminate end event");
 
             } else if (activityEvent.getActivityId().equals("CallActivity_1")) {
 
-                assertThat("The call activity must be terminated", activityEvent.getActivityId(), is("CallActivity_1"));
-                assertThat("The cause must be terminate end event", ((FlowNode) activityEvent.getCause()).getId(), is("EndEvent_3"));
+                assertThat(activityEvent.getActivityId()).isEqualTo("CallActivity_1").as("The call activity must be terminated");
+                assertThat(((FlowNode) activityEvent.getCause()).getId()).isEqualTo("EndEvent_3").as("The cause must be terminate end event");
 
             }
 
@@ -630,22 +646,22 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("catchErrorOnCallActivity");
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertEquals("Task in subprocess", task.getName());
+        assertThat(task.getName()).isEqualTo("Task in subprocess");
         List<ProcessInstance> subProcesses = runtimeService.createProcessInstanceQuery().superProcessInstanceId(pi.getId()).list();
-        assertEquals(1, subProcesses.size());
+        assertThat(subProcesses).hasSize(1);
 
         // Completing the task will reach the end error event,
         // which is caught on the call activity boundary
         taskService.complete(task.getId());
 
         List<FlowableEvent> processCompletedEvents = listener.filterEvents(FlowableEngineEventType.PROCESS_COMPLETED_WITH_ERROR_END_EVENT);
-        assertEquals("There should be exactly an FlowableEventType.PROCESS_COMPLETED_WITH_ERROR_END_EVENT event after the task complete.", 1,
-                processCompletedEvents.size());
+        assertThat(processCompletedEvents).hasSize(1)
+                .as("There should be exactly an FlowableEventType.PROCESS_COMPLETED_WITH_ERROR_END_EVENT event after the task complete.");
         FlowableEngineEntityEvent processCompletedEvent = (FlowableEngineEntityEvent) processCompletedEvents.get(0);
-        assertEquals(subProcesses.get(0).getId(), processCompletedEvent.getExecutionId());
+        assertThat(processCompletedEvent.getExecutionId()).isEqualTo(subProcesses.get(0).getId());
 
         task = taskService.createTaskQuery().singleResult();
-        assertEquals("Escalated Task", task.getName());
+        assertThat(task.getName()).isEqualTo("Escalated Task");
 
         // Completing the task will end the process instance
         taskService.complete(task.getId());
@@ -655,20 +671,22 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
     @Test
     @Deployment(resources = {
             "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testParallelCallActivity.bpmn20.xml",
-            "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml"})
+            "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml" })
     public void testDeleteMultiInstanceCallActivityProcessInstance() {
-        assertEquals(0, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(0);
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("miParallelCallActivity");
-        assertEquals(7, runtimeService.createProcessInstanceQuery().count());
-        assertEquals(12, taskService.createTaskQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(7);
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(12);
         this.listener.clearEventsReceived();
 
         runtimeService.deleteProcessInstance(processInstance.getId(), "testing instance deletion");
 
-        assertEquals("Task cancelled event has to be fired.", FlowableEngineEventType.ACTIVITY_CANCELLED, this.listener.getEventsReceived().get(0).getType());
-        assertEquals("SubProcess cancelled event has to be fired.", FlowableEngineEventType.PROCESS_CANCELLED, this.listener.getEventsReceived().get(2).getType());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
-        assertEquals(0, taskService.createTaskQuery().count());
+        assertThat(this.listener.getEventsReceived().get(0).getType()).as("Task cancelled event has to be fired.")
+                .isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(this.listener.getEventsReceived().get(2).getType()).as("SubProcess cancelled event has to be fired.")
+                .isEqualTo(FlowableEngineEventType.PROCESS_CANCELLED);
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(0);
     }
 
     @Test
@@ -677,13 +695,13 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("subProcessWithTerminateEndTest");
 
         long executionEntities = runtimeService.createExecutionQuery().processInstanceId(pi.getId()).count();
-        assertEquals(4, executionEntities);
+        assertThat(executionEntities).isEqualTo(4);
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(pi.getId()).list();
-        assertEquals(1, tasks.size());
+        assertThat(tasks).hasSize(1);
 
         Execution execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("cancel").singleResult();
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
 
         // message received cancels the SubProcess. We expect an event for all flow elements
         // when the process state changes. We expect the activity cancelled event for the task within the
@@ -691,7 +709,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
         runtimeService.messageEventReceived("cancel", execution.getId());
 
         List<FlowableEvent> activityTerminatedEvents = listener.filterEvents(FlowableEngineEventType.ACTIVITY_CANCELLED);
-        assertEquals(2, activityTerminatedEvents.size());
+        assertThat(activityTerminatedEvents).hasSize(2);
 
         boolean taskFound = false;
         boolean subProcessFound = false;
@@ -699,18 +717,17 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
             FlowableActivityCancelledEvent activityEvent = (FlowableActivityCancelledEvent) terminatedEvent;
             if ("userTask".equals(activityEvent.getActivityType())) {
                 taskFound = true;
-                assertEquals("task", activityEvent.getActivityId());
+                assertThat(activityEvent.getActivityId()).isEqualTo("task");
 
             } else if ("subProcess".equals(activityEvent.getActivityType())) {
                 subProcessFound = true;
-                assertEquals("embeddedSubprocess", activityEvent.getActivityId());
+                assertThat(activityEvent.getActivityId()).isEqualTo("embeddedSubprocess");
             }
         }
 
-        assertTrue(taskFound);
-        assertTrue(subProcessFound);
+        assertThat(taskFound).isTrue();
+        assertThat(subProcessFound).isTrue();
     }
-
 
     @Test
     @Deployment(resources = "org/flowable/engine/test/api/runtime/multipleSubprocessTerminateEnd.bpmn20.xml")
@@ -719,10 +736,10 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
 
         List<Execution> subprocesses = runtimeService.createExecutionQuery().processInstanceId(pi.getId())
                 .onlySubProcessExecutions().list();
-        assertEquals(2, subprocesses.size());
+        assertThat(subprocesses).hasSize(2);
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(pi.getId()).list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
 
         org.flowable.task.api.Task task2 = null;
         for (org.flowable.task.api.Task task : tasks) {
@@ -737,7 +754,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
         // the terminate end event. This will cause subprocess1 to be cancelled along
         // with the user task, boundary event and intermediate catch event defined in or
         // on subprocess1.
-        assertNotNull(task2);
+        assertThat(task2).isNotNull();
         taskService.complete(task2.getId());
 
         // Subprocess2 completed and transitioned to terminate end. We expect
@@ -749,46 +766,46 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
         boolean boundaryEventFound = false;
         List<FlowableEvent> activityTerminatedEvents = listener
                 .filterEvents(FlowableEngineEventType.ACTIVITY_CANCELLED);
-        assertEquals(4, activityTerminatedEvents.size());
+        assertThat(activityTerminatedEvents).hasSize(4);
         for (FlowableEvent flowableEvent : activityTerminatedEvents) {
             FlowableActivityCancelledEvent activityCancelledEvent = (FlowableActivityCancelledEvent) flowableEvent;
             if ("intermediateCatchEvent".equals(activityCancelledEvent.getActivityType())) {
-                assertEquals("timer", activityCancelledEvent.getActivityId());
+                assertThat(activityCancelledEvent.getActivityId()).isEqualTo("timer");
                 timerCatchEventFound = true;
             } else if ("boundaryEvent".equals(activityCancelledEvent.getActivityType())) {
                 boundaryEventFound = true;
             } else if ("userTask".equals(activityCancelledEvent.getActivityType())) {
-                assertEquals("Task in subprocess1", activityCancelledEvent.getActivityName());
+                assertThat(activityCancelledEvent.getActivityName()).isEqualTo("Task in subprocess1");
                 userTaskFound = true;
             } else if ("subProcess".equals(activityCancelledEvent.getActivityType())) {
-                assertEquals("subprocess1", activityCancelledEvent.getActivityId());
+                assertThat(activityCancelledEvent.getActivityId()).isEqualTo("subprocess1");
                 subprocessFound = true;
             }
         }
 
-        assertTrue(timerCatchEventFound);
-        assertTrue(boundaryEventFound);
-        assertTrue(userTaskFound);
-        assertTrue(subprocessFound);
+        assertThat(timerCatchEventFound).isTrue();
+        assertThat(boundaryEventFound).isTrue();
+        assertThat(userTaskFound).isTrue();
+        assertThat(subprocessFound).isTrue();
 
         List<FlowableEvent> processCompletedEvents = listener.filterEvents(FlowableEngineEventType.PROCESS_COMPLETED);
-        assertEquals(0, processCompletedEvents.size());
+        assertThat(processCompletedEvents).isEmpty();
 
         List<FlowableEvent> processCompletedTerminateEndEvents = listener
                 .filterEvents(FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT);
-        assertEquals(1, processCompletedTerminateEndEvents.size());
+        assertThat(processCompletedTerminateEndEvents).hasSize(1);
 
         // Only expect PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT, not
         // PROCESS_CANCELLED.
         List<FlowableEvent> processCanceledEvents = listener.filterEvents(FlowableEngineEventType.PROCESS_CANCELLED);
-        assertEquals(0, processCanceledEvents.size());
+        assertThat(processCanceledEvents).isEmpty();
     }
 
     @Test
     @Deployment(resources = "org/flowable/engine/test/api/event/ProcessInstanceEventsTest.testProcessInstanceEvents.bpmn20.xml")
     public void startAsyncProcessInstanceEvents() {
         ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("oneTaskProcess").startAsync();
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         assertProcessStartedEvents(processInstance);
         listener.clearEventsReceived();
@@ -796,7 +813,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
     }
 
     private void assertEventsEqual(FlowableEvent event1, FlowableEvent event2) {
-        assertTrue(EqualsBuilder.reflectionEquals(event1, event2));
+        assertThat(EqualsBuilder.reflectionEquals(event1, event2)).isTrue();
 
     }
 
@@ -838,7 +855,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
             if (event instanceof FlowableEntityEvent && ProcessInstance.class.isAssignableFrom(((FlowableEntityEvent) event).getEntity().getClass())) {
                 // check whether entity in the event is initialized before
                 // adding to the list.
-                assertNotNull(((ExecutionEntity) ((FlowableEntityEvent) event).getEntity()).getId());
+                assertThat(((ExecutionEntity) ((FlowableEntityEvent) event).getEntity()).getId()).isNotNull();
                 eventsReceived.add(event);
             } else if (FlowableEngineEventType.PROCESS_CANCELLED == event.getType() || FlowableEngineEventType.ACTIVITY_CANCELLED == event.getType()) {
                 eventsReceived.add(event);
@@ -871,7 +888,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
             if (event instanceof FlowableEntityEvent && ProcessInstance.class.isAssignableFrom(((FlowableEntityEvent) event).getEntity().getClass())) {
                 // check whether entity in the event is initialized before
                 // adding to the list.
-                assertNotNull(((ExecutionEntity) ((FlowableEntityEvent) event).getEntity()).getId());
+                assertThat(((ExecutionEntity) ((FlowableEntityEvent) event).getEntity()).getId()).isNotNull();
                 super.onEvent(event);
             } else if (FlowableEngineEventType.PROCESS_CANCELLED == event.getType() || FlowableEngineEventType.ACTIVITY_CANCELLED == event.getType()) {
                 super.onEvent(event);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ProcessInstanceEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ProcessInstanceEventsTest.java
@@ -177,7 +177,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
     protected void assertProcessStartedEvents(ProcessInstance processInstance) {
         assertThat(listener.getEventsReceived()).hasSize(6);
         assertThat(FilteredStaticTestFlowableEventListener.getEventsReceived()).hasSize(6);
-        assertThat(listener.getEventsReceived().get(0) instanceof FlowableEngineEntityEvent).isTrue();
+        assertThat(listener.getEventsReceived().get(0)).isInstanceOf(FlowableEngineEntityEvent.class);
 
         // process instance create event
         FlowableEngineEntityEvent event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(0);
@@ -222,7 +222,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
         assertThat(event.getType()).isEqualTo(FlowableEngineEventType.PROCESS_STARTED);
         assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
         assertThat(event.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
-        assertThat(event instanceof FlowableProcessStartedEvent).isTrue();
+        assertThat(event).isInstanceOf(FlowableProcessStartedEvent.class);
         assertThat(((FlowableProcessStartedEvent) event).getNestedProcessDefinitionId()).isNull();
         assertThat(((FlowableProcessStartedEvent) event).getNestedProcessInstanceId()).isNull();
         assertEventsEqual(event, FilteredStaticTestFlowableEventListener.getEventsReceived().get(5));
@@ -241,7 +241,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
 
         // Check create-event one main process the second one Scope execution, and the third one subprocess
         assertThat(listener.getEventsReceived()).hasSize(12);
-        assertThat(listener.getEventsReceived().get(0) instanceof FlowableEngineEntityEvent).isTrue();
+        assertThat(listener.getEventsReceived().get(0)).isInstanceOf(FlowableEngineEntityEvent.class);
 
         // process instance created event
         FlowableEngineEntityEvent event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(0);
@@ -284,7 +284,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
         assertThat(event.getType()).isEqualTo(FlowableEngineEventType.PROCESS_STARTED);
         assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
         assertThat(event.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
-        assertThat(event instanceof FlowableProcessStartedEvent).isTrue();
+        assertThat(event).isInstanceOf(FlowableProcessStartedEvent.class);
         assertThat(((FlowableProcessStartedEvent) event).getNestedProcessDefinitionId()).isNull();
         assertThat(((FlowableProcessStartedEvent) event).getNestedProcessInstanceId()).isNull();
 
@@ -329,7 +329,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
         assertThat(event.getType()).isEqualTo(FlowableEngineEventType.PROCESS_STARTED);
         assertThat(event.getProcessInstanceId()).isEqualTo(subProcessInstanceId);
         assertThat(event.getProcessDefinitionId()).isEqualTo(subProcessDefinitionId);
-        assertThat(event instanceof FlowableProcessStartedEvent).isTrue();
+        assertThat(event).isInstanceOf(FlowableProcessStartedEvent.class);
         assertThat(((FlowableProcessStartedEvent) event).getNestedProcessDefinitionId()).isEqualTo(processDefinitionId);
         assertThat(((FlowableProcessStartedEvent) event).getNestedProcessInstanceId()).isEqualTo(processInstance.getId());
 
@@ -423,8 +423,6 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
         List<FlowableEvent> processCancelledEvents = listener.filterEvents(FlowableEngineEventType.PROCESS_CANCELLED);
         assertThat(processCancelledEvents).as("ActivitiEventType.PROCESS_CANCELLED was expected 1 time.").hasSize(1);
         FlowableCancelledEvent processCancelledEvent = (FlowableCancelledEvent) processCancelledEvents.get(0);
-        assertThat(FlowableCancelledEvent.class.isAssignableFrom(processCancelledEvent.getClass()))
-                .as("The cause has to be the same as deleteProcessInstance method call").isTrue();
         assertThat(processCancelledEvent.getProcessInstanceId()).as("The process instance has to be the same as in deleteProcessInstance method call")
                 .isEqualTo(processInstance.getId());
         assertThat(processCancelledEvent.getExecutionId()).as("The execution instance has to be the same as in deleteProcessInstance method call")
@@ -434,8 +432,6 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
         List<FlowableEvent> taskCancelledEvents = listener.filterEvents(FlowableEngineEventType.ACTIVITY_CANCELLED);
         assertThat(taskCancelledEvents).as("ActivitiEventType.ACTIVITY_CANCELLED was expected 1 time.").hasSize(1);
         FlowableActivityCancelledEvent activityCancelledEvent = (FlowableActivityCancelledEvent) taskCancelledEvents.get(0);
-        assertThat(FlowableActivityCancelledEvent.class.isAssignableFrom(activityCancelledEvent.getClass()))
-                .as("The cause has to be the same as deleteProcessInstance method call").isTrue();
         assertThat(activityCancelledEvent.getProcessInstanceId()).as("The process instance has to be the same as in deleteProcessInstance method call")
                 .isEqualTo(processInstance.getId());
         assertThat(activityCancelledEvent.getCause()).as("The cause has to be the same as in deleteProcessInstance method call").isEqualTo("delete_test");
@@ -457,8 +453,6 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
         List<FlowableEvent> processCancelledEvents = listener.filterEvents(FlowableEngineEventType.PROCESS_CANCELLED);
         assertThat(processCancelledEvents).as("ActivitiEventType.PROCESS_CANCELLED was expected 2 times.").hasSize(2);
         FlowableCancelledEvent processCancelledEvent = (FlowableCancelledEvent) processCancelledEvents.get(0);
-        assertThat(FlowableCancelledEvent.class.isAssignableFrom(processCancelledEvent.getClass()))
-                .as("The cause has to be the same as deleteProcessInstance method call").isTrue();
         assertThat(processCancelledEvent.getProcessInstanceId()).as("The process instance has to be the same as in deleteProcessInstance method call")
                 .isEqualTo(subProcess.getId());
         assertThat(processCancelledEvent.getExecutionId()).as("The execution instance has to be the same as in deleteProcessInstance method call")
@@ -466,8 +460,6 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
         assertThat(processCancelledEvent.getCause()).as("The cause has to be the same as in deleteProcessInstance method call").isEqualTo("delete_test");
 
         processCancelledEvent = (FlowableCancelledEvent) processCancelledEvents.get(1);
-        assertThat(FlowableCancelledEvent.class.isAssignableFrom(processCancelledEvent.getClass()))
-                .as("The cause has to be the same as deleteProcessInstance method call").isTrue();
         assertThat(processCancelledEvent.getProcessInstanceId()).as("The process instance has to be the same as in deleteProcessInstance method call")
                 .isEqualTo(processInstance.getId());
         assertThat(processCancelledEvent.getExecutionId()).as("The execution instance has to be the same as in deleteProcessInstance method call")
@@ -481,14 +473,10 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
         assertThat(taskCancelledEvents).as("ActivitiEventType.ACTIVITY_CANCELLED was expected 2 times.").hasSize(2);
 
         FlowableActivityCancelledEvent activityCancelledEvent = (FlowableActivityCancelledEvent) taskCancelledEvents.get(0);
-        assertThat(FlowableActivityCancelledEvent.class.isAssignableFrom(activityCancelledEvent.getClass()))
-                .as("The cause has to be the same as deleteProcessInstance method call").isTrue();
         assertThat(activityCancelledEvent.getProcessInstanceId()).as("The process instance has to point to the subprocess").isEqualTo(subProcess.getId());
         assertThat(activityCancelledEvent.getCause()).as("The cause has to be the same as in deleteProcessInstance method call").isEqualTo("delete_test");
 
         activityCancelledEvent = (FlowableActivityCancelledEvent) taskCancelledEvents.get(1);
-        assertThat(FlowableActivityCancelledEvent.class.isAssignableFrom(activityCancelledEvent.getClass()))
-                .as("The cause has to be the same as deleteProcessInstance method call").isTrue();
         assertThat(activityCancelledEvent.getProcessInstanceId()).as("The process instance has to point to the main process")
                 .isEqualTo(processInstance.getId());
         assertThat(activityCancelledEvent.getActivityType()).as("expect callActivity type").isEqualTo("callActivity");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ProcessInstanceNameListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ProcessInstanceNameListenerTest.java
@@ -41,7 +41,7 @@ public class ProcessInstanceNameListenerTest extends PluggableFlowableTestCase {
     private TestInitializedEntityEventListener listener;
 
     @Test
-    @Deployment(resources = {"org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
+    @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testProcessCreateProcessNameEvent() throws Exception {
         ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().
                 processDefinitionKey("oneTaskProcess").
@@ -50,25 +50,29 @@ public class ProcessInstanceNameListenerTest extends PluggableFlowableTestCase {
 
         assertThat(processInstance).isNotNull();
 
-        assertThat(listener.getProcessName()).isEqualTo("oneTaskProcessInstanceName")
-                .as("Process instance name must be initialized before PROCESS_CREATED event is fired.");
+        assertThat(listener.getProcessName()).as("Process instance name must be initialized before PROCESS_CREATED event is fired.")
+                .isEqualTo("oneTaskProcessInstanceName");
     }
 
     @Test
     public void testCallActivityProcessCreatedDefinitionName() throws Exception {
-        BpmnModel mainBpmnModel = loadBPMNModel("org/flowable/engine/test/bpmn/subprocess/SubProcessTest.testSuspendedProcessCallActivity_mainProcess.bpmn.xml");
-        BpmnModel childBpmnModel = loadBPMNModel("org/flowable/engine/test/bpmn/subprocess/SubProcessTest.testSuspendedProcessCallActivity_childProcess.bpmn.xml");
+        BpmnModel mainBpmnModel = loadBPMNModel(
+                "org/flowable/engine/test/bpmn/subprocess/SubProcessTest.testSuspendedProcessCallActivity_mainProcess.bpmn.xml");
+        BpmnModel childBpmnModel = loadBPMNModel(
+                "org/flowable/engine/test/bpmn/subprocess/SubProcessTest.testSuspendedProcessCallActivity_childProcess.bpmn.xml");
 
-        org.flowable.engine.repository.Deployment childDeployment = processEngine.getRepositoryService().createDeployment().name("childProcessDeployment").addBpmnModel("childProcess.bpmn20.xml", childBpmnModel).deploy();
+        org.flowable.engine.repository.Deployment childDeployment = processEngine.getRepositoryService().createDeployment().name("childProcessDeployment")
+                .addBpmnModel("childProcess.bpmn20.xml", childBpmnModel).deploy();
 
-        org.flowable.engine.repository.Deployment masterDeployment = processEngine.getRepositoryService().createDeployment().name("masterProcessDeployment").addBpmnModel("masterProcess.bpmn20.xml", mainBpmnModel).deploy();
+        org.flowable.engine.repository.Deployment masterDeployment = processEngine.getRepositoryService().createDeployment().name("masterProcessDeployment")
+                .addBpmnModel("masterProcess.bpmn20.xml", mainBpmnModel).deploy();
 
         runtimeService.createProcessInstanceBuilder().
                 processDefinitionKey("masterProcess").
                 start();
 
-        assertThat(listener.getProcessDefinitionName()).isEqualTo("Child Process")
-                .as("SubProcessInstance PROCESS_CREATED event must have processDefinitionName set");
+        assertThat(listener.getProcessDefinitionName()).as("SubProcessInstance PROCESS_CREATED event must have processDefinitionName set")
+                .isEqualTo("Child Process");
 
         repositoryService.deleteDeployment(masterDeployment.getId(), true);
         repositoryService.deleteDeployment(childDeployment.getId());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ProcessInstanceNameListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ProcessInstanceNameListenerTest.java
@@ -12,8 +12,7 @@
  */
 package org.flowable.engine.test.api.event;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.InputStream;
 
@@ -49,10 +48,10 @@ public class ProcessInstanceNameListenerTest extends PluggableFlowableTestCase {
                 name("oneTaskProcessInstanceName").
                 start();
 
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
-        assertThat("Process instance name must be initialized before PROCESS_CREATED event is fired.",
-                listener.getProcessName(), is("oneTaskProcessInstanceName"));
+        assertThat(listener.getProcessName()).isEqualTo("oneTaskProcessInstanceName")
+                .as("Process instance name must be initialized before PROCESS_CREATED event is fired.");
     }
 
     @Test
@@ -68,7 +67,8 @@ public class ProcessInstanceNameListenerTest extends PluggableFlowableTestCase {
                 processDefinitionKey("masterProcess").
                 start();
 
-        assertThat("SubProcessInstance PROCESS_CREATED event must have processDefinitionName set", listener.getProcessDefinitionName(), is("Child Process"));
+        assertThat(listener.getProcessDefinitionName()).isEqualTo("Child Process")
+                .as("SubProcessInstance PROCESS_CREATED event must have processDefinitionName set");
 
         repositoryService.deleteDeployment(masterDeployment.getId(), true);
         repositoryService.deleteDeployment(childDeployment.getId());
@@ -98,7 +98,7 @@ public class ProcessInstanceNameListenerTest extends PluggableFlowableTestCase {
             if (event instanceof FlowableEntityEvent && ProcessInstance.class.isAssignableFrom(((FlowableEntityEvent) event).getEntity().getClass())) {
                 // check whether entity in the event is initialized before
                 // adding to the list.
-                assertNotNull(((FlowableEntityEvent) event).getEntity());
+                assertThat(((FlowableEntityEvent) event).getEntity()).isNotNull();
                 ProcessInstance processInstance = (ProcessInstance) ((FlowableEntityEvent) event).getEntity();
                 processName = processInstance.getName();
                 processDefinitionName = processInstance.getProcessDefinitionName();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/SignalThrowingEventListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/SignalThrowingEventListenerTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -11,6 +11,9 @@
  * limitations under the License.
  */
 package org.flowable.engine.test.api.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.flowable.common.engine.api.FlowableException;
 import org.flowable.common.engine.api.delegate.event.FlowableEngineEventType;
@@ -25,7 +28,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for all {@link FlowableEventListener}s that throws a signal BPMN event when an {@link FlowableEvent} has been dispatched.
- * 
+ *
  * @author Frederik Heremans
  */
 public class SignalThrowingEventListenerTest extends PluggableFlowableTestCase {
@@ -42,22 +45,23 @@ public class SignalThrowingEventListenerTest extends PluggableFlowableTestCase {
             processEngineConfiguration.getEventDispatcher().addEventListener(listener, FlowableEngineEventType.TASK_ASSIGNED);
 
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testSignal");
-            assertNotNull(processInstance);
+            assertThat(processInstance).isNotNull();
 
             // Fetch the task and re-assign it to trigger the event-listener
             org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-            assertNotNull(task);
+            assertThat(task).isNotNull();
             taskService.setAssignee(task.getId(), "kermit");
 
             // Boundary-event should have been signaled and a new task should be
             // available, on top of the already
             // existing one, since the cancelActivity='false'
             task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("subTask").singleResult();
-            assertNotNull(task);
-            assertEquals("kermit", task.getAssignee());
+            assertThat(task).isNotNull();
+            assertThat(task.getAssignee()).isEqualTo("kermit");
 
-            org.flowable.task.api.Task boundaryTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("boundaryTask").singleResult();
-            assertNotNull(boundaryTask);
+            org.flowable.task.api.Task boundaryTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("boundaryTask")
+                    .singleResult();
+            assertThat(boundaryTask).isNotNull();
 
         } finally {
             processEngineConfiguration.getEventDispatcher().removeEventListener(listener);
@@ -68,22 +72,23 @@ public class SignalThrowingEventListenerTest extends PluggableFlowableTestCase {
     @Deployment
     public void testThrowSignalDefinedInProcessDefinition() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testSignal");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         // Fetch the task and re-assign it to trigger the event-listener
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         taskService.setAssignee(task.getId(), "kermit");
 
         // Boundary-event should have been signaled and a new task should be
         // available, on top of the already
         // existing one, since the cancelActivity='false'
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("subTask").singleResult();
-        assertNotNull(task);
-        assertEquals("kermit", task.getAssignee());
+        assertThat(task).isNotNull();
+        assertThat(task.getAssignee()).isEqualTo("kermit");
 
-        org.flowable.task.api.Task boundaryTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("boundaryTask").singleResult();
-        assertNotNull(boundaryTask);
+        org.flowable.task.api.Task boundaryTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("boundaryTask")
+                .singleResult();
+        assertThat(boundaryTask).isNotNull();
     }
 
     @Test
@@ -97,21 +102,22 @@ public class SignalThrowingEventListenerTest extends PluggableFlowableTestCase {
             processEngineConfiguration.getEventDispatcher().addEventListener(listener, FlowableEngineEventType.TASK_ASSIGNED);
 
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testSignal");
-            assertNotNull(processInstance);
+            assertThat(processInstance).isNotNull();
 
             // Fetch the task and re-assign it to trigger the event-listener
             org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-            assertNotNull(task);
+            assertThat(task).isNotNull();
             taskService.setAssignee(task.getId(), "kermit");
 
             // Boundary-event should have been signalled and a new task should
             // be available, the already existing one is gone, since the cancelActivity='true'
             task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("subTask").singleResult();
-            assertNull(task);
+            assertThat(task).isNull();
 
-            org.flowable.task.api.Task boundaryTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("boundaryTask").singleResult();
-            assertNotNull(boundaryTask);
-            
+            org.flowable.task.api.Task boundaryTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("boundaryTask")
+                    .singleResult();
+            assertThat(boundaryTask).isNotNull();
+
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         } finally {
@@ -133,33 +139,26 @@ public class SignalThrowingEventListenerTest extends PluggableFlowableTestCase {
             processEngineConfiguration.getEventDispatcher().addEventListener(listener, FlowableEngineEventType.JOB_RETRIES_DECREMENTED);
 
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testSignal");
-            assertNotNull(processInstance);
+            assertThat(processInstance).isNotNull();
 
             Job signalJob = managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult();
 
-            try {
-                managementService.executeJob(signalJob.getId());
-                fail("Exception expected");
-            } catch (FlowableException ae) {
-                // Ignore, expected exception
-            }
+            assertThatThrownBy(() -> managementService.executeJob(signalJob.getId()))
+                    .isInstanceOf(FlowableException.class);
 
             Job failedJob = managementService.createTimerJobQuery().withException().processInstanceId(processInstance.getId()).singleResult();
 
-            assertNotNull(failedJob);
-            assertEquals(2, failedJob.getRetries());
+            assertThat(failedJob).isNotNull();
+            assertThat(failedJob.getRetries()).isEqualTo(2);
 
             // One retry should have triggered dispatching of a retry-decrement event
-            assertEquals(1, taskService.createTaskQuery().processInstanceId(processInstance.getId()).count());
+            assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(1);
 
-            try {
-                managementService.moveTimerToExecutableJob(failedJob.getId());
-                managementService.executeJob(failedJob.getId());
-                fail("Exception expected");
-            } catch (FlowableException ae) {
-                // Ignore, expected exception
-                assertEquals(2, taskService.createTaskQuery().processInstanceId(processInstance.getId()).count());
-            }
+            managementService.moveTimerToExecutableJob(failedJob.getId());
+            assertThatThrownBy(() -> managementService.executeJob(signalJob.getId()))
+                    .isInstanceOf(FlowableException.class);
+            assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(2);
+
         } finally {
             processEngineConfiguration.getEventDispatcher().removeEventListener(listener);
         }
@@ -180,33 +179,25 @@ public class SignalThrowingEventListenerTest extends PluggableFlowableTestCase {
             processEngineConfiguration.getEventDispatcher().addEventListener(listener, FlowableEngineEventType.JOB_EXECUTION_FAILURE);
 
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testSignal");
-            assertNotNull(processInstance);
+            assertThat(processInstance).isNotNull();
 
             Job signalJob = managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult();
 
-            try {
-                managementService.executeJob(signalJob.getId());
-                fail("Exception expected");
-            } catch (FlowableException ae) {
-                // Ignore, expected exception
-            }
+            assertThatThrownBy(() -> managementService.executeJob(signalJob.getId()))
+                    .isInstanceOf(FlowableException.class);
 
             Job failedJob = managementService.createTimerJobQuery().withException().processInstanceId(processInstance.getId()).singleResult();
 
-            assertNotNull("Expected job with exception, found no such job", failedJob);
-            assertEquals(2, failedJob.getRetries());
+            assertThat(failedJob).as("Expected job with exception, found no such job").isNotNull();
+            assertThat(failedJob.getRetries()).isEqualTo(2);
 
             // Three retries should each have triggered dispatching of a retry-decrement event
-            assertEquals(0, taskService.createTaskQuery().processInstanceId(processInstance.getId()).count());
+            assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0);
 
-            try {
-                managementService.moveTimerToExecutableJob(failedJob.getId());
-                managementService.executeJob(failedJob.getId());
-                fail("Exception expected");
-            } catch (FlowableException ae) {
-                // Ignore, expected exception
-                assertEquals(0, taskService.createTaskQuery().processInstanceId(processInstance.getId()).count());
-            }
+            managementService.moveTimerToExecutableJob(failedJob.getId());
+            assertThatThrownBy(() -> managementService.executeJob(signalJob.getId()))
+                    .isInstanceOf(FlowableException.class);
+            assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0);
         } finally {
             processEngineConfiguration.getEventDispatcher().removeEventListener(listener);
         }
@@ -228,28 +219,28 @@ public class SignalThrowingEventListenerTest extends PluggableFlowableTestCase {
             processEngineConfiguration.getEventDispatcher().addEventListener(listener, FlowableEngineEventType.TASK_ASSIGNED);
 
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("globalSignalProcess");
-            assertNotNull(processInstance);
+            assertThat(processInstance).isNotNull();
 
             ProcessInstance externalProcess = runtimeService.startProcessInstanceByKey("globalSignalProcessExternal");
-            assertNotNull(processInstance);
+            assertThat(processInstance).isNotNull();
             // Make sure process is not ended yet by querying it again
             externalProcess = runtimeService.createProcessInstanceQuery().processInstanceId(externalProcess.getId()).singleResult();
-            assertNotNull(externalProcess);
+            assertThat(externalProcess).isNotNull();
 
             org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-            assertNotNull(task);
+            assertThat(task).isNotNull();
 
             // Assign task to trigger signal
             taskService.setAssignee(task.getId(), "kermit");
 
             // Second process should have been signaled
             externalProcess = runtimeService.createProcessInstanceQuery().processInstanceId(externalProcess.getId()).singleResult();
-            assertNull(externalProcess);
+            assertThat(externalProcess).isNull();
 
             // org.flowable.task.service.Task assignee should still be set
             task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-            assertNotNull(task);
-            assertEquals("kermit", task.getAssignee());
+            assertThat(task).isNotNull();
+            assertThat(task.getAssignee()).isEqualTo("kermit");
 
         } finally {
             processEngineConfiguration.getEventDispatcher().removeEventListener(listener);
@@ -265,27 +256,27 @@ public class SignalThrowingEventListenerTest extends PluggableFlowableTestCase {
             "org/flowable/engine/test/api/event/SignalThrowingEventListenerTest.globalSignalExternalProcess.bpmn20.xml" })
     public void testGlobalSignalDefinedInProcessDefinition() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("globalSignalProcess");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         ProcessInstance externalProcess = runtimeService.startProcessInstanceByKey("globalSignalProcessExternal");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
         // Make sure process is not ended yet by querying it again
         externalProcess = runtimeService.createProcessInstanceQuery().processInstanceId(externalProcess.getId()).singleResult();
-        assertNotNull(externalProcess);
+        assertThat(externalProcess).isNotNull();
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
 
         // Assign task to trigger signal
         taskService.setAssignee(task.getId(), "kermit");
 
         // Second process should have been signaled
         externalProcess = runtimeService.createProcessInstanceQuery().processInstanceId(externalProcess.getId()).singleResult();
-        assertNull(externalProcess);
+        assertThat(externalProcess).isNull();
 
         // org.flowable.task.service.Task assignee should still be set
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(task);
-        assertEquals("kermit", task.getAssignee());
+        assertThat(task).isNotNull();
+        assertThat(task.getAssignee()).isEqualTo("kermit");
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/TaskEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/TaskEventsTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -11,6 +11,8 @@
  * limitations under the License.
  */
 package org.flowable.engine.test.api.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Date;
 import java.util.HashMap;
@@ -31,7 +33,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for all {@link FlowableEvent}s related to tasks.
- * 
+ *
  * @author Frederik Heremans
  */
 public class TaskEventsTest extends PluggableFlowableTestCase {
@@ -45,39 +47,39 @@ public class TaskEventsTest extends PluggableFlowableTestCase {
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testTaskEventsInProcess() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
 
         // Check create event
-        assertEquals(3, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(3);
         FlowableEngineEntityEvent event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ENTITY_CREATED, event.getType());
-        assertTrue(event.getEntity() instanceof org.flowable.task.api.Task);
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
+        assertThat(event.getEntity()).isInstanceOf(org.flowable.task.api.Task.class);
         org.flowable.task.api.Task taskFromEvent = (org.flowable.task.api.Task) event.getEntity();
-        assertEquals(task.getId(), taskFromEvent.getId());
+        assertThat(taskFromEvent.getId()).isEqualTo(task.getId());
         assertExecutionDetails(event, processInstance);
 
         event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.ENTITY_INITIALIZED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_INITIALIZED);
 
         event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(2);
-        assertEquals(FlowableEngineEventType.TASK_CREATED, event.getType());
-        assertTrue(event.getEntity() instanceof org.flowable.task.api.Task);
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.TASK_CREATED);
+        assertThat(event.getEntity()).isInstanceOf(org.flowable.task.api.Task.class);
         taskFromEvent = (org.flowable.task.api.Task) event.getEntity();
-        assertEquals(task.getId(), taskFromEvent.getId());
+        assertThat(taskFromEvent.getId()).isEqualTo(task.getId());
         assertExecutionDetails(event, processInstance);
 
         listener.clearEventsReceived();
 
         // Update duedate, owner and priority should trigger update-event
         taskService.setDueDate(task.getId(), new Date());
-        assertEquals(2, listener.getEventsReceived().size());
-        assertEquals(FlowableEngineEventType.TASK_DUEDATE_CHANGED, listener.getEventsReceived().get(0).getType());
+        assertThat(listener.getEventsReceived()).hasSize(2);
+        assertThat(listener.getEventsReceived().get(0).getType()).isEqualTo(FlowableEngineEventType.TASK_DUEDATE_CHANGED);
         event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(1);
         assertExecutionDetails(event, processInstance);
-        assertEquals(FlowableEngineEventType.ENTITY_UPDATED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_UPDATED);
         listener.clearEventsReceived();
 
         // Update name, owner and priority should trigger update-event
@@ -85,26 +87,26 @@ public class TaskEventsTest extends PluggableFlowableTestCase {
         listener.clearEventsReceived();
         task.setName("newName");
         taskService.saveTask(task);
-        assertEquals(2, listener.getEventsReceived().size());
-        assertEquals(FlowableEngineEventType.TASK_NAME_CHANGED, listener.getEventsReceived().get(0).getType());
+        assertThat(listener.getEventsReceived()).hasSize(2);
+        assertThat(listener.getEventsReceived().get(0).getType()).isEqualTo(FlowableEngineEventType.TASK_NAME_CHANGED);
         event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(1);
         assertExecutionDetails(event, processInstance);
-        assertEquals(FlowableEngineEventType.ENTITY_UPDATED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_UPDATED);
         listener.clearEventsReceived();
 
         taskService.setPriority(task.getId(), 12);
-        assertEquals(2, listener.getEventsReceived().size());
-        assertEquals(FlowableEngineEventType.TASK_PRIORITY_CHANGED, listener.getEventsReceived().get(0).getType());
+        assertThat(listener.getEventsReceived()).hasSize(2);
+        assertThat(listener.getEventsReceived().get(0).getType()).isEqualTo(FlowableEngineEventType.TASK_PRIORITY_CHANGED);
         event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.ENTITY_UPDATED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_UPDATED);
         assertExecutionDetails(event, processInstance);
         listener.clearEventsReceived();
 
         taskService.setOwner(task.getId(), "kermit");
-        assertEquals(2, listener.getEventsReceived().size());
-        assertEquals(FlowableEngineEventType.TASK_OWNER_CHANGED, listener.getEventsReceived().get(0).getType());
+        assertThat(listener.getEventsReceived()).hasSize(2);
+        assertThat(listener.getEventsReceived().get(0).getType()).isEqualTo(FlowableEngineEventType.TASK_OWNER_CHANGED);
         event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.ENTITY_UPDATED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_UPDATED);
         assertExecutionDetails(event, processInstance);
         listener.clearEventsReceived();
 
@@ -115,26 +117,26 @@ public class TaskEventsTest extends PluggableFlowableTestCase {
         task.setOwner("john");
         taskService.saveTask(task);
 
-        assertEquals(3, listener.getEventsReceived().size());
-        assertEquals(FlowableEngineEventType.TASK_OWNER_CHANGED, listener.getEventsReceived().get(0).getType());
-        assertEquals(FlowableEngineEventType.TASK_DUEDATE_CHANGED, listener.getEventsReceived().get(1).getType());
+        assertThat(listener.getEventsReceived()).hasSize(3);
+        assertThat(listener.getEventsReceived().get(0).getType()).isEqualTo(FlowableEngineEventType.TASK_OWNER_CHANGED);
+        assertThat(listener.getEventsReceived().get(1).getType()).isEqualTo(FlowableEngineEventType.TASK_DUEDATE_CHANGED);
         event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(2);
-        assertEquals(FlowableEngineEventType.ENTITY_UPDATED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_UPDATED);
         assertExecutionDetails(event, processInstance);
         listener.clearEventsReceived();
 
         // Check delete-event on complete
         taskService.complete(task.getId());
-        assertEquals(2, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(2);
         event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.TASK_COMPLETED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.TASK_COMPLETED);
         assertExecutionDetails(event, processInstance);
         TaskEntity taskEntity = (TaskEntity) event.getEntity();
-        assertNotNull(taskEntity.getDueDate());
+        assertThat(taskEntity.getDueDate()).isNotNull();
         event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.ENTITY_DELETED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_DELETED);
         assertExecutionDetails(event, processInstance);
-        
+
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
     }
 
@@ -142,26 +144,26 @@ public class TaskEventsTest extends PluggableFlowableTestCase {
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testTaskAssignmentEventInProcess() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
         listener.clearEventsReceived();
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
 
         // Set assignee through API
         taskService.setAssignee(task.getId(), "kermit");
-        assertEquals(2, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(2);
         FlowableEngineEntityEvent event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ENTITY_UPDATED, event.getType());
-        assertTrue(event.getEntity() instanceof org.flowable.task.api.Task);
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_UPDATED);
+        assertThat(event.getEntity()).isInstanceOf(org.flowable.task.api.Task.class);
         assertExecutionDetails(event, processInstance);
-        
+
         event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.TASK_ASSIGNED, event.getType());
-        assertTrue(event.getEntity() instanceof org.flowable.task.api.Task);
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.TASK_ASSIGNED);
+        assertThat(event.getEntity()).isInstanceOf(org.flowable.task.api.Task.class);
         org.flowable.task.api.Task taskFromEvent = (org.flowable.task.api.Task) event.getEntity();
-        assertEquals(task.getId(), taskFromEvent.getId());
-        assertEquals("kermit", taskFromEvent.getAssignee());
+        assertThat(taskFromEvent.getId()).isEqualTo(task.getId());
+        assertThat(taskFromEvent.getAssignee()).isEqualTo("kermit");
         assertExecutionDetails(event, processInstance);
 
         listener.clearEventsReceived();
@@ -171,35 +173,35 @@ public class TaskEventsTest extends PluggableFlowableTestCase {
         task.setAssignee("newAssignee");
         taskService.saveTask(task);
 
-        assertEquals(2, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(2);
         event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ENTITY_UPDATED, event.getType());
-        assertTrue(event.getEntity() instanceof org.flowable.task.api.Task);
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_UPDATED);
+        assertThat(event.getEntity()).isInstanceOf(org.flowable.task.api.Task.class);
         assertExecutionDetails(event, processInstance);
-        
+
         event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.TASK_ASSIGNED, event.getType());
-        assertTrue(event.getEntity() instanceof org.flowable.task.api.Task);
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.TASK_ASSIGNED);
+        assertThat(event.getEntity()).isInstanceOf(org.flowable.task.api.Task.class);
         taskFromEvent = (org.flowable.task.api.Task) event.getEntity();
-        assertEquals(task.getId(), taskFromEvent.getId());
-        assertEquals("newAssignee", taskFromEvent.getAssignee());
+        assertThat(taskFromEvent.getId()).isEqualTo(task.getId());
+        assertThat(taskFromEvent.getAssignee()).isEqualTo("newAssignee");
         assertExecutionDetails(event, processInstance);
         listener.clearEventsReceived();
 
         // Unclaim
         taskService.unclaim(task.getId());
-        assertEquals(2, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(2);
         event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ENTITY_UPDATED, event.getType());
-        assertTrue(event.getEntity() instanceof org.flowable.task.api.Task);
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_UPDATED);
+        assertThat(event.getEntity()).isInstanceOf(org.flowable.task.api.Task.class);
         assertExecutionDetails(event, processInstance);
-        
+
         event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.TASK_ASSIGNED, event.getType());
-        assertTrue(event.getEntity() instanceof org.flowable.task.api.Task);
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.TASK_ASSIGNED);
+        assertThat(event.getEntity()).isInstanceOf(org.flowable.task.api.Task.class);
         taskFromEvent = (org.flowable.task.api.Task) event.getEntity();
-        assertEquals(task.getId(), taskFromEvent.getId());
-        assertNull(taskFromEvent.getAssignee());
+        assertThat(taskFromEvent.getId()).isEqualTo(task.getId());
+        assertThat(taskFromEvent.getAssignee()).isNull();
         assertExecutionDetails(event, processInstance);
 
         listener.clearEventsReceived();
@@ -212,21 +214,21 @@ public class TaskEventsTest extends PluggableFlowableTestCase {
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testDeleteEventDoesNotDispathComplete() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
         listener.clearEventsReceived();
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
 
         // Delete process, should delete task as well, but not complete
         runtimeService.deleteProcessInstance(processInstance.getId(), "testing task delete events");
 
-        assertEquals(1, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(1);
         FlowableEngineEntityEvent event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.ENTITY_DELETED, event.getType());
-        assertTrue(event.getEntity() instanceof org.flowable.task.api.Task);
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_DELETED);
+        assertThat(event.getEntity()).isInstanceOf(org.flowable.task.api.Task.class);
         org.flowable.task.api.Task taskFromEvent = (org.flowable.task.api.Task) event.getEntity();
-        assertEquals(task.getId(), taskFromEvent.getId());
+        assertThat(taskFromEvent.getId()).isEqualTo(task.getId());
         assertExecutionDetails(event, processInstance);
 
         try {
@@ -239,15 +241,15 @@ public class TaskEventsTest extends PluggableFlowableTestCase {
             // Delete standalone task, only a delete-event should be dispatched
             taskService.deleteTask(task.getId());
 
-            assertEquals(1, listener.getEventsReceived().size());
+            assertThat(listener.getEventsReceived()).hasSize(1);
             event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(0);
-            assertEquals(FlowableEngineEventType.ENTITY_DELETED, event.getType());
-            assertTrue(event.getEntity() instanceof org.flowable.task.api.Task);
+            assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_DELETED);
+            assertThat(event.getEntity()).isInstanceOf(org.flowable.task.api.Task.class);
             taskFromEvent = (org.flowable.task.api.Task) event.getEntity();
-            assertEquals(task.getId(), taskFromEvent.getId());
-            assertNull(event.getProcessDefinitionId());
-            assertNull(event.getProcessInstanceId());
-            assertNull(event.getExecutionId());
+            assertThat(taskFromEvent.getId()).isEqualTo(task.getId());
+            assertThat(event.getProcessDefinitionId()).isNull();
+            assertThat(event.getProcessInstanceId()).isNull();
+            assertThat(event.getExecutionId()).isNull();
 
         } finally {
             if (task != null) {
@@ -290,22 +292,23 @@ public class TaskEventsTest extends PluggableFlowableTestCase {
             taskService.complete(task.getId(), taskParams, true);
 
             FlowableEntityEvent event = (FlowableEntityEvent) tlistener.getEventsReceived().get(0);
-            assertEquals(FlowableEngineEventType.ENTITY_CREATED, event.getType());
-            assertTrue(event.getEntity() instanceof org.flowable.task.api.Task);
+            assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
+            assertThat(event.getEntity()).isInstanceOf(org.flowable.task.api.Task.class);
 
             event = (FlowableEntityEvent) tlistener.getEventsReceived().get(1);
-            assertEquals(FlowableEngineEventType.ENTITY_INITIALIZED, event.getType());
-            assertTrue(event.getEntity() instanceof org.flowable.task.api.Task);
+            assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_INITIALIZED);
+            assertThat(event.getEntity()).isInstanceOf(org.flowable.task.api.Task.class);
 
             event = (FlowableEntityEvent) tlistener.getEventsReceived().get(2);
-            assertEquals(FlowableEngineEventType.TASK_CREATED, event.getType());
-            assertTrue(event.getEntity() instanceof org.flowable.task.api.Task);
+            assertThat(event.getType()).isEqualTo(FlowableEngineEventType.TASK_CREATED);
+            assertThat(event.getEntity()).isInstanceOf(org.flowable.task.api.Task.class);
             org.flowable.task.api.Task taskFromEvent = tlistener.getTasks().get(2);
-            assertEquals(task.getId(), taskFromEvent.getId());
+            assertThat(taskFromEvent.getId()).isEqualTo(task.getId());
 
             // verify script listener has done its job, on create before FlowableEntityEvent was fired
-            assertEquals("The ScriptTaskListener must set this value before the dispatchEvent fires.", "scriptedAssignee", taskFromEvent.getAssignee());
-            assertEquals("The ScriptTaskListener must set this value before the dispatchEvent fires.", 877, taskFromEvent.getPriority());
+            assertThat(taskFromEvent.getAssignee()).as("The ScriptTaskListener must set this value before the dispatchEvent fires.")
+                    .isEqualTo("scriptedAssignee");
+            assertThat(taskFromEvent.getPriority()).as("The ScriptTaskListener must set this value before the dispatchEvent fires.").isEqualTo(877);
 
             // Fetch second task
             taskService.createTaskQuery().singleResult();
@@ -328,81 +331,81 @@ public class TaskEventsTest extends PluggableFlowableTestCase {
             task.setDescription("Description");
             taskService.saveTask(task);
 
-            assertEquals(3, listener.getEventsReceived().size());
+            assertThat(listener.getEventsReceived()).hasSize(3);
 
             FlowableEngineEntityEvent event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(0);
-            assertEquals(FlowableEngineEventType.ENTITY_CREATED, event.getType());
-            assertTrue(event.getEntity() instanceof org.flowable.task.api.Task);
+            assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
+            assertThat(event.getEntity()).isInstanceOf(org.flowable.task.api.Task.class);
             org.flowable.task.api.Task taskFromEvent = (org.flowable.task.api.Task) event.getEntity();
-            assertEquals(task.getId(), taskFromEvent.getId());
-            assertNull(event.getProcessDefinitionId());
-            assertNull(event.getProcessInstanceId());
-            assertNull(event.getExecutionId());
+            assertThat(taskFromEvent.getId()).isEqualTo(task.getId());
+            assertThat(event.getProcessDefinitionId()).isNull();
+            assertThat(event.getProcessInstanceId()).isNull();
+            assertThat(event.getExecutionId()).isNull();
 
             event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(1);
-            assertEquals(FlowableEngineEventType.ENTITY_INITIALIZED, event.getType());
+            assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_INITIALIZED);
 
             event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(2);
-            assertEquals(FlowableEngineEventType.TASK_CREATED, event.getType());
+            assertThat(event.getType()).isEqualTo(FlowableEngineEventType.TASK_CREATED);
             listener.clearEventsReceived();
 
             // Update task
             taskService.setOwner(task.getId(), "owner");
-            assertEquals(2, listener.getEventsReceived().size());
-            assertEquals(FlowableEngineEventType.TASK_OWNER_CHANGED, listener.getEventsReceived().get(0).getType());
+            assertThat(listener.getEventsReceived()).hasSize(2);
+            assertThat(listener.getEventsReceived().get(0).getType()).isEqualTo(FlowableEngineEventType.TASK_OWNER_CHANGED);
             event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(1);
-            assertEquals(FlowableEngineEventType.ENTITY_UPDATED, event.getType());
-            assertTrue(event.getEntity() instanceof org.flowable.task.api.Task);
+            assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_UPDATED);
+            assertThat(event.getEntity()).isInstanceOf(org.flowable.task.api.Task.class);
             taskFromEvent = (org.flowable.task.api.Task) event.getEntity();
-            assertEquals(task.getId(), taskFromEvent.getId());
-            assertEquals("owner", taskFromEvent.getOwner());
-            assertNull(event.getProcessDefinitionId());
-            assertNull(event.getProcessInstanceId());
-            assertNull(event.getExecutionId());
+            assertThat(taskFromEvent.getId()).isEqualTo(task.getId());
+            assertThat(taskFromEvent.getOwner()).isEqualTo("owner");
+            assertThat(event.getProcessDefinitionId()).isNull();
+            assertThat(event.getProcessInstanceId()).isNull();
+            assertThat(event.getExecutionId()).isNull();
             listener.clearEventsReceived();
 
             // Assign task
             taskService.setAssignee(task.getId(), "kermit");
-            assertEquals(2, listener.getEventsReceived().size());
+            assertThat(listener.getEventsReceived()).hasSize(2);
             event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(0);
-            assertEquals(FlowableEngineEventType.ENTITY_UPDATED, event.getType());
-            assertTrue(event.getEntity() instanceof org.flowable.task.api.Task);
+            assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_UPDATED);
+            assertThat(event.getEntity()).isInstanceOf(org.flowable.task.api.Task.class);
             taskFromEvent = (org.flowable.task.api.Task) event.getEntity();
-            assertEquals(task.getId(), taskFromEvent.getId());
-            assertNull(event.getProcessDefinitionId());
-            assertNull(event.getProcessInstanceId());
-            assertNull(event.getExecutionId());
+            assertThat(taskFromEvent.getId()).isEqualTo(task.getId());
+            assertThat(event.getProcessDefinitionId()).isNull();
+            assertThat(event.getProcessInstanceId()).isNull();
+            assertThat(event.getExecutionId()).isNull();
             event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(1);
-            assertEquals(FlowableEngineEventType.TASK_ASSIGNED, event.getType());
-            assertTrue(event.getEntity() instanceof org.flowable.task.api.Task);
+            assertThat(event.getType()).isEqualTo(FlowableEngineEventType.TASK_ASSIGNED);
+            assertThat(event.getEntity()).isInstanceOf(org.flowable.task.api.Task.class);
             taskFromEvent = (org.flowable.task.api.Task) event.getEntity();
-            assertEquals(task.getId(), taskFromEvent.getId());
-            assertEquals("kermit", taskFromEvent.getAssignee());
-            assertNull(event.getProcessDefinitionId());
-            assertNull(event.getProcessInstanceId());
-            assertNull(event.getExecutionId());
+            assertThat(taskFromEvent.getId()).isEqualTo(task.getId());
+            assertThat(taskFromEvent.getAssignee()).isEqualTo("kermit");
+            assertThat(event.getProcessDefinitionId()).isNull();
+            assertThat(event.getProcessInstanceId()).isNull();
+            assertThat(event.getExecutionId()).isNull();
             listener.clearEventsReceived();
 
             // Complete task
             taskService.complete(task.getId());
-            assertEquals(2, listener.getEventsReceived().size());
+            assertThat(listener.getEventsReceived()).hasSize(2);
             event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(0);
-            assertEquals(FlowableEngineEventType.TASK_COMPLETED, event.getType());
-            assertTrue(event.getEntity() instanceof org.flowable.task.api.Task);
+            assertThat(event.getType()).isEqualTo(FlowableEngineEventType.TASK_COMPLETED);
+            assertThat(event.getEntity()).isInstanceOf(org.flowable.task.api.Task.class);
             taskFromEvent = (org.flowable.task.api.Task) event.getEntity();
-            assertEquals(task.getId(), taskFromEvent.getId());
-            assertNull(event.getProcessDefinitionId());
-            assertNull(event.getProcessInstanceId());
-            assertNull(event.getExecutionId());
+            assertThat(taskFromEvent.getId()).isEqualTo(task.getId());
+            assertThat(event.getProcessDefinitionId()).isNull();
+            assertThat(event.getProcessInstanceId()).isNull();
+            assertThat(event.getExecutionId()).isNull();
 
             event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(1);
-            assertEquals(FlowableEngineEventType.ENTITY_DELETED, event.getType());
-            assertTrue(event.getEntity() instanceof org.flowable.task.api.Task);
+            assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ENTITY_DELETED);
+            assertThat(event.getEntity()).isInstanceOf(org.flowable.task.api.Task.class);
             taskFromEvent = (org.flowable.task.api.Task) event.getEntity();
-            assertEquals(task.getId(), taskFromEvent.getId());
-            assertNull(event.getProcessDefinitionId());
-            assertNull(event.getProcessInstanceId());
-            assertNull(event.getExecutionId());
+            assertThat(taskFromEvent.getId()).isEqualTo(task.getId());
+            assertThat(event.getProcessDefinitionId()).isNull();
+            assertThat(event.getProcessInstanceId()).isNull();
+            assertThat(event.getExecutionId()).isNull();
 
         } finally {
             if (task != null) {
@@ -423,9 +426,9 @@ public class TaskEventsTest extends PluggableFlowableTestCase {
     }
 
     protected void assertExecutionDetails(FlowableEngineEntityEvent event, ProcessInstance processInstance) {
-        assertEquals(processInstance.getId(), event.getProcessInstanceId());
-        assertNotNull(event.getExecutionId());
-        assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
+        assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(event.getExecutionId()).isNotNull();
+        assertThat(event.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
     }
 
     @BeforeEach

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/TransactionEventListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/TransactionEventListenerTest.java
@@ -12,6 +12,7 @@
  */
 package org.flowable.engine.test.api.event;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
@@ -56,7 +57,7 @@ public class TransactionEventListenerTest extends PluggableFlowableTestCase {
     @Test
     public void testRegularProcessExecution() {
 
-        assertEquals(0, TestTransactionEventListener.eventsReceived.size());
+        assertThat(TestTransactionEventListener.eventsReceived).isEmpty();
 
         // In a 'normal' process execution, the transaction dependent event listener should
         // be similar to the normal event listener dispatching.
@@ -68,22 +69,22 @@ public class TransactionEventListenerTest extends PluggableFlowableTestCase {
         if (processEngineConfiguration.getHistoryManager().isHistoryEnabled()) {
             expectedCreatedEvents += 4;
         }
-        
+
         if (processEngineConfiguration.isAsyncHistoryEnabled()) {
             waitForHistoryJobExecutorToProcessAllJobs(7000L, 200L);
         }
 
-        assertEquals(expectedCreatedEvents, TestTransactionEventListener.eventsReceived.get(FlowableEngineEventType.ENTITY_CREATED.name()).size());
-        assertEquals(expectedCreatedEvents, TestTransactionEventListener.eventsReceived.get(FlowableEngineEventType.ENTITY_INITIALIZED.name()).size());
-        assertEquals(1, TestTransactionEventListener.eventsReceived.get(FlowableEngineEventType.PROCESS_STARTED.name()).size());
-        assertEquals(1, TestTransactionEventListener.eventsReceived.get(FlowableEngineEventType.TASK_CREATED.name()).size());
+        assertThat(TestTransactionEventListener.eventsReceived.get(FlowableEngineEventType.ENTITY_CREATED.name())).hasSize(expectedCreatedEvents);
+        assertThat(TestTransactionEventListener.eventsReceived.get(FlowableEngineEventType.ENTITY_INITIALIZED.name())).hasSize(expectedCreatedEvents);
+        assertThat(TestTransactionEventListener.eventsReceived.get(FlowableEngineEventType.PROCESS_STARTED.name())).hasSize(1);
+        assertThat(TestTransactionEventListener.eventsReceived.get(FlowableEngineEventType.TASK_CREATED.name())).hasSize(1);
 
         TestTransactionEventListener.eventsReceived.clear();
 
         taskService.complete(taskService.createTaskQuery().singleResult().getId());
-        assertEquals(1, TestTransactionEventListener.eventsReceived.get(FlowableEngineEventType.TASK_COMPLETED.name()).size());
-        assertEquals(1, TestTransactionEventListener.eventsReceived.get(FlowableEngineEventType.PROCESS_COMPLETED.name()).size());
-        
+        assertThat(TestTransactionEventListener.eventsReceived.get(FlowableEngineEventType.TASK_COMPLETED.name())).hasSize(1);
+        assertThat(TestTransactionEventListener.eventsReceived.get(FlowableEngineEventType.PROCESS_COMPLETED.name())).hasSize(1);
+
         if (processEngineConfiguration.isAsyncHistoryEnabled()) {
             waitForHistoryJobExecutorToProcessAllJobs(7000L, 200L);
         }
@@ -93,20 +94,21 @@ public class TransactionEventListenerTest extends PluggableFlowableTestCase {
     @Deployment
     public void testProcessExecutionWithRollback() {
 
-        assertEquals(0, TestTransactionEventListener.eventsReceived.size());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+        assertThat(TestTransactionEventListener.eventsReceived).isEmpty();
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(0);
 
         // Regular execution, no exception
         runtimeService.startProcessInstanceByKey("testProcessExecutionWithRollback", CollectionUtil.singletonMap("throwException", false));
-        assertTrue(TestTransactionEventListener.eventsReceived.size() > 0);
-        assertEquals(1, runtimeService.createProcessInstanceQuery().count());
+        assertThat(TestTransactionEventListener.eventsReceived.size() > 0).isTrue();
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(1);
 
         TestTransactionEventListener.eventsReceived.clear();
 
         // When process execution rolls back, the events should not be thrown, as they are only thrown on commit.
-        assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("testProcessExecutionWithRollback", CollectionUtil.singletonMap("throwException", true)));
-        assertEquals(0, TestTransactionEventListener.eventsReceived.size());
-        assertEquals(1, runtimeService.createProcessInstanceQuery().count());
+        assertThatThrownBy(
+                () -> runtimeService.startProcessInstanceByKey("testProcessExecutionWithRollback", CollectionUtil.singletonMap("throwException", true)));
+        assertThat(TestTransactionEventListener.eventsReceived).isEmpty();
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(1);
     }
 
     @Test
@@ -117,9 +119,9 @@ public class TransactionEventListenerTest extends PluggableFlowableTestCase {
         processEngineConfiguration.getEventDispatcher().removeEventListener(onCommitListener);
         TestTransactionEventListener.eventsReceived.clear();
 
-        assertEquals(0, TestTransactionEventListener.eventsReceived.size());
+        assertThat(TestTransactionEventListener.eventsReceived).isEmpty();
         runtimeService.startProcessInstanceByKey("testProcessExecutionWithRollback", CollectionUtil.singletonMap("throwException", false));
-        assertTrue(TestTransactionEventListener.eventsReceived.size() > 0);
+        assertThat(TestTransactionEventListener.eventsReceived.size()).isPositive();
     }
 
     public static class TestTransactionEventListener implements FlowableEventListener {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/UncaughtErrorEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/UncaughtErrorEventTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -11,6 +11,8 @@
  * limitations under the License.
  */
 package org.flowable.engine.test.api.event;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.flowable.common.engine.api.delegate.event.FlowableEvent;
 import org.flowable.engine.delegate.BpmnError;
@@ -22,7 +24,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link FlowableEvent} thrown when a BPMNError is not caught in the process.
- * 
+ *
  * @author Frederik Heremans
  */
 public class UncaughtErrorEventTest extends PluggableFlowableTestCase {
@@ -35,12 +37,9 @@ public class UncaughtErrorEventTest extends PluggableFlowableTestCase {
     @Test
     @Deployment
     public void testUncaughtError() throws Exception {
-        try {
-            runtimeService.startProcessInstanceByKey("errorProcess");
-            fail("Exception BPMN  error excepted due to not caught exception");
-        } catch (BpmnError e) {
 
-        }
+        assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("errorProcess"))
+                .isInstanceOf(BpmnError.class);
     }
 
     @BeforeEach

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/UserEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/UserEventsTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -11,6 +11,8 @@
  * limitations under the License.
  */
 package org.flowable.engine.test.api.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.common.engine.api.delegate.event.FlowableEntityEvent;
 import org.flowable.common.engine.api.delegate.event.FlowableEvent;
@@ -23,7 +25,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for all {@link FlowableEvent}s related to users.
- * 
+ *
  * @author Frederik Heremans
  */
 public class UserEventsTest extends PluggableFlowableTestCase {
@@ -42,38 +44,38 @@ public class UserEventsTest extends PluggableFlowableTestCase {
             user.setLastName("Heremans");
             identityService.saveUser(user);
 
-            assertEquals(2, listener.getEventsReceived().size());
+            assertThat(listener.getEventsReceived()).hasSize(2);
             FlowableEntityEvent event = (FlowableEntityEvent) listener.getEventsReceived().get(0);
-            assertEquals(FlowableIdmEventType.ENTITY_CREATED, event.getType());
-            assertTrue(event.getEntity() instanceof User);
+            assertThat(event.getType()).isEqualTo(FlowableIdmEventType.ENTITY_CREATED);
+            assertThat(event.getEntity()).isInstanceOf(User.class);
             User userFromEvent = (User) event.getEntity();
-            assertEquals("fred", userFromEvent.getId());
+            assertThat(userFromEvent.getId()).isEqualTo("fred");
 
             event = (FlowableEntityEvent) listener.getEventsReceived().get(1);
-            assertEquals(FlowableIdmEventType.ENTITY_INITIALIZED, event.getType());
+            assertThat(event.getType()).isEqualTo(FlowableIdmEventType.ENTITY_INITIALIZED);
             listener.clearEventsReceived();
 
             // Update user
             user.setFirstName("Anna");
             identityService.saveUser(user);
-            assertEquals(1, listener.getEventsReceived().size());
+            assertThat(listener.getEventsReceived()).hasSize(1);
             event = (FlowableEntityEvent) listener.getEventsReceived().get(0);
-            assertEquals(FlowableIdmEventType.ENTITY_UPDATED, event.getType());
-            assertTrue(event.getEntity() instanceof User);
+            assertThat(event.getType()).isEqualTo(FlowableIdmEventType.ENTITY_UPDATED);
+            assertThat(event.getEntity()).isInstanceOf(User.class);
             userFromEvent = (User) event.getEntity();
-            assertEquals("fred", userFromEvent.getId());
-            assertEquals("Anna", userFromEvent.getFirstName());
+            assertThat(userFromEvent.getId()).isEqualTo("fred");
+            assertThat(userFromEvent.getFirstName()).isEqualTo("Anna");
             listener.clearEventsReceived();
 
             // Delete user
             identityService.deleteUser(user.getId());
 
-            assertEquals(1, listener.getEventsReceived().size());
+            assertThat(listener.getEventsReceived()).hasSize(1);
             event = (FlowableEntityEvent) listener.getEventsReceived().get(0);
-            assertEquals(FlowableIdmEventType.ENTITY_DELETED, event.getType());
-            assertTrue(event.getEntity() instanceof User);
+            assertThat(event.getType()).isEqualTo(FlowableIdmEventType.ENTITY_DELETED);
+            assertThat(event.getEntity()).isInstanceOf(User.class);
             userFromEvent = (User) event.getEntity();
-            assertEquals("fred", userFromEvent.getId());
+            assertThat(userFromEvent.getId()).isEqualTo("fred");
             listener.clearEventsReceived();
 
         } finally {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/VariableEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/VariableEventsTest.java
@@ -111,7 +111,7 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
 
         // Delete nonexistent variable should not dispatch event
         runtimeService.removeVariable(processInstance.getId(), "unexistingVariable");
-        assertThat(listener.getEventsReceived().isEmpty()).isTrue();
+        assertThat(listener.getEventsReceived()).isEmpty();
     }
 
     @Test

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/VariableEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/VariableEventsTest.java
@@ -12,8 +12,7 @@
  */
 package org.flowable.engine.test.api.event;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -21,14 +20,12 @@ import java.util.Map;
 
 import org.flowable.common.engine.api.delegate.event.FlowableEngineEventType;
 import org.flowable.common.engine.api.delegate.event.FlowableEvent;
-import org.flowable.common.engine.api.delegate.event.FlowableEventType;
 import org.flowable.engine.impl.persistence.entity.ExecutionEntity;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.variable.api.event.FlowableVariableEvent;
-import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -49,47 +46,47 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testProcessInstanceVariableEvents() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         // Check create event
         runtimeService.setVariable(processInstance.getId(), "testVariable", "The value");
-        assertEquals(1, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(1);
         FlowableVariableEvent event = (FlowableVariableEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.VARIABLE_CREATED, event.getType());
-        assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
-        assertEquals(processInstance.getId(), event.getExecutionId());
-        assertEquals(processInstance.getId(), event.getProcessInstanceId());
-        assertNull(event.getTaskId());
-        assertEquals("testVariable", event.getVariableName());
-        assertEquals("The value", event.getVariableValue());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.VARIABLE_CREATED);
+        assertThat(event.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(event.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(event.getTaskId()).isNull();
+        assertThat(event.getVariableName()).isEqualTo("testVariable");
+        assertThat(event.getVariableValue()).isEqualTo("The value");
         listener.clearEventsReceived();
 
         // Update variable
         runtimeService.setVariable(processInstance.getId(), "testVariable", "Updated value");
-        assertEquals(1, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(1);
         event = (FlowableVariableEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.VARIABLE_UPDATED, event.getType());
-        assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
-        assertEquals(processInstance.getId(), event.getExecutionId());
-        assertEquals(processInstance.getId(), event.getProcessInstanceId());
-        assertNull(event.getTaskId());
-        assertEquals("testVariable", event.getVariableName());
-        assertEquals("Updated value", event.getVariableValue());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.VARIABLE_UPDATED);
+        assertThat(event.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(event.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(event.getTaskId()).isNull();
+        assertThat(event.getVariableName()).isEqualTo("testVariable");
+        assertThat(event.getVariableValue()).isEqualTo("Updated value");
         listener.clearEventsReceived();
 
         // Delete variable
         runtimeService.removeVariable(processInstance.getId(), "testVariable");
-        assertEquals(1, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(1);
         event = (FlowableVariableEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.VARIABLE_DELETED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.VARIABLE_DELETED);
         // process definition Id can't be recognized in DB flush
-        assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
-        assertEquals(processInstance.getId(), event.getExecutionId());
-        assertEquals(processInstance.getId(), event.getProcessInstanceId());
-        assertNull(event.getTaskId());
-        assertEquals("testVariable", event.getVariableName());
+        assertThat(event.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(event.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(event.getTaskId()).isNull();
+        assertThat(event.getVariableName()).isEqualTo("testVariable");
         // deleted variable value is always null
-        assertNull(event.getVariableValue());
+        assertThat(event.getVariableValue()).isNull();
         listener.clearEventsReceived();
 
         // Create, update and delete multiple variables
@@ -100,18 +97,21 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
         runtimeService.setVariables(processInstance.getId(), vars);
         runtimeService.removeVariables(processInstance.getId(), vars.keySet());
 
-        assertEquals(6, listener.getEventsReceived().size());
-        assertEquals(FlowableEngineEventType.VARIABLE_CREATED, listener.getEventsReceived().get(0).getType());
-        assertEquals(FlowableEngineEventType.VARIABLE_CREATED, listener.getEventsReceived().get(1).getType());
-        assertEquals(FlowableEngineEventType.VARIABLE_UPDATED, listener.getEventsReceived().get(2).getType());
-        assertEquals(FlowableEngineEventType.VARIABLE_UPDATED, listener.getEventsReceived().get(3).getType());
-        assertEquals(FlowableEngineEventType.VARIABLE_DELETED, listener.getEventsReceived().get(4).getType());
-        assertEquals(FlowableEngineEventType.VARIABLE_DELETED, listener.getEventsReceived().get(5).getType());
+        assertThat(listener.getEventsReceived())
+                .extracting(FlowableEvent::getType)
+                .containsExactly(
+                        FlowableEngineEventType.VARIABLE_CREATED,
+                        FlowableEngineEventType.VARIABLE_CREATED,
+                        FlowableEngineEventType.VARIABLE_UPDATED,
+                        FlowableEngineEventType.VARIABLE_UPDATED,
+                        FlowableEngineEventType.VARIABLE_DELETED,
+                        FlowableEngineEventType.VARIABLE_DELETED
+                );
         listener.clearEventsReceived();
 
         // Delete nonexistent variable should not dispatch event
         runtimeService.removeVariable(processInstance.getId(), "unexistingVariable");
-        assertTrue(listener.getEventsReceived().isEmpty());
+        assertThat(listener.getEventsReceived().isEmpty()).isTrue();
     }
 
     @Test
@@ -121,14 +121,15 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
         variables.put("var1", "value1");
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess", variables);
 
-        assertEquals(1, listener.getEventsReceived().size());
-        assertEquals(FlowableEngineEventType.VARIABLE_CREATED, listener.getEventsReceived().get(0).getType());
+        assertThat(listener.getEventsReceived())
+                .extracting(FlowableEvent::getType)
+                .containsExactly(FlowableEngineEventType.VARIABLE_CREATED);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         taskService.complete(task.getId());
 
-        assertEquals(2, listener.getEventsReceived().size());
-        assertEquals(FlowableEngineEventType.VARIABLE_DELETED, listener.getEventsReceived().get(1).getType());
+        assertThat(listener.getEventsReceived()).hasSize(2);
+        assertThat(listener.getEventsReceived().get(1).getType()).isEqualTo(FlowableEngineEventType.VARIABLE_DELETED);
     }
 
     /**
@@ -142,18 +143,18 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
         vars.put("testVariable", "The value");
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         // Check create event
-        assertEquals(1, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(1);
         FlowableVariableEvent event = (FlowableVariableEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.VARIABLE_CREATED, event.getType());
-        assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
-        assertEquals(processInstance.getId(), event.getExecutionId());
-        assertEquals(processInstance.getId(), event.getProcessInstanceId());
-        assertNull(event.getTaskId());
-        assertEquals("testVariable", event.getVariableName());
-        assertEquals("The value", event.getVariableValue());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.VARIABLE_CREATED);
+        assertThat(event.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(event.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(event.getTaskId()).isNull();
+        assertThat(event.getVariableName()).isEqualTo("testVariable");
+        assertThat(event.getVariableValue()).isEqualTo("The value");
         listener.clearEventsReceived();
     }
 
@@ -164,20 +165,21 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
     @Deployment
     public void testProcessInstanceVariableEventsOnChildExecution() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("variableProcess");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         Execution child = runtimeService.createExecutionQuery().parentId(processInstance.getId()).singleResult();
-        assertNotNull(child);
+        assertThat(child).isNotNull();
 
         runtimeService.setVariableLocal(child.getId(), "test", 1234567);
 
-        assertEquals(1, listener.getEventsReceived().size());
-        FlowableVariableEvent event = (FlowableVariableEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.VARIABLE_CREATED, event.getType());
+        assertThat(listener.getEventsReceived())
+                .extracting(FlowableEvent::getType)
+                .containsExactly(FlowableEngineEventType.VARIABLE_CREATED);
 
+        FlowableVariableEvent event = (FlowableVariableEvent) listener.getEventsReceived().get(0);
         // Execution and process-id should differ
-        assertEquals(child.getId(), event.getExecutionId());
-        assertEquals(processInstance.getId(), event.getProcessInstanceId());
+        assertThat(event.getExecutionId()).isEqualTo(child.getId());
+        assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
     }
 
     @Test
@@ -185,61 +187,61 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
     public void testProcessInstanceVariableEventsOnCallActivity() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("callVariableProcess",
                 Collections.<String, Object>singletonMap("parentVar1", "parentVar1Value"));
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
-        assertEquals(6, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(6);
         int nrOfCreated = 0;
         int nrOfDeleted = 0;
         for (int i = 0; i < listener.getEventsReceived().size(); i++) {
             FlowableVariableEvent event = (FlowableVariableEvent) listener.getEventsReceived().get(i);
             if (event.getType() == FlowableEngineEventType.VARIABLE_CREATED) {
-                
+
                 nrOfCreated++;
-                
+
                 if (event.getVariableName().equals("parentVar1")) {
-                    assertThat(event.getType(), CoreMatchers.<FlowableEventType>is(FlowableEngineEventType.VARIABLE_CREATED));
-                    assertThat(event.getVariableName(), is("parentVar1"));
-                    
+                    assertThat(event.getType()).isEqualTo(FlowableEngineEventType.VARIABLE_CREATED);
+                    assertThat(event.getVariableName()).isEqualTo("parentVar1");
+
                 } else if (event.getVariableName().equals("subVar1")) {
-                    assertThat(event.getType(), CoreMatchers.<FlowableEventType>is(FlowableEngineEventType.VARIABLE_CREATED));
-                    assertThat(event.getVariableName(), is("subVar1"));
-                    
+                    assertThat(event.getType()).isEqualTo(FlowableEngineEventType.VARIABLE_CREATED);
+                    assertThat(event.getVariableName()).isEqualTo("subVar1");
+
                 } else if (event.getVariableName().equals("parentVar2")) {
-                    assertThat(event.getType(), CoreMatchers.<FlowableEventType>is(FlowableEngineEventType.VARIABLE_CREATED));
-                    assertThat(event.getVariableName(), is("parentVar2"));
-                    
+                    assertThat(event.getType()).isEqualTo(FlowableEngineEventType.VARIABLE_CREATED);
+                    assertThat(event.getVariableName()).isEqualTo("parentVar2");
+
                 } else {
                     fail("Unknown variable name " + event.getVariableName());
                 }
-                
+
             } else if (event.getType() == FlowableEngineEventType.VARIABLE_DELETED) {
-                
+
                 nrOfDeleted++;
-                
+
                 if (event.getVariableName().equals("parentVar1")) {
-                    assertThat(event.getType(), CoreMatchers.<FlowableEventType>is(FlowableEngineEventType.VARIABLE_DELETED));
-                    assertThat(event.getVariableName(), is("parentVar1"));
-                    
+                    assertThat(event.getType()).isEqualTo(FlowableEngineEventType.VARIABLE_DELETED);
+                    assertThat(event.getVariableName()).isEqualTo("parentVar1");
+
                 } else if (event.getVariableName().equals("subVar1")) {
-                    assertThat(event.getType(), CoreMatchers.<FlowableEventType>is(FlowableEngineEventType.VARIABLE_DELETED));
-                    assertThat(event.getVariableName(), is("subVar1"));
-                    
+                    assertThat(event.getType()).isEqualTo(FlowableEngineEventType.VARIABLE_DELETED);
+                    assertThat(event.getVariableName()).isEqualTo("subVar1");
+
                 } else if (event.getVariableName().equals("parentVar2")) {
-                    assertThat(event.getType(), CoreMatchers.<FlowableEventType>is(FlowableEngineEventType.VARIABLE_DELETED));
-                    assertThat(event.getVariableName(), is("parentVar2"));
-                    
+                    assertThat(event.getType()).isEqualTo(FlowableEngineEventType.VARIABLE_DELETED);
+                    assertThat(event.getVariableName()).isEqualTo("parentVar2");
+
                 } else {
                     fail("Unknown variable name " + event.getVariableName());
                 }
-                
+
             } else {
                 fail("Unknown event type " + event.getType());
             }
-            
+
         }
-        
-        assertEquals(3, nrOfCreated);
-        assertEquals(3, nrOfDeleted);
+
+        assertThat(nrOfCreated).isEqualTo(3);
+        assertThat(nrOfDeleted).isEqualTo(3);
     }
 
     /**
@@ -249,40 +251,40 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
     @Deployment
     public void testProcessInstanceVariableEventsWithinProcess() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("variableProcess");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
-        assertEquals(3, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(3);
 
         // Check create event
         FlowableVariableEvent event = (FlowableVariableEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.VARIABLE_CREATED, event.getType());
-        assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
-        assertEquals(processInstance.getId(), event.getExecutionId());
-        assertEquals(processInstance.getId(), event.getProcessInstanceId());
-        assertNull(event.getTaskId());
-        assertEquals("variable", event.getVariableName());
-        assertEquals(123, event.getVariableValue());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.VARIABLE_CREATED);
+        assertThat(event.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(event.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(event.getTaskId()).isNull();
+        assertThat(event.getVariableName()).isEqualTo("variable");
+        assertThat(event.getVariableValue()).isEqualTo(123);
 
         // Check update event
         event = (FlowableVariableEvent) listener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.VARIABLE_UPDATED, event.getType());
-        assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
-        assertEquals(processInstance.getId(), event.getExecutionId());
-        assertEquals(processInstance.getId(), event.getProcessInstanceId());
-        assertNull(event.getTaskId());
-        assertEquals("variable", event.getVariableName());
-        assertEquals(456, event.getVariableValue());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.VARIABLE_UPDATED);
+        assertThat(event.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(event.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(event.getTaskId()).isNull();
+        assertThat(event.getVariableName()).isEqualTo("variable");
+        assertThat(event.getVariableValue()).isEqualTo(456);
 
         // Check delete event
         event = (FlowableVariableEvent) listener.getEventsReceived().get(2);
-        assertEquals(FlowableEngineEventType.VARIABLE_DELETED, event.getType());
-        assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
-        assertEquals(processInstance.getId(), event.getExecutionId());
-        assertEquals(processInstance.getId(), event.getProcessInstanceId());
-        assertNull(event.getTaskId());
-        assertEquals("variable", event.getVariableName());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.VARIABLE_DELETED);
+        assertThat(event.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(event.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(event.getTaskId()).isNull();
+        assertThat(event.getVariableName()).isEqualTo("variable");
         // deleted values are always null
-        assertNull(event.getVariableValue());
+        assertThat(event.getVariableValue()).isNull();
     }
 
     /**
@@ -292,42 +294,42 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
     @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void testTaskVariableEvents() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
 
         taskService.setVariableLocal(task.getId(), "testVariable", "The value");
         taskService.setVariableLocal(task.getId(), "testVariable", "Updated value");
         taskService.removeVariableLocal(task.getId(), "testVariable");
 
         // Check create event
-        assertEquals(3, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(3);
         FlowableVariableEvent event = (FlowableVariableEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.VARIABLE_CREATED, event.getType());
-        assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
-        assertEquals(processInstance.getId(), event.getProcessInstanceId());
-        assertEquals(task.getId(), event.getTaskId());
-        assertEquals("testVariable", event.getVariableName());
-        assertEquals("The value", event.getVariableValue());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.VARIABLE_CREATED);
+        assertThat(event.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(event.getTaskId()).isEqualTo(task.getId());
+        assertThat(event.getVariableName()).isEqualTo("testVariable");
+        assertThat(event.getVariableValue()).isEqualTo("The value");
 
         event = (FlowableVariableEvent) listener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.VARIABLE_UPDATED, event.getType());
-        assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
-        assertEquals(processInstance.getId(), event.getProcessInstanceId());
-        assertEquals(task.getId(), event.getTaskId());
-        assertEquals("testVariable", event.getVariableName());
-        assertEquals("Updated value", event.getVariableValue());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.VARIABLE_UPDATED);
+        assertThat(event.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(event.getTaskId()).isEqualTo(task.getId());
+        assertThat(event.getVariableName()).isEqualTo("testVariable");
+        assertThat(event.getVariableValue()).isEqualTo("Updated value");
 
         event = (FlowableVariableEvent) listener.getEventsReceived().get(2);
-        assertEquals(FlowableEngineEventType.VARIABLE_DELETED, event.getType());
-        assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
-        assertEquals(processInstance.getId(), event.getProcessInstanceId());
-        assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
-        assertEquals(task.getId(), event.getTaskId());
-        assertEquals("testVariable", event.getVariableName());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.VARIABLE_DELETED);
+        assertThat(event.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(event.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(event.getTaskId()).isEqualTo(task.getId());
+        assertThat(event.getVariableName()).isEqualTo("testVariable");
         // deleted values are always null
-        assertNull(event.getVariableValue());
+        assertThat(event.getVariableValue()).isNull();
         listener.clearEventsReceived();
     }
 
@@ -338,41 +340,41 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
     @Deployment
     public void testTaskVariableEventsWithinProcess() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("variableProcess");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
 
-        assertEquals(3, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(3);
 
         // Check create event
         FlowableVariableEvent event = (FlowableVariableEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.VARIABLE_CREATED, event.getType());
-        assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
-        assertEquals(processInstance.getId(), event.getProcessInstanceId());
-        assertEquals(task.getId(), event.getTaskId());
-        assertEquals("variable", event.getVariableName());
-        assertEquals(123, event.getVariableValue());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.VARIABLE_CREATED);
+        assertThat(event.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(event.getTaskId()).isEqualTo(task.getId());
+        assertThat(event.getVariableName()).isEqualTo("variable");
+        assertThat(event.getVariableValue()).isEqualTo(123);
 
         // Check update event
         event = (FlowableVariableEvent) listener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.VARIABLE_UPDATED, event.getType());
-        assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
-        assertEquals(processInstance.getId(), event.getProcessInstanceId());
-        assertEquals(task.getId(), event.getTaskId());
-        assertEquals("variable", event.getVariableName());
-        assertEquals(456, event.getVariableValue());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.VARIABLE_UPDATED);
+        assertThat(event.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(event.getTaskId()).isEqualTo(task.getId());
+        assertThat(event.getVariableName()).isEqualTo("variable");
+        assertThat(event.getVariableValue()).isEqualTo(456);
 
         // Check delete event
         event = (FlowableVariableEvent) listener.getEventsReceived().get(2);
-        assertEquals(FlowableEngineEventType.VARIABLE_DELETED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.VARIABLE_DELETED);
         // process definition Id can't be recognized in DB flush
-        assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
-        assertEquals(processInstance.getId(), event.getProcessInstanceId());
-        assertEquals(task.getId(), event.getTaskId());
-        assertEquals("variable", event.getVariableName());
+        assertThat(event.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(event.getTaskId()).isEqualTo(task.getId());
+        assertThat(event.getVariableName()).isEqualTo("variable");
         // deleted variable value is always null
-        assertNull(event.getVariableValue());
+        assertThat(event.getVariableValue()).isNull();
     }
 
     /**
@@ -386,39 +388,39 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
 
             taskService.setVariable(newTask.getId(), "testVariable", 123);
             taskService.setVariable(newTask.getId(), "testVariable", 456);
-            
+
             waitForJobExecutorToProcessAllHistoryJobs(7000, 200);
-            
+
             taskService.removeVariable(newTask.getId(), "testVariable");
 
-            assertEquals(3, listener.getEventsReceived().size());
+            assertThat(listener.getEventsReceived()).hasSize(3);
             FlowableVariableEvent event = (FlowableVariableEvent) listener.getEventsReceived().get(0);
-            assertEquals(FlowableEngineEventType.VARIABLE_CREATED, event.getType());
-            assertNull(event.getProcessDefinitionId());
-            assertNull(event.getExecutionId());
-            assertNull(event.getProcessInstanceId());
-            assertEquals(newTask.getId(), event.getTaskId());
-            assertEquals("testVariable", event.getVariableName());
-            assertEquals(123, event.getVariableValue());
+            assertThat(event.getType()).isEqualTo(FlowableEngineEventType.VARIABLE_CREATED);
+            assertThat(event.getProcessDefinitionId()).isNull();
+            assertThat(event.getExecutionId()).isNull();
+            assertThat(event.getProcessInstanceId()).isNull();
+            assertThat(event.getTaskId()).isEqualTo(newTask.getId());
+            assertThat(event.getVariableName()).isEqualTo("testVariable");
+            assertThat(event.getVariableValue()).isEqualTo(123);
 
             event = (FlowableVariableEvent) listener.getEventsReceived().get(1);
-            assertEquals(FlowableEngineEventType.VARIABLE_UPDATED, event.getType());
-            assertNull(event.getProcessDefinitionId());
-            assertNull(event.getExecutionId());
-            assertNull(event.getProcessInstanceId());
-            assertEquals(newTask.getId(), event.getTaskId());
-            assertEquals("testVariable", event.getVariableName());
-            assertEquals(456, event.getVariableValue());
+            assertThat(event.getType()).isEqualTo(FlowableEngineEventType.VARIABLE_UPDATED);
+            assertThat(event.getProcessDefinitionId()).isNull();
+            assertThat(event.getExecutionId()).isNull();
+            assertThat(event.getProcessInstanceId()).isNull();
+            assertThat(event.getTaskId()).isEqualTo(newTask.getId());
+            assertThat(event.getVariableName()).isEqualTo("testVariable");
+            assertThat(event.getVariableValue()).isEqualTo(456);
 
             event = (FlowableVariableEvent) listener.getEventsReceived().get(2);
-            assertEquals(FlowableEngineEventType.VARIABLE_DELETED, event.getType());
-            assertNull(event.getProcessDefinitionId());
-            assertNull(event.getExecutionId());
-            assertNull(event.getProcessInstanceId());
-            assertEquals(newTask.getId(), event.getTaskId());
-            assertEquals("testVariable", event.getVariableName());
+            assertThat(event.getType()).isEqualTo(FlowableEngineEventType.VARIABLE_DELETED);
+            assertThat(event.getProcessDefinitionId()).isNull();
+            assertThat(event.getExecutionId()).isNull();
+            assertThat(event.getProcessInstanceId()).isNull();
+            assertThat(event.getTaskId()).isEqualTo(newTask.getId());
+            assertThat(event.getVariableName()).isEqualTo("testVariable");
             // deleted variable value is always null
-            assertNull(event.getVariableValue());
+            assertThat(event.getVariableValue()).isNull();
         } finally {
 
             // Cleanup task and history to ensure a clean DB after test success/failure
@@ -437,27 +439,27 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
         vars.put("var2", "The value");
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("processVariableEvent", vars);
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         // Check create event
-        assertEquals(2, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(2);
         FlowableVariableEvent event = (FlowableVariableEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.VARIABLE_CREATED, event.getType());
-        assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
-        assertEquals(processInstance.getId(), event.getExecutionId());
-        assertEquals(processInstance.getId(), event.getProcessInstanceId());
-        assertNull(event.getTaskId());
-        assertEquals("var2", event.getVariableName());
-        assertEquals("var2 value", event.getVariableValue());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.VARIABLE_CREATED);
+        assertThat(event.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(event.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(event.getTaskId()).isNull();
+        assertThat(event.getVariableName()).isEqualTo("var2");
+        assertThat(event.getVariableValue()).isEqualTo("var2 value");
 
         event = (FlowableVariableEvent) listener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.VARIABLE_UPDATED, event.getType());
-        assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
-        assertEquals(processInstance.getId(), event.getExecutionId());
-        assertEquals(processInstance.getId(), event.getProcessInstanceId());
-        assertNull(event.getTaskId());
-        assertEquals("var2", event.getVariableName());
-        assertEquals("The value", event.getVariableValue());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.VARIABLE_UPDATED);
+        assertThat(event.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(event.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(event.getTaskId()).isNull();
+        assertThat(event.getVariableName()).isEqualTo("var2");
+        assertThat(event.getVariableValue()).isEqualTo("The value");
 
         listener.clearEventsReceived();
     }
@@ -466,47 +468,48 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
      * Test variables event for modeled data objects on callActivity.
      */
     @Test
-    @Deployment(resources = { "org/flowable/engine/test/api/runtime/callActivity.bpmn20.xml", "org/flowable/engine/test/api/runtime/calledActivity.bpmn20.xml" })
+    @Deployment(resources = { "org/flowable/engine/test/api/runtime/callActivity.bpmn20.xml",
+            "org/flowable/engine/test/api/runtime/calledActivity.bpmn20.xml" })
     public void testProcessInstanceVariableEventsForModeledDataObjectOnCallActivityStart() throws Exception {
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("callActivity");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         // Check create event
-        assertEquals(3, listener.getEventsReceived().size());
+        assertThat(listener.getEventsReceived()).hasSize(3);
 
         FlowableVariableEvent event = (FlowableVariableEvent) listener.getEventsReceived().get(0);
-        assertEquals(FlowableEngineEventType.VARIABLE_CREATED, event.getType());
-        assertEquals(processInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
-        assertEquals(processInstance.getId(), event.getExecutionId());
-        assertEquals(processInstance.getId(), event.getProcessInstanceId());
-        assertNull(event.getTaskId());
-        assertEquals("var1", event.getVariableName());
-        assertEquals("var1 value", event.getVariableValue());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.VARIABLE_CREATED);
+        assertThat(event.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+        assertThat(event.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(event.getTaskId()).isNull();
+        assertThat(event.getVariableName()).isEqualTo("var1");
+        assertThat(event.getVariableValue()).isEqualTo("var1 value");
 
         ExecutionEntity subprocessInstance = (ExecutionEntity) runtimeService.createExecutionQuery()
                 .rootProcessInstanceId(processInstance.getId())
                 .onlySubProcessExecutions()
                 .singleResult();
-        assertNotNull(subprocessInstance);
+        assertThat(subprocessInstance).isNotNull();
 
         event = (FlowableVariableEvent) listener.getEventsReceived().get(1);
-        assertEquals(FlowableEngineEventType.VARIABLE_CREATED, event.getType());
-        assertEquals(subprocessInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
-        assertEquals(subprocessInstance.getId(), event.getExecutionId());
-        assertEquals(subprocessInstance.getId(), event.getProcessInstanceId());
-        assertNull(event.getTaskId());
-        assertEquals("var3", event.getVariableName());
-        assertEquals("var3 value", event.getVariableValue());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.VARIABLE_CREATED);
+        assertThat(event.getProcessDefinitionId()).isEqualTo(subprocessInstance.getProcessDefinitionId());
+        assertThat(event.getExecutionId()).isEqualTo(subprocessInstance.getId());
+        assertThat(event.getProcessInstanceId()).isEqualTo(subprocessInstance.getId());
+        assertThat(event.getTaskId()).isNull();
+        assertThat(event.getVariableName()).isEqualTo("var3");
+        assertThat(event.getVariableValue()).isEqualTo("var3 value");
 
         event = (FlowableVariableEvent) listener.getEventsReceived().get(2);
-        assertEquals(FlowableEngineEventType.VARIABLE_UPDATED, event.getType());
-        assertEquals(subprocessInstance.getProcessDefinitionId(), event.getProcessDefinitionId());
-        assertEquals(subprocessInstance.getId(), event.getExecutionId());
-        assertEquals(subprocessInstance.getId(), event.getProcessInstanceId());
-        assertNull(event.getTaskId());
-        assertEquals("var3", event.getVariableName());
-        assertEquals("var1 value", event.getVariableValue());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.VARIABLE_UPDATED);
+        assertThat(event.getProcessDefinitionId()).isEqualTo(subprocessInstance.getProcessDefinitionId());
+        assertThat(event.getExecutionId()).isEqualTo(subprocessInstance.getId());
+        assertThat(event.getProcessInstanceId()).isEqualTo(subprocessInstance.getId());
+        assertThat(event.getTaskId()).isNull();
+        assertThat(event.getVariableName()).isEqualTo("var3");
+        assertThat(event.getVariableValue()).isEqualTo("var1 value");
     }
 
     @BeforeEach


### PR DESCRIPTION
This finishes the `org.flowable.engine.test.api.event` package.

Continuing quest to use only a single style in each file and in the module.

