### PR TITLE
Use assertj fluent style in flowable-engine.  Part 4

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/DatabaseEventLoggerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/DatabaseEventLoggerTest.java
@@ -145,8 +145,8 @@ public class DatabaseEventLoggerTest extends PluggableFlowableTestCase {
                 assertThat(variableMap).hasSize(1);
                 assertThat(variableMap.get("testVar")).isEqualTo("helloWorld");
 
-                assertThat(data.containsKey(Fields.NAME)).isFalse();
-                assertThat(data.containsKey(Fields.BUSINESS_KEY)).isFalse();
+                assertThat(data).doesNotContainKey(Fields.NAME);
+                assertThat(data).doesNotContainKey(Fields.BUSINESS_KEY);
             }
 
             // Activity started

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/TransactionEventListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/TransactionEventListenerTest.java
@@ -99,14 +99,15 @@ public class TransactionEventListenerTest extends PluggableFlowableTestCase {
 
         // Regular execution, no exception
         runtimeService.startProcessInstanceByKey("testProcessExecutionWithRollback", CollectionUtil.singletonMap("throwException", false));
-        assertThat(TestTransactionEventListener.eventsReceived.size() > 0).isTrue();
+        assertThat(TestTransactionEventListener.eventsReceived.size()).isPositive();
         assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(1);
 
         TestTransactionEventListener.eventsReceived.clear();
 
         // When process execution rolls back, the events should not be thrown, as they are only thrown on commit.
         assertThatThrownBy(
-                () -> runtimeService.startProcessInstanceByKey("testProcessExecutionWithRollback", CollectionUtil.singletonMap("throwException", true)));
+                () -> runtimeService.startProcessInstanceByKey("testProcessExecutionWithRollback", CollectionUtil.singletonMap("throwException", true)))
+                .isInstanceOf(RuntimeException.class);
         assertThat(TestTransactionEventListener.eventsReceived).isEmpty();
         assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(1);
     }


### PR DESCRIPTION
Small updates to the `org.flowable.engine.test.api.event` package; this should be the final pass for the package.

Continuing quest to use only a single style in each file and in the module.
