### PR TITLE
Use assertj fluent style in flowable-engine.

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricProcessInstanceAndVariablesQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricProcessInstanceAndVariablesQueryTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -11,6 +11,8 @@
  * limitations under the License.
  */
 package org.flowable.engine.test.api.history;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -73,116 +75,124 @@ public class HistoricProcessInstanceAndVariablesQueryTest extends PluggableFlowa
     @AfterEach
     protected void tearDown() throws Exception {
         deleteDeployments();
-        
+
     }
 
     @Test
     public void testQuery() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
-            HistoricProcessInstance processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().variableValueEquals("anothertest", 123).singleResult();
+            HistoricProcessInstance processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
+                    .variableValueEquals("anothertest", 123).singleResult();
             Map<String, Object> variableMap = processInstance.getProcessVariables();
-            assertEquals(1, variableMap.size());
-            assertEquals(123, variableMap.get("anothertest"));
+            assertThat(variableMap).hasSize(1);
+            assertThat(variableMap.get("anothertest")).isEqualTo(123);
 
             List<HistoricProcessInstance> instanceList = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().list();
-            assertEquals(6, instanceList.size());
+            assertThat(instanceList).hasSize(6);
 
             instanceList = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().processDefinitionKey(PROCESS_DEFINITION_KEY).list();
-            assertEquals(4, instanceList.size());
+            assertThat(instanceList).hasSize(4);
             processInstance = instanceList.get(0);
             variableMap = processInstance.getProcessVariables();
-            assertEquals(2, variableMap.size());
-            assertEquals("test", variableMap.get("test"));
-            assertEquals("test2", variableMap.get("test2"));
-            assertEquals(PROCESS_DEFINITION_KEY, instanceList.get(0).getProcessDefinitionKey());
+            assertThat(variableMap).hasSize(2);
+            assertThat(variableMap.get("test")).isEqualTo("test");
+            assertThat(variableMap.get("test2")).isEqualTo("test2");
+            assertThat(instanceList.get(0).getProcessDefinitionKey()).isEqualTo(PROCESS_DEFINITION_KEY);
 
-            processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().processDefinitionKey(PROCESS_DEFINITION_KEY_2).singleResult();
+            processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().processDefinitionKey(PROCESS_DEFINITION_KEY_2)
+                    .singleResult();
             variableMap = processInstance.getProcessVariables();
-            assertEquals(1, variableMap.size());
-            assertEquals(123, variableMap.get("anothertest"));
+            assertThat(variableMap).hasSize(1);
+            assertThat(variableMap.get("anothertest")).isEqualTo(123);
 
             processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().finished().singleResult();
             variableMap = processInstance.getProcessVariables();
-            assertEquals(2, variableMap.size());
-            assertEquals("test", variableMap.get("test"));
-            assertEquals("test2", variableMap.get("test2"));
+            assertThat(variableMap).hasSize(2);
+            assertThat(variableMap.get("test")).isEqualTo("test");
+            assertThat(variableMap.get("test2")).isEqualTo("test2");
 
             instanceList = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().listPage(0, 50);
-            assertEquals(6, instanceList.size());
-            assertEquals(6, historyService.createHistoricProcessInstanceQuery().includeProcessVariables().count());
+            assertThat(instanceList).hasSize(6);
+            assertThat(historyService.createHistoricProcessInstanceQuery().includeProcessVariables().count()).isEqualTo(6);
 
             instanceList = historyService.createHistoricProcessInstanceQuery()
                     .variableValueEquals("test", "test")
                     .includeProcessVariables()
                     .listPage(0, 50);
-            assertEquals(4, instanceList.size());
-            assertEquals(4, historyService.createHistoricProcessInstanceQuery().variableValueEquals("test", "test").includeProcessVariables().count());
+            assertThat(instanceList).hasSize(4);
+            assertThat(historyService.createHistoricProcessInstanceQuery().variableValueEquals("test", "test").includeProcessVariables().count()).isEqualTo(4);
 
             instanceList = historyService.createHistoricProcessInstanceQuery()
                     .variableValueLike("test", "te%")
                     .includeProcessVariables()
                     .list();
-            assertEquals(4, instanceList.size());
-            assertEquals(4, historyService.createHistoricProcessInstanceQuery().variableValueLike("test", "te%").includeProcessVariables().count());
+            assertThat(instanceList).hasSize(4);
+            assertThat(historyService.createHistoricProcessInstanceQuery().variableValueLike("test", "te%").includeProcessVariables().count()).isEqualTo(4);
 
             instanceList = historyService.createHistoricProcessInstanceQuery()
                     .variableValueLike("test2", "te%2")
                     .includeProcessVariables()
                     .list();
-            assertEquals(4, instanceList.size());
-            assertEquals(4, historyService.createHistoricProcessInstanceQuery().variableValueLike("test2", "te%2").includeProcessVariables().count());
+            assertThat(instanceList).hasSize(4);
+            assertThat(historyService.createHistoricProcessInstanceQuery().variableValueLike("test2", "te%2").includeProcessVariables().count()).isEqualTo(4);
 
             instanceList = historyService.createHistoricProcessInstanceQuery()
                     .variableValueLikeIgnoreCase("test", "te%")
                     .includeProcessVariables()
                     .list();
-            assertEquals(4, instanceList.size());
-            assertEquals(4, historyService.createHistoricProcessInstanceQuery().variableValueLikeIgnoreCase("test", "te%").includeProcessVariables().count());
+            assertThat(instanceList).hasSize(4);
+            assertThat(historyService.createHistoricProcessInstanceQuery().variableValueLikeIgnoreCase("test", "te%").includeProcessVariables().count())
+                    .isEqualTo(4);
 
             instanceList = historyService.createHistoricProcessInstanceQuery()
                     .variableValueLikeIgnoreCase("test", "t3%")
                     .includeProcessVariables()
                     .list();
-            assertEquals(0, instanceList.size());
-            assertEquals(0, historyService.createHistoricProcessInstanceQuery().variableValueLikeIgnoreCase("test", "t3%").includeProcessVariables().count());
+            assertThat(instanceList).isEmpty();
+            assertThat(historyService.createHistoricProcessInstanceQuery().variableValueLikeIgnoreCase("test", "t3%").includeProcessVariables().count())
+                    .isEqualTo(0);
 
             instanceList = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().listPage(0, 50);
-            assertEquals(6, instanceList.size());
-            assertEquals(6, historyService.createHistoricProcessInstanceQuery().includeProcessVariables().count());
+            assertThat(instanceList).hasSize(6);
+            assertThat(historyService.createHistoricProcessInstanceQuery().includeProcessVariables().count()).isEqualTo(6);
 
             instanceList = historyService.createHistoricProcessInstanceQuery()
                     .variableValueEquals("test", "test")
                     .includeProcessVariables()
                     .listPage(0, 1);
-            assertEquals(1, instanceList.size());
+            assertThat(instanceList).hasSize(1);
             processInstance = instanceList.get(0);
             variableMap = processInstance.getProcessVariables();
-            assertEquals(2, variableMap.size());
-            assertEquals("test", variableMap.get("test"));
-            assertEquals("test2", variableMap.get("test2"));
-            assertEquals(4, historyService.createHistoricProcessInstanceQuery().variableValueEquals("test", "test").includeProcessVariables().count());
+            assertThat(variableMap).hasSize(2);
+            assertThat(variableMap.get("test")).isEqualTo("test");
+            assertThat(variableMap.get("test2")).isEqualTo("test2");
+            assertThat(historyService.createHistoricProcessInstanceQuery().variableValueEquals("test", "test").includeProcessVariables().count()).isEqualTo(4);
 
-            instanceList = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().processDefinitionKey(PROCESS_DEFINITION_KEY).listPage(1, 2);
-            assertEquals(2, instanceList.size());
+            instanceList = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().processDefinitionKey(PROCESS_DEFINITION_KEY)
+                    .listPage(1, 2);
+            assertThat(instanceList).hasSize(2);
             processInstance = instanceList.get(0);
             variableMap = processInstance.getProcessVariables();
-            assertEquals(2, variableMap.size());
-            assertEquals("test", variableMap.get("test"));
-            assertEquals("test2", variableMap.get("test2"));
+            assertThat(variableMap).hasSize(2);
+            assertThat(variableMap.get("test")).isEqualTo("test");
+            assertThat(variableMap.get("test2")).isEqualTo("test2");
 
-            instanceList = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().processDefinitionKey(PROCESS_DEFINITION_KEY).listPage(3, 4);
-            assertEquals(1, instanceList.size());
+            instanceList = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().processDefinitionKey(PROCESS_DEFINITION_KEY)
+                    .listPage(3, 4);
+            assertThat(instanceList).hasSize(1);
             processInstance = instanceList.get(0);
             variableMap = processInstance.getProcessVariables();
-            assertEquals(2, variableMap.size());
-            assertEquals("test", variableMap.get("test"));
-            assertEquals("test2", variableMap.get("test2"));
+            assertThat(variableMap).hasSize(2);
+            assertThat(variableMap.get("test")).isEqualTo("test");
+            assertThat(variableMap.get("test2")).isEqualTo("test2");
 
-            instanceList = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().processDefinitionKey(PROCESS_DEFINITION_KEY).listPage(4, 2);
-            assertEquals(0, instanceList.size());
+            instanceList = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().processDefinitionKey(PROCESS_DEFINITION_KEY)
+                    .listPage(4, 2);
+            assertThat(instanceList).isEmpty();
 
-            instanceList = historyService.createHistoricProcessInstanceQuery().variableValueEquals("test", "test").includeProcessVariables().orderByProcessInstanceId().asc().listPage(0, 50);
-            assertEquals(4, instanceList.size());
+            instanceList = historyService.createHistoricProcessInstanceQuery().variableValueEquals("test", "test").includeProcessVariables()
+                    .orderByProcessInstanceId().asc().listPage(0, 50);
+            assertThat(instanceList).hasSize(4);
         }
     }
 
@@ -194,78 +204,79 @@ public class HistoricProcessInstanceAndVariablesQueryTest extends PluggableFlowa
             HistoricProcessInstance processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
                     .variableValueEquals("anothertest", 123).deploymentId(deploymentId).singleResult();
             Map<String, Object> variableMap = processInstance.getProcessVariables();
-            assertEquals(1, variableMap.size());
-            assertEquals(123, variableMap.get("anothertest"));
-            assertEquals(deploymentId, processInstance.getDeploymentId());
+            assertThat(variableMap).hasSize(1);
+            assertThat(variableMap.get("anothertest")).isEqualTo(123);
+            assertThat(processInstance.getDeploymentId()).isEqualTo(deploymentId);
 
             processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
                     .variableValueEquals("anothertest", "invalid").deploymentId(deploymentId).singleResult();
-            assertNull(processInstance);
+            assertThat(processInstance).isNull();
 
             // ProcessDefinitionName
             processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
                     .variableValueEquals("anothertest", 123).processDefinitionName(PROCESS_DEFINITION_NAME_2).singleResult();
             variableMap = processInstance.getProcessVariables();
-            assertEquals(1, variableMap.size());
-            assertEquals(123, variableMap.get("anothertest"));
-            assertEquals(PROCESS_DEFINITION_NAME_2, processInstance.getProcessDefinitionName());
+            assertThat(variableMap).hasSize(1);
+            assertThat(variableMap.get("anothertest")).isEqualTo(123);
+            assertThat(processInstance.getProcessDefinitionName()).isEqualTo(PROCESS_DEFINITION_NAME_2);
 
             processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
                     .variableValueEquals("test", "test").processDefinitionName(PROCESS_DEFINITION_NAME_2).singleResult();
-            assertNull(processInstance);
+            assertThat(processInstance).isNull();
 
             // ProcessDefinitionCategory
             processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
                     .variableValueEquals("anothertest", 123).processDefinitionCategory(PROCESS_DEFINITION_CATEGORY_2).singleResult();
             variableMap = processInstance.getProcessVariables();
-            assertEquals(1, variableMap.size());
-            assertEquals(123, variableMap.get("anothertest"));
+            assertThat(variableMap).hasSize(1);
+            assertThat(variableMap.get("anothertest")).isEqualTo(123);
 
             processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
                     .variableValueEquals("test", "test").processDefinitionCategory(PROCESS_DEFINITION_CATEGORY_2).singleResult();
-            assertNull(processInstance);
+            assertThat(processInstance).isNull();
         }
     }
-    
+
     @Test
     public void testQueryByVariableExist() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // DeploymentId
             String deploymentId = repositoryService.createDeploymentQuery().list().get(0).getId();
             HistoricProcessInstance processInstance = historyService.createHistoricProcessInstanceQuery().variableExists("anothertest")
-                            .deploymentId(deploymentId).singleResult();
-            assertNotNull(processInstance);
+                    .deploymentId(deploymentId).singleResult();
+            assertThat(processInstance).isNotNull();
 
             List<HistoricProcessInstance> processInstanceList = historyService.createHistoricProcessInstanceQuery()
-                            .variableNotExists("anothertest").deploymentId(deploymentId).list();
-            assertEquals(5, processInstanceList.size());
-            
+                    .variableNotExists("anothertest").deploymentId(deploymentId).list();
+            assertThat(processInstanceList).hasSize(5);
+
             processInstance = historyService.createHistoricProcessInstanceQuery().or().variableExists("anothertest")
-                            .processInstanceId("notexisting").endOr().deploymentId(deploymentId).singleResult();
-            assertNotNull(processInstance);
-            
+                    .processInstanceId("notexisting").endOr().deploymentId(deploymentId).singleResult();
+            assertThat(processInstance).isNotNull();
+
             processInstanceList = historyService.createHistoricProcessInstanceQuery().or().variableNotExists("anothertest")
-                            .processInstanceId("nonexisting").endOr().deploymentId(deploymentId).list();
-            assertEquals(5, processInstanceList.size());
-            
+                    .processInstanceId("nonexisting").endOr().deploymentId(deploymentId).list();
+            assertThat(processInstanceList).hasSize(5);
+
             processInstanceList = historyService.createHistoricProcessInstanceQuery().or().variableNotExists("anothertest")
-                            .variableValueEquals("test", "test").endOr().deploymentId(deploymentId).list();
-            assertEquals(5, processInstanceList.size());
-            
+                    .variableValueEquals("test", "test").endOr().deploymentId(deploymentId).list();
+            assertThat(processInstanceList).hasSize(5);
+
             processInstanceList = historyService.createHistoricProcessInstanceQuery().or().variableNotExists("anothertest").endOr().or()
-                            .variableValueEquals("test", "test").endOr().deploymentId(deploymentId).list();
-            assertEquals(4, processInstanceList.size());
+                    .variableValueEquals("test", "test").endOr().deploymentId(deploymentId).list();
+            assertThat(processInstanceList).hasSize(4);
         }
     }
 
     @Test
     public void testOrQuery() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
-            HistoricProcessInstance processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().or().variableValueEquals("anothertest", 123)
+            HistoricProcessInstance processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().or()
+                    .variableValueEquals("anothertest", 123)
                     .processDefinitionId("undefined").endOr().singleResult();
             Map<String, Object> variableMap = processInstance.getProcessVariables();
-            assertEquals(1, variableMap.size());
-            assertEquals(123, variableMap.get("anothertest"));
+            assertThat(variableMap).hasSize(1);
+            assertThat(variableMap.get("anothertest")).isEqualTo(123);
 
             processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
                     .or()
@@ -278,8 +289,8 @@ public class HistoricProcessInstanceAndVariablesQueryTest extends PluggableFlowa
                     .endOr()
                     .singleResult();
             variableMap = processInstance.getProcessVariables();
-            assertEquals(1, variableMap.size());
-            assertEquals(123, variableMap.get("anothertest"));
+            assertThat(variableMap).hasSize(1);
+            assertThat(variableMap.get("anothertest")).isEqualTo(123);
 
             processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
                     .or()
@@ -291,7 +302,7 @@ public class HistoricProcessInstanceAndVariablesQueryTest extends PluggableFlowa
                     .processDefinitionId("undefined")
                     .endOr()
                     .singleResult();
-            assertNull(processInstance);
+            assertThat(processInstance).isNull();
 
             processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
                     .or()
@@ -299,68 +310,76 @@ public class HistoricProcessInstanceAndVariablesQueryTest extends PluggableFlowa
                     .processDefinitionId("undefined")
                     .endOr()
                     .singleResult();
-            assertNotNull(processInstance);
+            assertThat(processInstance).isNotNull();
             variableMap = processInstance.getProcessVariables();
-            assertEquals(1, variableMap.size());
-            assertEquals("MyTest", variableMap.get("casetest"));
+            assertThat(variableMap).hasSize(1);
+            assertThat(variableMap.get("casetest")).isEqualTo("MyTest");
 
             List<HistoricProcessInstance> instanceList = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().or()
                     .processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionId("undefined").endOr().list();
-            assertEquals(4, instanceList.size());
+            assertThat(instanceList).hasSize(4);
             processInstance = instanceList.get(0);
             variableMap = processInstance.getProcessVariables();
-            assertEquals(2, variableMap.size());
-            assertEquals("test", variableMap.get("test"));
-            assertEquals("test2", variableMap.get("test2"));
+            assertThat(variableMap).hasSize(2);
+            assertThat(variableMap.get("test")).isEqualTo("test");
+            assertThat(variableMap.get("test2")).isEqualTo("test2");
 
-            processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().or().processDefinitionKey(PROCESS_DEFINITION_KEY_2).processDefinitionId("undefined").endOr()
+            processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().or().processDefinitionKey(PROCESS_DEFINITION_KEY_2)
+                    .processDefinitionId("undefined").endOr()
                     .singleResult();
             variableMap = processInstance.getProcessVariables();
-            assertEquals(1, variableMap.size());
-            assertEquals(123, variableMap.get("anothertest"));
+            assertThat(variableMap).hasSize(1);
+            assertThat(variableMap.get("anothertest")).isEqualTo(123);
 
-            processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().or().finished().processDefinitionId("undefined").endOr().singleResult();
+            processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().or().finished().processDefinitionId("undefined")
+                    .endOr().singleResult();
             variableMap = processInstance.getProcessVariables();
-            assertEquals(2, variableMap.size());
-            assertEquals("test", variableMap.get("test"));
-            assertEquals("test2", variableMap.get("test2"));
+            assertThat(variableMap).hasSize(2);
+            assertThat(variableMap.get("test")).isEqualTo("test");
+            assertThat(variableMap.get("test2")).isEqualTo("test2");
 
-            instanceList = historyService.createHistoricProcessInstanceQuery().or().variableValueEquals("test", "test").processDefinitionId("undefined").endOr().includeProcessVariables().listPage(0, 50);
-            assertEquals(4, instanceList.size());
+            instanceList = historyService.createHistoricProcessInstanceQuery().or().variableValueEquals("test", "test").processDefinitionId("undefined").endOr()
+                    .includeProcessVariables().listPage(0, 50);
+            assertThat(instanceList).hasSize(4);
 
-            instanceList = historyService.createHistoricProcessInstanceQuery().or().variableValueEquals("test", "test").processDefinitionId("undefined").endOr().includeProcessVariables().listPage(0, 1);
-            assertEquals(1, instanceList.size());
+            instanceList = historyService.createHistoricProcessInstanceQuery().or().variableValueEquals("test", "test").processDefinitionId("undefined").endOr()
+                    .includeProcessVariables().listPage(0, 1);
+            assertThat(instanceList).hasSize(1);
             processInstance = instanceList.get(0);
             variableMap = processInstance.getProcessVariables();
-            assertEquals(2, variableMap.size());
-            assertEquals("test", variableMap.get("test"));
-            assertEquals("test2", variableMap.get("test2"));
+            assertThat(variableMap).hasSize(2);
+            assertThat(variableMap.get("test")).isEqualTo("test");
+            assertThat(variableMap.get("test2")).isEqualTo("test2");
 
-            instanceList = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().or().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionId("undefined").endOr()
+            instanceList = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().or().processDefinitionKey(PROCESS_DEFINITION_KEY)
+                    .processDefinitionId("undefined").endOr()
                     .listPage(1, 2);
-            assertEquals(2, instanceList.size());
+            assertThat(instanceList).hasSize(2);
             processInstance = instanceList.get(0);
             variableMap = processInstance.getProcessVariables();
-            assertEquals(2, variableMap.size());
-            assertEquals("test", variableMap.get("test"));
-            assertEquals("test2", variableMap.get("test2"));
+            assertThat(variableMap).hasSize(2);
+            assertThat(variableMap.get("test")).isEqualTo("test");
+            assertThat(variableMap.get("test2")).isEqualTo("test2");
 
-            instanceList = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().or().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionId("undefined").endOr()
+            instanceList = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().or().processDefinitionKey(PROCESS_DEFINITION_KEY)
+                    .processDefinitionId("undefined").endOr()
                     .listPage(3, 4);
-            assertEquals(1, instanceList.size());
+            assertThat(instanceList).hasSize(1);
             processInstance = instanceList.get(0);
             variableMap = processInstance.getProcessVariables();
-            assertEquals(2, variableMap.size());
-            assertEquals("test", variableMap.get("test"));
-            assertEquals("test2", variableMap.get("test2"));
+            assertThat(variableMap).hasSize(2);
+            assertThat(variableMap.get("test")).isEqualTo("test");
+            assertThat(variableMap.get("test2")).isEqualTo("test2");
 
-            instanceList = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().or().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionId("undefined").endOr()
+            instanceList = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().or().processDefinitionKey(PROCESS_DEFINITION_KEY)
+                    .processDefinitionId("undefined").endOr()
                     .listPage(4, 2);
-            assertEquals(0, instanceList.size());
+            assertThat(instanceList).isEmpty();
 
-            instanceList = historyService.createHistoricProcessInstanceQuery().or().variableValueEquals("test", "test").processDefinitionId("undefined").endOr().includeProcessVariables()
+            instanceList = historyService.createHistoricProcessInstanceQuery().or().variableValueEquals("test", "test").processDefinitionId("undefined").endOr()
+                    .includeProcessVariables()
                     .orderByProcessInstanceId().asc().listPage(0, 50);
-            assertEquals(4, instanceList.size());
+            assertThat(instanceList).hasSize(4);
 
             instanceList = historyService.createHistoricProcessInstanceQuery()
                     .or()
@@ -375,7 +394,7 @@ public class HistoricProcessInstanceAndVariablesQueryTest extends PluggableFlowa
                     .orderByProcessInstanceId()
                     .asc()
                     .listPage(0, 50);
-            assertEquals(4, instanceList.size());
+            assertThat(instanceList).hasSize(4);
         }
     }
 
@@ -388,9 +407,10 @@ public class HistoricProcessInstanceAndVariablesQueryTest extends PluggableFlowa
             }
             query0 = query0.processDefinitionId("undefined").endOr();
 
-            assertNull(query0.singleResult());
+            assertThat(query0.singleResult()).isNull();
 
-            HistoricProcessInstanceQuery query1 = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().or().variableValueEquals("anothertest", 123);
+            HistoricProcessInstanceQuery query1 = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().or()
+                    .variableValueEquals("anothertest", 123);
             for (int i = 0; i < 20; i++) {
                 query1 = query1.variableValueEquals("anothertest", i);
             }
@@ -398,8 +418,8 @@ public class HistoricProcessInstanceAndVariablesQueryTest extends PluggableFlowa
 
             HistoricProcessInstance processInstance = query1.singleResult();
             Map<String, Object> variableMap = processInstance.getProcessVariables();
-            assertEquals(1, variableMap.size());
-            assertEquals(123, variableMap.get("anothertest"));
+            assertThat(variableMap).hasSize(1);
+            assertThat(variableMap.get("anothertest")).isEqualTo(123);
 
             HistoricProcessInstanceQuery query2 = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
                     .or();
@@ -412,7 +432,7 @@ public class HistoricProcessInstanceAndVariablesQueryTest extends PluggableFlowa
                     .processDefinitionKey(PROCESS_DEFINITION_KEY_2)
                     .processDefinitionId("undefined")
                     .endOr();
-            assertNull(query2.singleResult());
+            assertThat(query2.singleResult()).isNull();
 
             HistoricProcessInstanceQuery query3 = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
                     .or().variableValueEquals("anothertest", 123);
@@ -426,8 +446,8 @@ public class HistoricProcessInstanceAndVariablesQueryTest extends PluggableFlowa
                     .processDefinitionId("undefined")
                     .endOr();
             variableMap = query3.singleResult().getProcessVariables();
-            assertEquals(1, variableMap.size());
-            assertEquals(123, variableMap.get("anothertest"));
+            assertThat(variableMap).hasSize(1);
+            assertThat(variableMap.get("anothertest")).isEqualTo(123);
         }
     }
 
@@ -438,41 +458,41 @@ public class HistoricProcessInstanceAndVariablesQueryTest extends PluggableFlowa
             String deploymentId = repositoryService.createDeploymentQuery().list().get(0).getId();
             HistoricProcessInstanceQuery historicprocessInstanceQuery = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
                     .or().variableValueEquals("anothertest", "invalid").deploymentId(deploymentId).endOr();
-            assertEquals(6, historicprocessInstanceQuery.list().size());
-            assertEquals(6, historicprocessInstanceQuery.count());
+            assertThat(historicprocessInstanceQuery.list()).hasSize(6);
+            assertThat(historicprocessInstanceQuery.count()).isEqualTo(6);
             Map<String, Object> variableMap = historicprocessInstanceQuery.list().get(4).getProcessVariables();
-            assertEquals(1, variableMap.size());
-            assertEquals(123, variableMap.get("anothertest"));
+            assertThat(variableMap).hasSize(1);
+            assertThat(variableMap.get("anothertest")).isEqualTo(123);
             for (HistoricProcessInstance processInstance : historicprocessInstanceQuery.list()) {
-                assertEquals(deploymentId, processInstance.getDeploymentId());
+                assertThat(processInstance.getDeploymentId()).isEqualTo(deploymentId);
             }
 
             HistoricProcessInstance processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
                     .or().variableValueEquals("anothertest", "invalid").deploymentId("invalid").endOr().singleResult();
-            assertNull(processInstance);
+            assertThat(processInstance).isNull();
 
             // ProcessDefinitionName
             processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
                     .or().variableValueEquals("anothertest", "invalid").processDefinitionName(PROCESS_DEFINITION_NAME_2).endOr().singleResult();
             variableMap = processInstance.getProcessVariables();
-            assertEquals(1, variableMap.size());
-            assertEquals(123, variableMap.get("anothertest"));
-            assertEquals(PROCESS_DEFINITION_NAME_2, processInstance.getProcessDefinitionName());
+            assertThat(variableMap).hasSize(1);
+            assertThat(variableMap.get("anothertest")).isEqualTo(123);
+            assertThat(processInstance.getProcessDefinitionName()).isEqualTo(PROCESS_DEFINITION_NAME_2);
 
             processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
                     .or().variableValueEquals("anothertest", "invalid").processDefinitionName("invalid").endOr().singleResult();
-            assertNull(processInstance);
+            assertThat(processInstance).isNull();
 
             // ProcessDefinitionCategory
             processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
                     .or().variableValueEquals("anothertest", "invalid").processDefinitionCategory(PROCESS_DEFINITION_CATEGORY_2).endOr().singleResult();
             variableMap = processInstance.getProcessVariables();
-            assertEquals(1, variableMap.size());
-            assertEquals(123, variableMap.get("anothertest"));
+            assertThat(variableMap).hasSize(1);
+            assertThat(variableMap.get("anothertest")).isEqualTo(123);
 
             processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
                     .or().variableValueEquals("anothertest", "invalid").processDefinitionCategory("invalid").endOr().singleResult();
-            assertNull(processInstance);
+            assertThat(processInstance).isNull();
         }
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricProcessInstanceQueryAndWithExceptionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricProcessInstanceQueryAndWithExceptionTest.java
@@ -12,8 +12,12 @@
  */
 package org.flowable.engine.test.api.history;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.util.List;
 
+import org.flowable.common.engine.api.FlowableException;
 import org.flowable.common.engine.impl.history.HistoryLevel;
 import org.flowable.engine.history.HistoricProcessInstanceQuery;
 import org.flowable.engine.impl.test.HistoryTestHelper;
@@ -49,38 +53,40 @@ public class HistoricProcessInstanceQueryAndWithExceptionTest extends PluggableF
     public void testQueryWithException() throws InterruptedException {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             ProcessInstance processNoException = runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY_NO_EXCEPTION);
-            
+
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             HistoricProcessInstanceQuery queryNoException = historyService.createHistoricProcessInstanceQuery();
-            assertEquals(1, queryNoException.count());
-            assertEquals(1, queryNoException.list().size());
-            assertEquals(processNoException.getId(), queryNoException.list().get(0).getId());
+            assertThat(queryNoException.count()).isEqualTo(1);
+            assertThat(queryNoException.list()).hasSize(1);
+            assertThat(queryNoException.list().get(0).getId()).isEqualTo(processNoException.getId());
 
             HistoricProcessInstanceQuery queryWithException = historyService.createHistoricProcessInstanceQuery();
-            assertEquals(0, queryWithException.withJobException().count());
-            assertEquals(0, queryWithException.withJobException().list().size());
+            assertThat(queryWithException.withJobException().count()).isEqualTo(0);
+            assertThat(queryWithException.withJobException().list()).isEmpty();
 
             ProcessInstance processWithException1 = startProcessInstanceWithFailingJob(PROCESS_DEFINITION_KEY_WITH_EXCEPTION_1);
             TimerJobQuery jobQuery1 = managementService.createTimerJobQuery().processInstanceId(processWithException1.getId());
-            assertEquals(1, jobQuery1.withException().count());
-            assertEquals(1, jobQuery1.withException().list().size());
-            
+            assertThat(jobQuery1.withException().count()).isEqualTo(1);
+            assertThat(jobQuery1.withException().list()).hasSize(1);
+
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
-            assertEquals(1, queryWithException.withJobException().count());
-            assertEquals(1, queryWithException.withJobException().list().size());
-            assertEquals(processWithException1.getId(), queryWithException.withJobException().list().get(0).getId());
+            assertThat(queryWithException.withJobException().count()).isEqualTo(1);
+            assertThat(queryWithException.withJobException().list()).hasSize(1);
+            assertThat(queryWithException.withJobException().list().get(0).getId()).isEqualTo(processWithException1.getId());
 
             ProcessInstance processWithException2 = startProcessInstanceWithFailingJob(PROCESS_DEFINITION_KEY_WITH_EXCEPTION_2);
             TimerJobQuery jobQuery2 = managementService.createTimerJobQuery().processInstanceId(processWithException2.getId());
-            assertEquals(2, jobQuery2.withException().count());
-            assertEquals(2, jobQuery2.withException().list().size());
+            assertThat(jobQuery2.withException().count()).isEqualTo(2);
+            assertThat(jobQuery2.withException().list()).hasSize(2);
 
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
-            assertEquals(2, queryWithException.withJobException().count());
-            assertEquals(2, queryWithException.withJobException().list().size());
-            assertEquals(processWithException1.getId(), queryWithException.withJobException().processDefinitionKey(PROCESS_DEFINITION_KEY_WITH_EXCEPTION_1).list().get(0).getId());
-            assertEquals(processWithException2.getId(), queryWithException.withJobException().processDefinitionKey(PROCESS_DEFINITION_KEY_WITH_EXCEPTION_2).list().get(0).getId());
+            assertThat(queryWithException.withJobException().count()).isEqualTo(2);
+            assertThat(queryWithException.withJobException().list()).hasSize(2);
+            assertThat(queryWithException.withJobException().processDefinitionKey(PROCESS_DEFINITION_KEY_WITH_EXCEPTION_1).list().get(0).getId())
+                    .isEqualTo(processWithException1.getId());
+            assertThat(queryWithException.withJobException().processDefinitionKey(PROCESS_DEFINITION_KEY_WITH_EXCEPTION_2).list().get(0).getId())
+                    .isEqualTo(processWithException2.getId());
         }
     }
 
@@ -92,11 +98,8 @@ public class HistoricProcessInstanceQueryAndWithExceptionTest extends PluggableF
                 .list();
 
         for (Job job : jobList) {
-            try {
-                managementService.executeJob(job.getId());
-                fail("RuntimeException");
-            } catch (RuntimeException re) {
-            }
+            assertThatThrownBy(() -> managementService.executeJob(job.getId()))
+                    .isInstanceOf(FlowableException.class);
         }
         return processInstance;
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricProcessInstanceQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricProcessInstanceQueryTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -38,9 +38,9 @@ public class HistoricProcessInstanceQueryTest extends PluggableFlowableTestCase 
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             List<HistoricProcessInstance> processes = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstanceId).list();
-            assertEquals(1, processes.size());
-            assertNull(processes.get(0).getName());
-            assertNull(processes.get(0).getDescription());
+            assertThat(processes).hasSize(1);
+            assertThat(processes.get(0).getName()).isNull();
+            assertThat(processes.get(0).getDescription()).isNull();
 
             ObjectNode infoNode = dynamicBpmnService.changeLocalizationName("en-GB", "historicProcessLocalization", "Historic Process Name 'en-GB'");
             dynamicBpmnService.changeLocalizationDescription("en-GB", "historicProcessLocalization", "Historic Process Description 'en-GB'", infoNode);
@@ -51,51 +51,52 @@ public class HistoricProcessInstanceQueryTest extends PluggableFlowableTestCase 
             dynamicBpmnService.saveProcessDefinitionInfo(processInstance.getProcessDefinitionId(), infoNode);
 
             processes = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstanceId).list();
-            assertEquals(1, processes.size());
-            assertNull(processes.get(0).getName());
-            assertNull(processes.get(0).getDescription());
+            assertThat(processes).hasSize(1);
+            assertThat(processes.get(0).getName()).isNull();
+            assertThat(processes.get(0).getDescription()).isNull();
 
             processes = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstanceId).locale("en-GB").list();
-            assertEquals(1, processes.size());
-            assertEquals("Historic Process Name 'en-GB'", processes.get(0).getName());
-            assertEquals("Historic Process Description 'en-GB'", processes.get(0).getDescription());
+            assertThat(processes).hasSize(1);
+            assertThat(processes.get(0).getName()).isEqualTo("Historic Process Name 'en-GB'");
+            assertThat(processes.get(0).getDescription()).isEqualTo("Historic Process Description 'en-GB'");
 
             processes = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstanceId).listPage(0, 10);
-            assertEquals(1, processes.size());
-            assertNull(processes.get(0).getName());
-            assertNull(processes.get(0).getDescription());
+            assertThat(processes).hasSize(1);
+            assertThat(processes.get(0).getName()).isNull();
+            assertThat(processes.get(0).getDescription()).isNull();
 
             processes = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstanceId).locale("en-GB").listPage(0, 10);
-            assertEquals(1, processes.size());
-            assertEquals("Historic Process Name 'en-GB'", processes.get(0).getName());
-            assertEquals("Historic Process Description 'en-GB'", processes.get(0).getDescription());
+            assertThat(processes).hasSize(1);
+            assertThat(processes.get(0).getName()).isEqualTo("Historic Process Name 'en-GB'");
+            assertThat(processes.get(0).getDescription()).isEqualTo("Historic Process Description 'en-GB'");
 
             HistoricProcessInstance process = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstanceId).singleResult();
-            assertNull(process.getName());
-            assertNull(process.getDescription());
+            assertThat(process.getName()).isNull();
+            assertThat(process.getDescription()).isNull();
 
             process = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstanceId).locale("en-GB").singleResult();
-            assertEquals("Historic Process Name 'en-GB'", process.getName());
-            assertEquals("Historic Process Description 'en-GB'", process.getDescription());
+            assertThat(process.getName()).isEqualTo("Historic Process Name 'en-GB'");
+            assertThat(process.getDescription()).isEqualTo("Historic Process Description 'en-GB'");
 
             process = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstanceId).locale("en").singleResult();
-            assertEquals("Historic Process Name 'en'", process.getName());
-            assertEquals("Historic Process Description 'en'", process.getDescription());
+            assertThat(process.getName()).isEqualTo("Historic Process Name 'en'");
+            assertThat(process.getDescription()).isEqualTo("Historic Process Description 'en'");
 
-            process = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstanceId).locale("en-AU").withLocalizationFallback().singleResult();
-            assertEquals("Historic Process Name 'en'", process.getName());
-            assertEquals("Historic Process Description 'en'", process.getDescription());
+            process = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstanceId).locale("en-AU").withLocalizationFallback()
+                    .singleResult();
+            assertThat(process.getName()).isEqualTo("Historic Process Name 'en'");
+            assertThat(process.getDescription()).isEqualTo("Historic Process Description 'en'");
         }
     }
-    
+
     @Test
     public void testQueryByDeploymentId() {
         deployOneTaskTestProcess();
         String deploymentId = repositoryService.createDeploymentQuery().singleResult().getId();
         runtimeService.startProcessInstanceByKey("oneTaskProcess");
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
-            assertNotNull(historyService.createHistoricProcessInstanceQuery().deploymentId(deploymentId).singleResult());
-            assertEquals(1, historyService.createHistoricProcessInstanceQuery().deploymentId(deploymentId).count());
+            assertThat(historyService.createHistoricProcessInstanceQuery().deploymentId(deploymentId).singleResult()).isNotNull();
+            assertThat(historyService.createHistoricProcessInstanceQuery().deploymentId(deploymentId).count()).isEqualTo(1);
         }
     }
 
@@ -103,18 +104,18 @@ public class HistoricProcessInstanceQueryTest extends PluggableFlowableTestCase 
     public void testQueryByReferenceId() {
         deployOneTaskTestProcess();
         ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder()
-            .processDefinitionKey("oneTaskProcess")
-            .referenceId("testReferenceId")
-            .start();
+                .processDefinitionKey("oneTaskProcess")
+                .referenceId("testReferenceId")
+                .start();
 
         assertThat(historyService.createHistoricProcessInstanceQuery().processInstanceReferenceId("testReferenceId").list())
-            .extracting(HistoricProcessInstance::getId)
-            .contains(processInstance.getId());
+                .extracting(HistoricProcessInstance::getId)
+                .contains(processInstance.getId());
 
         assertThat(historyService.createHistoricProcessInstanceQuery().or()
                 .processInstanceReferenceId("testReferenceId").processInstanceName("doesn't exist").list())
-            .extracting(HistoricProcessInstance::getId)
-            .contains(processInstance.getId());
+                .extracting(HistoricProcessInstance::getId)
+                .contains(processInstance.getId());
 
         assertThat(historyService.createHistoricProcessInstanceQuery().processInstanceReferenceId("invalid").list()).isEmpty();
     }
@@ -123,18 +124,18 @@ public class HistoricProcessInstanceQueryTest extends PluggableFlowableTestCase 
     public void testQueryByReferenceType() {
         deployOneTaskTestProcess();
         ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder()
-            .processDefinitionKey("oneTaskProcess")
-            .referenceType("testReferenceType")
-            .start();
+                .processDefinitionKey("oneTaskProcess")
+                .referenceType("testReferenceType")
+                .start();
 
         assertThat(historyService.createHistoricProcessInstanceQuery().processInstanceReferenceType("testReferenceType").list())
-            .extracting(HistoricProcessInstance::getId)
-            .contains(processInstance.getId());
+                .extracting(HistoricProcessInstance::getId)
+                .contains(processInstance.getId());
 
         assertThat(historyService.createHistoricProcessInstanceQuery().or()
-            .processInstanceReferenceType("testReferenceType").processInstanceName("doesn't exist").list())
-            .extracting(HistoricProcessInstance::getId)
-            .contains(processInstance.getId());
+                .processInstanceReferenceType("testReferenceType").processInstanceName("doesn't exist").list())
+                .extracting(HistoricProcessInstance::getId)
+                .contains(processInstance.getId());
 
         assertThat(historyService.createHistoricProcessInstanceQuery().processInstanceReferenceType("invalid").list()).isEmpty();
     }
@@ -146,10 +147,10 @@ public class HistoricProcessInstanceQueryTest extends PluggableFlowableTestCase 
         String[] ids = new String[7];
         for (int i = 0; i < ids.length; i++) {
             ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder()
-                .processDefinitionKey("oneTaskProcess")
-                .referenceId("testReferenceId")
-                .referenceType("testReferenceType")
-                .start();
+                    .processDefinitionKey("oneTaskProcess")
+                    .referenceId("testReferenceId")
+                    .referenceType("testReferenceType")
+                    .start();
 
             ids[i] = processInstance.getId();
         }
@@ -157,8 +158,8 @@ public class HistoricProcessInstanceQueryTest extends PluggableFlowableTestCase 
         assertThat(historyService.createHistoricProcessInstanceQuery()
                 .processInstanceReferenceId("testReferenceId")
                 .processInstanceReferenceType("testReferenceType").list())
-            .extracting(HistoricProcessInstance::getId)
-            .containsExactlyInAnyOrder(ids);
+                .extracting(HistoricProcessInstance::getId)
+                .containsExactlyInAnyOrder(ids);
 
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricProcessInstanceQueryVersionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricProcessInstanceQueryVersionTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.api.history;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -45,7 +47,7 @@ public class HistoricProcessInstanceQueryVersionTest extends PluggableFlowableTe
         startMap.clear();
         startMap.put("anothertest", 456);
         runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY, startMap);
-        
+
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
     }
 
@@ -56,73 +58,85 @@ public class HistoricProcessInstanceQueryVersionTest extends PluggableFlowableTe
 
     @Test
     public void testHistoricProcessInstanceQueryByProcessDefinitionVersion() {
-        assertEquals(1, historyService.createHistoricProcessInstanceQuery().processDefinitionVersion(1).list().get(0).getProcessDefinitionVersion().intValue());
-        assertEquals(2, historyService.createHistoricProcessInstanceQuery().processDefinitionVersion(2).list().get(0).getProcessDefinitionVersion().intValue());
-        assertEquals(1, historyService.createHistoricProcessInstanceQuery().processDefinitionVersion(1).count());
-        assertEquals(1, historyService.createHistoricProcessInstanceQuery().processDefinitionVersion(2).count());
-        assertEquals(0, historyService.createHistoricProcessInstanceQuery().processDefinitionVersion(3).count());
-        assertEquals(1, historyService.createHistoricProcessInstanceQuery().processDefinitionVersion(1).count());
-        assertEquals(1, historyService.createHistoricProcessInstanceQuery().processDefinitionVersion(2).list().size());
-        assertEquals(0, historyService.createHistoricProcessInstanceQuery().processDefinitionVersion(3).list().size());
+        assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionVersion(1).list().get(0).getProcessDefinitionVersion().intValue())
+                .isEqualTo(1);
+        assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionVersion(2).list().get(0).getProcessDefinitionVersion().intValue())
+                .isEqualTo(2);
+        assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionVersion(1).count()).isEqualTo(1);
+        assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionVersion(2).count()).isEqualTo(1);
+        assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionVersion(3).count()).isEqualTo(0);
+        assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionVersion(1).count()).isEqualTo(1);
+        assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionVersion(2).list()).hasSize(1);
+        assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionVersion(3).list()).isEmpty();
 
         // Variables Case
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             HistoricProcessInstance processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
                     .variableValueEquals("test", 123).processDefinitionVersion(1).singleResult();
-            assertEquals(1, processInstance.getProcessDefinitionVersion().intValue());
+            assertThat(processInstance.getProcessDefinitionVersion().intValue()).isEqualTo(1);
             Map<String, Object> variableMap = processInstance.getProcessVariables();
-            assertEquals(123, variableMap.get("test"));
+            assertThat(variableMap.get("test")).isEqualTo(123);
 
             processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
                     .variableValueEquals("anothertest", 456).processDefinitionVersion(1).singleResult();
-            assertNull(processInstance);
+            assertThat(processInstance).isNull();
 
             processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
                     .variableValueEquals("anothertest", 456).processDefinitionVersion(2).singleResult();
-            assertEquals(2, processInstance.getProcessDefinitionVersion().intValue());
+            assertThat(processInstance.getProcessDefinitionVersion().intValue()).isEqualTo(2);
             variableMap = processInstance.getProcessVariables();
-            assertEquals(456, variableMap.get("anothertest"));
+            assertThat(variableMap.get("anothertest")).isEqualTo(456);
         }
     }
 
     @Test
     public void testHistoricProcessInstanceQueryByProcessDefinitionVersionAndKey() {
-        assertEquals(1, historyService.createHistoricProcessInstanceQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(1).count());
-        assertEquals(1, historyService.createHistoricProcessInstanceQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(2).count());
-        assertEquals(0, historyService.createHistoricProcessInstanceQuery().processDefinitionKey("undefined").processDefinitionVersion(1).count());
-        assertEquals(0, historyService.createHistoricProcessInstanceQuery().processDefinitionKey("undefined").processDefinitionVersion(2).count());
-        assertEquals(1, historyService.createHistoricProcessInstanceQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(1).list().size());
-        assertEquals(1, historyService.createHistoricProcessInstanceQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(2).list().size());
-        assertEquals(0, historyService.createHistoricProcessInstanceQuery().processDefinitionKey("undefined").processDefinitionVersion(1).list().size());
-        assertEquals(0, historyService.createHistoricProcessInstanceQuery().processDefinitionKey("undefined").processDefinitionVersion(2).list().size());
+        assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(1).count())
+                .isEqualTo(1);
+        assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(2).count())
+                .isEqualTo(1);
+        assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionKey("undefined").processDefinitionVersion(1).count()).isEqualTo(0);
+        assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionKey("undefined").processDefinitionVersion(2).count()).isEqualTo(0);
+        assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(1).list())
+                .hasSize(1);
+        assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(2).list())
+                .hasSize(1);
+        assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionKey("undefined").processDefinitionVersion(1).list()).isEmpty();
+        assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionKey("undefined").processDefinitionVersion(2).list()).isEmpty();
     }
 
     @Test
     public void testHistoricProcessInstanceOrQueryByProcessDefinitionVersion() {
-        assertEquals(1, historyService.createHistoricProcessInstanceQuery().or().processDefinitionVersion(1).processDefinitionId("undefined").endOr().count());
-        assertEquals(1, historyService.createHistoricProcessInstanceQuery().or().processDefinitionVersion(2).processDefinitionId("undefined").endOr().count());
-        assertEquals(0, historyService.createHistoricProcessInstanceQuery().or().processDefinitionVersion(3).processDefinitionId("undefined").endOr().count());
-        assertEquals(1, historyService.createHistoricProcessInstanceQuery().or().processDefinitionVersion(1).processDefinitionId("undefined").endOr().list().size());
-        assertEquals(1, historyService.createHistoricProcessInstanceQuery().or().processDefinitionVersion(2).processDefinitionId("undefined").endOr().list().size());
-        assertEquals(0, historyService.createHistoricProcessInstanceQuery().or().processDefinitionVersion(3).processDefinitionId("undefined").endOr().list().size());
+        assertThat(historyService.createHistoricProcessInstanceQuery().or().processDefinitionVersion(1).processDefinitionId("undefined").endOr().count())
+                .isEqualTo(1);
+        assertThat(historyService.createHistoricProcessInstanceQuery().or().processDefinitionVersion(2).processDefinitionId("undefined").endOr().count())
+                .isEqualTo(1);
+        assertThat(historyService.createHistoricProcessInstanceQuery().or().processDefinitionVersion(3).processDefinitionId("undefined").endOr().count())
+                .isEqualTo(0);
+        assertThat(historyService.createHistoricProcessInstanceQuery().or().processDefinitionVersion(1).processDefinitionId("undefined").endOr().list())
+                .hasSize(1);
+        assertThat(historyService.createHistoricProcessInstanceQuery().or().processDefinitionVersion(2).processDefinitionId("undefined").endOr().list())
+                .hasSize(1);
+        assertThat(historyService.createHistoricProcessInstanceQuery().or().processDefinitionVersion(3).processDefinitionId("undefined").endOr().list())
+                .isEmpty();
 
         // Variables Case
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             HistoricProcessInstance processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
                     .or().variableValueEquals("test", "invalid").processDefinitionVersion(1).endOr().singleResult();
-            assertEquals(1, processInstance.getProcessDefinitionVersion().intValue());
+            assertThat(processInstance.getProcessDefinitionVersion().intValue()).isEqualTo(1);
             Map<String, Object> variableMap = processInstance.getProcessVariables();
-            assertEquals(123, variableMap.get("test"));
+            assertThat(variableMap.get("test")).isEqualTo(123);
 
             processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
                     .or().variableValueEquals("anothertest", "invalid").processDefinitionVersion(2).endOr().singleResult();
-            assertEquals(2, processInstance.getProcessDefinitionVersion().intValue());
+            assertThat(processInstance.getProcessDefinitionVersion().intValue()).isEqualTo(2);
             variableMap = processInstance.getProcessVariables();
-            assertEquals(456, variableMap.get("anothertest"));
+            assertThat(variableMap.get("anothertest")).isEqualTo(456);
 
             processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
                     .variableValueEquals("anothertest", "invalid").processDefinitionVersion(3).singleResult();
-            assertNull(processInstance);
+            assertThat(processInstance).isNull();
         }
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricTaskAndVariablesQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricTaskAndVariablesQueryTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -11,6 +11,8 @@
  * limitations under the License.
  */
 package org.flowable.engine.test.api.history;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -73,113 +75,118 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             HistoricTaskInstance task = historyService.createHistoricTaskInstanceQuery().includeTaskLocalVariables().taskAssignee("gonzo").singleResult();
             Map<String, Object> variableMap = task.getTaskLocalVariables();
-            assertEquals(2, variableMap.size());
-            assertEquals(0, task.getProcessVariables().size());
-            assertNotNull(variableMap.get("testVar"));
-            assertEquals("someVariable", variableMap.get("testVar"));
-            assertNotNull(variableMap.get("testVar2"));
-            assertEquals(123, variableMap.get("testVar2"));
+            assertThat(variableMap).hasSize(2);
+            assertThat(task.getProcessVariables()).isEmpty();
+            assertThat(variableMap.get("testVar")).isNotNull();
+            assertThat(variableMap.get("testVar")).isEqualTo("someVariable");
+            assertThat(variableMap.get("testVar2")).isNotNull();
+            assertThat(variableMap.get("testVar2")).isEqualTo(123);
 
             List<HistoricTaskInstance> tasks = historyService.createHistoricTaskInstanceQuery().list();
-            assertEquals(3, tasks.size());
+            assertThat(tasks).hasSize(3);
 
             task = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().taskAssignee("gonzo").singleResult();
-            assertEquals(0, task.getProcessVariables().size());
-            assertEquals(0, task.getTaskLocalVariables().size());
+            assertThat(task.getProcessVariables()).isEmpty();
+            assertThat(task.getTaskLocalVariables()).isEmpty();
 
             Map<String, Object> startMap = new HashMap<>();
             startMap.put("processVar", true);
             runtimeService.startProcessInstanceByKey("oneTaskProcess", startMap);
             String taskId = taskService.createTaskQuery().taskAssignee("kermit").singleResult().getId();
             taskService.addGroupIdentityLink(
-                taskId,
-                "testGroup",
-                IdentityLinkType.PARTICIPANT
+                    taskId,
+                    "testGroup",
+                    IdentityLinkType.PARTICIPANT
             );
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             task = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().taskAssignee("kermit").singleResult();
-            assertEquals(1, task.getProcessVariables().size());
-            assertEquals(0, task.getTaskLocalVariables().size());
-            assertTrue((Boolean) task.getProcessVariables().get("processVar"));
+            assertThat(task.getProcessVariables()).hasSize(1);
+            assertThat(task.getTaskLocalVariables()).isEmpty();
+            assertThat((Boolean) task.getProcessVariables().get("processVar")).isTrue();
 
             taskService.setVariable(task.getId(), "anotherProcessVar", 123);
             taskService.setVariableLocal(task.getId(), "localVar", "test");
-            
+
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             task = historyService.createHistoricTaskInstanceQuery().includeTaskLocalVariables().taskAssignee("kermit").singleResult();
-            assertEquals(0, task.getProcessVariables().size());
-            assertEquals(1, task.getTaskLocalVariables().size());
-            assertEquals("test", task.getTaskLocalVariables().get("localVar"));
+            assertThat(task.getProcessVariables()).isEmpty();
+            assertThat(task.getTaskLocalVariables()).hasSize(1);
+            assertThat(task.getTaskLocalVariables().get("localVar")).isEqualTo("test");
 
             task = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().taskAssignee("kermit").singleResult();
-            assertEquals(2, task.getProcessVariables().size());
-            assertEquals(0, task.getTaskLocalVariables().size());
-            assertEquals(true, task.getProcessVariables().get("processVar"));
-            assertEquals(123, task.getProcessVariables().get("anotherProcessVar"));
+            assertThat(task.getProcessVariables()).hasSize(2);
+            assertThat(task.getTaskLocalVariables()).isEmpty();
+            assertThat(task.getProcessVariables().get("processVar")).isEqualTo(true);
+            assertThat(task.getProcessVariables().get("anotherProcessVar")).isEqualTo(123);
 
             task = historyService.createHistoricTaskInstanceQuery().taskVariableValueLike("testVar", "someVaria%").singleResult();
-            assertNotNull(task);
-            assertEquals("gonzoTask", task.getName());
+            assertThat(task).isNotNull();
+            assertThat(task.getName()).isEqualTo("gonzoTask");
 
             task = historyService.createHistoricTaskInstanceQuery().taskVariableValueLikeIgnoreCase("testVar", "somevaria%").singleResult();
-            assertNotNull(task);
-            assertEquals("gonzoTask", task.getName());
+            assertThat(task).isNotNull();
+            assertThat(task.getName()).isEqualTo("gonzoTask");
 
             task = historyService.createHistoricTaskInstanceQuery().taskVariableValueLikeIgnoreCase("testVar", "somevaria2%").singleResult();
-            assertNull(task);
+            assertThat(task).isNull();
 
-            tasks = historyService.createHistoricTaskInstanceQuery().includeTaskLocalVariables().taskInvolvedUser("kermit").orderByTaskCreateTime().asc().list();
-            assertEquals(3, tasks.size());
-            assertEquals(1, tasks.get(0).getTaskLocalVariables().size());
-            assertEquals("test", tasks.get(0).getTaskLocalVariables().get("test"));
-            assertEquals(0, tasks.get(0).getProcessVariables().size());
+            tasks = historyService.createHistoricTaskInstanceQuery().includeTaskLocalVariables().taskInvolvedUser("kermit").orderByTaskCreateTime().asc()
+                    .list();
+            assertThat(tasks).hasSize(3);
+            assertThat(tasks.get(0).getTaskLocalVariables()).hasSize(1);
+            assertThat(tasks.get(0).getTaskLocalVariables().get("test")).isEqualTo("test");
+            assertThat(tasks.get(0).getProcessVariables()).isEmpty();
 
             tasks = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().taskInvolvedUser("kermit").orderByTaskCreateTime().asc().list();
-            assertEquals(3, tasks.size());
-            assertEquals(0, tasks.get(0).getProcessVariables().size());
-            assertEquals(0, tasks.get(0).getTaskLocalVariables().size());
+            assertThat(tasks).hasSize(3);
+            assertThat(tasks.get(0).getProcessVariables()).isEmpty();
+            assertThat(tasks.get(0).getTaskLocalVariables()).isEmpty();
 
-            task = historyService.createHistoricTaskInstanceQuery().includeTaskLocalVariables().taskAssignee("kermit").taskVariableValueEquals("localVar", "test").singleResult();
-            assertEquals(0, task.getProcessVariables().size());
-            assertEquals(1, task.getTaskLocalVariables().size());
-            assertEquals("test", task.getTaskLocalVariables().get("localVar"));
+            task = historyService.createHistoricTaskInstanceQuery().includeTaskLocalVariables().taskAssignee("kermit")
+                    .taskVariableValueEquals("localVar", "test").singleResult();
+            assertThat(task.getProcessVariables()).isEmpty();
+            assertThat(task.getTaskLocalVariables()).hasSize(1);
+            assertThat(task.getTaskLocalVariables().get("localVar")).isEqualTo("test");
 
-            task = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().taskAssignee("kermit").taskVariableValueEquals("localVar", "test").singleResult();
-            assertEquals(2, task.getProcessVariables().size());
-            assertEquals(0, task.getTaskLocalVariables().size());
-            assertEquals(true, task.getProcessVariables().get("processVar"));
-            assertEquals(123, task.getProcessVariables().get("anotherProcessVar"));
+            task = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().taskAssignee("kermit").taskVariableValueEquals("localVar", "test")
+                    .singleResult();
+            assertThat(task.getProcessVariables()).hasSize(2);
+            assertThat(task.getTaskLocalVariables()).isEmpty();
+            assertThat(task.getProcessVariables().get("processVar")).isEqualTo(true);
+            assertThat(task.getProcessVariables().get("anotherProcessVar")).isEqualTo(123);
 
             task = historyService.createHistoricTaskInstanceQuery().includeTaskLocalVariables().includeProcessVariables().taskAssignee("kermit").singleResult();
-            assertEquals(2, task.getProcessVariables().size());
-            assertEquals(1, task.getTaskLocalVariables().size());
-            assertEquals("test", task.getTaskLocalVariables().get("localVar"));
-            assertEquals(true, task.getProcessVariables().get("processVar"));
-            assertEquals(123, task.getProcessVariables().get("anotherProcessVar"));
+            assertThat(task.getProcessVariables()).hasSize(2);
+            assertThat(task.getTaskLocalVariables()).hasSize(1);
+            assertThat(task.getTaskLocalVariables().get("localVar")).isEqualTo("test");
+            assertThat(task.getProcessVariables().get("processVar")).isEqualTo(true);
+            assertThat(task.getProcessVariables().get("anotherProcessVar")).isEqualTo(123);
 
             task = historyService.createHistoricTaskInstanceQuery().taskAssignee("gonzo").singleResult();
             taskService.complete(task.getId());
-            
+
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
-            
+
             task = (HistoricTaskInstance) historyService.createHistoricTaskInstanceQuery().includeTaskLocalVariables().finished().singleResult();
             variableMap = task.getTaskLocalVariables();
-            assertEquals(2, variableMap.size());
-            assertEquals(0, task.getProcessVariables().size());
-            assertNotNull(variableMap.get("testVar"));
-            assertEquals("someVariable", variableMap.get("testVar"));
-            assertNotNull(variableMap.get("testVar2"));
-            assertEquals(123, variableMap.get("testVar2"));
+            assertThat(variableMap).hasSize(2);
+            assertThat(task.getProcessVariables()).isEmpty();
+            assertThat(variableMap.get("testVar")).isNotNull();
+            assertThat(variableMap.get("testVar")).isEqualTo("someVariable");
+            assertThat(variableMap.get("testVar2")).isNotNull();
+            assertThat(variableMap.get("testVar2")).isEqualTo(123);
 
-            assertEquals(1L, historyService.createHistoricTaskInstanceQuery().taskInvolvedGroups(Collections.singleton("testGroup")).count());
-            assertEquals( taskId, historyService.createHistoricTaskInstanceQuery().taskInvolvedGroups(Collections.singleton("testGroup")).list().get(0).getId());
-            assertEquals( taskId, historyService.createHistoricTaskInstanceQuery().taskInvolvedGroups(Collections.singleton("testGroup")).singleResult().getId());
-            assertEquals(3L, historyService.createHistoricTaskInstanceQuery().
-                or().taskInvolvedGroups(Collections.singleton("testGroup")).taskInvolvedUser("kermit").endOr().count());
-            assertEquals(1L, historyService.createHistoricTaskInstanceQuery().
-                or().taskInvolvedGroups(Collections.singleton("testGroup")).processInstanceId("undefined").endOr().count());
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskInvolvedGroups(Collections.singleton("testGroup")).count()).isEqualTo(1L);
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskInvolvedGroups(Collections.singleton("testGroup")).list().get(0).getId())
+                    .isEqualTo(taskId);
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskInvolvedGroups(Collections.singleton("testGroup")).singleResult().getId())
+                    .isEqualTo(taskId);
+            assertThat(historyService.createHistoricTaskInstanceQuery().
+                    or().taskInvolvedGroups(Collections.singleton("testGroup")).taskInvolvedUser("kermit").endOr().count()).isEqualTo(3);
+            assertThat(historyService.createHistoricTaskInstanceQuery().
+                    or().taskInvolvedGroups(Collections.singleton("testGroup")).processInstanceId("undefined").endOr().count()).isEqualTo(1);
         }
     }
 
@@ -195,30 +202,32 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
                     .singleResult();
 
             Map<String, Object> variableMap = task.getTaskLocalVariables();
-            assertEquals(2, variableMap.size());
-            assertEquals(0, task.getProcessVariables().size());
-            assertNotNull(variableMap.get("testVar"));
-            assertEquals("someVariable", variableMap.get("testVar"));
-            assertNotNull(variableMap.get("testVar2"));
-            assertEquals(123, variableMap.get("testVar2"));
+            assertThat(variableMap).hasSize(2);
+            assertThat(task.getProcessVariables()).isEmpty();
+            assertThat(variableMap.get("testVar")).isNotNull();
+            assertThat(variableMap.get("testVar")).isEqualTo("someVariable");
+            assertThat(variableMap.get("testVar2")).isNotNull();
+            assertThat(variableMap.get("testVar2")).isEqualTo(123);
 
             List<HistoricTaskInstance> tasks = historyService.createHistoricTaskInstanceQuery().list();
-            assertEquals(3, tasks.size());
+            assertThat(tasks).hasSize(3);
 
-            task = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().or().taskAssignee("gonzo").taskVariableValueEquals("localVar", "nonExisting").endOr().singleResult();
-            assertEquals(0, task.getProcessVariables().size());
-            assertEquals(0, task.getTaskLocalVariables().size());
+            task = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().or().taskAssignee("gonzo")
+                    .taskVariableValueEquals("localVar", "nonExisting").endOr().singleResult();
+            assertThat(task.getProcessVariables()).isEmpty();
+            assertThat(task.getTaskLocalVariables()).isEmpty();
 
             Map<String, Object> startMap = new HashMap<>();
             startMap.put("processVar", true);
             runtimeService.startProcessInstanceByKey("oneTaskProcess", startMap);
-            
+
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
-            task = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().or().taskAssignee("kermit").taskVariableValueEquals("localVar", "nonExisting").endOr().singleResult();
-            assertEquals(1, task.getProcessVariables().size());
-            assertEquals(0, task.getTaskLocalVariables().size());
-            assertTrue((Boolean) task.getProcessVariables().get("processVar"));
+            task = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().or().taskAssignee("kermit")
+                    .taskVariableValueEquals("localVar", "nonExisting").endOr().singleResult();
+            assertThat(task.getProcessVariables()).hasSize(1);
+            assertThat(task.getTaskLocalVariables()).isEmpty();
+            assertThat((Boolean) task.getProcessVariables().get("processVar")).isTrue();
 
             task = historyService.createHistoricTaskInstanceQuery()
                     .includeProcessVariables()
@@ -232,26 +241,28 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
                     .endOr()
                     .singleResult();
 
-            assertNotNull(task);
-            assertEquals(1, task.getProcessVariables().size());
-            assertEquals(0, task.getTaskLocalVariables().size());
-            assertTrue((Boolean) task.getProcessVariables().get("processVar"));
+            assertThat(task).isNotNull();
+            assertThat(task.getProcessVariables()).hasSize(1);
+            assertThat(task.getTaskLocalVariables()).isEmpty();
+            assertThat((Boolean) task.getProcessVariables().get("processVar")).isTrue();
 
             taskService.setVariable(task.getId(), "anotherProcessVar", 123);
             taskService.setVariableLocal(task.getId(), "localVar", "test");
-            
+
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
-            task = historyService.createHistoricTaskInstanceQuery().includeTaskLocalVariables().or().taskAssignee("kermit").taskVariableValueEquals("localVar", "nonExisting").endOr().singleResult();
-            assertEquals(0, task.getProcessVariables().size());
-            assertEquals(1, task.getTaskLocalVariables().size());
-            assertEquals("test", task.getTaskLocalVariables().get("localVar"));
+            task = historyService.createHistoricTaskInstanceQuery().includeTaskLocalVariables().or().taskAssignee("kermit")
+                    .taskVariableValueEquals("localVar", "nonExisting").endOr().singleResult();
+            assertThat(task.getProcessVariables()).isEmpty();
+            assertThat(task.getTaskLocalVariables()).hasSize(1);
+            assertThat(task.getTaskLocalVariables().get("localVar")).isEqualTo("test");
 
-            task = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().or().taskAssignee("kermit").taskVariableValueEquals("localVar", "nonExisting").endOr().singleResult();
-            assertEquals(2, task.getProcessVariables().size());
-            assertEquals(0, task.getTaskLocalVariables().size());
-            assertEquals(true, task.getProcessVariables().get("processVar"));
-            assertEquals(123, task.getProcessVariables().get("anotherProcessVar"));
+            task = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().or().taskAssignee("kermit")
+                    .taskVariableValueEquals("localVar", "nonExisting").endOr().singleResult();
+            assertThat(task.getProcessVariables()).hasSize(2);
+            assertThat(task.getTaskLocalVariables()).isEmpty();
+            assertThat(task.getProcessVariables().get("processVar")).isEqualTo(true);
+            assertThat(task.getProcessVariables().get("anotherProcessVar")).isEqualTo(123);
 
             task = historyService.createHistoricTaskInstanceQuery()
                     .includeTaskLocalVariables()
@@ -260,10 +271,10 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
                     .taskVariableValueLike("testVar", "someVar%")
                     .endOr()
                     .singleResult();
-            assertEquals(2, task.getTaskLocalVariables().size());
-            assertEquals(0, task.getProcessVariables().size());
-            assertEquals("someVariable", task.getTaskLocalVariables().get("testVar"));
-            assertEquals(123, task.getTaskLocalVariables().get("testVar2"));
+            assertThat(task.getTaskLocalVariables()).hasSize(2);
+            assertThat(task.getProcessVariables()).isEmpty();
+            assertThat(task.getTaskLocalVariables().get("testVar")).isEqualTo("someVariable");
+            assertThat(task.getTaskLocalVariables().get("testVar2")).isEqualTo(123);
 
             task = historyService.createHistoricTaskInstanceQuery()
                     .includeTaskLocalVariables()
@@ -272,10 +283,10 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
                     .taskVariableValueLikeIgnoreCase("testVar", "somevar%")
                     .endOr()
                     .singleResult();
-            assertEquals(2, task.getTaskLocalVariables().size());
-            assertEquals(0, task.getProcessVariables().size());
-            assertEquals("someVariable", task.getTaskLocalVariables().get("testVar"));
-            assertEquals(123, task.getTaskLocalVariables().get("testVar2"));
+            assertThat(task.getTaskLocalVariables()).hasSize(2);
+            assertThat(task.getProcessVariables()).isEmpty();
+            assertThat(task.getTaskLocalVariables().get("testVar")).isEqualTo("someVariable");
+            assertThat(task.getTaskLocalVariables().get("testVar2")).isEqualTo(123);
 
             task = historyService.createHistoricTaskInstanceQuery()
                     .includeTaskLocalVariables()
@@ -284,7 +295,7 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
                     .taskVariableValueLike("testVar", "someVar2%")
                     .endOr()
                     .singleResult();
-            assertNull(task);
+            assertThat(task).isNull();
 
             tasks = historyService.createHistoricTaskInstanceQuery().includeTaskLocalVariables()
                     .or()
@@ -292,10 +303,10 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
                     .taskVariableValueEquals("localVar", "nonExisting")
                     .endOr()
                     .orderByTaskCreateTime().asc().list();
-            assertEquals(3, tasks.size());
-            assertEquals(1, tasks.get(0).getTaskLocalVariables().size());
-            assertEquals("test", tasks.get(0).getTaskLocalVariables().get("test"));
-            assertEquals(0, tasks.get(0).getProcessVariables().size());
+            assertThat(tasks).hasSize(3);
+            assertThat(tasks.get(0).getTaskLocalVariables()).hasSize(1);
+            assertThat(tasks.get(0).getTaskLocalVariables().get("test")).isEqualTo("test");
+            assertThat(tasks.get(0).getProcessVariables()).isEmpty();
 
             tasks = historyService.createHistoricTaskInstanceQuery().includeProcessVariables()
                     .or()
@@ -303,44 +314,48 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
                     .taskVariableValueEquals("localVar", "nonExisting")
                     .endOr()
                     .orderByTaskCreateTime().asc().list();
-            assertEquals(3, tasks.size());
-            assertEquals(0, tasks.get(0).getProcessVariables().size());
-            assertEquals(0, tasks.get(0).getTaskLocalVariables().size());
+            assertThat(tasks).hasSize(3);
+            assertThat(tasks.get(0).getProcessVariables()).isEmpty();
+            assertThat(tasks.get(0).getTaskLocalVariables()).isEmpty();
 
-            task = historyService.createHistoricTaskInstanceQuery().includeTaskLocalVariables().taskAssignee("kermit").or().taskVariableValueEquals("localVar", "test")
+            task = historyService.createHistoricTaskInstanceQuery().includeTaskLocalVariables().taskAssignee("kermit").or()
+                    .taskVariableValueEquals("localVar", "test")
                     .taskVariableValueEquals("localVar", "nonExisting").endOr().singleResult();
-            assertEquals(0, task.getProcessVariables().size());
-            assertEquals(1, task.getTaskLocalVariables().size());
-            assertEquals("test", task.getTaskLocalVariables().get("localVar"));
+            assertThat(task.getProcessVariables()).isEmpty();
+            assertThat(task.getTaskLocalVariables()).hasSize(1);
+            assertThat(task.getTaskLocalVariables().get("localVar")).isEqualTo("test");
 
-            task = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().taskAssignee("kermit").or().taskVariableValueEquals("localVar", "test")
+            task = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().taskAssignee("kermit").or()
+                    .taskVariableValueEquals("localVar", "test")
                     .taskVariableValueEquals("localVar", "nonExisting").endOr().singleResult();
-            assertEquals(2, task.getProcessVariables().size());
-            assertEquals(0, task.getTaskLocalVariables().size());
-            assertEquals(true, task.getProcessVariables().get("processVar"));
-            assertEquals(123, task.getProcessVariables().get("anotherProcessVar"));
+            assertThat(task.getProcessVariables()).hasSize(2);
+            assertThat(task.getTaskLocalVariables()).isEmpty();
+            assertThat(task.getProcessVariables().get("processVar")).isEqualTo(true);
+            assertThat(task.getProcessVariables().get("anotherProcessVar")).isEqualTo(123);
 
-            task = historyService.createHistoricTaskInstanceQuery().includeTaskLocalVariables().includeProcessVariables().or().taskAssignee("kermit").taskVariableValueEquals("localVar", "nonExisting")
+            task = historyService.createHistoricTaskInstanceQuery().includeTaskLocalVariables().includeProcessVariables().or().taskAssignee("kermit")
+                    .taskVariableValueEquals("localVar", "nonExisting")
                     .endOr().singleResult();
-            assertEquals(2, task.getProcessVariables().size());
-            assertEquals(1, task.getTaskLocalVariables().size());
-            assertEquals("test", task.getTaskLocalVariables().get("localVar"));
-            assertEquals(true, task.getProcessVariables().get("processVar"));
-            assertEquals(123, task.getProcessVariables().get("anotherProcessVar"));
+            assertThat(task.getProcessVariables()).hasSize(2);
+            assertThat(task.getTaskLocalVariables()).hasSize(1);
+            assertThat(task.getTaskLocalVariables().get("localVar")).isEqualTo("test");
+            assertThat(task.getProcessVariables().get("processVar")).isEqualTo(true);
+            assertThat(task.getProcessVariables().get("anotherProcessVar")).isEqualTo(123);
 
             task = historyService.createHistoricTaskInstanceQuery().taskAssignee("gonzo").singleResult();
             taskService.complete(task.getId());
-            
+
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
-            
-            task = historyService.createHistoricTaskInstanceQuery().includeTaskLocalVariables().or().finished().taskVariableValueEquals("localVar", "nonExisting").endOr().singleResult();
+
+            task = historyService.createHistoricTaskInstanceQuery().includeTaskLocalVariables().or().finished()
+                    .taskVariableValueEquals("localVar", "nonExisting").endOr().singleResult();
             variableMap = task.getTaskLocalVariables();
-            assertEquals(2, variableMap.size());
-            assertEquals(0, task.getProcessVariables().size());
-            assertNotNull(variableMap.get("testVar"));
-            assertEquals("someVariable", variableMap.get("testVar"));
-            assertNotNull(variableMap.get("testVar2"));
-            assertEquals(123, variableMap.get("testVar2"));
+            assertThat(variableMap).hasSize(2);
+            assertThat(task.getProcessVariables()).isEmpty();
+            assertThat(variableMap.get("testVar")).isNotNull();
+            assertThat(variableMap.get("testVar")).isEqualTo("someVariable");
+            assertThat(variableMap.get("testVar2")).isNotNull();
+            assertThat(variableMap.get("testVar2")).isEqualTo(123);
         }
     }
 
@@ -355,7 +370,7 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
 
             startMap.put("anotherProcessVar", 999);
             runtimeService.startProcessInstanceByKey("oneTaskProcess", startMap);
-            
+
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             HistoricTaskInstanceQuery query0 = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().or();
@@ -363,17 +378,18 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
                 query0 = query0.processVariableValueEquals("anotherProcessVar", i);
             }
             query0 = query0.endOr();
-            assertNull(query0.singleResult());
+            assertThat(query0.singleResult()).isNull();
 
-            HistoricTaskInstanceQuery query1 = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().or().processVariableValueEquals("anotherProcessVar", 123);
+            HistoricTaskInstanceQuery query1 = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().or()
+                    .processVariableValueEquals("anotherProcessVar", 123);
             for (int i = 0; i < 20; i++) {
                 query1 = query1.processVariableValueEquals("anotherProcessVar", i);
             }
             query1 = query1.endOr();
             HistoricTaskInstance task = query1.singleResult();
-            assertEquals(2, task.getProcessVariables().size());
-            assertEquals(true, task.getProcessVariables().get("processVar"));
-            assertEquals(123, task.getProcessVariables().get("anotherProcessVar"));
+            assertThat(task.getProcessVariables()).hasSize(2);
+            assertThat(task.getProcessVariables().get("processVar")).isEqualTo(true);
+            assertThat(task.getProcessVariables().get("anotherProcessVar")).isEqualTo(123);
         }
     }
 
@@ -382,63 +398,63 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
     public void testCandidate() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
-            
+
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
-            
+
             List<HistoricTaskInstance> tasks = historyService.createHistoricTaskInstanceQuery().taskCandidateUser("kermit").list();
-            assertEquals(3, tasks.size());
+            assertThat(tasks).hasSize(3);
 
             tasks = historyService.createHistoricTaskInstanceQuery().taskCandidateUser("gonzo").list();
-            assertEquals(0, tasks.size());
+            assertThat(tasks).isEmpty();
 
             tasks = historyService.createHistoricTaskInstanceQuery().taskCandidateUser("fozzie").list();
-            assertEquals(1, tasks.size());
+            assertThat(tasks).hasSize(1);
 
             tasks = historyService.createHistoricTaskInstanceQuery().taskCandidateGroup("management").list();
-            assertEquals(1, tasks.size());
+            assertThat(tasks).hasSize(1);
             List<String> groups = new ArrayList<>();
             groups.add("management");
             groups.add("accountancy");
             tasks = historyService.createHistoricTaskInstanceQuery().taskCandidateGroupIn(groups).list();
-            assertEquals(1, tasks.size());
+            assertThat(tasks).hasSize(1);
 
             tasks = historyService.createHistoricTaskInstanceQuery().taskCandidateUser("kermit").taskCandidateGroupIn(groups).list();
-            assertEquals(3, tasks.size());
+            assertThat(tasks).hasSize(3);
 
             tasks = historyService.createHistoricTaskInstanceQuery().taskCandidateUser("gonzo").taskCandidateGroupIn(groups).list();
-            assertEquals(1, tasks.size());
+            assertThat(tasks).hasSize(1);
 
             org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
             taskService.complete(task.getId());
 
-            assertEquals(0, taskService.createTaskQuery().processInstanceId(processInstance.getId()).count());
+            assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0);
 
             tasks = historyService.createHistoricTaskInstanceQuery().taskCandidateUser("kermit").list();
-            assertEquals(3, tasks.size());
+            assertThat(tasks).hasSize(3);
 
             tasks = historyService.createHistoricTaskInstanceQuery().taskCandidateUser("gonzo").list();
-            assertEquals(0, tasks.size());
+            assertThat(tasks).isEmpty();
 
             tasks = historyService.createHistoricTaskInstanceQuery().taskCandidateUser("fozzie").list();
-            assertEquals(1, tasks.size());
+            assertThat(tasks).hasSize(1);
 
             tasks = historyService.createHistoricTaskInstanceQuery().taskCandidateGroup("management").list();
-            assertEquals(1, tasks.size());
+            assertThat(tasks).hasSize(1);
 
             tasks = historyService.createHistoricTaskInstanceQuery().taskCandidateUser("kermit").taskCandidateGroup("management").list();
-            assertEquals(3, tasks.size());
+            assertThat(tasks).hasSize(3);
 
             tasks = historyService.createHistoricTaskInstanceQuery().taskCandidateUser("gonzo").taskCandidateGroup("management").list();
-            assertEquals(1, tasks.size());
+            assertThat(tasks).hasSize(1);
 
             tasks = historyService.createHistoricTaskInstanceQuery().taskCandidateUser("gonzo").taskCandidateGroup("invalid").list();
-            assertEquals(0, tasks.size());
+            assertThat(tasks).isEmpty();
 
             tasks = historyService.createHistoricTaskInstanceQuery().taskCandidateGroupIn(groups).list();
-            assertEquals(1, tasks.size());
+            assertThat(tasks).hasSize(1);
         }
     }
-    
+
     @Test
     @Deployment(resources = { "org/flowable/engine/test/api/history/HistoricTaskAndVariablesQueryTest.testCandidate.bpmn20.xml" })
     public void testIgnoreAssigneeValue() {
@@ -459,32 +475,32 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
                     .createHistoricTaskInstanceQuery()
                     .taskCandidateUser("kermit")
                     .list();
-            assertEquals(2, tasks.size());
+            assertThat(tasks).hasSize(2);
 
             tasks = historyService
                     .createHistoricTaskInstanceQuery()
                     .taskCandidateUser("kermit")
                     .ignoreAssigneeValue()
                     .list();
-            assertEquals(3, tasks.size());
+            assertThat(tasks).hasSize(3);
 
             tasks = historyService
                     .createHistoricTaskInstanceQuery()
                     .taskCandidateGroup("management")
                     .list();
-            assertEquals(0, tasks.size());
+            assertThat(tasks).isEmpty();
 
             tasks = historyService
                     .createHistoricTaskInstanceQuery()
                     .taskCandidateGroup("management")
                     .ignoreAssigneeValue()
                     .list();
-            assertEquals(1, tasks.size());
+            assertThat(tasks).hasSize(1);
         }
     }
 
     @Test
-    @Deployment(resources = {"org/flowable/engine/test/api/history/HistoricTaskAndVariablesQueryTest.testCandidate.bpmn20.xml"})
+    @Deployment(resources = { "org/flowable/engine/test/api/history/HistoricTaskAndVariablesQueryTest.testCandidate.bpmn20.xml" })
     public void testIgnoreAssigneeValueOr() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -499,7 +515,7 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
             taskService.setAssignee(taskId, "kermit");
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
-            List<HistoricTaskInstance>  tasks = historyService.createHistoricTaskInstanceQuery()
+            List<HistoricTaskInstance> tasks = historyService.createHistoricTaskInstanceQuery()
                     .or()
                     .taskCandidateUser("kermit")
                     .taskAssignee("gonzo")
@@ -507,7 +523,7 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
                     .endOr()
                     .list();
 
-            assertEquals(4, tasks.size());
+            assertThat(tasks).hasSize(4);
 
             tasks = historyService.createHistoricTaskInstanceQuery()
                     .or()
@@ -515,156 +531,165 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
                     .taskAssignee("gonzo")
                     .endOr()
                     .list();
-            assertEquals(3, tasks.size());
+            assertThat(tasks).hasSize(3);
         }
     }
 
     @Test
     public void testQueryWithPagingAndVariables() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-            List<HistoricTaskInstance> tasks = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().includeTaskLocalVariables().orderByTaskPriority().desc().listPage(0, 1);
-            assertEquals(1, tasks.size());
+            List<HistoricTaskInstance> tasks = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().includeTaskLocalVariables()
+                    .orderByTaskPriority().desc().listPage(0, 1);
+            assertThat(tasks).hasSize(1);
             HistoricTaskInstance task = tasks.get(0);
             Map<String, Object> variableMap = task.getTaskLocalVariables();
-            assertEquals(2, variableMap.size());
-            assertEquals("someVariable", variableMap.get("testVar"));
-            assertEquals(123, variableMap.get("testVar2"));
+            assertThat(variableMap).hasSize(2);
+            assertThat(variableMap.get("testVar")).isEqualTo("someVariable");
+            assertThat(variableMap.get("testVar2")).isEqualTo(123);
 
-            tasks = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().includeTaskLocalVariables().orderByTaskPriority().asc().listPage(1, 2);
-            assertEquals(2, tasks.size());
+            tasks = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().includeTaskLocalVariables().orderByTaskPriority().asc()
+                    .listPage(1, 2);
+            assertThat(tasks).hasSize(2);
             task = tasks.get(1);
             variableMap = task.getTaskLocalVariables();
-            assertEquals(2, variableMap.size());
-            assertEquals("someVariable", variableMap.get("testVar"));
-            assertEquals(123, variableMap.get("testVar2"));
+            assertThat(variableMap).hasSize(2);
+            assertThat(variableMap.get("testVar")).isEqualTo("someVariable");
+            assertThat(variableMap.get("testVar2")).isEqualTo(123);
 
-            tasks = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().includeTaskLocalVariables().orderByTaskPriority().asc().listPage(2, 4);
-            assertEquals(1, tasks.size());
+            tasks = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().includeTaskLocalVariables().orderByTaskPriority().asc()
+                    .listPage(2, 4);
+            assertThat(tasks).hasSize(1);
             task = tasks.get(0);
             variableMap = task.getTaskLocalVariables();
-            assertEquals(2, variableMap.size());
-            assertEquals("someVariable", variableMap.get("testVar"));
-            assertEquals(123, variableMap.get("testVar2"));
+            assertThat(variableMap).hasSize(2);
+            assertThat(variableMap.get("testVar")).isEqualTo("someVariable");
+            assertThat(variableMap.get("testVar2")).isEqualTo(123);
 
-            tasks = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().includeTaskLocalVariables().orderByTaskPriority().asc().listPage(4, 2);
-            assertEquals(0, tasks.size());
+            tasks = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().includeTaskLocalVariables().orderByTaskPriority().asc()
+                    .listPage(4, 2);
+            assertThat(tasks).isEmpty();
         }
     }
 
     @Test
     public void testQueryWithPagingVariablesAndIdentityLinks() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-            
-            List<HistoricTaskInstance> tasks = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().includeTaskLocalVariables().includeIdentityLinks().orderByTaskPriority().desc().listPage(0, 1);
-            assertEquals(1, tasks.size());
+
+            List<HistoricTaskInstance> tasks = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().includeTaskLocalVariables()
+                    .includeIdentityLinks().orderByTaskPriority().desc().listPage(0, 1);
+            assertThat(tasks).hasSize(1);
             HistoricTaskInstance task = tasks.get(0);
             Map<String, Object> variableMap = task.getTaskLocalVariables();
-            assertEquals(2, variableMap.size());
-            assertEquals("someVariable", variableMap.get("testVar"));
-            assertEquals(123, variableMap.get("testVar2"));
-            assertEquals(1, task.getIdentityLinks().size());
+            assertThat(variableMap).hasSize(2);
+            assertThat(variableMap.get("testVar")).isEqualTo("someVariable");
+            assertThat(variableMap.get("testVar2")).isEqualTo(123);
+            assertThat(task.getIdentityLinks()).hasSize(1);
             IdentityLinkInfo identityLink = task.getIdentityLinks().get(0);
-            assertNull(identityLink.getProcessInstanceId());
-            assertEquals("assignee", identityLink.getType());
-            assertNull(identityLink.getGroupId());
-            assertEquals("gonzo", identityLink.getUserId());
-            assertEquals(task.getId(), identityLink.getTaskId());
+            assertThat(identityLink.getProcessInstanceId()).isNull();
+            assertThat(identityLink.getType()).isEqualTo("assignee");
+            assertThat(identityLink.getGroupId()).isNull();
+            assertThat(identityLink.getUserId()).isEqualTo("gonzo");
+            assertThat(identityLink.getTaskId()).isEqualTo(task.getId());
 
-            tasks = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().includeTaskLocalVariables().includeIdentityLinks().orderByTaskPriority().asc().listPage(1, 2);
-            assertEquals(2, tasks.size());
+            tasks = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().includeTaskLocalVariables().includeIdentityLinks()
+                    .orderByTaskPriority().asc().listPage(1, 2);
+            assertThat(tasks).hasSize(2);
             task = tasks.get(1);
             variableMap = task.getTaskLocalVariables();
-            assertEquals(2, variableMap.size());
-            assertEquals("someVariable", variableMap.get("testVar"));
-            assertEquals(123, variableMap.get("testVar2"));
-            assertEquals(1, task.getIdentityLinks().size());
+            assertThat(variableMap).hasSize(2);
+            assertThat(variableMap.get("testVar")).isEqualTo("someVariable");
+            assertThat(variableMap.get("testVar2")).isEqualTo(123);
+            assertThat(task.getIdentityLinks()).hasSize(1);
             identityLink = task.getIdentityLinks().get(0);
-            assertNull(identityLink.getProcessInstanceId());
-            assertEquals("assignee", identityLink.getType());
-            assertNull(identityLink.getGroupId());
-            assertEquals("gonzo", identityLink.getUserId());
-            assertEquals(task.getId(), identityLink.getTaskId());
+            assertThat(identityLink.getProcessInstanceId()).isNull();
+            assertThat(identityLink.getType()).isEqualTo("assignee");
+            assertThat(identityLink.getGroupId()).isNull();
+            assertThat(identityLink.getUserId()).isEqualTo("gonzo");
+            assertThat(identityLink.getTaskId()).isEqualTo(task.getId());
 
-            tasks = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().includeTaskLocalVariables().includeIdentityLinks().orderByTaskPriority().asc().listPage(2, 4);
-            assertEquals(1, tasks.size());
+            tasks = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().includeTaskLocalVariables().includeIdentityLinks()
+                    .orderByTaskPriority().asc().listPage(2, 4);
+            assertThat(tasks).hasSize(1);
             task = tasks.get(0);
             variableMap = task.getTaskLocalVariables();
-            assertEquals(2, variableMap.size());
-            assertEquals("someVariable", variableMap.get("testVar"));
-            assertEquals(123, variableMap.get("testVar2"));
-            assertEquals(1, task.getIdentityLinks().size());
+            assertThat(variableMap).hasSize(2);
+            assertThat(variableMap.get("testVar")).isEqualTo("someVariable");
+            assertThat(variableMap.get("testVar2")).isEqualTo(123);
+            assertThat(task.getIdentityLinks()).hasSize(1);
             identityLink = task.getIdentityLinks().get(0);
-            assertNull(identityLink.getProcessInstanceId());
-            assertEquals("assignee", identityLink.getType());
-            assertNull(identityLink.getGroupId());
-            assertEquals("gonzo", identityLink.getUserId());
-            assertEquals(task.getId(), identityLink.getTaskId());
+            assertThat(identityLink.getProcessInstanceId()).isNull();
+            assertThat(identityLink.getType()).isEqualTo("assignee");
+            assertThat(identityLink.getGroupId()).isNull();
+            assertThat(identityLink.getUserId()).isEqualTo("gonzo");
+            assertThat(identityLink.getTaskId()).isEqualTo(task.getId());
 
-            tasks = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().includeTaskLocalVariables().includeIdentityLinks().orderByTaskPriority().asc().listPage(4, 2);
-            assertEquals(0, tasks.size());
+            tasks = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().includeTaskLocalVariables().includeIdentityLinks()
+                    .orderByTaskPriority().asc().listPage(4, 2);
+            assertThat(tasks).isEmpty();
         }
     }
-    
+
     @Test
     @Deployment(resources = { "org/flowable/engine/test/api/history/HistoricTaskAndVariablesQueryTest.testCandidate.bpmn20.xml" })
     public void testQueryVariableExists() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             HistoricTaskInstance task = historyService.createHistoricTaskInstanceQuery().taskVariableExists("testVar").singleResult();
-            assertNotNull(task);
-            
+            assertThat(task).isNotNull();
+
             List<HistoricTaskInstance> tasks = historyService.createHistoricTaskInstanceQuery().taskVariableNotExists("testVar").list();
-            assertEquals(2, tasks.size());
-            
+            assertThat(tasks).hasSize(2);
+
             tasks = historyService.createHistoricTaskInstanceQuery().or().taskVariableNotExists("testVar").processDefinitionId("unexisting").list();
-            assertEquals(2, tasks.size());
-            
+            assertThat(tasks).hasSize(2);
+
             tasks = historyService.createHistoricTaskInstanceQuery().or().taskVariableExists("testVar").processDefinitionId("unexisting").list();
-            assertEquals(1, tasks.size());
-            
-            tasks = historyService.createHistoricTaskInstanceQuery().or().taskVariableNotExists("testVar").endOr().or().processDefinitionId("unexisting").list();
-            assertEquals(0, tasks.size());
-            
+            assertThat(tasks).hasSize(1);
+
+            tasks = historyService.createHistoricTaskInstanceQuery().or().taskVariableNotExists("testVar").endOr().or().processDefinitionId("unexisting")
+                    .list();
+            assertThat(tasks).isEmpty();
+
             tasks = historyService.createHistoricTaskInstanceQuery().or().taskVariableExists("testVar").endOr().or().processDefinitionId("unexisting").list();
-            assertEquals(0, tasks.size());
-            
+            assertThat(tasks).isEmpty();
+
             Map<String, Object> varMap = Collections.singletonMap("processVar", (Object) "test");
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess", varMap);
-            
+
             waitForHistoryJobExecutorToProcessAllJobs(7000, 250);
-            
+
             tasks = historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId()).processVariableExists("processVar").list();
-            assertEquals(1, tasks.size());
-            
+            assertThat(tasks).hasSize(1);
+
             tasks = historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId()).processVariableNotExists("processVar").list();
-            assertEquals(0, tasks.size());
-            
+            assertThat(tasks).isEmpty();
+
             tasks = historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId())
-                            .or().processVariableExists("processVar").processDefinitionId("undexisting").endOr().list();
-            assertEquals(1, tasks.size());
-            
+                    .or().processVariableExists("processVar").processDefinitionId("undexisting").endOr().list();
+            assertThat(tasks).hasSize(1);
+
             tasks = historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId())
-                            .or().processVariableNotExists("processVar").processInstanceId(processInstance.getId()).endOr().list();
-            assertEquals(1, tasks.size());
-            
+                    .or().processVariableNotExists("processVar").processInstanceId(processInstance.getId()).endOr().list();
+            assertThat(tasks).hasSize(1);
+
             runtimeService.setVariable(processInstance.getId(), "processVar2", "test2");
-            
+
             waitForHistoryJobExecutorToProcessAllJobs(7000, 250);
-            
+
             tasks = historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId())
-                            .processVariableExists("processVar").processVariableValueEquals("processVar2", "test2").list();
-            assertEquals(1, tasks.size());
-            
+                    .processVariableExists("processVar").processVariableValueEquals("processVar2", "test2").list();
+            assertThat(tasks).hasSize(1);
+
             tasks = historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId())
-                            .processVariableNotExists("processVar").processVariableValueEquals("processVar2", "test2").list();
-            assertEquals(0, tasks.size());
-            
+                    .processVariableNotExists("processVar").processVariableValueEquals("processVar2", "test2").list();
+            assertThat(tasks).isEmpty();
+
             tasks = historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId())
-                            .or().processVariableExists("processVar").processVariableValueEquals("processVar2", "test2").endOr().list();
-            assertEquals(1, tasks.size());
-            
+                    .or().processVariableExists("processVar").processVariableValueEquals("processVar2", "test2").endOr().list();
+            assertThat(tasks).hasSize(1);
+
             tasks = historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId())
-                            .or().processVariableNotExists("processVar").processVariableValueEquals("processVar2", "test2").endOr().list();
-            assertEquals(1, tasks.size());
+                    .or().processVariableNotExists("processVar").processVariableValueEquals("processVar2", "test2").endOr().list();
+            assertThat(tasks).hasSize(1);
         }
     }
 
@@ -673,7 +698,7 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
     public void testQueryVariableExistsForCompletedTasks() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             taskService.createTaskQuery().list().forEach(
-                task -> taskService.complete(task.getId())
+                    task -> taskService.complete(task.getId())
             );
             testQueryVariableExists();
         }
@@ -684,32 +709,33 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
     public void testWithoutDueDateQuery() throws Exception {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
-            
+
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
-            
-            HistoricTaskInstance historicTask = historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId()).withoutTaskDueDate().singleResult();
-            assertNotNull(historicTask);
-            assertNull(historicTask.getDueDate());
+
+            HistoricTaskInstance historicTask = historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId()).withoutTaskDueDate()
+                    .singleResult();
+            assertThat(historicTask).isNotNull();
+            assertThat(historicTask.getDueDate()).isNull();
 
             // Set due-date on task
             org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
             Date dueDate = new SimpleDateFormat("dd/MM/yyyy hh:mm:ss").parse("01/02/2003 01:12:13");
             task.setDueDate(dueDate);
             taskService.saveTask(task);
-            
+
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
-            assertEquals(0, historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId()).withoutTaskDueDate().count());
+            assertThat(historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId()).withoutTaskDueDate().count()).isEqualTo(0);
 
             task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
 
             // Clear due-date on task
             task.setDueDate(null);
             taskService.saveTask(task);
-            
+
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
-            assertEquals(1, historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId()).withoutTaskDueDate().count());
+            assertThat(historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId()).withoutTaskDueDate().count()).isEqualTo(1);
         }
     }
 
@@ -718,20 +744,20 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
     public void testQueryWithIncludeTaskVariableAndTaskCategory() {
         List<HistoricTaskInstance> tasks = historyService.createHistoricTaskInstanceQuery().taskAssignee("gonzo").list();
         for (HistoricTaskInstance task : tasks) {
-            assertNotNull(task.getCategory());
-            assertEquals("testCategory", task.getCategory());
+            assertThat(task.getCategory()).isNotNull();
+            assertThat(task.getCategory()).isEqualTo("testCategory");
         }
 
         tasks = historyService.createHistoricTaskInstanceQuery().taskAssignee("gonzo").includeTaskLocalVariables().list();
         for (HistoricTaskInstance task : tasks) {
-            assertNotNull(task.getCategory());
-            assertEquals("testCategory", task.getCategory());
+            assertThat(task.getCategory()).isNotNull();
+            assertThat(task.getCategory()).isEqualTo("testCategory");
         }
 
         tasks = historyService.createHistoricTaskInstanceQuery().taskAssignee("gonzo").includeProcessVariables().list();
         for (HistoricTaskInstance task : tasks) {
-            assertNotNull(task.getCategory());
-            assertEquals("testCategory", task.getCategory());
+            assertThat(task.getCategory()).isNotNull();
+            assertThat(task.getCategory()).isEqualTo("testCategory");
         }
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoryLevelServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoryLevelServiceTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,6 +12,8 @@
  */
 
 package org.flowable.engine.test.api.history;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
@@ -33,224 +35,224 @@ import org.junit.jupiter.api.Test;
  */
 public class HistoryLevelServiceTest extends PluggableFlowableTestCase {
 
-  @Deployment(resources = { "org/flowable/engine/test/api/history/oneTaskHistoryLevelNoneProcess.bpmn20.xml" })
-  @Test
-  public void testNoneHistoryLevel() {
-    // With a clean ProcessEngine, no instances should be available
-    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
-    
-    HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
-    
-    assertTrue(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count() == 0);
+    @Deployment(resources = { "org/flowable/engine/test/api/history/oneTaskHistoryLevelNoneProcess.bpmn20.xml" })
+    @Test
+    public void testNoneHistoryLevel() {
+        // With a clean ProcessEngine, no instances should be available
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
-    // Complete the task and check if the size is count 1
-    Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-    assertNotNull(task);
-    taskService.claim(task.getId(), "test");
-    taskService.setOwner(task.getId(), "test");
-    taskService.setAssignee(task.getId(), "anotherTest");
-    taskService.setPriority(task.getId(), 40);
-    taskService.setDueDate(task.getId(), new Date());
-    taskService.setVariable(task.getId(), "var1", "test");
-    taskService.setVariableLocal(task.getId(), "localVar1", "test2");
-    taskService.complete(task.getId());
-    
-    HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
-    
-    assertTrue(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count() == 0);
-    assertTrue(historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId()).count() == 0);
-    assertTrue(historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstance.getId()).count() == 0);
-    assertTrue(historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).count() == 0);
-  }
-  
-  @Deployment(resources = { "org/flowable/engine/test/api/history/oneTaskHistoryLevelActivityProcess.bpmn20.xml" })
-  @Test
-  public void testActivityHistoryLevel() {
-    // With a clean ProcessEngine, no instances should be available
-    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
-    
-    HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
-    
-    assertTrue(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count() == 1);
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
-    // Complete the task and check if the size is count 1
-    Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-    assertNotNull(task);
-    
-    assertEquals(3, historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstance.getId()).count());
-    
-    taskService.claim(task.getId(), "test");
-    taskService.setOwner(task.getId(), "test");
-    taskService.setAssignee(task.getId(), "anotherTest");
-    taskService.setPriority(task.getId(), 40);
-    Date dueDateValue = new Date();
-    taskService.setDueDate(task.getId(), dueDateValue);
-    taskService.setVariable(task.getId(), "var1", "test");
-    taskService.setVariableLocal(task.getId(), "localVar1", "test2");
-    taskService.complete(task.getId());
-    
-    HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
-    
-    assertTrue(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count() == 1);
-    assertTrue(historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId()).count() == 0);
-    assertEquals(5, historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstance.getId()).count());
-    
-    assertEquals(2, historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).count());
-    
-    boolean hasProcessVariable = false;
-    boolean hasTaskVariable = false;
-    List<HistoricVariableInstance> variables = historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).list();
-    for (HistoricVariableInstance historicVariableInstance : variables) {
-      if ("var1".equals(historicVariableInstance.getVariableName())) {
-        hasProcessVariable = true;
-        assertEquals("test", historicVariableInstance.getValue());
-        assertEquals(processInstance.getProcessInstanceId(), historicVariableInstance.getProcessInstanceId());
-        assertNull(historicVariableInstance.getTaskId());
-      
-      } else if ("localVar1".equals(historicVariableInstance.getVariableName())) {
-        hasTaskVariable = true;
-        assertEquals("test2", historicVariableInstance.getValue());
-        assertEquals(processInstance.getProcessInstanceId(), historicVariableInstance.getProcessInstanceId());
-        assertEquals(task.getId(), historicVariableInstance.getTaskId());
-      }
+        assertThat(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0);
+
+        // Complete the task and check if the size is count 1
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task).isNotNull();
+        taskService.claim(task.getId(), "test");
+        taskService.setOwner(task.getId(), "test");
+        taskService.setAssignee(task.getId(), "anotherTest");
+        taskService.setPriority(task.getId(), 40);
+        taskService.setDueDate(task.getId(), new Date());
+        taskService.setVariable(task.getId(), "var1", "test");
+        taskService.setVariableLocal(task.getId(), "localVar1", "test2");
+        taskService.complete(task.getId());
+
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
+
+        assertThat(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0);
+        assertThat(historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0);
+        assertThat(historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0);
+        assertThat(historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0);
     }
-    
-    assertTrue(hasProcessVariable);
-    assertTrue(hasTaskVariable);
-    
-    assertEquals(0, historyService.createHistoricDetailQuery().processInstanceId(processInstance.getId()).count());
-  }
-  
-  @Deployment(resources = { "org/flowable/engine/test/api/history/oneTaskHistoryLevelAuditProcess.bpmn20.xml" })
-  @Test
-  public void testAuditHistoryLevel() {
-    // With a clean ProcessEngine, no instances should be available
-    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
-    
-    HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
-    
-    assertTrue(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count() == 1);
 
-    // Complete the task and check if the size is count 1
-    Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-    assertNotNull(task);
-    
-    assertEquals(3, historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstance.getId()).count());
-    
-    taskService.claim(task.getId(), "test");
-    taskService.setOwner(task.getId(), "test");
-    taskService.setAssignee(task.getId(), "anotherTest");
-    taskService.setPriority(task.getId(), 40);
-    Calendar dueDateCalendar = new GregorianCalendar();
-    taskService.setDueDate(task.getId(), dueDateCalendar.getTime());
-    taskService.setVariable(task.getId(), "var1", "test");
-    taskService.setVariableLocal(task.getId(), "localVar1", "test2");
-    taskService.complete(task.getId());
-    
-    HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
-    
-    assertTrue(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count() == 1);
-    assertTrue(historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId()).count() == 1);
-    assertEquals(5, historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstance.getId()).count());
-    
-    HistoricTaskInstance historicTask = historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId()).singleResult();
-    assertEquals("test", historicTask.getOwner());
-    assertEquals("anotherTest", historicTask.getAssignee());
-    assertEquals(40, historicTask.getPriority());
-    
-    SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-    assertEquals(simpleDateFormat.format(dueDateCalendar.getTime()), simpleDateFormat.format(historicTask.getDueDate()));
-    
-    assertEquals(2, historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).count());
-    
-    boolean hasProcessVariable = false;
-    boolean hasTaskVariable = false;
-    List<HistoricVariableInstance> variables = historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).list();
-    for (HistoricVariableInstance historicVariableInstance : variables) {
-      if ("var1".equals(historicVariableInstance.getVariableName())) {
-        hasProcessVariable = true;
-        assertEquals("test", historicVariableInstance.getValue());
-        assertEquals(processInstance.getProcessInstanceId(), historicVariableInstance.getProcessInstanceId());
-        assertNull(historicVariableInstance.getTaskId());
-      
-      } else if ("localVar1".equals(historicVariableInstance.getVariableName())) {
-        hasTaskVariable = true;
-        assertEquals("test2", historicVariableInstance.getValue());
-        assertEquals(processInstance.getProcessInstanceId(), historicVariableInstance.getProcessInstanceId());
-        assertEquals(task.getId(), historicVariableInstance.getTaskId());
-      }
-    }
-    
-    assertTrue(hasProcessVariable);
-    assertTrue(hasTaskVariable);
-    
-    assertEquals(0, historyService.createHistoricDetailQuery().processInstanceId(processInstance.getId()).count());
-  }
-  
-  @Deployment(resources = { "org/flowable/engine/test/api/history/oneTaskHistoryLevelFullProcess.bpmn20.xml" })
-  @Test
-  public void testFullHistoryLevel() {
-    // With a clean ProcessEngine, no instances should be available
-    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
-    
-    HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
-    
-    assertTrue(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count() == 1);
+    @Deployment(resources = { "org/flowable/engine/test/api/history/oneTaskHistoryLevelActivityProcess.bpmn20.xml" })
+    @Test
+    public void testActivityHistoryLevel() {
+        // With a clean ProcessEngine, no instances should be available
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
-    // Complete the task and check if the size is count 1
-    Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-    assertNotNull(task);
-    
-    assertEquals(3, historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstance.getId()).count());
-    
-    taskService.claim(task.getId(), "test");
-    taskService.setOwner(task.getId(), "test");
-    taskService.setAssignee(task.getId(), "anotherTest");
-    taskService.setPriority(task.getId(), 40);
-    Date dueDateValue = new Date();
-    taskService.setDueDate(task.getId(), dueDateValue);
-    taskService.setVariable(task.getId(), "var1", "test");
-    taskService.setVariableLocal(task.getId(), "localVar1", "test2");
-    taskService.complete(task.getId());
-    
-    HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
-    
-    assertTrue(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count() == 1);
-    assertTrue(historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId()).count() == 1);
-    assertEquals(5, historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstance.getId()).count());
-    
-    HistoricTaskInstance historicTask = historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId()).singleResult();
-    assertEquals("test", historicTask.getOwner());
-    assertEquals("anotherTest", historicTask.getAssignee());
-    assertEquals(40, historicTask.getPriority());
-    
-    SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-    assertEquals(simpleDateFormat.format(dueDateValue), simpleDateFormat.format(historicTask.getDueDate()));
-    
-    assertEquals(2, historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).count());
-    
-    boolean hasProcessVariable = false;
-    boolean hasTaskVariable = false;
-    List<HistoricVariableInstance> variables = historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).list();
-    for (HistoricVariableInstance historicVariableInstance : variables) {
-      if ("var1".equals(historicVariableInstance.getVariableName())) {
-        hasProcessVariable = true;
-        assertEquals("test", historicVariableInstance.getValue());
-        assertEquals(processInstance.getProcessInstanceId(), historicVariableInstance.getProcessInstanceId());
-        assertNull(historicVariableInstance.getTaskId());
-      
-      } else if ("localVar1".equals(historicVariableInstance.getVariableName())) {
-        hasTaskVariable = true;
-        assertEquals("test2", historicVariableInstance.getValue());
-        assertEquals(processInstance.getProcessInstanceId(), historicVariableInstance.getProcessInstanceId());
-        assertEquals(task.getId(), historicVariableInstance.getTaskId());
-      }
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
+
+        assertThat(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(1);
+
+        // Complete the task and check if the size is count 1
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task).isNotNull();
+
+        assertThat(historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
+
+        taskService.claim(task.getId(), "test");
+        taskService.setOwner(task.getId(), "test");
+        taskService.setAssignee(task.getId(), "anotherTest");
+        taskService.setPriority(task.getId(), 40);
+        Date dueDateValue = new Date();
+        taskService.setDueDate(task.getId(), dueDateValue);
+        taskService.setVariable(task.getId(), "var1", "test");
+        taskService.setVariableLocal(task.getId(), "localVar1", "test2");
+        taskService.complete(task.getId());
+
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
+
+        assertThat(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0);
+        assertThat(historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(5);
+
+        assertThat(historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(2);
+
+        boolean hasProcessVariable = false;
+        boolean hasTaskVariable = false;
+        List<HistoricVariableInstance> variables = historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).list();
+        for (HistoricVariableInstance historicVariableInstance : variables) {
+            if ("var1".equals(historicVariableInstance.getVariableName())) {
+                hasProcessVariable = true;
+                assertThat(historicVariableInstance.getValue()).isEqualTo("test");
+                assertThat(historicVariableInstance.getProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
+                assertThat(historicVariableInstance.getTaskId()).isNull();
+
+            } else if ("localVar1".equals(historicVariableInstance.getVariableName())) {
+                hasTaskVariable = true;
+                assertThat(historicVariableInstance.getValue()).isEqualTo("test2");
+                assertThat(historicVariableInstance.getProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
+                assertThat(historicVariableInstance.getTaskId()).isEqualTo(task.getId());
+            }
+        }
+
+        assertThat(hasProcessVariable).isTrue();
+        assertThat(hasTaskVariable).isTrue();
+
+        assertThat(historyService.createHistoricDetailQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0);
     }
-    
-    assertTrue(hasProcessVariable);
-    assertTrue(hasTaskVariable);
-    
-    assertEquals(2, historyService.createHistoricDetailQuery().processInstanceId(processInstance.getId()).count());
-  }
-  
+
+    @Deployment(resources = { "org/flowable/engine/test/api/history/oneTaskHistoryLevelAuditProcess.bpmn20.xml" })
+    @Test
+    public void testAuditHistoryLevel() {
+        // With a clean ProcessEngine, no instances should be available
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
+
+        assertThat(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(1);
+
+        // Complete the task and check if the size is count 1
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task).isNotNull();
+
+        assertThat(historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
+
+        taskService.claim(task.getId(), "test");
+        taskService.setOwner(task.getId(), "test");
+        taskService.setAssignee(task.getId(), "anotherTest");
+        taskService.setPriority(task.getId(), 40);
+        Calendar dueDateCalendar = new GregorianCalendar();
+        taskService.setDueDate(task.getId(), dueDateCalendar.getTime());
+        taskService.setVariable(task.getId(), "var1", "test");
+        taskService.setVariableLocal(task.getId(), "localVar1", "test2");
+        taskService.complete(task.getId());
+
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
+
+        assertThat(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(1);
+        assertThat(historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(5);
+
+        HistoricTaskInstance historicTask = historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(historicTask.getOwner()).isEqualTo("test");
+        assertThat(historicTask.getAssignee()).isEqualTo("anotherTest");
+        assertThat(historicTask.getPriority()).isEqualTo(40);
+
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        assertThat(simpleDateFormat.format(historicTask.getDueDate())).isEqualTo(simpleDateFormat.format(dueDateCalendar.getTime()));
+
+        assertThat(historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(2);
+
+        boolean hasProcessVariable = false;
+        boolean hasTaskVariable = false;
+        List<HistoricVariableInstance> variables = historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).list();
+        for (HistoricVariableInstance historicVariableInstance : variables) {
+            if ("var1".equals(historicVariableInstance.getVariableName())) {
+                hasProcessVariable = true;
+                assertThat(historicVariableInstance.getValue()).isEqualTo("test");
+                assertThat(historicVariableInstance.getProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
+                assertThat(historicVariableInstance.getTaskId()).isNull();
+
+            } else if ("localVar1".equals(historicVariableInstance.getVariableName())) {
+                hasTaskVariable = true;
+                assertThat(historicVariableInstance.getValue()).isEqualTo("test2");
+                assertThat(historicVariableInstance.getProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
+                assertThat(historicVariableInstance.getTaskId()).isEqualTo(task.getId());
+            }
+        }
+
+        assertThat(hasProcessVariable).isTrue();
+        assertThat(hasTaskVariable).isTrue();
+
+        assertThat(historyService.createHistoricDetailQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0);
+    }
+
+    @Deployment(resources = { "org/flowable/engine/test/api/history/oneTaskHistoryLevelFullProcess.bpmn20.xml" })
+    @Test
+    public void testFullHistoryLevel() {
+        // With a clean ProcessEngine, no instances should be available
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
+
+        assertThat(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(1);
+
+        // Complete the task and check if the size is count 1
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task).isNotNull();
+
+        assertThat(historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
+
+        taskService.claim(task.getId(), "test");
+        taskService.setOwner(task.getId(), "test");
+        taskService.setAssignee(task.getId(), "anotherTest");
+        taskService.setPriority(task.getId(), 40);
+        Date dueDateValue = new Date();
+        taskService.setDueDate(task.getId(), dueDateValue);
+        taskService.setVariable(task.getId(), "var1", "test");
+        taskService.setVariableLocal(task.getId(), "localVar1", "test2");
+        taskService.complete(task.getId());
+
+        HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
+
+        assertThat(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(1);
+        assertThat(historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(5);
+
+        HistoricTaskInstance historicTask = historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(historicTask.getOwner()).isEqualTo("test");
+        assertThat(historicTask.getAssignee()).isEqualTo("anotherTest");
+        assertThat(historicTask.getPriority()).isEqualTo(40);
+
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        assertThat(simpleDateFormat.format(historicTask.getDueDate())).isEqualTo(simpleDateFormat.format(dueDateValue));
+
+        assertThat(historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(2);
+
+        boolean hasProcessVariable = false;
+        boolean hasTaskVariable = false;
+        List<HistoricVariableInstance> variables = historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).list();
+        for (HistoricVariableInstance historicVariableInstance : variables) {
+            if ("var1".equals(historicVariableInstance.getVariableName())) {
+                hasProcessVariable = true;
+                assertThat(historicVariableInstance.getValue()).isEqualTo("test");
+                assertThat(historicVariableInstance.getProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
+                assertThat(historicVariableInstance.getTaskId()).isNull();
+
+            } else if ("localVar1".equals(historicVariableInstance.getVariableName())) {
+                hasTaskVariable = true;
+                assertThat(historicVariableInstance.getValue()).isEqualTo("test2");
+                assertThat(historicVariableInstance.getProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
+                assertThat(historicVariableInstance.getTaskId()).isEqualTo(task.getId());
+            }
+        }
+
+        assertThat(hasProcessVariable).isTrue();
+        assertThat(hasTaskVariable).isTrue();
+
+        assertThat(historyService.createHistoricDetailQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(2);
+    }
+
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoryServiceDisableTaskLogTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoryServiceDisableTaskLogTest.java
@@ -48,8 +48,8 @@ public class HistoryServiceDisableTaskLogTest extends CustomConfigurationFlowabl
     @Test
     public void createTaskEvent() {
         task = taskService.createTaskBuilder().
-            assignee("testAssignee").
-            create();
+                assignee("testAssignee").
+                create();
     }
 
     @Test
@@ -58,8 +58,8 @@ public class HistoryServiceDisableTaskLogTest extends CustomConfigurationFlowabl
         Authentication.setAuthenticatedUserId("testUser");
         try {
             task = taskService.createTaskBuilder().
-                assignee("testAssignee").
-                create();
+                    assignee("testAssignee").
+                    create();
         } finally {
             Authentication.setAuthenticatedUserId(previousUserId);
         }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoryServiceTaskLogTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoryServiceTaskLogTest.java
@@ -13,9 +13,6 @@
 package org.flowable.engine.test.api.history;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
@@ -49,7 +46,6 @@ import org.flowable.task.api.history.HistoricTaskLogEntryQuery;
 import org.flowable.task.service.impl.HistoricTaskLogEntryQueryImpl;
 import org.flowable.task.service.impl.persistence.entity.HistoricTaskLogEntryEntity;
 import org.flowable.task.service.impl.persistence.entity.HistoricTaskLogEntryEntityManager;
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -70,14 +66,17 @@ public class HistoryServiceTaskLogTest {
         }
     }
 
-    protected void deleteTaskWithLogEntries(TaskService taskService, ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration, String taskId) {
+    protected void deleteTaskWithLogEntries(TaskService taskService, ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration,
+            String taskId) {
         taskService.deleteTask(taskId, true);
         managementService.executeCommand(new Command<Void>() {
 
             @Override
             public Void execute(CommandContext commandContext) {
-                HistoricTaskLogEntryEntityManager historicTaskLogEntryEntityManager = CommandContextUtil.getTaskServiceConfiguration(commandContext).getHistoricTaskLogEntryEntityManager();
-                List<HistoricTaskLogEntry> taskLogEntries = historicTaskLogEntryEntityManager.findHistoricTaskLogEntriesByQueryCriteria(new HistoricTaskLogEntryQueryImpl(processEngineConfiguration.getCommandExecutor()));
+                HistoricTaskLogEntryEntityManager historicTaskLogEntryEntityManager = CommandContextUtil.getTaskServiceConfiguration(commandContext)
+                        .getHistoricTaskLogEntryEntityManager();
+                List<HistoricTaskLogEntry> taskLogEntries = historicTaskLogEntryEntityManager
+                        .findHistoricTaskLogEntriesByQueryCriteria(new HistoricTaskLogEntryQueryImpl(processEngineConfiguration.getCommandExecutor()));
                 for (HistoricTaskLogEntry historicTaskLogEntry : taskLogEntries) {
                     historicTaskLogEntryEntityManager.deleteHistoricTaskLogEntry(historicTaskLogEntry.getLogNumber());
                 }
@@ -102,16 +101,20 @@ public class HistoryServiceTaskLogTest {
         try {
             if (HistoryTestHelper.isHistoricTaskLoggingEnabled(processEngineConfiguration)) {
                 List<HistoricTaskLogEntry> taskLogsByTaskInstanceId = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
-                assertThat(taskLogsByTaskInstanceId).size().isEqualTo(1);
+                assertThat(taskLogsByTaskInstanceId).hasSize(1);
 
                 assertThat(taskLogsByTaskInstanceId.get(0)).
-                        extracting(HistoricTaskLogEntry::getTaskId).isEqualTo(task.getId());
+                        extracting(HistoricTaskLogEntry::getTaskId)
+                        .isEqualTo(task.getId());
                 assertThat(taskLogsByTaskInstanceId.get(0)).
-                        extracting(HistoricTaskLogEntry::getType).isEqualTo("USER_TASK_CREATED");
+                        extracting(HistoricTaskLogEntry::getType)
+                        .isEqualTo("USER_TASK_CREATED");
                 assertThat(taskLogsByTaskInstanceId.get(0)).
-                        extracting(HistoricTaskLogEntry::getTimeStamp).isNotNull();
+                        extracting(HistoricTaskLogEntry::getTimeStamp)
+                        .isNotNull();
                 assertThat(taskLogsByTaskInstanceId.get(0)).
-                        extracting(HistoricTaskLogEntry::getUserId).isNull();
+                        extracting(HistoricTaskLogEntry::getUserId)
+                        .isNull();
             }
 
         } finally {
@@ -120,7 +123,8 @@ public class HistoryServiceTaskLogTest {
     }
 
     @Test
-    public void createTaskEventAsAuthenticatedUser(TaskService taskService, HistoryService historyService, ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
+    public void createTaskEventAsAuthenticatedUser(TaskService taskService, HistoryService historyService, ManagementService managementService,
+            ProcessEngineConfiguration processEngineConfiguration) {
         String previousUserId = Authentication.getAuthenticatedUserId();
         Authentication.setAuthenticatedUserId("testUser");
         try {
@@ -130,10 +134,11 @@ public class HistoryServiceTaskLogTest {
 
             if (HistoryTestHelper.isHistoricTaskLoggingEnabled(processEngineConfiguration)) {
                 List<HistoricTaskLogEntry> taskLogsByTaskInstanceId = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
-                assertThat(taskLogsByTaskInstanceId).size().isEqualTo(1);
+                assertThat(taskLogsByTaskInstanceId).hasSize(1);
 
                 assertThat(taskLogsByTaskInstanceId.get(0)).
-                        extracting(HistoricTaskLogEntry::getUserId).isEqualTo("testUser");
+                        extracting(HistoricTaskLogEntry::getUserId)
+                        .isEqualTo("testUser");
             }
 
         } finally {
@@ -152,7 +157,7 @@ public class HistoryServiceTaskLogTest {
 
     @Test
     public void queryForNullTaskLogEntries_returnsAll(TaskService taskService, HistoryService historyService,
-                                                      ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
+            ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
 
         Task taskA = taskService.createTaskBuilder().create();
         Task taskB = taskService.createTaskBuilder().create();
@@ -161,7 +166,7 @@ public class HistoryServiceTaskLogTest {
         try {
             if (HistoryTestHelper.isHistoricTaskLoggingEnabled(processEngineConfiguration)) {
                 List<HistoricTaskLogEntry> taskLogsByTaskInstanceId = historyService.createHistoricTaskLogEntryQuery().taskId(null).list();
-                assertThat(taskLogsByTaskInstanceId).size().isEqualTo(3L);
+                assertThat(taskLogsByTaskInstanceId).hasSize(3);
             }
 
         } finally {
@@ -172,14 +177,15 @@ public class HistoryServiceTaskLogTest {
     }
 
     @Test
-    public void deleteTaskEventLogEntry(TaskService taskService, HistoryService historyService, ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
+    public void deleteTaskEventLogEntry(TaskService taskService, HistoryService historyService, ManagementService managementService,
+            ProcessEngineConfiguration processEngineConfiguration) {
         task = taskService.createTaskBuilder().
                 assignee("testAssignee").
                 create();
 
         if (HistoryTestHelper.isHistoricTaskLoggingEnabled(processEngineConfiguration)) {
             List<HistoricTaskLogEntry> taskLogsByTaskInstanceId = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
-            assertThat(taskLogsByTaskInstanceId).size().isEqualTo(1);
+            assertThat(taskLogsByTaskInstanceId).hasSize(1);
 
             historyService.deleteHistoricTaskLogEntry(taskLogsByTaskInstanceId.get(0).getLogNumber());
 
@@ -190,14 +196,15 @@ public class HistoryServiceTaskLogTest {
     }
 
     @Test
-    public void deleteNonExistingTaskEventLogEntry(TaskService taskService, HistoryService historyService, ProcessEngineConfiguration processEngineConfiguration) {
+    public void deleteNonExistingTaskEventLogEntry(TaskService taskService, HistoryService historyService,
+            ProcessEngineConfiguration processEngineConfiguration) {
         task = taskService.createTaskBuilder().create();
 
         if (HistoryTestHelper.isHistoricTaskLoggingEnabled(processEngineConfiguration)) {
             // non existing log entry delete should be successful
             historyService.deleteHistoricTaskLogEntry(Long.MIN_VALUE);
 
-            assertThat(historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list().size()).isEqualTo(1);
+            assertThat(historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list()).hasSize(1);
         }
     }
 
@@ -211,10 +218,10 @@ public class HistoryServiceTaskLogTest {
 
         if (HistoryTestHelper.isHistoricTaskLoggingEnabled(processEngineConfiguration)) {
             List<HistoricTaskLogEntry> taskLogEntries = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
-            assertThat(taskLogEntries).size().isEqualTo(2);
+            assertThat(taskLogEntries).hasSize(2);
 
             taskLogEntries = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type("USER_TASK_ASSIGNEE_CHANGED").list();
-            assertThat(taskLogEntries).size().isEqualTo(1);
+            assertThat(taskLogEntries).hasSize(1);
             assertThat(taskLogEntries.get(0).getData()).contains("\"newAssigneeId\":\"newAssignee\"", "\"previousAssigneeId\":\"initialAssignee\"");
             assertThat(taskLogEntries.get(0)).extracting(HistoricTaskLogEntry::getTimeStamp).isNotNull();
             assertThat(taskLogEntries.get(0)).extracting(HistoricTaskLogEntry::getTaskId).isEqualTo(task.getId());
@@ -224,12 +231,14 @@ public class HistoryServiceTaskLogTest {
     }
 
     @Test
-    public void changeAssigneeTaskEventAsAuthenticatedUser(TaskService taskService, HistoryService historyService, ProcessEngineConfiguration processEngineConfiguration) {
+    public void changeAssigneeTaskEventAsAuthenticatedUser(TaskService taskService, HistoryService historyService,
+            ProcessEngineConfiguration processEngineConfiguration) {
         assertThatAuthenticatedUserIsSet(taskService, historyService, taskId -> taskService.setAssignee(taskId, "newAssignee"), processEngineConfiguration);
     }
 
     @Test
-    public void taskOwnerEvent(TaskService taskService, HistoryService historyService, ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
+    public void taskOwnerEvent(TaskService taskService, HistoryService historyService, ManagementService managementService,
+            ProcessEngineConfiguration processEngineConfiguration) {
         task = taskService.createTaskBuilder().
                 assignee("initialAssignee").
                 create();
@@ -238,10 +247,10 @@ public class HistoryServiceTaskLogTest {
 
         if (HistoryTestHelper.isHistoricTaskLoggingEnabled(processEngineConfiguration)) {
             List<HistoricTaskLogEntry> taskLogEntries = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
-            assertThat(taskLogEntries).size().isEqualTo(2);
+            assertThat(taskLogEntries).hasSize(2);
 
             taskLogEntries = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type("USER_TASK_OWNER_CHANGED").list();
-            assertThat(taskLogEntries).size().isEqualTo(1);
+            assertThat(taskLogEntries).hasSize(1);
             assertThat(taskLogEntries.get(0).getData()).
                     contains("\"previousOwnerId\":null", "\"newOwnerId\":\"newOwner\"");
             assertThat(taskLogEntries.get(0)).extracting(HistoricTaskLogEntry::getTimeStamp).isNotNull();
@@ -252,22 +261,24 @@ public class HistoryServiceTaskLogTest {
     }
 
     @Test
-    public void changeOwnerTaskEventAsAuthenticatedUser(TaskService taskService, HistoryService historyService, ProcessEngineConfiguration processEngineConfiguration) {
+    public void changeOwnerTaskEventAsAuthenticatedUser(TaskService taskService, HistoryService historyService,
+            ProcessEngineConfiguration processEngineConfiguration) {
         assertThatAuthenticatedUserIsSet(taskService, historyService, taskId -> taskService.setOwner(taskId, "newOwner"), processEngineConfiguration);
     }
 
     @Test
-    public void claimTaskEvent(TaskService taskService, HistoryService historyService, ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
+    public void claimTaskEvent(TaskService taskService, HistoryService historyService, ManagementService managementService,
+            ProcessEngineConfiguration processEngineConfiguration) {
         task = taskService.createTaskBuilder().create();
 
         taskService.claim(task.getId(), "testUser");
 
         if (HistoryTestHelper.isHistoricTaskLoggingEnabled(processEngineConfiguration)) {
             List<HistoricTaskLogEntry> taskLogEntries = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
-            assertThat(taskLogEntries).size().isEqualTo(2);
+            assertThat(taskLogEntries).hasSize(2);
 
             taskLogEntries = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type("USER_TASK_ASSIGNEE_CHANGED").list();
-            assertThat(taskLogEntries).size().isEqualTo(1);
+            assertThat(taskLogEntries).hasSize(1);
             assertThat(taskLogEntries.get(0).getData()).contains("\"newAssigneeId\":\"testUser\"", "\"previousAssigneeId\":null");
             assertThat(taskLogEntries.get(0)).extracting(HistoricTaskLogEntry::getTimeStamp).isNotNull();
             assertThat(taskLogEntries.get(0)).extracting(HistoricTaskLogEntry::getTaskId).isEqualTo(task.getId());
@@ -286,10 +297,10 @@ public class HistoryServiceTaskLogTest {
 
         if (HistoryTestHelper.isHistoricTaskLoggingEnabled(processEngineConfiguration)) {
             List<HistoricTaskLogEntry> taskLogEntries = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
-            assertThat(taskLogEntries).size().isEqualTo(2);
+            assertThat(taskLogEntries).hasSize(2);
 
             taskLogEntries = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type("USER_TASK_ASSIGNEE_CHANGED").list();
-            assertThat(taskLogEntries).size().isEqualTo(1);
+            assertThat(taskLogEntries).hasSize(1);
             assertThat(taskLogEntries.get(0).getData()).
                     contains("\"newAssigneeId\":null", "\"previousAssigneeId\":\"initialAssignee\"");
             assertThat(taskLogEntries.get(0)).extracting(HistoricTaskLogEntry::getTimeStamp).isNotNull();
@@ -306,10 +317,10 @@ public class HistoryServiceTaskLogTest {
 
         if (HistoryTestHelper.isHistoricTaskLoggingEnabled(processEngineConfiguration)) {
             List<HistoricTaskLogEntry> taskLogEntries = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
-            assertThat(taskLogEntries).size().isEqualTo(2);
+            assertThat(taskLogEntries).hasSize(2);
 
             taskLogEntries = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type("USER_TASK_PRIORITY_CHANGED").list();
-            assertThat(taskLogEntries).size().isEqualTo(1);
+            assertThat(taskLogEntries).hasSize(1);
             assertThat(taskLogEntries.get(0).getData()).
                     contains("\"newPriority\":2147483647", "\"previousPriority\":50}");
             assertThat(taskLogEntries.get(0)).extracting(HistoricTaskLogEntry::getTimeStamp).isNotNull();
@@ -320,12 +331,13 @@ public class HistoryServiceTaskLogTest {
     }
 
     @Test
-    public void changePriorityEventAsAuthenticatedUser(TaskService taskService, HistoryService historyService, ProcessEngineConfiguration processEngineConfiguration) {
+    public void changePriorityEventAsAuthenticatedUser(TaskService taskService, HistoryService historyService,
+            ProcessEngineConfiguration processEngineConfiguration) {
         assertThatAuthenticatedUserIsSet(taskService, historyService, taskId -> taskService.setPriority(taskId, Integer.MAX_VALUE), processEngineConfiguration);
     }
 
     protected void assertThatAuthenticatedUserIsSet(TaskService taskService, HistoryService historyService,
-                                                    Consumer<String> functionToAssert, ProcessEngineConfiguration processEngineConfiguration) {
+            Consumer<String> functionToAssert, ProcessEngineConfiguration processEngineConfiguration) {
 
         String previousUserId = Authentication.getAuthenticatedUserId();
         task = taskService.createTaskBuilder().
@@ -338,10 +350,10 @@ public class HistoryServiceTaskLogTest {
 
             if (HistoryTestHelper.isHistoricTaskLoggingEnabled(processEngineConfiguration)) {
                 List<HistoricTaskLogEntry> taskLogsByTaskInstanceId = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
-                assertThat(taskLogsByTaskInstanceId).size().isEqualTo(2);
+                assertThat(taskLogsByTaskInstanceId).hasSize(2);
 
                 taskLogsByTaskInstanceId = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).userId("testUser").list();
-                assertThat(taskLogsByTaskInstanceId).size().isEqualTo(1);
+                assertThat(taskLogsByTaskInstanceId).hasSize(1);
             }
 
         } finally {
@@ -350,17 +362,18 @@ public class HistoryServiceTaskLogTest {
     }
 
     @Test
-    public void changeDueDate(TaskService taskService, HistoryService historyService, ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
+    public void changeDueDate(TaskService taskService, HistoryService historyService, ManagementService managementService,
+            ProcessEngineConfiguration processEngineConfiguration) {
         task = taskService.createTaskBuilder().create();
 
         taskService.setDueDate(task.getId(), new Date());
 
         if (HistoryTestHelper.isHistoricTaskLoggingEnabled(processEngineConfiguration)) {
             List<HistoricTaskLogEntry> taskLogEntries = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
-            assertThat(taskLogEntries).size().isEqualTo(2);
+            assertThat(taskLogEntries).hasSize(2);
 
             taskLogEntries = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type("USER_TASK_DUEDATE_CHANGED").list();
-            assertThat(taskLogEntries).size().isEqualTo(1);
+            assertThat(taskLogEntries).hasSize(1);
             assertThat(taskLogEntries.get(0).getData()).contains("\"newDueDate\"", "\"previousDueDate\":null}");
             assertThat(taskLogEntries.get(0)).extracting(HistoricTaskLogEntry::getTimeStamp).isNotNull();
             assertThat(taskLogEntries.get(0)).extracting(HistoricTaskLogEntry::getTaskId).isEqualTo(task.getId());
@@ -383,17 +396,19 @@ public class HistoryServiceTaskLogTest {
 
         if (HistoryTestHelper.isHistoricTaskLoggingEnabled(configuration)) {
             List<HistoricTaskLogEntry> taskLogEntries = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
-            assertThat(taskLogEntries).as("The only event is user task created").size().isEqualTo(1);
+            assertThat(taskLogEntries).as("The only event is user task created").hasSize(1);
         }
     }
 
     @Test
-    public void changeDueDateEventAsAuthenticatedUser(TaskService taskService, HistoryService historyService, ProcessEngineConfiguration processEngineConfiguration) {
+    public void changeDueDateEventAsAuthenticatedUser(TaskService taskService, HistoryService historyService,
+            ProcessEngineConfiguration processEngineConfiguration) {
         assertThatAuthenticatedUserIsSet(taskService, historyService, taskId -> taskService.setDueDate(taskId, new Date()), processEngineConfiguration);
     }
 
     @Test
-    public void createCustomTaskEventLog(TaskService taskService, HistoryService historyService, ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
+    public void createCustomTaskEventLog(TaskService taskService, HistoryService historyService, ManagementService managementService,
+            ProcessEngineConfiguration processEngineConfiguration) {
         task = taskService.createTaskBuilder().create();
 
         Date todayDate = new Date();
@@ -406,10 +421,10 @@ public class HistoryServiceTaskLogTest {
 
         if (HistoryTestHelper.isHistoricTaskLoggingEnabled(processEngineConfiguration)) {
             List<HistoricTaskLogEntry> logEntries = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
-            assertThat(logEntries.size()).isEqualTo(2);
+            assertThat(logEntries).hasSize(2);
 
             logEntries = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type("customType").list();
-            assertThat(logEntries).size().isEqualTo(1);
+            assertThat(logEntries).hasSize(1);
             HistoricTaskLogEntry historicTaskLogEntry = logEntries.get(0);
             assertThat(historicTaskLogEntry.getLogNumber()).isNotNull();
             assertThat(historicTaskLogEntry.getUserId()).isEqualTo("testUser");
@@ -422,7 +437,8 @@ public class HistoryServiceTaskLogTest {
     }
 
     @Test
-    public void createCustomTaskEventLog_taskIdIsEnoughToCreateTaskLogEntry(TaskService taskService, HistoryService historyService, ProcessEngineConfiguration processEngineConfiguration) {
+    public void createCustomTaskEventLog_taskIdIsEnoughToCreateTaskLogEntry(TaskService taskService, HistoryService historyService,
+            ProcessEngineConfiguration processEngineConfiguration) {
         task = taskService.createTaskBuilder().create();
 
         HistoricTaskLogEntryBuilder historicTaskLogEntryBuilder = historyService.createHistoricTaskLogEntryBuilder(task);
@@ -431,7 +447,7 @@ public class HistoryServiceTaskLogTest {
         if (HistoryTestHelper.isHistoricTaskLoggingEnabled(processEngineConfiguration)) {
             List<HistoricTaskLogEntry> logEntries = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
 
-            assertThat(logEntries.size()).isEqualTo(2);
+            assertThat(logEntries).hasSize(2);
             HistoricTaskLogEntry historicTaskLogEntry = logEntries.get(1);
             assertThat(historicTaskLogEntry.getLogNumber()).isNotNull();
             assertThat(historicTaskLogEntry.getUserId()).isNull();
@@ -443,7 +459,8 @@ public class HistoryServiceTaskLogTest {
     }
 
     @Test
-    public void createCustomTaskEventLog_withoutTimeStamp_addsDefault(TaskService taskService, HistoryService historyService, ProcessEngineConfiguration processEngineConfiguration) {
+    public void createCustomTaskEventLog_withoutTimeStamp_addsDefault(TaskService taskService, HistoryService historyService,
+            ProcessEngineConfiguration processEngineConfiguration) {
         task = taskService.createTaskBuilder().create();
 
         HistoricTaskLogEntryBuilder historicTaskLogEntryBuilder = historyService.createHistoricTaskLogEntryBuilder(task);
@@ -455,7 +472,7 @@ public class HistoryServiceTaskLogTest {
         if (HistoryTestHelper.isHistoricTaskLoggingEnabled(processEngineConfiguration)) {
             List<HistoricTaskLogEntry> logEntries = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
 
-            MatcherAssert.assertThat(logEntries.size(), is(2));
+            assertThat(logEntries).hasSize(2);
             HistoricTaskLogEntry historicTaskLogEntry = logEntries.get(1);
             assertThat(historicTaskLogEntry.getLogNumber()).isNotNull();
             assertThat(historicTaskLogEntry.getTimeStamp()).isNotNull();
@@ -463,38 +480,38 @@ public class HistoryServiceTaskLogTest {
     }
 
     @Test
-    @Deployment(resources = {"org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
+    @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void logSuspensionStateEvents(RuntimeService runtimeService, TaskService taskService, HistoryService historyService,
-                                         ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
+            ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         try {
             runtimeService.suspendProcessInstanceById(processInstance.getId());
             org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-            assertNotNull(task);
+            assertThat(task).isNotNull();
 
             if (HistoryTestHelper.isHistoricTaskLoggingEnabled(processEngineConfiguration)) {
                 List<HistoricTaskLogEntry> logEntries = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId())
                         .type("USER_TASK_SUSPENSIONSTATE_CHANGED")
                         .list();
-                assertThat(logEntries).size().isEqualTo(1);
+                assertThat(logEntries).hasSize(1);
 
                 logEntries = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
-                assertThat(logEntries).size().isEqualTo(2);
+                assertThat(logEntries).hasSize(2);
             }
 
             runtimeService.activateProcessInstanceById(processInstance.getId());
 
             HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 10000, 200);
             List<HistoricTaskLogEntry> logEntries = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
-            assertThat(logEntries).size().isEqualTo(3);
+            assertThat(logEntries).hasSize(3);
 
             logEntries = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId())
                     .type("USER_TASK_SUSPENSIONSTATE_CHANGED")
                     .list();
-            assertThat(logEntries).size().isEqualTo(2);
+            assertThat(logEntries).hasSize(2);
 
         } finally {
             String taskId = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getId();
@@ -507,15 +524,15 @@ public class HistoryServiceTaskLogTest {
     }
 
     @Test
-    @Deployment(resources = {"org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
+    @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void logProcessTaskEvents(RuntimeService runtimeService, TaskService taskService, HistoryService historyService,
-                                     ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
+            ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         try {
             taskService.setAssignee(task.getId(), "newAssignee");
             taskService.setOwner(task.getId(), "newOwner");
@@ -523,10 +540,10 @@ public class HistoryServiceTaskLogTest {
 
             if (HistoryTestHelper.isHistoricTaskLoggingEnabled(processEngineConfiguration)) {
                 List<HistoricTaskLogEntry> logEntries = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
-                assertThat(logEntries).size().isEqualTo(4);
+                assertThat(logEntries).hasSize(4);
 
                 HistoricTaskLogEntry logEntry = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type("USER_TASK_CREATED").singleResult();
-                assertNotNull(logEntry);
+                assertThat(logEntry).isNotNull();
                 assertThat(logEntry.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
                 assertThat(logEntry.getExecutionId()).isEqualTo(task.getExecutionId());
                 assertThat(logEntry.getProcessInstanceId()).isEqualTo(processInstance.getId());
@@ -542,26 +559,26 @@ public class HistoryServiceTaskLogTest {
     }
 
     @Test
-    @Deployment(resources = {"org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
+    @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void logAddCandidateUser(RuntimeService runtimeService, TaskService taskService, HistoryService historyService,
-                                    ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
+            ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         try {
-            assertNotNull(processInstance);
-            assertNotNull(task);
+            assertThat(processInstance).isNotNull();
+            assertThat(task).isNotNull();
 
             taskService.addCandidateUser(task.getId(), "newCandidateUser");
 
             if (HistoryTestHelper.isHistoricTaskLoggingEnabled(processEngineConfiguration)) {
                 List<HistoricTaskLogEntry> logEntries = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
-                assertThat(logEntries).size().isEqualTo(2);
+                assertThat(logEntries).hasSize(2);
 
                 logEntries = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId())
                         .type("USER_TASK_IDENTITY_LINK_ADDED")
                         .list();
-                assertThat(logEntries).size().isEqualTo(1);
+                assertThat(logEntries).hasSize(1);
                 assertThat(logEntries.get(0).getData()).contains(
                         "\"type\":\"candidate\"",
                         "\"userId\":\"newCandidateUser\""
@@ -575,26 +592,26 @@ public class HistoryServiceTaskLogTest {
     }
 
     @Test
-    @Deployment(resources = {"org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
+    @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void logAddParticipantUser(RuntimeService runtimeService, TaskService taskService, HistoryService historyService,
-                                      ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
+            ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         try {
-            assertNotNull(processInstance);
-            assertNotNull(task);
+            assertThat(processInstance).isNotNull();
+            assertThat(task).isNotNull();
 
             taskService.addUserIdentityLink(task.getId(), "newCandidateUser", IdentityLinkType.PARTICIPANT);
 
             if (HistoryTestHelper.isHistoricTaskLoggingEnabled(processEngineConfiguration)) {
                 List<HistoricTaskLogEntry> logEntries = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
-                assertThat(logEntries).size().isEqualTo(2);
+                assertThat(logEntries).hasSize(2);
 
                 logEntries = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId())
                         .type("USER_TASK_IDENTITY_LINK_ADDED")
                         .list();
-                assertThat(logEntries).size().isEqualTo(1);
+                assertThat(logEntries).hasSize(1);
                 assertThat(logEntries.get(0).getData()).contains(
                         "\"type\":\"participant\"",
                         "\"userId\":\"newCandidateUser\""
@@ -608,26 +625,26 @@ public class HistoryServiceTaskLogTest {
     }
 
     @Test
-    @Deployment(resources = {"org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
+    @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void logAddCandidateGroup(RuntimeService runtimeService, TaskService taskService, HistoryService historyService,
-                                     ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
+            ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
 
         try {
             taskService.addCandidateGroup(task.getId(), "newCandidateGroup");
 
             if (HistoryTestHelper.isHistoricTaskLoggingEnabled(processEngineConfiguration)) {
                 List<HistoricTaskLogEntry> logEntries = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
-                assertThat(logEntries).size().isEqualTo(2);
+                assertThat(logEntries).hasSize(2);
 
                 logEntries = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId())
                         .type("USER_TASK_IDENTITY_LINK_ADDED")
                         .list();
-                assertThat(logEntries).size().isEqualTo(1);
+                assertThat(logEntries).hasSize(1);
                 assertThat(logEntries.get(0).getData()).contains(
                         "\"type\":\"candidate\"",
                         "\"groupId\":\"newCandidateGroup\""
@@ -641,26 +658,26 @@ public class HistoryServiceTaskLogTest {
     }
 
     @Test
-    @Deployment(resources = {"org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
+    @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void logAddGroup(RuntimeService runtimeService, TaskService taskService, HistoryService historyService,
-                            ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
+            ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         try {
 
             taskService.addGroupIdentityLink(task.getId(), "newCandidateGroup", IdentityLinkType.PARTICIPANT);
 
             if (HistoryTestHelper.isHistoricTaskLoggingEnabled(processEngineConfiguration)) {
                 List<HistoricTaskLogEntry> logEntries = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
-                assertThat(logEntries).size().isEqualTo(2);
+                assertThat(logEntries).hasSize(2);
 
                 logEntries = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId())
                         .type("USER_TASK_IDENTITY_LINK_ADDED")
                         .list();
-                assertThat(logEntries).size().isEqualTo(1);
+                assertThat(logEntries).hasSize(1);
                 assertThat(logEntries.get(0).getData()).contains(
                         "\"type\":\"participant\"",
                         "\"groupId\":\"newCandidateGroup\""
@@ -674,26 +691,26 @@ public class HistoryServiceTaskLogTest {
     }
 
     @Test
-    @Deployment(resources = {"org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
+    @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void logDeleteCandidateGroup(RuntimeService runtimeService, TaskService taskService, HistoryService historyService,
-                                        ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
+            ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         taskService.addCandidateGroup(task.getId(), "newCandidateGroup");
         try {
             taskService.deleteCandidateGroup(task.getId(), "newCandidateGroup");
 
             if (HistoryTestHelper.isHistoricTaskLoggingEnabled(processEngineConfiguration)) {
                 List<HistoricTaskLogEntry> logEntries = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
-                assertThat(logEntries).size().isEqualTo(3);
+                assertThat(logEntries).hasSize(3);
 
                 logEntries = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId())
                         .type("USER_TASK_IDENTITY_LINK_REMOVED")
                         .list();
-                assertThat(logEntries).size().isEqualTo(1);
+                assertThat(logEntries).hasSize(1);
                 assertThat(logEntries.get(0).getData()).contains(
                         "\"type\":\"candidate\"",
                         "\"groupId\":\"newCandidateGroup\""
@@ -707,14 +724,14 @@ public class HistoryServiceTaskLogTest {
     }
 
     @Test
-    @Deployment(resources = {"org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
+    @Deployment(resources = { "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
     public void logDeleteCandidateUser(RuntimeService runtimeService, TaskService taskService, HistoryService historyService,
-                                       ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
+            ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(processInstance);
-        assertNotNull(task);
+        assertThat(processInstance).isNotNull();
+        assertThat(task).isNotNull();
         taskService.addCandidateUser(task.getId(), "newCandidateUser");
 
         try {
@@ -722,12 +739,12 @@ public class HistoryServiceTaskLogTest {
 
             if (HistoryTestHelper.isHistoricTaskLoggingEnabled(processEngineConfiguration)) {
                 List<HistoricTaskLogEntry> logEntries = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
-                assertThat(logEntries).size().isEqualTo(3);
+                assertThat(logEntries).hasSize(3);
 
                 logEntries = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId())
                         .type("USER_TASK_IDENTITY_LINK_REMOVED")
                         .list();
-                assertThat(logEntries).size().isEqualTo(1);
+                assertThat(logEntries).hasSize(1);
                 assertThat(logEntries.get(0).getData()).contains(
                         "\"type\":\"candidate\"",
                         "\"userId\":\"newCandidateUser\""
@@ -743,22 +760,22 @@ public class HistoryServiceTaskLogTest {
     @Test
     @Deployment(resources = "org/flowable/engine/test/api/task/TaskIdentityLinksTest.testCustomIdentityLink.bpmn20.xml")
     public void logIdentityLinkEventsForProcessIdentityLinks(RuntimeService runtimeService, TaskService taskService, HistoryService historyService,
-                                                             ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
+            ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
 
         runtimeService.startProcessInstanceByKey("customIdentityLink");
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().taskInvolvedUser("kermit").list();
-        assertThat(tasks).size().isEqualTo(1);
+        assertThat(tasks).hasSize(1);
         task = tasks.get(0);
 
         if (HistoryTestHelper.isHistoricTaskLoggingEnabled(processEngineConfiguration)) {
             List<HistoricTaskLogEntry> logEntries = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
             // create, identityLinkAdded, identityLinkAdded
-            assertThat(logEntries).size().isEqualTo(3);
+            assertThat(logEntries).hasSize(3);
 
             logEntries = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId())
                     .type("USER_TASK_IDENTITY_LINK_ADDED")
                     .list();
-            assertThat(logEntries).size().isEqualTo(2);
+            assertThat(logEntries).hasSize(2);
 
             boolean hasKermit = false;
             boolean hasManagement = false;
@@ -784,18 +801,18 @@ public class HistoryServiceTaskLogTest {
             HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 10000, 200);
             logEntries = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
             // + completed event. Do not expect identity link removed events
-            assertThat(logEntries).size().isEqualTo(4);
+            assertThat(logEntries).hasSize(4);
 
             logEntries = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId())
                     .type("USER_TASK_COMPLETED")
                     .list();
-            assertThat(logEntries).size().isEqualTo(1);
+            assertThat(logEntries).hasSize(1);
         }
     }
 
     @Test
     public void queryForTaskLogEntriesByTasKId(TaskService taskService, HistoryService historyService,
-                                               ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
+            ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
 
         task = taskService.createTaskBuilder().
                 assignee("testAssignee").
@@ -805,7 +822,7 @@ public class HistoryServiceTaskLogTest {
         try {
             if (HistoryTestHelper.isHistoricTaskLoggingEnabled(processEngineConfiguration)) {
                 List<HistoricTaskLogEntry> logEntries = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
-                assertThat(logEntries.size()).isEqualTo(1);
+                assertThat(logEntries).hasSize(1);
                 assertThat(logEntries.get(0)).extracting(HistoricTaskLogEntry::getTaskId).isEqualTo(task.getId());
 
                 assertThat(historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).count()).isEqualTo(1l);
@@ -818,14 +835,14 @@ public class HistoryServiceTaskLogTest {
 
     @Test
     public void queryForTaskLogEntriesByUserId(TaskService taskService, HistoryService historyService,
-                                               ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
+            ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
 
         assertThatTaskLogIsFetched(taskService, historyService.createHistoricTaskLogEntryBuilder().userId("testUser"),
                 historyService.createHistoricTaskLogEntryQuery().userId("testUser"), managementService, processEngineConfiguration);
     }
 
     protected void assertThatTaskLogIsFetched(TaskService taskService, HistoricTaskLogEntryBuilder historicTaskLogEntryBuilder,
-                                              HistoricTaskLogEntryQuery historicTaskLogEntryQuery, ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
+            HistoricTaskLogEntryQuery historicTaskLogEntryQuery, ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
 
         task = taskService.createTaskBuilder().
                 assignee("testAssignee").
@@ -838,13 +855,13 @@ public class HistoryServiceTaskLogTest {
         try {
             if (HistoryTestHelper.isHistoricTaskLoggingEnabled(processEngineConfiguration)) {
                 List<HistoricTaskLogEntry> logEntries = historicTaskLogEntryQuery.list();
-                assertThat(logEntries.size()).isEqualTo(3);
+                assertThat(logEntries).hasSize(3);
                 assertThat(logEntries).extracting(HistoricTaskLogEntry::getTaskId).containsExactly(task.getId(), task.getId(), task.getId());
 
                 assertThat(historicTaskLogEntryQuery.count()).isEqualTo(3l);
 
                 List<HistoricTaskLogEntry> pagedLogEntries = historicTaskLogEntryQuery.listPage(1, 1);
-                assertThat(pagedLogEntries.size()).isEqualTo(1);
+                assertThat(pagedLogEntries).hasSize(1);
                 assertThat(pagedLogEntries.get(0)).isEqualToComparingFieldByField(logEntries.get(1));
             }
 
@@ -855,7 +872,7 @@ public class HistoryServiceTaskLogTest {
 
     @Test
     public void queryForTaskLogEntriesByType(TaskService taskService, HistoryService historyService,
-                                             ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
+            ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
 
         assertThatTaskLogIsFetched(taskService, historyService.createHistoricTaskLogEntryBuilder().type("testType"),
                 historyService.createHistoricTaskLogEntryQuery().type("testType"), managementService, processEngineConfiguration);
@@ -863,7 +880,7 @@ public class HistoryServiceTaskLogTest {
 
     @Test
     public void queryForTaskLogEntriesByProcessInstanceId(TaskService taskService, HistoryService historyService,
-                                                          ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
+            ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
 
         assertThatTaskLogIsFetched(taskService, historyService.createHistoricTaskLogEntryBuilder().processInstanceId("testProcess"),
                 historyService.createHistoricTaskLogEntryQuery().processInstanceId("testProcess"), managementService, processEngineConfiguration);
@@ -871,7 +888,7 @@ public class HistoryServiceTaskLogTest {
 
     @Test
     public void queryForTaskLogEntriesByScopeId(TaskService taskService, HistoryService historyService,
-                                                ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
+            ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
 
         assertThatTaskLogIsFetched(taskService, historyService.createHistoricTaskLogEntryBuilder().scopeId("testScopeId"),
                 historyService.createHistoricTaskLogEntryQuery().scopeId("testScopeId"), managementService, processEngineConfiguration);
@@ -879,7 +896,7 @@ public class HistoryServiceTaskLogTest {
 
     @Test
     public void queryForTaskLogEntriesBySubScopeId(TaskService taskService, HistoryService historyService,
-                                                   ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
+            ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
 
         assertThatTaskLogIsFetched(taskService, historyService.createHistoricTaskLogEntryBuilder().subScopeId("testSubScopeId"),
                 historyService.createHistoricTaskLogEntryQuery().subScopeId("testSubScopeId"), managementService, processEngineConfiguration);
@@ -887,7 +904,7 @@ public class HistoryServiceTaskLogTest {
 
     @Test
     public void queryForTaskLogEntriesByScopeType(TaskService taskService, HistoryService historyService,
-                                                  ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
+            ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
 
         assertThatTaskLogIsFetched(taskService, historyService.createHistoricTaskLogEntryBuilder().scopeType("testScopeType"),
                 historyService.createHistoricTaskLogEntryQuery().scopeType("testScopeType"), managementService, processEngineConfiguration);
@@ -895,14 +912,15 @@ public class HistoryServiceTaskLogTest {
 
     @Test
     public void queryForTaskLogEntriesByFromTimeStamp(TaskService taskService, HistoryService historyService,
-                                                      ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
+            ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
 
         assertThatTaskLogIsFetched(taskService, historyService.createHistoricTaskLogEntryBuilder().timeStamp(getInsertDate()),
                 historyService.createHistoricTaskLogEntryQuery().from(getCompareBeforeDate()), managementService, processEngineConfiguration);
     }
 
     @Test
-    public void queryForTaskLogEntriesByToTimeStamp(TaskService taskService, HistoryService historyService, ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
+    public void queryForTaskLogEntriesByToTimeStamp(TaskService taskService, HistoryService historyService, ManagementService managementService,
+            ProcessEngineConfiguration processEngineConfiguration) {
         HistoricTaskLogEntryBuilder historicTaskLogEntryBuilder = historyService.createHistoricTaskLogEntryBuilder().timeStamp(getInsertDate());
         HistoricTaskLogEntryQuery historicTaskLogEntryQuery = historyService.createHistoricTaskLogEntryQuery().to(getCompareAfterDate());
 
@@ -917,13 +935,14 @@ public class HistoryServiceTaskLogTest {
         try {
             if (HistoryTestHelper.isHistoricTaskLoggingEnabled(processEngineConfiguration)) {
                 List<HistoricTaskLogEntry> logEntries = historicTaskLogEntryQuery.list();
-                assertThat(logEntries.size()).isEqualTo(5);
-                assertThat(logEntries).extracting(HistoricTaskLogEntry::getTaskId).containsExactly(task.getId(), anotherTask.getId(), task.getId(), task.getId(), task.getId());
+                assertThat(logEntries).hasSize(5);
+                assertThat(logEntries).extracting(HistoricTaskLogEntry::getTaskId)
+                        .containsExactly(task.getId(), anotherTask.getId(), task.getId(), task.getId(), task.getId());
 
                 assertThat(historicTaskLogEntryQuery.count()).isEqualTo(5);
 
                 List<HistoricTaskLogEntry> pagedLogEntries = historicTaskLogEntryQuery.listPage(1, 1);
-                assertThat(pagedLogEntries.size()).isEqualTo(1);
+                assertThat(pagedLogEntries).hasSize(1);
                 assertThat(pagedLogEntries.get(0)).isEqualToComparingFieldByField(logEntries.get(1));
             }
 
@@ -935,23 +954,25 @@ public class HistoryServiceTaskLogTest {
 
     @Test
     public void queryForTaskLogEntriesByFromToTimeStamp(TaskService taskService, HistoryService historyService,
-                                                        ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
+            ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
 
         assertThatTaskLogIsFetched(taskService, historyService.createHistoricTaskLogEntryBuilder().timeStamp(getInsertDate()),
-                historyService.createHistoricTaskLogEntryQuery().from(getCompareBeforeDate()).to(getCompareAfterDate()), managementService, processEngineConfiguration);
+                historyService.createHistoricTaskLogEntryQuery().from(getCompareBeforeDate()).to(getCompareAfterDate()), managementService,
+                processEngineConfiguration);
     }
 
     @Test
     public void queryForTaskLogEntriesByTenantId(TaskService taskService, HistoryService historyService,
-                                                 ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
+            ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
 
         assertThatTaskLogIsFetched(taskService, historyService.createHistoricTaskLogEntryBuilder().timeStamp(getInsertDate()),
-                historyService.createHistoricTaskLogEntryQuery().from(getCompareBeforeDate()).to(getCompareAfterDate()), managementService, processEngineConfiguration);
+                historyService.createHistoricTaskLogEntryQuery().from(getCompareBeforeDate()).to(getCompareAfterDate()), managementService,
+                processEngineConfiguration);
     }
 
     @Test
     public void queryForTaskLogEntriesByLogNumber(TaskService taskService, HistoryService historyService,
-                                                  ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
+            ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
 
         task = taskService.createTaskBuilder().
                 assignee("testAssignee").
@@ -973,7 +994,7 @@ public class HistoryServiceTaskLogTest {
                         toLogNumber(allLogEntries.get(allLogEntries.size() - 2).getLogNumber());
                 List<HistoricTaskLogEntry> logEntries = historicTaskLogEntryQuery.
                         list();
-                assertThat(logEntries.size()).isEqualTo(3);
+                assertThat(logEntries).hasSize(3);
                 assertThat(logEntries).extracting(HistoricTaskLogEntry::getLogNumber).containsExactly(
                         allLogEntries.get(1).getLogNumber(), allLogEntries.get(2).getLogNumber(), allLogEntries.get(3).getLogNumber()
                 );
@@ -983,7 +1004,7 @@ public class HistoryServiceTaskLogTest {
                 ).isEqualTo(3l);
 
                 List<HistoricTaskLogEntry> pagedLogEntries = historicTaskLogEntryQuery.listPage(1, 1);
-                assertThat(pagedLogEntries.size()).isEqualTo(1);
+                assertThat(pagedLogEntries).hasSize(1);
                 assertThat(pagedLogEntries.get(0).getLogNumber()).isEqualTo(logEntries.get(1).getLogNumber());
             }
         } finally {
@@ -992,9 +1013,10 @@ public class HistoryServiceTaskLogTest {
     }
 
     @Test
-    public void queryForTaskLogEntriesByNativeQuery(TaskService taskService, HistoryService historyService, ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
-        assertEquals("ACT_HI_TSK_LOG", managementService.getTableName(HistoricTaskLogEntryEntity.class, false));
-        assertEquals("ACT_HI_TSK_LOG", managementService.getTableName(HistoricTaskLogEntry.class, false));
+    public void queryForTaskLogEntriesByNativeQuery(TaskService taskService, HistoryService historyService, ManagementService managementService,
+            ProcessEngineConfiguration processEngineConfiguration) {
+        assertThat(managementService.getTableName(HistoricTaskLogEntryEntity.class, false)).isEqualTo("ACT_HI_TSK_LOG");
+        assertThat(managementService.getTableName(HistoricTaskLogEntry.class, false)).isEqualTo("ACT_HI_TSK_LOG");
         HistoricTaskLogEntryBuilder historicTaskLogEntryBuilder = historyService.createHistoricTaskLogEntryBuilder();
         historicTaskLogEntryBuilder.taskId("1").create();
         historicTaskLogEntryBuilder.taskId("2").create();
@@ -1002,15 +1024,17 @@ public class HistoryServiceTaskLogTest {
 
         if (HistoryTestHelper.isHistoricTaskLoggingEnabled(processEngineConfiguration)) {
             try {
-                assertEquals(3,
-                        historyService.createNativeHistoricTaskLogEntryQuery().sql("SELECT * FROM " + managementService.getTableName(HistoricTaskLogEntry.class)).list().size());
-                assertEquals(3,
-                        historyService.createNativeHistoricTaskLogEntryQuery().sql("SELECT count(*) FROM " + managementService.getTableName(HistoricTaskLogEntry.class)).count());
+                assertThat(historyService.createNativeHistoricTaskLogEntryQuery()
+                        .sql("SELECT * FROM " + managementService.getTableName(HistoricTaskLogEntry.class)).list()).hasSize(3);
+                assertThat(historyService.createNativeHistoricTaskLogEntryQuery()
+                        .sql("SELECT count(*) FROM " + managementService.getTableName(HistoricTaskLogEntry.class)).count()).isEqualTo(3);
 
-                assertEquals(1, historyService.createNativeHistoricTaskLogEntryQuery().parameter("taskId", "1").
-                        sql("SELECT count(*) FROM " + managementService.getTableName(HistoricTaskLogEntry.class) + " WHERE TASK_ID_ = #{taskId}").list().size());
-                assertEquals(1, historyService.createNativeHistoricTaskLogEntryQuery().parameter("taskId", "1").
-                        sql("SELECT count(*) FROM " + managementService.getTableName(HistoricTaskLogEntry.class) + " WHERE TASK_ID_ = #{taskId}").count());
+                assertThat(historyService.createNativeHistoricTaskLogEntryQuery().parameter("taskId", "1").
+                        sql("SELECT count(*) FROM " + managementService.getTableName(HistoricTaskLogEntry.class) + " WHERE TASK_ID_ = #{taskId}").list())
+                        .hasSize(1);
+                assertThat(historyService.createNativeHistoricTaskLogEntryQuery().parameter("taskId", "1").
+                        sql("SELECT count(*) FROM " + managementService.getTableName(HistoricTaskLogEntry.class) + " WHERE TASK_ID_ = #{taskId}").count())
+                        .isEqualTo(1);
             } finally {
                 deleteTaskWithLogEntries(taskService, managementService, processEngineConfiguration, "1");
                 deleteTaskWithLogEntries(taskService, managementService, processEngineConfiguration, "2");
@@ -1020,7 +1044,8 @@ public class HistoryServiceTaskLogTest {
     }
 
     @Test
-    public void queryForTaskLogOrderBy(TaskService taskService, HistoryService historyService, ManagementService managementService, ProcessEngineConfiguration processEngineConfiguration) {
+    public void queryForTaskLogOrderBy(TaskService taskService, HistoryService historyService, ManagementService managementService,
+            ProcessEngineConfiguration processEngineConfiguration) {
         HistoricTaskLogEntryBuilder historicTaskLogEntryBuilder = historyService.createHistoricTaskLogEntryBuilder();
         historicTaskLogEntryBuilder.taskId("1").timeStamp(getInsertDate()).create();
         historicTaskLogEntryBuilder.taskId("2").timeStamp(getCompareAfterDate()).create();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoryServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoryServiceTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,6 +14,7 @@
 package org.flowable.engine.test.api.history;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -60,36 +61,36 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testHistoricProcessInstanceQuery() {
         // With a clean ProcessEngine, no instances should be available
-        assertEquals(0, historyService.createHistoricProcessInstanceQuery().count());
+        assertThat(historyService.createHistoricProcessInstanceQuery().count()).isEqualTo(0);
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
-        
+
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
-        
-        assertEquals(1, historyService.createHistoricProcessInstanceQuery().count());
+
+        assertThat(historyService.createHistoricProcessInstanceQuery().count()).isEqualTo(1);
 
         // Complete the task and check if the size is count 1
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(1, tasks.size());
+        assertThat(tasks).hasSize(1);
         taskService.complete(tasks.get(0).getId());
-        
+
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
-        
-        assertEquals(1, historyService.createHistoricProcessInstanceQuery().count());
+
+        assertThat(historyService.createHistoricProcessInstanceQuery().count()).isEqualTo(1);
     }
 
     @Test
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testHistoricProcessInstanceQueryOrderBy() {
         // With a clean ProcessEngine, no instances should be available
-        assertEquals(0, historyService.createHistoricProcessInstanceQuery().count());
+        assertThat(historyService.createHistoricProcessInstanceQuery().count()).isEqualTo(0);
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(1, tasks.size());
+        assertThat(tasks).hasSize(1);
         taskService.complete(tasks.get(0).getId());
 
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
-        
+
         historyService.createHistoricTaskInstanceQuery().orderByDeleteReason().asc().list();
         historyService.createHistoricTaskInstanceQuery().orderByExecutionId().asc().list();
         historyService.createHistoricTaskInstanceQuery().orderByHistoricActivityInstanceId().asc().list();
@@ -112,25 +113,26 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
     public void testHistoricProcessInstanceUserIdAndActivityId() {
         identityService.setAuthenticatedUserId("johndoe");
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
-        
+
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
-        
+
         HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery().singleResult();
-        assertEquals("johndoe", historicProcessInstance.getStartUserId());
-        assertEquals("theStart", historicProcessInstance.getStartActivityId());
+        assertThat(historicProcessInstance.getStartUserId()).isEqualTo("johndoe");
+        assertThat(historicProcessInstance.getStartActivityId()).isEqualTo("theStart");
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(1, tasks.size());
+        assertThat(tasks).hasSize(1);
         taskService.complete(tasks.get(0).getId());
-        
+
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
         historicProcessInstance = historyService.createHistoricProcessInstanceQuery().singleResult();
-        assertEquals("theEnd", historicProcessInstance.getEndActivityId());
+        assertThat(historicProcessInstance.getEndActivityId()).isEqualTo("theEnd");
     }
 
     @Test
-    @Deployment(resources = { "org/flowable/examples/bpmn/callactivity/orderProcess.bpmn20.xml", "org/flowable/examples/bpmn/callactivity/checkCreditProcess.bpmn20.xml" })
+    @Deployment(resources = { "org/flowable/examples/bpmn/callactivity/orderProcess.bpmn20.xml",
+            "org/flowable/examples/bpmn/callactivity/checkCreditProcess.bpmn20.xml" })
     public void testOrderProcessWithCallActivity() {
         // After the process has started, the 'verify credit history' task should be active
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("orderProcess");
@@ -140,29 +142,30 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         // Completing the task with approval, will end the subprocess and continue the original process
         taskService.complete(verifyCreditTask.getId(), CollectionUtil.singletonMap("creditApproved", true));
         org.flowable.task.api.Task prepareAndShipTask = taskQuery.singleResult();
-        assertEquals("Prepare and Ship", prepareAndShipTask.getName());
-        
+        assertThat(prepareAndShipTask.getName()).isEqualTo("Prepare and Ship");
+
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
         // verify
         HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery().superProcessInstanceId(pi.getId()).singleResult();
-        assertNotNull(historicProcessInstance);
-        assertTrue(historicProcessInstance.getProcessDefinitionId().contains("checkCreditProcess"));
+        assertThat(historicProcessInstance).isNotNull();
+        assertThat(historicProcessInstance.getProcessDefinitionId()).contains("checkCreditProcess");
     }
 
     @Test
-    @Deployment(resources = { "org/flowable/examples/bpmn/callactivity/orderProcess.bpmn20.xml", "org/flowable/examples/bpmn/callactivity/checkCreditProcess.bpmn20.xml" })
+    @Deployment(resources = { "org/flowable/examples/bpmn/callactivity/orderProcess.bpmn20.xml",
+            "org/flowable/examples/bpmn/callactivity/checkCreditProcess.bpmn20.xml" })
     public void testExcludeSubprocesses() {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("orderProcess");
-        
+
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
         HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery().excludeSubprocesses(true).singleResult();
-        assertNotNull(historicProcessInstance);
-        assertEquals(pi.getId(), historicProcessInstance.getId());
+        assertThat(historicProcessInstance).isNotNull();
+        assertThat(historicProcessInstance.getId()).isEqualTo(pi.getId());
 
         List<HistoricProcessInstance> instanceList = historyService.createHistoricProcessInstanceQuery().excludeSubprocesses(false).list();
-        assertEquals(2, instanceList.size());
+        assertThat(instanceList).hasSize(2);
     }
 
     @Test
@@ -173,26 +176,29 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         String processDefinitionKey = "oneTaskProcess";
         runtimeService.startProcessInstanceByKey(processDefinitionKey);
         runtimeService.startProcessInstanceByKey("orderProcess");
-        
+
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
-        
-        HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery().processDefinitionKey(processDefinitionKey).singleResult();
-        assertNotNull(historicProcessInstance);
-        assertEquals(processDefinitionKey, historicProcessInstance.getProcessDefinitionKey());
-        assertEquals("theStart", historicProcessInstance.getStartActivityId());
+
+        HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery().processDefinitionKey(processDefinitionKey)
+                .singleResult();
+        assertThat(historicProcessInstance).isNotNull();
+        assertThat(historicProcessInstance.getProcessDefinitionKey()).isEqualTo(processDefinitionKey);
+        assertThat(historicProcessInstance.getStartActivityId()).isEqualTo("theStart");
 
         // now complete the task to end the process instance
         org.flowable.task.api.Task task = taskService.createTaskQuery().processDefinitionKey("checkCreditProcess").singleResult();
         Map<String, Object> map = new HashMap<>();
         map.put("creditApproved", true);
         taskService.complete(task.getId(), map);
-        
+
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
         // and make sure the super process instance is set correctly on the HistoricProcessInstance
-        HistoricProcessInstance historicProcessInstanceSub = historyService.createHistoricProcessInstanceQuery().processDefinitionKey("checkCreditProcess").singleResult();
-        HistoricProcessInstance historicProcessInstanceSuper = historyService.createHistoricProcessInstanceQuery().processDefinitionKey("orderProcess").singleResult();
-        assertEquals(historicProcessInstanceSuper.getId(), historicProcessInstanceSub.getSuperProcessInstanceId());
+        HistoricProcessInstance historicProcessInstanceSub = historyService.createHistoricProcessInstanceQuery().processDefinitionKey("checkCreditProcess")
+                .singleResult();
+        HistoricProcessInstance historicProcessInstanceSuper = historyService.createHistoricProcessInstanceQuery().processDefinitionKey("orderProcess")
+                .singleResult();
+        assertThat(historicProcessInstanceSub.getSuperProcessInstanceId()).isEqualTo(historicProcessInstanceSuper.getId());
     }
 
     @Test
@@ -208,37 +214,31 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("oneTaskProcess2", "2");
 
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
-        
+
         HistoricProcessInstanceQuery processInstanceQuery = historyService.createHistoricProcessInstanceQuery().processInstanceIds(processInstanceIds);
-        assertEquals(5, processInstanceQuery.count());
+        assertThat(processInstanceQuery.count()).isEqualTo(5);
 
         List<HistoricProcessInstance> processInstances = processInstanceQuery.list();
-        assertNotNull(processInstances);
-        assertEquals(5, processInstances.size());
+        assertThat(processInstances).isNotNull();
+        assertThat(processInstances).hasSize(5);
 
         for (HistoricProcessInstance historicProcessInstance : processInstances) {
-            assertTrue(processInstanceIds.contains(historicProcessInstance.getId()));
+            assertThat(processInstanceIds).contains(historicProcessInstance.getId());
         }
     }
 
     @Test
     public void testHistoricProcessInstanceQueryByProcessInstanceIdsEmpty() {
-        try {
-            historyService.createHistoricProcessInstanceQuery().processInstanceIds(new HashSet<>());
-            fail("ActivitiException expected");
-        } catch (FlowableIllegalArgumentException re) {
-            assertTextPresent("Set of process instance ids is empty", re.getMessage());
-        }
+        assertThatThrownBy(() -> historyService.createHistoricProcessInstanceQuery().processInstanceIds(new HashSet<>()))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage("Set of process instance ids is empty");
     }
 
     @Test
     public void testHistoricProcessInstanceQueryByProcessInstanceIdsNull() {
-        try {
-            historyService.createHistoricProcessInstanceQuery().processInstanceIds(null);
-            fail("ActivitiException expected");
-        } catch (FlowableIllegalArgumentException re) {
-            assertTextPresent("Set of process instance ids is null", re.getMessage());
-        }
+        assertThatThrownBy(() -> historyService.createHistoricProcessInstanceQuery().processInstanceIds(null))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage("Set of process instance ids is null");
     }
 
     @Test
@@ -246,50 +246,50 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
     public void testHistoricProcessInstanceQueryForDelete() {
         String processInstanceId = runtimeService.startProcessInstanceByKey("oneTaskProcess").getId();
         runtimeService.deleteProcessInstance(processInstanceId, null);
-        
+
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
         HistoricProcessInstanceQuery processInstanceQuery = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstanceId);
-        assertEquals(1, processInstanceQuery.count());
+        assertThat(processInstanceQuery.count()).isEqualTo(1);
         HistoricProcessInstance processInstance = processInstanceQuery.singleResult();
-        assertEquals(processInstanceId, processInstance.getId());
-        assertEquals(DeleteReason.PROCESS_INSTANCE_DELETED, processInstance.getDeleteReason());
+        assertThat(processInstance.getId()).isEqualTo(processInstanceId);
+        assertThat(processInstance.getDeleteReason()).isEqualTo(DeleteReason.PROCESS_INSTANCE_DELETED);
 
         processInstanceQuery = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstanceId).deleted();
-        assertEquals(1, processInstanceQuery.count());
+        assertThat(processInstanceQuery.count()).isEqualTo(1);
         processInstance = processInstanceQuery.singleResult();
-        assertEquals(processInstanceId, processInstance.getId());
-        assertEquals(DeleteReason.PROCESS_INSTANCE_DELETED, processInstance.getDeleteReason());
+        assertThat(processInstance.getId()).isEqualTo(processInstanceId);
+        assertThat(processInstance.getDeleteReason()).isEqualTo(DeleteReason.PROCESS_INSTANCE_DELETED);
 
         processInstanceQuery = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstanceId).notDeleted();
-        assertEquals(0, processInstanceQuery.count());
+        assertThat(processInstanceQuery.count()).isEqualTo(0);
 
         historyService.deleteHistoricProcessInstance(processInstanceId);
-        
+
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
-        
+
         processInstanceQuery = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstanceId);
-        assertEquals(0, processInstanceQuery.count());
+        assertThat(processInstanceQuery.count()).isEqualTo(0);
 
         processInstanceId = runtimeService.startProcessInstanceByKey("oneTaskProcess").getId();
         runtimeService.deleteProcessInstance(processInstanceId, "custom message");
-        
+
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
         processInstanceQuery = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstanceId);
-        assertEquals(1, processInstanceQuery.count());
+        assertThat(processInstanceQuery.count()).isEqualTo(1);
         processInstance = processInstanceQuery.singleResult();
-        assertEquals(processInstanceId, processInstance.getId());
-        assertEquals("custom message", processInstance.getDeleteReason());
+        assertThat(processInstance.getId()).isEqualTo(processInstanceId);
+        assertThat(processInstance.getDeleteReason()).isEqualTo("custom message");
 
         processInstanceQuery = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstanceId).deleted();
-        assertEquals(1, processInstanceQuery.count());
+        assertThat(processInstanceQuery.count()).isEqualTo(1);
         processInstance = processInstanceQuery.singleResult();
-        assertEquals(processInstanceId, processInstance.getId());
-        assertEquals("custom message", processInstance.getDeleteReason());
+        assertThat(processInstance.getId()).isEqualTo(processInstanceId);
+        assertThat(processInstance.getDeleteReason()).isEqualTo("custom message");
 
         processInstanceQuery = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstanceId).notDeleted();
-        assertEquals(0, processInstanceQuery.count());
+        assertThat(processInstanceQuery.count()).isEqualTo(0);
     }
 
     @Test
@@ -300,19 +300,19 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
             runtimeService.startProcessInstanceByKey("oneTaskProcess", String.valueOf(i));
         }
         runtimeService.startProcessInstanceByKey("oneTaskProcess2", "1");
-        
+
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
         HistoricProcessInstanceQuery processInstanceQuery = historyService.createHistoricProcessInstanceQuery().deploymentId(deployment.getId());
-        assertEquals(5, processInstanceQuery.count());
-        assertEquals(deployment.getId(), processInstanceQuery.list().get(0).getDeploymentId());
+        assertThat(processInstanceQuery.count()).isEqualTo(5);
+        assertThat(processInstanceQuery.list().get(0).getDeploymentId()).isEqualTo(deployment.getId());
 
         List<HistoricProcessInstance> processInstances = processInstanceQuery.list();
-        assertNotNull(processInstances);
-        assertEquals(5, processInstances.size());
+        assertThat(processInstances).isNotNull();
+        assertThat(processInstances).hasSize(5);
 
         processInstanceQuery = historyService.createHistoricProcessInstanceQuery().deploymentId("invalid");
-        assertEquals(0, processInstanceQuery.count());
+        assertThat(processInstanceQuery.count()).isEqualTo(0);
     }
 
     @Test
@@ -323,23 +323,23 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
             runtimeService.startProcessInstanceByKey("oneTaskProcess", String.valueOf(i));
         }
         runtimeService.startProcessInstanceByKey("oneTaskProcess2", "1");
-        
+
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
         List<String> deploymentIds = new ArrayList<>();
         deploymentIds.add(deployment.getId());
         deploymentIds.add("invalid");
         HistoricProcessInstanceQuery processInstanceQuery = historyService.createHistoricProcessInstanceQuery().deploymentIdIn(deploymentIds);
-        assertEquals(5, processInstanceQuery.count());
+        assertThat(processInstanceQuery.count()).isEqualTo(5);
 
         List<HistoricProcessInstance> processInstances = processInstanceQuery.list();
-        assertNotNull(processInstances);
-        assertEquals(5, processInstances.size());
+        assertThat(processInstances).isNotNull();
+        assertThat(processInstances).hasSize(5);
 
         deploymentIds = new ArrayList<>();
         deploymentIds.add("invalid");
         processInstanceQuery = historyService.createHistoricProcessInstanceQuery().deploymentIdIn(deploymentIds);
-        assertEquals(0, processInstanceQuery.count());
+        assertThat(processInstanceQuery.count()).isEqualTo(0);
     }
 
     @Test
@@ -350,18 +350,18 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
             runtimeService.startProcessInstanceByKey("oneTaskProcess", String.valueOf(i));
         }
         runtimeService.startProcessInstanceByKey("oneTaskProcess2", "1");
-        
+
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
         HistoricTaskInstanceQuery taskInstanceQuery = historyService.createHistoricTaskInstanceQuery().deploymentId(deployment.getId());
-        assertEquals(5, taskInstanceQuery.count());
+        assertThat(taskInstanceQuery.count()).isEqualTo(5);
 
         List<HistoricTaskInstance> taskInstances = taskInstanceQuery.list();
-        assertNotNull(taskInstances);
-        assertEquals(5, taskInstances.size());
+        assertThat(taskInstances).isNotNull();
+        assertThat(taskInstances).hasSize(5);
 
         taskInstanceQuery = historyService.createHistoricTaskInstanceQuery().deploymentId("invalid");
-        assertEquals(0, taskInstanceQuery.count());
+        assertThat(taskInstanceQuery.count()).isEqualTo(0);
     }
 
     @Test
@@ -372,26 +372,26 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
             runtimeService.startProcessInstanceByKey("oneTaskProcess", String.valueOf(i));
         }
         runtimeService.startProcessInstanceByKey("oneTaskProcess2", "1");
-        
+
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
         List<String> deploymentIds = new ArrayList<>();
         deploymentIds.add(deployment.getId());
         HistoricTaskInstanceQuery taskInstanceQuery = historyService.createHistoricTaskInstanceQuery().deploymentIdIn(deploymentIds);
-        assertEquals(5, taskInstanceQuery.count());
+        assertThat(taskInstanceQuery.count()).isEqualTo(5);
 
         List<HistoricTaskInstance> taskInstances = taskInstanceQuery.list();
-        assertNotNull(taskInstances);
-        assertEquals(5, taskInstances.size());
+        assertThat(taskInstances).isNotNull();
+        assertThat(taskInstances).hasSize(5);
 
         deploymentIds.add("invalid");
         taskInstanceQuery = historyService.createHistoricTaskInstanceQuery().deploymentIdIn(deploymentIds);
-        assertEquals(5, taskInstanceQuery.count());
+        assertThat(taskInstanceQuery.count()).isEqualTo(5);
 
         deploymentIds = new ArrayList<>();
         deploymentIds.add("invalid");
         taskInstanceQuery = historyService.createHistoricTaskInstanceQuery().deploymentIdIn(deploymentIds);
-        assertEquals(0, taskInstanceQuery.count());
+        assertThat(taskInstanceQuery.count()).isEqualTo(0);
     }
 
     @Test
@@ -402,24 +402,24 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
             runtimeService.startProcessInstanceByKey("oneTaskProcess", String.valueOf(i));
         }
         runtimeService.startProcessInstanceByKey("oneTaskProcess2", "1");
-        
+
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
         HistoricTaskInstanceQuery taskInstanceQuery = historyService.createHistoricTaskInstanceQuery().or().deploymentId(deployment.getId()).endOr();
-        assertEquals(5, taskInstanceQuery.count());
+        assertThat(taskInstanceQuery.count()).isEqualTo(5);
 
         List<HistoricTaskInstance> taskInstances = taskInstanceQuery.list();
-        assertNotNull(taskInstances);
-        assertEquals(5, taskInstances.size());
+        assertThat(taskInstances).isNotNull();
+        assertThat(taskInstances).hasSize(5);
 
         taskInstanceQuery = historyService.createHistoricTaskInstanceQuery().or().deploymentId("invalid").endOr();
-        assertEquals(0, taskInstanceQuery.count());
+        assertThat(taskInstanceQuery.count()).isEqualTo(0);
 
         taskInstanceQuery = historyService.createHistoricTaskInstanceQuery().or().taskDefinitionKey("theTask").deploymentId("invalid").endOr();
-        assertEquals(5, taskInstanceQuery.count());
+        assertThat(taskInstanceQuery.count()).isEqualTo(5);
 
         taskInstanceQuery = historyService.createHistoricTaskInstanceQuery().taskDefinitionKey("theTask").or().deploymentId("invalid").endOr();
-        assertEquals(0, taskInstanceQuery.count());
+        assertThat(taskInstanceQuery.count()).isEqualTo(0);
 
         taskInstanceQuery = historyService.createHistoricTaskInstanceQuery()
                 .or()
@@ -430,7 +430,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
                 .processDefinitionKey("oneTaskProcess")
                 .processDefinitionId("invalid")
                 .endOr();
-        assertEquals(4, taskInstanceQuery.count());
+        assertThat(taskInstanceQuery.count()).isEqualTo(4);
 
         taskInstanceQuery = historyService.createHistoricTaskInstanceQuery()
                 .or()
@@ -441,7 +441,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
                 .processDefinitionKey("oneTaskProcess2")
                 .processDefinitionId("invalid")
                 .endOr();
-        assertEquals(1, taskInstanceQuery.count());
+        assertThat(taskInstanceQuery.count()).isEqualTo(1);
 
         taskInstanceQuery = historyService.createHistoricTaskInstanceQuery()
                 .or()
@@ -453,7 +453,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
                 .processDefinitionId("invalid")
                 .endOr()
                 .processInstanceBusinessKey("1");
-        assertEquals(1, taskInstanceQuery.count());
+        assertThat(taskInstanceQuery.count()).isEqualTo(1);
 
         taskInstanceQuery = historyService.createHistoricTaskInstanceQuery()
                 .or()
@@ -465,7 +465,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
                 .processDefinitionId("invalid")
                 .endOr()
                 .processInstanceBusinessKey("1");
-        assertEquals(1, taskInstanceQuery.count());
+        assertThat(taskInstanceQuery.count()).isEqualTo(1);
 
         taskInstanceQuery = historyService.createHistoricTaskInstanceQuery()
                 .or()
@@ -477,7 +477,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
                 .processDefinitionId("invalid")
                 .endOr()
                 .processInstanceBusinessKey("2");
-        assertEquals(0, taskInstanceQuery.count());
+        assertThat(taskInstanceQuery.count()).isEqualTo(0);
     }
 
     @Test
@@ -488,32 +488,33 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
             runtimeService.startProcessInstanceByKey("oneTaskProcess", String.valueOf(i));
         }
         runtimeService.startProcessInstanceByKey("oneTaskProcess2", "1");
-        
+
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
         List<String> deploymentIds = new ArrayList<>();
         deploymentIds.add(deployment.getId());
-        HistoricTaskInstanceQuery taskInstanceQuery = historyService.createHistoricTaskInstanceQuery().or().deploymentIdIn(deploymentIds).processDefinitionId("invalid").endOr();
-        assertEquals(5, taskInstanceQuery.count());
+        HistoricTaskInstanceQuery taskInstanceQuery = historyService.createHistoricTaskInstanceQuery().or().deploymentIdIn(deploymentIds)
+                .processDefinitionId("invalid").endOr();
+        assertThat(taskInstanceQuery.count()).isEqualTo(5);
 
         List<HistoricTaskInstance> taskInstances = taskInstanceQuery.list();
-        assertNotNull(taskInstances);
-        assertEquals(5, taskInstances.size());
+        assertThat(taskInstances).isNotNull();
+        assertThat(taskInstances).hasSize(5);
 
         deploymentIds.add("invalid");
         taskInstanceQuery = historyService.createHistoricTaskInstanceQuery().or().deploymentIdIn(deploymentIds).processDefinitionId("invalid").endOr();
-        assertEquals(5, taskInstanceQuery.count());
+        assertThat(taskInstanceQuery.count()).isEqualTo(5);
 
         deploymentIds = new ArrayList<>();
         deploymentIds.add("invalid");
         taskInstanceQuery = historyService.createHistoricTaskInstanceQuery().or().deploymentIdIn(deploymentIds).processDefinitionId("invalid").endOr();
-        assertEquals(0, taskInstanceQuery.count());
+        assertThat(taskInstanceQuery.count()).isEqualTo(0);
 
         taskInstanceQuery = historyService.createHistoricTaskInstanceQuery().or().taskDefinitionKey("theTask").deploymentIdIn(deploymentIds).endOr();
-        assertEquals(5, taskInstanceQuery.count());
+        assertThat(taskInstanceQuery.count()).isEqualTo(5);
 
         taskInstanceQuery = historyService.createHistoricTaskInstanceQuery().taskDefinitionKey("theTask").or().deploymentIdIn(deploymentIds).endOr();
-        assertEquals(0, taskInstanceQuery.count());
+        assertThat(taskInstanceQuery.count()).isEqualTo(0);
     }
 
     @Test
@@ -522,10 +523,11 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
-        List<HistoricTaskInstance> tasks = historyService.createHistoricTaskInstanceQuery().processDefinitionId(processInstance.getProcessDefinitionId()).list();
-        assertEquals(1, tasks.size());
-        assertEquals("my task", tasks.get(0).getName());
-        assertNull(tasks.get(0).getDescription());
+        List<HistoricTaskInstance> tasks = historyService.createHistoricTaskInstanceQuery().processDefinitionId(processInstance.getProcessDefinitionId())
+                .list();
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.get(0).getName()).isEqualTo("my task");
+        assertThat(tasks.get(0).getDescription()).isNull();
 
         ObjectNode infoNode = dynamicBpmnService.changeLocalizationName("en-GB", "theTask", "My localized name");
         dynamicBpmnService.changeLocalizationDescription("en-GB", "theTask", "My localized description", infoNode);
@@ -533,36 +535,37 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
 
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
         tasks = historyService.createHistoricTaskInstanceQuery().processDefinitionId(processInstance.getProcessDefinitionId()).list();
-        assertEquals(1, tasks.size());
-        assertEquals("my task", tasks.get(0).getName());
-        assertNull(tasks.get(0).getDescription());
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.get(0).getName()).isEqualTo("my task");
+        assertThat(tasks.get(0).getDescription()).isNull();
 
         tasks = historyService.createHistoricTaskInstanceQuery().processDefinitionId(processInstance.getProcessDefinitionId()).locale("en-GB").list();
-        assertEquals(1, tasks.size());
-        assertEquals("My localized name", tasks.get(0).getName());
-        assertEquals("My localized description", tasks.get(0).getDescription());
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.get(0).getName()).isEqualTo("My localized name");
+        assertThat(tasks.get(0).getDescription()).isEqualTo("My localized description");
 
         tasks = historyService.createHistoricTaskInstanceQuery().processDefinitionId(processInstance.getProcessDefinitionId()).listPage(0, 10);
-        assertEquals(1, tasks.size());
-        assertEquals("my task", tasks.get(0).getName());
-        assertNull(tasks.get(0).getDescription());
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.get(0).getName()).isEqualTo("my task");
+        assertThat(tasks.get(0).getDescription()).isNull();
 
         tasks = historyService.createHistoricTaskInstanceQuery().processDefinitionId(processInstance.getProcessDefinitionId()).locale("en-GB").listPage(0, 10);
-        assertEquals(1, tasks.size());
-        assertEquals("My localized name", tasks.get(0).getName());
-        assertEquals("My localized description", tasks.get(0).getDescription());
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.get(0).getName()).isEqualTo("My localized name");
+        assertThat(tasks.get(0).getDescription()).isEqualTo("My localized description");
 
-        HistoricTaskInstance task = historyService.createHistoricTaskInstanceQuery().processDefinitionId(processInstance.getProcessDefinitionId()).singleResult();
-        assertEquals("my task", task.getName());
-        assertNull(task.getDescription());
+        HistoricTaskInstance task = historyService.createHistoricTaskInstanceQuery().processDefinitionId(processInstance.getProcessDefinitionId())
+                .singleResult();
+        assertThat(task.getName()).isEqualTo("my task");
+        assertThat(task.getDescription()).isNull();
 
         task = historyService.createHistoricTaskInstanceQuery().processDefinitionId(processInstance.getProcessDefinitionId()).locale("en-GB").singleResult();
-        assertEquals("My localized name", task.getName());
-        assertEquals("My localized description", task.getDescription());
+        assertThat(task.getName()).isEqualTo("My localized name");
+        assertThat(task.getDescription()).isEqualTo("My localized description");
 
         task = historyService.createHistoricTaskInstanceQuery().processDefinitionId(processInstance.getProcessDefinitionId()).singleResult();
-        assertEquals("my task", task.getName());
-        assertNull(task.getDescription());
+        assertThat(task.getName()).isEqualTo("my task");
+        assertThat(task.getDescription()).isNull();
     }
 
     @Test
@@ -582,14 +585,14 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
             taskService.complete(task.getId(), variables);
         }
         taskService.complete(taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult().getId());
-        
+
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
-        assertEquals(1, historyService.createHistoricProcessInstanceQuery().variableValueEquals("rootValue", "test").count());
+        assertThat(historyService.createHistoricProcessInstanceQuery().variableValueEquals("rootValue", "test").count()).isEqualTo(1);
 
-        assertEquals(1, historyService.createHistoricProcessInstanceQuery().variableValueEquals("parallelValue1", "Receive Payment").count());
-        assertEquals(1, historyService.createHistoricProcessInstanceQuery().variableValueEquals("parallelValue1", "Ship Order").count());
-        assertEquals(1, historyService.createHistoricProcessInstanceQuery().variableValueEquals("parallelValue2", "test").count());
+        assertThat(historyService.createHistoricProcessInstanceQuery().variableValueEquals("parallelValue1", "Receive Payment").count()).isEqualTo(1);
+        assertThat(historyService.createHistoricProcessInstanceQuery().variableValueEquals("parallelValue1", "Ship Order").count()).isEqualTo(1);
+        assertThat(historyService.createHistoricProcessInstanceQuery().variableValueEquals("parallelValue2", "test").count()).isEqualTo(1);
     }
 
     /**
@@ -613,95 +616,95 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         vars.put("stringVar", "azerty");
         ProcessInstance processInstance3 = runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
         taskService.complete(taskService.createTaskQuery().processInstanceId(processInstance3.getId()).singleResult().getId());
-        
+
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
         // Test EQUAL on single string variable, should result in 2 matches
         HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery().variableValueEquals("stringVar", "abcdef");
         List<HistoricProcessInstance> processInstances = query.list();
-        assertNotNull(processInstances);
-        assertEquals(2, processInstances.size());
+        assertThat(processInstances).isNotNull();
+        assertThat(processInstances).hasSize(2);
 
         // Test EQUAL on two string variables, should result in single match
         query = historyService.createHistoricProcessInstanceQuery().variableValueEquals("stringVar", "abcdef").variableValueEquals("stringVar2", "ghijkl");
         HistoricProcessInstance resultInstance = query.singleResult();
-        assertNotNull(resultInstance);
-        assertEquals(processInstance2.getId(), resultInstance.getId());
+        assertThat(resultInstance).isNotNull();
+        assertThat(resultInstance.getId()).isEqualTo(processInstance2.getId());
 
         // Test NOT_EQUAL, should return only 1 resultInstance
         resultInstance = historyService.createHistoricProcessInstanceQuery().variableValueNotEquals("stringVar", "abcdef").singleResult();
-        assertNotNull(resultInstance);
-        assertEquals(processInstance3.getId(), resultInstance.getId());
+        assertThat(resultInstance).isNotNull();
+        assertThat(resultInstance.getId()).isEqualTo(processInstance3.getId());
 
         // Test GREATER_THAN, should return only matching 'azerty'
         resultInstance = historyService.createHistoricProcessInstanceQuery().variableValueGreaterThan("stringVar", "abcdef").singleResult();
-        assertNotNull(resultInstance);
-        assertEquals(processInstance3.getId(), resultInstance.getId());
+        assertThat(resultInstance).isNotNull();
+        assertThat(resultInstance.getId()).isEqualTo(processInstance3.getId());
 
         resultInstance = historyService.createHistoricProcessInstanceQuery().variableValueGreaterThan("stringVar", "z").singleResult();
-        assertNull(resultInstance);
+        assertThat(resultInstance).isNull();
 
         // Test GREATER_THAN_OR_EQUAL, should return 3 results
-        assertEquals(3, historyService.createHistoricProcessInstanceQuery().variableValueGreaterThanOrEqual("stringVar", "abcdef").count());
-        assertEquals(0, historyService.createHistoricProcessInstanceQuery().variableValueGreaterThanOrEqual("stringVar", "z").count());
+        assertThat(historyService.createHistoricProcessInstanceQuery().variableValueGreaterThanOrEqual("stringVar", "abcdef").count()).isEqualTo(3);
+        assertThat(historyService.createHistoricProcessInstanceQuery().variableValueGreaterThanOrEqual("stringVar", "z").count()).isEqualTo(0);
 
         // Test LESS_THAN, should return 2 results
         processInstances = historyService.createHistoricProcessInstanceQuery().variableValueLessThan("stringVar", "abcdeg").list();
-        assertEquals(2, processInstances.size());
+        assertThat(processInstances).hasSize(2);
         List<String> expectedIds = Arrays.asList(processInstance1.getId(), processInstance2.getId());
         List<String> ids = new ArrayList<>(Arrays.asList(processInstances.get(0).getId(), processInstances.get(1).getId()));
         ids.removeAll(expectedIds);
-        assertTrue(ids.isEmpty());
+        assertThat(ids).isEmpty();
 
-        assertEquals(0, historyService.createHistoricProcessInstanceQuery().variableValueLessThan("stringVar", "abcdef").count());
-        assertEquals(3, historyService.createHistoricProcessInstanceQuery().variableValueLessThanOrEqual("stringVar", "z").count());
+        assertThat(historyService.createHistoricProcessInstanceQuery().variableValueLessThan("stringVar", "abcdef").count()).isEqualTo(0);
+        assertThat(historyService.createHistoricProcessInstanceQuery().variableValueLessThanOrEqual("stringVar", "z").count()).isEqualTo(3);
 
         // Test LESS_THAN_OR_EQUAL
         processInstances = historyService.createHistoricProcessInstanceQuery().variableValueLessThanOrEqual("stringVar", "abcdef").list();
-        assertEquals(2, processInstances.size());
+        assertThat(processInstances).hasSize(2);
         expectedIds = Arrays.asList(processInstance1.getId(), processInstance2.getId());
         ids = new ArrayList<>(Arrays.asList(processInstances.get(0).getId(), processInstances.get(1).getId()));
         ids.removeAll(expectedIds);
-        assertTrue(ids.isEmpty());
+        assertThat(ids).isEmpty();
 
-        assertEquals(3, historyService.createHistoricProcessInstanceQuery().variableValueLessThanOrEqual("stringVar", "z").count());
-        assertEquals(0, historyService.createHistoricProcessInstanceQuery().variableValueLessThanOrEqual("stringVar", "aa").count());
+        assertThat(historyService.createHistoricProcessInstanceQuery().variableValueLessThanOrEqual("stringVar", "z").count()).isEqualTo(3);
+        assertThat(historyService.createHistoricProcessInstanceQuery().variableValueLessThanOrEqual("stringVar", "aa").count()).isEqualTo(0);
 
         // Test LIKE
         resultInstance = historyService.createHistoricProcessInstanceQuery().variableValueLike("stringVar", "azert%").singleResult();
-        assertNotNull(resultInstance);
-        assertEquals(processInstance3.getId(), resultInstance.getId());
+        assertThat(resultInstance).isNotNull();
+        assertThat(resultInstance.getId()).isEqualTo(processInstance3.getId());
 
         resultInstance = historyService.createHistoricProcessInstanceQuery().variableValueLike("stringVar", "%y").singleResult();
-        assertNotNull(resultInstance);
-        assertEquals(processInstance3.getId(), resultInstance.getId());
+        assertThat(resultInstance).isNotNull();
+        assertThat(resultInstance.getId()).isEqualTo(processInstance3.getId());
 
         resultInstance = historyService.createHistoricProcessInstanceQuery().variableValueLike("stringVar", "%zer%").singleResult();
-        assertNotNull(resultInstance);
-        assertEquals(processInstance3.getId(), resultInstance.getId());
+        assertThat(resultInstance).isNotNull();
+        assertThat(resultInstance.getId()).isEqualTo(processInstance3.getId());
 
-        assertEquals(3, historyService.createHistoricProcessInstanceQuery().variableValueLike("stringVar", "a%").count());
-        assertEquals(0, historyService.createHistoricProcessInstanceQuery().variableValueLike("stringVar", "%x%").count());
+        assertThat(historyService.createHistoricProcessInstanceQuery().variableValueLike("stringVar", "a%").count()).isEqualTo(3);
+        assertThat(historyService.createHistoricProcessInstanceQuery().variableValueLike("stringVar", "%x%").count()).isEqualTo(0);
 
         // Test value-only matching
         resultInstance = historyService.createHistoricProcessInstanceQuery().variableValueEquals("azerty").singleResult();
-        assertNotNull(resultInstance);
-        assertEquals(processInstance3.getId(), resultInstance.getId());
+        assertThat(resultInstance).isNotNull();
+        assertThat(resultInstance.getId()).isEqualTo(processInstance3.getId());
 
         processInstances = historyService.createHistoricProcessInstanceQuery().variableValueEquals("abcdef").list();
-        assertEquals(2, processInstances.size());
+        assertThat(processInstances).hasSize(2);
         expectedIds = Arrays.asList(processInstance1.getId(), processInstance2.getId());
         ids = new ArrayList<>(Arrays.asList(processInstances.get(0).getId(), processInstances.get(1).getId()));
         ids.removeAll(expectedIds);
-        assertTrue(ids.isEmpty());
+        assertThat(ids).isEmpty();
 
         resultInstance = historyService.createHistoricProcessInstanceQuery().variableValueEquals("notmatchinganyvalues").singleResult();
-        assertNull(resultInstance);
+        assertThat(resultInstance).isNull();
 
         historyService.deleteHistoricProcessInstance(processInstance1.getId());
         historyService.deleteHistoricProcessInstance(processInstance2.getId());
         historyService.deleteHistoricProcessInstance(processInstance3.getId());
-        
+
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
     }
 
@@ -713,41 +716,35 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         vars.put("lower", "ABCDEFG");
         vars.put("upper", "abcdefg");
         ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
-        
+
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
         HistoricProcessInstance instance = historyService.createHistoricProcessInstanceQuery().variableValueEqualsIgnoreCase("mixed", "abcdefg").singleResult();
-        assertNotNull(instance);
-        assertEquals(processInstance1.getId(), instance.getId());
+        assertThat(instance).isNotNull();
+        assertThat(instance.getId()).isEqualTo(processInstance1.getId());
 
         instance = historyService.createHistoricProcessInstanceQuery().variableValueEqualsIgnoreCase("lower", "abcdefg").singleResult();
-        assertNotNull(instance);
-        assertEquals(processInstance1.getId(), instance.getId());
+        assertThat(instance).isNotNull();
+        assertThat(instance.getId()).isEqualTo(processInstance1.getId());
 
         instance = historyService.createHistoricProcessInstanceQuery().variableValueEqualsIgnoreCase("upper", "abcdefg").singleResult();
-        assertNotNull(instance);
-        assertEquals(processInstance1.getId(), instance.getId());
+        assertThat(instance).isNotNull();
+        assertThat(instance.getId()).isEqualTo(processInstance1.getId());
 
         // Pass in non-lower-case string
         instance = historyService.createHistoricProcessInstanceQuery().variableValueEqualsIgnoreCase("upper", "ABCdefg").singleResult();
-        assertNotNull(instance);
-        assertEquals(processInstance1.getId(), instance.getId());
+        assertThat(instance).isNotNull();
+        assertThat(instance.getId()).isEqualTo(processInstance1.getId());
 
         // Pass in null-value, should cause exception
-        try {
-            historyService.createHistoricProcessInstanceQuery().variableValueEqualsIgnoreCase("upper", null).singleResult();
-            fail("Exception expected");
-        } catch (FlowableIllegalArgumentException ae) {
-            assertEquals("value is null", ae.getMessage());
-        }
+        assertThatThrownBy(() -> historyService.createHistoricProcessInstanceQuery().variableValueEqualsIgnoreCase("upper", null).singleResult())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage("value is null");
 
         // Pass in null name, should cause exception
-        try {
-            historyService.createHistoricProcessInstanceQuery().variableValueEqualsIgnoreCase(null, "abcdefg").singleResult();
-            fail("Exception expected");
-        } catch (FlowableIllegalArgumentException ae) {
-            assertEquals("name is null", ae.getMessage());
-        }
+        assertThatThrownBy(() -> historyService.createHistoricProcessInstanceQuery().variableValueEqualsIgnoreCase(null, "abcdefg").singleResult())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage("name is null");
     }
 
     /**
@@ -786,87 +783,87 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
 
         Calendar oneYearAgo = Calendar.getInstance();
         oneYearAgo.add(Calendar.YEAR, -1);
-        
+
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
         // Query on single short variable, should result in 2 matches
         HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery().variableValueEquals("dateVar", date1);
         List<HistoricProcessInstance> processInstances = query.list();
-        assertNotNull(processInstances);
-        assertEquals(2, processInstances.size());
+        assertThat(processInstances).isNotNull();
+        assertThat(processInstances).hasSize(2);
 
         // Query on two short variables, should result in single value
         query = historyService.createHistoricProcessInstanceQuery().variableValueEquals("dateVar", date1).variableValueEquals("dateVar2", date2);
         HistoricProcessInstance resultInstance = query.singleResult();
-        assertNotNull(resultInstance);
-        assertEquals(processInstance2.getId(), resultInstance.getId());
+        assertThat(resultInstance).isNotNull();
+        assertThat(resultInstance.getId()).isEqualTo(processInstance2.getId());
 
         // Query with unexisting variable value
         Date unexistingDate = new SimpleDateFormat("dd/MM/yyyy hh:mm:ss").parse("01/01/1989 12:00:00");
         resultInstance = historyService.createHistoricProcessInstanceQuery().variableValueEquals("dateVar", unexistingDate).singleResult();
-        assertNull(resultInstance);
+        assertThat(resultInstance).isNull();
 
         // Test NOT_EQUALS
         resultInstance = historyService.createHistoricProcessInstanceQuery().variableValueNotEquals("dateVar", date1).singleResult();
-        assertNotNull(resultInstance);
-        assertEquals(processInstance3.getId(), resultInstance.getId());
+        assertThat(resultInstance).isNotNull();
+        assertThat(resultInstance.getId()).isEqualTo(processInstance3.getId());
 
         // Test GREATER_THAN
         resultInstance = historyService.createHistoricProcessInstanceQuery().variableValueGreaterThan("dateVar", nextMonth.getTime()).singleResult();
-        assertNotNull(resultInstance);
-        assertEquals(processInstance3.getId(), resultInstance.getId());
+        assertThat(resultInstance).isNotNull();
+        assertThat(resultInstance.getId()).isEqualTo(processInstance3.getId());
 
-        assertEquals(0, historyService.createHistoricProcessInstanceQuery().variableValueGreaterThan("dateVar", nextYear.getTime()).count());
-        assertEquals(3, historyService.createHistoricProcessInstanceQuery().variableValueGreaterThan("dateVar", oneYearAgo.getTime()).count());
+        assertThat(historyService.createHistoricProcessInstanceQuery().variableValueGreaterThan("dateVar", nextYear.getTime()).count()).isEqualTo(0);
+        assertThat(historyService.createHistoricProcessInstanceQuery().variableValueGreaterThan("dateVar", oneYearAgo.getTime()).count()).isEqualTo(3);
 
         // Test GREATER_THAN_OR_EQUAL
         resultInstance = historyService.createHistoricProcessInstanceQuery().variableValueGreaterThanOrEqual("dateVar", nextMonth.getTime()).singleResult();
-        assertNotNull(resultInstance);
-        assertEquals(processInstance3.getId(), resultInstance.getId());
+        assertThat(resultInstance).isNotNull();
+        assertThat(resultInstance.getId()).isEqualTo(processInstance3.getId());
 
         resultInstance = historyService.createHistoricProcessInstanceQuery().variableValueGreaterThanOrEqual("dateVar", nextYear.getTime()).singleResult();
-        assertNotNull(resultInstance);
-        assertEquals(processInstance3.getId(), resultInstance.getId());
+        assertThat(resultInstance).isNotNull();
+        assertThat(resultInstance.getId()).isEqualTo(processInstance3.getId());
 
-        assertEquals(3, historyService.createHistoricProcessInstanceQuery().variableValueGreaterThanOrEqual("dateVar", oneYearAgo.getTime()).count());
+        assertThat(historyService.createHistoricProcessInstanceQuery().variableValueGreaterThanOrEqual("dateVar", oneYearAgo.getTime()).count()).isEqualTo(3);
 
         // Test LESS_THAN
         processInstances = historyService.createHistoricProcessInstanceQuery().variableValueLessThan("dateVar", nextYear.getTime()).list();
-        assertEquals(2, processInstances.size());
+        assertThat(processInstances).hasSize(2);
 
         List<String> expectedIds = Arrays.asList(processInstance1.getId(), processInstance2.getId());
         List<String> ids = new ArrayList<>(Arrays.asList(processInstances.get(0).getId(), processInstances.get(1).getId()));
         ids.removeAll(expectedIds);
-        assertTrue(ids.isEmpty());
+        assertThat(ids).isEmpty();
 
-        assertEquals(0, historyService.createHistoricProcessInstanceQuery().variableValueLessThan("dateVar", date1).count());
-        assertEquals(3, historyService.createHistoricProcessInstanceQuery().variableValueLessThan("dateVar", twoYearsLater.getTime()).count());
+        assertThat(historyService.createHistoricProcessInstanceQuery().variableValueLessThan("dateVar", date1).count()).isEqualTo(0);
+        assertThat(historyService.createHistoricProcessInstanceQuery().variableValueLessThan("dateVar", twoYearsLater.getTime()).count()).isEqualTo(3);
 
         // Test LESS_THAN_OR_EQUAL
         processInstances = historyService.createHistoricProcessInstanceQuery().variableValueLessThanOrEqual("dateVar", nextYear.getTime()).list();
-        assertEquals(3, processInstances.size());
+        assertThat(processInstances).hasSize(3);
 
-        assertEquals(0, historyService.createHistoricProcessInstanceQuery().variableValueLessThanOrEqual("dateVar", oneYearAgo.getTime()).count());
+        assertThat(historyService.createHistoricProcessInstanceQuery().variableValueLessThanOrEqual("dateVar", oneYearAgo.getTime()).count()).isEqualTo(0);
 
         // Test value-only matching
         resultInstance = historyService.createHistoricProcessInstanceQuery().variableValueEquals(nextYear.getTime()).singleResult();
-        assertNotNull(resultInstance);
-        assertEquals(processInstance3.getId(), resultInstance.getId());
+        assertThat(resultInstance).isNotNull();
+        assertThat(resultInstance.getId()).isEqualTo(processInstance3.getId());
 
         processInstances = historyService.createHistoricProcessInstanceQuery().variableValueEquals(date1).list();
-        assertEquals(2, processInstances.size());
+        assertThat(processInstances).hasSize(2);
         expectedIds = Arrays.asList(processInstance1.getId(), processInstance2.getId());
         ids = new ArrayList<>(Arrays.asList(processInstances.get(0).getId(), processInstances.get(1).getId()));
         ids.removeAll(expectedIds);
-        assertTrue(ids.isEmpty());
+        assertThat(ids).isEmpty();
 
         resultInstance = historyService.createHistoricProcessInstanceQuery().variableValueEquals(twoYearsLater.getTime()).singleResult();
-        assertNull(resultInstance);
+        assertThat(resultInstance).isNull();
 
         historyService.deleteHistoricProcessInstance(processInstance1.getId());
         historyService.deleteHistoricProcessInstance(processInstance2.getId());
         historyService.deleteHistoricProcessInstance(processInstance3.getId());
-        
+
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
     }
 
@@ -876,9 +873,12 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         // just test that the query will be constructed and executed, details are tested in the TaskQueryTest
         runtimeService.startProcessInstanceByKey("oneTaskProcess");
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
-        assertEquals(1, historyService.createNativeHistoricProcessInstanceQuery().sql("SELECT count(*) FROM " + managementService.getTableName(HistoricProcessInstance.class)).count());
-        assertEquals(1, historyService.createNativeHistoricProcessInstanceQuery().sql("SELECT * FROM " + managementService.getTableName(HistoricProcessInstance.class)).list().size());
-        // assertEquals(1, historyService.createNativeHistoricProcessInstanceQuery().sql("SELECT * FROM " +
+        assertThat(historyService.createNativeHistoricProcessInstanceQuery()
+                .sql("SELECT count(*) FROM " + managementService.getTableName(HistoricProcessInstance.class)).count()).isEqualTo(1);
+        assertThat(
+                historyService.createNativeHistoricProcessInstanceQuery().sql("SELECT * FROM " + managementService.getTableName(HistoricProcessInstance.class))
+                        .list()).hasSize(1);
+        // assertThat(historyService.createNativeHistoricProcessInstanceQuery().isEqualTo(1).sql("SELECT * FROM " +
         // managementService.getTableName(HistoricProcessInstance.class)).listPage(0, 1).size());
     }
 
@@ -887,9 +887,12 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
     public void testNativeHistoricTaskInstanceTest() {
         runtimeService.startProcessInstanceByKey("oneTaskProcess");
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
-        assertEquals(1, historyService.createNativeHistoricTaskInstanceQuery().sql("SELECT count(*) FROM " + managementService.getTableName(HistoricProcessInstance.class)).count());
-        assertEquals(1, historyService.createNativeHistoricTaskInstanceQuery().sql("SELECT * FROM " + managementService.getTableName(HistoricProcessInstance.class)).list().size());
-        assertEquals(1, historyService.createNativeHistoricTaskInstanceQuery().sql("SELECT * FROM " + managementService.getTableName(HistoricProcessInstance.class)).listPage(0, 1).size());
+        assertThat(historyService.createNativeHistoricTaskInstanceQuery()
+                .sql("SELECT count(*) FROM " + managementService.getTableName(HistoricProcessInstance.class)).count()).isEqualTo(1);
+        assertThat(historyService.createNativeHistoricTaskInstanceQuery().sql("SELECT * FROM " + managementService.getTableName(HistoricProcessInstance.class))
+                .list()).hasSize(1);
+        assertThat(historyService.createNativeHistoricTaskInstanceQuery().sql("SELECT * FROM " + managementService.getTableName(HistoricProcessInstance.class))
+                .listPage(0, 1)).hasSize(1);
     }
 
     @Test
@@ -897,9 +900,14 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
     public void testNativeHistoricActivityInstanceTest() {
         runtimeService.startProcessInstanceByKey("oneTaskProcess");
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
-        assertEquals(1, historyService.createNativeHistoricActivityInstanceQuery().sql("SELECT count(*) FROM " + managementService.getTableName(HistoricProcessInstance.class)).count());
-        assertEquals(1, historyService.createNativeHistoricActivityInstanceQuery().sql("SELECT * FROM " + managementService.getTableName(HistoricProcessInstance.class)).list().size());
-        assertEquals(1, historyService.createNativeHistoricActivityInstanceQuery().sql("SELECT * FROM " + managementService.getTableName(HistoricProcessInstance.class)).listPage(0, 1).size());
+        assertThat(historyService.createNativeHistoricActivityInstanceQuery()
+                .sql("SELECT count(*) FROM " + managementService.getTableName(HistoricProcessInstance.class)).count()).isEqualTo(1);
+        assertThat(
+                historyService.createNativeHistoricActivityInstanceQuery().sql("SELECT * FROM " + managementService.getTableName(HistoricProcessInstance.class))
+                        .list()).hasSize(1);
+        assertThat(
+                historyService.createNativeHistoricActivityInstanceQuery().sql("SELECT * FROM " + managementService.getTableName(HistoricProcessInstance.class))
+                        .listPage(0, 1)).hasSize(1);
     }
 
     @Test
@@ -909,17 +917,21 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         String processDefinitionKey = "oneTaskProcess";
         String processDefinitionName = "The One Task Process";
         runtimeService.startProcessInstanceByKey(processDefinitionKey);
-        
+
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
-        assertEquals(processDefinitionName, historyService.createHistoricProcessInstanceQuery().processDefinitionName(processDefinitionName).list().get(0).getProcessDefinitionName());
-        assertEquals(1, historyService.createHistoricProcessInstanceQuery().processDefinitionName(processDefinitionName).list().size());
-        assertEquals(1, historyService.createHistoricProcessInstanceQuery().processDefinitionName(processDefinitionName).count());
-        assertEquals(0, historyService.createHistoricProcessInstanceQuery().processDefinitionName("invalid").list().size());
-        assertEquals(0, historyService.createHistoricProcessInstanceQuery().processDefinitionName("invalid").count());
-        assertEquals(processDefinitionName, historyService.createHistoricProcessInstanceQuery().or().processDefinitionName(processDefinitionName).processDefinitionId("invalid").endOr().list().get(0).getProcessDefinitionName());
-        assertEquals(1, historyService.createHistoricProcessInstanceQuery().or().processDefinitionName(processDefinitionName).processDefinitionId("invalid").endOr().list().size());
-        assertEquals(1, historyService.createHistoricProcessInstanceQuery().or().processDefinitionName(processDefinitionName).processDefinitionId("invalid").endOr().count());
+        assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionName(processDefinitionName).list().get(0).getProcessDefinitionName())
+                .isEqualTo(processDefinitionName);
+        assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionName(processDefinitionName).list()).hasSize(1);
+        assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionName(processDefinitionName).count()).isEqualTo(1);
+        assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionName("invalid").list()).isEmpty();
+        assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionName("invalid").count()).isEqualTo(0);
+        assertThat(historyService.createHistoricProcessInstanceQuery().or().processDefinitionName(processDefinitionName).processDefinitionId("invalid").endOr()
+                .list().get(0).getProcessDefinitionName()).isEqualTo(processDefinitionName);
+        assertThat(historyService.createHistoricProcessInstanceQuery().or().processDefinitionName(processDefinitionName).processDefinitionId("invalid").endOr()
+                .list()).hasSize(1);
+        assertThat(historyService.createHistoricProcessInstanceQuery().or().processDefinitionName(processDefinitionName).processDefinitionId("invalid").endOr()
+                .count()).isEqualTo(1);
     }
 
     @Test
@@ -928,15 +940,17 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         String processDefinitionKey = "oneTaskProcess";
         String processDefinitionCategory = "ExamplesCategory";
         runtimeService.startProcessInstanceByKey(processDefinitionKey);
-        
+
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
-        assertEquals(1, historyService.createHistoricProcessInstanceQuery().processDefinitionCategory(processDefinitionCategory).list().size());
-        assertEquals(1, historyService.createHistoricProcessInstanceQuery().processDefinitionCategory(processDefinitionCategory).count());
-        assertEquals(0, historyService.createHistoricProcessInstanceQuery().processDefinitionCategory("invalid").list().size());
-        assertEquals(0, historyService.createHistoricProcessInstanceQuery().processDefinitionCategory("invalid").count());
-        assertEquals(1, historyService.createHistoricProcessInstanceQuery().or().processDefinitionCategory(processDefinitionCategory).processDefinitionId("invalid").endOr().list().size());
-        assertEquals(1, historyService.createHistoricProcessInstanceQuery().or().processDefinitionCategory(processDefinitionCategory).processDefinitionId("invalid").endOr().count());
+        assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionCategory(processDefinitionCategory).list()).hasSize(1);
+        assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionCategory(processDefinitionCategory).count()).isEqualTo(1);
+        assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionCategory("invalid").list()).isEmpty();
+        assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionCategory("invalid").count()).isEqualTo(0);
+        assertThat(historyService.createHistoricProcessInstanceQuery().or().processDefinitionCategory(processDefinitionCategory).processDefinitionId("invalid")
+                .endOr().list()).hasSize(1);
+        assertThat(historyService.createHistoricProcessInstanceQuery().or().processDefinitionCategory(processDefinitionCategory).processDefinitionId("invalid")
+                .endOr().count()).isEqualTo(1);
     }
 
     @Test
@@ -959,8 +973,8 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         assertThat(historicIdentityLink.getCreateTime()).isNotNull();
 
         HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery().singleResult();
-        assertEquals("johndoe", historicProcessInstance.getStartUserId());
-        assertEquals("theStart", historicProcessInstance.getStartActivityId());
+        assertThat(historicProcessInstance.getStartUserId()).isEqualTo("johndoe");
+        assertThat(historicProcessInstance.getStartActivityId()).isEqualTo("theStart");
 
         Date taskCompleteTime = new Date();
         processEngineConfiguration.getClock().setCurrentTime(taskCompleteTime);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/ProcessInstanceLogQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/ProcessInstanceLogQueryTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.api.history;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -63,7 +65,7 @@ public class ProcessInstanceLogQueryTest extends PluggableFlowableTestCase {
         for (org.flowable.task.api.Task task : taskService.createTaskQuery().list()) {
             taskService.complete(task.getId());
         }
-        
+
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
     }
 
@@ -79,22 +81,22 @@ public class ProcessInstanceLogQueryTest extends PluggableFlowableTestCase {
     @Test
     public void testBaseProperties() {
         ProcessInstanceHistoryLog log = historyService.createProcessInstanceHistoryLogQuery(processInstanceId).singleResult();
-        assertNotNull(log.getId());
-        assertNotNull(log.getProcessDefinitionId());
-        assertNotNull(log.getStartActivityId());
-        assertNotNull(log.getDurationInMillis());
-        assertNotNull(log.getEndTime());
-        assertNotNull(log.getStartTime());
+        assertThat(log.getId()).isNotNull();
+        assertThat(log.getProcessDefinitionId()).isNotNull();
+        assertThat(log.getStartActivityId()).isNotNull();
+        assertThat(log.getDurationInMillis()).isNotNull();
+        assertThat(log.getEndTime()).isNotNull();
+        assertThat(log.getStartTime()).isNotNull();
     }
 
     @Test
     public void testIncludeTasks() {
         ProcessInstanceHistoryLog log = historyService.createProcessInstanceHistoryLogQuery(processInstanceId).includeTasks().singleResult();
         List<HistoricData> events = log.getHistoricData();
-        assertEquals(2, events.size());
+        assertThat(events).hasSize(2);
 
         for (HistoricData event : events) {
-            assertTrue(event instanceof HistoricTaskInstance);
+            assertThat(event).isInstanceOf(HistoricTaskInstance.class);
         }
     }
 
@@ -102,10 +104,10 @@ public class ProcessInstanceLogQueryTest extends PluggableFlowableTestCase {
     public void testIncludeComments() {
         ProcessInstanceHistoryLog log = historyService.createProcessInstanceHistoryLogQuery(processInstanceId).includeComments().singleResult();
         List<HistoricData> events = log.getHistoricData();
-        assertEquals(3, events.size());
+        assertThat(events).hasSize(3);
 
         for (HistoricData event : events) {
-            assertTrue(event instanceof Comment);
+            assertThat(event).isInstanceOf(Comment.class);
         }
     }
 
@@ -113,7 +115,7 @@ public class ProcessInstanceLogQueryTest extends PluggableFlowableTestCase {
     public void testIncludeTasksAndComments() {
         ProcessInstanceHistoryLog log = historyService.createProcessInstanceHistoryLogQuery(processInstanceId).includeTasks().includeComments().singleResult();
         List<HistoricData> events = log.getHistoricData();
-        assertEquals(5, events.size());
+        assertThat(events).hasSize(5);
 
         int taskCounter = 0;
         int commentCounter = 0;
@@ -125,19 +127,19 @@ public class ProcessInstanceLogQueryTest extends PluggableFlowableTestCase {
                 commentCounter++;
             }
         }
-        
-        assertEquals(2, taskCounter);
-        assertEquals(3, commentCounter);
+
+        assertThat(taskCounter).isEqualTo(2);
+        assertThat(commentCounter).isEqualTo(3);
     }
 
     @Test
     public void testIncludeActivities() {
         ProcessInstanceHistoryLog log = historyService.createProcessInstanceHistoryLogQuery(processInstanceId).includeActivities().singleResult();
         List<HistoricData> events = log.getHistoricData();
-        assertEquals(9, events.size());
+        assertThat(events).hasSize(9);
 
         for (HistoricData event : events) {
-            assertTrue(event instanceof HistoricActivityInstance);
+            assertThat(event).isInstanceOf(HistoricActivityInstance.class);
         }
     }
 
@@ -146,10 +148,10 @@ public class ProcessInstanceLogQueryTest extends PluggableFlowableTestCase {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.FULL, processEngineConfiguration)) {
             ProcessInstanceHistoryLog log = historyService.createProcessInstanceHistoryLogQuery(processInstanceId).includeVariables().singleResult();
             List<HistoricData> events = log.getHistoricData();
-            assertEquals(2, events.size());
+            assertThat(events).hasSize(2);
 
             for (HistoricData event : events) {
-                assertTrue(event instanceof HistoricVariableInstance);
+                assertThat(event).isInstanceOf(HistoricVariableInstance.class);
             }
         }
     }
@@ -159,10 +161,10 @@ public class ProcessInstanceLogQueryTest extends PluggableFlowableTestCase {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.FULL, processEngineConfiguration)) {
             ProcessInstanceHistoryLog log = historyService.createProcessInstanceHistoryLogQuery(processInstanceId).includeVariableUpdates().singleResult();
             List<HistoricData> events = log.getHistoricData();
-            assertEquals(3, events.size());
+            assertThat(events).hasSize(3);
 
             for (HistoricData event : events) {
-                assertTrue(event instanceof HistoricVariableUpdate);
+                assertThat(event).isInstanceOf(HistoricVariableUpdate.class);
             }
         }
     }
@@ -170,10 +172,11 @@ public class ProcessInstanceLogQueryTest extends PluggableFlowableTestCase {
     @Test
     public void testEverything() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.FULL, processEngineConfiguration)) {
-            ProcessInstanceHistoryLog log = historyService.createProcessInstanceHistoryLogQuery(processInstanceId).includeTasks().includeActivities().includeComments().includeVariables()
+            ProcessInstanceHistoryLog log = historyService.createProcessInstanceHistoryLogQuery(processInstanceId).includeTasks().includeActivities()
+                    .includeComments().includeVariables()
                     .includeVariableUpdates().singleResult();
             List<HistoricData> events = log.getHistoricData();
-            assertEquals(19, events.size());
+            assertThat(events).hasSize(19);
         }
     }
 


### PR DESCRIPTION
All files in the `org.flowable.engine.test.api.history` package are included.

Continuing quest to use only a single style in each file and in the module.

