### PR TITLE
Mapping missing case instance data

### DIFF
--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/runtime/CaseInstanceHelperImpl.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/runtime/CaseInstanceHelperImpl.java
@@ -387,6 +387,8 @@ public class CaseInstanceHelperImpl implements CaseInstanceHelper {
         
         CmmnEngineConfiguration cmmnEngineConfiguration = CommandContextUtil.getCmmnEngineConfiguration(commandContext);
         caseInstanceEntity.setCaseDefinitionId(caseDefinition.getId());
+        caseInstanceEntity.setName(caseDefinition.getName());
+        caseInstanceEntity.setBusinessKey(caseDefinition.getKey());
         caseInstanceEntity.setStartTime(cmmnEngineConfiguration.getClock().getCurrentTime());
         caseInstanceEntity.setState(CaseInstanceState.ACTIVE);
         caseInstanceEntity.setTenantId(caseDefinition.getTenantId());


### PR DESCRIPTION
Some CaseInstanceEntity data are not populated when calling `CaseInstanceHelperImpl.createCaseInstanceEntityFromDefinition`. 

In my use case these fields (businessKey and name) cannot be seen in the case-related event logging without calling additional queries.

The fix is to simply add the missing mapping.
