### PR TITLE
Use assertj fluent style in flowable-engine.

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/variables/InstantVariableTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/variables/InstantVariableTest.java
@@ -43,11 +43,11 @@ class InstantVariableTest extends PluggableFlowableTestCase {
         Instant oneYearLater = nowInstant.plus(365, ChronoUnit.DAYS);
         Instant oneYearLaterWithoutNanos = oneYearLater.truncatedTo(ChronoUnit.MILLIS);
         ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder()
-            .processDefinitionKey("oneTaskProcess")
-            .variable("nowInstant", nowInstant)
-            .variable("oneYearBefore", oneYearBefore)
-            .variable("oneYearLater", oneYearLater)
-            .start();
+                .processDefinitionKey("oneTaskProcess")
+                .variable("nowInstant", nowInstant)
+                .variable("oneYearBefore", oneYearBefore)
+                .variable("oneYearLater", oneYearLater)
+                .start();
 
         VariableInstance nowInstantVariableInstance = runtimeService.getVariableInstance(processInstance.getId(), "nowInstant");
         assertThat(nowInstantVariableInstance.getTypeName()).isEqualTo(InstantType.TYPE_NAME);
@@ -62,19 +62,19 @@ class InstantVariableTest extends PluggableFlowableTestCase {
         assertThat(oneYearLaterVariableInstance.getValue()).isEqualTo(oneYearLaterWithoutNanos);
 
         assertThat(runtimeService.getVariables(processInstance.getId()))
-            .containsOnly(
-                entry("nowInstant", nowInstantWithoutNanos),
-                entry("oneYearBefore", oneYearBeforeWithoutNanos),
-                entry("oneYearLater", oneYearLaterWithoutNanos)
-            );
+                .containsOnly(
+                        entry("nowInstant", nowInstantWithoutNanos),
+                        entry("oneYearBefore", oneYearBeforeWithoutNanos),
+                        entry("oneYearLater", oneYearLaterWithoutNanos)
+                );
     }
 
     @Test
     @Deployment(resources = "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml")
     void testGetInstantVariableFromTask() {
         ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder()
-            .processDefinitionKey("oneTaskProcess")
-            .start();
+                .processDefinitionKey("oneTaskProcess")
+                .start();
 
         Map<String, Object> variables = new HashMap<>();
         Instant nowInstant = Instant.now();
@@ -95,9 +95,9 @@ class InstantVariableTest extends PluggableFlowableTestCase {
         assertThat(oneYearLaterVariableInstance.getValue()).isEqualTo(oneYearLaterWithoutNanos);
 
         assertThat(taskService.getVariables(task.getId()))
-            .containsOnly(
-                entry("nowInstant", nowInstantWithoutNanos),
-                entry("oneYearLater", oneYearLaterWithoutNanos)
-            );
+                .containsOnly(
+                        entry("nowInstant", nowInstantWithoutNanos),
+                        entry("oneYearLater", oneYearLaterWithoutNanos)
+                );
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/variables/LocalDateTimeVariableTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/variables/LocalDateTimeVariableTest.java
@@ -40,11 +40,11 @@ class LocalDateTimeVariableTest extends PluggableFlowableTestCase {
         LocalDateTime oneYearBefore = nowLocalDateTime.minusYears(1);
         LocalDateTime oneYearLater = nowLocalDateTime.plusYears(1);
         ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder()
-            .processDefinitionKey("oneTaskProcess")
-            .variable("nowLocalDateTime", nowLocalDateTime)
-            .variable("oneYearBefore", oneYearBefore)
-            .variable("oneYearLater", oneYearLater)
-            .start();
+                .processDefinitionKey("oneTaskProcess")
+                .variable("nowLocalDateTime", nowLocalDateTime)
+                .variable("oneYearBefore", oneYearBefore)
+                .variable("oneYearLater", oneYearLater)
+                .start();
 
         VariableInstance nowLocalDateTimeVariableInstance = runtimeService.getVariableInstance(processInstance.getId(), "nowLocalDateTime");
         assertThat(nowLocalDateTimeVariableInstance.getTypeName()).isEqualTo(LocalDateTimeType.TYPE_NAME);
@@ -59,19 +59,19 @@ class LocalDateTimeVariableTest extends PluggableFlowableTestCase {
         assertThat(oneYearLaterVariableInstance.getValue()).isEqualTo(oneYearLater);
 
         assertThat(runtimeService.getVariables(processInstance.getId()))
-            .containsOnly(
-                entry("nowLocalDateTime", nowLocalDateTime),
-                entry("oneYearBefore", oneYearBefore),
-                entry("oneYearLater", oneYearLater)
-            );
+                .containsOnly(
+                        entry("nowLocalDateTime", nowLocalDateTime),
+                        entry("oneYearBefore", oneYearBefore),
+                        entry("oneYearLater", oneYearLater)
+                );
     }
 
     @Test
     @Deployment(resources = "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml")
     void testGetLocalDateTimeVariableFromTask() {
         ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder()
-            .processDefinitionKey("oneTaskProcess")
-            .start();
+                .processDefinitionKey("oneTaskProcess")
+                .start();
 
         Map<String, Object> variables = new HashMap<>();
         LocalDateTime nowLocalDateTime = LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS);
@@ -90,9 +90,9 @@ class LocalDateTimeVariableTest extends PluggableFlowableTestCase {
         assertThat(oneYearLaterVariableInstance.getValue()).isEqualTo(oneYearLater);
 
         assertThat(taskService.getVariables(task.getId()))
-            .containsOnly(
-                entry("nowLocalDateTime", nowLocalDateTime),
-                entry("oneYearLater", oneYearLater)
-            );
+                .containsOnly(
+                        entry("nowLocalDateTime", nowLocalDateTime),
+                        entry("oneYearLater", oneYearLater)
+                );
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/variables/LocalDateVariableTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/variables/LocalDateVariableTest.java
@@ -39,11 +39,11 @@ class LocalDateVariableTest extends PluggableFlowableTestCase {
         LocalDate oneYearBefore = nowLocalDate.minusYears(1);
         LocalDate oneYearLater = nowLocalDate.plusYears(1);
         ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder()
-            .processDefinitionKey("oneTaskProcess")
-            .variable("nowLocalDate", nowLocalDate)
-            .variable("oneYearBefore", oneYearBefore)
-            .variable("oneYearLater", oneYearLater)
-            .start();
+                .processDefinitionKey("oneTaskProcess")
+                .variable("nowLocalDate", nowLocalDate)
+                .variable("oneYearBefore", oneYearBefore)
+                .variable("oneYearLater", oneYearLater)
+                .start();
 
         VariableInstance nowLocalDateVariableInstance = runtimeService.getVariableInstance(processInstance.getId(), "nowLocalDate");
         assertThat(nowLocalDateVariableInstance.getTypeName()).isEqualTo(LocalDateType.TYPE_NAME);
@@ -58,19 +58,19 @@ class LocalDateVariableTest extends PluggableFlowableTestCase {
         assertThat(oneYearLaterVariableInstance.getValue()).isEqualTo(oneYearLater);
 
         assertThat(runtimeService.getVariables(processInstance.getId()))
-            .containsOnly(
-                entry("nowLocalDate", nowLocalDate),
-                entry("oneYearBefore", oneYearBefore),
-                entry("oneYearLater", oneYearLater)
-            );
+                .containsOnly(
+                        entry("nowLocalDate", nowLocalDate),
+                        entry("oneYearBefore", oneYearBefore),
+                        entry("oneYearLater", oneYearLater)
+                );
     }
 
     @Test
     @Deployment(resources = "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml")
     void testGetLocalDateVariableFromTask() {
         ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder()
-            .processDefinitionKey("oneTaskProcess")
-            .start();
+                .processDefinitionKey("oneTaskProcess")
+                .start();
 
         Map<String, Object> variables = new HashMap<>();
         LocalDate nowLocalDate = LocalDate.now();
@@ -89,9 +89,9 @@ class LocalDateVariableTest extends PluggableFlowableTestCase {
         assertThat(oneYearLaterVariableInstance.getValue()).isEqualTo(oneYearLater);
 
         assertThat(taskService.getVariables(task.getId()))
-            .containsOnly(
-                entry("nowLocalDate", nowLocalDate),
-                entry("oneYearLater", oneYearLater)
-            );
+                .containsOnly(
+                        entry("nowLocalDate", nowLocalDate),
+                        entry("oneYearLater", oneYearLater)
+                );
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/variables/SerializableVariableTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/variables/SerializableVariableTest.java
@@ -49,11 +49,12 @@ public class SerializableVariableTest extends PluggableFlowableTestCase {
         taskService.complete(task.getId());
 
         TestSerializableVariable testSerializableVariable = (TestSerializableVariable) runtimeService.getVariable(processInstance.getId(), "myVar");
-        assertEquals(2, testSerializableVariable.getNumber());
+        assertThat(testSerializableVariable.getNumber()).isEqualTo(2);
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
-            testSerializableVariable = (TestSerializableVariable) managementService.executeCommand(commandContext -> historyService.createHistoricVariableInstanceQuery().variableName("myVar").singleResult().getValue());
-            assertEquals(2, testSerializableVariable.getNumber());
+            testSerializableVariable = (TestSerializableVariable) managementService
+                    .executeCommand(commandContext -> historyService.createHistoricVariableInstanceQuery().variableName("myVar").singleResult().getValue());
+            assertThat(testSerializableVariable.getNumber()).isEqualTo(2);
         }
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/variables/TransientVariablesTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/variables/TransientVariablesTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,16 +12,18 @@
  */
 package org.flowable.engine.test.api.variables;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.flowable.engine.delegate.DelegateExecution;
-import org.flowable.engine.delegate.ExecutionListener;
 import org.flowable.common.engine.api.delegate.Expression;
 import org.flowable.common.engine.impl.util.CollectionUtil;
+import org.flowable.engine.delegate.DelegateExecution;
+import org.flowable.engine.delegate.ExecutionListener;
 import org.flowable.engine.delegate.JavaDelegate;
 import org.flowable.engine.delegate.TaskListener;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
@@ -46,10 +48,10 @@ public class TransientVariablesTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("transientVarsTest");
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         String message = (String) taskService.getVariable(task.getId(), "message");
-        assertEquals("Hello World!", message);
+        assertThat(message).isEqualTo("Hello World!");
 
         // Variable should not be there after user task
-        assertNull(runtimeService.getVariable(processInstance.getId(), "response"));
+        assertThat(runtimeService.getVariable(processInstance.getId(), "response")).isNull();
     }
 
     @Test
@@ -57,10 +59,10 @@ public class TransientVariablesTest extends PluggableFlowableTestCase {
     public void testUseTransientVariableInExclusiveGateway() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("transientVarsTest");
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("responseOk", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("responseOk");
 
         // Variable should not be there after user task
-        assertNull(runtimeService.getVariable(processInstance.getId(), "response"));
+        assertThat(runtimeService.getVariable(processInstance.getId(), "response")).isNull();
     }
 
     @Test
@@ -72,7 +74,7 @@ public class TransientVariablesTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("transientVarsTest", persistentVars);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("My Task", task.getName());
+        assertThat(task.getName()).isEqualTo("My Task");
 
         persistentVars.clear();
         Map<String, Object> transientVars = new HashMap<>();
@@ -82,15 +84,15 @@ public class TransientVariablesTest extends PluggableFlowableTestCase {
 
         // Combined var has been set by execution listener
         String combinedVar = (String) runtimeService.getVariable(processInstance.getId(), "combinedVar");
-        assertEquals("Hello WorldABC123", combinedVar);
+        assertThat(combinedVar).isEqualTo("Hello WorldABC123");
 
-        assertNotNull(runtimeService.getVariable(processInstance.getId(), "persistentVar1"));
-        assertNotNull(runtimeService.getVariable(processInstance.getId(), "persistentVar2"));
+        assertThat(runtimeService.getVariable(processInstance.getId(), "persistentVar1")).isNotNull();
+        assertThat(runtimeService.getVariable(processInstance.getId(), "persistentVar2")).isNotNull();
 
-        assertNull(runtimeService.getVariable(processInstance.getId(), "unusedTransientVar"));
-        assertNull(runtimeService.getVariable(processInstance.getId(), "transientVar"));
-        assertNull(runtimeService.getVariable(processInstance.getId(), "secondTransientVar"));
-        assertNull(runtimeService.getVariable(processInstance.getId(), "thirdTransientVar"));
+        assertThat(runtimeService.getVariable(processInstance.getId(), "unusedTransientVar")).isNull();
+        assertThat(runtimeService.getVariable(processInstance.getId(), "transientVar")).isNull();
+        assertThat(runtimeService.getVariable(processInstance.getId(), "secondTransientVar")).isNull();
+        assertThat(runtimeService.getVariable(processInstance.getId(), "thirdTransientVar")).isNull();
     }
 
     @Test
@@ -102,7 +104,7 @@ public class TransientVariablesTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("transientVarsTest", persistentVars);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("My Task", task.getName());
+        assertThat(task.getName()).isEqualTo("My Task");
 
         persistentVars.clear();
         Map<String, Object> transientVars = new HashMap<>();
@@ -112,15 +114,15 @@ public class TransientVariablesTest extends PluggableFlowableTestCase {
 
         // Combined var has been set by execution listener
         String combinedVar = (String) runtimeService.getVariable(processInstance.getId(), "combinedVar");
-        assertEquals("Hello WorldABC123", combinedVar);
+        assertThat(combinedVar).isEqualTo("Hello WorldABC123");
 
-        assertNotNull(runtimeService.getVariable(processInstance.getId(), "persistentVar1"));
-        assertNotNull(runtimeService.getVariable(processInstance.getId(), "persistentVar2"));
+        assertThat(runtimeService.getVariable(processInstance.getId(), "persistentVar1")).isNotNull();
+        assertThat(runtimeService.getVariable(processInstance.getId(), "persistentVar2")).isNotNull();
 
-        assertNull(runtimeService.getVariable(processInstance.getId(), "unusedTransientVar"));
-        assertNull(runtimeService.getVariable(processInstance.getId(), "transientVar"));
-        assertNull(runtimeService.getVariable(processInstance.getId(), "secondTransientVar"));
-        assertNull(runtimeService.getVariable(processInstance.getId(), "thirdTransientVar"));
+        assertThat(runtimeService.getVariable(processInstance.getId(), "unusedTransientVar")).isNull();
+        assertThat(runtimeService.getVariable(processInstance.getId(), "transientVar")).isNull();
+        assertThat(runtimeService.getVariable(processInstance.getId(), "secondTransientVar")).isNull();
+        assertThat(runtimeService.getVariable(processInstance.getId(), "thirdTransientVar")).isNull();
     }
 
     @Test
@@ -129,10 +131,10 @@ public class TransientVariablesTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("transientVarsTest");
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("Task after", task.getName());
+        assertThat(task.getName()).isEqualTo("Task after");
 
         String mergedResult = (String) taskService.getVariable(task.getId(), "mergedResult");
-        assertEquals("transientVar01transientVar02transientVar03", mergedResult);
+        assertThat(mergedResult).isEqualTo("transientVar01transientVar02transientVar03");
     }
 
     @Test
@@ -141,7 +143,7 @@ public class TransientVariablesTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("transientVarsTest", CollectionUtil.singletonMap("theVar", "Hello World"));
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         String varValue = (String) taskService.getVariable(task.getId(), "resultVar");
-        assertEquals("I am shadowed", varValue);
+        assertThat(varValue).isEqualTo("I am shadowed");
     }
 
     @Test
@@ -153,13 +155,14 @@ public class TransientVariablesTest extends PluggableFlowableTestCase {
         runtimeService.trigger(executionInWait1.getId(), CollectionUtil.singletonMap("persistentVar", "persistentValue01"));
 
         Execution executionInWait2 = runtimeService.createExecutionQuery().activityId("wait2").singleResult();
-        runtimeService.trigger(executionInWait2.getId(), CollectionUtil.singletonMap("anotherPersistentVar", "persistentValue02"), CollectionUtil.singletonMap("transientVar", "transientValue"));
+        runtimeService.trigger(executionInWait2.getId(), CollectionUtil.singletonMap("anotherPersistentVar", "persistentValue02"),
+                CollectionUtil.singletonMap("transientVar", "transientValue"));
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         String result = (String) taskService.getVariable(task.getId(), "result");
-        assertEquals("persistentValue02persistentValue01transientValue", result);
+        assertThat(result).isEqualTo("persistentValue02persistentValue01transientValue");
 
-        assertNull(runtimeService.getVariable(processInstance.getId(), "transientVar"));
+        assertThat(runtimeService.getVariable(processInstance.getId(), "transientVar")).isNull();
     }
 
     @Test
@@ -170,24 +173,24 @@ public class TransientVariablesTest extends PluggableFlowableTestCase {
                 .transientVariable("variable", "gotoA")
                 .start();
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("A", task.getName());
-        assertEquals(0, runtimeService.getVariables(processInstance.getId()).size());
+        assertThat(task.getName()).isEqualTo("A");
+        assertThat(runtimeService.getVariables(processInstance.getId())).isEmpty();
 
         processInstance = runtimeService.createProcessInstanceBuilder()
                 .processDefinitionKey("transientVarsTest")
                 .transientVariable("variable", "gotoB")
                 .start();
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("B", task.getName());
-        assertEquals(0, runtimeService.getVariables(processInstance.getId()).size());
+        assertThat(task.getName()).isEqualTo("B");
+        assertThat(runtimeService.getVariables(processInstance.getId())).isEmpty();
 
         processInstance = runtimeService.createProcessInstanceBuilder()
                 .processDefinitionKey("transientVarsTest")
                 .transientVariable("variable", "somethingElse")
                 .start();
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("Default", task.getName());
-        assertEquals(0, runtimeService.getVariables(processInstance.getId()).size());
+        assertThat(task.getName()).isEqualTo("Default");
+        assertThat(runtimeService.getVariables(processInstance.getId())).isEmpty();
     }
 
     @Test
@@ -201,24 +204,24 @@ public class TransientVariablesTest extends PluggableFlowableTestCase {
                 .transientVariable("variable", "gotoA")
                 .start();
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("A", task.getName());
-        assertEquals(0, runtimeService.getVariables(processInstance.getId()).size());
+        assertThat(task.getName()).isEqualTo("A");
+        assertThat(runtimeService.getVariables(processInstance.getId())).isEmpty();
 
         processInstance = runtimeService.createProcessInstanceBuilder()
                 .processDefinitionId(processDefinitionId)
                 .transientVariable("variable", "gotoB")
                 .start();
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("B", task.getName());
-        assertEquals(0, runtimeService.getVariables(processInstance.getId()).size());
+        assertThat(task.getName()).isEqualTo("B");
+        assertThat(runtimeService.getVariables(processInstance.getId())).isEmpty();
 
         processInstance = runtimeService.createProcessInstanceBuilder()
                 .processDefinitionId(processDefinitionId)
                 .transientVariable("variable", "somethingElse")
                 .start();
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("Default", task.getName());
-        assertEquals(0, runtimeService.getVariables(processInstance.getId()).size());
+        assertThat(task.getName()).isEqualTo("Default");
+        assertThat(runtimeService.getVariables(processInstance.getId())).isEmpty();
     }
 
     @Test
@@ -230,24 +233,24 @@ public class TransientVariablesTest extends PluggableFlowableTestCase {
                 .transientVariable("variable", "gotoA")
                 .start();
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("A", task.getName());
-        assertEquals(0, runtimeService.getVariables(processInstance.getId()).size());
+        assertThat(task.getName()).isEqualTo("A");
+        assertThat(runtimeService.getVariables(processInstance.getId())).isEmpty();
 
         processInstance = runtimeService.createProcessInstanceBuilder()
                 .messageName("myMessage")
                 .transientVariable("variable", "gotoB")
                 .start();
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("B", task.getName());
-        assertEquals(0, runtimeService.getVariables(processInstance.getId()).size());
+        assertThat(task.getName()).isEqualTo("B");
+        assertThat(runtimeService.getVariables(processInstance.getId())).isEmpty();
 
         processInstance = runtimeService.createProcessInstanceBuilder()
                 .messageName("myMessage")
                 .transientVariable("variable", "somethingElse")
                 .start();
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("Default", task.getName());
-        assertEquals(0, runtimeService.getVariables(processInstance.getId()).size());
+        assertThat(task.getName()).isEqualTo("Default");
+        assertThat(runtimeService.getVariables(processInstance.getId())).isEmpty();
     }
 
     @Test
@@ -257,23 +260,23 @@ public class TransientVariablesTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("loopingTransientVarsTest");
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("task1", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("task1");
         Map<String, Object> transientVarMap = new HashMap<>();
         transientVarMap.put("status", 201);
         taskService.complete(task.getId(), new HashMap<>(), transientVarMap);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("task2", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("task2");
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("task1", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("task1");
         transientVarMap.clear();
         transientVarMap.put("status", 200);
         taskService.complete(task.getId(), new HashMap<>(), transientVarMap);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("task3", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("task3");
         transientVarMap.clear();
         transientVarMap.put("status2", 200);
         taskService.complete(task.getId(), new HashMap<>(), transientVarMap);
@@ -285,6 +288,7 @@ public class TransientVariablesTest extends PluggableFlowableTestCase {
      * Mimics a service task that fetches data from a server and stored the whole thing in a transient variable.
      */
     public static class FetchDataServiceTask implements JavaDelegate {
+
         @Override
         public void execute(DelegateExecution execution) {
             execution.setTransientVariable("response", "author=kermit;version=3;message=Hello World");
@@ -296,6 +300,7 @@ public class TransientVariablesTest extends PluggableFlowableTestCase {
      * Processes the transient variable and puts the relevant bits in real variables
      */
     public static class ServiceTask02 implements JavaDelegate {
+
         @Override
         public void execute(DelegateExecution execution) {
             String response = (String) execution.getTransientVariable("response");
@@ -309,6 +314,7 @@ public class TransientVariablesTest extends PluggableFlowableTestCase {
     }
 
     public static class CombineVariablesExecutionListener implements ExecutionListener {
+
         @Override
         public void notify(DelegateExecution execution) {
             String persistentVar1 = (String) execution.getVariable("persistentVar1");
@@ -327,6 +333,7 @@ public class TransientVariablesTest extends PluggableFlowableTestCase {
     }
 
     public static class GetDataDelegate implements JavaDelegate {
+
         private Expression variableName;
 
         @Override
@@ -337,6 +344,7 @@ public class TransientVariablesTest extends PluggableFlowableTestCase {
     }
 
     public static class ProcessDataDelegate implements JavaDelegate {
+
         private Expression dataVariableName;
         private Expression resultVariableName;
 
@@ -356,6 +364,7 @@ public class TransientVariablesTest extends PluggableFlowableTestCase {
     }
 
     public static class MergeTransientVariablesTaskListener implements TaskListener {
+
         @Override
         public void notify(DelegateTask delegateTask) {
             Map<String, Object> transientVariables = delegateTask.getTransientVariables();
@@ -375,6 +384,7 @@ public class TransientVariablesTest extends PluggableFlowableTestCase {
     }
 
     public static class MergeVariableValues implements JavaDelegate {
+
         @Override
         public void execute(DelegateExecution execution) {
             Map<String, Object> vars = execution.getVariables();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/variables/VariablesTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/variables/VariablesTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.api.variables;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -35,7 +37,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Testing various constructs with variables. Created to test the changes done in https://jira.codehaus.org/browse/ACT-1900.
- * 
+ *
  * @author Joram Barrez
  */
 public class VariablesTest extends PluggableFlowableTestCase {
@@ -106,7 +108,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
 
         // Regular getVariables after process instance start
         Map<String, Object> vars = runtimeService.getVariables(processInstanceId);
-        assertEquals(70, vars.size());
+        assertThat(vars).hasSize(70);
         int nrOfStrings = 0;
         int nrOfInts = 0;
         int nrOfDates = 0;
@@ -133,13 +135,13 @@ public class VariablesTest extends PluggableFlowableTestCase {
             }
         }
 
-        assertEquals(10, nrOfStrings);
-        assertEquals(10, nrOfBooleans);
-        assertEquals(10, nrOfDates);
-        assertEquals(10, nrOfLocalDates);
-        assertEquals(10, nrOfDateTimes);
-        assertEquals(10, nrOfInts);
-        assertEquals(10, nrOfSerializable);
+        assertThat(nrOfStrings).isEqualTo(10);
+        assertThat(nrOfBooleans).isEqualTo(10);
+        assertThat(nrOfDates).isEqualTo(10);
+        assertThat(nrOfLocalDates).isEqualTo(10);
+        assertThat(nrOfDateTimes).isEqualTo(10);
+        assertThat(nrOfInts).isEqualTo(10);
+        assertThat(nrOfSerializable).isEqualTo(10);
 
         // Trying the same after moving the process
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
@@ -147,10 +149,10 @@ public class VariablesTest extends PluggableFlowableTestCase {
 
         task = taskService.createTaskQuery().taskName("Task 3").singleResult();
         String executionId = task.getExecutionId();
-        assertFalse(processInstanceId.equals(executionId));
+        assertThat(processInstanceId).isNotEqualTo(executionId);
 
         vars = runtimeService.getVariables(processInstanceId);
-        assertEquals(70, vars.size());
+        assertThat(vars).hasSize(70);
         nrOfStrings = 0;
         nrOfInts = 0;
         nrOfDates = 0;
@@ -177,13 +179,13 @@ public class VariablesTest extends PluggableFlowableTestCase {
             }
         }
 
-        assertEquals(10, nrOfStrings);
-        assertEquals(10, nrOfBooleans);
-        assertEquals(10, nrOfDates);
-        assertEquals(10, nrOfLocalDates);
-        assertEquals(10, nrOfDateTimes);
-        assertEquals(10, nrOfInts);
-        assertEquals(10, nrOfSerializable);
+        assertThat(nrOfStrings).isEqualTo(10);
+        assertThat(nrOfBooleans).isEqualTo(10);
+        assertThat(nrOfDates).isEqualTo(10);
+        assertThat(nrOfLocalDates).isEqualTo(10);
+        assertThat(nrOfDateTimes).isEqualTo(10);
+        assertThat(nrOfInts).isEqualTo(10);
+        assertThat(nrOfSerializable).isEqualTo(10);
     }
 
     @Test
@@ -191,7 +193,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
 
         // Regular getVariables after process instance start
         Map<String, Object> vars = runtimeService.getVariablesLocal(processInstanceId);
-        assertEquals(70, vars.size());
+        assertThat(vars).hasSize(70);
         int nrOfStrings = 0;
         int nrOfInts = 0;
         int nrOfDates = 0;
@@ -218,13 +220,13 @@ public class VariablesTest extends PluggableFlowableTestCase {
             }
         }
 
-        assertEquals(10, nrOfStrings);
-        assertEquals(10, nrOfBooleans);
-        assertEquals(10, nrOfDates);
-        assertEquals(10, nrOfLocalDates);
-        assertEquals(10, nrOfDateTimes);
-        assertEquals(10, nrOfInts);
-        assertEquals(10, nrOfSerializable);
+        assertThat(nrOfStrings).isEqualTo(10);
+        assertThat(nrOfBooleans).isEqualTo(10);
+        assertThat(nrOfDates).isEqualTo(10);
+        assertThat(nrOfLocalDates).isEqualTo(10);
+        assertThat(nrOfDateTimes).isEqualTo(10);
+        assertThat(nrOfInts).isEqualTo(10);
+        assertThat(nrOfSerializable).isEqualTo(10);
 
         // Trying the same after moving the process
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
@@ -232,11 +234,11 @@ public class VariablesTest extends PluggableFlowableTestCase {
 
         task = taskService.createTaskQuery().taskName("Task 3").singleResult();
         String executionId = task.getExecutionId();
-        assertFalse(processInstanceId.equals(executionId));
+        assertThat(processInstanceId).isNotEqualTo(executionId);
 
         // On the local scope level, the vars shouldn't be visible
         vars = runtimeService.getVariablesLocal(executionId);
-        assertEquals(0, vars.size());
+        assertThat(vars).isEmpty();
     }
 
     @Test
@@ -247,7 +249,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         // See the logging to verify this
 
         String value = (String) runtimeService.getVariable(processInstanceId, "stringVar3");
-        assertEquals("stringVarValue-3", value);
+        assertThat(value).isEqualTo("stringVarValue-3");
     }
 
     @Test
@@ -259,14 +261,14 @@ public class VariablesTest extends PluggableFlowableTestCase {
 
         task = taskService.createTaskQuery().taskName("Task 3").singleResult();
         String executionId = task.getExecutionId();
-        assertFalse(processInstanceId.equals(executionId));
+        assertThat(processInstanceId).isNotEqualTo(executionId);
 
         runtimeService.setVariableLocal(executionId, "stringVar1", "hello");
         runtimeService.setVariableLocal(executionId, "stringVar2", "world");
         runtimeService.setVariableLocal(executionId, "myVar", "test123");
 
         Map<String, Object> vars = runtimeService.getVariables(processInstanceId);
-        assertEquals(70, vars.size());
+        assertThat(vars).hasSize(70);
         int nrOfStrings = 0;
         int nrOfInts = 0;
         int nrOfDates = 0;
@@ -293,17 +295,17 @@ public class VariablesTest extends PluggableFlowableTestCase {
             }
         }
 
-        assertEquals(10, nrOfStrings);
-        assertEquals(10, nrOfBooleans);
-        assertEquals(10, nrOfDates);
-        assertEquals(10, nrOfLocalDates);
-        assertEquals(10, nrOfDateTimes);
-        assertEquals(10, nrOfInts);
-        assertEquals(10, nrOfSerializable);
+        assertThat(nrOfStrings).isEqualTo(10);
+        assertThat(nrOfBooleans).isEqualTo(10);
+        assertThat(nrOfDates).isEqualTo(10);
+        assertThat(nrOfLocalDates).isEqualTo(10);
+        assertThat(nrOfDateTimes).isEqualTo(10);
+        assertThat(nrOfInts).isEqualTo(10);
+        assertThat(nrOfSerializable).isEqualTo(10);
 
-        assertEquals("stringVarValue-1", vars.get("stringVar1"));
-        assertEquals("stringVarValue-2", vars.get("stringVar2"));
-        assertNull(vars.get("myVar"));
+        assertThat(vars.get("stringVar1")).isEqualTo("stringVarValue-1");
+        assertThat(vars.get("stringVar2")).isEqualTo("stringVarValue-2");
+        assertThat(vars.get("myVar")).isNull();
 
         // Execution local
 
@@ -335,31 +337,30 @@ public class VariablesTest extends PluggableFlowableTestCase {
             }
         }
 
-        assertEquals(11, nrOfStrings);
-        assertEquals(10, nrOfBooleans);
-        assertEquals(10, nrOfDates);
-        assertEquals(10, nrOfLocalDates);
-        assertEquals(10, nrOfDateTimes);
-        assertEquals(10, nrOfInts);
-        assertEquals(10, nrOfSerializable);
+        assertThat(nrOfStrings).isEqualTo(11);
+        assertThat(nrOfBooleans).isEqualTo(10);
+        assertThat(nrOfDates).isEqualTo(10);
+        assertThat(nrOfLocalDates).isEqualTo(10);
+        assertThat(nrOfDateTimes).isEqualTo(10);
+        assertThat(nrOfInts).isEqualTo(10);
+        assertThat(nrOfSerializable).isEqualTo(10);
 
-        assertEquals("hello", vars.get("stringVar1"));
-        assertEquals("world", vars.get("stringVar2"));
-        assertEquals("test123", vars.get("myVar"));
-
+        assertThat(vars.get("stringVar1")).isEqualTo("hello");
+        assertThat(vars.get("stringVar2")).isEqualTo("world");
+        assertThat(vars.get("myVar")).isEqualTo("test123");
     }
 
     @Test
     public void testGetVariablesWithCollectionThroughRuntimeService() {
 
         Map<String, Object> vars = runtimeService.getVariables(processInstanceId, Arrays.asList("intVar1", "intVar3", "intVar5", "intVar9"));
-        assertEquals(4, vars.size());
-        assertEquals(100, vars.get("intVar1"));
-        assertEquals(300, vars.get("intVar3"));
-        assertEquals(500, vars.get("intVar5"));
-        assertEquals(900, vars.get("intVar9"));
+        assertThat(vars).hasSize(4);
+        assertThat(vars.get("intVar1")).isEqualTo(100);
+        assertThat(vars.get("intVar3")).isEqualTo(300);
+        assertThat(vars.get("intVar5")).isEqualTo(500);
+        assertThat(vars.get("intVar9")).isEqualTo(900);
 
-        assertEquals(4, runtimeService.getVariablesLocal(processInstanceId, Arrays.asList("intVar1", "intVar3", "intVar5", "intVar9")).size());
+        assertThat(runtimeService.getVariablesLocal(processInstanceId, Arrays.asList("intVar1", "intVar3", "intVar5", "intVar9"))).hasSize(4);
 
         // Trying the same after moving the process
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
@@ -367,10 +368,9 @@ public class VariablesTest extends PluggableFlowableTestCase {
 
         task = taskService.createTaskQuery().taskName("Task 3").singleResult();
         String executionId = task.getExecutionId();
-        assertFalse(processInstanceId.equals(executionId));
+        assertThat(processInstanceId).isNotEqualTo(executionId);
 
-        assertEquals(0, runtimeService.getVariablesLocal(executionId, Arrays.asList("intVar1", "intVar3", "intVar5", "intVar9")).size());
-
+        assertThat(runtimeService.getVariablesLocal(executionId, Arrays.asList("intVar1", "intVar3", "intVar5", "intVar9"))).isEmpty();
     }
 
     @Test
@@ -387,10 +387,10 @@ public class VariablesTest extends PluggableFlowableTestCase {
         taskService.complete(taskService.createTaskQuery().taskName("Task B").singleResult().getId()); // Triggers service task invocation
 
         vars = runtimeService.getVariables(processInstanceId);
-        assertEquals(71, vars.size());
+        assertThat(vars).hasSize(71);
 
         String varValue = (String) runtimeService.getVariable(processInstanceId, "testVar");
-        assertEquals("HELLO world", varValue);
+        assertThat(varValue).isEqualTo("HELLO world");
     }
 
     @Test
@@ -405,7 +405,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         taskService.complete(taskService.createTaskQuery().taskName("Task B").singleResult().getId()); // Triggers service task invocation
 
         String varValue = (String) runtimeService.getVariable(processInstanceId, "testVar");
-        assertEquals("HELLO world!", varValue);
+        assertThat(varValue).isEqualTo("HELLO world!");
     }
 
     @Test
@@ -418,8 +418,8 @@ public class VariablesTest extends PluggableFlowableTestCase {
         taskService.complete(taskService.createTaskQuery().taskName("Task A").singleResult().getId());
         taskService.complete(taskService.createTaskQuery().taskName("Task B").singleResult().getId()); // Triggers service task invocation
 
-        assertEquals("test 1 2 3", (String) runtimeService.getVariable(processInstanceId, "testVar"));
-        assertEquals("Hiya", (String) runtimeService.getVariable(processInstanceId, "testVar2"));
+        assertThat((String) runtimeService.getVariable(processInstanceId, "testVar")).isEqualTo("test 1 2 3");
+        assertThat((String) runtimeService.getVariable(processInstanceId, "testVar2")).isEqualTo("Hiya");
     }
 
     @Test
@@ -433,7 +433,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         taskService.complete(taskService.createTaskQuery().taskName("Task A").singleResult().getId());
         taskService.complete(taskService.createTaskQuery().taskName("Task B").singleResult().getId()); // Triggers service task invocation
 
-        assertEquals("1234", (String) runtimeService.getVariable(processInstanceId, "testVar"));
+        assertThat((String) runtimeService.getVariable(processInstanceId, "testVar")).isEqualTo("1234");
     }
 
     @Test
@@ -447,14 +447,11 @@ public class VariablesTest extends PluggableFlowableTestCase {
         String processInstanceId = runtimeService.startProcessInstanceByKey("variablesFetchingTestProcess", vars).getId();
 
         taskService.complete(taskService.createTaskQuery().taskName("Task A").singleResult().getId());
-        taskService.complete(taskService.createTaskQuery().taskName("Task B").singleResult().getId()); // Triggers
-                                                                                                       // service
-                                                                                                       // task
-                                                                                                       // invocation
+        taskService.complete(taskService.createTaskQuery().taskName("Task B").singleResult().getId()); // Triggers service task invocation
 
-        assertEquals("one-CHANGED", (String) runtimeService.getVariable(processInstanceId, "testVar1"));
-        assertEquals("two-CHANGED", (String) runtimeService.getVariable(processInstanceId, "testVar2"));
-        assertNull(runtimeService.getVariable(processInstanceId, "testVar3"));
+        assertThat((String) runtimeService.getVariable(processInstanceId, "testVar1")).isEqualTo("one-CHANGED");
+        assertThat((String) runtimeService.getVariable(processInstanceId, "testVar2")).isEqualTo("two-CHANGED");
+        assertThat(runtimeService.getVariable(processInstanceId, "testVar3")).isNull();
     }
 
     @Test
@@ -462,7 +459,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskName("Task 1").singleResult();
         Map<String, Object> vars = taskService.getVariables(task.getId());
-        assertEquals(70, vars.size());
+        assertThat(vars).hasSize(70);
         int nrOfStrings = 0;
         int nrOfInts = 0;
         int nrOfDates = 0;
@@ -489,45 +486,44 @@ public class VariablesTest extends PluggableFlowableTestCase {
             }
         }
 
-        assertEquals(10, nrOfStrings);
-        assertEquals(10, nrOfBooleans);
-        assertEquals(10, nrOfDates);
-        assertEquals(10, nrOfLocalDates);
-        assertEquals(10, nrOfDateTimes);
-        assertEquals(10, nrOfInts);
-        assertEquals(10, nrOfSerializable);
+        assertThat(nrOfStrings).isEqualTo(10);
+        assertThat(nrOfBooleans).isEqualTo(10);
+        assertThat(nrOfDates).isEqualTo(10);
+        assertThat(nrOfLocalDates).isEqualTo(10);
+        assertThat(nrOfDateTimes).isEqualTo(10);
+        assertThat(nrOfInts).isEqualTo(10);
+        assertThat(nrOfSerializable).isEqualTo(10);
 
         // Get variables local
-        assertEquals(0, taskService.getVariablesLocal(task.getId()).size());
+        assertThat(taskService.getVariablesLocal(task.getId())).isEmpty();
 
         // Get collection of variables
-        assertEquals(2, taskService.getVariables(task.getId(), Arrays.asList("intVar2", "intVar5")).size());
-        assertEquals(0, taskService.getVariablesLocal(task.getId(), Arrays.asList("intVar2", "intVar5")).size());
+        assertThat(taskService.getVariables(task.getId(), Arrays.asList("intVar2", "intVar5"))).hasSize(2);
+        assertThat(taskService.getVariablesLocal(task.getId(), Arrays.asList("intVar2", "intVar5"))).isEmpty();
 
         // Get Variable
-        assertEquals("stringVarValue-3", taskService.getVariable(task.getId(), "stringVar3"));
-        assertNull(taskService.getVariable(task.getId(), "stringVarDoesNotExist"));
-        assertNull(taskService.getVariableLocal(task.getId(), "stringVar3"));
+        assertThat(taskService.getVariable(task.getId(), "stringVar3")).isEqualTo("stringVarValue-3");
+        assertThat(taskService.getVariable(task.getId(), "stringVarDoesNotExist")).isNull();
+        assertThat(taskService.getVariableLocal(task.getId(), "stringVar3")).isNull();
 
         // Set local variable
         taskService.setVariableLocal(task.getId(), "localTaskVar", "localTaskVarValue");
-        assertEquals(71, taskService.getVariables(task.getId()).size());
-        assertEquals(1, taskService.getVariablesLocal(task.getId()).size());
-        assertEquals(2, taskService.getVariables(task.getId(), Arrays.asList("intVar2", "intVar5")).size());
-        assertEquals(0, taskService.getVariablesLocal(task.getId(), Arrays.asList("intVar2", "intVar5")).size());
-        assertEquals("localTaskVarValue", taskService.getVariable(task.getId(), "localTaskVar"));
-        assertEquals("localTaskVarValue", taskService.getVariableLocal(task.getId(), "localTaskVar"));
+        assertThat(taskService.getVariables(task.getId())).hasSize(71);
+        assertThat(taskService.getVariablesLocal(task.getId())).hasSize(1);
+        assertThat(taskService.getVariables(task.getId(), Arrays.asList("intVar2", "intVar5"))).hasSize(2);
+        assertThat(taskService.getVariablesLocal(task.getId(), Arrays.asList("intVar2", "intVar5"))).isEmpty();
+        assertThat(taskService.getVariable(task.getId(), "localTaskVar")).isEqualTo("localTaskVarValue");
+        assertThat(taskService.getVariableLocal(task.getId(), "localTaskVar")).isEqualTo("localTaskVarValue");
 
         // Override process variable
         Collection<String> varNames = new ArrayList<>();
         varNames.add("stringVar1");
-        assertEquals("stringVarValue-1", taskService.getVariable(task.getId(), "stringVar1"));
-        assertEquals("stringVarValue-1", taskService.getVariable(task.getId(), "stringVar1"));
-        assertEquals("stringVarValue-1", taskService.getVariables(task.getId(), varNames).get("stringVar1"));
+        assertThat(taskService.getVariable(task.getId(), "stringVar1")).isEqualTo("stringVarValue-1");
+        assertThat(taskService.getVariables(task.getId(), varNames).get("stringVar1")).isEqualTo("stringVarValue-1");
         taskService.setVariableLocal(task.getId(), "stringVar1", "Override");
-        assertEquals(71, taskService.getVariables(task.getId()).size());
-        assertEquals("Override", taskService.getVariable(task.getId(), "stringVar1"));
-        assertEquals("Override", taskService.getVariables(task.getId(), varNames).get("stringVar1"));
+        assertThat(taskService.getVariables(task.getId())).hasSize(71);
+        assertThat(taskService.getVariable(task.getId(), "stringVar1")).isEqualTo("Override");
+        assertThat(taskService.getVariables(task.getId(), varNames).get("stringVar1")).isEqualTo("Override");
     }
 
     @Test
@@ -540,29 +536,29 @@ public class VariablesTest extends PluggableFlowableTestCase {
 
         // Regular getVariables after process instance start
         LocalDate date1 = (LocalDate) runtimeService.getVariable(processInstanceId, "localdateVar1");
-        assertEquals(todayYear, date1.getYear());
-        assertEquals(todayMonth + 1, date1.getMonthOfYear());
-        assertEquals(todayDate, date1.getDayOfMonth());
+        assertThat(date1.getYear()).isEqualTo(todayYear);
+        assertThat(date1.getMonthOfYear()).isEqualTo(todayMonth + 1);
+        assertThat(date1.getDayOfMonth()).isEqualTo(todayDate);
 
         date1 = new LocalDate(2010, 11, 10);
         runtimeService.setVariable(processInstanceId, "localdateVar1", date1);
         date1 = (LocalDate) runtimeService.getVariable(processInstanceId, "localdateVar1");
-        assertEquals(2010, date1.getYear());
-        assertEquals(11, date1.getMonthOfYear());
-        assertEquals(10, date1.getDayOfMonth());
+        assertThat(date1.getYear()).isEqualTo(2010);
+        assertThat(date1.getMonthOfYear()).isEqualTo(11);
+        assertThat(date1.getDayOfMonth()).isEqualTo(10);
 
         LocalDate queryDate = new LocalDate(2010, 11, 9);
         ProcessInstance processInstance = runtimeService.createProcessInstanceQuery().variableValueGreaterThan("localdateVar1", queryDate).singleResult();
-        assertNotNull(processInstance);
-        assertEquals(processInstanceId, processInstance.getId());
+        assertThat(processInstance).isNotNull();
+        assertThat(processInstance.getId()).isEqualTo(processInstanceId);
 
         queryDate = new LocalDate(2010, 11, 10);
         processInstance = runtimeService.createProcessInstanceQuery().variableValueGreaterThan("localdateVar1", queryDate).singleResult();
-        assertNull(processInstance);
+        assertThat(processInstance).isNull();
 
         processInstance = runtimeService.createProcessInstanceQuery().variableValueGreaterThanOrEqual("localdateVar1", queryDate).singleResult();
-        assertNotNull(processInstance);
-        assertEquals(processInstanceId, processInstance.getId());
+        assertThat(processInstance).isNotNull();
+        assertThat(processInstance.getId()).isEqualTo(processInstanceId);
     }
 
     @Test
@@ -575,31 +571,31 @@ public class VariablesTest extends PluggableFlowableTestCase {
 
         // Regular getVariables after process instance start
         DateTime date1 = (DateTime) runtimeService.getVariable(processInstanceId, "datetimeVar1");
-        assertEquals(todayYear, date1.getYear());
-        assertEquals(todayMonth + 1, date1.getMonthOfYear());
-        assertEquals(todayDate, date1.getDayOfMonth());
+        assertThat(date1.getYear()).isEqualTo(todayYear);
+        assertThat(date1.getMonthOfYear()).isEqualTo(todayMonth + 1);
+        assertThat(date1.getDayOfMonth()).isEqualTo(todayDate);
 
         date1 = new DateTime(2010, 11, 10, 10, 15);
         runtimeService.setVariable(processInstanceId, "datetimeVar1", date1);
         date1 = (DateTime) runtimeService.getVariable(processInstanceId, "datetimeVar1");
-        assertEquals(2010, date1.getYear());
-        assertEquals(11, date1.getMonthOfYear());
-        assertEquals(10, date1.getDayOfMonth());
-        assertEquals(10, date1.getHourOfDay());
-        assertEquals(15, date1.getMinuteOfHour());
+        assertThat(date1.getYear()).isEqualTo(2010);
+        assertThat(date1.getMonthOfYear()).isEqualTo(11);
+        assertThat(date1.getDayOfMonth()).isEqualTo(10);
+        assertThat(date1.getHourOfDay()).isEqualTo(10);
+        assertThat(date1.getMinuteOfHour()).isEqualTo(15);
 
         DateTime queryDate = new DateTime(2010, 11, 10, 9, 15);
         ProcessInstance processInstance = runtimeService.createProcessInstanceQuery().variableValueGreaterThan("datetimeVar1", queryDate).singleResult();
-        assertNotNull(processInstance);
-        assertEquals(processInstanceId, processInstance.getId());
+        assertThat(processInstance).isNotNull();
+        assertThat(processInstance.getId()).isEqualTo(processInstanceId);
 
         queryDate = new DateTime(2010, 11, 10, 10, 15);
         processInstance = runtimeService.createProcessInstanceQuery().variableValueGreaterThan("datetimeVar1", queryDate).singleResult();
-        assertNull(processInstance);
+        assertThat(processInstance).isNull();
 
         processInstance = runtimeService.createProcessInstanceQuery().variableValueGreaterThanOrEqual("datetimeVar1", queryDate).singleResult();
-        assertNotNull(processInstance);
-        assertEquals(processInstanceId, processInstance.getId());
+        assertThat(processInstance).isNotNull();
+        assertThat(processInstance.getId()).isEqualTo(processInstanceId);
     }
 
     // Class to test variable serialization
@@ -624,6 +620,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
 
     // Test delegates
     public static class TestJavaDelegate1 implements JavaDelegate {
+
         @Override
         public void execute(DelegateExecution execution) {
             String var = (String) execution.getVariable("testVar");
@@ -632,6 +629,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
     }
 
     public static class TestJavaDelegate2 implements JavaDelegate {
+
         @Override
         public void execute(DelegateExecution execution) {
             String var = (String) execution.getVariable("testVar");
@@ -640,6 +638,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
     }
 
     public static class TestJavaDelegate3 implements JavaDelegate {
+
         @Override
         public void execute(DelegateExecution execution) {
 
@@ -649,6 +648,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
     // ////////////////////////////////////////
 
     public static class TestJavaDelegate4 implements JavaDelegate {
+
         @Override
         public void execute(DelegateExecution execution) {
             String var = (String) execution.getVariable("testVar", false);
@@ -657,6 +657,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
     }
 
     public static class TestJavaDelegate5 implements JavaDelegate {
+
         @Override
         public void execute(DelegateExecution execution) {
             String var = (String) execution.getVariable("testVar", false);
@@ -665,6 +666,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
     }
 
     public static class TestJavaDelegate6 implements JavaDelegate {
+
         @Override
         public void execute(DelegateExecution execution) {
             String var = (String) execution.getVariable("testVar", false);
@@ -675,6 +677,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
     // ////////////////////////////////////////
 
     public static class TestJavaDelegate7 implements JavaDelegate {
+
         @Override
         public void execute(DelegateExecution execution) {
 
@@ -685,6 +688,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
     }
 
     public static class TestJavaDelegate8 implements JavaDelegate {
+
         @Override
         public void execute(DelegateExecution execution) {
             String var = (String) execution.getVariable("testVar", false);
@@ -693,6 +697,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
     }
 
     public static class TestJavaDelegate9 implements JavaDelegate {
+
         @Override
         public void execute(DelegateExecution execution) {
             execution.setVariable("testVar2", "Hiya");
@@ -702,6 +707,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
     // ////////////////////////////////////////
 
     public static class TestJavaDelegate10 implements JavaDelegate {
+
         @Override
         public void execute(DelegateExecution execution) {
             String testVar = (String) execution.getVariable("testVar", false);
@@ -710,6 +716,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
     }
 
     public static class TestJavaDelegate11 implements JavaDelegate {
+
         @Override
         public void execute(DelegateExecution execution) {
             String testVar = (String) execution.getVariable("testVar", false);
@@ -718,6 +725,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
     }
 
     public static class TestJavaDelegate12 implements JavaDelegate {
+
         @Override
         public void execute(DelegateExecution execution) {
             String testVar = (String) execution.getVariable("testVar");
@@ -728,6 +736,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
     // ////////////////////////////////////////
 
     public static class TestJavaDelegate13 implements JavaDelegate {
+
         @Override
         public void execute(DelegateExecution execution) {
             Map<String, Object> vars = execution.getVariables(Arrays.asList("testVar1", "testVar2", "testVar3"), false);
@@ -745,6 +754,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
     }
 
     public static class TestJavaDelegate14 implements JavaDelegate {
+
         @Override
         public void execute(DelegateExecution execution) {
             String value = (String) execution.getVariable("testVar2");
@@ -754,6 +764,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
     }
 
     public static class TestJavaDelegate15 implements JavaDelegate {
+
         @Override
         public void execute(DelegateExecution execution) {
             execution.removeVariable("testVar3");


### PR DESCRIPTION
All files in the `org.flowable.engine.test.api.variables` package are included.

Continuing quest to use only a single style in each file and in the module.

