### PR TITLE
Use assertj fluent style in flowable-engine.

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/identity/ChangePasswordIdentityServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/identity/ChangePasswordIdentityServiceTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.engine.test.api.identity;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.flowable.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.flowable.engine.test.impl.CustomConfigurationFlowableTestCase;
 import org.flowable.idm.api.User;
@@ -27,10 +29,9 @@ public class ChangePasswordIdentityServiceTest extends CustomConfigurationFlowab
     @Override
     protected void configureConfiguration(ProcessEngineConfigurationImpl processEngineConfiguration) {
         processEngineConfiguration.setIdmEngineConfigurator(
-            new PasswordEncoderIdmEngineConfigurator()
+                new PasswordEncoderIdmEngineConfigurator()
         );
     }
-
 
     @Test
     public void testChangePassword() {
@@ -43,19 +44,19 @@ public class ChangePasswordIdentityServiceTest extends CustomConfigurationFlowab
             user.setFirstName("John Doe");
             identityService.saveUser(user);
             User johndoe = identityService.createUserQuery().userId("johndoe").list().get(0);
-            assertFalse(johndoe.getPassword().equals("xxx"));
-            assertEquals("John Doe", johndoe.getFirstName());
-            assertTrue(identityService.checkPassword("johndoe", "xxx"));
+            assertThat(johndoe.getPassword()).isNotEqualTo("xxx");
+            assertThat(johndoe.getFirstName()).isEqualTo("John Doe");
+            assertThat(identityService.checkPassword("johndoe", "xxx")).isTrue();
 
             user = identityService.createUserQuery().userId("johndoe").list().get(0);
             user.setPassword("yyy");
             identityService.saveUser(user);
-            assertTrue(identityService.checkPassword("johndoe", "xxx"));
+            assertThat(identityService.checkPassword("johndoe", "xxx")).isTrue();
 
             user = identityService.createUserQuery().userId("johndoe").list().get(0);
             user.setPassword("yyy");
             identityService.updateUserPassword(user);
-            assertTrue(identityService.checkPassword("johndoe", "yyy"));
+            assertThat(identityService.checkPassword("johndoe", "yyy")).isTrue();
 
         } finally {
             identityService.deleteUser("johndoe");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/identity/GroupQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/identity/GroupQueryTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,6 +12,9 @@
  */
 
 package org.flowable.engine.test.api.identity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 
@@ -86,11 +89,8 @@ public class GroupQueryTest extends PluggableFlowableTestCase {
         GroupQuery query = identityService.createGroupQuery().groupId("invalid");
         verifyQueryResults(query, 0);
 
-        try {
-            identityService.createGroupQuery().groupId(null).list();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> identityService.createGroupQuery().groupId(null).list())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
@@ -107,11 +107,8 @@ public class GroupQueryTest extends PluggableFlowableTestCase {
         GroupQuery query = identityService.createGroupQuery().groupName("invalid");
         verifyQueryResults(query, 0);
 
-        try {
-            identityService.createGroupQuery().groupName(null).list();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> identityService.createGroupQuery().groupName(null).list())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
@@ -131,11 +128,8 @@ public class GroupQueryTest extends PluggableFlowableTestCase {
         GroupQuery query = identityService.createGroupQuery().groupNameLike("%invalid%");
         verifyQueryResults(query, 0);
 
-        try {
-            identityService.createGroupQuery().groupNameLike(null).list();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> identityService.createGroupQuery().groupNameLike(null).list())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
@@ -152,11 +146,8 @@ public class GroupQueryTest extends PluggableFlowableTestCase {
         GroupQuery query = identityService.createGroupQuery().groupType("invalid");
         verifyQueryResults(query, 0);
 
-        try {
-            identityService.createGroupQuery().groupType(null).list();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> identityService.createGroupQuery().groupType(null).list())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
@@ -169,16 +160,16 @@ public class GroupQueryTest extends PluggableFlowableTestCase {
 
         query = query.orderByGroupId().asc();
         List<Group> groups = query.list();
-        assertEquals(3, groups.size());
-        assertEquals("admin", groups.get(0).getId());
-        assertEquals("frogs", groups.get(1).getId());
-        assertEquals("muppets", groups.get(2).getId());
+        assertThat(groups).hasSize(3);
+        assertThat(groups.get(0).getId()).isEqualTo("admin");
+        assertThat(groups.get(1).getId()).isEqualTo("frogs");
+        assertThat(groups.get(2).getId()).isEqualTo("muppets");
 
         query = query.groupType("user");
         groups = query.list();
-        assertEquals(2, groups.size());
-        assertEquals("frogs", groups.get(0).getId());
-        assertEquals("muppets", groups.get(1).getId());
+        assertThat(groups)
+                .extracting(Group::getId)
+                .containsExactly("frogs", "muppets");
     }
 
     @Test
@@ -186,99 +177,85 @@ public class GroupQueryTest extends PluggableFlowableTestCase {
         GroupQuery query = identityService.createGroupQuery().groupMember("invalid");
         verifyQueryResults(query, 0);
 
-        try {
-            identityService.createGroupQuery().groupMember(null).list();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> identityService.createGroupQuery().groupMember(null).list())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
     public void testQuerySorting() {
         // asc
-        assertEquals(4, identityService.createGroupQuery().orderByGroupId().asc().count());
-        assertEquals(4, identityService.createGroupQuery().orderByGroupName().asc().count());
-        assertEquals(4, identityService.createGroupQuery().orderByGroupType().asc().count());
+        assertThat(identityService.createGroupQuery().orderByGroupId().asc().count()).isEqualTo(4);
+        assertThat(identityService.createGroupQuery().orderByGroupName().asc().count()).isEqualTo(4);
+        assertThat(identityService.createGroupQuery().orderByGroupType().asc().count()).isEqualTo(4);
 
         // desc
-        assertEquals(4, identityService.createGroupQuery().orderByGroupId().desc().count());
-        assertEquals(4, identityService.createGroupQuery().orderByGroupName().desc().count());
-        assertEquals(4, identityService.createGroupQuery().orderByGroupType().desc().count());
+        assertThat(identityService.createGroupQuery().orderByGroupId().desc().count()).isEqualTo(4);
+        assertThat(identityService.createGroupQuery().orderByGroupName().desc().count()).isEqualTo(4);
+        assertThat(identityService.createGroupQuery().orderByGroupType().desc().count()).isEqualTo(4);
 
         // Multiple sortings
         GroupQuery query = identityService.createGroupQuery().orderByGroupType().asc().orderByGroupName().desc();
         List<Group> groups = query.list();
-        assertEquals(4, query.count());
+        assertThat(query.count()).isEqualTo(4);
 
-        assertEquals("security", groups.get(0).getType());
-        assertEquals("user", groups.get(1).getType());
-        assertEquals("user", groups.get(2).getType());
-        assertEquals("user", groups.get(3).getType());
+        assertThat(groups.get(0).getType()).isEqualTo("security");
+        assertThat(groups.get(1).getType()).isEqualTo("user");
+        assertThat(groups.get(2).getType()).isEqualTo("user");
+        assertThat(groups.get(3).getType()).isEqualTo("user");
 
-        assertEquals("admin", groups.get(0).getId());
-        assertEquals("muppets", groups.get(1).getId());
-        assertEquals("mammals", groups.get(2).getId());
-        assertEquals("frogs", groups.get(3).getId());
+        assertThat(groups.get(0).getId()).isEqualTo("admin");
+        assertThat(groups.get(1).getId()).isEqualTo("muppets");
+        assertThat(groups.get(2).getId()).isEqualTo("mammals");
+        assertThat(groups.get(3).getId()).isEqualTo("frogs");
     }
 
     @Test
     public void testQueryInvalidSortingUsage() {
-        try {
-            identityService.createGroupQuery().orderByGroupId().list();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> identityService.createGroupQuery().orderByGroupId().list())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
 
-        try {
-            identityService.createGroupQuery().orderByGroupId().orderByGroupName().list();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> identityService.createGroupQuery().orderByGroupName().list())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     private void verifyQueryResults(GroupQuery query, int countExpected) {
-        assertEquals(countExpected, query.list().size());
-        assertEquals(countExpected, query.count());
+        assertThat(query.list()).hasSize(countExpected);
+        assertThat(query.count()).isEqualTo(countExpected);
 
         if (countExpected == 1) {
-            assertNotNull(query.singleResult());
+            assertThat(query.singleResult()).isNotNull();
         } else if (countExpected > 1) {
             verifySingleResultFails(query);
         } else if (countExpected == 0) {
-            assertNull(query.singleResult());
+            assertThat(query.singleResult()).isNull();
         }
     }
 
     private void verifySingleResultFails(GroupQuery query) {
-        try {
-            query.singleResult();
-            fail();
-        } catch (FlowableException e) {
-        }
+        assertThatThrownBy(() -> query.singleResult())
+                .isExactlyInstanceOf(FlowableException.class);
     }
 
     @Test
     public void testNativeQuery() {
         String baseQuerySql = "SELECT * FROM " + IdentityTestUtil.getTableName("ACT_ID_GROUP", processEngineConfiguration);
 
-        assertEquals(4, identityService.createNativeGroupQuery().sql(baseQuerySql).list().size());
+        assertThat(identityService.createNativeGroupQuery().sql(baseQuerySql).list()).hasSize(4);
 
-        assertEquals(1, identityService.createNativeGroupQuery().sql(baseQuerySql + " where ID_ = #{id}").parameter("id", "admin").list().size());
+        assertThat(identityService.createNativeGroupQuery().sql(baseQuerySql + " where ID_ = #{id}").parameter("id", "admin").list()).hasSize(1);
 
-        assertEquals(
-                3,
-                identityService
-                        .createNativeGroupQuery()
-                        .sql(
-                                "SELECT aig.* from " + IdentityTestUtil.getTableName("ACT_ID_GROUP", processEngineConfiguration) + " aig" + " inner join "
-                                        + IdentityTestUtil.getTableName("ACT_ID_MEMBERSHIP", processEngineConfiguration) + " aim on aig.ID_ = aim.GROUP_ID_ "
-                                        + " inner join " + IdentityTestUtil.getTableName("ACT_ID_USER", processEngineConfiguration) + " aiu on aiu.ID_ = aim.USER_ID_ where aiu.ID_ = #{id}")
-                        .parameter("id", "kermit").list().size());
+        assertThat(identityService.createNativeGroupQuery()
+                .sql(
+                        "SELECT aig.* from " + IdentityTestUtil.getTableName("ACT_ID_GROUP", processEngineConfiguration) + " aig" + " inner join "
+                                + IdentityTestUtil.getTableName("ACT_ID_MEMBERSHIP", processEngineConfiguration) + " aim on aig.ID_ = aim.GROUP_ID_ "
+                                + " inner join " + IdentityTestUtil.getTableName("ACT_ID_USER", processEngineConfiguration)
+                                + " aiu on aiu.ID_ = aim.USER_ID_ where aiu.ID_ = #{id}")
+                .parameter("id", "kermit").list()).hasSize(3);
 
         // paging
-        assertEquals(2, identityService.createNativeGroupQuery().sql(baseQuerySql).listPage(0, 2).size());
-        assertEquals(3, identityService.createNativeGroupQuery().sql(baseQuerySql).listPage(1, 3).size());
-        assertEquals(1, identityService.createNativeGroupQuery().sql(baseQuerySql + " where ID_ = #{id}").parameter("id", "admin").listPage(0, 1).size());
+        assertThat(identityService.createNativeGroupQuery().sql(baseQuerySql).listPage(0, 2)).hasSize(2);
+        assertThat(identityService.createNativeGroupQuery().sql(baseQuerySql).listPage(1, 3)).hasSize(3);
+        assertThat(identityService.createNativeGroupQuery().sql(baseQuerySql + " where ID_ = #{id}").parameter("id", "admin").listPage(0, 1)).hasSize(1);
     }
 
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/identity/IdentityServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/identity/IdentityServiceTest.java
@@ -206,21 +206,21 @@ public class IdentityServiceTest extends PluggableFlowableTestCase {
     public void testSaveGroupNullArgument() {
         assertThatThrownBy(() -> identityService.saveGroup(null))
                 .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
-                .hasMessage("group is null");
+                .hasMessageContaining("group is null");
     }
 
     @Test
     public void testSaveUserNullArgument() {
         assertThatThrownBy(() -> identityService.saveUser(null))
                 .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
-                .hasMessage("user is null");
+                .hasMessageContaining("user is null");
     }
 
     @Test
     public void testFindGroupByIdNullArgument() {
         assertThatThrownBy(() -> identityService.createGroupQuery().groupId(null).singleResult())
                 .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
-                .hasMessage("id is null");
+                .hasMessageContaining("id is null");
     }
 
     @Test

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/identity/IdentityServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/identity/IdentityServiceTest.java
@@ -13,10 +13,12 @@
 
 package org.flowable.engine.test.api.identity;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.util.Arrays;
 import java.util.List;
 
-import org.flowable.common.engine.api.FlowableException;
 import org.flowable.common.engine.api.FlowableIllegalArgumentException;
 import org.flowable.common.engine.api.FlowableOptimisticLockingException;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
@@ -36,13 +38,13 @@ public class IdentityServiceTest extends PluggableFlowableTestCase {
         identityService.saveUser(user);
 
         identityService.setUserInfo("testuser", "myinfo", "myvalue");
-        assertEquals("myvalue", identityService.getUserInfo("testuser", "myinfo"));
+        assertThat(identityService.getUserInfo("testuser", "myinfo")).isEqualTo("myvalue");
 
         identityService.setUserInfo("testuser", "myinfo", "myvalue2");
-        assertEquals("myvalue2", identityService.getUserInfo("testuser", "myinfo"));
+        assertThat(identityService.getUserInfo("testuser", "myinfo")).isEqualTo("myvalue2");
 
         identityService.deleteUserInfo("testuser", "myinfo");
-        assertNull(identityService.getUserInfo("testuser", "myinfo"));
+        assertThat(identityService.getUserInfo("testuser", "myinfo")).isNull();
 
         identityService.deleteUser(user.getId());
     }
@@ -51,14 +53,12 @@ public class IdentityServiceTest extends PluggableFlowableTestCase {
     public void testCreateExistingUser() {
         User user = identityService.newUser("testuser");
         identityService.saveUser(user);
-        try {
+
+        assertThatThrownBy(() -> {
             User secondUser = identityService.newUser("testuser");
             identityService.saveUser(secondUser);
-            fail("Exception should have been thrown");
-        } catch (RuntimeException re) {
-            // Expected exception while saving new user with the same name as an
-            // existing one.
-        }
+        })
+                .isInstanceOf(RuntimeException.class);
 
         identityService.deleteUser(user.getId());
     }
@@ -82,10 +82,10 @@ public class IdentityServiceTest extends PluggableFlowableTestCase {
         identityService.saveUser(user);
 
         user = identityService.createUserQuery().userId("johndoe").singleResult();
-        assertEquals("Jane", user.getFirstName());
-        assertEquals("Donnel", user.getLastName());
-        assertEquals("updated@alfresco.com", user.getEmail());
-        assertEquals("flowable", user.getTenantId());
+        assertThat(user.getFirstName()).isEqualTo("Jane");
+        assertThat(user.getLastName()).isEqualTo("Donnel");
+        assertThat(user.getEmail()).isEqualTo("updated@alfresco.com");
+        assertThat(user.getTenantId()).isEqualTo("flowable");
 
         identityService.deleteUser(user.getId());
     }
@@ -101,10 +101,10 @@ public class IdentityServiceTest extends PluggableFlowableTestCase {
 
         // Fetch and update the user
         user = identityService.createUserQuery().userId("johndoe").singleResult();
-        assertEquals("John", user.getFirstName());
-        assertEquals("Doe", user.getLastName());
-        assertEquals("johndoe@alfresco.com", user.getEmail());
-        assertEquals(null, user.getTenantId());
+        assertThat(user.getFirstName()).isEqualTo("John");
+        assertThat(user.getLastName()).isEqualTo("Doe");
+        assertThat(user.getEmail()).isEqualTo("johndoe@alfresco.com");
+        assertThat(user.getTenantId()).isEqualTo(null);
 
         identityService.deleteUser(user.getId());
     }
@@ -123,14 +123,14 @@ public class IdentityServiceTest extends PluggableFlowableTestCase {
 
         // Fetch and update the user
         user = identityService.createUserQuery().userId("johndoe").singleResult();
-        assertTrue("byte arrays differ", Arrays.equals("niceface".getBytes(), picture.getBytes()));
-        assertEquals("image/string", picture.getMimeType());
+        assertThat(Arrays.equals("niceface".getBytes(), picture.getBytes())).as("byte arrays differ").isTrue();
+        assertThat(picture.getMimeType()).isEqualTo("image/string");
 
         // interface definition states that setting picture to null should delete it
         identityService.setUserPicture(userId, null);
-        assertNull("it should be possible to nullify user picture", identityService.getUserPicture(userId));
+        assertThat(identityService.getUserPicture(userId)).as("it should be possible to nullify user picture").isNull();
         user = identityService.createUserQuery().userId("johndoe").singleResult();
-        assertNull("it should be possible to delete user picture", identityService.getUserPicture(userId));
+        assertThat(identityService.getUserPicture(userId)).as("it should be possible to delete user picture").isNull();
 
         identityService.deleteUser(user.getId());
     }
@@ -146,7 +146,7 @@ public class IdentityServiceTest extends PluggableFlowableTestCase {
         identityService.saveGroup(group);
 
         group = identityService.createGroupQuery().groupId("sales").singleResult();
-        assertEquals("Updated", group.getName());
+        assertThat(group.getName()).isEqualTo("Updated");
 
         identityService.deleteGroup(group.getId());
     }
@@ -154,13 +154,13 @@ public class IdentityServiceTest extends PluggableFlowableTestCase {
     @Test
     public void testFindUserByUnexistingId() {
         User user = identityService.createUserQuery().userId("unexistinguser").singleResult();
-        assertNull(user);
+        assertThat(user).isNull();
     }
 
     @Test
     public void testFindGroupByUnexistingId() {
         Group group = identityService.createGroupQuery().groupId("unexistinggroup").singleResult();
-        assertNull(group);
+        assertThat(group).isNull();
     }
 
     @Test
@@ -168,12 +168,8 @@ public class IdentityServiceTest extends PluggableFlowableTestCase {
         User johndoe = identityService.newUser("johndoe");
         identityService.saveUser(johndoe);
 
-        try {
-            identityService.createMembership(johndoe.getId(), "unexistinggroup");
-            fail("Expected exception");
-        } catch (RuntimeException re) {
-            // Exception expected
-        }
+        assertThatThrownBy(() -> identityService.createMembership(johndoe.getId(), "unexistinggroup"))
+                .isInstanceOf(RuntimeException.class);
 
         identityService.deleteUser(johndoe.getId());
     }
@@ -183,12 +179,8 @@ public class IdentityServiceTest extends PluggableFlowableTestCase {
         Group sales = identityService.newGroup("sales");
         identityService.saveGroup(sales);
 
-        try {
-            identityService.createMembership("unexistinguser", sales.getId());
-            fail("Expected exception");
-        } catch (RuntimeException re) {
-            // Exception expected
-        }
+        assertThatThrownBy(() -> identityService.createMembership("unexistinguser", sales.getId()))
+                .isInstanceOf(RuntimeException.class);
 
         identityService.deleteGroup(sales.getId());
     }
@@ -203,11 +195,8 @@ public class IdentityServiceTest extends PluggableFlowableTestCase {
         // Create the membership
         identityService.createMembership(johndoe.getId(), sales.getId());
 
-        try {
-            identityService.createMembership(johndoe.getId(), sales.getId());
-        } catch (RuntimeException re) {
-            // Expected exception, membership already exists
-        }
+        assertThatThrownBy(() -> identityService.createMembership(johndoe.getId(), sales.getId()))
+                .isInstanceOf(RuntimeException.class);
 
         identityService.deleteGroup(sales.getId());
         identityService.deleteUser(johndoe.getId());
@@ -215,76 +204,52 @@ public class IdentityServiceTest extends PluggableFlowableTestCase {
 
     @Test
     public void testSaveGroupNullArgument() {
-        try {
-            identityService.saveGroup(null);
-            fail("ActivitiException expected");
-        } catch (FlowableIllegalArgumentException ae) {
-            assertTextPresent("group is null", ae.getMessage());
-        }
+        assertThatThrownBy(() -> identityService.saveGroup(null))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
     public void testSaveUserNullArgument() {
-        try {
-            identityService.saveUser(null);
-            fail("ActivitiException expected");
-        } catch (FlowableIllegalArgumentException ae) {
-            assertTextPresent("user is null", ae.getMessage());
-        }
+        assertThatThrownBy(() -> identityService.saveUser(null))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
     public void testFindGroupByIdNullArgument() {
-        try {
-            identityService.createGroupQuery().groupId(null).singleResult();
-            fail("ActivitiException expected");
-        } catch (FlowableIllegalArgumentException ae) {
-            assertTextPresent("id is null", ae.getMessage());
-        }
+        assertThatThrownBy(() -> identityService.createGroupQuery().groupId(null).singleResult())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
     public void testCreateMembershipNullArguments() {
-        try {
-            identityService.createMembership(null, "group");
-            fail("ActivitiException expected");
-        } catch (FlowableIllegalArgumentException ae) {
-            assertTextPresent("userId is null", ae.getMessage());
-        }
+        assertThatThrownBy(() -> identityService.createMembership(null, "group"))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessageContaining("userId is null");
 
-        try {
-            identityService.createMembership("userId", null);
-            fail("ActivitiException expected");
-        } catch (FlowableException ae) {
-            assertTextPresent("groupId is null", ae.getMessage());
-        }
+        assertThatThrownBy(() -> identityService.createMembership("userId", null))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessageContaining("groupId is null");
     }
 
     @Test
     public void testFindGroupsByUserIdNullArguments() {
-        try {
-            identityService.createGroupQuery().groupMember(null).singleResult();
-            fail("ActivitiException expected");
-        } catch (FlowableIllegalArgumentException ae) {
-            assertTextPresent("userId is null", ae.getMessage());
-        }
+        assertThatThrownBy(() -> identityService.createGroupQuery().groupMember(null).singleResult())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessageContaining("userId is null");
     }
 
     @Test
     public void testFindUsersByGroupUnexistingGroup() {
         List<User> users = identityService.createUserQuery().memberOfGroup("unexistinggroup").list();
-        assertNotNull(users);
-        assertTrue(users.isEmpty());
+        assertThat(users).isNotNull();
+        assertThat(users).isEmpty();
     }
 
     @Test
     public void testDeleteGroupNullArguments() {
-        try {
-            identityService.deleteGroup(null);
-            fail("ActivitiException expected");
-        } catch (FlowableIllegalArgumentException ae) {
-            assertTextPresent("groupId is null", ae.getMessage());
-        }
+        assertThatThrownBy(() -> identityService.deleteGroup(null))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessageContaining("groupId is null");
     }
 
     @Test
@@ -298,13 +263,14 @@ public class IdentityServiceTest extends PluggableFlowableTestCase {
         identityService.createMembership(johndoe.getId(), sales.getId());
 
         List<Group> groups = identityService.createGroupQuery().groupMember(johndoe.getId()).list();
-        assertEquals(1, groups.size());
-        assertEquals("sales", groups.get(0).getId());
+        assertThat(groups)
+                .extracting(Group::getId)
+                .containsExactly("sales");
 
         // Delete the membership and check members of sales group
         identityService.deleteMembership(johndoe.getId(), sales.getId());
         groups = identityService.createGroupQuery().groupMember(johndoe.getId()).list();
-        assertTrue(groups.isEmpty());
+        assertThat(groups).isEmpty();
 
         identityService.deleteGroup("sales");
         identityService.deleteUser("johndoe");
@@ -344,30 +310,21 @@ public class IdentityServiceTest extends PluggableFlowableTestCase {
     }
 
     @Test
-    public void testDeleteMemberschipNullArguments() {
-        try {
-            identityService.deleteMembership(null, "group");
-            fail("ActivitiException expected");
-        } catch (FlowableIllegalArgumentException ae) {
-            assertTextPresent("userId is null", ae.getMessage());
-        }
+    public void testDeleteMembershipNullArguments() {
+        assertThatThrownBy(() -> identityService.deleteMembership(null, "group"))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessageContaining("userId is null");
 
-        try {
-            identityService.deleteMembership("user", null);
-            fail("ActivitiException expected");
-        } catch (FlowableException ae) {
-            assertTextPresent("groupId is null", ae.getMessage());
-        }
+        assertThatThrownBy(() -> identityService.deleteMembership("user", null))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessageContaining("groupId is null");
     }
 
     @Test
     public void testDeleteUserNullArguments() {
-        try {
-            identityService.deleteUser(null);
-            fail("ActivitiException expected");
-        } catch (FlowableIllegalArgumentException ae) {
-            assertTextPresent("userId is null", ae.getMessage());
-        }
+        assertThatThrownBy(() -> identityService.deleteUser(null))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessageContaining("userId is null");
     }
 
     @Test
@@ -379,9 +336,9 @@ public class IdentityServiceTest extends PluggableFlowableTestCase {
 
     @Test
     public void testCheckPasswordNullSafe() {
-        assertFalse(identityService.checkPassword("userId", null));
-        assertFalse(identityService.checkPassword(null, "passwd"));
-        assertFalse(identityService.checkPassword(null, null));
+        assertThat(identityService.checkPassword("userId", null)).isFalse();
+        assertThat(identityService.checkPassword(null, "passwd")).isFalse();
+        assertThat(identityService.checkPassword(null, null)).isFalse();
     }
 
     @Test
@@ -395,15 +352,11 @@ public class IdentityServiceTest extends PluggableFlowableTestCase {
         user1.setFirstName("name one");
         identityService.saveUser(user1);
 
-        try {
-
+        assertThatThrownBy(() -> {
             user2.setFirstName("name two");
             identityService.saveUser(user2);
-
-            fail("Expected an exception");
-        } catch (FlowableOptimisticLockingException e) {
-            // Expected an exception
-        }
+        })
+                .isExactlyInstanceOf(FlowableOptimisticLockingException.class);
 
         identityService.deleteUser(user.getId());
     }
@@ -419,15 +372,11 @@ public class IdentityServiceTest extends PluggableFlowableTestCase {
         group1.setName("name one");
         identityService.saveGroup(group1);
 
-        try {
-
+        assertThatThrownBy(() -> {
             group2.setName("name two");
             identityService.saveGroup(group2);
-
-            fail("Expected an exception");
-        } catch (FlowableOptimisticLockingException e) {
-            // Expected an exception
-        }
+        })
+                .isExactlyInstanceOf(FlowableOptimisticLockingException.class);
 
         identityService.deleteGroup(group.getId());
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/identity/IdentityServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/identity/IdentityServiceTest.java
@@ -205,19 +205,22 @@ public class IdentityServiceTest extends PluggableFlowableTestCase {
     @Test
     public void testSaveGroupNullArgument() {
         assertThatThrownBy(() -> identityService.saveGroup(null))
-                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage("group is null");
     }
 
     @Test
     public void testSaveUserNullArgument() {
         assertThatThrownBy(() -> identityService.saveUser(null))
-                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage("user is null");
     }
 
     @Test
     public void testFindGroupByIdNullArgument() {
         assertThatThrownBy(() -> identityService.createGroupQuery().groupId(null).singleResult())
-                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage("id is null");
     }
 
     @Test

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/identity/IdmTransactionsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/identity/IdmTransactionsTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,6 +12,7 @@
  */
 package org.flowable.engine.test.api.identity;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
@@ -53,13 +54,13 @@ public class IdmTransactionsTest extends PluggableFlowableTestCase {
     public void testCommitOnNoException() {
 
         // No users should exist prior to this test
-        assertEquals(0, identityService.createUserQuery().list().size());
+        assertThat(identityService.createUserQuery().list()).isEmpty();
 
         runtimeService.startProcessInstanceByKey("testProcess");
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
 
         taskService.complete(task.getId());
-        assertEquals(1, identityService.createUserQuery().list().size());
+        assertThat(identityService.createUserQuery().list()).hasSize(1);
 
     }
 
@@ -68,7 +69,7 @@ public class IdmTransactionsTest extends PluggableFlowableTestCase {
     public void testTransactionRolledBackOnException() {
 
         // No users should exist prior to this test
-        assertEquals(0, identityService.createUserQuery().list().size());
+        assertThat(identityService.createUserQuery().list()).isEmpty();
 
         runtimeService.startProcessInstanceByKey("testProcess");
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
@@ -77,12 +78,12 @@ public class IdmTransactionsTest extends PluggableFlowableTestCase {
         assertThatThrownBy(() -> taskService.complete(task.getId()));
 
         // Should have rolled back to task
-        assertNotNull(taskService.createTaskQuery().singleResult());
-        assertEquals(0L, historyService.createHistoricProcessInstanceQuery().finished().count());
+        assertThat(taskService.createTaskQuery().singleResult()).isNotNull();
+        assertThat(historyService.createHistoricProcessInstanceQuery().finished().count()).isEqualTo(0L);
 
         // The logic in the tasklistener (creating a new user) should rolled back too:
         // no new user should have been created
-        assertEquals(0, identityService.createUserQuery().list().size());
+        assertThat(identityService.createUserQuery().list()).isEmpty();
 
     }
 
@@ -93,10 +94,10 @@ public class IdmTransactionsTest extends PluggableFlowableTestCase {
 
         // The service task should have created a user which is part of the admin group
         User user = identityService.createUserQuery().singleResult();
-        assertEquals("Kermit", user.getId());
+        assertThat(user.getId()).isEqualTo("Kermit");
         Group group = identityService.createGroupQuery().groupMember(user.getId()).singleResult();
-        assertNotNull(group);
-        assertEquals("admin", group.getId());
+        assertThat(group).isNotNull();
+        assertThat(group.getId()).isEqualTo("admin");
 
         identityService.deleteMembership("Kermit", "admin");
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/identity/ProcessInstanceIdentityLinkTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/identity/ProcessInstanceIdentityLinkTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/identity/UserQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/identity/UserQueryTest.java
@@ -13,8 +13,8 @@
 
 package org.flowable.engine.test.api.identity;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
 import java.util.List;
@@ -89,11 +89,8 @@ public class UserQueryTest extends PluggableFlowableTestCase {
         UserQuery query = identityService.createUserQuery().userId("invalid");
         verifyQueryResults(query, 0);
 
-        try {
-            identityService.createUserQuery().userId(null).singleResult();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> identityService.createUserQuery().userId(null).singleResult())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
@@ -102,7 +99,7 @@ public class UserQueryTest extends PluggableFlowableTestCase {
         verifyQueryResults(query, 1);
 
         User result = query.singleResult();
-        assertEquals("gonzo", result.getId());
+        assertThat(result.getId()).isEqualTo("gonzo");
     }
 
     @Test
@@ -110,11 +107,8 @@ public class UserQueryTest extends PluggableFlowableTestCase {
         UserQuery query = identityService.createUserQuery().userFirstName("invalid");
         verifyQueryResults(query, 0);
 
-        try {
-            identityService.createUserQuery().userFirstName(null).singleResult();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> identityService.createUserQuery().userFirstName(null).singleResult())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
@@ -131,11 +125,8 @@ public class UserQueryTest extends PluggableFlowableTestCase {
         UserQuery query = identityService.createUserQuery().userFirstNameLike("%mispiggy%");
         verifyQueryResults(query, 0);
 
-        try {
-            identityService.createUserQuery().userFirstNameLike(null).singleResult();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> identityService.createUserQuery().userFirstNameLike(null).singleResult())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
@@ -144,7 +135,7 @@ public class UserQueryTest extends PluggableFlowableTestCase {
         verifyQueryResults(query, 1);
 
         User result = query.singleResult();
-        assertEquals("fozzie", result.getId());
+        assertThat(result.getId()).isEqualTo("fozzie");
     }
 
     @Test
@@ -152,11 +143,8 @@ public class UserQueryTest extends PluggableFlowableTestCase {
         UserQuery query = identityService.createUserQuery().userLastName("invalid");
         verifyQueryResults(query, 0);
 
-        try {
-            identityService.createUserQuery().userLastName(null).singleResult();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> identityService.createUserQuery().userLastName(null).singleResult())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
@@ -185,11 +173,8 @@ public class UserQueryTest extends PluggableFlowableTestCase {
         UserQuery query = identityService.createUserQuery().userLastNameLike("%invalid%");
         verifyQueryResults(query, 0);
 
-        try {
-            identityService.createUserQuery().userLastNameLike(null).singleResult();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> identityService.createUserQuery().userLastNameLike(null).singleResult())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
@@ -203,11 +188,8 @@ public class UserQueryTest extends PluggableFlowableTestCase {
         UserQuery query = identityService.createUserQuery().userEmail("invalid");
         verifyQueryResults(query, 0);
 
-        try {
-            identityService.createUserQuery().userEmail(null).singleResult();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> identityService.createUserQuery().userEmail(null).singleResult())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
@@ -224,48 +206,39 @@ public class UserQueryTest extends PluggableFlowableTestCase {
         UserQuery query = identityService.createUserQuery().userEmailLike("%invalid%");
         verifyQueryResults(query, 0);
 
-        try {
-            identityService.createUserQuery().userEmailLike(null).singleResult();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> identityService.createUserQuery().userEmailLike(null).singleResult())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
     public void testQuerySorting() {
         // asc
-        assertEquals(4, identityService.createUserQuery().orderByUserId().asc().count());
-        assertEquals(4, identityService.createUserQuery().orderByUserEmail().asc().count());
-        assertEquals(4, identityService.createUserQuery().orderByUserFirstName().asc().count());
-        assertEquals(4, identityService.createUserQuery().orderByUserLastName().asc().count());
+        assertThat(identityService.createUserQuery().orderByUserId().asc().count()).isEqualTo(4);
+        assertThat(identityService.createUserQuery().orderByUserEmail().asc().count()).isEqualTo(4);
+        assertThat(identityService.createUserQuery().orderByUserFirstName().asc().count()).isEqualTo(4);
+        assertThat(identityService.createUserQuery().orderByUserLastName().asc().count()).isEqualTo(4);
 
         // desc
-        assertEquals(4, identityService.createUserQuery().orderByUserId().desc().count());
-        assertEquals(4, identityService.createUserQuery().orderByUserEmail().desc().count());
-        assertEquals(4, identityService.createUserQuery().orderByUserFirstName().desc().count());
-        assertEquals(4, identityService.createUserQuery().orderByUserLastName().desc().count());
+        assertThat(identityService.createUserQuery().orderByUserId().desc().count()).isEqualTo(4);
+        assertThat(identityService.createUserQuery().orderByUserEmail().desc().count()).isEqualTo(4);
+        assertThat(identityService.createUserQuery().orderByUserFirstName().desc().count()).isEqualTo(4);
+        assertThat(identityService.createUserQuery().orderByUserLastName().desc().count()).isEqualTo(4);
 
         // Combined with criteria
         UserQuery query = identityService.createUserQuery().userLastNameLike("%ea%").orderByUserFirstName().asc();
         List<User> users = query.list();
-        assertEquals(2, users.size());
-        assertEquals("Fozzie", users.get(0).getFirstName());
-        assertEquals("Gonzo", users.get(1).getFirstName());
+        assertThat(users)
+                .extracting(User::getFirstName)
+                .containsExactly("Fozzie", "Gonzo");
     }
 
     @Test
     public void testQueryInvalidSortingUsage() {
-        try {
-            identityService.createUserQuery().orderByUserId().list();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> identityService.createUserQuery().orderByUserId().list())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
 
-        try {
-            identityService.createUserQuery().orderByUserId().orderByUserEmail().list();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> identityService.createUserQuery().orderByUserId().orderByUserEmail().list())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
@@ -277,7 +250,7 @@ public class UserQueryTest extends PluggableFlowableTestCase {
         verifyQueryResults(query, 1);
 
         User result = query.singleResult();
-        assertEquals("kermit", result.getId());
+        assertThat(result.getId()).isEqualTo("kermit");
     }
 
     @Test
@@ -285,36 +258,30 @@ public class UserQueryTest extends PluggableFlowableTestCase {
         UserQuery query = identityService.createUserQuery().memberOfGroup("invalid");
         verifyQueryResults(query, 0);
 
-        try {
-            identityService.createUserQuery().memberOfGroup(null).list();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> identityService.createUserQuery().memberOfGroup(null).list())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
-    
+
     @Test
     public void testQueryByMemberOfGroups() {
         List<User> users = identityService.createUserQuery().memberOfGroups(Arrays.asList("muppets", "frogs")).orderByUserId().asc().list();
-        assertEquals(3, users.size());
-        assertEquals("fozzie", users.get(0).getId());
-        assertEquals("gonzo", users.get(1).getId());
-        assertEquals("kermit", users.get(2).getId());
-        
+        assertThat(users)
+                .extracting(User::getId)
+                .containsExactly("fozzie", "gonzo", "kermit");
+
         users = identityService.createUserQuery().memberOfGroups(Arrays.asList("frogs")).list();
-        assertEquals(1, users.size());
-        assertEquals("kermit", users.get(0).getId());
+        assertThat(users)
+                .extracting(User::getId)
+                .containsExactly("kermit");
     }
-    
+
     @Test
     public void testQueryByInvalidMemberOfGroups() {
         UserQuery query = identityService.createUserQuery().memberOfGroups(Arrays.asList("invalid"));
         verifyQueryResults(query, 0);
 
-        try {
-            identityService.createUserQuery().memberOfGroups(null).list();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> identityService.createUserQuery().memberOfGroups(null).list())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
@@ -334,47 +301,41 @@ public class UserQueryTest extends PluggableFlowableTestCase {
 
     @Test
     public void testQueryByNullTenantId() {
-        try {
-            identityService.createUserQuery().tenantId(null);
-            fail("FlowableIllegalArgumentException expected");
-        } catch (FlowableIllegalArgumentException e) {
-            assertThat(e.getMessage(), containsString("TenantId is null"));
-        }
+        assertThatThrownBy(() -> identityService.createUserQuery().tenantId(null))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessageContaining("TenantId is null");
     }
 
     private void verifyQueryResults(UserQuery query, int countExpected) {
-        assertEquals(countExpected, query.list().size());
-        assertEquals(countExpected, query.count());
+        assertThat(query.list()).hasSize(countExpected);
+        assertThat(query.count()).isEqualTo(countExpected);
 
         if (countExpected == 1) {
-            assertNotNull(query.singleResult());
+            assertThat(query.singleResult()).isNotNull();
         } else if (countExpected > 1) {
             verifySingleResultFails(query);
         } else if (countExpected == 0) {
-            assertNull(query.singleResult());
+            assertThat(query.singleResult()).isNull();
         }
     }
 
     private void verifySingleResultFails(UserQuery query) {
-        try {
-            query.singleResult();
-            fail();
-        } catch (FlowableException e) {
-        }
+        assertThatThrownBy(() -> query.singleResult())
+                .isExactlyInstanceOf(FlowableException.class);
     }
 
     @Test
     public void testNativeQuery() {
         String baseQuerySql = "SELECT * FROM " + IdentityTestUtil.getTableName("ACT_ID_USER", processEngineConfiguration);
 
-        assertEquals(4, identityService.createNativeUserQuery().sql(baseQuerySql).list().size());
+        assertThat(identityService.createNativeUserQuery().sql(baseQuerySql).list()).hasSize(4);
 
-        assertEquals(1, identityService.createNativeUserQuery().sql(baseQuerySql + " where ID_ = #{id}").parameter("id", "kermit").list().size());
+        assertThat(identityService.createNativeUserQuery().sql(baseQuerySql + " where ID_ = #{id}").parameter("id", "kermit").list()).hasSize(1);
 
         // paging
-        assertEquals(2, identityService.createNativeUserQuery().sql(baseQuerySql).listPage(0, 2).size());
-        assertEquals(3, identityService.createNativeUserQuery().sql(baseQuerySql).listPage(1, 4).size());
-        assertEquals(1, identityService.createNativeUserQuery().sql(baseQuerySql + " where ID_ = #{id}").parameter("id", "kermit").listPage(0, 1).size());
+        assertThat(identityService.createNativeUserQuery().sql(baseQuerySql).listPage(0, 2)).hasSize(2);
+        assertThat(identityService.createNativeUserQuery().sql(baseQuerySql).listPage(1, 4)).hasSize(3);
+        assertThat(identityService.createNativeUserQuery().sql(baseQuerySql + " where ID_ = #{id}").parameter("id", "kermit").listPage(0, 1)).hasSize(1);
     }
 
 }


### PR DESCRIPTION
All test files in the `org.flowable.engine.test.api.identity` package are included.

Continuing quest to use only a single style in each file and in the module.

