### PR TITLE
Use assertj fluent style in flowable-engine.

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/changestate/ChangeStateForCallActivityTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/changestate/ChangeStateForCallActivityTest.java
@@ -13,6 +13,9 @@
 
 package org.flowable.engine.test.api.runtime.changestate;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.util.List;
 
 import org.flowable.common.engine.api.FlowableException;
@@ -49,29 +52,29 @@ public class ChangeStateForCallActivityTest extends PluggableFlowableTestCase {
     public void testSetCurrentActivityInParentProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksParentProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("firstTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("firstTask");
 
         taskService.complete(task.getId());
 
         ProcessInstance subProcessInstance = runtimeService.createProcessInstanceQuery().superProcessInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(subProcessInstance);
+        assertThat(subProcessInstance).isNotNull();
 
         task = taskService.createTaskQuery().processInstanceId(subProcessInstance.getId()).singleResult();
-        assertEquals("theTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("theTask");
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(subProcessInstance.getId())
-            .moveActivityIdToParentActivityId("theTask", "secondTask")
-            .changeState();
+                .processInstanceId(subProcessInstance.getId())
+                .moveActivityIdToParentActivityId("theTask", "secondTask")
+                .changeState();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("secondTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
 
-        assertEquals(0, runtimeService.createProcessInstanceQuery().superProcessInstanceId(processInstance.getId()).count());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(subProcessInstance.getId()).count());
+        assertThat(runtimeService.createProcessInstanceQuery().superProcessInstanceId(processInstance.getId()).count()).isEqualTo(0);
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(subProcessInstance.getId()).count()).isEqualTo(0);
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(1, executions.size());
+        assertThat(executions).hasSize(1);
 
         taskService.complete(task.getId());
 
@@ -83,32 +86,32 @@ public class ChangeStateForCallActivityTest extends PluggableFlowableTestCase {
     public void testSetCurrentActivityInParentProcessV2() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksParentProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("firstTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("firstTask");
         taskService.complete(task.getId());
 
         ProcessInstance subProcessInstance = runtimeService.createProcessInstanceQuery().superProcessInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(subProcessInstance);
+        assertThat(subProcessInstance).isNotNull();
 
         task = taskService.createTaskQuery().processInstanceId(subProcessInstance.getId()).singleResult();
-        assertEquals("firstTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("firstTask");
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(subProcessInstance.getId()).singleResult();
-        assertEquals("secondTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(subProcessInstance.getId())
-            .moveActivityIdToParentActivityId("secondTask", "secondTask")
-            .changeState();
+                .processInstanceId(subProcessInstance.getId())
+                .moveActivityIdToParentActivityId("secondTask", "secondTask")
+                .changeState();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("secondTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
 
-        assertEquals(0, runtimeService.createProcessInstanceQuery().superProcessInstanceId(processInstance.getId()).count());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(subProcessInstance.getId()).count());
+        assertThat(runtimeService.createProcessInstanceQuery().superProcessInstanceId(processInstance.getId()).count()).isEqualTo(0);
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(subProcessInstance.getId()).count()).isEqualTo(0);
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(1, executions.size());
+        assertThat(executions).hasSize(1);
 
         taskService.complete(task.getId());
 
@@ -120,30 +123,30 @@ public class ChangeStateForCallActivityTest extends PluggableFlowableTestCase {
     public void testSetCurrentActivityInSubProcessInstance() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksParentProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("firstTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("firstTask");
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdToSubProcessInstanceActivityId("firstTask", "theTask", "callActivity")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdToSubProcessInstanceActivityId("firstTask", "theTask", "callActivity")
+                .changeState();
 
         ProcessInstance subProcessInstance = runtimeService.createProcessInstanceQuery().superProcessInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(subProcessInstance);
+        assertThat(subProcessInstance).isNotNull();
 
-        assertEquals(0, taskService.createTaskQuery().processInstanceId(processInstance.getId()).count());
-        assertEquals(1, taskService.createTaskQuery().processInstanceId(subProcessInstance.getId()).count());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0);
+        assertThat(taskService.createTaskQuery().processInstanceId(subProcessInstance.getId()).count()).isEqualTo(1);
 
-        assertEquals(1, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count());
-        assertEquals(1, runtimeService.createExecutionQuery().processInstanceId(subProcessInstance.getId()).onlyChildExecutions().count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count()).isEqualTo(1);
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(subProcessInstance.getId()).onlyChildExecutions().count()).isEqualTo(1);
 
         task = taskService.createTaskQuery().processInstanceId(subProcessInstance.getId()).singleResult();
-        assertEquals("theTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("theTask");
         taskService.complete(task.getId());
 
-        assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(subProcessInstance.getId()).count());
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(subProcessInstance.getId()).count()).isEqualTo(0);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("secondTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
 
         taskService.complete(task.getId());
 
@@ -155,30 +158,30 @@ public class ChangeStateForCallActivityTest extends PluggableFlowableTestCase {
     public void testSetCurrentActivityInSubProcessInstanceV2() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksParentProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("firstTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("firstTask");
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdToSubProcessInstanceActivityId("firstTask", "secondTask", "callActivity")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdToSubProcessInstanceActivityId("firstTask", "secondTask", "callActivity")
+                .changeState();
 
         ProcessInstance subProcessInstance = runtimeService.createProcessInstanceQuery().superProcessInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(subProcessInstance);
+        assertThat(subProcessInstance).isNotNull();
 
-        assertEquals(0, taskService.createTaskQuery().processInstanceId(processInstance.getId()).count());
-        assertEquals(1, taskService.createTaskQuery().processInstanceId(subProcessInstance.getId()).count());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0);
+        assertThat(taskService.createTaskQuery().processInstanceId(subProcessInstance.getId()).count()).isEqualTo(1);
 
-        assertEquals(1, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count());
-        assertEquals(1, runtimeService.createExecutionQuery().processInstanceId(subProcessInstance.getId()).onlyChildExecutions().count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count()).isEqualTo(1);
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(subProcessInstance.getId()).onlyChildExecutions().count()).isEqualTo(1);
 
         task = taskService.createTaskQuery().processInstanceId(subProcessInstance.getId()).singleResult();
-        assertEquals("secondTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
         taskService.complete(task.getId());
 
-        assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(subProcessInstance.getId()).count());
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(subProcessInstance.getId()).count()).isEqualTo(0);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("secondTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
 
         taskService.complete(task.getId());
 
@@ -195,43 +198,40 @@ public class ChangeStateForCallActivityTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("calledElementExpression");
 
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("firstTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("firstTask");
 
         //First change state attempt fails as the calledElement expression cannot be evaluated
-        try {
-            runtimeService.createChangeActivityStateBuilder()
+        assertThatThrownBy(() -> runtimeService.createChangeActivityStateBuilder()
                 .processInstanceId(processInstance.getId())
                 .moveActivityIdToSubProcessInstanceActivityId("firstTask", "theTask", "callActivity")
-                .changeState();
-            fail("Change state should not be possible calledElement expression could not be evaluated");
-        } catch (FlowableException e) {
-            assertTextPresent("Cannot resolve calledElement expression '${subProcessDefId}' of callActivity 'callActivity'", e.getMessage());
-        }
+                .changeState())
+                .isExactlyInstanceOf(FlowableException.class)
+                .hasMessage("Cannot resolve calledElement expression '${subProcessDefId}' of callActivity 'callActivity'");
 
         //Change state specifying the variable with the value
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdToSubProcessInstanceActivityId("firstTask", "theTask", "callActivity", 1)
-            .processVariable("subProcessDefId", "oneTaskProcess")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdToSubProcessInstanceActivityId("firstTask", "theTask", "callActivity", 1)
+                .processVariable("subProcessDefId", "oneTaskProcess")
+                .changeState();
 
         ProcessInstance subProcessInstance = runtimeService.createProcessInstanceQuery().superProcessInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(subProcessInstance);
+        assertThat(subProcessInstance).isNotNull();
 
-        assertEquals(0, taskService.createTaskQuery().processInstanceId(processInstance.getId()).count());
-        assertEquals(1, taskService.createTaskQuery().processInstanceId(subProcessInstance.getId()).count());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0);
+        assertThat(taskService.createTaskQuery().processInstanceId(subProcessInstance.getId()).count()).isEqualTo(1);
 
-        assertEquals(1, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count());
-        assertEquals(1, runtimeService.createExecutionQuery().processInstanceId(subProcessInstance.getId()).onlyChildExecutions().count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count()).isEqualTo(1);
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(subProcessInstance.getId()).onlyChildExecutions().count()).isEqualTo(1);
 
         task = taskService.createTaskQuery().processInstanceId(subProcessInstance.getId()).singleResult();
-        assertEquals("theTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("theTask");
         taskService.complete(task.getId());
 
-        assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(subProcessInstance.getId()).count());
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(subProcessInstance.getId()).count()).isEqualTo(0);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("lastTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("lastTask");
 
         taskService.complete(task.getId());
 
@@ -249,52 +249,46 @@ public class ChangeStateForCallActivityTest extends PluggableFlowableTestCase {
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksParentProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("firstTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("firstTask");
 
-        try {
-            runtimeService.createChangeActivityStateBuilder()
+        assertThatThrownBy(() -> runtimeService.createChangeActivityStateBuilder()
                 .processInstanceId(processInstance.getId())
                 .moveActivityIdToSubProcessInstanceActivityId("firstTask", "theTask", "callActivity")
-                .changeState();
-            fail("Change state should not be possible as it referring to an activity of a previous version");
-        } catch (FlowableException e) {
-            assertTextPresent("Cannot find activity 'theTask' in process definition with id 'oneTaskProcess'", e.getMessage());
-        }
+                .changeState())
+                .isExactlyInstanceOf(FlowableException.class)
+                .hasMessage("Cannot find activity 'theTask' in process definition with id 'oneTaskProcess'");
 
         //Invalid "unExistent" process definition version
-        try {
-            runtimeService.createChangeActivityStateBuilder()
+        assertThatThrownBy(() -> runtimeService.createChangeActivityStateBuilder()
                 .processInstanceId(processInstance.getId())
                 .moveActivityIdToSubProcessInstanceActivityId("firstTask", "theTask", "callActivity", 5)
-                .changeState();
-            fail("Change state should not be possible as it referring to an activity of a previous version");
-        } catch (FlowableException e) {
-            assertTextPresent("Cannot find activity 'theTask' in process definition with id 'oneTaskProcess'", e.getMessage());
-        }
+                .changeState())
+                .isExactlyInstanceOf(FlowableException.class)
+                .hasMessage("Cannot find activity 'theTask' in process definition with id 'oneTaskProcess'");
 
         //Change state specifying the first version
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdToSubProcessInstanceActivityId("firstTask", "theTask", "callActivity", 1)
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdToSubProcessInstanceActivityId("firstTask", "theTask", "callActivity", 1)
+                .changeState();
 
         ProcessInstance subProcessInstance = runtimeService.createProcessInstanceQuery().superProcessInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(subProcessInstance);
+        assertThat(subProcessInstance).isNotNull();
 
-        assertEquals(0, taskService.createTaskQuery().processInstanceId(processInstance.getId()).count());
-        assertEquals(1, taskService.createTaskQuery().processInstanceId(subProcessInstance.getId()).count());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0);
+        assertThat(taskService.createTaskQuery().processInstanceId(subProcessInstance.getId()).count()).isEqualTo(1);
 
-        assertEquals(1, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count());
-        assertEquals(1, runtimeService.createExecutionQuery().processInstanceId(subProcessInstance.getId()).onlyChildExecutions().count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count()).isEqualTo(1);
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(subProcessInstance.getId()).onlyChildExecutions().count()).isEqualTo(1);
 
         task = taskService.createTaskQuery().processInstanceId(subProcessInstance.getId()).singleResult();
-        assertEquals("theTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("theTask");
         taskService.complete(task.getId());
 
-        assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(subProcessInstance.getId()).count());
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(subProcessInstance.getId()).count()).isEqualTo(0);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("secondTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
 
         taskService.complete(task.getId());
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/changestate/ChangeStateForEventSubProcessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/changestate/ChangeStateForEventSubProcessTest.java
@@ -54,33 +54,33 @@ public class ChangeStateForEventSubProcessTest extends PluggableFlowableTestCase
 
         List<Execution> executions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
         Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
-        assertEquals(2, executionsByActivity.size());
-        assertEquals(1, executionsByActivity.get("processTask").size());
-        assertEquals(1, executionsByActivity.get("eventSubProcessStart").size());
+        assertThat(executionsByActivity).hasSize(2);
+        assertThat(executionsByActivity.get("processTask")).hasSize(1);
+        assertThat(executionsByActivity.get("eventSubProcessStart")).hasSize(1);
 
         List<Task> tasks = taskService.createTaskQuery().list();
         Map<String, List<Task>> tasksByKey = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertEquals(1, tasksByKey.size());
-        assertEquals(1, tasksByKey.get("processTask").size());
+        assertThat(tasksByKey).hasSize(1);
+        assertThat(tasksByKey.get("processTask")).hasSize(1);
 
         EventSubscription eventSubscription = runtimeService.createEventSubscriptionQuery().singleResult();
-        assertEquals("eventSubProcessStart", eventSubscription.getActivityId());
-        assertEquals("message", eventSubscription.getEventType());
-        assertEquals("eventMessage", eventSubscription.getEventName());
+        assertThat(eventSubscription.getActivityId()).isEqualTo("eventSubProcessStart");
+        assertThat(eventSubscription.getEventType()).isEqualTo("message");
+        assertThat(eventSubscription.getEventName()).isEqualTo("eventMessage");
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("eventSubProcessStart", "eventSubProcessTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("eventSubProcessStart", "eventSubProcessTask")
+                .changeState();
 
         tasks = taskService.createTaskQuery().list();
         tasksByKey = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertEquals(2, tasksByKey.size());
-        assertEquals(1, tasksByKey.get("processTask").size());
-        assertEquals(1, tasksByKey.get("eventSubProcessTask").size());
+        assertThat(tasksByKey).hasSize(2);
+        assertThat(tasksByKey.get("processTask")).hasSize(1);
+        assertThat(tasksByKey.get("eventSubProcessTask")).hasSize(1);
 
         eventSubscription = runtimeService.createEventSubscriptionQuery().singleResult();
-        assertNull(eventSubscription);
+        assertThat(eventSubscription).isNull();
 
         taskService.complete(tasksByKey.get("eventSubProcessTask").get(0).getId());
         taskService.complete(tasksByKey.get("processTask").get(0).getId());
@@ -95,32 +95,32 @@ public class ChangeStateForEventSubProcessTest extends PluggableFlowableTestCase
 
         List<Execution> executions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
         Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
-        assertEquals(2, executionsByActivity.size());
-        assertEquals(1, executionsByActivity.get("processTask").size());
-        assertEquals(1, executionsByActivity.get("eventSubProcessStart").size());
+        assertThat(executionsByActivity).hasSize(2);
+        assertThat(executionsByActivity.get("processTask")).hasSize(1);
+        assertThat(executionsByActivity.get("eventSubProcessStart")).hasSize(1);
 
         List<Task> tasks = taskService.createTaskQuery().list();
         Map<String, List<Task>> tasksByKey = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertEquals(1, tasksByKey.size());
-        assertEquals(1, tasksByKey.get("processTask").size());
+        assertThat(tasksByKey).hasSize(1);
+        assertThat(tasksByKey.get("processTask")).hasSize(1);
 
         EventSubscription eventSubscription = runtimeService.createEventSubscriptionQuery().singleResult();
-        assertEquals("eventSubProcessStart", eventSubscription.getActivityId());
-        assertEquals("message", eventSubscription.getEventType());
-        assertEquals("eventMessage", eventSubscription.getEventName());
+        assertThat(eventSubscription.getActivityId()).isEqualTo("eventSubProcessStart");
+        assertThat(eventSubscription.getEventType()).isEqualTo("message");
+        assertThat(eventSubscription.getEventName()).isEqualTo("eventMessage");
 
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionToActivityId(executionsByActivity.get("eventSubProcessStart").get(0).getId(), "eventSubProcessTask")
-            .changeState();
+                .moveExecutionToActivityId(executionsByActivity.get("eventSubProcessStart").get(0).getId(), "eventSubProcessTask")
+                .changeState();
 
         tasks = taskService.createTaskQuery().list();
         tasksByKey = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertEquals(2, tasksByKey.size());
-        assertEquals(1, tasksByKey.get("processTask").size());
-        assertEquals(1, tasksByKey.get("eventSubProcessTask").size());
+        assertThat(tasksByKey).hasSize(2);
+        assertThat(tasksByKey.get("processTask")).hasSize(1);
+        assertThat(tasksByKey.get("eventSubProcessTask")).hasSize(1);
 
         eventSubscription = runtimeService.createEventSubscriptionQuery().singleResult();
-        assertNull(eventSubscription);
+        assertThat(eventSubscription).isNull();
 
         taskService.complete(tasksByKey.get("eventSubProcessTask").get(0).getId());
         taskService.complete(tasksByKey.get("processTask").get(0).getId());
@@ -135,33 +135,33 @@ public class ChangeStateForEventSubProcessTest extends PluggableFlowableTestCase
 
         List<Execution> executions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
         Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
-        assertEquals(2, executionsByActivity.size());
-        assertEquals(1, executionsByActivity.get("processTask").size());
-        assertEquals(1, executionsByActivity.get("eventSubProcessStart").size());
+        assertThat(executionsByActivity).hasSize(2);
+        assertThat(executionsByActivity.get("processTask")).hasSize(1);
+        assertThat(executionsByActivity.get("eventSubProcessStart")).hasSize(1);
 
         List<Task> tasks = taskService.createTaskQuery().list();
         Map<String, List<Task>> tasksByKey = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertEquals(1, tasksByKey.size());
-        assertEquals(1, tasksByKey.get("processTask").size());
+        assertThat(tasksByKey).hasSize(1);
+        assertThat(tasksByKey.get("processTask")).hasSize(1);
 
         EventSubscription eventSubscription = runtimeService.createEventSubscriptionQuery().singleResult();
-        assertEquals("eventSubProcessStart", eventSubscription.getActivityId());
-        assertEquals("signal", eventSubscription.getEventType());
-        assertEquals("eventSignal", eventSubscription.getEventName());
+        assertThat(eventSubscription.getActivityId()).isEqualTo("eventSubProcessStart");
+        assertThat(eventSubscription.getEventType()).isEqualTo("signal");
+        assertThat(eventSubscription.getEventName()).isEqualTo("eventSignal");
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("eventSubProcessStart", "eventSubProcessTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("eventSubProcessStart", "eventSubProcessTask")
+                .changeState();
 
         tasks = taskService.createTaskQuery().list();
         tasksByKey = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertEquals(2, tasksByKey.size());
-        assertEquals(1, tasksByKey.get("processTask").size());
-        assertEquals(1, tasksByKey.get("eventSubProcessTask").size());
+        assertThat(tasksByKey).hasSize(2);
+        assertThat(tasksByKey.get("processTask")).hasSize(1);
+        assertThat(tasksByKey.get("eventSubProcessTask")).hasSize(1);
 
         eventSubscription = runtimeService.createEventSubscriptionQuery().singleResult();
-        assertNull(eventSubscription);
+        assertThat(eventSubscription).isNull();
 
         taskService.complete(tasksByKey.get("eventSubProcessTask").get(0).getId());
         taskService.complete(tasksByKey.get("processTask").get(0).getId());
@@ -176,32 +176,32 @@ public class ChangeStateForEventSubProcessTest extends PluggableFlowableTestCase
 
         List<Execution> executions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
         Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
-        assertEquals(2, executionsByActivity.size());
-        assertEquals(1, executionsByActivity.get("processTask").size());
-        assertEquals(1, executionsByActivity.get("eventSubProcessStart").size());
+        assertThat(executionsByActivity).hasSize(2);
+        assertThat(executionsByActivity.get("processTask")).hasSize(1);
+        assertThat(executionsByActivity.get("eventSubProcessStart")).hasSize(1);
 
         List<Task> tasks = taskService.createTaskQuery().list();
         Map<String, List<Task>> tasksByKey = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertEquals(1, tasksByKey.size());
-        assertEquals(1, tasksByKey.get("processTask").size());
+        assertThat(tasksByKey).hasSize(1);
+        assertThat(tasksByKey.get("processTask")).hasSize(1);
 
         EventSubscription eventSubscription = runtimeService.createEventSubscriptionQuery().singleResult();
-        assertEquals("eventSubProcessStart", eventSubscription.getActivityId());
-        assertEquals("signal", eventSubscription.getEventType());
-        assertEquals("eventSignal", eventSubscription.getEventName());
+        assertThat(eventSubscription.getActivityId()).isEqualTo("eventSubProcessStart");
+        assertThat(eventSubscription.getEventType()).isEqualTo("signal");
+        assertThat(eventSubscription.getEventName()).isEqualTo("eventSignal");
 
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionToActivityId(executionsByActivity.get("eventSubProcessStart").get(0).getId(), "eventSubProcessTask")
-            .changeState();
+                .moveExecutionToActivityId(executionsByActivity.get("eventSubProcessStart").get(0).getId(), "eventSubProcessTask")
+                .changeState();
 
         tasks = taskService.createTaskQuery().list();
         tasksByKey = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertEquals(2, tasksByKey.size());
-        assertEquals(1, tasksByKey.get("processTask").size());
-        assertEquals(1, tasksByKey.get("eventSubProcessTask").size());
+        assertThat(tasksByKey).hasSize(2);
+        assertThat(tasksByKey.get("processTask")).hasSize(1);
+        assertThat(tasksByKey.get("eventSubProcessTask")).hasSize(1);
 
         eventSubscription = runtimeService.createEventSubscriptionQuery().singleResult();
-        assertNull(eventSubscription);
+        assertThat(eventSubscription).isNull();
 
         taskService.complete(tasksByKey.get("eventSubProcessTask").get(0).getId());
         taskService.complete(tasksByKey.get("processTask").get(0).getId());
@@ -221,23 +221,27 @@ public class ChangeStateForEventSubProcessTest extends PluggableFlowableTestCase
         assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask");
 
         EventSubscription eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(eventSubscription).extracting(EventSubscription::getActivityId).isEqualTo("eventSubProcessStart");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventType).isEqualTo("signal");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventName).isEqualTo("eventSignal");
+        assertThat(eventSubscription)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly("eventSubProcessStart", "signal", "eventSignal");
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("processTask", "eventSubProcessTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("processTask", "eventSubProcessTask")
+                .changeState();
 
         executions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("eventSubProcess", "eventSubProcessTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("eventSubProcess", "eventSubProcessTask");
 
         tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("eventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("eventSubProcessTask");
 
         eventSubscription = runtimeService.createEventSubscriptionQuery().singleResult();
-        assertNull(eventSubscription);
+        assertThat(eventSubscription).isNull();
 
         completeProcessInstanceTasks(processInstance.getId());
         assertProcessEnded(processInstance.getId());
@@ -252,26 +256,32 @@ public class ChangeStateForEventSubProcessTest extends PluggableFlowableTestCase
         assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("processTask", "eventSubProcessStart");
 
         List<Task> tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .contains("processTask");
 
         EventSubscription eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(eventSubscription).extracting(EventSubscription::getActivityId).isEqualTo("eventSubProcessStart");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventType).isEqualTo("message");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventName).isEqualTo("eventMessage");
+        assertThat(eventSubscription)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly("eventSubProcessStart", "message", "eventMessage");
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("processTask", "eventSubProcessTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("processTask", "eventSubProcessTask")
+                .changeState();
 
         executions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("eventSubProcess", "eventSubProcessTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("eventSubProcess", "eventSubProcessTask");
 
         tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("eventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("eventSubProcessTask");
 
         eventSubscription = runtimeService.createEventSubscriptionQuery().singleResult();
-        assertNull(eventSubscription);
+        assertThat(eventSubscription).isNull();
 
         completeProcessInstanceTasks(processInstance.getId());
         assertProcessEnded(processInstance.getId());
@@ -283,104 +293,131 @@ public class ChangeStateForEventSubProcessTest extends PluggableFlowableTestCase
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForEventSubProcess");
 
         List<Execution> executions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("processTask", "eventSubProcessStart");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("processTask", "eventSubProcessStart");
 
         List<Task> tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("processTask");
 
         Job job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(job);
+        assertThat(job).isNotNull();
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("processTask", "eventSubProcessTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("processTask", "eventSubProcessTask")
+                .changeState();
 
         executions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("eventSubProcess", "eventSubProcessTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("eventSubProcess", "eventSubProcessTask");
 
         tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("eventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("eventSubProcessTask");
 
         job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(job);
+        assertThat(job).isNull();
 
         completeProcessInstanceTasks(processInstance.getId());
         assertProcessEnded(processInstance.getId());
     }
 
     @Test
-    @Deployment(resources = { "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleNonInterruptingSignalEventSubProcess.bpmn20.xml" })
+    @Deployment(resources = {
+            "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleNonInterruptingSignalEventSubProcess.bpmn20.xml" })
     public void testSetCurrentOnlyActivityToActivityInsideNonInterruptingSignalEventSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForEventSubProcess");
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("processTask", "eventSubProcessStart");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("processTask", "eventSubProcessStart");
 
         List<Task> tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("processTask");
 
         EventSubscription eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(eventSubscription).extracting(EventSubscription::getActivityId).isEqualTo("eventSubProcessStart");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventType).isEqualTo("signal");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventName).isEqualTo("eventSignal");
+        assertThat(eventSubscription)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly("eventSubProcessStart", "signal", "eventSignal");
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("processTask", "eventSubProcessTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("processTask", "eventSubProcessTask")
+                .changeState();
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("eventSubProcess", "eventSubProcessTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("eventSubProcess", "eventSubProcessTask");
 
         tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("eventSubProcessTask");
+        assertThat(tasks).
+                extracting(Task::getTaskDefinitionKey)
+                .containsExactly("eventSubProcessTask");
 
         //SINCE THE LAST EXECUTION ON THE PARENT SCOPE WAS MOVED, THERE SHOULD BE NO EVENT SUBSCRIPTION
         eventSubscription = runtimeService.createEventSubscriptionQuery().singleResult();
-        assertNull(eventSubscription);
+        assertThat(eventSubscription).isNull();
 
         completeProcessInstanceTasks(processInstance.getId());
         assertProcessEnded(processInstance.getId());
     }
 
     @Test
-    @Deployment(resources = { "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleNonInterruptingMessageEventSubProcess.bpmn20.xml" })
+    @Deployment(resources = {
+            "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleNonInterruptingMessageEventSubProcess.bpmn20.xml" })
     public void testSetCurrentOnlyActivityToActivityInsideNonInterruptingMessageEventSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForEventSubProcess");
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("processTask", "eventSubProcessStart");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("processTask", "eventSubProcessStart");
 
         List<Task> tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("processTask");
 
         EventSubscription eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(eventSubscription).extracting(EventSubscription::getActivityId).isEqualTo("eventSubProcessStart");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventType).isEqualTo("message");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventName).isEqualTo("eventMessage");
+        assertThat(eventSubscription)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly("eventSubProcessStart", "message", "eventMessage");
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("processTask", "eventSubProcessTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("processTask", "eventSubProcessTask")
+                .changeState();
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("eventSubProcess", "eventSubProcessTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("eventSubProcess", "eventSubProcessTask");
 
         tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("eventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("eventSubProcessTask");
 
         //SINCE THE LAST EXECUTION ON THE PARENT SCOPE WAS MOVED, THERE SHOULD BE NO EVENT SUBSCRIPTION//SINCE THE LAST EXECUTION ON THE PARENT SCOPE WAS MOVED, THERE SHOULD BE NO EVENT SUBSCRIPTION
         eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(eventSubscription);
+        assertThat(eventSubscription).isNull();
 
         completeProcessInstanceTasks(processInstance.getId());
         assertProcessEnded(processInstance.getId());
     }
 
     @Test
-    @Deployment(resources = { "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleNonInterruptingTimerEventSubProcess.bpmn20.xml" })
+    @Deployment(resources = {
+            "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleNonInterruptingTimerEventSubProcess.bpmn20.xml" })
     public void testSetCurrentOnlyActivityToActivityInsideNonInterruptingTimerEventSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForEventSubProcess");
 
@@ -388,24 +425,30 @@ public class ChangeStateForEventSubProcessTest extends PluggableFlowableTestCase
         assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("processTask", "eventSubProcessStart");
 
         List<Task> tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("processTask");
 
         Job job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(job);
+        assertThat(job).isNotNull();
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("processTask", "eventSubProcessTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("processTask", "eventSubProcessTask")
+                .changeState();
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("eventSubProcess", "eventSubProcessTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("eventSubProcess", "eventSubProcessTask");
 
         tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("eventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("eventSubProcessTask");
 
         job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(job);
+        assertThat(job).isNull();
 
         //SINCE THE LAST EXECUTION ON THE PARENT SCOPE WAS MOVED, THERE SHOULD BE NO EVENT SUBSCRIPTION
         completeProcessInstanceTasks(processInstance.getId());
@@ -418,12 +461,14 @@ public class ChangeStateForEventSubProcessTest extends PluggableFlowableTestCase
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("TAES");
 
         List<Execution> executions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("spawnParallelTask", "processTask", "eventSubProcessStart");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("spawnParallelTask", "processTask", "eventSubProcessStart");
 
         EventSubscription eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(eventSubscription).extracting(EventSubscription::getActivityId).isEqualTo("eventSubProcessStart");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventType).isEqualTo("signal");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventName).isEqualTo("eventSignal");
+        assertThat(eventSubscription)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly("eventSubProcessStart", "signal", "eventSignal");
 
         //Spawn a parallel task
         Job job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
@@ -431,24 +476,32 @@ public class ChangeStateForEventSubProcessTest extends PluggableFlowableTestCase
         managementService.executeJob(job.getId());
 
         executions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("spawnParallelTask", "processTask", "parallelTask", "eventSubProcessStart");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("spawnParallelTask", "processTask", "parallelTask", "eventSubProcessStart");
 
         List<Task> tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "parallelTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("processTask", "parallelTask");
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("processTask", "eventSubProcessTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("processTask", "eventSubProcessTask")
+                .changeState();
 
         executions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("eventSubProcess", "eventSubProcessTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("eventSubProcess", "eventSubProcessTask");
 
         tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("eventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("eventSubProcessTask");
 
         eventSubscription = runtimeService.createEventSubscriptionQuery().singleResult();
-        assertNull(eventSubscription);
+        assertThat(eventSubscription).isNull();
 
         completeProcessInstanceTasks(processInstance.getId());
         assertProcessEnded(processInstance.getId());
@@ -460,12 +513,14 @@ public class ChangeStateForEventSubProcessTest extends PluggableFlowableTestCase
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("TAES");
 
         List<Execution> executions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("spawnParallelTask", "processTask", "eventSubProcessStart");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("spawnParallelTask", "processTask", "eventSubProcessStart");
 
         EventSubscription eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(eventSubscription).extracting(EventSubscription::getActivityId).isEqualTo("eventSubProcessStart");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventType).isEqualTo("message");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventName).isEqualTo("myMessage");
+        assertThat(eventSubscription)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly("eventSubProcessStart", "message", "myMessage");
 
         //Spawn a parallel task
         Job job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
@@ -473,24 +528,32 @@ public class ChangeStateForEventSubProcessTest extends PluggableFlowableTestCase
         managementService.executeJob(job.getId());
 
         executions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("spawnParallelTask", "processTask", "parallelTask", "eventSubProcessStart");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("spawnParallelTask", "processTask", "parallelTask", "eventSubProcessStart");
 
         List<Task> tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "parallelTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("processTask", "parallelTask");
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("processTask", "eventSubProcessTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("processTask", "eventSubProcessTask")
+                .changeState();
 
         executions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("eventSubProcess", "eventSubProcessTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("eventSubProcess", "eventSubProcessTask");
 
         tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("eventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("eventSubProcessTask");
 
         eventSubscription = runtimeService.createEventSubscriptionQuery().singleResult();
-        assertNull(eventSubscription);
+        assertThat(eventSubscription).isNull();
 
         completeProcessInstanceTasks(processInstance.getId());
         assertProcessEnded(processInstance.getId());
@@ -502,55 +565,70 @@ public class ChangeStateForEventSubProcessTest extends PluggableFlowableTestCase
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("TAES");
 
         List<Execution> executions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("spawnParallelTask", "processTask", "eventSubProcessStart");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("spawnParallelTask", "processTask", "eventSubProcessStart");
 
         //Spawn the parallel task
         Job job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId())
-            .list().stream()
-            .filter(j -> getJobActivityId(j).equals("spawnParallelTask"))
-            .findFirst().get();
+                .list().stream()
+                .filter(j -> getJobActivityId(j).equals("spawnParallelTask"))
+                .findFirst().get();
         managementService.moveTimerToExecutableJob(job.getId());
         managementService.executeJob(job.getId());
 
         executions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("spawnParallelTask", "processTask", "parallelTask", "eventSubProcessStart");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("spawnParallelTask", "processTask", "parallelTask", "eventSubProcessStart");
 
         List<Task> tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "parallelTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("processTask", "parallelTask");
 
         List<Job> jobs = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(jobs).extracting(this::getJobActivityId).containsExactlyInAnyOrder("eventSubProcessStart");
+        assertThat(jobs)
+                .extracting(this::getJobActivityId)
+                .containsExactly("eventSubProcessStart");
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("processTask", "eventSubProcessTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("processTask", "eventSubProcessTask")
+                .changeState();
 
         executions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("eventSubProcess", "eventSubProcessTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("eventSubProcess", "eventSubProcessTask");
 
         tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("eventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("eventSubProcessTask");
 
         job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(job);
+        assertThat(job).isNull();
 
         completeProcessInstanceTasks(processInstance.getId());
         assertProcessEnded(processInstance.getId());
     }
 
     @Test
-    @Deployment(resources = { "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNonInterruptingSignalEventSubProcess.bpmn20.xml" })
+    @Deployment(resources = {
+            "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNonInterruptingSignalEventSubProcess.bpmn20.xml" })
     public void testSetParallelActivityToActivityInsideNonInterruptingSignalEventSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("TAES");
 
         List<Execution> executions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("spawnParallelTask", "processTask", "eventSubProcessStart");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("spawnParallelTask", "processTask", "eventSubProcessStart");
 
         EventSubscription eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(eventSubscription).extracting(EventSubscription::getActivityId).isEqualTo("eventSubProcessStart");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventType).isEqualTo("signal");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventName).isEqualTo("eventSignal");
+        assertThat(eventSubscription)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly("eventSubProcessStart", "signal", "eventSignal");
 
         //Spawn a parallel task
         Job job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
@@ -558,57 +636,73 @@ public class ChangeStateForEventSubProcessTest extends PluggableFlowableTestCase
         managementService.executeJob(job.getId());
 
         executions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("spawnParallelTask", "processTask", "parallelTask", "eventSubProcessStart");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("spawnParallelTask", "processTask", "parallelTask", "eventSubProcessStart");
 
         List<Task> tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "parallelTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("processTask", "parallelTask");
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("parallelTask", "eventSubProcessTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("parallelTask", "eventSubProcessTask")
+                .changeState();
 
         executions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("spawnParallelTask", "processTask", "eventSubProcess", "eventSubProcessStart", "eventSubProcessTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("spawnParallelTask", "processTask", "eventSubProcess", "eventSubProcessStart", "eventSubProcessTask");
 
         tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("eventSubProcessTask", "processTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("eventSubProcessTask", "processTask");
 
         eventSubscription = runtimeService.createEventSubscriptionQuery().singleResult();
-        assertThat(eventSubscription).extracting(EventSubscription::getActivityId).isEqualTo("eventSubProcessStart");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventType).isEqualTo("signal");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventName).isEqualTo("eventSignal");
+        assertThat(eventSubscription)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly("eventSubProcessStart", "signal", "eventSignal");
 
         //Fire the signal
         runtimeService.signalEventReceived("eventSignal");
 
         executions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("spawnParallelTask", "processTask", "eventSubProcess", "eventSubProcess", "eventSubProcessStart", "eventSubProcessTask", "eventSubProcessTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("spawnParallelTask", "processTask", "eventSubProcess", "eventSubProcess", "eventSubProcessStart",
+                        "eventSubProcessTask", "eventSubProcessTask");
 
         tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("eventSubProcessTask", "eventSubProcessTask", "processTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("eventSubProcessTask", "eventSubProcessTask", "processTask");
 
         eventSubscription = runtimeService.createEventSubscriptionQuery().singleResult();
-        assertThat(eventSubscription).extracting(EventSubscription::getActivityId).isEqualTo("eventSubProcessStart");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventType).isEqualTo("signal");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventName).isEqualTo("eventSignal");
+        assertThat(eventSubscription)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly("eventSubProcessStart", "signal", "eventSignal");
 
         completeProcessInstanceTasks(processInstance.getId());
         assertProcessEnded(processInstance.getId());
     }
 
     @Test
-    @Deployment(resources = { "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNonInterruptingMessageEventSubProcess.bpmn20.xml" })
+    @Deployment(resources = {
+            "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNonInterruptingMessageEventSubProcess.bpmn20.xml" })
     public void testSetParallelActivityToActivityInsideNonInterruptingMessageEventSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("TAES");
 
         List<Execution> executions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("spawnParallelTask", "processTask", "eventSubProcessStart");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("spawnParallelTask", "processTask", "eventSubProcessStart");
 
         EventSubscription eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(eventSubscription).extracting(EventSubscription::getActivityId).isEqualTo("eventSubProcessStart");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventType).isEqualTo("message");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventName).isEqualTo("myMessage");
+        assertThat(eventSubscription)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly("eventSubProcessStart", "message", "myMessage");
 
         //Spawn a parallel task
         Job job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
@@ -616,100 +710,138 @@ public class ChangeStateForEventSubProcessTest extends PluggableFlowableTestCase
         managementService.executeJob(job.getId());
 
         executions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("spawnParallelTask", "processTask", "parallelTask", "eventSubProcessStart");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("spawnParallelTask", "processTask", "parallelTask", "eventSubProcessStart");
 
         List<Task> tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "parallelTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("processTask", "parallelTask");
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("parallelTask", "eventSubProcessTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("parallelTask", "eventSubProcessTask")
+                .changeState();
 
         executions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("spawnParallelTask", "processTask", "eventSubProcess", "eventSubProcessTask", "eventSubProcessStart");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("spawnParallelTask", "processTask", "eventSubProcess", "eventSubProcessTask", "eventSubProcessStart");
 
         tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("eventSubProcessTask", "processTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("eventSubProcessTask", "processTask");
 
         eventSubscription = runtimeService.createEventSubscriptionQuery().singleResult();
-        assertThat(eventSubscription).extracting(EventSubscription::getActivityId).isEqualTo("eventSubProcessStart");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventType).isEqualTo("message");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventName).isEqualTo("myMessage");
+        assertThat(eventSubscription)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly("eventSubProcessStart", "message", "myMessage");
 
         //Trigger the event
-        Execution messageSubscriptionExecution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).messageEventSubscriptionName("myMessage").singleResult();
+        Execution messageSubscriptionExecution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId())
+                .messageEventSubscriptionName("myMessage").singleResult();
         runtimeService.messageEventReceived("myMessage", messageSubscriptionExecution.getId());
 
         executions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("spawnParallelTask", "processTask", "eventSubProcess", "eventSubProcess", "eventSubProcessStart", "eventSubProcessTask", "eventSubProcessTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("spawnParallelTask", "processTask", "eventSubProcess", "eventSubProcess", "eventSubProcessStart",
+                        "eventSubProcessTask", "eventSubProcessTask");
 
         tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("eventSubProcessTask", "eventSubProcessTask", "processTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("eventSubProcessTask", "eventSubProcessTask", "processTask");
 
         eventSubscription = runtimeService.createEventSubscriptionQuery().singleResult();
-        assertThat(eventSubscription).extracting(EventSubscription::getActivityId).isEqualTo("eventSubProcessStart");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventType).isEqualTo("message");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventName).isEqualTo("myMessage");
+        assertThat(eventSubscription)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly("eventSubProcessStart", "message", "myMessage");
 
         completeProcessInstanceTasks(processInstance.getId());
         assertProcessEnded(processInstance.getId());
     }
 
     @Test
-    @Deployment(resources = { "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNonInterruptingTimerEventSubProcess.bpmn20.xml" })
+    @Deployment(resources = {
+            "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNonInterruptingTimerEventSubProcess.bpmn20.xml" })
     public void testSetParallelActivityToActivityInsideNonInterruptingTimerEventSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("TAES");
 
         List<Execution> executions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("spawnParallelTask", "processTask", "eventSubProcessStart");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("spawnParallelTask", "processTask", "eventSubProcessStart");
 
         List<Job> jobs = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(jobs).extracting(this::getJobActivityId).containsExactlyInAnyOrder("spawnParallelTask", "eventSubProcessStart");
+        assertThat(jobs)
+                .extracting(this::getJobActivityId)
+                .containsExactlyInAnyOrder("spawnParallelTask", "eventSubProcessStart");
 
         //Spawn the parallel task
         Job job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId())
-            .list().stream()
-            .filter(j -> getJobActivityId(j).equals("spawnParallelTask"))
-            .findFirst().get();
+                .list().stream()
+                .filter(j -> getJobActivityId(j).equals("spawnParallelTask"))
+                .findFirst().get();
         managementService.moveTimerToExecutableJob(job.getId());
         managementService.executeJob(job.getId());
 
         jobs = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(jobs).extracting(this::getJobActivityId).containsExactlyInAnyOrder("eventSubProcessStart");
+        assertThat(jobs)
+                .extracting(this::getJobActivityId)
+                .containsExactly("eventSubProcessStart");
 
         executions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("spawnParallelTask", "processTask", "parallelTask", "eventSubProcessStart");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("spawnParallelTask", "processTask", "parallelTask", "eventSubProcessStart");
 
         List<Task> tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "parallelTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("processTask", "parallelTask");
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("parallelTask", "eventSubProcessTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("parallelTask", "eventSubProcessTask")
+                .changeState();
 
         executions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("spawnParallelTask", "processTask", "eventSubProcess", "eventSubProcessStart", "eventSubProcessTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("spawnParallelTask", "processTask", "eventSubProcess", "eventSubProcessStart", "eventSubProcessTask");
 
         tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("eventSubProcessTask", "processTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("eventSubProcessTask", "processTask");
 
         job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(job).extracting(this::getJobActivityId).isEqualTo("eventSubProcessStart");
+        assertThat(job)
+                .extracting(this::getJobActivityId)
+                .isEqualTo("eventSubProcessStart");
 
         //Trigger the eventSubProcess timer
         managementService.moveTimerToExecutableJob(job.getId());
         managementService.executeJob(job.getId());
 
         executions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("spawnParallelTask", "processTask", "eventSubProcess", "eventSubProcess", "eventSubProcessStart", "eventSubProcessTask", "eventSubProcessTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("spawnParallelTask", "processTask", "eventSubProcess", "eventSubProcess", "eventSubProcessStart",
+                        "eventSubProcessTask", "eventSubProcessTask");
 
         tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("eventSubProcessTask", "eventSubProcessTask", "processTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("eventSubProcessTask", "eventSubProcessTask", "processTask");
 
         jobs = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(jobs).extracting(this::getJobActivityId).containsExactlyInAnyOrder("eventSubProcessStart");
+        assertThat(jobs)
+                .extracting(this::getJobActivityId)
+                .containsExactly("eventSubProcessStart");
 
         completeProcessInstanceTasks(processInstance.getId());
         assertProcessEnded(processInstance.getId());
@@ -721,41 +853,53 @@ public class ChangeStateForEventSubProcessTest extends PluggableFlowableTestCase
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForEventSubProcess");
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("processTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("processTask");
 
         List<Task> tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("processTask");
 
         EventSubscription eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(eventSubscription);
+        assertThat(eventSubscription).isNull();
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("processTask", "subProcessTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("processTask", "subProcessTask")
+                .changeState();
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "subProcessTask", "eventSubProcessStart");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "subProcessTask", "eventSubProcessStart");
 
         tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("subProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("subProcessTask");
 
         eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(eventSubscription).extracting(EventSubscription::getActivityId).isEqualTo("eventSubProcessStart");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventType).isEqualTo("signal");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventName).isEqualTo("eventSignal");
+        assertThat(eventSubscription)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly("eventSubProcessStart", "signal", "eventSignal");
 
         //Trigger the event
         runtimeService.signalEventReceived("eventSignal");
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "eventSubProcess", "eventSubProcessStart", "eventSubProcessTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "eventSubProcess", "eventSubProcessStart", "eventSubProcessTask");
 
         tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("eventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("eventSubProcessTask");
 
         eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(eventSubscription);
+        assertThat(eventSubscription).isNull();
 
         completeProcessInstanceTasks(processInstance.getId());
         assertProcessEnded(processInstance.getId());
@@ -767,41 +911,53 @@ public class ChangeStateForEventSubProcessTest extends PluggableFlowableTestCase
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForEventSubProcess");
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("processTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("processTask");
 
         List<Task> tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("processTask");
 
         EventSubscription eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(eventSubscription);
+        assertThat(eventSubscription).isNull();
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("processTask", "subProcessTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("processTask", "subProcessTask")
+                .changeState();
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "subProcessTask", "eventSubProcessStart");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "subProcessTask", "eventSubProcessStart");
 
         tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("subProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("subProcessTask");
 
         eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(eventSubscription).extracting(EventSubscription::getActivityId).isEqualTo("eventSubProcessStart");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventType).isEqualTo("message");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventName).isEqualTo("eventMessage");
+        assertThat(eventSubscription)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly("eventSubProcessStart", "message", "eventMessage");
 
         //Trigger the event
         runtimeService.messageEventReceived("eventMessage", eventSubscription.getExecutionId());
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "eventSubProcess", "eventSubProcessStart", "eventSubProcessTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "eventSubProcess", "eventSubProcessStart", "eventSubProcessTask");
 
         tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("eventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("eventSubProcessTask");
 
         eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(eventSubscription);
+        assertThat(eventSubscription).isNull();
 
         completeProcessInstanceTasks(processInstance.getId());
         assertProcessEnded(processInstance.getId());
@@ -813,40 +969,54 @@ public class ChangeStateForEventSubProcessTest extends PluggableFlowableTestCase
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForEventSubProcess");
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("processTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("processTask");
 
         List<Task> tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("processTask");
 
         Job job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(job);
+        assertThat(job).isNull();
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("processTask", "subProcessTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("processTask", "subProcessTask")
+                .changeState();
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "subProcessTask", "eventSubProcessStart");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "subProcessTask", "eventSubProcessStart");
 
         tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("subProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("subProcessTask");
 
         job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(job).extracting(this::getJobActivityId).isEqualTo("eventSubProcessStart");
+        assertThat(job)
+                .extracting(this::getJobActivityId)
+                .isEqualTo("eventSubProcessStart");
 
         //Fire the timer
         managementService.moveTimerToExecutableJob(job.getId());
         managementService.executeJob(job.getId());
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "eventSubProcess", "eventSubProcessStart", "eventSubProcessTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "eventSubProcess", "eventSubProcessStart", "eventSubProcessTask");
 
         tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("eventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("eventSubProcessTask");
 
         job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(job);
+        assertThat(job).isNull();
 
         completeProcessInstanceTasks(processInstance.getId());
         assertProcessEnded(processInstance.getId());
@@ -861,29 +1031,37 @@ public class ChangeStateForEventSubProcessTest extends PluggableFlowableTestCase
         completeTask(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult());
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "subProcessTask", "eventSubProcessStart");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "subProcessTask", "eventSubProcessStart");
 
         List<Task> tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("subProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("subProcessTask");
 
         EventSubscription eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(eventSubscription).extracting(EventSubscription::getActivityId).isEqualTo("eventSubProcessStart");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventType).isEqualTo("signal");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventName).isEqualTo("eventSignal");
+        assertThat(eventSubscription)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly("eventSubProcessStart", "signal", "eventSignal");
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("subProcessTask", "eventSubProcessTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("subProcessTask", "eventSubProcessTask")
+                .changeState();
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "eventSubProcess", "eventSubProcessTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "eventSubProcess", "eventSubProcessTask");
 
         tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("eventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("eventSubProcessTask");
 
         eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(eventSubscription);
+        assertThat(eventSubscription).isNull();
 
         completeProcessInstanceTasks(processInstance.getId());
         assertProcessEnded(processInstance.getId());
@@ -898,29 +1076,37 @@ public class ChangeStateForEventSubProcessTest extends PluggableFlowableTestCase
         completeTask(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult());
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "subProcessTask", "eventSubProcessStart");
+        assertThat(executions).
+                extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "subProcessTask", "eventSubProcessStart");
 
         List<Task> tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("subProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("subProcessTask");
 
         EventSubscription eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(eventSubscription).extracting(EventSubscription::getActivityId).isEqualTo("eventSubProcessStart");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventType).isEqualTo("message");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventName).isEqualTo("eventMessage");
+        assertThat(eventSubscription)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly("eventSubProcessStart", "message", "eventMessage");
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("subProcessTask", "eventSubProcessTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("subProcessTask", "eventSubProcessTask")
+                .changeState();
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "eventSubProcess", "eventSubProcessTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "eventSubProcess", "eventSubProcessTask");
 
         tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("eventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("eventSubProcessTask");
 
         eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(eventSubscription);
+        assertThat(eventSubscription).isNull();
 
         completeProcessInstanceTasks(processInstance.getId());
         assertProcessEnded(processInstance.getId());
@@ -935,34 +1121,45 @@ public class ChangeStateForEventSubProcessTest extends PluggableFlowableTestCase
         completeTask(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult());
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "subProcessTask", "eventSubProcessStart");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "subProcessTask", "eventSubProcessStart");
 
         List<Task> tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("subProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("subProcessTask");
 
         Job job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(job).extracting(this::getJobActivityId).isEqualTo("eventSubProcessStart");
+        assertThat(job)
+                .extracting(this::getJobActivityId)
+                .isEqualTo("eventSubProcessStart");
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("subProcessTask", "eventSubProcessTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("subProcessTask", "eventSubProcessTask")
+                .changeState();
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "eventSubProcess", "eventSubProcessTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "eventSubProcess", "eventSubProcessTask");
 
         tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("eventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("eventSubProcessTask");
 
         job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(job);
+        assertThat(job).isNull();
 
         completeProcessInstanceTasks(processInstance.getId());
         assertProcessEnded(processInstance.getId());
     }
 
     @Test
-    @Deployment(resources = { "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.nestedNonInterruptingSignalEventSubProcess.bpmn20.xml" })
+    @Deployment(resources = {
+            "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.nestedNonInterruptingSignalEventSubProcess.bpmn20.xml" })
     public void testSetCurrentActivityToActivityInsideNestedNonInterruptingSignalEventSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForEventSubProcess");
 
@@ -970,37 +1167,46 @@ public class ChangeStateForEventSubProcessTest extends PluggableFlowableTestCase
         completeTask(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult());
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "subProcessTask", "eventSubProcessStart");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "subProcessTask", "eventSubProcessStart");
 
         List<Task> tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("subProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("subProcessTask");
 
         EventSubscription eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(eventSubscription).extracting(EventSubscription::getActivityId).isEqualTo("eventSubProcessStart");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventType).isEqualTo("signal");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventName).isEqualTo("eventSignal");
+        assertThat(eventSubscription)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly("eventSubProcessStart", "signal", "eventSignal");
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("subProcessTask", "eventSubProcessTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("subProcessTask", "eventSubProcessTask")
+                .changeState();
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "eventSubProcess", "eventSubProcessTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "eventSubProcess", "eventSubProcessTask");
 
         tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("eventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("eventSubProcessTask");
 
         //SINCE THE LAST EXECUTION ON THE PARENT SCOPE WAS MOVED, THERE SHOULD BE NO EVENT SUBSCRIPTION
         eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(eventSubscription);
+        assertThat(eventSubscription).isNull();
 
         completeProcessInstanceTasks(processInstance.getId());
         assertProcessEnded(processInstance.getId());
     }
 
     @Test
-    @Deployment(resources = { "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.nestedNonInterruptingMessageEventSubProcess.bpmn20.xml" })
+    @Deployment(resources = {
+            "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.nestedNonInterruptingMessageEventSubProcess.bpmn20.xml" })
     public void testSetCurrentActivityToActivityInsideNestedNonInterruptingMessageEventSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForEventSubProcess");
 
@@ -1008,37 +1214,46 @@ public class ChangeStateForEventSubProcessTest extends PluggableFlowableTestCase
         completeTask(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult());
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "subProcessTask", "eventSubProcessStart");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "subProcessTask", "eventSubProcessStart");
 
         List<Task> tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("subProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("subProcessTask");
 
         EventSubscription eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(eventSubscription).extracting(EventSubscription::getActivityId).isEqualTo("eventSubProcessStart");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventType).isEqualTo("message");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventName).isEqualTo("eventMessage");
+        assertThat(eventSubscription)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly("eventSubProcessStart", "message", "eventMessage");
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("subProcessTask", "eventSubProcessTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("subProcessTask", "eventSubProcessTask")
+                .changeState();
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "eventSubProcess", "eventSubProcessTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "eventSubProcess", "eventSubProcessTask");
 
         tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("eventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("eventSubProcessTask");
 
         //SINCE THE LAST EXECUTION ON THE PARENT SCOPE WAS MOVED, THERE SHOULD BE NO EVENT SUBSCRIPTION
         eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(eventSubscription);
+        assertThat(eventSubscription).isNull();
 
         completeProcessInstanceTasks(processInstance.getId());
         assertProcessEnded(processInstance.getId());
     }
 
     @Test
-    @Deployment(resources = { "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.nestedNonInterruptingTimerEventSubProcess.bpmn20.xml" })
+    @Deployment(resources = {
+            "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.nestedNonInterruptingTimerEventSubProcess.bpmn20.xml" })
     public void testSetCurrentActivityToActivityInsideNestedNonInterruptingTimerEventSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForEventSubProcess");
 
@@ -1046,35 +1261,46 @@ public class ChangeStateForEventSubProcessTest extends PluggableFlowableTestCase
         completeTask(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult());
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "subProcessTask", "eventSubProcessStart");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "subProcessTask", "eventSubProcessStart");
 
         List<Task> tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("subProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("subProcessTask");
 
         Job job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(job).extracting(this::getJobActivityId).isEqualTo("eventSubProcessStart");
+        assertThat(job)
+                .extracting(this::getJobActivityId)
+                .isEqualTo("eventSubProcessStart");
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("subProcessTask", "eventSubProcessTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("subProcessTask", "eventSubProcessTask")
+                .changeState();
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "eventSubProcess", "eventSubProcessTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "eventSubProcess", "eventSubProcessTask");
 
         tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("eventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("eventSubProcessTask");
 
         //SINCE THE LAST EXECUTION ON THE PARENT SCOPE WAS MOVED, THERE SHOULD BE NO EVENT SUBSCRIPTION
         job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(job);
+        assertThat(job).isNull();
 
         completeProcessInstanceTasks(processInstance.getId());
         assertProcessEnded(processInstance.getId());
     }
 
     @Test
-    @Deployment(resources = { "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNestedSignalEventSubProcess.bpmn20.xml" })
+    @Deployment(resources = {
+            "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNestedSignalEventSubProcess.bpmn20.xml" })
     public void testSetParallelActivityToActivityInsideNestedSignalEventSubProcessWithActivityAtRootScope() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForEventSubProcess");
 
@@ -1084,34 +1310,43 @@ public class ChangeStateForEventSubProcessTest extends PluggableFlowableTestCase
         managementService.executeJob(job.getId());
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("processTask", "parallelTask", "spawnParallelTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("processTask", "parallelTask", "spawnParallelTask");
 
         List<Task> tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "parallelTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("processTask", "parallelTask");
 
         EventSubscription eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(eventSubscription);
+        assertThat(eventSubscription).isNull();
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("parallelTask", "signalEventSubProcessTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("parallelTask", "signalEventSubProcessTask")
+                .changeState();
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "signalEventSubProcess", "signalEventSubProcessTask", "processTask", "spawnParallelTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "signalEventSubProcess", "signalEventSubProcessTask", "processTask", "spawnParallelTask");
 
         tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("signalEventSubProcessTask", "processTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("signalEventSubProcessTask", "processTask");
 
         eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(eventSubscription);
+        assertThat(eventSubscription).isNull();
 
         completeProcessInstanceTasks(processInstance.getId());
         assertProcessEnded(processInstance.getId());
     }
 
     @Test
-    @Deployment(resources = { "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNestedSignalEventSubProcess.bpmn20.xml" })
+    @Deployment(resources = {
+            "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNestedSignalEventSubProcess.bpmn20.xml" })
     public void testSetParallelActivityToActivityInsideNestedSignalEventSubProcessWithActivityAtParentScope() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForEventSubProcess");
 
@@ -1126,36 +1361,45 @@ public class ChangeStateForEventSubProcessTest extends PluggableFlowableTestCase
         completeTask(currentTask);
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("parallelTask", "subProcess", "subProcessTask", "signalEventSubProcessStart");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("parallelTask", "subProcess", "subProcessTask", "signalEventSubProcessStart");
 
         List<Task> tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("subProcessTask", "parallelTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("subProcessTask", "parallelTask");
 
         EventSubscription eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(eventSubscription).extracting(EventSubscription::getActivityId).isEqualTo("signalEventSubProcessStart");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventType).isEqualTo("signal");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventName).isEqualTo("eventSignal");
+        assertThat(eventSubscription)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly("signalEventSubProcessStart", "signal", "eventSignal");
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("parallelTask", "signalEventSubProcessTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("parallelTask", "signalEventSubProcessTask")
+                .changeState();
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "signalEventSubProcess", "signalEventSubProcessTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "signalEventSubProcess", "signalEventSubProcessTask");
 
         tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("signalEventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("signalEventSubProcessTask");
 
         eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(eventSubscription);
+        assertThat(eventSubscription).isNull();
 
         completeProcessInstanceTasks(processInstance.getId());
         assertProcessEnded(processInstance.getId());
     }
 
     @Test
-    @Deployment(resources = { "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNestedMessageEventSubProcess.bpmn20.xml" })
+    @Deployment(resources = {
+            "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNestedMessageEventSubProcess.bpmn20.xml" })
     public void testSetParallelActivityToActivityInsideNestedMessageEventSubProcessWithActivityAtRootScope() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForEventSubProcess");
 
@@ -1165,34 +1409,43 @@ public class ChangeStateForEventSubProcessTest extends PluggableFlowableTestCase
         managementService.executeJob(job.getId());
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("processTask", "parallelTask", "spawnParallelTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("processTask", "parallelTask", "spawnParallelTask");
 
         List<Task> tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "parallelTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("processTask", "parallelTask");
 
         EventSubscription eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(eventSubscription);
+        assertThat(eventSubscription).isNull();
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("parallelTask", "messageEventSubProcessTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("parallelTask", "messageEventSubProcessTask")
+                .changeState();
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "messageEventSubProcess", "messageEventSubProcessTask", "processTask", "spawnParallelTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "messageEventSubProcess", "messageEventSubProcessTask", "processTask", "spawnParallelTask");
 
         tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("messageEventSubProcessTask", "processTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("messageEventSubProcessTask", "processTask");
 
         eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(eventSubscription);
+        assertThat(eventSubscription).isNull();
 
         completeProcessInstanceTasks(processInstance.getId());
         assertProcessEnded(processInstance.getId());
     }
 
     @Test
-    @Deployment(resources = { "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNestedMessageEventSubProcess.bpmn20.xml" })
+    @Deployment(resources = {
+            "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNestedMessageEventSubProcess.bpmn20.xml" })
     public void testSetParallelActivityToActivityInsideNestedMessageEventSubProcessWithActivityAtParentScope() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForEventSubProcess");
 
@@ -1207,36 +1460,43 @@ public class ChangeStateForEventSubProcessTest extends PluggableFlowableTestCase
         completeTask(currentTask);
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("parallelTask", "subProcess", "subProcessTask", "messageEventSubProcessStart");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("parallelTask", "subProcess", "subProcessTask", "messageEventSubProcessStart");
 
         List<Task> tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("subProcessTask", "parallelTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("subProcessTask", "parallelTask");
 
         EventSubscription eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(eventSubscription).extracting(EventSubscription::getActivityId).isEqualTo("messageEventSubProcessStart");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventType).isEqualTo("message");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventName).isEqualTo("eventMessage");
+        assertThat(eventSubscription)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly("messageEventSubProcessStart", "message", "eventMessage");
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("parallelTask", "messageEventSubProcessTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("parallelTask", "messageEventSubProcessTask")
+                .changeState();
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "messageEventSubProcess", "messageEventSubProcessTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "messageEventSubProcess", "messageEventSubProcessTask");
 
         tasks = taskService.createTaskQuery().list();
         assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("messageEventSubProcessTask");
 
         eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(eventSubscription);
+        assertThat(eventSubscription).isNull();
 
         completeProcessInstanceTasks(processInstance.getId());
         assertProcessEnded(processInstance.getId());
     }
 
     @Test
-    @Deployment(resources = { "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNestedTimerEventSubProcess.bpmn20.xml" })
+    @Deployment(resources = {
+            "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNestedTimerEventSubProcess.bpmn20.xml" })
     public void testSetParallelActivityToActivityInsideNestedTimerEventSubProcessWithActivityAtRootScope() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForEventSubProcess");
 
@@ -1246,35 +1506,44 @@ public class ChangeStateForEventSubProcessTest extends PluggableFlowableTestCase
         managementService.executeJob(job.getId());
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("processTask", "parallelTask", "spawnParallelTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("processTask", "parallelTask", "spawnParallelTask");
 
         List<Task> tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "parallelTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("processTask", "parallelTask");
 
         //The TimerEvent SubProcess stat time is not registered
         job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(job);
+        assertThat(job).isNull();
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("parallelTask", "timerEventSubProcessTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("parallelTask", "timerEventSubProcessTask")
+                .changeState();
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "timerEventSubProcess", "timerEventSubProcessTask", "processTask", "spawnParallelTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "timerEventSubProcess", "timerEventSubProcessTask", "processTask", "spawnParallelTask");
 
         tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("timerEventSubProcessTask", "processTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("timerEventSubProcessTask", "processTask");
 
         job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(job);
+        assertThat(job).isNull();
 
         completeProcessInstanceTasks(processInstance.getId());
         assertProcessEnded(processInstance.getId());
     }
 
     @Test
-    @Deployment(resources = { "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNestedTimerEventSubProcess.bpmn20.xml" })
+    @Deployment(resources = {
+            "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNestedTimerEventSubProcess.bpmn20.xml" })
     public void testSetParallelActivityToActivityInsideNestedTimerEventSubProcessWithActivityAtParentScope() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForEventSubProcess");
 
@@ -1289,35 +1558,46 @@ public class ChangeStateForEventSubProcessTest extends PluggableFlowableTestCase
         completeTask(currentTask);
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("parallelTask", "subProcess", "subProcessTask", "timerEventSubProcessStart");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("parallelTask", "subProcess", "subProcessTask", "timerEventSubProcessStart");
 
         List<Task> tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("subProcessTask", "parallelTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("subProcessTask", "parallelTask");
 
         //The TimerEvent SubProcess stat time is not registered
         job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(job).extracting(this::getJobActivityId).isEqualTo("timerEventSubProcessStart");
+        assertThat(job)
+                .extracting(this::getJobActivityId)
+                .isEqualTo("timerEventSubProcessStart");
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("parallelTask", "timerEventSubProcessTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("parallelTask", "timerEventSubProcessTask")
+                .changeState();
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "timerEventSubProcess", "timerEventSubProcessTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "timerEventSubProcess", "timerEventSubProcessTask");
 
         tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("timerEventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("timerEventSubProcessTask");
 
         job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(job);
+        assertThat(job).isNull();
 
         completeProcessInstanceTasks(processInstance.getId());
         assertProcessEnded(processInstance.getId());
     }
 
     @Test
-    @Deployment(resources = { "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNestedNonInterruptingSignalEventSubProcess.bpmn20.xml" })
+    @Deployment(resources = {
+            "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNestedNonInterruptingSignalEventSubProcess.bpmn20.xml" })
     public void testSetParallelActivityToActivityInsideNestedNonInterruptingSignalEventSubProcessWithActivityAtRootScope() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForEventSubProcess");
 
@@ -1327,35 +1607,44 @@ public class ChangeStateForEventSubProcessTest extends PluggableFlowableTestCase
         managementService.executeJob(job.getId());
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("processTask", "parallelTask", "spawnParallelTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("processTask", "parallelTask", "spawnParallelTask");
 
         List<Task> tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "parallelTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("processTask", "parallelTask");
 
         EventSubscription eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(eventSubscription);
+        assertThat(eventSubscription).isNull();
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("parallelTask", "signalEventSubProcessTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("parallelTask", "signalEventSubProcessTask")
+                .changeState();
 
         //Behaves like interrupting eventSubProcess since there are other executions at the parentScope
         eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(eventSubscription);
+        assertThat(eventSubscription).isNull();
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "signalEventSubProcess", "signalEventSubProcessTask", "processTask", "spawnParallelTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "signalEventSubProcess", "signalEventSubProcessTask", "processTask", "spawnParallelTask");
 
         tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("signalEventSubProcessTask", "processTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("signalEventSubProcessTask", "processTask");
 
         completeProcessInstanceTasks(processInstance.getId());
         assertProcessEnded(processInstance.getId());
     }
 
     @Test
-    @Deployment(resources = { "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNestedNonInterruptingSignalEventSubProcess.bpmn20.xml" })
+    @Deployment(resources = {
+            "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNestedNonInterruptingSignalEventSubProcess.bpmn20.xml" })
     public void testSetParallelActivityToActivityInsideNestedNonInterruptingSignalEventSubProcessWithActivityAtParentScope() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForEventSubProcess");
 
@@ -1370,48 +1659,61 @@ public class ChangeStateForEventSubProcessTest extends PluggableFlowableTestCase
         completeTask(currentTask);
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("parallelTask", "subProcess", "subProcessTask", "signalEventSubProcessStart");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("parallelTask", "subProcess", "subProcessTask", "signalEventSubProcessStart");
 
         List<Task> tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("subProcessTask", "parallelTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("subProcessTask", "parallelTask");
 
         EventSubscription eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(eventSubscription).extracting(EventSubscription::getActivityId).isEqualTo("signalEventSubProcessStart");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventType).isEqualTo("signal");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventName).isEqualTo("eventSignal");
+        assertThat(eventSubscription)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly("signalEventSubProcessStart", "signal", "eventSignal");
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("parallelTask", "signalEventSubProcessTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("parallelTask", "signalEventSubProcessTask")
+                .changeState();
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "subProcessTask", "signalEventSubProcessStart", "signalEventSubProcess", "signalEventSubProcessTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "subProcessTask", "signalEventSubProcessStart", "signalEventSubProcess", "signalEventSubProcessTask");
 
         tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("subProcessTask", "signalEventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("subProcessTask", "signalEventSubProcessTask");
 
         eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(eventSubscription).extracting(EventSubscription::getActivityId).isEqualTo("signalEventSubProcessStart");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventType).isEqualTo("signal");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventName).isEqualTo("eventSignal");
+        assertThat(eventSubscription)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly("signalEventSubProcessStart", "signal", "eventSignal");
 
         //We can trigger the event again
         runtimeService.signalEventReceived("eventSignal");
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId)
-            .containsExactlyInAnyOrder("subProcess", "subProcessTask", "signalEventSubProcessStart", "signalEventSubProcess", "signalEventSubProcessTask", "signalEventSubProcess", "signalEventSubProcessTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "subProcessTask", "signalEventSubProcessStart", "signalEventSubProcess", "signalEventSubProcessTask",
+                        "signalEventSubProcess", "signalEventSubProcessTask");
 
         tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("subProcessTask", "signalEventSubProcessTask", "signalEventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("subProcessTask", "signalEventSubProcessTask", "signalEventSubProcessTask");
 
         completeProcessInstanceTasks(processInstance.getId());
         assertProcessEnded(processInstance.getId());
     }
 
     @Test
-    @Deployment(resources = { "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNestedNonInterruptingMessageEventSubProcess.bpmn20.xml" })
+    @Deployment(resources = {
+            "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNestedNonInterruptingMessageEventSubProcess.bpmn20.xml" })
     public void testSetParallelActivityToActivityInsideNestedNonInterruptingMessageEventSubProcessWithActivityAtRootScope() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForEventSubProcess");
 
@@ -1421,35 +1723,44 @@ public class ChangeStateForEventSubProcessTest extends PluggableFlowableTestCase
         managementService.executeJob(job.getId());
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("processTask", "parallelTask", "spawnParallelTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("processTask", "parallelTask", "spawnParallelTask");
 
         List<Task> tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "parallelTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("processTask", "parallelTask");
 
         EventSubscription eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(eventSubscription);
+        assertThat(eventSubscription).isNull();
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("parallelTask", "messageEventSubProcessTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("parallelTask", "messageEventSubProcessTask")
+                .changeState();
 
         //Behaves like interrupting eventSubProcess since there are other executions at the parentScope
         eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(eventSubscription);
+        assertThat(eventSubscription).isNull();
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "messageEventSubProcess", "messageEventSubProcessTask", "processTask", "spawnParallelTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "messageEventSubProcess", "messageEventSubProcessTask", "processTask", "spawnParallelTask");
 
         tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("messageEventSubProcessTask", "processTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("messageEventSubProcessTask", "processTask");
 
         completeProcessInstanceTasks(processInstance.getId());
         assertProcessEnded(processInstance.getId());
     }
 
     @Test
-    @Deployment(resources = { "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNestedNonInterruptingMessageEventSubProcess.bpmn20.xml" })
+    @Deployment(resources = {
+            "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNestedNonInterruptingMessageEventSubProcess.bpmn20.xml" })
     public void testSetParallelActivityToActivityInsideNestedNonInterruptingMessageEventSubProcessWithActivityAtParentScope() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForEventSubProcess");
 
@@ -1464,49 +1775,64 @@ public class ChangeStateForEventSubProcessTest extends PluggableFlowableTestCase
         completeTask(currentTask);
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("parallelTask", "subProcess", "subProcessTask", "messageEventSubProcessStart");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("parallelTask", "subProcess", "subProcessTask", "messageEventSubProcessStart");
 
         List<Task> tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("subProcessTask", "parallelTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("subProcessTask", "parallelTask");
 
         EventSubscription eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(eventSubscription).extracting(EventSubscription::getActivityId).isEqualTo("messageEventSubProcessStart");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventType).isEqualTo("message");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventName).isEqualTo("eventMessage");
+        assertThat(eventSubscription)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly("messageEventSubProcessStart", "message", "eventMessage");
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("parallelTask", "messageEventSubProcessTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("parallelTask", "messageEventSubProcessTask")
+                .changeState();
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "subProcessTask", "messageEventSubProcessStart", "messageEventSubProcess", "messageEventSubProcessTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "subProcessTask", "messageEventSubProcessStart", "messageEventSubProcess",
+                        "messageEventSubProcessTask");
 
         tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("subProcessTask", "messageEventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("subProcessTask", "messageEventSubProcessTask");
 
         eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(eventSubscription).extracting(EventSubscription::getActivityId).isEqualTo("messageEventSubProcessStart");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventType).isEqualTo("message");
-        assertThat(eventSubscription).extracting(EventSubscription::getEventName).isEqualTo("eventMessage");
+        assertThat(eventSubscription)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly("messageEventSubProcessStart", "message", "eventMessage");
 
         //We can trigger the event again
-        Execution messageSubscriptionExecution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).messageEventSubscriptionName("eventMessage").singleResult();
+        Execution messageSubscriptionExecution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId())
+                .messageEventSubscriptionName("eventMessage").singleResult();
         runtimeService.messageEventReceived("eventMessage", messageSubscriptionExecution.getId());
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId)
-            .containsExactlyInAnyOrder("subProcess", "subProcessTask", "messageEventSubProcessStart", "messageEventSubProcess", "messageEventSubProcessTask", "messageEventSubProcess", "messageEventSubProcessTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "subProcessTask", "messageEventSubProcessStart", "messageEventSubProcess",
+                        "messageEventSubProcessTask", "messageEventSubProcess", "messageEventSubProcessTask");
 
         tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("subProcessTask", "messageEventSubProcessTask", "messageEventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("subProcessTask", "messageEventSubProcessTask", "messageEventSubProcessTask");
 
         completeProcessInstanceTasks(processInstance.getId());
         assertProcessEnded(processInstance.getId());
     }
 
     @Test
-    @Deployment(resources = { "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNestedNonInterruptingTimerEventSubProcess.bpmn20.xml" })
+    @Deployment(resources = {
+            "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNestedNonInterruptingTimerEventSubProcess.bpmn20.xml" })
     public void testSetParallelActivityToActivityInsideNestedNonInterruptingTimerEventSubProcessWithActivityAtRootScope() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForEventSubProcess");
 
@@ -1516,35 +1842,44 @@ public class ChangeStateForEventSubProcessTest extends PluggableFlowableTestCase
         managementService.executeJob(job.getId());
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("processTask", "parallelTask", "spawnParallelTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("processTask", "parallelTask", "spawnParallelTask");
 
         List<Task> tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "parallelTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("processTask", "parallelTask");
 
         EventSubscription eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(eventSubscription);
+        assertThat(eventSubscription).isNull();
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("parallelTask", "timerEventSubProcessTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("parallelTask", "timerEventSubProcessTask")
+                .changeState();
 
         //Behaves like interrupting eventSubProcess since there are other executions at the parentScope
         job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(job);
+        assertThat(job).isNull();
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "timerEventSubProcess", "timerEventSubProcessTask", "processTask", "spawnParallelTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "timerEventSubProcess", "timerEventSubProcessTask", "processTask", "spawnParallelTask");
 
         tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("timerEventSubProcessTask", "processTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("timerEventSubProcessTask", "processTask");
 
         completeProcessInstanceTasks(processInstance.getId());
         assertProcessEnded(processInstance.getId());
     }
 
     @Test
-    @Deployment(resources = { "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNestedNonInterruptingTimerEventSubProcess.bpmn20.xml" })
+    @Deployment(resources = {
+            "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNestedNonInterruptingTimerEventSubProcess.bpmn20.xml" })
     public void testSetParallelActivityToActivityInsideNestedNonInterruptingTimerEventSubProcessWithActivityAtParentScope() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForEventSubProcess");
 
@@ -1559,38 +1894,54 @@ public class ChangeStateForEventSubProcessTest extends PluggableFlowableTestCase
         completeTask(currentTask);
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("parallelTask", "subProcess", "subProcessTask", "timerEventSubProcessStart");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("parallelTask", "subProcess", "subProcessTask", "timerEventSubProcessStart");
 
         List<Task> tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("subProcessTask", "parallelTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("subProcessTask", "parallelTask");
 
         List<Job> jobs = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(jobs).extracting(this::getJobActivityId).contains("timerEventSubProcessStart");
+        assertThat(jobs)
+                .extracting(this::getJobActivityId)
+                .contains("timerEventSubProcessStart");
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("parallelTask", "timerEventSubProcessTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("parallelTask", "timerEventSubProcessTask")
+                .changeState();
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "subProcessTask", "timerEventSubProcessStart", "timerEventSubProcess", "timerEventSubProcessTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "subProcessTask", "timerEventSubProcessStart", "timerEventSubProcess", "timerEventSubProcessTask");
 
         tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("subProcessTask", "timerEventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("subProcessTask", "timerEventSubProcessTask");
 
         job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(job).extracting(this::getJobActivityId).isEqualTo("timerEventSubProcessStart");
+        assertThat(job)
+                .extracting(this::getJobActivityId)
+                .isEqualTo("timerEventSubProcessStart");
 
         //We can trigger the event again
         managementService.moveTimerToExecutableJob(job.getId());
         managementService.executeJob(job.getId());
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId)
-            .containsExactlyInAnyOrder("subProcess", "subProcessTask", "timerEventSubProcessStart", "timerEventSubProcess", "timerEventSubProcessTask", "timerEventSubProcess", "timerEventSubProcessTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "subProcessTask", "timerEventSubProcessStart", "timerEventSubProcess", "timerEventSubProcessTask",
+                        "timerEventSubProcess", "timerEventSubProcessTask");
 
         tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("subProcessTask", "timerEventSubProcessTask", "timerEventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("subProcessTask", "timerEventSubProcessTask", "timerEventSubProcessTask");
 
         completeProcessInstanceTasks(processInstance.getId());
         assertProcessEnded(processInstance.getId());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/changestate/ChangeStateForGatewaysTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/changestate/ChangeStateForGatewaysTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.engine.test.api.runtime.changestate;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -60,7 +62,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
     public void testSetCurrentActivityToMultipleActivitiesForParallelGateway() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         List<String> newActivityIds = new ArrayList<>();
         newActivityIds.add("task1");
@@ -69,19 +71,18 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         changeStateEventListener.clear();
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveSingleActivityIdToActivityIds("taskBefore", newActivityIds)
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveSingleActivityIdToActivityIds("taskBefore", newActivityIds)
+                .changeState();
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
         Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
-        assertTrue(executionsByActivity.containsKey("task1"));
-        assertTrue(executionsByActivity.containsKey("task2"));
-        assertFalse(executionsByActivity.containsKey("parallelJoin"));
+        assertThat(executionsByActivity).containsKeys("task1", "task2");
+        assertThat(executionsByActivity).doesNotContainKey("parallelJoin");
 
         //Complete one task1
         Optional<Task> task1 = tasks.stream().filter(t -> t.getTaskDefinitionKey().equals("task1")).findFirst();
@@ -91,40 +92,39 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
 
         // Verify events
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
 
         FlowableEvent event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("taskBefore", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("taskBefore");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("task1", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("task1");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("task2", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("task2");
 
-        assertTrue(!iterator.hasNext());
+        assertThat(!iterator.hasNext()).isTrue();
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(1, tasks.size());
+        assertThat(tasks).hasSize(1);
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
         executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
-        assertFalse(executionsByActivity.containsKey("task1"));
-        assertTrue(executionsByActivity.containsKey("task2"));
-        assertTrue(executionsByActivity.containsKey("parallelJoin"));
+        assertThat(executionsByActivity).doesNotContainKey("task1");
+        assertThat(executionsByActivity).containsKeys("task2", "parallelJoin");
 
-        assertFalse(((ExecutionEntity) executionsByActivity.get("parallelJoin").get(0)).isActive());
+        assertThat(((ExecutionEntity) executionsByActivity.get("parallelJoin").get(0)).isActive()).isFalse();
 
         taskService.complete(tasks.get(0).getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -135,15 +135,15 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
     public void testSetMultipleActivitiesToSingleActivityAfterParallelGateway() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         taskService.complete(task.getId());
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
 
         List<String> currentActivityIds = new ArrayList<>();
         currentActivityIds.add("task1");
@@ -152,36 +152,36 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         changeStateEventListener.clear();
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdsToSingleActivityId(currentActivityIds, "taskAfter")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdsToSingleActivityId(currentActivityIds, "taskAfter")
+                .changeState();
 
         // Verify events
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
 
         FlowableEvent event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("task1", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("task1");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("task2", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("task2");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("taskAfter", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("taskAfter");
 
-        assertTrue(!iterator.hasNext());
+        assertThat(!iterator.hasNext()).isTrue();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(1, executions.size());
+        assertThat(executions).hasSize(1);
 
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -194,29 +194,28 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         //Move all parallelGateway activities to the synchronizing gateway
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         taskService.complete(task.getId());
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
         Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
-        assertTrue(executionsByActivity.containsKey("task1"));
-        assertTrue(executionsByActivity.containsKey("task2"));
+        assertThat(executionsByActivity).containsOnlyKeys("task1", "task2");
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdsToSingleActivityId(Arrays.asList("task1", "task2"), "parallelJoin")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdsToSingleActivityId(Arrays.asList("task1", "task2"), "parallelJoin")
+                .changeState();
 
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().singleResult();
-        assertEquals("taskAfter", execution.getActivityId());
+        assertThat(execution.getActivityId()).isEqualTo("taskAfter");
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
 
         taskService.complete(task.getId());
         assertProcessEnded(processInstance.getId());
@@ -229,18 +228,17 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         //Move all parallelGateway activities to the synchronizing gateway
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         taskService.complete(task.getId());
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
         Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
-        assertTrue(executionsByActivity.containsKey("task1"));
-        assertTrue(executionsByActivity.containsKey("task2"));
+        assertThat(executionsByActivity).containsKeys("task1", "task2");
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
 
         //Complete task1
         for (Task t : tasks) {
@@ -250,23 +248,23 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         }
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
         Map<String, List<Execution>> classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
-        assertNotNull(classifiedExecutions.get("task2"));
-        assertEquals(1, classifiedExecutions.get("task2").size());
-        assertNotNull(classifiedExecutions.get("parallelJoin"));
-        assertEquals(1, classifiedExecutions.get("parallelJoin").size());
+        assertThat(classifiedExecutions.get("task2")).isNotNull();
+        assertThat(classifiedExecutions.get("task2")).hasSize(1);
+        assertThat(classifiedExecutions.get("parallelJoin")).isNotNull();
+        assertThat(classifiedExecutions.get("parallelJoin")).hasSize(1);
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdsToSingleActivityId(Arrays.asList("task2", "parallelJoin"), "taskAfter")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdsToSingleActivityId(Arrays.asList("task2", "parallelJoin"), "taskAfter")
+                .changeState();
 
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().singleResult();
-        assertEquals("taskAfter", execution.getActivityId());
+        assertThat(execution.getActivityId()).isEqualTo("taskAfter");
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
 
         taskService.complete(task.getId());
         assertProcessEnded(processInstance.getId());
@@ -279,38 +277,37 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         //Move one task to the synchronizing gateway, then complete the remaining task
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         taskService.complete(task.getId());
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("task1", "parallelJoin")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("task1", "parallelJoin")
+                .changeState();
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
         Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
-        assertNull(executionsByActivity.get("task1"));
-        assertNotNull(executionsByActivity.get("task2"));
-        assertNotNull(executionsByActivity.get("parallelJoin"));
+        assertThat(executionsByActivity).doesNotContainKey("task1");
+        assertThat(executionsByActivity).containsKeys("task2", "parallelJoin");
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("task2", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("task2");
 
         taskService.complete(task.getId());
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(1, executions.size());
+        assertThat(executions).hasSize(1);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
 
         taskService.complete(task.getId());
         assertProcessEnded(processInstance.getId());
@@ -323,15 +320,15 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         //Complete one task and then move the last remaining task to the synchronizing gateway
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         taskService.complete(task.getId());
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
 
         //Complete task1
         Optional<Task> task1 = tasks.stream().filter(t -> t.getTaskDefinitionKey().equals("task1")).findFirst();
@@ -340,26 +337,25 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         }
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
         Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
-        assertNull(executionsByActivity.get("task1"));
-        assertNotNull(executionsByActivity.get("task2"));
-        assertNotNull(executionsByActivity.get("parallelJoin"));
+        assertThat(executionsByActivity).doesNotContainKey("task1");
+        assertThat(executionsByActivity).containsKeys("task2", "parallelJoin");
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("task2", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("task2");
 
         //Move task2
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("task2", "parallelJoin")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("task2", "parallelJoin")
+                .changeState();
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(1, executions.size());
+        assertThat(executions).hasSize(1);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
 
         taskService.complete(task.getId());
         assertProcessEnded(processInstance.getId());
@@ -370,7 +366,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
     public void testSetCurrentExecutionToMultipleActivitiesForParallelGateway() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         Execution taskBeforeExecution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().singleResult();
 
@@ -381,19 +377,18 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         changeStateEventListener.clear();
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveSingleExecutionToActivityIds(taskBeforeExecution.getId(), newActivityIds)
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveSingleExecutionToActivityIds(taskBeforeExecution.getId(), newActivityIds)
+                .changeState();
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
         Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
-        assertNotNull(executionsByActivity.get("task1"));
-        assertNotNull(executionsByActivity.get("task2"));
-        assertNull(executionsByActivity.get("parallelJoin"));
+        assertThat(executionsByActivity).containsKeys("task1", "task2");
+        assertThat(executionsByActivity).doesNotContainKey("parallelJoin");
 
         //Complete one task1
         Optional<Task> task1 = tasks.stream().filter(t -> t.getTaskDefinitionKey().equals("task1")).findFirst();
@@ -402,21 +397,20 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         }
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(1, tasks.size());
+        assertThat(tasks).hasSize(1);
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
         executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
-        assertFalse(executionsByActivity.containsKey("task1"));
-        assertTrue(executionsByActivity.containsKey("task2"));
-        assertTrue(executionsByActivity.containsKey("parallelJoin"));
+        assertThat(executionsByActivity).containsKeys("task2", "parallelJoin");
+        assertThat(executionsByActivity).doesNotContainKey("task1");
 
-        assertFalse(((ExecutionEntity) executionsByActivity.get("parallelJoin").get(0)).isActive());
+        assertThat(((ExecutionEntity) executionsByActivity.get("parallelJoin").get(0)).isActive()).isFalse();
 
         taskService.complete(tasks.get(0).getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -427,29 +421,29 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
     public void testSetMultipleExecutionsToSingleActivityAfterParallelGateway() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         taskService.complete(task.getId());
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
 
         List<String> currentExecutionIds = new ArrayList<>();
         currentExecutionIds.add(executions.get(0).getId());
         currentExecutionIds.add(executions.get(1).getId());
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionsToSingleActivityId(currentExecutionIds, "taskAfter")
-            .changeState();
+                .moveExecutionsToSingleActivityId(currentExecutionIds, "taskAfter")
+                .changeState();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(1, executions.size());
+        assertThat(executions).hasSize(1);
 
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -462,30 +456,29 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         //Move all gateway executions to the synchronizing gateway
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         taskService.complete(task.getId());
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
         Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
-        assertTrue(executionsByActivity.containsKey("task1"));
-        assertTrue(executionsByActivity.containsKey("task2"));
+        assertThat(executionsByActivity).containsKeys("task1", "task2");
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
 
         List<String> executionIds = executions.stream().map(Execution::getId).collect(Collectors.toList());
 
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionsToSingleActivityId(executionIds, "parallelJoin")
-            .changeState();
+                .moveExecutionsToSingleActivityId(executionIds, "parallelJoin")
+                .changeState();
 
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().singleResult();
-        assertEquals("taskAfter", execution.getActivityId());
+        assertThat(execution.getActivityId()).isEqualTo("taskAfter");
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
 
         taskService.complete(task.getId());
         assertProcessEnded(processInstance.getId());
@@ -498,18 +491,17 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         //Move all gateway executions to the synchronizing gateway
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         taskService.complete(task.getId());
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
         Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
-        assertTrue(executionsByActivity.containsKey("task1"));
-        assertTrue(executionsByActivity.containsKey("task2"));
+        assertThat(executionsByActivity).containsKeys("task1", "task2");
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
 
         //Complete task1
         for (Task t : tasks) {
@@ -519,24 +511,24 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         }
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
         Map<String, List<Execution>> classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
-        assertNotNull(classifiedExecutions.get("task2"));
-        assertEquals(1, classifiedExecutions.get("task2").size());
-        assertNotNull(classifiedExecutions.get("parallelJoin"));
-        assertEquals(1, classifiedExecutions.get("parallelJoin").size());
+        assertThat(classifiedExecutions.get("task2")).isNotNull();
+        assertThat(classifiedExecutions.get("task2")).hasSize(1);
+        assertThat(classifiedExecutions.get("parallelJoin")).isNotNull();
+        assertThat(classifiedExecutions.get("parallelJoin")).hasSize(1);
 
         List<String> executionIds = executions.stream().map(Execution::getId).collect(Collectors.toList());
 
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionsToSingleActivityId(executionIds, "taskAfter")
-            .changeState();
+                .moveExecutionsToSingleActivityId(executionIds, "taskAfter")
+                .changeState();
 
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().singleResult();
-        assertEquals("taskAfter", execution.getActivityId());
+        assertThat(execution.getActivityId()).isEqualTo("taskAfter");
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
 
         taskService.complete(task.getId());
         assertProcessEnded(processInstance.getId());
@@ -549,38 +541,37 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         //Move one task to the synchronizing gateway, then complete the remaining task
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         taskService.complete(task.getId());
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
 
         String executionId = executions.stream().filter(e -> "task1".equals(e.getActivityId())).findFirst().map(Execution::getId).get();
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionToActivityId(executionId, "parallelJoin")
-            .changeState();
+                .moveExecutionToActivityId(executionId, "parallelJoin")
+                .changeState();
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
         Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
-        assertNull(executionsByActivity.get("task1"));
-        assertNotNull(executionsByActivity.get("task2"));
-        assertNotNull(executionsByActivity.get("parallelJoin"));
+        assertThat(executionsByActivity).containsKeys("task2", "parallelJoin");
+        assertThat(executionsByActivity).doesNotContainKey("task1");
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("task2", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("task2");
 
         taskService.complete(task.getId());
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(1, executions.size());
+        assertThat(executions).hasSize(1);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
 
         taskService.complete(task.getId());
         assertProcessEnded(processInstance.getId());
@@ -593,15 +584,15 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         //Complete one task and then move the last remaining task to the synchronizing gateway
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         taskService.complete(task.getId());
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
 
         //Complete task1
         Optional<Task> task1 = tasks.stream().filter(t -> t.getTaskDefinitionKey().equals("task1")).findFirst();
@@ -610,27 +601,26 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         }
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
         Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
-        assertNull(executionsByActivity.get("task1"));
-        assertNotNull(executionsByActivity.get("task2"));
-        assertNotNull(executionsByActivity.get("parallelJoin"));
+        assertThat(executionsByActivity).containsKeys("task2", "parallelJoin");
+        assertThat(executionsByActivity).doesNotContainKey("task1");
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("task2", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("task2");
 
         //Move task2 execution
         String executionId = executions.stream().filter(e -> "task2".equals(e.getActivityId())).findFirst().map(Execution::getId).get();
 
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionToActivityId(executionId, "parallelJoin")
-            .changeState();
+                .moveExecutionToActivityId(executionId, "parallelJoin")
+                .changeState();
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(1, executions.size());
+        assertThat(executions).hasSize(1);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
 
         taskService.complete(task.getId());
         assertProcessEnded(processInstance.getId());
@@ -641,51 +631,48 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
     public void testSetCurrentActivityToMultipleActivitiesForInclusiveGateway() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startInclusiveGwProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         List<String> newActivityIds = new ArrayList<>();
         newActivityIds.add("task1");
         newActivityIds.add("task2");
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveSingleActivityIdToActivityIds("taskBefore", newActivityIds)
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveSingleActivityIdToActivityIds("taskBefore", newActivityIds)
+                .changeState();
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
 
         Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
-        assertTrue(executionsByActivity.containsKey("task1"));
-        assertTrue(executionsByActivity.containsKey("task2"));
-        assertFalse(executionsByActivity.containsKey("gwJoin"));
+        assertThat(executionsByActivity).containsKeys("task1", "task2");
+        assertThat(executionsByActivity).doesNotContainKey("gwJoin");
 
         //Complete one task1
         Optional<Task> task1 = tasks.stream().filter(t -> t.getTaskDefinitionKey().equals("task1")).findFirst();
         if (task1.isPresent()) {
             taskService.complete(task1.get().getId());
-
         }
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(1, tasks.size());
+        assertThat(tasks).hasSize(1);
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
         executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
-        assertFalse(executionsByActivity.containsKey("task1"));
-        assertTrue(executionsByActivity.containsKey("task2"));
-        assertTrue(executionsByActivity.containsKey("gwJoin"));
+        assertThat(executionsByActivity).containsKeys("task2", "gwJoin");
+        assertThat(executionsByActivity).doesNotContainKey("task1");
 
-        assertFalse(((ExecutionEntity) executionsByActivity.get("gwJoin").get(0)).isActive());
+        assertThat(((ExecutionEntity) executionsByActivity.get("gwJoin").get(0)).isActive()).isFalse();
 
         taskService.complete(tasks.get(0).getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -696,31 +683,31 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
     public void testSetMultipleActivitiesToSingleActivityAfterInclusiveGateway() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startInclusiveGwProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         taskService.complete(task.getId());
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
 
         List<String> currentActivityIds = new ArrayList<>();
         currentActivityIds.add("task1");
         currentActivityIds.add("task2");
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdsToSingleActivityId(currentActivityIds, "taskAfter")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdsToSingleActivityId(currentActivityIds, "taskAfter")
+                .changeState();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(1, executions.size());
+        assertThat(executions).hasSize(1);
 
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
 
         taskService.complete(task.getId());
 
@@ -734,29 +721,28 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         //Move all parallelGateway activities to the synchronizing gateway
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startInclusiveGwProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         taskService.complete(task.getId());
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
         Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
-        assertTrue(executionsByActivity.containsKey("task1"));
-        assertTrue(executionsByActivity.containsKey("task2"));
+        assertThat(executionsByActivity).containsKeys("task1", "task2");
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdsToSingleActivityId(Arrays.asList("task1", "task2"), "gwJoin")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdsToSingleActivityId(Arrays.asList("task1", "task2"), "gwJoin")
+                .changeState();
 
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().singleResult();
-        assertEquals("taskAfter", execution.getActivityId());
+        assertThat(execution.getActivityId()).isEqualTo("taskAfter");
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
 
         taskService.complete(task.getId());
         assertProcessEnded(processInstance.getId());
@@ -769,18 +755,17 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         //Move all parallelGateway activities to the synchronizing gateway
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startInclusiveGwProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         taskService.complete(task.getId());
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
         Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
-        assertTrue(executionsByActivity.containsKey("task1"));
-        assertTrue(executionsByActivity.containsKey("task2"));
+        assertThat(executionsByActivity).containsKeys("task1", "task2");
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
 
         //Complete task1
         for (Task t : tasks) {
@@ -790,23 +775,23 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         }
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
         Map<String, List<Execution>> classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
-        assertNotNull(classifiedExecutions.get("task2"));
-        assertEquals(1, classifiedExecutions.get("task2").size());
-        assertNotNull(classifiedExecutions.get("gwJoin"));
-        assertEquals(1, classifiedExecutions.get("gwJoin").size());
+        assertThat(classifiedExecutions.get("task2")).isNotNull();
+        assertThat(classifiedExecutions.get("task2")).hasSize(1);
+        assertThat(classifiedExecutions.get("gwJoin")).isNotNull();
+        assertThat(classifiedExecutions.get("gwJoin")).hasSize(1);
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdsToSingleActivityId(Arrays.asList("task2", "gwJoin"), "taskAfter")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdsToSingleActivityId(Arrays.asList("task2", "gwJoin"), "taskAfter")
+                .changeState();
 
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().singleResult();
-        assertEquals("taskAfter", execution.getActivityId());
+        assertThat(execution.getActivityId()).isEqualTo("taskAfter");
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
 
         taskService.complete(task.getId());
         assertProcessEnded(processInstance.getId());
@@ -819,39 +804,38 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         //Move one task to the synchronizing gateway, then complete the remaining task
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startInclusiveGwProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         taskService.complete(task.getId());
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("task1", "gwJoin")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("task1", "gwJoin")
+                .changeState();
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
         Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
-        assertNull(executionsByActivity.get("task1"));
-        assertNotNull(executionsByActivity.get("task2"));
-        assertNotNull(executionsByActivity.get("gwJoin"));
+        assertThat(executionsByActivity).containsKeys("task2", "gwJoin");
+        assertThat(executionsByActivity).doesNotContainKey("task1");
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
 
-        assertEquals("task2", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("task2");
 
         taskService.complete(task.getId());
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(1, executions.size());
+        assertThat(executions).hasSize(1);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
 
         taskService.complete(task.getId());
         assertProcessEnded(processInstance.getId());
@@ -864,15 +848,15 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         //Complete one task and then move the last remaining task to the synchronizing gateway
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startInclusiveGwProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         taskService.complete(task.getId());
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
 
         //Complete task1
         Optional<Task> task1 = tasks.stream().filter(t -> t.getTaskDefinitionKey().equals("task1")).findFirst();
@@ -881,26 +865,25 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         }
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
         Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
-        assertNull(executionsByActivity.get("task1"));
-        assertNotNull(executionsByActivity.get("task2"));
-        assertNotNull(executionsByActivity.get("gwJoin"));
+        assertThat(executionsByActivity).containsKeys("task2", "gwJoin");
+        assertThat(executionsByActivity).doesNotContainKey("task1");
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("task2", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("task2");
 
         //Move task2
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("task2", "gwJoin")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("task2", "gwJoin")
+                .changeState();
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(1, executions.size());
+        assertThat(executions).hasSize(1);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
 
         taskService.complete(task.getId());
         assertProcessEnded(processInstance.getId());
@@ -911,7 +894,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
     public void testSetCurrentExecutionToMultipleActivitiesForInclusiveGateway() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startInclusiveGwProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         Execution taskBeforeExecution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().singleResult();
 
@@ -919,19 +902,18 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         newActivityIds.add("task1");
         newActivityIds.add("task2");
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveSingleExecutionToActivityIds(taskBeforeExecution.getId(), newActivityIds)
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveSingleExecutionToActivityIds(taskBeforeExecution.getId(), newActivityIds)
+                .changeState();
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
         Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
-        assertNotNull(executionsByActivity.get("task1"));
-        assertNotNull(executionsByActivity.get("task2"));
-        assertNull(executionsByActivity.get("gwJoin"));
+        assertThat(executionsByActivity).containsKeys("task1", "task2");
+        assertThat(executionsByActivity).doesNotContainKey("gwJoin");
 
         //Complete one task1
         Optional<Task> task1 = tasks.stream().filter(t -> t.getTaskDefinitionKey().equals("task1")).findFirst();
@@ -940,21 +922,20 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         }
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(1, tasks.size());
+        assertThat(tasks).hasSize(1);
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
         executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
-        assertFalse(executionsByActivity.containsKey("task1"));
-        assertTrue(executionsByActivity.containsKey("task2"));
-        assertTrue(executionsByActivity.containsKey("gwJoin"));
+        assertThat(executionsByActivity).containsKeys("task2", "gwJoin");
+        assertThat(executionsByActivity).doesNotContainKey("task1");
 
-        assertFalse(((ExecutionEntity) executionsByActivity.get("gwJoin").get(0)).isActive());
+        assertThat(((ExecutionEntity) executionsByActivity.get("gwJoin").get(0)).isActive()).isFalse();
 
         taskService.complete(tasks.get(0).getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -965,29 +946,29 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
     public void testSetMultipleExecutionsToSingleActivityAfterInclusiveGateway() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startInclusiveGwProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         taskService.complete(task.getId());
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
 
         List<String> currentExecutionIds = new ArrayList<>();
         currentExecutionIds.add(executions.get(0).getId());
         currentExecutionIds.add(executions.get(1).getId());
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionsToSingleActivityId(currentExecutionIds, "taskAfter")
-            .changeState();
+                .moveExecutionsToSingleActivityId(currentExecutionIds, "taskAfter")
+                .changeState();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(1, executions.size());
+        assertThat(executions).hasSize(1);
 
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -1000,30 +981,29 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         //Move all gateway executions to the synchronizing gateway
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startInclusiveGwProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         taskService.complete(task.getId());
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
         Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
-        assertTrue(executionsByActivity.containsKey("task1"));
-        assertTrue(executionsByActivity.containsKey("task2"));
+        assertThat(executionsByActivity).containsKeys("task1", "task2");
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
 
         List<String> executionIds = executions.stream().map(Execution::getId).collect(Collectors.toList());
 
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionsToSingleActivityId(executionIds, "gwJoin")
-            .changeState();
+                .moveExecutionsToSingleActivityId(executionIds, "gwJoin")
+                .changeState();
 
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().singleResult();
-        assertEquals("taskAfter", execution.getActivityId());
+        assertThat(execution.getActivityId()).isEqualTo("taskAfter");
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
 
         taskService.complete(task.getId());
         assertProcessEnded(processInstance.getId());
@@ -1036,18 +1016,17 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         //Move all gateway executions to the synchronizing gateway
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startInclusiveGwProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         taskService.complete(task.getId());
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
         Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
-        assertTrue(executionsByActivity.containsKey("task1"));
-        assertTrue(executionsByActivity.containsKey("task2"));
+        assertThat(executionsByActivity).containsKeys("task1", "task2");
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
 
         //Complete task1
         for (Task t : tasks) {
@@ -1057,24 +1036,24 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         }
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
         Map<String, List<Execution>> classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
-        assertNotNull(classifiedExecutions.get("task2"));
-        assertEquals(1, classifiedExecutions.get("task2").size());
-        assertNotNull(classifiedExecutions.get("gwJoin"));
-        assertEquals(1, classifiedExecutions.get("gwJoin").size());
+        assertThat(classifiedExecutions.get("task2")).isNotNull();
+        assertThat(classifiedExecutions.get("task2")).hasSize(1);
+        assertThat(classifiedExecutions.get("gwJoin")).isNotNull();
+        assertThat(classifiedExecutions.get("gwJoin")).hasSize(1);
 
         List<String> executionIds = executions.stream().map(Execution::getId).collect(Collectors.toList());
 
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionsToSingleActivityId(executionIds, "taskAfter")
-            .changeState();
+                .moveExecutionsToSingleActivityId(executionIds, "taskAfter")
+                .changeState();
 
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().singleResult();
-        assertEquals("taskAfter", execution.getActivityId());
+        assertThat(execution.getActivityId()).isEqualTo("taskAfter");
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
 
         taskService.complete(task.getId());
         assertProcessEnded(processInstance.getId());
@@ -1087,38 +1066,37 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         //Move one task to the synchronizing gateway, then complete the remaining task
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startInclusiveGwProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         taskService.complete(task.getId());
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
 
         String executionId = executions.stream().filter(e -> "task1".equals(e.getActivityId())).findFirst().map(Execution::getId).get();
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionToActivityId(executionId, "gwJoin")
-            .changeState();
+                .moveExecutionToActivityId(executionId, "gwJoin")
+                .changeState();
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
         Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
-        assertNull(executionsByActivity.get("task1"));
-        assertNotNull(executionsByActivity.get("task2"));
-        assertNotNull(executionsByActivity.get("gwJoin"));
+        assertThat(executionsByActivity).containsKeys("task2", "gwJoin");
+        assertThat(executionsByActivity).doesNotContainKey("task1");
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("task2", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("task2");
 
         taskService.complete(task.getId());
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(1, executions.size());
+        assertThat(executions).hasSize(1);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
 
         taskService.complete(task.getId());
         assertProcessEnded(processInstance.getId());
@@ -1131,15 +1109,15 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         //Complete one task and then move the last remaining task to the synchronizing gateway
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startInclusiveGwProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         taskService.complete(task.getId());
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
 
         //Complete task1
         Optional<Task> task1 = tasks.stream().filter(t -> t.getTaskDefinitionKey().equals("task1")).findFirst();
@@ -1148,26 +1126,25 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         }
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
         Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
-        assertNull(executionsByActivity.get("task1"));
-        assertNotNull(executionsByActivity.get("task2"));
-        assertNotNull(executionsByActivity.get("gwJoin"));
+        assertThat(executionsByActivity).containsKeys("task2", "gwJoin");
+        assertThat(executionsByActivity).doesNotContainKey("task1");
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("task2", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("task2");
 
         //Move task2 execution
         String executionId = executions.stream().filter(e -> "task2".equals(e.getActivityId())).findFirst().map(Execution::getId).get();
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionToActivityId(executionId, "gwJoin")
-            .changeState();
+                .moveExecutionToActivityId(executionId, "gwJoin")
+                .changeState();
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(1, executions.size());
+        assertThat(executions).hasSize(1);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
 
         taskService.complete(task.getId());
         assertProcessEnded(processInstance.getId());
@@ -1178,41 +1155,41 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
     public void testSetCurrentActivityToMultipleActivitiesForParallelSubProcesses() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         List<String> newActivityIds = new ArrayList<>();
         newActivityIds.add("subtask");
         newActivityIds.add("subtask2");
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveSingleActivityIdToActivityIds("taskBefore", newActivityIds)
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveSingleActivityIdToActivityIds("taskBefore", newActivityIds)
+                .changeState();
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(4, executions.size());
+        assertThat(executions).hasSize(4);
 
         Optional<Execution> parallelJoinExecution = executions.stream().filter(e -> e.getActivityId().equals("parallelJoin")).findFirst();
-        assertFalse(parallelJoinExecution.isPresent());
+        assertThat(parallelJoinExecution.isPresent()).isFalse();
 
         taskService.complete(tasks.get(0).getId());
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(1, tasks.size());
+        assertThat(tasks).hasSize(1);
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(3, executions.size());
+        assertThat(executions).hasSize(3);
 
         parallelJoinExecution = executions.stream().filter(e -> e.getActivityId().equals("parallelJoin")).findFirst();
-        assertTrue(parallelJoinExecution.isPresent());
-        assertFalse(((ExecutionEntity) parallelJoinExecution.get()).isActive());
+        assertThat(parallelJoinExecution.isPresent()).isTrue();
+        assertThat(((ExecutionEntity) parallelJoinExecution.get()).isActive()).isFalse();
 
         taskService.complete(tasks.get(0).getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -1223,30 +1200,30 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
     public void testSetMultipleActivitiesToSingleActivityAfterParallelSubProcesses() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         taskService.complete(task.getId());
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(4, executions.size());
+        assertThat(executions).hasSize(4);
 
         List<String> currentActivityIds = new ArrayList<>();
         currentActivityIds.add("subtask");
         currentActivityIds.add("subtask2");
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdsToSingleActivityId(currentActivityIds, "taskAfter")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdsToSingleActivityId(currentActivityIds, "taskAfter")
+                .changeState();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(1, executions.size());
+        assertThat(executions).hasSize(1);
 
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -1257,48 +1234,48 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
     public void testMoveCurrentActivityInParallelSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         taskService.complete(task.getId());
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(4, executions.size());
+        assertThat(executions).hasSize(4);
 
         Execution subProcessExecution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("subProcess1")
-            .singleResult();
+                .singleResult();
         String subProcessExecutionId = subProcessExecution.getId();
         runtimeService.setVariableLocal(subProcessExecutionId, "subProcessVar", "test");
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("subtask", "subtask2")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("subtask", "subtask2")
+                .changeState();
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(4, executions.size());
+        assertThat(executions).hasSize(4);
 
         subProcessExecution = runtimeService.createExecutionQuery().executionId(subProcessExecutionId).singleResult();
-        assertNotNull(subProcessExecution);
-        assertEquals("test", runtimeService.getVariableLocal(subProcessExecutionId, "subProcessVar"));
+        assertThat(subProcessExecution).isNotNull();
+        assertThat(runtimeService.getVariableLocal(subProcessExecutionId, "subProcessVar")).isEqualTo("test");
 
         taskService.complete(tasks.get(0).getId());
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(1, tasks.size());
+        assertThat(tasks).hasSize(1);
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(3, executions.size());
+        assertThat(executions).hasSize(3);
 
         taskService.complete(tasks.get(0).getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -1309,59 +1286,59 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
     public void testSetCurrentActivityToMultipleActivitiesForInclusiveAndParallelSubProcesses() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess", Collections.singletonMap("var1", "test2"));
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         List<String> newActivityIds = new ArrayList<>();
         newActivityIds.add("taskInclusive3");
         newActivityIds.add("subtask");
         newActivityIds.add("subtask3");
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveSingleActivityIdToActivityIds("taskBefore", newActivityIds)
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveSingleActivityIdToActivityIds("taskBefore", newActivityIds)
+                .changeState();
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(3, tasks.size());
+        assertThat(tasks).hasSize(3);
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(5, executions.size());
+        assertThat(executions).hasSize(5);
 
         Optional<Execution> parallelJoinExecution = executions.stream().filter(e -> e.getActivityId().equals("parallelJoin")).findFirst();
-        assertFalse(parallelJoinExecution.isPresent());
+        assertThat(parallelJoinExecution.isPresent()).isFalse();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("subtask").singleResult();
         taskService.complete(task.getId());
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(3, tasks.size());
+        assertThat(tasks).hasSize(3);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("subtask2").singleResult();
         taskService.complete(task.getId());
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(4, executions.size());
+        assertThat(executions).hasSize(4);
 
         parallelJoinExecution = executions.stream().filter(e -> e.getActivityId().equals("parallelJoin")).findFirst();
-        assertTrue(parallelJoinExecution.isPresent());
-        assertFalse(((ExecutionEntity) parallelJoinExecution.get()).isActive());
+        assertThat(parallelJoinExecution.isPresent()).isTrue();
+        assertThat(((ExecutionEntity) parallelJoinExecution.get()).isActive()).isFalse();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("subtask3").singleResult();
         taskService.complete(task.getId());
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(1, tasks.size());
+        assertThat(tasks).hasSize(1);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("taskInclusive3").singleResult();
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -1374,23 +1351,23 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         variableMap.put("var1", "test2");
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess", variableMap);
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         taskService.complete(task.getId());
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("taskInclusive1").singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         taskService.complete(task.getId());
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(3, tasks.size());
+        assertThat(tasks).hasSize(3);
 
-        assertEquals(1, taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("taskInclusive3").count());
-        assertEquals(1, taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("subtask").count());
-        assertEquals(1, taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("subtask3").count());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("taskInclusive3").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("subtask").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("subtask3").count()).isEqualTo(1);
 
         List<String> currentActivityIds = new ArrayList<>();
         currentActivityIds.add("taskInclusive3");
@@ -1398,18 +1375,18 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         currentActivityIds.add("subtask3");
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdsToSingleActivityId(currentActivityIds, "taskAfter")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdsToSingleActivityId(currentActivityIds, "taskAfter")
+                .changeState();
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(1, tasks.size());
+        assertThat(tasks).hasSize(1);
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(1, executions.size());
+        assertThat(executions).hasSize(1);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -1422,38 +1399,38 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         variableMap.put("var1", "test2");
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess", variableMap);
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         taskService.complete(task.getId());
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("taskInclusive1").singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         taskService.complete(task.getId());
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(3, tasks.size());
+        assertThat(tasks).hasSize(3);
 
-        assertEquals(1, taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("taskInclusive3").count());
-        assertEquals(1, taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("subtask").count());
-        assertEquals(1, taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("subtask3").count());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("taskInclusive3").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("subtask").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("subtask3").count()).isEqualTo(1);
 
         List<String> currentActivityIds = new ArrayList<>();
         currentActivityIds.add("subtask");
         currentActivityIds.add("subtask3");
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdsToSingleActivityId(currentActivityIds, "taskInclusive1")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdsToSingleActivityId(currentActivityIds, "taskInclusive1")
+                .changeState();
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("taskInclusive3").singleResult();
         taskService.complete(task.getId());
@@ -1462,11 +1439,11 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         taskService.complete(task.getId());
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(5, executions.size());
+        assertThat(executions).hasSize(5);
 
         Optional<Execution> inclusiveJoinExecution = executions.stream().filter(e -> e.getActivityId().equals("inclusiveJoin")).findFirst();
-        assertTrue(inclusiveJoinExecution.isPresent());
-        assertFalse(((ExecutionEntity) inclusiveJoinExecution.get()).isActive());
+        assertThat(inclusiveJoinExecution.isPresent()).isTrue();
+        assertThat(((ExecutionEntity) inclusiveJoinExecution.get()).isActive()).isFalse();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("subtask3").singleResult();
         taskService.complete(task.getId());
@@ -1478,7 +1455,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/changestate/ChangeStateForMultiInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/changestate/ChangeStateForMultiInstanceTest.java
@@ -58,32 +58,40 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
     @Deployment(resources = "org/flowable/engine/test/api/multiInstanceSequential.bpmn20.xml")
     public void testSetCurrentActivityToSequentialMultiInstanceTask() {
         ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("sequentialMultiInstance")
-            .variable("nrOfLoops", 3)
-            .start();
+                .variable("nrOfLoops", 3)
+                .start();
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("beforeMultiInstance");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("beforeMultiInstance");
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactly("beforeMultiInstance");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("beforeMultiInstance");
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("beforeMultiInstance", "seqTasks")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("beforeMultiInstance", "seqTasks")
+                .changeState();
 
         //First in the loop
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         //One MI root and one seq Execution
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("seqTasks", "seqTasks");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("seqTasks", "seqTasks");
 
         Execution miRoot = executions.stream().filter(e -> ((ExecutionEntity) e).isMultiInstanceRoot()).findFirst().get();
         Map<String, Object> miRootVars = runtimeService.getVariables(miRoot.getId());
-        assertThat(miRootVars).extracting("nrOfActiveInstances").isEqualTo(1);
-        assertThat(miRootVars).extracting("nrOfCompletedInstances").isEqualTo(0);
-        assertThat(miRootVars).extracting("nrOfLoops").isEqualTo(3);
+        assertThat(miRootVars)
+                .extracting("nrOfActiveInstances", "nrOfCompletedInstances", "nrOfLoops")
+                .containsExactly(1, 0, 3);
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).active().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactly("seqTasks");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("seqTasks");
         assertThat(taskService.getVariable(tasks.get(0).getId(), "loopCounter")).isEqualTo(0);
 
         taskService.complete(tasks.get(0).getId());
@@ -91,16 +99,20 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         //Second in the loop
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         //One MI root and one seq Execution
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("seqTasks", "seqTasks");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("seqTasks", "seqTasks");
 
         miRoot = executions.stream().filter(e -> ((ExecutionEntity) e).isMultiInstanceRoot()).findFirst().get();
         miRootVars = runtimeService.getVariables(miRoot.getId());
-        assertThat(miRootVars).extracting("nrOfActiveInstances").isEqualTo(1);
-        assertThat(miRootVars).extracting("nrOfCompletedInstances").isEqualTo(1);
-        assertThat(miRootVars).extracting("nrOfLoops").isEqualTo(3);
+        assertThat(miRootVars)
+                .extracting("nrOfActiveInstances", "nrOfCompletedInstances", "nrOfLoops")
+                .containsExactly(1, 1, 3);
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).active().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactly("seqTasks");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("seqTasks");
         assertThat(taskService.getVariable(tasks.get(0).getId(), "loopCounter")).isEqualTo(1);
 
         //Complete second and third
@@ -110,11 +122,17 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
 
         //After the MI
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("nextTask");
-        assertThat((ExecutionEntity) executions.get(0)).extracting(ExecutionEntity::isMultiInstanceRoot).isEqualTo(false);
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("nextTask");
+        assertThat((ExecutionEntity) executions.get(0))
+                .extracting(ExecutionEntity::isMultiInstanceRoot)
+                .isEqualTo(false);
 
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).active().singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("nextTask");
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey)
+                .isEqualTo("nextTask");
         assertThat(taskService.getVariable(task.getId(), "loopCounter")).isNull();
 
         //Complete the process
@@ -126,37 +144,37 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
     @Deployment(resources = "org/flowable/engine/test/api/multiInstanceSequential.bpmn20.xml")
     public void testSetCurrentActivityOfSequentialMultiInstanceTask() {
         ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("sequentialMultiInstance")
-            .variable("nrOfLoops", 5)
-            .start();
+                .variable("nrOfLoops", 5)
+                .start();
 
         completeTask(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult());
 
         List<Execution> seqExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, seqExecutions.size());
+        assertThat(seqExecutions).hasSize(2);
         List<Task> activeSeqTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).active().list();
-        assertEquals(1, activeSeqTasks.size());
+        assertThat(activeSeqTasks).hasSize(1);
 
         //First in the loop
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("seqTasks", task.getTaskDefinitionKey());
-        assertEquals(0, taskService.getVariable(task.getId(), "loopCounter"));
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("seqTasks");
+        assertThat(taskService.getVariable(task.getId(), "loopCounter")).isEqualTo(0);
         taskService.complete(task.getId());
 
         //Second in the loop
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("seqTasks", task.getTaskDefinitionKey());
-        assertEquals(1, taskService.getVariable(task.getId(), "loopCounter"));
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("seqTasks");
+        assertThat(taskService.getVariable(task.getId(), "loopCounter")).isEqualTo(1);
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("seqTasks", "nextTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("seqTasks", "nextTask")
+                .changeState();
 
         seqExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(1, seqExecutions.size());
+        assertThat(seqExecutions).hasSize(1);
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("nextTask", task.getTaskDefinitionKey());
-        assertNull(taskService.getVariable(task.getId(), "loopCounter"));
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("nextTask");
+        assertThat(taskService.getVariable(task.getId(), "loopCounter")).isNull();
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -166,38 +184,38 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
     @Deployment(resources = "org/flowable/engine/test/api/multiInstanceSequential.bpmn20.xml")
     public void testSetCurrentParentExecutionOfSequentialMultiInstanceTask() {
         ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("sequentialMultiInstance")
-            .variable("nrOfLoops", 5)
-            .start();
+                .variable("nrOfLoops", 5)
+                .start();
 
         completeTask(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult());
 
         List<Execution> seqExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, seqExecutions.size());
+        assertThat(seqExecutions).hasSize(2);
         List<Task> activeSeqTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).active().list();
-        assertEquals(1, activeSeqTasks.size());
+        assertThat(activeSeqTasks).hasSize(1);
 
         //First in the loop
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("seqTasks", task.getTaskDefinitionKey());
-        assertEquals(0, taskService.getVariable(task.getId(), "loopCounter"));
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("seqTasks");
+        assertThat(taskService.getVariable(task.getId(), "loopCounter")).isEqualTo(0);
         taskService.complete(task.getId());
 
         //Second in the loop
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("seqTasks", task.getTaskDefinitionKey());
-        assertEquals(1, taskService.getVariable(task.getId(), "loopCounter"));
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("seqTasks");
+        assertThat(taskService.getVariable(task.getId(), "loopCounter")).isEqualTo(1);
 
         //move the parent execution - otherwise the parent multi instance execution remains, although active==false.
         String parentExecutionId = runtimeService.createExecutionQuery().executionId(task.getExecutionId()).singleResult().getParentId();
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionToActivityId(parentExecutionId, "nextTask")
-            .changeState();
+                .moveExecutionToActivityId(parentExecutionId, "nextTask")
+                .changeState();
 
         seqExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(1, seqExecutions.size());
+        assertThat(seqExecutions).hasSize(1);
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("nextTask", task.getTaskDefinitionKey());
-        assertNull(taskService.getVariable(task.getId(), "loopCounter"));
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("nextTask");
+        assertThat(taskService.getVariable(task.getId(), "loopCounter")).isNull();
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -207,33 +225,43 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
     @Deployment(resources = "org/flowable/engine/test/api/multiInstanceParallel.bpmn20.xml")
     public void testSetCurrentActivityToParallelMultiInstanceTask() {
         ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("parallelMultiInstance")
-            .variable("nrOfLoops", 3)
-            .start();
+                .variable("nrOfLoops", 3)
+                .start();
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("beforeMultiInstance");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("beforeMultiInstance");
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactly("beforeMultiInstance");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("beforeMultiInstance");
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("beforeMultiInstance", "parallelTasks")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("beforeMultiInstance", "parallelTasks")
+                .changeState();
 
         //First in the loop
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         //One MI root and 3 parallel Executions
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("parallelTasks", "parallelTasks", "parallelTasks", "parallelTasks");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("parallelTasks", "parallelTasks", "parallelTasks", "parallelTasks");
 
         Execution miRoot = executions.stream().filter(e -> ((ExecutionEntity) e).isMultiInstanceRoot()).findFirst().get();
         Map<String, Object> miRootVars = runtimeService.getVariables(miRoot.getId());
-        assertThat(miRootVars).extracting("nrOfActiveInstances").isEqualTo(3);
-        assertThat(miRootVars).extracting("nrOfCompletedInstances").isEqualTo(0);
-        assertThat(miRootVars).extracting("nrOfLoops").isEqualTo(3);
+        assertThat(miRootVars)
+                .extracting("nrOfActiveInstances", "nrOfCompletedInstances", "nrOfLoops")
+                .containsExactly(3, 0, 3);
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).active().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactly("parallelTasks", "parallelTasks", "parallelTasks");
-        assertThat(tasks).extracting(task -> taskService.getVariable(task.getId(), "loopCounter")).isNotNull();
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("parallelTasks", "parallelTasks", "parallelTasks");
+        assertThat(tasks)
+                .extracting(task -> taskService.getVariable(task.getId(), "loopCounter"))
+                .isNotNull();
         //        assertThat(taskService.getVariable(tasks.get(0).getId(), "loopCounter")).isNotNull()
 
         //Complete one execution
@@ -241,19 +269,24 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
 
         //Confirm new state
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("parallelTasks", "parallelTasks", "parallelTasks", "parallelTasks");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("parallelTasks", "parallelTasks", "parallelTasks", "parallelTasks");
 
         miRoot = executions.stream().filter(e -> ((ExecutionEntity) e).isMultiInstanceRoot()).findFirst().get();
         miRootVars = runtimeService.getVariables(miRoot.getId());
-        assertThat(miRootVars).extracting("nrOfActiveInstances").isEqualTo(2);
-        assertThat(miRootVars).extracting("nrOfCompletedInstances").isEqualTo(1);
-        assertThat(miRootVars).extracting("nrOfLoops").isEqualTo(3);
+        assertThat(miRootVars)
+                .extracting("nrOfActiveInstances", "nrOfCompletedInstances", "nrOfLoops")
+                .containsExactly(2, 1, 3);
 
         //Two executions are inactive, the completed before and the MI root
-        assertThat(executions).haveExactly(2, new Condition<>((Execution execution) -> !((ExecutionEntity) execution).isActive(), "inactive"));
+        assertThat(executions)
+                .haveExactly(2, new Condition<>((Execution execution) -> !((ExecutionEntity) execution).isActive(), "inactive"));
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).active().list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactly("parallelTasks", "parallelTasks");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("parallelTasks", "parallelTasks");
         assertThat(taskService.getVariable(tasks.get(0).getId(), "loopCounter")).isEqualTo(1);
 
         //Complete the rest of the Tasks
@@ -261,11 +294,16 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
 
         //After the MI
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("nextTask");
-        assertThat((ExecutionEntity) executions.get(0)).extracting(ExecutionEntity::isMultiInstanceRoot).isEqualTo(false);
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("nextTask");
+        assertThat((ExecutionEntity) executions.get(0))
+                .extracting(ExecutionEntity::isMultiInstanceRoot).isEqualTo(false);
 
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).active().singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("nextTask");
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey)
+                .isEqualTo("nextTask");
         assertThat(taskService.getVariable(task.getId(), "loopCounter")).isNull();
 
         //Complete the process
@@ -277,32 +315,32 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
     @Deployment(resources = "org/flowable/engine/test/api/multiInstanceParallel.bpmn20.xml")
     public void testSetCurrentActivityOfParallelMultiInstanceTask() {
         ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("parallelMultiInstance")
-            .variable("nrOfLoops", 3)
-            .start();
+                .variable("nrOfLoops", 3)
+                .start();
 
         completeTask(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult());
 
         List<Execution> parallelExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(4, parallelExecutions.size());
+        assertThat(parallelExecutions).hasSize(4);
         List<Task> activeParallelTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).active().list();
-        assertEquals(3, activeParallelTasks.size());
+        assertThat(activeParallelTasks).hasSize(3);
 
         //Complete one of the tasks
         taskService.complete(activeParallelTasks.get(1).getId());
         parallelExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(4, parallelExecutions.size());
+        assertThat(parallelExecutions).hasSize(4);
         activeParallelTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).active().list();
-        assertEquals(2, activeParallelTasks.size());
+        assertThat(activeParallelTasks).hasSize(2);
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("parallelTasks", "nextTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("parallelTasks", "nextTask")
+                .changeState();
 
         parallelExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(1, parallelExecutions.size());
+        assertThat(parallelExecutions).hasSize(1);
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("nextTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("nextTask");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -312,33 +350,33 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
     @Deployment(resources = "org/flowable/engine/test/api/multiInstanceParallel.bpmn20.xml")
     public void testSetCurrentParentExecutionOfParallelMultiInstanceTask() {
         ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("parallelMultiInstance")
-            .variable("nrOfLoops", 3)
-            .start();
+                .variable("nrOfLoops", 3)
+                .start();
 
         completeTask(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult());
 
         List<Execution> parallelExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(4, parallelExecutions.size());
+        assertThat(parallelExecutions).hasSize(4);
         List<Task> activeParallelTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).active().list();
-        assertEquals(3, activeParallelTasks.size());
+        assertThat(activeParallelTasks).hasSize(3);
 
         //Complete one of the tasks
         taskService.complete(activeParallelTasks.get(1).getId());
         parallelExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(4, parallelExecutions.size());
+        assertThat(parallelExecutions).hasSize(4);
         activeParallelTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).active().list();
-        assertEquals(2, activeParallelTasks.size());
+        assertThat(activeParallelTasks).hasSize(2);
 
         //Fetch the parent execution of the multi instance task execution
         String parentExecutionId = runtimeService.createExecutionQuery().executionId(activeParallelTasks.get(0).getExecutionId()).singleResult().getParentId();
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionToActivityId(parentExecutionId, "nextTask")
-            .changeState();
+                .moveExecutionToActivityId(parentExecutionId, "nextTask")
+                .changeState();
 
         parallelExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(1, parallelExecutions.size());
+        assertThat(parallelExecutions).hasSize(1);
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("nextTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("nextTask");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -348,43 +386,43 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
     @Deployment(resources = "org/flowable/engine/test/api/multiInstanceParallelSubProcess.bpmn20.xml")
     public void testSetCurrentExecutionWithinMultiInstanceParallelSubProcess() {
         ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("parallelMultiInstanceSubProcess")
-            .variable("nrOfLoops", 3)
-            .start();
+                .variable("nrOfLoops", 3)
+                .start();
 
         //One of the child executions is the parent of the multiInstance "loop"
         long executionsCount = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(7, executionsCount);
+        assertThat(executionsCount).isEqualTo(7);
         long parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcess").count();
-        assertEquals(3, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(3);
         List<Execution> subTask1Executions = runtimeService.createExecutionQuery().activityId("subTask1").list();
-        assertEquals(3, subTask1Executions.size());
+        assertThat(subTask1Executions).hasSize(3);
 
         //Move one of the executions within the multiInstance subProcess
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionToActivityId(subTask1Executions.get(0).getId(), "subTask2")
-            .changeState();
+                .moveExecutionToActivityId(subTask1Executions.get(0).getId(), "subTask2")
+                .changeState();
 
         executionsCount = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(7, executionsCount);
+        assertThat(executionsCount).isEqualTo(7);
         parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcess").count();
-        assertEquals(3, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(3);
         subTask1Executions = runtimeService.createExecutionQuery().activityId("subTask1").list();
-        assertEquals(2, subTask1Executions.size());
+        assertThat(subTask1Executions).hasSize(2);
         List<Execution> subTask2Executions = runtimeService.createExecutionQuery().activityId("subTask2").list();
-        assertEquals(1, subTask2Executions.size());
+        assertThat(subTask2Executions).hasSize(1);
 
         //Complete one of the parallel subProcesses "subTask2"
         Task task = taskService.createTaskQuery().executionId(subTask2Executions.get(0).getId()).singleResult();
         taskService.complete(task.getId());
 
         executionsCount = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(5, executionsCount);
+        assertThat(executionsCount).isEqualTo(5);
         parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcess").count();
-        assertEquals(2, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(2);
         subTask1Executions = runtimeService.createExecutionQuery().activityId("subTask1").list();
-        assertEquals(2, subTask1Executions.size());
+        assertThat(subTask1Executions).hasSize(2);
         subTask2Executions = runtimeService.createExecutionQuery().activityId("subTask2").list();
-        assertEquals(0, subTask2Executions.size());
+        assertThat(subTask2Executions).isEmpty();
 
         //Move the other two executions, one by one
         ChangeActivityStateBuilder changeActivityStateBuilder = runtimeService.createChangeActivityStateBuilder();
@@ -392,25 +430,25 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         changeActivityStateBuilder.changeState();
 
         executionsCount = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(5, executionsCount);
+        assertThat(executionsCount).isEqualTo(5);
         parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcess").count();
-        assertEquals(2, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(2);
         subTask1Executions = runtimeService.createExecutionQuery().activityId("subTask1").list();
-        assertEquals(0, subTask1Executions.size());
+        assertThat(subTask1Executions).isEmpty();
         subTask2Executions = runtimeService.createExecutionQuery().activityId("subTask2").list();
-        assertEquals(2, subTask2Executions.size());
+        assertThat(subTask2Executions).hasSize(2);
 
         //Complete the rest of the SubProcesses
         List<Task> tasks = taskService.createTaskQuery().taskDefinitionKey("subTask2").list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
         tasks.forEach(t -> taskService.complete(t.getId()));
 
         //There's no multiInstance anymore
         executionsCount = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(1, executionsCount);
+        assertThat(executionsCount).isEqualTo(1);
 
         task = taskService.createTaskQuery().active().singleResult();
-        assertEquals("lastTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("lastTask");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -420,43 +458,43 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
     @Deployment(resources = "org/flowable/engine/test/api/multiInstanceParallelSubProcess.bpmn20.xml")
     public void testSetCurrentActivityWithinMultiInstanceParallelSubProcess() {
         ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("parallelMultiInstanceSubProcess")
-            .variable("nrOfLoops", 3)
-            .start();
+                .variable("nrOfLoops", 3)
+                .start();
 
         //One of the child executions is the parent of the multiInstance "loop"
         long executionsCount = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(7, executionsCount);
+        assertThat(executionsCount).isEqualTo(7);
         long parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcess").count();
-        assertEquals(3, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(3);
         List<Execution> subTask1Executions = runtimeService.createExecutionQuery().activityId("subTask1").list();
-        assertEquals(3, subTask1Executions.size());
+        assertThat(subTask1Executions).hasSize(3);
 
         //Move one of the executions within the multiInstance subProcess
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("subTask1", "subTask2")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("subTask1", "subTask2")
+                .changeState();
 
         executionsCount = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(7, executionsCount);
+        assertThat(executionsCount).isEqualTo(7);
         parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcess").count();
-        assertEquals(3, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(3);
         subTask1Executions = runtimeService.createExecutionQuery().activityId("subTask1").list();
-        assertEquals(0, subTask1Executions.size());
+        assertThat(subTask1Executions).isEmpty();
         List<Execution> subTask2Executions = runtimeService.createExecutionQuery().activityId("subTask2").list();
-        assertEquals(3, subTask2Executions.size());
+        assertThat(subTask2Executions).hasSize(3);
 
         //Complete the parallel subProcesses "subTask2"
         List<Task> tasks = taskService.createTaskQuery().taskDefinitionKey("subTask2").list();
-        assertEquals(3, tasks.size());
+        assertThat(tasks).hasSize(3);
         tasks.forEach(t -> taskService.complete(t.getId()));
 
         //There's no multiInstance anymore
         executionsCount = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(1, executionsCount);
+        assertThat(executionsCount).isEqualTo(1);
 
         Task task = taskService.createTaskQuery().active().singleResult();
-        assertEquals("lastTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("lastTask");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -468,15 +506,15 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("parallelNestedMultiInstanceSubProcesses").start();
 
         long totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(7, totalChildExecutions);
+        assertThat(totalChildExecutions).isEqualTo(7);
         long parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcessOuter").count();
-        assertEquals(3, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(3);
         List<Execution> subTask1Executions = runtimeService.createExecutionQuery().activityId("subTask1").list();
-        assertEquals(3, subTask1Executions.size());
+        assertThat(subTask1Executions).hasSize(3);
 
         //Start the nested subProcesses by completing the first task of the outer subProcess
         List<Task> tasks = taskService.createTaskQuery().taskDefinitionKey("subTask1").list();
-        assertEquals(3, tasks.size());
+        assertThat(tasks).hasSize(3);
         tasks.forEach(t -> taskService.complete(t.getId()));
 
         // 3 instances of the outerSubProcess and each have 3 instances of a nestedSubProcess, for a total of 9 nestedSubTask executions
@@ -484,31 +522,31 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         // 1 Parent execution for the outerSubProcess and 1 parent for each nestedSubProcess -> 4 extra parent executions
         // Grand Total ->
         totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(25, totalChildExecutions);
+        assertThat(totalChildExecutions).isEqualTo(25);
         parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcessOuter").count();
-        assertEquals(3, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(3);
         parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelNestedSubProcess").count();
-        assertEquals(9, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(9);
         List<Execution> nestedSubTask1Executions = runtimeService.createExecutionQuery().activityId("nestedSubTask1").list();
-        assertEquals(9, nestedSubTask1Executions.size());
+        assertThat(nestedSubTask1Executions).hasSize(9);
 
         //Move one of the executions within of the nested multiInstance subProcesses
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionToActivityId(nestedSubTask1Executions.get(0).getId(), "nestedSubTask2")
-            .moveExecutionToActivityId(nestedSubTask1Executions.get(3).getId(), "nestedSubTask2")
-            .moveExecutionToActivityId(nestedSubTask1Executions.get(6).getId(), "nestedSubTask2")
-            .changeState();
+                .moveExecutionToActivityId(nestedSubTask1Executions.get(0).getId(), "nestedSubTask2")
+                .moveExecutionToActivityId(nestedSubTask1Executions.get(3).getId(), "nestedSubTask2")
+                .moveExecutionToActivityId(nestedSubTask1Executions.get(6).getId(), "nestedSubTask2")
+                .changeState();
 
         totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(25, totalChildExecutions);
+        assertThat(totalChildExecutions).isEqualTo(25);
         parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcessOuter").count();
-        assertEquals(3, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(3);
         parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelNestedSubProcess").count();
-        assertEquals(9, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(9);
         nestedSubTask1Executions = runtimeService.createExecutionQuery().activityId("nestedSubTask1").list();
-        assertEquals(6, nestedSubTask1Executions.size());
+        assertThat(nestedSubTask1Executions).hasSize(6);
         List<Execution> nestedSubTask2Executions = runtimeService.createExecutionQuery().activityId("nestedSubTask2").list();
-        assertEquals(3, nestedSubTask2Executions.size());
+        assertThat(nestedSubTask2Executions).hasSize(3);
 
         //Complete one of the outer subProcesses
         Task task = taskService.createTaskQuery().executionId(nestedSubTask2Executions.get(0).getId()).singleResult();
@@ -516,15 +554,15 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
 
         //One less task execution and one less nested instance
         totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(23, totalChildExecutions);
+        assertThat(totalChildExecutions).isEqualTo(23);
         parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcessOuter").count();
-        assertEquals(3, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(3);
         parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelNestedSubProcess").count();
-        assertEquals(8, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(8);
         nestedSubTask1Executions = runtimeService.createExecutionQuery().activityId("nestedSubTask1").list();
-        assertEquals(6, nestedSubTask1Executions.size());
+        assertThat(nestedSubTask1Executions).hasSize(6);
         nestedSubTask2Executions = runtimeService.createExecutionQuery().activityId("nestedSubTask2").list();
-        assertEquals(2, nestedSubTask2Executions.size());
+        assertThat(nestedSubTask2Executions).hasSize(2);
 
         //Move the rest of the nestedSubTask1 executions
         ChangeActivityStateBuilder changeActivityStateBuilder = runtimeService.createChangeActivityStateBuilder();
@@ -532,39 +570,39 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         changeActivityStateBuilder.changeState();
 
         totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(23, totalChildExecutions);
+        assertThat(totalChildExecutions).isEqualTo(23);
         parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcessOuter").count();
-        assertEquals(3, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(3);
         parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelNestedSubProcess").count();
-        assertEquals(8, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(8);
         nestedSubTask1Executions = runtimeService.createExecutionQuery().activityId("nestedSubTask1").list();
-        assertEquals(0, nestedSubTask1Executions.size());
+        assertThat(nestedSubTask1Executions).isEmpty();
         nestedSubTask2Executions = runtimeService.createExecutionQuery().activityId("nestedSubTask2").list();
-        assertEquals(8, nestedSubTask2Executions.size());
+        assertThat(nestedSubTask2Executions).hasSize(8);
 
         //Complete all the nestedSubTask2
         tasks = taskService.createTaskQuery().taskDefinitionKey("nestedSubTask2").list();
-        assertEquals(8, tasks.size());
+        assertThat(tasks).hasSize(8);
         tasks.forEach(t -> taskService.complete(t.getId()));
 
         //Nested subProcesses have completed, only outer subProcess remain
         totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(7, totalChildExecutions);
+        assertThat(totalChildExecutions).isEqualTo(7);
         parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcessOuter").count();
-        assertEquals(3, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(3);
         List<Execution> subTask2Executions = runtimeService.createExecutionQuery().activityId("subTask2").list();
-        assertEquals(3, subTask2Executions.size());
+        assertThat(subTask2Executions).hasSize(3);
 
         //Complete the outer subProcesses
         tasks = taskService.createTaskQuery().taskDefinitionKey("subTask2").list();
-        assertEquals(3, tasks.size());
+        assertThat(tasks).hasSize(3);
         tasks.forEach(t -> taskService.complete(t.getId()));
 
         totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(1, totalChildExecutions);
+        assertThat(totalChildExecutions).isEqualTo(1);
 
         task = taskService.createTaskQuery().active().singleResult();
-        assertEquals("lastTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("lastTask");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -576,15 +614,15 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("parallelNestedMultiInstanceSubProcesses").start();
 
         long totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(7, totalChildExecutions);
+        assertThat(totalChildExecutions).isEqualTo(7);
         long parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcessOuter").count();
-        assertEquals(3, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(3);
         List<Execution> subTask1Executions = runtimeService.createExecutionQuery().activityId("subTask1").list();
-        assertEquals(3, subTask1Executions.size());
+        assertThat(subTask1Executions).hasSize(3);
 
         //Start the nested subProcesses by completing the first task of the outer subProcess
         List<Task> tasks = taskService.createTaskQuery().taskDefinitionKey("subTask1").list();
-        assertEquals(3, tasks.size());
+        assertThat(tasks).hasSize(3);
         tasks.forEach(t -> taskService.complete(t.getId()));
 
         // 3 instances of the outerSubProcess and each have 3 instances of a nestedSubProcess, for a total of 9 nestedSubTask executions
@@ -592,13 +630,13 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         // 1 Parent execution for the outerSubProcess and 1 parent for each nestedSubProcess -> 4 extra parent executions
         // Grand Total ->
         totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(25, totalChildExecutions);
+        assertThat(totalChildExecutions).isEqualTo(25);
         parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcessOuter").count();
-        assertEquals(3, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(3);
         parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelNestedSubProcess").count();
-        assertEquals(9, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(9);
         List<Execution> nestedSubTask1Executions = runtimeService.createExecutionQuery().activityId("nestedSubTask1").list();
-        assertEquals(9, nestedSubTask1Executions.size());
+        assertThat(nestedSubTask1Executions).hasSize(9);
 
         //Complete one task for each nestedSubProcess
         taskService.complete(taskService.createTaskQuery().executionId(nestedSubTask1Executions.get(0).getId()).singleResult().getId());
@@ -606,56 +644,56 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         taskService.complete(taskService.createTaskQuery().executionId(nestedSubTask1Executions.get(6).getId()).singleResult().getId());
 
         totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(25, totalChildExecutions);
+        assertThat(totalChildExecutions).isEqualTo(25);
         parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcessOuter").count();
-        assertEquals(3, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(3);
         parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelNestedSubProcess").count();
-        assertEquals(9, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(9);
         nestedSubTask1Executions = runtimeService.createExecutionQuery().activityId("nestedSubTask1").list();
-        assertEquals(6, nestedSubTask1Executions.size());
+        assertThat(nestedSubTask1Executions).hasSize(6);
         List<Execution> nestedSubTask2Executions = runtimeService.createExecutionQuery().activityId("nestedSubTask2").list();
-        assertEquals(3, nestedSubTask2Executions.size());
+        assertThat(nestedSubTask2Executions).hasSize(3);
 
         //Moving the nestedSubTask1 activity should move all its executions
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("nestedSubTask1", "nestedSubTask2")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("nestedSubTask1", "nestedSubTask2")
+                .changeState();
 
         totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(25, totalChildExecutions);
+        assertThat(totalChildExecutions).isEqualTo(25);
         parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcessOuter").count();
-        assertEquals(3, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(3);
         parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelNestedSubProcess").count();
-        assertEquals(9, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(9);
         nestedSubTask1Executions = runtimeService.createExecutionQuery().activityId("nestedSubTask1").list();
-        assertEquals(0, nestedSubTask1Executions.size());
+        assertThat(nestedSubTask1Executions).isEmpty();
         nestedSubTask2Executions = runtimeService.createExecutionQuery().activityId("nestedSubTask2").list();
-        assertEquals(9, nestedSubTask2Executions.size());
+        assertThat(nestedSubTask2Executions).hasSize(9);
 
         //Complete all the nestedSubTask2
         tasks = taskService.createTaskQuery().taskDefinitionKey("nestedSubTask2").list();
-        assertEquals(9, tasks.size());
+        assertThat(tasks).hasSize(9);
         tasks.forEach(t -> taskService.complete(t.getId()));
 
         //Nested subProcesses have completed, only outer subProcess remain
         totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(7, totalChildExecutions);
+        assertThat(totalChildExecutions).isEqualTo(7);
         parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcessOuter").count();
-        assertEquals(3, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(3);
         List<Execution> subTask2Executions = runtimeService.createExecutionQuery().activityId("subTask2").list();
-        assertEquals(3, subTask2Executions.size());
+        assertThat(subTask2Executions).hasSize(3);
 
         //Complete the outer subProcesses
         tasks = taskService.createTaskQuery().taskDefinitionKey("subTask2").list();
-        assertEquals(3, tasks.size());
+        assertThat(tasks).hasSize(3);
         tasks.forEach(t -> taskService.complete(t.getId()));
 
         totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(1, totalChildExecutions);
+        assertThat(totalChildExecutions).isEqualTo(1);
 
         Task task = taskService.createTaskQuery().active().singleResult();
-        assertEquals("lastTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("lastTask");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -665,50 +703,50 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
     @Deployment(resources = "org/flowable/engine/test/api/multiInstanceParallelSubProcess.bpmn20.xml")
     public void testSetCurrentMultiInstanceSubProcessParentExecutionWithinProcess() {
         ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("parallelMultiInstanceSubProcess")
-            .variable("nrOfLoops", 3)
-            .start();
+                .variable("nrOfLoops", 3)
+                .start();
 
         //One of the child executions is the parent of the multiInstance "loop"
         long executionsCount = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(7, executionsCount);
+        assertThat(executionsCount).isEqualTo(7);
         long parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcess").count();
-        assertEquals(3, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(3);
         List<Execution> subTask1Executions = runtimeService.createExecutionQuery().activityId("subTask1").list();
-        assertEquals(3, subTask1Executions.size());
+        assertThat(subTask1Executions).hasSize(3);
 
         //Complete one of the Tasks
         Task task = taskService.createTaskQuery().executionId(subTask1Executions.get(1).getId()).singleResult();
         taskService.complete(task.getId());
 
         executionsCount = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(7, executionsCount);
+        assertThat(executionsCount).isEqualTo(7);
         parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcess").count();
-        assertEquals(3, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(3);
         subTask1Executions = runtimeService.createExecutionQuery().activityId("subTask1").list();
-        assertEquals(2, subTask1Executions.size());
+        assertThat(subTask1Executions).hasSize(2);
         List<Execution> subTask2Executions = runtimeService.createExecutionQuery().activityId("subTask2").list();
-        assertEquals(1, subTask2Executions.size());
+        assertThat(subTask2Executions).hasSize(1);
 
         //Move the parallelSubProcess via the parentExecution Ids
         String ParallelSubProcessParentExecutionId = runtimeService.createExecutionQuery()
-            .processInstanceId(processInstance.getId())
-            .activityId("parallelSubProcess")
-            .list()
-            .stream()
-            .findFirst()
-            .map(Execution::getParentId)
-            .get();
+                .processInstanceId(processInstance.getId())
+                .activityId("parallelSubProcess")
+                .list()
+                .stream()
+                .findFirst()
+                .map(Execution::getParentId)
+                .get();
 
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionToActivityId(ParallelSubProcessParentExecutionId, "lastTask")
-            .changeState();
+                .moveExecutionToActivityId(ParallelSubProcessParentExecutionId, "lastTask")
+                .changeState();
 
         //There's no multiInstance anymore
         executionsCount = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(1, executionsCount);
+        assertThat(executionsCount).isEqualTo(1);
 
         task = taskService.createTaskQuery().active().singleResult();
-        assertEquals("lastTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("lastTask");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -718,42 +756,42 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
     @Deployment(resources = "org/flowable/engine/test/api/multiInstanceParallelSubProcess.bpmn20.xml")
     public void testSetCurrentMultiInstanceSubProcessParentActivityWithinProcess() {
         ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("parallelMultiInstanceSubProcess")
-            .variable("nrOfLoops", 3)
-            .start();
+                .variable("nrOfLoops", 3)
+                .start();
 
         //One of the child executions is the parent of the multiInstance "loop"
         long executionsCount = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(7, executionsCount);
+        assertThat(executionsCount).isEqualTo(7);
         long parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcess").count();
-        assertEquals(3, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(3);
         List<Execution> subTask1Executions = runtimeService.createExecutionQuery().activityId("subTask1").list();
-        assertEquals(3, subTask1Executions.size());
+        assertThat(subTask1Executions).hasSize(3);
 
         //Complete one of the Tasks
         Task task = taskService.createTaskQuery().executionId(subTask1Executions.get(1).getId()).singleResult();
         taskService.complete(task.getId());
 
         executionsCount = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(7, executionsCount);
+        assertThat(executionsCount).isEqualTo(7);
         parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcess").count();
-        assertEquals(3, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(3);
         subTask1Executions = runtimeService.createExecutionQuery().activityId("subTask1").list();
-        assertEquals(2, subTask1Executions.size());
+        assertThat(subTask1Executions).hasSize(2);
         List<Execution> subTask2Executions = runtimeService.createExecutionQuery().activityId("subTask2").list();
-        assertEquals(1, subTask2Executions.size());
+        assertThat(subTask2Executions).hasSize(1);
 
         //Move the parallelSubProcess
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("parallelSubProcess", "lastTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("parallelSubProcess", "lastTask")
+                .changeState();
 
         //There's no multiInstance anymore
         executionsCount = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(1, executionsCount);
+        assertThat(executionsCount).isEqualTo(1);
 
         task = taskService.createTaskQuery().active().singleResult();
-        assertEquals("lastTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("lastTask");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -765,15 +803,15 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("parallelNestedMultiInstanceSubProcesses").start();
 
         long totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(7, totalChildExecutions);
+        assertThat(totalChildExecutions).isEqualTo(7);
         long parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcessOuter").count();
-        assertEquals(3, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(3);
         List<Execution> subTask1Executions = runtimeService.createExecutionQuery().activityId("subTask1").list();
-        assertEquals(3, subTask1Executions.size());
+        assertThat(subTask1Executions).hasSize(3);
 
         //Start the nested subProcesses by completing the first task of the outer subProcess
         List<Task> tasks = taskService.createTaskQuery().taskDefinitionKey("subTask1").list();
-        assertEquals(3, tasks.size());
+        assertThat(tasks).hasSize(3);
         tasks.forEach(t -> taskService.complete(t.getId()));
 
         // 3 instances of the outerSubProcess and each have 3 instances of a nestedSubProcess, for a total of 9 nestedSubTask executions
@@ -781,13 +819,13 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         // 1 Parent execution for the outerSubProcess and 1 parent for each nestedSubProcess -> 4 extra parent executions
         // Grand Total ->
         totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(25, totalChildExecutions);
+        assertThat(totalChildExecutions).isEqualTo(25);
         parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcessOuter").count();
-        assertEquals(3, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(3);
         parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelNestedSubProcess").count();
-        assertEquals(9, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(9);
         List<Execution> nestedSubTask1Executions = runtimeService.createExecutionQuery().activityId("nestedSubTask1").list();
-        assertEquals(9, nestedSubTask1Executions.size());
+        assertThat(nestedSubTask1Executions).hasSize(9);
 
         //Complete some of the Nested tasks
         taskService.complete(taskService.createTaskQuery().executionId(nestedSubTask1Executions.get(0).getId()).singleResult().getId());
@@ -795,15 +833,15 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         taskService.complete(taskService.createTaskQuery().executionId(nestedSubTask1Executions.get(6).getId()).singleResult().getId());
 
         totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(25, totalChildExecutions);
+        assertThat(totalChildExecutions).isEqualTo(25);
         parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcessOuter").count();
-        assertEquals(3, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(3);
         parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelNestedSubProcess").count();
-        assertEquals(9, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(9);
         nestedSubTask1Executions = runtimeService.createExecutionQuery().activityId("nestedSubTask1").list();
-        assertEquals(6, nestedSubTask1Executions.size());
+        assertThat(nestedSubTask1Executions).hasSize(6);
         List<Execution> nestedSubTask2Executions = runtimeService.createExecutionQuery().activityId("nestedSubTask2").list();
-        assertEquals(3, nestedSubTask2Executions.size());
+        assertThat(nestedSubTask2Executions).hasSize(3);
 
         //Complete one of the nested subProcesses
         Task task = taskService.createTaskQuery().executionId(nestedSubTask2Executions.get(0).getId()).singleResult();
@@ -811,49 +849,49 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
 
         //One less task execution and one less nested instance
         totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(23, totalChildExecutions);
+        assertThat(totalChildExecutions).isEqualTo(23);
         parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcessOuter").count();
-        assertEquals(3, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(3);
         parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelNestedSubProcess").count();
-        assertEquals(8, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(8);
         nestedSubTask1Executions = runtimeService.createExecutionQuery().activityId("nestedSubTask1").list();
-        assertEquals(6, nestedSubTask1Executions.size());
+        assertThat(nestedSubTask1Executions).hasSize(6);
         nestedSubTask2Executions = runtimeService.createExecutionQuery().activityId("nestedSubTask2").list();
-        assertEquals(2, nestedSubTask2Executions.size());
+        assertThat(nestedSubTask2Executions).hasSize(2);
 
         //Move each nested multiInstance parent
         Stream<String> parallelNestedSubProcessesParentIds = runtimeService.createExecutionQuery()
-            .processInstanceId(processInstance.getId())
-            .activityId("parallelNestedSubProcess")
-            .list()
-            .stream()
-            .map(Execution::getParentId)
-            .distinct();
+                .processInstanceId(processInstance.getId())
+                .activityId("parallelNestedSubProcess")
+                .list()
+                .stream()
+                .map(Execution::getParentId)
+                .distinct();
 
         parallelNestedSubProcessesParentIds.forEach(parentId -> {
             runtimeService.createChangeActivityStateBuilder()
-                .moveExecutionToActivityId(parentId, "subTask2")
-                .changeState();
+                    .moveExecutionToActivityId(parentId, "subTask2")
+                    .changeState();
         });
 
         //Nested subProcesses have completed, only outer subProcess remain
         totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(7, totalChildExecutions);
+        assertThat(totalChildExecutions).isEqualTo(7);
         parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcessOuter").count();
-        assertEquals(3, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(3);
         List<Execution> subTask2Executions = runtimeService.createExecutionQuery().activityId("subTask2").list();
-        assertEquals(3, subTask2Executions.size());
+        assertThat(subTask2Executions).hasSize(3);
 
         //Complete the outer subProcesses
         tasks = taskService.createTaskQuery().taskDefinitionKey("subTask2").list();
-        assertEquals(3, tasks.size());
+        assertThat(tasks).hasSize(3);
         tasks.forEach(t -> taskService.complete(t.getId()));
 
         totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(1, totalChildExecutions);
+        assertThat(totalChildExecutions).isEqualTo(1);
 
         task = taskService.createTaskQuery().active().singleResult();
-        assertEquals("lastTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("lastTask");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -865,15 +903,15 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("parallelNestedMultiInstanceSubProcesses").start();
 
         long totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(7, totalChildExecutions);
+        assertThat(totalChildExecutions).isEqualTo(7);
         long parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcessOuter").count();
-        assertEquals(3, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(3);
         List<Execution> subTask1Executions = runtimeService.createExecutionQuery().activityId("subTask1").list();
-        assertEquals(3, subTask1Executions.size());
+        assertThat(subTask1Executions).hasSize(3);
 
         //Start the nested subProcesses by completing the first task of the outer subProcess
         List<Task> tasks = taskService.createTaskQuery().taskDefinitionKey("subTask1").list();
-        assertEquals(3, tasks.size());
+        assertThat(tasks).hasSize(3);
         tasks.forEach(t -> taskService.complete(t.getId()));
 
         // 3 instances of the outerSubProcess and each have 3 instances of a nestedSubProcess, for a total of 9 nestedSubTask executions
@@ -881,13 +919,13 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         // 1 Parent execution for the outerSubProcess and 1 parent for each nestedSubProcess -> 4 extra parent executions
         // Grand Total ->
         totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(25, totalChildExecutions);
+        assertThat(totalChildExecutions).isEqualTo(25);
         parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcessOuter").count();
-        assertEquals(3, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(3);
         parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelNestedSubProcess").count();
-        assertEquals(9, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(9);
         List<Execution> nestedSubTask1Executions = runtimeService.createExecutionQuery().activityId("nestedSubTask1").list();
-        assertEquals(9, nestedSubTask1Executions.size());
+        assertThat(nestedSubTask1Executions).hasSize(9);
 
         //Complete some of the Nested tasks
         taskService.complete(taskService.createTaskQuery().executionId(nestedSubTask1Executions.get(0).getId()).singleResult().getId());
@@ -895,15 +933,15 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         taskService.complete(taskService.createTaskQuery().executionId(nestedSubTask1Executions.get(6).getId()).singleResult().getId());
 
         totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(25, totalChildExecutions);
+        assertThat(totalChildExecutions).isEqualTo(25);
         parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcessOuter").count();
-        assertEquals(3, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(3);
         parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelNestedSubProcess").count();
-        assertEquals(9, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(9);
         nestedSubTask1Executions = runtimeService.createExecutionQuery().activityId("nestedSubTask1").list();
-        assertEquals(6, nestedSubTask1Executions.size());
+        assertThat(nestedSubTask1Executions).hasSize(6);
         List<Execution> nestedSubTask2Executions = runtimeService.createExecutionQuery().activityId("nestedSubTask2").list();
-        assertEquals(3, nestedSubTask2Executions.size());
+        assertThat(nestedSubTask2Executions).hasSize(3);
 
         //Complete one of the nested subProcesses
         Task task = taskService.createTaskQuery().executionId(nestedSubTask2Executions.get(0).getId()).singleResult();
@@ -911,40 +949,40 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
 
         //One less task execution and one less nested instance
         totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(23, totalChildExecutions);
+        assertThat(totalChildExecutions).isEqualTo(23);
         parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcessOuter").count();
-        assertEquals(3, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(3);
         parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelNestedSubProcess").count();
-        assertEquals(8, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(8);
         nestedSubTask1Executions = runtimeService.createExecutionQuery().activityId("nestedSubTask1").list();
-        assertEquals(6, nestedSubTask1Executions.size());
+        assertThat(nestedSubTask1Executions).hasSize(6);
         nestedSubTask2Executions = runtimeService.createExecutionQuery().activityId("nestedSubTask2").list();
-        assertEquals(2, nestedSubTask2Executions.size());
+        assertThat(nestedSubTask2Executions).hasSize(2);
 
         //Move the activity nested multiInstance parent
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("parallelNestedSubProcess", "subTask2")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("parallelNestedSubProcess", "subTask2")
+                .changeState();
 
         //Nested subProcesses have completed, only outer subProcess remain
         totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(7, totalChildExecutions);
+        assertThat(totalChildExecutions).isEqualTo(7);
         parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcessOuter").count();
-        assertEquals(3, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(3);
         List<Execution> subTask2Executions = runtimeService.createExecutionQuery().activityId("subTask2").list();
-        assertEquals(3, subTask2Executions.size());
+        assertThat(subTask2Executions).hasSize(3);
 
         //Complete the outer subProcesses
         tasks = taskService.createTaskQuery().taskDefinitionKey("subTask2").list();
-        assertEquals(3, tasks.size());
+        assertThat(tasks).hasSize(3);
         tasks.forEach(t -> taskService.complete(t.getId()));
 
         totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(1, totalChildExecutions);
+        assertThat(totalChildExecutions).isEqualTo(1);
 
         task = taskService.createTaskQuery().active().singleResult();
-        assertEquals("lastTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("lastTask");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -956,73 +994,73 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("parallelGatewayInsideMultiInstanceSubProcess");
 
         long totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(7, totalChildExecutions);
+        assertThat(totalChildExecutions).isEqualTo(7);
         long parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcess").count();
-        assertEquals(3, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(3);
         List<Execution> preForkTaskExecutions = runtimeService.createExecutionQuery().activityId("preForkTask").list();
-        assertEquals(3, preForkTaskExecutions.size());
+        assertThat(preForkTaskExecutions).hasSize(3);
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(3, tasks.size());
-        assertEquals("preForkTask", tasks.get(0).getTaskDefinitionKey());
+        assertThat(tasks).hasSize(3);
+        assertThat(tasks.get(0).getTaskDefinitionKey()).isEqualTo("preForkTask");
 
         //Move a task before the fork within the multiInstance subProcess
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveSingleActivityIdToActivityIds("preForkTask", Arrays.asList("forkTask1", "forkTask2"))
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveSingleActivityIdToActivityIds("preForkTask", Arrays.asList("forkTask1", "forkTask2"))
+                .changeState();
 
         totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(10, totalChildExecutions);
+        assertThat(totalChildExecutions).isEqualTo(10);
         parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcess").count();
-        assertEquals(3, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(3);
         List<Execution> forkTask1Executions = runtimeService.createExecutionQuery().activityId("forkTask1").list();
-        assertEquals(3, forkTask1Executions.size());
+        assertThat(forkTask1Executions).hasSize(3);
         List<Execution> forkTask2Executions = runtimeService.createExecutionQuery().activityId("forkTask2").list();
-        assertEquals(3, forkTask2Executions.size());
+        assertThat(forkTask2Executions).hasSize(3);
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(6, tasks.size());
+        assertThat(tasks).hasSize(6);
         Map<String, List<Task>> taskGroups = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertEquals(2, taskGroups.keySet().size());
-        assertEquals(new HashSet<>(Arrays.asList("forkTask1", "forkTask2")), taskGroups.keySet());
-        assertEquals(3, taskGroups.get("forkTask1").size());
-        assertEquals(3, taskGroups.get("forkTask2").size());
+        assertThat(taskGroups.keySet()).hasSize(2);
+        assertThat(taskGroups.keySet()).isEqualTo(new HashSet<>(Arrays.asList("forkTask1", "forkTask2")));
+        assertThat(taskGroups.get("forkTask1")).hasSize(3);
+        assertThat(taskGroups.get("forkTask2")).hasSize(3);
 
         //Move the parallel gateway task forward
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdsToSingleActivityId(Arrays.asList("forkTask1", "forkTask2"), "parallelJoin")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdsToSingleActivityId(Arrays.asList("forkTask1", "forkTask2"), "parallelJoin")
+                .changeState();
 
         totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(7, totalChildExecutions);
+        assertThat(totalChildExecutions).isEqualTo(7);
         parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcess").count();
-        assertEquals(3, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(3);
         List<Execution> postForkTaskExecutions = runtimeService.createExecutionQuery().activityId("postForkTask").list();
-        assertEquals(3, postForkTaskExecutions.size());
+        assertThat(postForkTaskExecutions).hasSize(3);
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(3, tasks.size());
-        tasks.forEach(t -> assertEquals("postForkTask", t.getTaskDefinitionKey()));
+        assertThat(tasks).hasSize(3);
+        tasks.forEach(t -> assertThat(t.getTaskDefinitionKey()).isEqualTo("postForkTask"));
 
         //Complete one of the tasks
         taskService.complete(tasks.get(1).getId());
 
         totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(5, totalChildExecutions);
+        assertThat(totalChildExecutions).isEqualTo(5);
         parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcess").count();
-        assertEquals(2, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(2);
         postForkTaskExecutions = runtimeService.createExecutionQuery().activityId("postForkTask").list();
-        assertEquals(2, postForkTaskExecutions.size());
+        assertThat(postForkTaskExecutions).hasSize(2);
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, tasks.size());
-        tasks.forEach(t -> assertEquals("postForkTask", t.getTaskDefinitionKey()));
+        assertThat(tasks).hasSize(2);
+        tasks.forEach(t -> assertThat(t.getTaskDefinitionKey()).isEqualTo("postForkTask"));
 
         //Finish the rest since we cannot move out of a multiInstance subProcess
         tasks.forEach(t -> taskService.complete(t.getId()));
 
         totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(1, totalChildExecutions);
+        assertThat(totalChildExecutions).isEqualTo(1);
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("lastTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("lastTask");
 
         taskService.complete(task.getId());
 
@@ -1035,72 +1073,73 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("parallelGatewayInsideMultiInstanceSubProcess");
 
         long totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(7, totalChildExecutions);
+        assertThat(totalChildExecutions).isEqualTo(7);
         long parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcess").count();
-        assertEquals(3, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(3);
         List<Execution> preForkTaskExecutions = runtimeService.createExecutionQuery().activityId("preForkTask").list();
-        assertEquals(3, preForkTaskExecutions.size());
+        assertThat(preForkTaskExecutions).hasSize(3);
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(3, tasks.size());
-        assertEquals("preForkTask", tasks.get(0).getTaskDefinitionKey());
+        assertThat(tasks).hasSize(3);
+        assertThat(tasks.get(0).getTaskDefinitionKey()).isEqualTo("preForkTask");
 
         //Move a task before the fork within the multiInstance subProcess
         preForkTaskExecutions.forEach(e -> runtimeService.createChangeActivityStateBuilder()
-            .moveSingleExecutionToActivityIds(e.getId(), Arrays.asList("forkTask1", "forkTask2"))
-            .changeState());
+                .moveSingleExecutionToActivityIds(e.getId(), Arrays.asList("forkTask1", "forkTask2"))
+                .changeState());
 
         totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(10, totalChildExecutions);
+        assertThat(totalChildExecutions).isEqualTo(10);
         parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcess").count();
-        assertEquals(3, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(3);
         List<Execution> forkTask1Executions = runtimeService.createExecutionQuery().activityId("forkTask1").list();
-        assertEquals(3, forkTask1Executions.size());
+        assertThat(forkTask1Executions).hasSize(3);
         List<Execution> forkTask2Executions = runtimeService.createExecutionQuery().activityId("forkTask2").list();
-        assertEquals(3, forkTask2Executions.size());
+        assertThat(forkTask2Executions).hasSize(3);
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(6, tasks.size());
+        assertThat(tasks).hasSize(6);
         Map<String, List<Task>> taskGroups = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertEquals(2, taskGroups.keySet().size());
-        assertEquals(new HashSet<>(Arrays.asList("forkTask1", "forkTask2")), taskGroups.keySet());
-        assertEquals(3, taskGroups.get("forkTask1").size());
-        assertEquals(3, taskGroups.get("forkTask2").size());
+        assertThat(taskGroups.keySet()).hasSize(2);
+        assertThat(taskGroups.keySet()).isEqualTo(new HashSet<>(Arrays.asList("forkTask1", "forkTask2")));
+        assertThat(taskGroups.get("forkTask1")).hasSize(3);
+        assertThat(taskGroups.get("forkTask2")).hasSize(3);
 
         //Move the parallel gateway task forward
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionsToSingleActivityId(
-                Stream.concat(forkTask1Executions.stream().map(Execution::getId), forkTask2Executions.stream().map(Execution::getId)).collect(Collectors.toList()), "postForkTask")
-            .changeState();
+                .moveExecutionsToSingleActivityId(
+                        Stream.concat(forkTask1Executions.stream().map(Execution::getId), forkTask2Executions.stream().map(Execution::getId))
+                                .collect(Collectors.toList()), "postForkTask")
+                .changeState();
 
         totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(7, totalChildExecutions);
+        assertThat(totalChildExecutions).isEqualTo(7);
         parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcess").count();
-        assertEquals(3, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(3);
         List<Execution> postForkTaskExecutions = runtimeService.createExecutionQuery().activityId("postForkTask").list();
-        assertEquals(3, postForkTaskExecutions.size());
+        assertThat(postForkTaskExecutions).hasSize(3);
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(3, tasks.size());
-        tasks.forEach(t -> assertEquals("postForkTask", t.getTaskDefinitionKey()));
+        assertThat(tasks).hasSize(3);
+        tasks.forEach(t -> assertThat(t.getTaskDefinitionKey()).isEqualTo("postForkTask"));
 
         //Complete one of the tasks
         taskService.complete(tasks.get(1).getId());
 
         totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(5, totalChildExecutions);
+        assertThat(totalChildExecutions).isEqualTo(5);
         parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcess").count();
-        assertEquals(2, parallelSubProcessCount);
+        assertThat(parallelSubProcessCount).isEqualTo(2);
         postForkTaskExecutions = runtimeService.createExecutionQuery().activityId("postForkTask").list();
-        assertEquals(2, postForkTaskExecutions.size());
+        assertThat(postForkTaskExecutions).hasSize(2);
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, tasks.size());
-        tasks.forEach(t -> assertEquals("postForkTask", t.getTaskDefinitionKey()));
+        assertThat(tasks).hasSize(2);
+        tasks.forEach(t -> assertThat(t.getTaskDefinitionKey()).isEqualTo("postForkTask"));
 
         //Finish the rest since we cannot move out of a multiInstance subProcess
         tasks.forEach(t -> taskService.complete(t.getId()));
 
         totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
-        assertEquals(1, totalChildExecutions);
+        assertThat(totalChildExecutions).isEqualTo(1);
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("lastTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("lastTask");
 
         taskService.complete(task.getId());
 
@@ -1114,52 +1153,49 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
 
         //1x MI subProc root, 3x parallel MI subProc, 9x Task executions (3 tasks per Gw path)
         List<Execution> childExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(13, childExecutions.size());
+        assertThat(childExecutions).hasSize(13);
         Map<String, List<Execution>> classifiedExecutions = groupListContentBy(childExecutions, Execution::getActivityId);
-        assertNotNull(classifiedExecutions.get("parallelSubProcess"));
-        assertEquals(4, classifiedExecutions.get("parallelSubProcess").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive1"));
-        assertEquals(3, classifiedExecutions.get("taskInclusive1").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive2"));
-        assertEquals(3, classifiedExecutions.get("taskInclusive2").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive3"));
-        assertEquals(3, classifiedExecutions.get("taskInclusive3").size());
+        assertThat(classifiedExecutions.get("parallelSubProcess")).isNotNull();
+        assertThat(classifiedExecutions.get("parallelSubProcess")).hasSize(4);
+        assertThat(classifiedExecutions.get("taskInclusive1")).isNotNull();
+        assertThat(classifiedExecutions.get("taskInclusive1")).hasSize(3);
+        assertThat(classifiedExecutions.get("taskInclusive2")).isNotNull();
+        assertThat(classifiedExecutions.get("taskInclusive2")).hasSize(3);
+        assertThat(classifiedExecutions.get("taskInclusive3")).isNotNull();
+        assertThat(classifiedExecutions.get("taskInclusive3")).hasSize(3);
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         Map<String, List<Task>> classifiedTasks = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertEquals(3, classifiedTasks.size());
-        assertTrue(classifiedTasks.containsKey("taskInclusive1"));
-        assertTrue(classifiedTasks.containsKey("taskInclusive2"));
-        assertTrue(classifiedTasks.containsKey("taskInclusive3"));
+        assertThat(classifiedTasks).hasSize(3);
+        assertThat(classifiedTasks).containsKeys("taskInclusive1", "taskInclusive2", "taskInclusive3");
 
         //Move all activities
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdsToSingleActivityId(Arrays.asList("taskInclusive1", "taskInclusive2", "taskInclusive3"), "inclusiveJoin")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdsToSingleActivityId(Arrays.asList("taskInclusive1", "taskInclusive2", "taskInclusive3"), "inclusiveJoin")
+                .changeState();
 
         //Still 3 subProcesses running, all of them past the gateway fork/join
         childExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(7, childExecutions.size());
+        assertThat(childExecutions).hasSize(7);
         classifiedExecutions = groupListContentBy(childExecutions, Execution::getActivityId);
-        assertNotNull(classifiedExecutions.get("parallelSubProcess"));
-        assertEquals(4, classifiedExecutions.get("parallelSubProcess").size());
-        assertNotNull(classifiedExecutions.get("postForkTask"));
-        assertEquals(3, classifiedExecutions.get("postForkTask").size());
+        assertThat(classifiedExecutions).containsKeys("parallelSubProcess", "postForkTask");
+        assertThat(classifiedExecutions.get("parallelSubProcess")).hasSize(4);
+        assertThat(classifiedExecutions.get("postForkTask")).hasSize(3);
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(3, tasks.size());
-        tasks.forEach(t -> assertEquals("postForkTask", t.getTaskDefinitionKey()));
+        assertThat(tasks).hasSize(3);
+        tasks.forEach(t -> assertThat(t.getTaskDefinitionKey()).isEqualTo("postForkTask"));
 
         //Finish the remaining subProcesses tasks
         tasks.forEach(t -> taskService.complete(t.getId()));
 
         //Only one execution and task remaining
         childExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(1, childExecutions.size());
-        assertEquals("lastTask", childExecutions.get(0).getActivityId());
+        assertThat(childExecutions).hasSize(1);
+        assertThat(childExecutions.get(0).getActivityId()).isEqualTo("lastTask");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("lastTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("lastTask");
 
         //Complete the process
         taskService.complete(task.getId());
@@ -1173,23 +1209,18 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
 
         //1x MI subProc root, 3x parallel MI subProc, 9x Task executions (3 tasks per Gw path)
         List<Execution> childExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(13, childExecutions.size());
+        assertThat(childExecutions).hasSize(13);
         Map<String, List<Execution>> classifiedExecutions = groupListContentBy(childExecutions, Execution::getActivityId);
-        assertNotNull(classifiedExecutions.get("parallelSubProcess"));
-        assertEquals(4, classifiedExecutions.get("parallelSubProcess").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive1"));
-        assertEquals(3, classifiedExecutions.get("taskInclusive1").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive2"));
-        assertEquals(3, classifiedExecutions.get("taskInclusive2").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive3"));
-        assertEquals(3, classifiedExecutions.get("taskInclusive3").size());
+        assertThat(classifiedExecutions).containsKeys("parallelSubProcess", "taskInclusive1", "taskInclusive2", "taskInclusive3");
+        assertThat(classifiedExecutions.get("parallelSubProcess")).hasSize(4);
+        assertThat(classifiedExecutions.get("taskInclusive1")).hasSize(3);
+        assertThat(classifiedExecutions.get("taskInclusive2")).hasSize(3);
+        assertThat(classifiedExecutions.get("taskInclusive3")).hasSize(3);
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         Map<String, List<Task>> classifiedTasks = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertEquals(3, classifiedTasks.size());
-        assertTrue(classifiedTasks.containsKey("taskInclusive1"));
-        assertTrue(classifiedTasks.containsKey("taskInclusive2"));
-        assertTrue(classifiedTasks.containsKey("taskInclusive3"));
+        assertThat(classifiedTasks).hasSize(3);
+        assertThat(classifiedTasks).containsKeys("taskInclusive1", "taskInclusive2", "taskInclusive3");
 
         //Finish one activity in two MI subProcesses
         taskService.complete(classifiedTasks.get("taskInclusive1").get(1).getId());
@@ -1197,82 +1228,69 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
 
         //1x MI subProc root, 3x parallel MI subProc, 7x Gw Task executions, 2x Gw join executions
         childExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(13, childExecutions.size());
+        assertThat(childExecutions).hasSize(13);
         classifiedExecutions = groupListContentBy(childExecutions, Execution::getActivityId);
-        assertNotNull(classifiedExecutions.get("parallelSubProcess"));
-        assertEquals(4, classifiedExecutions.get("parallelSubProcess").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive1"));
-        assertEquals(2, classifiedExecutions.get("taskInclusive1").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive2"));
-        assertEquals(2, classifiedExecutions.get("taskInclusive2").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive3"));
-        assertEquals(3, classifiedExecutions.get("taskInclusive3").size());
-        assertNotNull(classifiedExecutions.get("inclusiveJoin"));
-        assertEquals(2, classifiedExecutions.get("inclusiveJoin").size());
+        assertThat(classifiedExecutions).containsKeys("parallelSubProcess", "taskInclusive1", "taskInclusive2", "taskInclusive3", "inclusiveJoin");
+        assertThat(classifiedExecutions.get("parallelSubProcess")).hasSize(4);
+        assertThat(classifiedExecutions.get("taskInclusive1")).hasSize(2);
+        assertThat(classifiedExecutions.get("taskInclusive2")).hasSize(2);
+        assertThat(classifiedExecutions.get("taskInclusive3")).hasSize(3);
+        assertThat(classifiedExecutions.get("inclusiveJoin")).hasSize(2);
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         classifiedTasks = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertEquals(3, classifiedTasks.size());
-        assertTrue(classifiedTasks.containsKey("taskInclusive1"));
-        assertEquals(2, classifiedExecutions.get("taskInclusive1").size());
-        assertTrue(classifiedTasks.containsKey("taskInclusive2"));
-        assertEquals(2, classifiedExecutions.get("taskInclusive2").size());
-        assertTrue(classifiedTasks.containsKey("taskInclusive3"));
-        assertEquals(3, classifiedExecutions.get("taskInclusive3").size());
+        assertThat(classifiedTasks).hasSize(3);
+        assertThat(classifiedExecutions).containsKeys("taskInclusive1", "taskInclusive2", "taskInclusive3");
+        assertThat(classifiedExecutions.get("taskInclusive1")).hasSize(2);
+        assertThat(classifiedExecutions.get("taskInclusive2")).hasSize(2);
+        assertThat(classifiedExecutions.get("taskInclusive3")).hasSize(3);
 
         //TEST 1 (move all)... change state of "all" executions in a gateway at once
         //Move the executions of the gateway that still contains 3 tasks in execution
         Stream<Execution> tempStream = Stream.concat(classifiedExecutions.get("taskInclusive1").stream(), classifiedExecutions.get("taskInclusive2").stream());
         Map<String, List<Execution>> taskExecutionsByParent = Stream.concat(tempStream, classifiedExecutions.get("taskInclusive3").stream())
-            .collect(Collectors.groupingBy(Execution::getParentId));
+                .collect(Collectors.groupingBy(Execution::getParentId));
 
         List<String> ids = taskExecutionsByParent.values().stream()
-            .filter(l -> l.size() == 3)
-            .findFirst().orElseGet(ArrayList::new)
-            .stream().map(Execution::getId)
-            .collect(Collectors.toList());
+                .filter(l -> l.size() == 3)
+                .findFirst().orElseGet(ArrayList::new)
+                .stream().map(Execution::getId)
+                .collect(Collectors.toList());
 
         //Move into the synchronizing gateway
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionsToSingleActivityId(ids, "inclusiveJoin")
-            .changeState();
+                .moveExecutionsToSingleActivityId(ids, "inclusiveJoin")
+                .changeState();
 
         //There'll be still 3 subProcesses running, 2 with "gateways" still in execution, one with task3 & task1 & join, one with task3, task2 and join
         // the 3rd subProcess should be past the gateway fork/join
         childExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(11, childExecutions.size());
+        assertThat(childExecutions).hasSize(11);
         classifiedExecutions = groupListContentBy(childExecutions, Execution::getActivityId);
-        assertNotNull(classifiedExecutions.get("parallelSubProcess"));
-        assertEquals(4, classifiedExecutions.get("parallelSubProcess").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive1"));
-        assertEquals(1, classifiedExecutions.get("taskInclusive1").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive2"));
-        assertEquals(1, classifiedExecutions.get("taskInclusive2").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive3"));
-        assertEquals(2, classifiedExecutions.get("taskInclusive3").size());
-        assertNotNull(classifiedExecutions.get("inclusiveJoin"));
-        assertEquals(2, classifiedExecutions.get("inclusiveJoin").size());
-        assertNotNull(classifiedExecutions.get("postForkTask"));
-        assertEquals(1, classifiedExecutions.get("postForkTask").size());
+        assertThat(classifiedExecutions)
+                .containsKeys("parallelSubProcess", "taskInclusive1", "taskInclusive2", "taskInclusive3", "inclusiveJoin", "postForkTask");
+        assertThat(classifiedExecutions.get("parallelSubProcess")).hasSize(4);
+        assertThat(classifiedExecutions.get("taskInclusive1")).hasSize(1);
+        assertThat(classifiedExecutions.get("taskInclusive2")).hasSize(1);
+        assertThat(classifiedExecutions.get("taskInclusive3")).hasSize(2);
+        assertThat(classifiedExecutions.get("inclusiveJoin")).hasSize(2);
+        assertThat(classifiedExecutions.get("postForkTask")).hasSize(1);
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         classifiedTasks = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertEquals(4, classifiedTasks.size());
-        assertTrue(classifiedTasks.containsKey("taskInclusive1"));
-        assertEquals(1, classifiedTasks.get("taskInclusive1").size());
-        assertTrue(classifiedTasks.containsKey("taskInclusive2"));
-        assertEquals(1, classifiedTasks.get("taskInclusive2").size());
-        assertTrue(classifiedTasks.containsKey("taskInclusive3"));
-        assertEquals(2, classifiedTasks.get("taskInclusive3").size());
-        assertTrue(classifiedTasks.containsKey("postForkTask"));
-        assertEquals(1, classifiedTasks.get("postForkTask").size());
+        assertThat(classifiedTasks).hasSize(4);
+        assertThat(classifiedTasks).containsKeys("taskInclusive1", "taskInclusive2", "taskInclusive3", "postForkTask");
+        assertThat(classifiedTasks.get("taskInclusive1")).hasSize(1);
+        assertThat(classifiedTasks.get("taskInclusive2")).hasSize(1);
+        assertThat(classifiedTasks.get("taskInclusive3")).hasSize(2);
+        assertThat(classifiedTasks.get("postForkTask")).hasSize(1);
 
         //TEST 2 (complete last execution)... complete the last execution of a gateway were a task execution was already moved into the synchronizing join
         ids = classifiedExecutions.get("taskInclusive1").stream().map(Execution::getId).collect(Collectors.toList());
         //Move into the synchronizing gateway
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionsToSingleActivityId(ids, "inclusiveJoin")
-            .changeState();
+                .moveExecutionsToSingleActivityId(ids, "inclusiveJoin")
+                .changeState();
 
         //Complete remaining task3, the next inline test needs the task to be completed too
         for (Task t : tasks) {
@@ -1283,54 +1301,49 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
 
         //Still 3 subProcesses running, two of them past the gateway fork/join and the remaining one with a task2 pending
         childExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(9, childExecutions.size());
+        assertThat(childExecutions).hasSize(9);
         classifiedExecutions = groupListContentBy(childExecutions, Execution::getActivityId);
-        assertNotNull(classifiedExecutions.get("parallelSubProcess"));
-        assertEquals(4, classifiedExecutions.get("parallelSubProcess").size());
-        assertNotNull(classifiedExecutions.get("postForkTask"));
-        assertEquals(2, classifiedExecutions.get("postForkTask").size());
-        assertNotNull(classifiedExecutions.get("inclusiveJoin"));
-        assertEquals(2, classifiedExecutions.get("inclusiveJoin").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive2"));
-        assertEquals(1, classifiedExecutions.get("taskInclusive2").size());
+        assertThat(classifiedExecutions).containsKeys("parallelSubProcess", "postForkTask", "inclusiveJoin", "taskInclusive2");
+        assertThat(classifiedExecutions.get("parallelSubProcess")).hasSize(4);
+        assertThat(classifiedExecutions.get("postForkTask")).hasSize(2);
+        assertThat(classifiedExecutions.get("inclusiveJoin")).hasSize(2);
+        assertThat(classifiedExecutions.get("taskInclusive2")).hasSize(1);
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         classifiedTasks = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertEquals(2, classifiedTasks.size());
-        assertTrue(classifiedTasks.containsKey("postForkTask"));
-        assertEquals(2, classifiedTasks.get("postForkTask").size());
-        assertTrue(classifiedTasks.containsKey("taskInclusive2"));
-        assertEquals(1, classifiedTasks.get("taskInclusive2").size());
+        assertThat(classifiedTasks).hasSize(2);
+        assertThat(classifiedTasks).containsKeys("postForkTask", "taskInclusive2");
+        assertThat(classifiedTasks.get("postForkTask")).hasSize(2);
+        assertThat(classifiedTasks.get("taskInclusive2")).hasSize(1);
 
         //TEST 3 (move last execution)... move the remaining execution of a gateway with previously completed executions into the synchronizing join
         ids = classifiedExecutions.get("taskInclusive2").stream().map(Execution::getId).collect(Collectors.toList());
         //Move into the synchronizing gateway
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionsToSingleActivityId(ids, "inclusiveJoin")
-            .changeState();
+                .moveExecutionsToSingleActivityId(ids, "inclusiveJoin")
+                .changeState();
 
         //Still 3 subProcesses running, all of them past the gateway fork/join
         childExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(7, childExecutions.size());
+        assertThat(childExecutions).hasSize(7);
         classifiedExecutions = groupListContentBy(childExecutions, Execution::getActivityId);
-        assertNotNull(classifiedExecutions.get("parallelSubProcess"));
-        assertEquals(4, classifiedExecutions.get("parallelSubProcess").size());
-        assertNotNull(classifiedExecutions.get("postForkTask"));
-        assertEquals(3, classifiedExecutions.get("postForkTask").size());
+        assertThat(classifiedExecutions).containsKeys("parallelSubProcess", "postForkTask");
+        assertThat(classifiedExecutions.get("parallelSubProcess")).hasSize(4);
+        assertThat(classifiedExecutions.get("postForkTask")).hasSize(3);
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(3, tasks.size());
-        tasks.forEach(t -> assertEquals("postForkTask", t.getTaskDefinitionKey()));
+        assertThat(tasks).hasSize(3);
+        tasks.forEach(t -> assertThat(t.getTaskDefinitionKey()).isEqualTo("postForkTask"));
 
         //Finish the remaining subProcesses tasks
         tasks.forEach(t -> taskService.complete(t.getId()));
 
         //Only one execution and task remaining
         childExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(1, childExecutions.size());
-        assertEquals("lastTask", childExecutions.get(0).getActivityId());
+        assertThat(childExecutions).hasSize(1);
+        assertThat(childExecutions.get(0).getActivityId()).isEqualTo("lastTask");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("lastTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("lastTask");
 
         //Complete the process
         taskService.complete(task.getId());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/changestate/ChangeStateTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/changestate/ChangeStateTest.java
@@ -65,37 +65,37 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("secondTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
 
         changeStateEventListener.clear();
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("secondTask", "firstTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("secondTask", "firstTask")
+                .changeState();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("firstTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("firstTask");
 
         // Verify events
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
 
         FlowableEvent event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("secondTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("secondTask");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("firstTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("firstTask");
 
-        assertTrue(!iterator.hasNext());
+        assertThat(!iterator.hasNext()).isTrue();
 
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("secondTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -109,36 +109,36 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("secondTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
 
         changeStateEventListener.clear();
 
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionToActivityId(task.getExecutionId(), "firstTask")
-            .changeState();
+                .moveExecutionToActivityId(task.getExecutionId(), "firstTask")
+                .changeState();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("firstTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("firstTask");
 
         // Verify events
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
 
         FlowableEvent event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("secondTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("secondTask");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("firstTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("firstTask");
 
-        assertTrue(!iterator.hasNext());
+        assertThat(!iterator.hasNext()).isTrue();
 
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("secondTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -149,32 +149,32 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
     public void testSetCurrentActivityForwardForSimpleProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("firstTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("firstTask");
 
         changeStateEventListener.clear();
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("firstTask", "secondTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("firstTask", "secondTask")
+                .changeState();
 
         // Verify events
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
 
         FlowableEvent event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("firstTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("firstTask");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("secondTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("secondTask");
 
-        assertTrue(!iterator.hasNext());
+        assertThat(!iterator.hasNext()).isTrue();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("secondTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -185,31 +185,31 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
     public void testSetCurrentExecutionForwardForSimpleProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("firstTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("firstTask");
 
         changeStateEventListener.clear();
 
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionToActivityId(task.getExecutionId(), "secondTask")
-            .changeState();
+                .moveExecutionToActivityId(task.getExecutionId(), "secondTask")
+                .changeState();
 
         // Verify events
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
 
         FlowableEvent event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("firstTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("firstTask");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("secondTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("secondTask");
 
-        assertTrue(!iterator.hasNext());
+        assertThat(!iterator.hasNext()).isTrue();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("secondTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -221,48 +221,48 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksProcess");
 
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("firstTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("firstTask");
 
         Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
         Execution execution = runtimeService.createExecutionQuery().parentId(task.getExecutionId()).singleResult();
         managementService.createTimerJobQuery().executionId(execution.getId()).singleResult();
 
-        assertNotNull(timerJob);
+        assertThat(timerJob).isNotNull();
 
         changeStateEventListener.clear();
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("firstTask", "secondTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("firstTask", "secondTask")
+                .changeState();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("secondTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
 
         timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(timerJob);
+        assertThat(timerJob).isNull();
 
         // Verify events
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
 
         FlowableEvent event = iterator.next();
-        assertEquals(FlowableEngineEventType.JOB_CANCELED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.JOB_CANCELED);
         FlowableEngineEntityEvent entityEvent = (FlowableEngineEntityEvent) event;
         Job timer = (Job) entityEvent.getEntity();
-        assertEquals("boundaryTimerEvent", getJobActivityId(timer));
+        assertThat(getJobActivityId(timer)).isEqualTo("boundaryTimerEvent");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("firstTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("firstTask");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("secondTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("secondTask");
 
-        assertTrue(!iterator.hasNext());
+        assertThat(!iterator.hasNext()).isTrue();
 
         taskService.complete(task.getId());
 
@@ -275,44 +275,44 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksProcess");
 
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("firstTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("firstTask");
 
         Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(timerJob);
+        assertThat(timerJob).isNotNull();
 
         changeStateEventListener.clear();
 
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionToActivityId(task.getExecutionId(), "secondTask")
-            .changeState();
+                .moveExecutionToActivityId(task.getExecutionId(), "secondTask")
+                .changeState();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("secondTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
 
         timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(timerJob);
+        assertThat(timerJob).isNull();
 
         // Verify events
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
 
         FlowableEvent event = iterator.next();
-        assertEquals(FlowableEngineEventType.JOB_CANCELED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.JOB_CANCELED);
         FlowableEngineEntityEvent entityEvent = (FlowableEngineEntityEvent) event;
         Job timer = (Job) entityEvent.getEntity();
-        assertEquals("boundaryTimerEvent", getJobActivityId(timer));
+        assertThat(getJobActivityId(timer)).isEqualTo("boundaryTimerEvent");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("firstTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("firstTask");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("secondTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("secondTask");
 
-        assertTrue(!iterator.hasNext());
+        assertThat(!iterator.hasNext()).isTrue();
 
         taskService.complete(task.getId());
 
@@ -325,56 +325,56 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksProcess");
 
         Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(timerJob);
+        assertThat(timerJob).isNotNull();
 
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("secondTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
 
         timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(timerJob);
+        assertThat(timerJob).isNull();
 
         changeStateEventListener.clear();
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("secondTask", "firstTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("secondTask", "firstTask")
+                .changeState();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("firstTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("firstTask");
 
         timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(timerJob);
+        assertThat(timerJob).isNotNull();
 
         // Verify events
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
 
         FlowableEvent event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("secondTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("secondTask");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("firstTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("firstTask");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.TIMER_SCHEDULED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.TIMER_SCHEDULED);
         FlowableEngineEntityEvent entityEvent = (FlowableEngineEntityEvent) event;
         Job timer = (Job) entityEvent.getEntity();
-        assertEquals("boundaryTimerEvent", getJobActivityId(timer));
+        assertThat(getJobActivityId(timer)).isEqualTo("boundaryTimerEvent");
 
-        assertTrue(!iterator.hasNext());
+        assertThat(!iterator.hasNext()).isTrue();
 
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("secondTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -386,55 +386,55 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksProcess");
 
         Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(timerJob);
+        assertThat(timerJob).isNotNull();
 
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("secondTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
 
         timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(timerJob);
+        assertThat(timerJob).isNull();
 
         changeStateEventListener.clear();
 
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionToActivityId(task.getExecutionId(), "firstTask")
-            .changeState();
+                .moveExecutionToActivityId(task.getExecutionId(), "firstTask")
+                .changeState();
 
         // Verify events
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
 
         FlowableEvent event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("secondTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("secondTask");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("firstTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("firstTask");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.TIMER_SCHEDULED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.TIMER_SCHEDULED);
         FlowableEngineEntityEvent entityEvent = (FlowableEngineEntityEvent) event;
         Job timer = (Job) entityEvent.getEntity();
-        assertEquals("boundaryTimerEvent", getJobActivityId(timer));
+        assertThat(getJobActivityId(timer)).isEqualTo("boundaryTimerEvent");
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("firstTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("firstTask");
 
         timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(timerJob);
+        assertThat(timerJob).isNotNull();
 
-        assertTrue(!iterator.hasNext());
+        assertThat(!iterator.hasNext()).isTrue();
 
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("secondTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -446,58 +446,58 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksProcessWithTimers");
 
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("firstTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("firstTask");
         Execution execution = runtimeService.createExecutionQuery().parentId(task.getExecutionId()).singleResult();
         Job timerJob1 = managementService.createTimerJobQuery().executionId(execution.getId()).singleResult();
-        assertNotNull(timerJob1);
+        assertThat(timerJob1).isNotNull();
 
         changeStateEventListener.clear();
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("firstTask", "secondTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("firstTask", "secondTask")
+                .changeState();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("secondTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
         Job timerJob2 = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(timerJob2);
-        assertTrue(!timerJob1.getExecutionId().equals(timerJob2.getExecutionId()));
+        assertThat(timerJob2).isNotNull();
+        assertThat(!timerJob1.getExecutionId().equals(timerJob2.getExecutionId())).isTrue();
 
         // Verify events
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
 
         FlowableEvent event = iterator.next();
-        assertEquals(FlowableEngineEventType.JOB_CANCELED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.JOB_CANCELED);
         FlowableEngineEntityEvent entityEvent = (FlowableEngineEntityEvent) event;
         Job timer = (Job) entityEvent.getEntity();
-        assertEquals("firstTimerEvent", getJobActivityId(timer));
+        assertThat(getJobActivityId(timer)).isEqualTo("firstTimerEvent");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("firstTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("firstTask");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("secondTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("secondTask");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.TIMER_SCHEDULED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.TIMER_SCHEDULED);
         entityEvent = (FlowableEngineEntityEvent) event;
         timer = (Job) entityEvent.getEntity();
-        assertEquals("secondTimerEvent", getJobActivityId(timer));
+        assertThat(getJobActivityId(timer)).isEqualTo("secondTimerEvent");
 
-        assertTrue(!iterator.hasNext());
+        assertThat(!iterator.hasNext()).isTrue();
 
         Job job = managementService.moveTimerToExecutableJob(timerJob2.getId());
         managementService.executeJob(job.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("thirdTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("thirdTask");
 
         taskService.complete(task.getId());
 
@@ -512,49 +512,49 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
 
         changeStateEventListener.clear();
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("subTask", "taskBefore")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("subTask", "taskBefore")
+                .changeState();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
 
         // Verify events
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
 
         FlowableEvent event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("subTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subTask");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("subProcess", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subProcess");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("taskBefore", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("taskBefore");
 
-        assertTrue(!iterator.hasNext());
+        assertThat(!iterator.hasNext()).isTrue();
 
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -568,48 +568,48 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
 
         changeStateEventListener.clear();
 
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionToActivityId(task.getExecutionId(), "taskBefore")
-            .changeState();
+                .moveExecutionToActivityId(task.getExecutionId(), "taskBefore")
+                .changeState();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
 
         // Verify events
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
 
         FlowableEvent event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("subTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subTask");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("subProcess", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subProcess");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("taskBefore", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("taskBefore");
 
-        assertTrue(!iterator.hasNext());
+        assertThat(!iterator.hasNext()).isTrue();
 
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -621,51 +621,51 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
 
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         changeStateEventListener.clear();
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("taskBefore", "subTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("taskBefore", "subTask")
+                .changeState();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(3, executions.size());
+        assertThat(executions).hasSize(3);
 
         // Verify events
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
 
         FlowableEvent event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("taskBefore", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("taskBefore");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("subProcess", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subProcess");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.VARIABLE_CREATED, event.getType());
-        assertEquals("name", ((FlowableVariableEvent) event).getVariableName());
-        assertEquals("John", ((FlowableVariableEvent) event).getVariableValue());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.VARIABLE_CREATED);
+        assertThat(((FlowableVariableEvent) event).getVariableName()).isEqualTo("name");
+        assertThat(((FlowableVariableEvent) event).getVariableValue()).isEqualTo("John");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("subTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subTask");
 
-        assertTrue(!iterator.hasNext());
+        assertThat(!iterator.hasNext()).isTrue();
 
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -677,50 +677,50 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
 
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         changeStateEventListener.clear();
 
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionToActivityId(task.getExecutionId(), "subTask")
-            .changeState();
+                .moveExecutionToActivityId(task.getExecutionId(), "subTask")
+                .changeState();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(3, executions.size());
+        assertThat(executions).hasSize(3);
 
         // Verify events
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
 
         FlowableEvent event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("taskBefore", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("taskBefore");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("subProcess", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subProcess");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.VARIABLE_CREATED, event.getType());
-        assertEquals("name", ((FlowableVariableEvent) event).getVariableName());
-        assertEquals("John", ((FlowableVariableEvent) event).getVariableValue());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.VARIABLE_CREATED);
+        assertThat(((FlowableVariableEvent) event).getVariableName()).isEqualTo("name");
+        assertThat(((FlowableVariableEvent) event).getVariableValue()).isEqualTo("John");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("subTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subTask");
 
-        assertTrue(!iterator.hasNext());
+        assertThat(!iterator.hasNext()).isTrue();
 
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -732,58 +732,58 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
 
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         changeStateEventListener.clear();
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("taskBefore", "subTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("taskBefore", "subTask")
+                .changeState();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(3, executions.size());
+        assertThat(executions).hasSize(3);
 
         Execution subProcessExecution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("subProcess")
-            .singleResult();
-        assertNotNull(runtimeService.getVariableLocal(subProcessExecution.getId(), "name", String.class));
+                .singleResult();
+        assertThat(runtimeService.getVariableLocal(subProcessExecution.getId(), "name", String.class)).isNotNull();
         DataObject nameDataObject = runtimeService.getDataObjectLocal(subProcessExecution.getId(), "name");
-        assertNotNull(nameDataObject);
-        assertEquals("John", nameDataObject.getValue());
+        assertThat(nameDataObject).isNotNull();
+        assertThat(nameDataObject.getValue()).isEqualTo("John");
 
         // Verify events
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
 
         FlowableEvent event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("taskBefore", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("taskBefore");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("subProcess", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subProcess");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.VARIABLE_CREATED, event.getType());
-        assertEquals("name", ((FlowableVariableEvent) event).getVariableName());
-        assertEquals("John", ((FlowableVariableEvent) event).getVariableValue());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.VARIABLE_CREATED);
+        assertThat(((FlowableVariableEvent) event).getVariableName()).isEqualTo("name");
+        assertThat(((FlowableVariableEvent) event).getVariableValue()).isEqualTo("John");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("subTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subTask");
 
-        assertTrue(!iterator.hasNext());
+        assertThat(!iterator.hasNext()).isTrue();
 
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -795,58 +795,58 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
 
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         changeStateEventListener.clear();
 
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionToActivityId(task.getExecutionId(), "subTask")
-            .changeState();
+                .moveExecutionToActivityId(task.getExecutionId(), "subTask")
+                .changeState();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(3, executions.size());
+        assertThat(executions).hasSize(3);
 
         Execution subProcessExecution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("subProcess")
-            .singleResult();
-        assertNotNull(runtimeService.getVariableLocal(subProcessExecution.getId(), "name", String.class));
+                .singleResult();
+        assertThat(runtimeService.getVariableLocal(subProcessExecution.getId(), "name", String.class)).isNotNull();
 
         DataObject nameDataObject = runtimeService.getDataObjectLocal(subProcessExecution.getId(), "name");
-        assertNotNull(nameDataObject);
-        assertEquals("John", nameDataObject.getValue());
+        assertThat(nameDataObject).isNotNull();
+        assertThat(nameDataObject.getValue()).isEqualTo("John");
 
         // Verify events
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
 
         FlowableEvent event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("taskBefore", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("taskBefore");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("subProcess", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subProcess");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.VARIABLE_CREATED, event.getType());
-        assertEquals("name", ((FlowableVariableEvent) event).getVariableName());
-        assertEquals("John", ((FlowableVariableEvent) event).getVariableValue());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.VARIABLE_CREATED);
+        assertThat(((FlowableVariableEvent) event).getVariableName()).isEqualTo("name");
+        assertThat(((FlowableVariableEvent) event).getVariableValue()).isEqualTo("John");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("subTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subTask");
 
-        assertTrue(!iterator.hasNext());
+        assertThat(!iterator.hasNext()).isTrue();
 
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -860,65 +860,65 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
 
         Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(timerJob);
+        assertThat(timerJob).isNotNull();
 
         changeStateEventListener.clear();
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("subTask", "taskBefore")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("subTask", "taskBefore")
+                .changeState();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
 
         timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(timerJob);
+        assertThat(timerJob).isNull();
 
         // Verify events
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
 
         FlowableEvent event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("subTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subTask");
 
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.JOB_CANCELED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.JOB_CANCELED);
         FlowableEngineEntityEvent entityEvent = (FlowableEngineEntityEvent) event;
         Job timer = (Job) entityEvent.getEntity();
-        assertEquals("boundaryTimerEvent", getJobActivityId(timer));
+        assertThat(getJobActivityId(timer)).isEqualTo("boundaryTimerEvent");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("subProcess", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subProcess");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("taskBefore", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("taskBefore");
 
-        assertTrue(!iterator.hasNext());
+        assertThat(!iterator.hasNext()).isTrue();
 
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
 
         timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(timerJob);
+        assertThat(timerJob).isNotNull();
 
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -932,64 +932,64 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
 
         Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(timerJob);
+        assertThat(timerJob).isNotNull();
 
         changeStateEventListener.clear();
 
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionToActivityId(task.getExecutionId(), "taskBefore")
-            .changeState();
+                .moveExecutionToActivityId(task.getExecutionId(), "taskBefore")
+                .changeState();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
 
         timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(timerJob);
+        assertThat(timerJob).isNull();
 
         // Verify events
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
 
         FlowableEvent event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("subTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subTask");
 
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.JOB_CANCELED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.JOB_CANCELED);
         FlowableEngineEntityEvent entityEvent = (FlowableEngineEntityEvent) event;
         Job timer = (Job) entityEvent.getEntity();
-        assertEquals("boundaryTimerEvent", getJobActivityId(timer));
+        assertThat(getJobActivityId(timer)).isEqualTo("boundaryTimerEvent");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("subProcess", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subProcess");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("taskBefore", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("taskBefore");
 
-        assertTrue(!iterator.hasNext());
+        assertThat(!iterator.hasNext()).isTrue();
 
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
 
         timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(timerJob);
+        assertThat(timerJob).isNotNull();
 
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -1000,54 +1000,54 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
     public void testSetCurrentActivityToTaskInSubProcessWithTimer() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         changeStateEventListener.clear();
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("taskBefore", "subTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("taskBefore", "subTask")
+                .changeState();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(4, executions.size());
+        assertThat(executions).hasSize(4);
 
         Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(timerJob);
+        assertThat(timerJob).isNotNull();
 
         // Verify events
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
 
         FlowableEvent event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("taskBefore", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("taskBefore");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("subProcess", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subProcess");
 
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.TIMER_SCHEDULED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.TIMER_SCHEDULED);
         FlowableEngineEntityEvent entityEvent = (FlowableEngineEntityEvent) event;
         Job timer = (Job) entityEvent.getEntity();
-        assertEquals("boundaryTimerEvent", getJobActivityId(timer));
+        assertThat(getJobActivityId(timer)).isEqualTo("boundaryTimerEvent");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("subTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subTask");
 
-        assertTrue(!iterator.hasNext());
+        assertThat(!iterator.hasNext()).isTrue();
 
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -1058,53 +1058,53 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
     public void testSetCurrentExecutionToTaskInSubProcessWithTimer() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         changeStateEventListener.clear();
 
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionToActivityId(task.getExecutionId(), "subTask")
-            .changeState();
+                .moveExecutionToActivityId(task.getExecutionId(), "subTask")
+                .changeState();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(4, executions.size());
+        assertThat(executions).hasSize(4);
 
         Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(timerJob);
+        assertThat(timerJob).isNotNull();
 
         // Verify events
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
 
         FlowableEvent event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("taskBefore", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("taskBefore");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("subProcess", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subProcess");
 
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.TIMER_SCHEDULED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.TIMER_SCHEDULED);
         FlowableEngineEntityEvent entityEvent = (FlowableEngineEntityEvent) event;
         Job timer = (Job) entityEvent.getEntity();
-        assertEquals("boundaryTimerEvent", getJobActivityId(timer));
+        assertThat(getJobActivityId(timer)).isEqualTo("boundaryTimerEvent");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("subTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subTask");
 
-        assertTrue(!iterator.hasNext());
+        assertThat(!iterator.hasNext()).isTrue();
 
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -1115,46 +1115,46 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
     public void testSetCurrentActivityToTaskInSubProcessAndExecuteTimer() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         changeStateEventListener.clear();
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("taskBefore", "subTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("taskBefore", "subTask")
+                .changeState();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
 
         Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(timerJob);
+        assertThat(timerJob).isNotNull();
 
         // Verify events
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
 
         FlowableEvent event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("taskBefore", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("taskBefore");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("subProcess", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subProcess");
 
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.TIMER_SCHEDULED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.TIMER_SCHEDULED);
         FlowableEngineEntityEvent entityEvent = (FlowableEngineEntityEvent) event;
         Job timer = (Job) entityEvent.getEntity();
-        assertEquals("boundaryTimerEvent", getJobActivityId(timer));
+        assertThat(getJobActivityId(timer)).isEqualTo("boundaryTimerEvent");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("subTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subTask");
 
-        assertTrue(!iterator.hasNext());
+        assertThat(!iterator.hasNext()).isTrue();
 
         Job executableJob = managementService.moveTimerToExecutableJob(timerJob.getId());
         managementService.executeJob(executableJob.getId());
@@ -1170,53 +1170,53 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
 
         Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(timerJob);
+        assertThat(timerJob).isNotNull();
 
         changeStateEventListener.clear();
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("subTask", "subTask2")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("subTask", "subTask2")
+                .changeState();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTask2", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask2");
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(3, executions.size());
+        assertThat(executions).hasSize(3);
 
         timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(timerJob);
+        assertThat(timerJob).isNull();
 
         // Verify events
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
 
         FlowableEvent event = iterator.next();
-        assertEquals(FlowableEngineEventType.JOB_CANCELED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.JOB_CANCELED);
         FlowableEngineEntityEvent entityEvent = (FlowableEngineEntityEvent) event;
         Job timer = (Job) entityEvent.getEntity();
-        assertEquals("boundaryTimerEvent", getJobActivityId(timer));
+        assertThat(getJobActivityId(timer)).isEqualTo("boundaryTimerEvent");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("subTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subTask");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("subTask2", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subTask2");
 
-        assertTrue(!iterator.hasNext());
+        assertThat(!iterator.hasNext()).isTrue();
 
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -1230,52 +1230,52 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
 
         Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(timerJob);
+        assertThat(timerJob).isNotNull();
 
         changeStateEventListener.clear();
 
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionToActivityId(task.getExecutionId(), "subTask2")
-            .changeState();
+                .moveExecutionToActivityId(task.getExecutionId(), "subTask2")
+                .changeState();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTask2", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask2");
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(3, executions.size());
+        assertThat(executions).hasSize(3);
 
         timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(timerJob);
+        assertThat(timerJob).isNull();
 
         // Verify events
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
 
         FlowableEvent event = iterator.next();
-        assertEquals(FlowableEngineEventType.JOB_CANCELED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.JOB_CANCELED);
         FlowableEngineEntityEvent entityEvent = (FlowableEngineEntityEvent) event;
         Job timer = (Job) entityEvent.getEntity();
-        assertEquals("boundaryTimerEvent", getJobActivityId(timer));
+        assertThat(getJobActivityId(timer)).isEqualTo("boundaryTimerEvent");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("subTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subTask");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("subTask2", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subTask2");
 
-        assertTrue(!iterator.hasNext());
+        assertThat(!iterator.hasNext()).isTrue();
 
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -1286,56 +1286,56 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
     public void testSetCurrentActivityToTaskWithTimerInSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         changeStateEventListener.clear();
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("taskBefore", "subTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("taskBefore", "subTask")
+                .changeState();
 
         // Verify events
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
 
         FlowableEvent event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("taskBefore", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("taskBefore");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("subProcess", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subProcess");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("subTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subTask");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.TIMER_SCHEDULED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.TIMER_SCHEDULED);
         FlowableEngineEntityEvent entityEvent = (FlowableEngineEntityEvent) event;
         Job timer = (Job) entityEvent.getEntity();
-        assertEquals("boundaryTimerEvent", getJobActivityId(timer));
+        assertThat(getJobActivityId(timer)).isEqualTo("boundaryTimerEvent");
 
-        assertTrue(!iterator.hasNext());
+        assertThat(!iterator.hasNext()).isTrue();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(4, executions.size());
+        assertThat(executions).hasSize(4);
         Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(timerJob);
+        assertThat(timerJob).isNotNull();
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTask2", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask2");
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -1346,57 +1346,57 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
     public void testSetCurrentExecutionToTaskWithTimerInSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         changeStateEventListener.clear();
 
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionToActivityId(task.getExecutionId(), "subTask")
-            .changeState();
+                .moveExecutionToActivityId(task.getExecutionId(), "subTask")
+                .changeState();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(4, executions.size());
+        assertThat(executions).hasSize(4);
         Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(timerJob);
+        assertThat(timerJob).isNotNull();
 
         // Verify events
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
 
         FlowableEvent event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("taskBefore", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("taskBefore");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("subProcess", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subProcess");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("subTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subTask");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
 
-        assertEquals(FlowableEngineEventType.TIMER_SCHEDULED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.TIMER_SCHEDULED);
         FlowableEngineEntityEvent entityEvent = (FlowableEngineEntityEvent) event;
         Job timer = (Job) entityEvent.getEntity();
-        assertEquals("boundaryTimerEvent", getJobActivityId(timer));
+        assertThat(getJobActivityId(timer)).isEqualTo("boundaryTimerEvent");
 
-        assertTrue(!iterator.hasNext());
+        assertThat(!iterator.hasNext()).isTrue();
 
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTask2", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask2");
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -1407,54 +1407,54 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
     public void testSetCurrentActivityToTaskWithTimerInSubProcessAndExecuteTimer() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         changeStateEventListener.clear();
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("taskBefore", "subTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("taskBefore", "subTask")
+                .changeState();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(4, executions.size());
+        assertThat(executions).hasSize(4);
         Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(timerJob);
+        assertThat(timerJob).isNotNull();
 
         // Verify events
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
 
         FlowableEvent event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("taskBefore", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("taskBefore");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("subProcess", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subProcess");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("subTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subTask");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.TIMER_SCHEDULED, event.getType());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.TIMER_SCHEDULED);
         FlowableEngineEntityEvent entityEvent = (FlowableEngineEntityEvent) event;
         Job timer = (Job) entityEvent.getEntity();
-        assertEquals("boundaryTimerEvent", getJobActivityId(timer));
+        assertThat(getJobActivityId(timer)).isEqualTo("boundaryTimerEvent");
 
-        assertTrue(!iterator.hasNext());
+        assertThat(!iterator.hasNext()).isTrue();
 
         Job executableTimerJob = managementService.moveTimerToExecutableJob(timerJob.getId());
         managementService.executeJob(executableTimerJob.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -1465,51 +1465,52 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
     public void testSetCurrentActivityIntoNestedSubProcessExecutionFromRoot() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startNestedSubProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         changeStateEventListener.clear();
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("taskBefore", "nestedSubTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("taskBefore", "nestedSubTask")
+                .changeState();
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).hasSize(3);
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "nestedSubProcess", "nestedSubTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "nestedSubProcess", "nestedSubTask");
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("nestedSubTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("nestedSubTask");
 
         // Verify events
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
 
         FlowableEvent event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("taskBefore", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("taskBefore");
 
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("subProcess", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subProcess");
 
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("nestedSubProcess", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("nestedSubProcess");
 
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("nestedSubTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("nestedSubTask");
 
-        assertTrue(!iterator.hasNext());
+        assertThat(!iterator.hasNext()).isTrue();
 
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTaskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTaskAfter");
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -1520,62 +1521,64 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
     public void testSetCurrentActivityIntoNestedSubProcessExecutionFromRootWithDataObject() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startNestedSubProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         changeStateEventListener.clear();
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("taskBefore", "nestedSubTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("taskBefore", "nestedSubTask")
+                .changeState();
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).hasSize(3);
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "nestedSubProcess", "nestedSubTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "nestedSubProcess", "nestedSubTask");
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("nestedSubTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("nestedSubTask");
 
-        Execution nestedSubProcess = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("nestedSubProcess").singleResult();
-        assertNotNull(runtimeService.getVariableLocal(nestedSubProcess.getId(), "name", String.class));
+        Execution nestedSubProcess = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("nestedSubProcess")
+                .singleResult();
+        assertThat(runtimeService.getVariableLocal(nestedSubProcess.getId(), "name", String.class)).isNotNull();
         DataObject nameDataObject = runtimeService.getDataObjectLocal(nestedSubProcess.getId(), "name");
-        assertNotNull(nameDataObject);
-        assertEquals("John", nameDataObject.getValue());
+        assertThat(nameDataObject).isNotNull();
+        assertThat(nameDataObject.getValue()).isEqualTo("John");
 
         // Verify events
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
 
         FlowableEvent event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("taskBefore", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("taskBefore");
 
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("subProcess", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subProcess");
 
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("nestedSubProcess", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("nestedSubProcess");
 
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.VARIABLE_CREATED, event.getType());
-        assertEquals("name", ((FlowableVariableEvent) event).getVariableName());
-        assertEquals("John", ((FlowableVariableEvent) event).getVariableValue());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.VARIABLE_CREATED);
+        assertThat(((FlowableVariableEvent) event).getVariableName()).isEqualTo("name");
+        assertThat(((FlowableVariableEvent) event).getVariableValue()).isEqualTo("John");
 
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("nestedSubTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("nestedSubTask");
 
-        assertTrue(!iterator.hasNext());
+        assertThat(!iterator.hasNext()).isTrue();
 
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTaskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTaskAfter");
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -1586,50 +1589,51 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
     public void testSetCurrentExecutionIntoNestedSubProcessExecutionFromRoot() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startNestedSubProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         changeStateEventListener.clear();
 
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionToActivityId(task.getExecutionId(), "nestedSubTask")
-            .changeState();
+                .moveExecutionToActivityId(task.getExecutionId(), "nestedSubTask")
+                .changeState();
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).hasSize(3);
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "nestedSubProcess", "nestedSubTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "nestedSubProcess", "nestedSubTask");
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("nestedSubTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("nestedSubTask");
 
         // Verify events
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
 
         FlowableEvent event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("taskBefore", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("taskBefore");
 
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("subProcess", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subProcess");
 
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("nestedSubProcess", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("nestedSubProcess");
 
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("nestedSubTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("nestedSubTask");
 
-        assertTrue(!iterator.hasNext());
+        assertThat(!iterator.hasNext()).isTrue();
 
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTaskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTaskAfter");
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -1640,61 +1644,63 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
     public void testSetCurrentExecutionIntoNestedSubProcessExecutionFromRootWithDataObject() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startNestedSubProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         changeStateEventListener.clear();
 
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionToActivityId(task.getExecutionId(), "nestedSubTask")
-            .changeState();
+                .moveExecutionToActivityId(task.getExecutionId(), "nestedSubTask")
+                .changeState();
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).hasSize(3);
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "nestedSubProcess", "nestedSubTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "nestedSubProcess", "nestedSubTask");
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("nestedSubTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("nestedSubTask");
 
-        Execution nestedSubProcess = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("nestedSubProcess").singleResult();
-        assertNotNull(runtimeService.getVariableLocal(nestedSubProcess.getId(), "name", String.class));
+        Execution nestedSubProcess = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("nestedSubProcess")
+                .singleResult();
+        assertThat(runtimeService.getVariableLocal(nestedSubProcess.getId(), "name", String.class)).isNotNull();
         DataObject nameDataObject = runtimeService.getDataObjectLocal(nestedSubProcess.getId(), "name");
-        assertNotNull(nameDataObject);
-        assertEquals("John", nameDataObject.getValue());
+        assertThat(nameDataObject).isNotNull();
+        assertThat(nameDataObject.getValue()).isEqualTo("John");
 
         // Verify events
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
 
         FlowableEvent event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("taskBefore", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("taskBefore");
 
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("subProcess", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subProcess");
 
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("nestedSubProcess", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("nestedSubProcess");
 
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.VARIABLE_CREATED, event.getType());
-        assertEquals("name", ((FlowableVariableEvent) event).getVariableName());
-        assertEquals("John", ((FlowableVariableEvent) event).getVariableValue());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.VARIABLE_CREATED);
+        assertThat(((FlowableVariableEvent) event).getVariableName()).isEqualTo("name");
+        assertThat(((FlowableVariableEvent) event).getVariableValue()).isEqualTo("John");
 
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("nestedSubTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("nestedSubTask");
 
-        assertTrue(!iterator.hasNext());
+        assertThat(!iterator.hasNext()).isTrue();
 
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTaskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTaskAfter");
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -1707,47 +1713,48 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         taskService.complete(task.getId());
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
 
         changeStateEventListener.clear();
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("subTask", "nestedSubTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("subTask", "nestedSubTask")
+                .changeState();
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).hasSize(3);
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "nestedSubProcess", "nestedSubTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "nestedSubProcess", "nestedSubTask");
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("nestedSubTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("nestedSubTask");
 
         // Verify events
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
 
         FlowableEvent event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("subTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subTask");
 
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("nestedSubProcess", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("nestedSubProcess");
 
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("nestedSubTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("nestedSubTask");
 
-        assertTrue(!iterator.hasNext());
+        assertThat(!iterator.hasNext()).isTrue();
 
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTaskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTaskAfter");
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -1760,58 +1767,60 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         taskService.complete(task.getId());
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
 
         changeStateEventListener.clear();
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("subTask", "nestedSubTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("subTask", "nestedSubTask")
+                .changeState();
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).hasSize(3);
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "nestedSubProcess", "nestedSubTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "nestedSubProcess", "nestedSubTask");
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("nestedSubTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("nestedSubTask");
 
-        Execution nestedSubProcess = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("nestedSubProcess").singleResult();
-        assertNotNull(runtimeService.getVariableLocal(nestedSubProcess.getId(), "name", String.class));
+        Execution nestedSubProcess = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("nestedSubProcess")
+                .singleResult();
+        assertThat(runtimeService.getVariableLocal(nestedSubProcess.getId(), "name", String.class)).isNotNull();
         DataObject nameDataObject = runtimeService.getDataObjectLocal(nestedSubProcess.getId(), "name");
-        assertNotNull(nameDataObject);
-        assertEquals("John", nameDataObject.getValue());
+        assertThat(nameDataObject).isNotNull();
+        assertThat(nameDataObject.getValue()).isEqualTo("John");
 
         // Verify events
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
 
         FlowableEvent event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("subTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subTask");
 
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("nestedSubProcess", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("nestedSubProcess");
 
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.VARIABLE_CREATED, event.getType());
-        assertEquals("name", ((FlowableVariableEvent) event).getVariableName());
-        assertEquals("John", ((FlowableVariableEvent) event).getVariableValue());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.VARIABLE_CREATED);
+        assertThat(((FlowableVariableEvent) event).getVariableName()).isEqualTo("name");
+        assertThat(((FlowableVariableEvent) event).getVariableValue()).isEqualTo("John");
 
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("nestedSubTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("nestedSubTask");
 
-        assertTrue(!iterator.hasNext());
+        assertThat(!iterator.hasNext()).isTrue();
 
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTaskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTaskAfter");
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -1824,46 +1833,47 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         taskService.complete(task.getId());
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
 
         changeStateEventListener.clear();
 
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionToActivityId(task.getExecutionId(), "nestedSubTask")
-            .changeState();
+                .moveExecutionToActivityId(task.getExecutionId(), "nestedSubTask")
+                .changeState();
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).hasSize(3);
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "nestedSubProcess", "nestedSubTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "nestedSubProcess", "nestedSubTask");
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("nestedSubTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("nestedSubTask");
 
         // Verify events
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
 
         FlowableEvent event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("subTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subTask");
 
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("nestedSubProcess", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("nestedSubProcess");
 
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("nestedSubTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("nestedSubTask");
 
-        assertTrue(!iterator.hasNext());
+        assertThat(!iterator.hasNext()).isTrue();
 
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTaskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTaskAfter");
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -1876,7 +1886,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         taskService.complete(task.getId());
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         assertThat(executions).hasSize(2);
@@ -1884,52 +1894,54 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         changeStateEventListener.clear();
 
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionToActivityId(task.getExecutionId(), "nestedSubTask")
-            .changeState();
+                .moveExecutionToActivityId(task.getExecutionId(), "nestedSubTask")
+                .changeState();
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).hasSize(3);
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "nestedSubProcess", "nestedSubTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "nestedSubProcess", "nestedSubTask");
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("nestedSubTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("nestedSubTask");
 
-        Execution nestedSubProcess = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("nestedSubProcess").singleResult();
-        assertNotNull(runtimeService.getVariableLocal(nestedSubProcess.getId(), "name", String.class));
+        Execution nestedSubProcess = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("nestedSubProcess")
+                .singleResult();
+        assertThat(runtimeService.getVariableLocal(nestedSubProcess.getId(), "name", String.class)).isNotNull();
         DataObject nameDataObject = runtimeService.getDataObjectLocal(nestedSubProcess.getId(), "name");
-        assertNotNull(nameDataObject);
-        assertEquals("John", nameDataObject.getValue());
+        assertThat(nameDataObject).isNotNull();
+        assertThat(nameDataObject.getValue()).isEqualTo("John");
 
         // Verify events
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
 
         FlowableEvent event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("subTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subTask");
 
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("nestedSubProcess", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("nestedSubProcess");
 
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.VARIABLE_CREATED, event.getType());
-        assertEquals("name", ((FlowableVariableEvent) event).getVariableName());
-        assertEquals("John", ((FlowableVariableEvent) event).getVariableValue());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.VARIABLE_CREATED);
+        assertThat(((FlowableVariableEvent) event).getVariableName()).isEqualTo("name");
+        assertThat(((FlowableVariableEvent) event).getVariableValue()).isEqualTo("John");
 
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("nestedSubTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("nestedSubTask");
 
-        assertTrue(!iterator.hasNext());
+        assertThat(!iterator.hasNext()).isTrue();
 
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTaskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTaskAfter");
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -1943,49 +1955,49 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("nestedSubTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("nestedSubTask");
 
         changeStateEventListener.clear();
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("nestedSubTask", "subTaskAfter")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("nestedSubTask", "subTaskAfter")
+                .changeState();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTaskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTaskAfter");
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(3, executions.size());
+        assertThat(executions).hasSize(3);
 
         // Verify events
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
 
         FlowableEvent event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("nestedSubTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("nestedSubTask");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("nestedSubProcess", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("nestedSubProcess");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("subTaskAfter", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subTaskAfter");
 
-        assertTrue(!iterator.hasNext());
+        assertThat(!iterator.hasNext()).isTrue();
 
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -1999,48 +2011,48 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("nestedSubTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("nestedSubTask");
 
         changeStateEventListener.clear();
 
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionToActivityId(task.getExecutionId(), "subTaskAfter")
-            .changeState();
+                .moveExecutionToActivityId(task.getExecutionId(), "subTaskAfter")
+                .changeState();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTaskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTaskAfter");
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(3, executions.size());
+        assertThat(executions).hasSize(3);
 
         // Verify events
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
 
         FlowableEvent event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("nestedSubTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("nestedSubTask");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("nestedSubProcess", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("nestedSubProcess");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("subTaskAfter", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subTaskAfter");
 
-        assertTrue(!iterator.hasNext());
+        assertThat(!iterator.hasNext()).isTrue();
 
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -2054,56 +2066,56 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("nestedSubTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("nestedSubTask");
 
         changeStateEventListener.clear();
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("nestedSubTask", "subTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("nestedSubTask", "subTask")
+                .changeState();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(3, executions.size());
+        assertThat(executions).hasSize(3);
 
         // Verify events
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
 
         FlowableEvent event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("nestedSubTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("nestedSubTask");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("nestedSubProcess", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("nestedSubProcess");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("subTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subTask");
 
-        assertTrue(!iterator.hasNext());
+        assertThat(!iterator.hasNext()).isTrue();
 
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("nestedSubTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("nestedSubTask");
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTaskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTaskAfter");
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -2117,55 +2129,55 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("nestedSubTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("nestedSubTask");
 
         changeStateEventListener.clear();
 
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionToActivityId(task.getExecutionId(), "subTask")
-            .changeState();
+                .moveExecutionToActivityId(task.getExecutionId(), "subTask")
+                .changeState();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(3, executions.size());
+        assertThat(executions).hasSize(3);
 
         // Verify events
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
 
         FlowableEvent event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("nestedSubTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("nestedSubTask");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("nestedSubProcess", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("nestedSubProcess");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("subTask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subTask");
 
-        assertTrue(!iterator.hasNext());
+        assertThat(!iterator.hasNext()).isTrue();
 
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("nestedSubTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("nestedSubTask");
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTaskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTaskAfter");
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -2179,50 +2191,50 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subtask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subtask");
 
         changeStateEventListener.clear();
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("subtask", "subtask2")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("subtask", "subtask2")
+                .changeState();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subtask2", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subtask2");
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(3, executions.size());
+        assertThat(executions).hasSize(3);
 
         // Verify events
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
 
         FlowableEvent event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("subtask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subtask");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("subProcess", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subProcess");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("subProcess2", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subProcess2");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("subtask2", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subtask2");
 
-        assertTrue(!iterator.hasNext());
+        assertThat(!iterator.hasNext()).isTrue();
 
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -2236,49 +2248,49 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subtask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subtask");
 
         changeStateEventListener.clear();
 
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionToActivityId(task.getExecutionId(), "subtask2")
-            .changeState();
+                .moveExecutionToActivityId(task.getExecutionId(), "subtask2")
+                .changeState();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subtask2", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subtask2");
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(3, executions.size());
+        assertThat(executions).hasSize(3);
 
         // Verify events
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
 
         FlowableEvent event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("subtask", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subtask");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_CANCELLED, event.getType());
-        assertEquals("subProcess", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subProcess");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("subProcess2", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subProcess2");
 
-        assertTrue(iterator.hasNext());
+        assertThat(iterator.hasNext()).isTrue();
         event = iterator.next();
-        assertEquals(FlowableEngineEventType.ACTIVITY_STARTED, event.getType());
-        assertEquals("subtask2", ((FlowableActivityEvent) event).getActivityId());
+        assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subtask2");
 
-        assertTrue(!iterator.hasNext());
+        assertThat(!iterator.hasNext()).isTrue();
 
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -2292,35 +2304,35 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
 
         changeStateEventListener.clear();
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("subTask", "taskBefore")
-            .processVariable("processVar1", "test")
-            .processVariable("processVar2", 10)
-            .localVariable("taskBefore", "localVar1", "test2")
-            .localVariable("taskBefore", "localVar2", 20)
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("subTask", "taskBefore")
+                .processVariable("processVar1", "test")
+                .processVariable("processVar2", 10)
+                .localVariable("taskBefore", "localVar1", "test2")
+                .localVariable("taskBefore", "localVar2", 20)
+                .changeState();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
 
         Map<String, Object> processVariables = runtimeService.getVariables(processInstance.getId());
-        assertEquals("test", processVariables.get("processVar1"));
-        assertEquals(10, processVariables.get("processVar2"));
-        assertNull(processVariables.get("localVar1"));
-        assertNull(processVariables.get("localVar2"));
+        assertThat(processVariables.get("processVar1")).isEqualTo("test");
+        assertThat(processVariables.get("processVar2")).isEqualTo(10);
+        assertThat(processVariables.get("localVar1")).isNull();
+        assertThat(processVariables.get("localVar2")).isNull();
 
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("taskBefore").singleResult();
         Map<String, Object> localVariables = runtimeService.getVariablesLocal(execution.getId());
-        assertEquals("test2", localVariables.get("localVar1"));
-        assertEquals(20, localVariables.get("localVar2"));
+        assertThat(localVariables.get("localVar1")).isEqualTo("test2");
+        assertThat(localVariables.get("localVar2")).isEqualTo(20);
 
         // Verify events
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
@@ -2338,7 +2350,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
                 );
 
         assertThat(changeStateEventListener.getEvents())
-                .filteredOn(stateEvent -> stateEvent instanceof  FlowableVariableEvent)
+                .filteredOn(stateEvent -> stateEvent instanceof FlowableVariableEvent)
                 .extracting(
                         stateEvent -> ((FlowableVariableEvent) stateEvent).getVariableName(),
                         stateEvent -> ((FlowableVariableEvent) stateEvent).getVariableValue()
@@ -2351,10 +2363,8 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
                 );
 
         assertThat(changeStateEventListener.getEvents())
-                .filteredOn(stateEvent -> stateEvent instanceof  FlowableActivityEvent)
-                .extracting(
-                        stateEvent -> ((FlowableActivityEvent) stateEvent).getActivityId()
-                        )
+                .filteredOn(stateEvent -> stateEvent instanceof FlowableActivityEvent)
+                .extracting(stateEvent -> ((FlowableActivityEvent) stateEvent).getActivityId())
                 .containsExactlyInAnyOrder(
                         "subTask",
                         "subProcess",
@@ -2364,11 +2374,11 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -2382,34 +2392,34 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
 
         changeStateEventListener.clear();
 
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionToActivityId(task.getExecutionId(), "taskBefore")
-            .processVariable("processVar1", "test")
-            .processVariable("processVar2", 10)
-            .localVariable("taskBefore", "localVar1", "test2")
-            .localVariable("taskBefore", "localVar2", 20)
-            .changeState();
+                .moveExecutionToActivityId(task.getExecutionId(), "taskBefore")
+                .processVariable("processVar1", "test")
+                .processVariable("processVar2", 10)
+                .localVariable("taskBefore", "localVar1", "test2")
+                .localVariable("taskBefore", "localVar2", 20)
+                .changeState();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
 
         Map<String, Object> processVariables = runtimeService.getVariables(processInstance.getId());
-        assertEquals("test", processVariables.get("processVar1"));
-        assertEquals(10, processVariables.get("processVar2"));
-        assertNull(processVariables.get("localVar1"));
-        assertNull(processVariables.get("localVar2"));
+        assertThat(processVariables.get("processVar1")).isEqualTo("test");
+        assertThat(processVariables.get("processVar2")).isEqualTo(10);
+        assertThat(processVariables.get("localVar1")).isNull();
+        assertThat(processVariables.get("localVar2")).isNull();
 
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("taskBefore").singleResult();
         Map<String, Object> localVariables = runtimeService.getVariablesLocal(execution.getId());
-        assertEquals("test2", localVariables.get("localVar1"));
-        assertEquals(20, localVariables.get("localVar2"));
+        assertThat(localVariables.get("localVar1")).isEqualTo("test2");
+        assertThat(localVariables.get("localVar2")).isEqualTo(20);
 
         // Verify events
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
@@ -2426,7 +2436,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
                 );
 
         assertThat(changeStateEventListener.getEvents())
-                .filteredOn(stateEvent -> stateEvent instanceof  FlowableVariableEvent)
+                .filteredOn(stateEvent -> stateEvent instanceof FlowableVariableEvent)
                 .extracting(
                         stateEvent -> ((FlowableVariableEvent) stateEvent).getVariableName(),
                         stateEvent -> ((FlowableVariableEvent) stateEvent).getVariableValue()
@@ -2439,10 +2449,8 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
                 );
 
         assertThat(changeStateEventListener.getEvents())
-                .filteredOn(stateEvent -> stateEvent instanceof  FlowableActivityEvent)
-                .extracting(
-                        stateEvent -> ((FlowableActivityEvent) stateEvent).getActivityId()
-                )
+                .filteredOn(stateEvent -> stateEvent instanceof FlowableActivityEvent)
+                .extracting(stateEvent -> ((FlowableActivityEvent) stateEvent).getActivityId())
                 .containsExactlyInAnyOrder(
                         "subTask",
                         "subProcess",
@@ -2452,11 +2460,11 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -2468,27 +2476,28 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("taskBefore", "subTask")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("taskBefore", "subTask")
+                .changeState();
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(3, executions.size());
+        assertThat(executions).hasSize(3);
 
-        Execution subProcessExecution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("subProcess").singleResult();
-        assertNotNull(runtimeService.getVariableLocal(subProcessExecution.getId(), "name", String.class));
+        Execution subProcessExecution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("subProcess")
+                .singleResult();
+        assertThat(runtimeService.getVariableLocal(subProcessExecution.getId(), "name", String.class)).isNotNull();
 
         DataObject nameDataObject = runtimeService.getDataObjectLocal(subProcessExecution.getId(), "name");
-        assertNotNull(nameDataObject);
-        assertEquals("John", nameDataObject.getValue());
+        assertThat(nameDataObject).isNotNull();
+        assertThat(nameDataObject.getValue()).isEqualTo("John");
 
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -2500,28 +2509,29 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("taskBefore", "subTask")
-            .localVariable("subProcess", "name", "Joe")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("taskBefore", "subTask")
+                .localVariable("subProcess", "name", "Joe")
+                .changeState();
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(3, executions.size());
+        assertThat(executions).hasSize(3);
 
-        Execution subProcessExecution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("subProcess").singleResult();
-        assertNotNull(runtimeService.getVariableLocal(subProcessExecution.getId(), "name", String.class));
+        Execution subProcessExecution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("subProcess")
+                .singleResult();
+        assertThat(runtimeService.getVariableLocal(subProcessExecution.getId(), "name", String.class)).isNotNull();
 
         DataObject nameDataObject = runtimeService.getDataObjectLocal(subProcessExecution.getId(), "name");
-        assertNotNull(nameDataObject);
-        assertEquals("Joe", nameDataObject.getValue());
+        assertThat(nameDataObject).isNotNull();
+        assertThat(nameDataObject.getValue()).isEqualTo("Joe");
 
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -2534,44 +2544,44 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         Map<String, List<Execution>> classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
-        assertEquals(1, classifiedExecutions.size());
-        assertNotNull(classifiedExecutions.get("beforeCatchEvent"));
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("beforeCatchEvent")).isNotNull();
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         Map<String, List<Task>> classifiedTasks = groupListContentBy(tasks, Task::getTaskDefinitionKey);
-        assertEquals(1, classifiedTasks.get("beforeCatchEvent").size());
+        assertThat(classifiedTasks.get("beforeCatchEvent")).hasSize(1);
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         Map<String, List<EventSubscription>> classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
-        assertTrue(classifiedEventSubscriptions.isEmpty());
+        assertThat(classifiedEventSubscriptions).isEmpty();
 
         //Move to catchEvent
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("beforeCatchEvent", "intermediateCatchEvent")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("beforeCatchEvent", "intermediateCatchEvent")
+                .changeState();
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
-        assertEquals(1, classifiedExecutions.size());
-        assertEquals(1, classifiedExecutions.get("intermediateCatchEvent").size());
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertTrue(tasks.isEmpty());
+        assertThat(tasks).isEmpty();
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
-        assertEquals(1, classifiedEventSubscriptions.get("intermediateCatchEvent").size());
-        assertEquals("signal", classifiedEventSubscriptions.get("intermediateCatchEvent").get(0).getEventType());
+        assertThat(classifiedEventSubscriptions.get("intermediateCatchEvent")).hasSize(1);
+        assertThat(classifiedEventSubscriptions.get("intermediateCatchEvent").get(0).getEventType()).isEqualTo("signal");
 
         //Trigger the event
         runtimeService.signalEventReceived("someSignal");
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
-        assertEquals(1, classifiedExecutions.size());
-        assertEquals(1, classifiedExecutions.get("afterCatchEvent").size());
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("afterCatchEvent")).hasSize(1);
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         classifiedTasks = groupListContentBy(tasks, Task::getTaskDefinitionKey);
-        assertEquals(1, classifiedTasks.get("afterCatchEvent").size());
+        assertThat(classifiedTasks.get("afterCatchEvent")).hasSize(1);
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertTrue(eventSubscriptions.isEmpty());
+        assertThat(eventSubscriptions).isEmpty();
 
         //Complete the process
         taskService.complete(tasks.get(0).getId());
@@ -2586,43 +2596,46 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         Map<String, List<Execution>> classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
-        assertEquals(1, classifiedExecutions.size());
-        assertNotNull(classifiedExecutions.get("beforeCatchEvent"));
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("beforeCatchEvent")).isNotNull();
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         Map<String, List<Task>> classifiedTasks = groupListContentBy(tasks, Task::getTaskDefinitionKey);
-        assertEquals(1, classifiedTasks.get("beforeCatchEvent").size());
+        assertThat(classifiedTasks.get("beforeCatchEvent")).hasSize(1);
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         Map<String, List<EventSubscription>> classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
-        assertTrue(classifiedEventSubscriptions.isEmpty());
+        assertThat(classifiedEventSubscriptions).isEmpty();
+        ;
 
         //Move to catchEvent
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionToActivityId(classifiedExecutions.get("beforeCatchEvent").get(0).getId(), "intermediateCatchEvent")
-            .changeState();
+                .moveExecutionToActivityId(classifiedExecutions.get("beforeCatchEvent").get(0).getId(), "intermediateCatchEvent")
+                .changeState();
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
-        assertEquals(1, classifiedExecutions.size());
-        assertEquals(1, classifiedExecutions.get("intermediateCatchEvent").size());
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertTrue(tasks.isEmpty());
+        assertThat(tasks).isEmpty();
+        ;
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
-        assertEquals(1, classifiedEventSubscriptions.get("intermediateCatchEvent").size());
-        assertEquals("signal", classifiedEventSubscriptions.get("intermediateCatchEvent").get(0).getEventType());
+        assertThat(classifiedEventSubscriptions.get("intermediateCatchEvent")).hasSize(1);
+        assertThat(classifiedEventSubscriptions.get("intermediateCatchEvent").get(0).getEventType()).isEqualTo("signal");
 
         //Trigger the event
         runtimeService.signalEventReceived("someSignal");
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
-        assertEquals(1, classifiedExecutions.size());
-        assertEquals(1, classifiedExecutions.get("afterCatchEvent").size());
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("afterCatchEvent")).hasSize(1);
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         classifiedTasks = groupListContentBy(tasks, Task::getTaskDefinitionKey);
-        assertEquals(1, classifiedTasks.get("afterCatchEvent").size());
+        assertThat(classifiedTasks.get("afterCatchEvent")).hasSize(1);
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertTrue(eventSubscriptions.isEmpty());
+        assertThat(eventSubscriptions).isEmpty();
+        ;
 
         //Complete the process
         taskService.complete(tasks.get(0).getId());
@@ -2636,8 +2649,8 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForSimpleIntermediateEvent");
 
         Task task = taskService.createTaskQuery().singleResult();
-        assertNotNull(task);
-        assertEquals("beforeCatchEvent", task.getTaskDefinitionKey());
+        assertThat(task).isNotNull();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("beforeCatchEvent");
 
         //Complete initial task
         taskService.complete(task.getId());
@@ -2645,31 +2658,33 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         //Process is waiting for event invocation
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         Map<String, List<Execution>> classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
-        assertEquals(1, classifiedExecutions.size());
-        assertEquals(1, classifiedExecutions.get("intermediateCatchEvent").size());
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertTrue(tasks.isEmpty());
+        assertThat(tasks).isEmpty();
+        ;
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         Map<String, List<EventSubscription>> classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
-        assertEquals(1, classifiedEventSubscriptions.get("intermediateCatchEvent").size());
+        assertThat(classifiedEventSubscriptions.get("intermediateCatchEvent")).hasSize(1);
 
         //Move back to the initial task
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("intermediateCatchEvent", "beforeCatchEvent")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("intermediateCatchEvent", "beforeCatchEvent")
+                .changeState();
 
         //Process is in the initial state, no subscriptions exists
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
-        assertEquals(1, classifiedExecutions.size());
-        assertEquals(1, classifiedExecutions.get("beforeCatchEvent").size());
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("beforeCatchEvent")).hasSize(1);
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         Map<String, List<Task>> classifiedTasks = groupListContentBy(tasks, Task::getTaskDefinitionKey);
-        assertEquals(1, classifiedTasks.size());
-        assertEquals(1, classifiedTasks.get("beforeCatchEvent").size());
+        assertThat(classifiedTasks).hasSize(1);
+        assertThat(classifiedTasks.get("beforeCatchEvent")).hasSize(1);
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertTrue(eventSubscriptions.isEmpty());
+        assertThat(eventSubscriptions).isEmpty();
+        ;
 
         //Complete the task once more
         taskService.complete(tasks.get(0).getId());
@@ -2677,31 +2692,33 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         //Process is waiting for signal again
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
-        assertEquals(1, classifiedExecutions.size());
-        assertEquals(1, classifiedExecutions.get("intermediateCatchEvent").size());
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertTrue(tasks.isEmpty());
+        assertThat(tasks).isEmpty();
+        ;
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
-        assertEquals(1, classifiedEventSubscriptions.get("intermediateCatchEvent").size());
-        assertEquals("signal", classifiedEventSubscriptions.get("intermediateCatchEvent").get(0).getEventType());
+        assertThat(classifiedEventSubscriptions.get("intermediateCatchEvent")).hasSize(1);
+        assertThat(classifiedEventSubscriptions.get("intermediateCatchEvent").get(0).getEventType()).isEqualTo("signal");
 
         //Move forward from the event catch
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("intermediateCatchEvent", "afterCatchEvent")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("intermediateCatchEvent", "afterCatchEvent")
+                .changeState();
 
         //Process is on the last task
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
-        assertEquals(1, classifiedExecutions.size());
-        assertEquals(1, classifiedExecutions.get("afterCatchEvent").size());
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("afterCatchEvent")).hasSize(1);
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         classifiedTasks = groupListContentBy(tasks, Task::getTaskDefinitionKey);
-        assertEquals(1, classifiedTasks.get("afterCatchEvent").size());
+        assertThat(classifiedTasks.get("afterCatchEvent")).hasSize(1);
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertTrue(eventSubscriptions.isEmpty());
+        assertThat(eventSubscriptions).isEmpty();
+        ;
 
         //Complete the process
         taskService.complete(tasks.get(0).getId());
@@ -2714,8 +2731,8 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForSimpleIntermediateEvent");
 
         Task task = taskService.createTaskQuery().singleResult();
-        assertNotNull(task);
-        assertEquals("beforeCatchEvent", task.getTaskDefinitionKey());
+        assertThat(task).isNotNull();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("beforeCatchEvent");
 
         //Complete initial task
         taskService.complete(task.getId());
@@ -2723,30 +2740,32 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         //Process is waiting for event invocation
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         Map<String, List<Execution>> classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
-        assertEquals(1, classifiedExecutions.size());
-        assertEquals(1, classifiedExecutions.get("intermediateCatchEvent").size());
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertTrue(tasks.isEmpty());
+        assertThat(tasks).isEmpty();
+        ;
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         Map<String, List<EventSubscription>> classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
-        assertEquals(1, classifiedEventSubscriptions.get("intermediateCatchEvent").size());
+        assertThat(classifiedEventSubscriptions.get("intermediateCatchEvent")).hasSize(1);
 
         //Move back to the initial task
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionToActivityId(classifiedExecutions.get("intermediateCatchEvent").get(0).getId(), "beforeCatchEvent")
-            .changeState();
+                .moveExecutionToActivityId(classifiedExecutions.get("intermediateCatchEvent").get(0).getId(), "beforeCatchEvent")
+                .changeState();
 
         //Process is in the initial state, no subscriptions exists
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
-        assertEquals(1, classifiedExecutions.size());
-        assertEquals(1, classifiedExecutions.get("beforeCatchEvent").size());
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("beforeCatchEvent")).hasSize(1);
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         Map<String, List<Task>> classifiedTasks = groupListContentBy(tasks, Task::getTaskDefinitionKey);
-        assertEquals(1, classifiedTasks.size());
-        assertEquals(1, classifiedTasks.get("beforeCatchEvent").size());
+        assertThat(classifiedTasks).hasSize(1);
+        assertThat(classifiedTasks.get("beforeCatchEvent")).hasSize(1);
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertTrue(eventSubscriptions.isEmpty());
+        assertThat(eventSubscriptions).isEmpty();
+        ;
 
         //Complete the task once more
         taskService.complete(tasks.get(0).getId());
@@ -2754,30 +2773,32 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         //Process is waiting for signal again
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
-        assertEquals(1, classifiedExecutions.size());
-        assertEquals(1, classifiedExecutions.get("intermediateCatchEvent").size());
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertTrue(tasks.isEmpty());
+        assertThat(tasks).isEmpty();
+        ;
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
-        assertEquals(1, classifiedEventSubscriptions.get("intermediateCatchEvent").size());
-        assertEquals("signal", classifiedEventSubscriptions.get("intermediateCatchEvent").get(0).getEventType());
+        assertThat(classifiedEventSubscriptions.get("intermediateCatchEvent")).hasSize(1);
+        assertThat(classifiedEventSubscriptions.get("intermediateCatchEvent").get(0).getEventType()).isEqualTo("signal");
 
         //Move forward from the event catch
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionToActivityId(classifiedExecutions.get("intermediateCatchEvent").get(0).getId(), "afterCatchEvent")
-            .changeState();
+                .moveExecutionToActivityId(classifiedExecutions.get("intermediateCatchEvent").get(0).getId(), "afterCatchEvent")
+                .changeState();
 
         //Process is on the last task
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
-        assertEquals(1, classifiedExecutions.size());
-        assertEquals(1, classifiedExecutions.get("afterCatchEvent").size());
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("afterCatchEvent")).hasSize(1);
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         classifiedTasks = groupListContentBy(tasks, Task::getTaskDefinitionKey);
-        assertEquals(1, classifiedTasks.get("afterCatchEvent").size());
+        assertThat(classifiedTasks.get("afterCatchEvent")).hasSize(1);
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertTrue(eventSubscriptions.isEmpty());
+        assertThat(eventSubscriptions).isEmpty();
+        ;
 
         //Complete the process
         taskService.complete(tasks.get(0).getId());
@@ -2791,31 +2812,33 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         Map<String, List<Execution>> classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
-        assertEquals(1, classifiedExecutions.size());
-        assertNotNull(classifiedExecutions.get("beforeCatchEvent"));
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("beforeCatchEvent")).isNotNull();
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         Map<String, List<Task>> classifiedTasks = groupListContentBy(tasks, Task::getTaskDefinitionKey);
-        assertEquals(1, classifiedTasks.get("beforeCatchEvent").size());
+        assertThat(classifiedTasks.get("beforeCatchEvent")).hasSize(1);
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         Map<String, List<EventSubscription>> classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
-        assertTrue(classifiedEventSubscriptions.isEmpty());
+        assertThat(classifiedEventSubscriptions).isEmpty();
+        ;
 
         //Move to catchEvent
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("beforeCatchEvent", "intermediateCatchEvent")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("beforeCatchEvent", "intermediateCatchEvent")
+                .changeState();
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
-        assertEquals(1, classifiedExecutions.size());
-        assertEquals(1, classifiedExecutions.get("intermediateCatchEvent").size());
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertTrue(tasks.isEmpty());
+        assertThat(tasks).isEmpty();
+        ;
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
-        assertEquals(1, classifiedEventSubscriptions.get("intermediateCatchEvent").size());
-        assertEquals("message", classifiedEventSubscriptions.get("intermediateCatchEvent").get(0).getEventType());
+        assertThat(classifiedEventSubscriptions.get("intermediateCatchEvent")).hasSize(1);
+        assertThat(classifiedEventSubscriptions.get("intermediateCatchEvent").get(0).getEventType()).isEqualTo("message");
 
         //Trigger the event
         String messageCatchingExecutionId = classifiedExecutions.get("intermediateCatchEvent").get(0).getId();
@@ -2823,13 +2846,14 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
-        assertEquals(1, classifiedExecutions.size());
-        assertEquals(1, classifiedExecutions.get("afterCatchEvent").size());
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("afterCatchEvent")).hasSize(1);
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         classifiedTasks = groupListContentBy(tasks, Task::getTaskDefinitionKey);
-        assertEquals(1, classifiedTasks.get("afterCatchEvent").size());
+        assertThat(classifiedTasks.get("afterCatchEvent")).hasSize(1);
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertTrue(eventSubscriptions.isEmpty());
+        assertThat(eventSubscriptions).isEmpty();
+        ;
 
         //Complete the process
         taskService.complete(tasks.get(0).getId());
@@ -2844,30 +2868,32 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         Map<String, List<Execution>> classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
-        assertEquals(1, classifiedExecutions.size());
-        assertNotNull(classifiedExecutions.get("beforeCatchEvent"));
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("beforeCatchEvent")).isNotNull();
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         Map<String, List<Task>> classifiedTasks = groupListContentBy(tasks, Task::getTaskDefinitionKey);
-        assertEquals(1, classifiedTasks.get("beforeCatchEvent").size());
+        assertThat(classifiedTasks.get("beforeCatchEvent")).hasSize(1);
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         Map<String, List<EventSubscription>> classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
-        assertTrue(classifiedEventSubscriptions.isEmpty());
+        assertThat(classifiedEventSubscriptions).isEmpty();
+        ;
 
         //Move to catchEvent
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionToActivityId(classifiedExecutions.get("beforeCatchEvent").get(0).getId(), "intermediateCatchEvent")
-            .changeState();
+                .moveExecutionToActivityId(classifiedExecutions.get("beforeCatchEvent").get(0).getId(), "intermediateCatchEvent")
+                .changeState();
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
-        assertEquals(1, classifiedExecutions.size());
-        assertEquals(1, classifiedExecutions.get("intermediateCatchEvent").size());
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertTrue(tasks.isEmpty());
+        assertThat(tasks).isEmpty();
+        ;
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
-        assertEquals(1, classifiedEventSubscriptions.get("intermediateCatchEvent").size());
-        assertEquals("message", classifiedEventSubscriptions.get("intermediateCatchEvent").get(0).getEventType());
+        assertThat(classifiedEventSubscriptions.get("intermediateCatchEvent")).hasSize(1);
+        assertThat(classifiedEventSubscriptions.get("intermediateCatchEvent").get(0).getEventType()).isEqualTo("message");
 
         //Trigger the event
         String messageCatchingExecutionId = classifiedExecutions.get("intermediateCatchEvent").get(0).getId();
@@ -2875,13 +2901,14 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
-        assertEquals(1, classifiedExecutions.size());
-        assertEquals(1, classifiedExecutions.get("afterCatchEvent").size());
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("afterCatchEvent")).hasSize(1);
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         classifiedTasks = groupListContentBy(tasks, Task::getTaskDefinitionKey);
-        assertEquals(1, classifiedTasks.get("afterCatchEvent").size());
+        assertThat(classifiedTasks.get("afterCatchEvent")).hasSize(1);
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertTrue(eventSubscriptions.isEmpty());
+        assertThat(eventSubscriptions).isEmpty();
+        ;
 
         //Complete the process
         taskService.complete(tasks.get(0).getId());
@@ -2895,8 +2922,8 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForSimpleIntermediateEvent");
 
         Task task = taskService.createTaskQuery().singleResult();
-        assertNotNull(task);
-        assertEquals("beforeCatchEvent", task.getTaskDefinitionKey());
+        assertThat(task).isNotNull();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("beforeCatchEvent");
 
         //Complete initial task
         taskService.complete(task.getId());
@@ -2904,31 +2931,33 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         //Process is waiting for event invocation
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         Map<String, List<Execution>> classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
-        assertEquals(1, classifiedExecutions.size());
-        assertEquals(1, classifiedExecutions.get("intermediateCatchEvent").size());
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertTrue(tasks.isEmpty());
+        assertThat(tasks).isEmpty();
+        ;
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         Map<String, List<EventSubscription>> classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
-        assertEquals(1, classifiedEventSubscriptions.get("intermediateCatchEvent").size());
+        assertThat(classifiedEventSubscriptions.get("intermediateCatchEvent")).hasSize(1);
 
         //Move back to the initial task
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("intermediateCatchEvent", "beforeCatchEvent")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("intermediateCatchEvent", "beforeCatchEvent")
+                .changeState();
 
         //Process is in the initial state, no subscriptions exists
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
-        assertEquals(1, classifiedExecutions.size());
-        assertEquals(1, classifiedExecutions.get("beforeCatchEvent").size());
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("beforeCatchEvent")).hasSize(1);
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         Map<String, List<Task>> classifiedTasks = groupListContentBy(tasks, Task::getTaskDefinitionKey);
-        assertEquals(1, classifiedTasks.size());
-        assertEquals(1, classifiedTasks.get("beforeCatchEvent").size());
+        assertThat(classifiedTasks).hasSize(1);
+        assertThat(classifiedTasks.get("beforeCatchEvent")).hasSize(1);
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertTrue(eventSubscriptions.isEmpty());
+        assertThat(eventSubscriptions).isEmpty();
+        ;
 
         //Complete the task once more
         taskService.complete(tasks.get(0).getId());
@@ -2936,31 +2965,33 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         //Process is waiting for signal again
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
-        assertEquals(1, classifiedExecutions.size());
-        assertEquals(1, classifiedExecutions.get("intermediateCatchEvent").size());
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertTrue(tasks.isEmpty());
+        assertThat(tasks).isEmpty();
+        ;
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
-        assertEquals(1, classifiedEventSubscriptions.get("intermediateCatchEvent").size());
-        assertEquals("message", classifiedEventSubscriptions.get("intermediateCatchEvent").get(0).getEventType());
+        assertThat(classifiedEventSubscriptions.get("intermediateCatchEvent")).hasSize(1);
+        assertThat(classifiedEventSubscriptions.get("intermediateCatchEvent").get(0).getEventType()).isEqualTo("message");
 
         //Move forward from the event catch
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance.getId())
-            .moveActivityIdTo("intermediateCatchEvent", "afterCatchEvent")
-            .changeState();
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("intermediateCatchEvent", "afterCatchEvent")
+                .changeState();
 
         //Process is on the last task
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
-        assertEquals(1, classifiedExecutions.size());
-        assertEquals(1, classifiedExecutions.get("afterCatchEvent").size());
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("afterCatchEvent")).hasSize(1);
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         classifiedTasks = groupListContentBy(tasks, Task::getTaskDefinitionKey);
-        assertEquals(1, classifiedTasks.get("afterCatchEvent").size());
+        assertThat(classifiedTasks.get("afterCatchEvent")).hasSize(1);
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertTrue(eventSubscriptions.isEmpty());
+        assertThat(eventSubscriptions).isEmpty();
+        ;
 
         //Complete the process
         taskService.complete(tasks.get(0).getId());
@@ -2973,8 +3004,8 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForSimpleIntermediateEvent");
 
         Task task = taskService.createTaskQuery().singleResult();
-        assertNotNull(task);
-        assertEquals("beforeCatchEvent", task.getTaskDefinitionKey());
+        assertThat(task).isNotNull();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("beforeCatchEvent");
 
         //Complete initial task
         taskService.complete(task.getId());
@@ -2982,30 +3013,32 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         //Process is waiting for event invocation
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         Map<String, List<Execution>> classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
-        assertEquals(1, classifiedExecutions.size());
-        assertEquals(1, classifiedExecutions.get("intermediateCatchEvent").size());
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertTrue(tasks.isEmpty());
+        assertThat(tasks).isEmpty();
+        ;
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         Map<String, List<EventSubscription>> classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
-        assertEquals(1, classifiedEventSubscriptions.get("intermediateCatchEvent").size());
+        assertThat(classifiedEventSubscriptions.get("intermediateCatchEvent")).hasSize(1);
 
         //Move back to the initial task
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionToActivityId(classifiedExecutions.get("intermediateCatchEvent").get(0).getId(), "beforeCatchEvent")
-            .changeState();
+                .moveExecutionToActivityId(classifiedExecutions.get("intermediateCatchEvent").get(0).getId(), "beforeCatchEvent")
+                .changeState();
 
         //Process is in the initial state, no subscriptions exists
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
-        assertEquals(1, classifiedExecutions.size());
-        assertEquals(1, classifiedExecutions.get("beforeCatchEvent").size());
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("beforeCatchEvent")).hasSize(1);
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         Map<String, List<Task>> classifiedTasks = groupListContentBy(tasks, Task::getTaskDefinitionKey);
-        assertEquals(1, classifiedTasks.size());
-        assertEquals(1, classifiedTasks.get("beforeCatchEvent").size());
+        assertThat(classifiedTasks).hasSize(1);
+        assertThat(classifiedTasks.get("beforeCatchEvent")).hasSize(1);
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertTrue(eventSubscriptions.isEmpty());
+        assertThat(eventSubscriptions).isEmpty();
+        ;
 
         //Complete the task once more
         taskService.complete(tasks.get(0).getId());
@@ -3013,30 +3046,32 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         //Process is waiting for signal again
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
-        assertEquals(1, classifiedExecutions.size());
-        assertEquals(1, classifiedExecutions.get("intermediateCatchEvent").size());
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertTrue(tasks.isEmpty());
+        assertThat(tasks).isEmpty();
+        ;
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
-        assertEquals(1, classifiedEventSubscriptions.get("intermediateCatchEvent").size());
-        assertEquals("message", classifiedEventSubscriptions.get("intermediateCatchEvent").get(0).getEventType());
+        assertThat(classifiedEventSubscriptions.get("intermediateCatchEvent")).hasSize(1);
+        assertThat(classifiedEventSubscriptions.get("intermediateCatchEvent").get(0).getEventType()).isEqualTo("message");
 
         //Move forward from the event catch
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionToActivityId(classifiedExecutions.get("intermediateCatchEvent").get(0).getId(), "afterCatchEvent")
-            .changeState();
+                .moveExecutionToActivityId(classifiedExecutions.get("intermediateCatchEvent").get(0).getId(), "afterCatchEvent")
+                .changeState();
 
         //Process is on the last task
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
-        assertEquals(1, classifiedExecutions.size());
-        assertEquals(1, classifiedExecutions.get("afterCatchEvent").size());
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("afterCatchEvent")).hasSize(1);
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         classifiedTasks = groupListContentBy(tasks, Task::getTaskDefinitionKey);
-        assertEquals(1, classifiedTasks.get("afterCatchEvent").size());
+        assertThat(classifiedTasks.get("afterCatchEvent")).hasSize(1);
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertTrue(eventSubscriptions.isEmpty());
+        assertThat(eventSubscriptions).isEmpty();
+        ;
 
         //Complete the process
         taskService.complete(tasks.get(0).getId());
@@ -3046,40 +3081,43 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
     protected void checkInitialStateForMultipleProcessesWithSimpleEventCatch(Map<String, List<Execution>> executionsByProcessInstance) {
         executionsByProcessInstance.forEach((processId, executions) -> {
             Map<String, List<Execution>> classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
-            assertEquals(1, classifiedExecutions.size());
-            assertNotNull(classifiedExecutions.get("beforeCatchEvent"));
+            assertThat(classifiedExecutions).hasSize(1);
+            assertThat(classifiedExecutions.get("beforeCatchEvent")).isNotNull();
             List<Task> tasks = taskService.createTaskQuery().processInstanceId(processId).list();
             Map<String, List<Task>> classifiedTasks = groupListContentBy(tasks, Task::getTaskDefinitionKey);
-            assertEquals(1, classifiedTasks.get("beforeCatchEvent").size());
+            assertThat(classifiedTasks.get("beforeCatchEvent")).hasSize(1);
             List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processId).list();
             Map<String, List<EventSubscription>> classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
-            assertTrue(classifiedEventSubscriptions.isEmpty());
+            assertThat(classifiedEventSubscriptions).isEmpty();
+            ;
         });
     }
 
     protected void checkWaitStateForMultipleProcessesWithSimpleEventCatch(Map<String, List<Execution>> executionsByProcessInstance) {
         executionsByProcessInstance.forEach((processId, executions) -> {
             Map<String, List<Execution>> classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
-            assertEquals(1, classifiedExecutions.size());
-            assertEquals(1, classifiedExecutions.get("intermediateCatchEvent").size());
+            assertThat(classifiedExecutions).hasSize(1);
+            assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
             List<Task> tasks = taskService.createTaskQuery().processInstanceId(processId).list();
-            assertTrue(tasks.isEmpty());
+            assertThat(tasks).isEmpty();
+            ;
             List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processId).list();
             Map<String, List<EventSubscription>> classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
-            assertEquals(1, classifiedEventSubscriptions.get("intermediateCatchEvent").size());
+            assertThat(classifiedEventSubscriptions.get("intermediateCatchEvent")).hasSize(1);
         });
     }
 
     protected void checkFinalStateForMultipleProcessesWithSimpleEventCatch(Map<String, List<Execution>> executionsByProcessInstance) {
         executionsByProcessInstance.forEach((processId, executions) -> {
             Map<String, List<Execution>> classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
-            assertEquals(1, classifiedExecutions.size());
-            assertEquals(1, classifiedExecutions.get("afterCatchEvent").size());
+            assertThat(classifiedExecutions).hasSize(1);
+            assertThat(classifiedExecutions.get("afterCatchEvent")).hasSize(1);
             List<Task> tasks = taskService.createTaskQuery().processInstanceId(processId).list();
             Map<String, List<Task>> classifiedTasks = groupListContentBy(tasks, Task::getTaskDefinitionKey);
-            assertEquals(1, classifiedTasks.get("afterCatchEvent").size());
+            assertThat(classifiedTasks.get("afterCatchEvent")).hasSize(1);
             List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processId).list();
-            assertTrue(eventSubscriptions.isEmpty());
+            assertThat(eventSubscriptions).isEmpty();
+            ;
         });
     }
 
@@ -3091,24 +3129,24 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         List<Execution> allExecutions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
         Map<String, List<Execution>> executionsByProcessInstance = groupListContentBy(allExecutions, Execution::getProcessInstanceId);
-        assertEquals(2, executionsByProcessInstance.size());
+        assertThat(executionsByProcessInstance).hasSize(2);
 
         checkInitialStateForMultipleProcessesWithSimpleEventCatch(executionsByProcessInstance);
 
         //Move both processes to the eventCatch
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance1.getId())
-            .moveActivityIdTo("beforeCatchEvent", "intermediateCatchEvent")
-            .changeState();
+                .processInstanceId(processInstance1.getId())
+                .moveActivityIdTo("beforeCatchEvent", "intermediateCatchEvent")
+                .changeState();
 
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance2.getId())
-            .moveActivityIdTo("beforeCatchEvent", "intermediateCatchEvent")
-            .changeState();
+                .processInstanceId(processInstance2.getId())
+                .moveActivityIdTo("beforeCatchEvent", "intermediateCatchEvent")
+                .changeState();
 
         allExecutions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
         executionsByProcessInstance = groupListContentBy(allExecutions, Execution::getProcessInstanceId);
-        assertEquals(2, executionsByProcessInstance.size());
+        assertThat(executionsByProcessInstance).hasSize(2);
 
         checkWaitStateForMultipleProcessesWithSimpleEventCatch(executionsByProcessInstance);
 
@@ -3118,7 +3156,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         //Both processes should be on the final task execution
         allExecutions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
         executionsByProcessInstance = groupListContentBy(allExecutions, Execution::getProcessInstanceId);
-        assertEquals(2, executionsByProcessInstance.size());
+        assertThat(executionsByProcessInstance).hasSize(2);
 
         checkFinalStateForMultipleProcessesWithSimpleEventCatch(executionsByProcessInstance);
 
@@ -3136,21 +3174,21 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         List<Execution> allExecutions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
         Map<String, List<Execution>> executionsByProcessInstance = groupListContentBy(allExecutions, Execution::getProcessInstanceId);
-        assertEquals(2, executionsByProcessInstance.size());
+        assertThat(executionsByProcessInstance).hasSize(2);
 
         checkInitialStateForMultipleProcessesWithSimpleEventCatch(executionsByProcessInstance);
 
         //Move both processes to the eventCatch
         ChangeActivityStateBuilder changeActivityStateBuilder = runtimeService.createChangeActivityStateBuilder();
         allExecutions.stream()
-            .filter(e -> e.getActivityId().equals("beforeCatchEvent"))
-            .map(Execution::getId)
-            .forEach(id -> changeActivityStateBuilder.moveExecutionToActivityId(id, "intermediateCatchEvent"));
+                .filter(e -> e.getActivityId().equals("beforeCatchEvent"))
+                .map(Execution::getId)
+                .forEach(id -> changeActivityStateBuilder.moveExecutionToActivityId(id, "intermediateCatchEvent"));
         changeActivityStateBuilder.changeState();
 
         allExecutions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
         executionsByProcessInstance = groupListContentBy(allExecutions, Execution::getProcessInstanceId);
-        assertEquals(2, executionsByProcessInstance.size());
+        assertThat(executionsByProcessInstance).hasSize(2);
 
         checkWaitStateForMultipleProcessesWithSimpleEventCatch(executionsByProcessInstance);
 
@@ -3160,7 +3198,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         //Both processes should be on the final task execution
         allExecutions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
         executionsByProcessInstance = groupListContentBy(allExecutions, Execution::getProcessInstanceId);
-        assertEquals(2, executionsByProcessInstance.size());
+        assertThat(executionsByProcessInstance).hasSize(2);
 
         checkFinalStateForMultipleProcessesWithSimpleEventCatch(executionsByProcessInstance);
 
@@ -3178,77 +3216,81 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         List<Execution> allExecutions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
         Map<String, List<Execution>> executionsByProcessInstance = groupListContentBy(allExecutions, Execution::getProcessInstanceId);
-        assertEquals(2, executionsByProcessInstance.size());
+        assertThat(executionsByProcessInstance).hasSize(2);
 
         checkInitialStateForMultipleProcessesWithSimpleEventCatch(executionsByProcessInstance);
 
         //Move one process to the eventCatch
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance1.getId())
-            .moveActivityIdTo("beforeCatchEvent", "intermediateCatchEvent")
-            .changeState();
+                .processInstanceId(processInstance1.getId())
+                .moveActivityIdTo("beforeCatchEvent", "intermediateCatchEvent")
+                .changeState();
 
         allExecutions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
         executionsByProcessInstance = groupListContentBy(allExecutions, Execution::getProcessInstanceId);
-        assertEquals(2, executionsByProcessInstance.size());
+        assertThat(executionsByProcessInstance).hasSize(2);
 
         //ProcessInstance1 waiting for event
         String processId = processInstance1.getId();
         List<Execution> executions = executionsByProcessInstance.get(processId);
         Map<String, List<Execution>> classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
-        assertEquals(1, classifiedExecutions.size());
-        assertEquals(1, classifiedExecutions.get("intermediateCatchEvent").size());
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processId).list();
-        assertTrue(tasks.isEmpty());
+        assertThat(tasks).isEmpty();
+        ;
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processId).list();
         Map<String, List<EventSubscription>> classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
-        assertEquals(1, classifiedEventSubscriptions.get("intermediateCatchEvent").size());
+        assertThat(classifiedEventSubscriptions.get("intermediateCatchEvent")).hasSize(1);
 
         //processInstance2 Execution still on initial state
         processId = processInstance2.getId();
         executions = executionsByProcessInstance.get(processId);
         classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
-        assertEquals(1, classifiedExecutions.size());
-        assertNotNull(classifiedExecutions.get("beforeCatchEvent"));
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("beforeCatchEvent")).isNotNull();
         tasks = taskService.createTaskQuery().processInstanceId(processId).list();
         Map<String, List<Task>> classifiedTasks = groupListContentBy(tasks, Task::getTaskDefinitionKey);
-        assertEquals(1, classifiedTasks.get("beforeCatchEvent").size());
+        assertThat(classifiedTasks.get("beforeCatchEvent")).hasSize(1);
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processId).list();
         classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
-        assertTrue(classifiedEventSubscriptions.isEmpty());
+        assertThat(classifiedEventSubscriptions).isEmpty();
+        ;
 
         //Trigger signal
         runtimeService.signalEventReceived("someSignal");
 
         //Move the second process to the eventCatch
         runtimeService.createChangeActivityStateBuilder()
-            .processInstanceId(processInstance2.getId())
-            .moveActivityIdTo("beforeCatchEvent", "intermediateCatchEvent")
-            .changeState();
+                .processInstanceId(processInstance2.getId())
+                .moveActivityIdTo("beforeCatchEvent", "intermediateCatchEvent")
+                .changeState();
 
         //ProcessInstance1 is on the postEvent task
         processId = processInstance1.getId();
         executions = runtimeService.createExecutionQuery().processInstanceId(processId).onlyChildExecutions().list();
         classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
-        assertEquals(1, classifiedExecutions.size());
-        assertEquals(1, classifiedExecutions.get("afterCatchEvent").size());
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("afterCatchEvent")).hasSize(1);
         tasks = taskService.createTaskQuery().processInstanceId(processId).list();
         classifiedTasks = groupListContentBy(tasks, Task::getTaskDefinitionKey);
-        assertEquals(1, classifiedTasks.get("afterCatchEvent").size());
+        assertThat(classifiedTasks.get("afterCatchEvent")).hasSize(1);
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processId).list();
-        assertTrue(eventSubscriptions.isEmpty());
+        assertThat(eventSubscriptions).isEmpty();
+        ;
 
         //ProcessInstance2 is waiting for the event
         processId = processInstance2.getId();
         executions = runtimeService.createExecutionQuery().processInstanceId(processId).onlyChildExecutions().list();
         classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
-        assertEquals(1, classifiedExecutions.size());
-        assertEquals(1, classifiedExecutions.get("intermediateCatchEvent").size());
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
         tasks = taskService.createTaskQuery().processInstanceId(processId).list();
-        assertTrue(tasks.isEmpty());
+        assertThat(tasks).isEmpty();
+        ;
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processId).list();
         classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
-        assertEquals(1, classifiedEventSubscriptions.get("intermediateCatchEvent").size());
+        assertThat(classifiedEventSubscriptions.get("intermediateCatchEvent")).hasSize(1);
 
         //Fire the event once more
         runtimeService.signalEventReceived("someSignal");
@@ -3256,7 +3298,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         //Both process should be on the postEvent task execution
         allExecutions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
         executionsByProcessInstance = groupListContentBy(allExecutions, Execution::getProcessInstanceId);
-        assertEquals(2, executionsByProcessInstance.size());
+        assertThat(executionsByProcessInstance).hasSize(2);
 
         checkFinalStateForMultipleProcessesWithSimpleEventCatch(executionsByProcessInstance);
 
@@ -3274,85 +3316,89 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         List<Execution> allExecutions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
         Map<String, List<Execution>> executionsByProcessInstance = groupListContentBy(allExecutions, Execution::getProcessInstanceId);
-        assertEquals(2, executionsByProcessInstance.size());
+        assertThat(executionsByProcessInstance).hasSize(2);
 
         checkInitialStateForMultipleProcessesWithSimpleEventCatch(executionsByProcessInstance);
 
         //Move one execution to the event catch
         String executionId = executionsByProcessInstance.get(processInstance1.getId()).stream()
-            .filter(e -> e.getActivityId().equals("beforeCatchEvent"))
-            .findFirst()
-            .map(Execution::getId)
-            .get();
+                .filter(e -> e.getActivityId().equals("beforeCatchEvent"))
+                .findFirst()
+                .map(Execution::getId)
+                .get();
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionToActivityId(executionId, "intermediateCatchEvent")
-            .changeState();
+                .moveExecutionToActivityId(executionId, "intermediateCatchEvent")
+                .changeState();
 
         allExecutions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
         executionsByProcessInstance = groupListContentBy(allExecutions, Execution::getProcessInstanceId);
-        assertEquals(2, executionsByProcessInstance.size());
+        assertThat(executionsByProcessInstance).hasSize(2);
 
         //ProcessInstance1 waiting for event
         String processId = processInstance1.getId();
         List<Execution> executions = executionsByProcessInstance.get(processId);
         Map<String, List<Execution>> classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
-        assertEquals(1, classifiedExecutions.size());
-        assertEquals(1, classifiedExecutions.get("intermediateCatchEvent").size());
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processId).list();
-        assertTrue(tasks.isEmpty());
+        assertThat(tasks).isEmpty();
+        ;
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processId).list();
         Map<String, List<EventSubscription>> classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
-        assertEquals(1, classifiedEventSubscriptions.get("intermediateCatchEvent").size());
+        assertThat(classifiedEventSubscriptions.get("intermediateCatchEvent")).hasSize(1);
 
         //processInstance2 Execution still on initial state
         processId = processInstance2.getId();
         executions = executionsByProcessInstance.get(processId);
         classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
-        assertEquals(1, classifiedExecutions.size());
-        assertNotNull(classifiedExecutions.get("beforeCatchEvent"));
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("beforeCatchEvent")).isNotNull();
         tasks = taskService.createTaskQuery().processInstanceId(processId).list();
         Map<String, List<Task>> classifiedTasks = groupListContentBy(tasks, Task::getTaskDefinitionKey);
-        assertEquals(1, classifiedTasks.get("beforeCatchEvent").size());
+        assertThat(classifiedTasks.get("beforeCatchEvent")).hasSize(1);
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processId).list();
         classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
-        assertTrue(classifiedEventSubscriptions.isEmpty());
+        assertThat(classifiedEventSubscriptions).isEmpty();
+        ;
 
         //Trigger signal
         runtimeService.signalEventReceived("someSignal");
 
         //Move the second process to the eventCatch
         executionId = executionsByProcessInstance.get(processInstance2.getId()).stream()
-            .filter(e -> e.getActivityId().equals("beforeCatchEvent"))
-            .findFirst()
-            .map(Execution::getId)
-            .get();
+                .filter(e -> e.getActivityId().equals("beforeCatchEvent"))
+                .findFirst()
+                .map(Execution::getId)
+                .get();
         runtimeService.createChangeActivityStateBuilder()
-            .moveExecutionToActivityId(executionId, "intermediateCatchEvent")
-            .changeState();
+                .moveExecutionToActivityId(executionId, "intermediateCatchEvent")
+                .changeState();
 
         //ProcessInstance1 is on the postEvent task
         processId = processInstance1.getId();
         executions = runtimeService.createExecutionQuery().processInstanceId(processId).onlyChildExecutions().list();
         classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
-        assertEquals(1, classifiedExecutions.size());
-        assertEquals(1, classifiedExecutions.get("afterCatchEvent").size());
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("afterCatchEvent")).hasSize(1);
         tasks = taskService.createTaskQuery().processInstanceId(processId).list();
         classifiedTasks = groupListContentBy(tasks, Task::getTaskDefinitionKey);
-        assertEquals(1, classifiedTasks.get("afterCatchEvent").size());
+        assertThat(classifiedTasks.get("afterCatchEvent")).hasSize(1);
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processId).list();
-        assertTrue(eventSubscriptions.isEmpty());
+        assertThat(eventSubscriptions).isEmpty();
+        ;
 
         //ProcessInstance2 is waiting for the event
         processId = processInstance2.getId();
         executions = runtimeService.createExecutionQuery().processInstanceId(processId).onlyChildExecutions().list();
         classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
-        assertEquals(1, classifiedExecutions.size());
-        assertEquals(1, classifiedExecutions.get("intermediateCatchEvent").size());
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
         tasks = taskService.createTaskQuery().processInstanceId(processId).list();
-        assertTrue(tasks.isEmpty());
+        assertThat(tasks).isEmpty();
+        ;
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processId).list();
         classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
-        assertEquals(1, classifiedEventSubscriptions.get("intermediateCatchEvent").size());
+        assertThat(classifiedEventSubscriptions.get("intermediateCatchEvent")).hasSize(1);
 
         //Fire the event once more
         runtimeService.signalEventReceived("someSignal");
@@ -3360,7 +3406,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         //Both process should be on the postEvent task execution
         allExecutions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
         executionsByProcessInstance = groupListContentBy(allExecutions, Execution::getProcessInstanceId);
-        assertEquals(2, executionsByProcessInstance.size());
+        assertThat(executionsByProcessInstance).hasSize(2);
 
         checkFinalStateForMultipleProcessesWithSimpleEventCatch(executionsByProcessInstance);
 


### PR DESCRIPTION
All test files in the `org.flowable.engine.test.api.runtime.changestate` package are included.

Continuing quest to use only a single style in each file and in the module.

