### PR TITLE
Change the posted value of people/group fields from userid/groupid to user/group object when save/complete a task to match the backend api's need

### DIFF
--- a/modules/flowable-ui-task/flowable-ui-task-app/src/main/resources/static/workflow/scripts/controllers/render-form.js
+++ b/modules/flowable-ui-task/flowable-ui-task-app/src/main/resources/static/workflow/scripts/controllers/render-form.js
@@ -740,7 +740,7 @@ angular.module('flowableApp')
                             postData.values[field.id] = field.value.getFullYear() + '-' + (field.value.getMonth() + 1) + '-' + field.value.getDate();
 
                         } else if ((field.type === 'people' || field.type === 'functional-group') && field.value) {
-                            postData.values[field.id] = field.value.id;
+                            postData.values[field.id] = field.value;
                         } else {
                             postData.values[field.id] = field.value;
                         }


### PR DESCRIPTION
In the flowable-task ui, only the user id or group id will be sent to the backend api when a user save or complete a task that a people or group field is used in the form. But the backend service will check the posted data type, it will discard the data if the data type is not a Map. So the selected user or group can not be set to the process variables.  

#### Check List:
* Unit tests: NO
* Documentation: NO
