### PR TITLE
Use assertj fluent style in flowable-engine.

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/AbstractProcessInstanceMigrationTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/AbstractProcessInstanceMigrationTest.java
@@ -27,39 +27,50 @@ import org.flowable.task.api.history.HistoricTaskInstance;
 
 public class AbstractProcessInstanceMigrationTest extends PluggableFlowableTestCase {
 
-    protected void checkActivityInstances(ProcessDefinition processDefinition, ProcessInstance processInstance, String activityType, String... expectedActivityIds) {
+    protected void checkActivityInstances(ProcessDefinition processDefinition, ProcessInstance processInstance, String activityType,
+            String... expectedActivityIds) {
         List<HistoricActivityInstance> historicTaskExecutions = historyService.createHistoricActivityInstanceQuery()
-            .processInstanceId(processInstance.getId())
-            .activityType(activityType)
-            .list();
-        assertThat(historicTaskExecutions).extracting(HistoricActivityInstance::getActivityId).containsExactlyInAnyOrder(expectedActivityIds);
-        assertThat(historicTaskExecutions).extracting(HistoricActivityInstance::getProcessDefinitionId).containsOnly(processDefinition.getId());
+                .processInstanceId(processInstance.getId())
+                .activityType(activityType)
+                .list();
+        assertThat(historicTaskExecutions)
+                .extracting(HistoricActivityInstance::getActivityId)
+                .containsExactlyInAnyOrder(expectedActivityIds);
+        assertThat(historicTaskExecutions)
+                .extracting(HistoricActivityInstance::getProcessDefinitionId)
+                .containsOnly(processDefinition.getId());
         List<ActivityInstance> activityInstances = runtimeService.createActivityInstanceQuery()
-            .processInstanceId(processInstance.getId())
-            .activityType(activityType)
-            .list();
+                .processInstanceId(processInstance.getId())
+                .activityType(activityType)
+                .list();
         if (runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count() == 1) {
-            assertThat(activityInstances).extracting(ActivityInstance::getActivityId).containsExactlyInAnyOrder(expectedActivityIds);
+            assertThat(activityInstances)
+                    .extracting(ActivityInstance::getActivityId)
+                    .containsExactlyInAnyOrder(expectedActivityIds);
             assertThat(activityInstances).extracting(ActivityInstance::getProcessDefinitionId).containsOnly(processDefinition.getId());
             activityInstances.forEach(
-                activityInstance -> {
-                    HistoricActivityInstance historicActivityInstance = historyService.createHistoricActivityInstanceQuery()
-                        .activityInstanceId(activityInstance.getId()).singleResult();
-                    assertThat(activityInstance).isEqualToComparingFieldByField(historicActivityInstance);
-                }
+                    activityInstance -> {
+                        HistoricActivityInstance historicActivityInstance = historyService.createHistoricActivityInstanceQuery()
+                                .activityInstanceId(activityInstance.getId()).singleResult();
+                        assertThat(activityInstance).isEqualToComparingFieldByField(historicActivityInstance);
+                    }
             );
         } else {
             assertThat(activityInstances).isEmpty();
         }
     }
 
-    protected void checkTaskInstance(ProcessDefinition processDefinition, ProcessInstance processInstance, String... expectestTaskDefinitionKeys) {
+    protected void checkTaskInstance(ProcessDefinition processDefinition, ProcessInstance processInstance, String... expectedTaskDefinitionKeys) {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             List<HistoricTaskInstance> historicTasks = historyService.createHistoricTaskInstanceQuery()
-                .processInstanceId(processInstance.getId())
-                .list();
-            assertThat(historicTasks).extracting(HistoricTaskInstance::getTaskDefinitionKey).containsExactlyInAnyOrder(expectestTaskDefinitionKeys);
-            assertThat(historicTasks).extracting(HistoricTaskInstance::getProcessDefinitionId).containsOnly(processDefinition.getId());
+                    .processInstanceId(processInstance.getId())
+                    .list();
+            assertThat(historicTasks)
+                    .extracting(HistoricTaskInstance::getTaskDefinitionKey)
+                    .containsExactlyInAnyOrder(expectedTaskDefinitionKeys);
+            assertThat(historicTasks)
+                    .extracting(HistoricTaskInstance::getProcessDefinitionId)
+                    .containsOnly(processDefinition.getId());
         }
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationBatchTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationBatchTest.java
@@ -10,19 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.flowable.engine.test.api.runtime.migration;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationBatchTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationBatchTest.java
@@ -10,6 +10,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.flowable.engine.test.api.runtime.migration;
 
@@ -60,7 +72,8 @@ public class ProcessInstanceMigrationBatchTest extends PluggableFlowableTestCase
     @Test
     public void testProcessMigrationBatchMissingMapping() {
         // Deploy first version of the process
-        ProcessDefinition version1ProcessDef = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/two-tasks-simple-process.bpmn20.xml");
+        ProcessDefinition version1ProcessDef = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/two-tasks-simple-process.bpmn20.xml");
 
         // Start and instance of the recent first version of the process for migration and one for reference
         ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("MP");
@@ -79,24 +92,25 @@ public class ProcessInstanceMigrationBatchTest extends PluggableFlowableTestCase
         assertThat(task.getProcessDefinitionId()).isEqualTo(version1ProcessDef.getId());
 
         //Deploy second version of the process
-        ProcessDefinition version2ProcessDef = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition version2ProcessDef = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
 
         List<ProcessDefinition> processDefinitions = repositoryService.createProcessDefinitionQuery()
-            .processDefinitionKey("MP")
-            .list();
+                .processDefinitionKey("MP")
+                .list();
 
-        assertEquals(2, processDefinitions.size());
         processDefinitions.sort(Comparator.comparingInt(ProcessDefinition::getVersion));
-        assertEquals(processDefinitions.get(0).getId(), version1ProcessDef.getId());
-        assertEquals(processDefinitions.get(1).getId(), version2ProcessDef.getId());
+        assertThat(processDefinitions)
+                .extracting(ProcessDefinition::getId)
+                .containsExactly(version1ProcessDef.getId(), version2ProcessDef.getId());
 
         // Prepare the process Instance migration builder as usual
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(version2ProcessDef.getId());
+                .migrateToProcessDefinition(version2ProcessDef.getId());
 
         // Try batch migrate the process instances
         Batch migrationBatch = processInstanceMigrationBuilder.batchMigrateProcessInstances(version1ProcessDef.getId());
-        assertTrue(JobTestHelper.areJobsAvailable(managementService));
+        assertThat(JobTestHelper.areJobsAvailable(managementService)).isTrue();
 
         // Confirm the batch is not finished
         ProcessInstanceBatchMigrationResult migrationResult = processMigrationService.getResultsOfBatchProcessInstanceMigration(migrationBatch.getId());
@@ -105,10 +119,10 @@ public class ProcessInstanceMigrationBatchTest extends PluggableFlowableTestCase
         assertThat(migrationResult).isNotNull();
         assertThat(migrationResult.getBatchId()).isEqualTo(migrationBatch.getId());
         assertThat(migrationResult.getStatus()).isEqualTo(ProcessInstanceBatchMigrationResult.STATUS_IN_PROGRESS);
-        assertThat(migrationResult.getAllMigrationParts().size()).isEqualTo(2L);
-        assertThat(migrationResult.getWaitingMigrationParts().size()).isEqualTo(2L);
-        assertThat(migrationResult.getSuccessfulMigrationParts().size()).isEqualTo(0L);
-        assertThat(migrationResult.getFailedMigrationParts().size()).isEqualTo(0L);
+        assertThat(migrationResult.getAllMigrationParts()).hasSize(2);
+        assertThat(migrationResult.getWaitingMigrationParts()).hasSize(2);
+        assertThat(migrationResult.getSuccessfulMigrationParts()).isEmpty();
+        assertThat(migrationResult.getFailedMigrationParts()).isEmpty();
 
         for (ProcessInstanceBatchMigrationPartResult part : migrationResult.getAllMigrationParts()) {
             assertThat(part.getStatus()).isEqualTo(ProcessInstanceBatchMigrationResult.STATUS_WAITING);
@@ -117,8 +131,8 @@ public class ProcessInstanceMigrationBatchTest extends PluggableFlowableTestCase
 
         // Start async executor to process the batches
         JobTestHelper.waitForJobExecutorToProcessAllJobs(processEngineConfiguration, managementService, 1000L, 500L, true);
-        assertFalse(JobTestHelper.areJobsAvailable(managementService));
-        
+        assertThat(JobTestHelper.areJobsAvailable(managementService)).isFalse();
+
         List<Job> timerJobs = managementService.createTimerJobQuery().handlerType(ProcessInstanceMigrationStatusJobHandler.TYPE).list();
         for (Job timerJob : timerJobs) {
             Job executableJob = managementService.moveTimerToExecutableJob(timerJob.getId());
@@ -132,10 +146,10 @@ public class ProcessInstanceMigrationBatchTest extends PluggableFlowableTestCase
         assertThat(migrationResult).isNotNull();
         assertThat(migrationResult.getBatchId()).isEqualTo(migrationBatch.getId());
         assertThat(migrationResult.getStatus()).isEqualTo(ProcessInstanceBatchMigrationResult.STATUS_COMPLETED);
-        assertThat(migrationResult.getAllMigrationParts().size()).isEqualTo(2L);
-        assertThat(migrationResult.getWaitingMigrationParts().size()).isEqualTo(0L);
-        assertThat(migrationResult.getSuccessfulMigrationParts().size()).isEqualTo(0L);
-        assertThat(migrationResult.getFailedMigrationParts().size()).isEqualTo(2L);
+        assertThat(migrationResult.getAllMigrationParts()).hasSize(2);
+        assertThat(migrationResult.getWaitingMigrationParts()).isEmpty();
+        assertThat(migrationResult.getSuccessfulMigrationParts()).isEmpty();
+        assertThat(migrationResult.getFailedMigrationParts()).hasSize(2);
 
         for (ProcessInstanceBatchMigrationPartResult part : migrationResult.getAllMigrationParts()) {
             assertThat(part.getStatus()).isEqualTo(ProcessInstanceBatchMigrationResult.STATUS_COMPLETED);
@@ -162,7 +176,8 @@ public class ProcessInstanceMigrationBatchTest extends PluggableFlowableTestCase
     @Test
     public void testProcessMigrationBatchPartialMissingMapping() {
         // Deploy first version of the process
-        ProcessDefinition version1ProcessDef = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/two-tasks-simple-process.bpmn20.xml");
+        ProcessDefinition version1ProcessDef = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/two-tasks-simple-process.bpmn20.xml");
 
         //Start and instance of the recent first version of the process for migration and one for reference
         ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("MP");
@@ -179,25 +194,26 @@ public class ProcessInstanceMigrationBatchTest extends PluggableFlowableTestCase
         assertThat(task.getProcessDefinitionId()).isEqualTo(version1ProcessDef.getId());
 
         // Deploy second version of the process
-        ProcessDefinition version2ProcessDef = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition version2ProcessDef = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
 
         List<ProcessDefinition> processDefinitions = repositoryService.createProcessDefinitionQuery()
-            .processDefinitionKey("MP")
-            .list();
+                .processDefinitionKey("MP")
+                .list();
 
-        assertEquals(2, processDefinitions.size());
+        assertThat(processDefinitions).hasSize(2);
         processDefinitions.sort(Comparator.comparingInt(ProcessDefinition::getVersion));
-        
-        assertEquals(processDefinitions.get(0).getId(), version1ProcessDef.getId());
-        assertEquals(processDefinitions.get(1).getId(), version2ProcessDef.getId());
+
+        assertThat(version1ProcessDef.getId()).isEqualTo(processDefinitions.get(0).getId());
+        assertThat(version2ProcessDef.getId()).isEqualTo(processDefinitions.get(1).getId());
 
         // Prepare the process Instance migration builder as usual
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-                        .migrateToProcessDefinition(version2ProcessDef.getId()); 
+                .migrateToProcessDefinition(version2ProcessDef.getId());
 
         // Try batch migrate the process instances
         Batch migrationBatch = processInstanceMigrationBuilder.batchMigrateProcessInstances(version1ProcessDef.getId());
-        assertTrue(JobTestHelper.areJobsAvailable(managementService));
+        assertThat(JobTestHelper.areJobsAvailable(managementService)).isTrue();
 
         //Confirm the batch is not finished
         ProcessInstanceBatchMigrationResult migrationResult = processMigrationService.getResultsOfBatchProcessInstanceMigration(migrationBatch.getId());
@@ -206,10 +222,10 @@ public class ProcessInstanceMigrationBatchTest extends PluggableFlowableTestCase
         assertThat(migrationResult).isNotNull();
         assertThat(migrationResult.getBatchId()).isEqualTo(migrationBatch.getId());
         assertThat(migrationResult.getStatus()).isEqualTo(ProcessInstanceBatchMigrationResult.STATUS_IN_PROGRESS);
-        assertThat(migrationResult.getAllMigrationParts().size()).isEqualTo(2L);
-        assertThat(migrationResult.getWaitingMigrationParts().size()).isEqualTo(2L);
-        assertThat(migrationResult.getSuccessfulMigrationParts().size()).isEqualTo(0L);
-        assertThat(migrationResult.getFailedMigrationParts().size()).isEqualTo(0L);
+        assertThat(migrationResult.getAllMigrationParts()).hasSize(2);
+        assertThat(migrationResult.getWaitingMigrationParts()).hasSize(2);
+        assertThat(migrationResult.getSuccessfulMigrationParts()).isEmpty();
+        assertThat(migrationResult.getFailedMigrationParts()).isEmpty();
 
         for (ProcessInstanceBatchMigrationPartResult part : migrationResult.getAllMigrationParts()) {
             assertThat(part.getStatus()).isEqualTo(ProcessInstanceBatchMigrationResult.STATUS_WAITING);
@@ -218,8 +234,8 @@ public class ProcessInstanceMigrationBatchTest extends PluggableFlowableTestCase
 
         // Start async executor to process the batches
         JobTestHelper.waitForJobExecutorToProcessAllJobs(processEngineConfiguration, managementService, 5000L, 500L, true);
-        assertFalse(JobTestHelper.areJobsAvailable(managementService));
-        
+        assertThat(JobTestHelper.areJobsAvailable(managementService)).isFalse();
+
         List<Job> timerJobs = managementService.createTimerJobQuery().handlerType(ProcessInstanceMigrationStatusJobHandler.TYPE).list();
         for (Job timerJob : timerJobs) {
             Job executableJob = managementService.moveTimerToExecutableJob(timerJob.getId());
@@ -232,10 +248,10 @@ public class ProcessInstanceMigrationBatchTest extends PluggableFlowableTestCase
         assertThat(migrationResult).isNotNull();
         assertThat(migrationResult.getBatchId()).isEqualTo(migrationBatch.getId());
         assertThat(migrationResult.getStatus()).isEqualTo(ProcessInstanceBatchMigrationResult.STATUS_COMPLETED);
-        assertThat(migrationResult.getAllMigrationParts().size()).isEqualTo(2L);
-        assertThat(migrationResult.getWaitingMigrationParts().size()).isEqualTo(0L);
-        assertThat(migrationResult.getSuccessfulMigrationParts().size()).isEqualTo(1L);
-        assertThat(migrationResult.getFailedMigrationParts().size()).isEqualTo(1L);
+        assertThat(migrationResult.getAllMigrationParts()).hasSize(2);
+        assertThat(migrationResult.getWaitingMigrationParts()).isEmpty();
+        assertThat(migrationResult.getSuccessfulMigrationParts()).hasSize(1);
+        assertThat(migrationResult.getFailedMigrationParts()).hasSize(1);
 
         for (ProcessInstanceBatchMigrationPartResult part : migrationResult.getSuccessfulMigrationParts()) {
             assertThat(part.getStatus()).isEqualTo(ProcessInstanceBatchMigrationResult.STATUS_COMPLETED);
@@ -255,7 +271,7 @@ public class ProcessInstanceMigrationBatchTest extends PluggableFlowableTestCase
         assertThat(task.getProcessDefinitionId()).isEqualTo(version1ProcessDef.getId());
         task = taskService.createTaskQuery().processInstanceId(processInstance2.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("userTask1Id");
-        
+
         // This task migrated
         assertThat(task.getProcessDefinitionId()).isEqualTo(version2ProcessDef.getId());
 
@@ -270,7 +286,8 @@ public class ProcessInstanceMigrationBatchTest extends PluggableFlowableTestCase
     @Test
     public void testProcessMigrationBatchTwentyMixedSuccessAndFails() {
         // Deploy first version of the process
-        ProcessDefinition version1ProcessDef = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/two-tasks-simple-process.bpmn20.xml");
+        ProcessDefinition version1ProcessDef = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/two-tasks-simple-process.bpmn20.xml");
 
         // Instances that will validate and migrate properly
         List<String> successInstances = new ArrayList<>();
@@ -281,14 +298,14 @@ public class ProcessInstanceMigrationBatchTest extends PluggableFlowableTestCase
         for (int i = 0; i < 12; i++) {
             successInstances.add(runtimeService.startProcessInstanceByKey("MP").getId());
         }
-        
+
         for (int i = 0; i < 8; i++) {
             failedInstances.add(runtimeService.startProcessInstanceByKey("MP").getId());
         }
-        
+
         List<String> allInstances = new ArrayList<>(successInstances);
         allInstances.addAll(failedInstances);
-        
+
         // Set the instances to fail in a state where they won't map properly during validation and migration
         for (String processInstanceId : failedInstances) {
             Task task = taskService.createTaskQuery().processInstanceId(processInstanceId).singleResult();
@@ -296,26 +313,27 @@ public class ProcessInstanceMigrationBatchTest extends PluggableFlowableTestCase
         }
 
         // Deploy second version of the process
-        ProcessDefinition version2ProcessDef = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition version2ProcessDef = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
 
         // Prepare the process instance migration builder
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService
-                        .createProcessInstanceMigrationBuilder()
-                        .migrateToProcessDefinition(version2ProcessDef.getId());
-        
+                .createProcessInstanceMigrationBuilder()
+                .migrateToProcessDefinition(version2ProcessDef.getId());
+
         // Migrate the processes
         Batch migrationBatch = processInstanceMigrationBuilder.batchMigrateProcessInstances(version1ProcessDef.getId());
-        assertTrue(JobTestHelper.areJobsAvailable(managementService));
+        assertThat(JobTestHelper.areJobsAvailable(managementService)).isTrue();
 
         // Partial Results - migration inProgress
         ProcessInstanceBatchMigrationResult migrationResult = processMigrationService.getResultsOfBatchProcessInstanceMigration(migrationBatch.getId());
         assertThat(migrationResult).isNotNull();
         assertThat(migrationResult.getBatchId()).isEqualTo(migrationBatch.getId());
         assertThat(migrationResult.getStatus()).isEqualTo(ProcessInstanceBatchMigrationResult.STATUS_IN_PROGRESS);
-        assertThat(migrationResult.getAllMigrationParts().size()).isEqualTo(successInstances.size() + failedInstances.size());
-        assertThat(migrationResult.getWaitingMigrationParts().size()).isEqualTo(successInstances.size() + failedInstances.size());
-        assertThat(migrationResult.getSuccessfulMigrationParts().size()).isEqualTo(0L);
-        assertThat(migrationResult.getFailedMigrationParts().size()).isEqualTo(0L);
+        assertThat(migrationResult.getAllMigrationParts()).hasSize(successInstances.size() + failedInstances.size());
+        assertThat(migrationResult.getWaitingMigrationParts()).hasSize(successInstances.size() + failedInstances.size());
+        assertThat(migrationResult.getSuccessfulMigrationParts()).isEmpty();
+        assertThat(migrationResult.getFailedMigrationParts()).isEmpty();
 
         // Each batch part is inProgress
         for (ProcessInstanceBatchMigrationPartResult part : migrationResult.getAllMigrationParts()) {
@@ -325,8 +343,8 @@ public class ProcessInstanceMigrationBatchTest extends PluggableFlowableTestCase
 
         // Start async executor to process the batches
         JobTestHelper.waitForJobExecutorToProcessAllJobs(processEngineConfiguration, managementService, 10000L, 500L, true);
-        assertFalse(JobTestHelper.areJobsAvailable(managementService));
-        
+        assertThat(JobTestHelper.areJobsAvailable(managementService)).isFalse();
+
         List<Job> timerJobs = managementService.createTimerJobQuery().handlerType(ProcessInstanceMigrationStatusJobHandler.TYPE).list();
         for (Job timerJob : timerJobs) {
             Job executableJob = managementService.moveTimerToExecutableJob(timerJob.getId());
@@ -338,10 +356,10 @@ public class ProcessInstanceMigrationBatchTest extends PluggableFlowableTestCase
         assertThat(migrationResult).isNotNull();
         assertThat(migrationResult.getBatchId()).isEqualTo(migrationBatch.getId());
         assertThat(migrationResult.getStatus()).isEqualTo(ProcessInstanceBatchMigrationResult.STATUS_COMPLETED);
-        assertThat(migrationResult.getAllMigrationParts().size()).isEqualTo(successInstances.size() + failedInstances.size());
-        assertThat(migrationResult.getWaitingMigrationParts().size()).isEqualTo(0L);
-        assertThat(migrationResult.getSuccessfulMigrationParts().size()).isEqualTo(successInstances.size());
-        assertThat(migrationResult.getFailedMigrationParts().size()).isEqualTo(failedInstances.size());
+        assertThat(migrationResult.getAllMigrationParts()).hasSize(successInstances.size() + failedInstances.size());
+        assertThat(migrationResult.getWaitingMigrationParts()).isEmpty();
+        assertThat(migrationResult.getSuccessfulMigrationParts()).hasSize(successInstances.size());
+        assertThat(migrationResult.getFailedMigrationParts()).hasSize(failedInstances.size());
 
         for (ProcessInstanceBatchMigrationPartResult part : migrationResult.getSuccessfulMigrationParts()) {
             assertThat(part.getStatus()).isEqualTo(ProcessInstanceBatchMigrationResult.STATUS_COMPLETED);
@@ -354,24 +372,24 @@ public class ProcessInstanceMigrationBatchTest extends PluggableFlowableTestCase
             assertThat(part.getResult()).isEqualTo(ProcessInstanceBatchMigrationResult.RESULT_FAIL);
             assertThat(part.getMigrationMessage()).isEqualTo("Migration Activity mapping missing for activity definition Id:'userTask2Id' or its MI Parent");
         }
-        
+
         List<Batch> searchBatches = managementService.findBatchesBySearchKey(version1ProcessDef.getId());
-        assertThat(searchBatches.size()).isEqualTo(1);
+        assertThat(searchBatches).hasSize(1);
         assertThat(searchBatches.get(0).getId()).isEqualTo(migrationBatch.getId());
         assertThat(searchBatches.get(0).getBatchSearchKey()).isEqualTo(version1ProcessDef.getId());
         assertThat(searchBatches.get(0).getBatchSearchKey2()).isEqualTo(version2ProcessDef.getId());
         assertThat(searchBatches.get(0).getBatchType()).isEqualTo(Batch.PROCESS_MIGRATION_TYPE);
         assertThat(searchBatches.get(0).getCreateTime()).isNotNull();
-        
+
         assertThat(managementService.createBatchQuery().searchKey(version1ProcessDef.getId()).count()).isEqualTo(1);
         assertThat(managementService.createBatchQuery().searchKey(version2ProcessDef.getId()).count()).isEqualTo(0);
         assertThat(managementService.createBatchQuery().searchKey2(version1ProcessDef.getId()).count()).isEqualTo(0);
         assertThat(managementService.createBatchQuery().searchKey2(version2ProcessDef.getId()).count()).isEqualTo(1);
         assertThat(managementService.createBatchQuery().createTimeLowerThan(new Date()).count()).isEqualTo(1);
         assertThat(managementService.createBatchQuery().createTimeHigherThan(new Date()).count()).isEqualTo(0);
-        
+
         List<BatchPart> searchBatchParts = managementService.findBatchPartsByBatchId(migrationBatch.getId());
-        assertThat(searchBatchParts.size()).isEqualTo(20);
+        assertThat(searchBatchParts).hasSize(20);
         for (BatchPart batchPart : searchBatchParts) {
             assertThat(batchPart.getBatchId()).isEqualTo(migrationBatch.getId());
             assertThat(batchPart.getBatchSearchKey()).isEqualTo(version1ProcessDef.getId());
@@ -390,25 +408,25 @@ public class ProcessInstanceMigrationBatchTest extends PluggableFlowableTestCase
             assertThat(task.getTaskDefinitionKey()).isEqualTo("userTask1Id");
             assertThat(task.getProcessDefinitionId()).isEqualTo(version2ProcessDef.getId());
         }
-        
+
         // Confirm the migration of failedParts
         for (String processInstanceId : failedInstances) {
             Task task = taskService.createTaskQuery().processInstanceId(processInstanceId).singleResult();
             assertThat(task.getTaskDefinitionKey()).isEqualTo("userTask2Id");
             assertThat(task.getProcessDefinitionId()).isEqualTo(version1ProcessDef.getId());
         }
-        
+
         // Complete the processes
         for (String processInstanceId : successInstances) {
             completeProcessInstanceTasks(processInstanceId);
             assertProcessEnded(processInstanceId);
         }
-        
+
         for (String processInstanceId : failedInstances) {
             completeProcessInstanceTasks(processInstanceId);
             assertProcessEnded(processInstanceId);
         }
-        
+
         managementService.deleteBatch(migrationBatch.getId());
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationDocumentTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationDocumentTest.java
@@ -42,15 +42,17 @@ public class ProcessInstanceMigrationDocumentTest extends AbstractTestCase {
         String definitionTenantId = "admin";
 
         ActivityMigrationMapping oneToOneMapping = ActivityMigrationMapping.createMappingFor("originalActivity1", "newActivity1")
-            .withLocalVariable("varForNewActivity1", "varValue")
-            .withNewAssignee("kermit");
+                .withLocalVariable("varForNewActivity1", "varValue")
+                .withNewAssignee("kermit");
 
-        ActivityMigrationMapping manyToOneMapping = ActivityMigrationMapping.createMappingFor(Arrays.asList("originalActivity3", "originalActivity4"), "newActivity3")
-            .withLocalVariable("varForNewActivity3", 9876);
+        ActivityMigrationMapping manyToOneMapping = ActivityMigrationMapping
+                .createMappingFor(Arrays.asList("originalActivity3", "originalActivity4"), "newActivity3")
+                .withLocalVariable("varForNewActivity3", 9876);
 
-        ActivityMigrationMapping oneToManyMapping = ActivityMigrationMapping.createMappingFor("originalActivity2", Arrays.asList("newActivity2.1", "newActivity2.2"))
-            .withLocalVariableForAllActivities("var1ForNewActivity2.x", "varValue")
-            .withLocalVariableForAllActivities("var2ForNewActivity2.x", 1234.567);
+        ActivityMigrationMapping oneToManyMapping = ActivityMigrationMapping
+                .createMappingFor("originalActivity2", Arrays.asList("newActivity2.1", "newActivity2.2"))
+                .withLocalVariableForAllActivities("var1ForNewActivity2.x", "varValue")
+                .withLocalVariableForAllActivities("var2ForNewActivity2.x", 1234.567);
 
         HashMap<String, Map<String, Object>> activityLocalVariables = new HashMap<String, Map<String, Object>>() {
 
@@ -95,11 +97,12 @@ public class ProcessInstanceMigrationDocumentTest extends AbstractTestCase {
         String jsonAsStr = IoUtil.readFileAsString("org/flowable/engine/test/api/runtime/migration/completeProcessInstanceMigrationDocument.json");
 
         ProcessInstanceMigrationDocument migrationDocument = ProcessInstanceMigrationDocumentImpl.fromJson(jsonAsStr);
-        assertEquals(definitionId, migrationDocument.getMigrateToProcessDefinitionId());
-        assertEquals(definitionKey, migrationDocument.getMigrateToProcessDefinitionKey());
-        assertEquals(definitionVer, migrationDocument.getMigrateToProcessDefinitionVersion());
-        assertEquals(definitionTenantId, migrationDocument.getMigrateToProcessDefinitionTenantId());
-        assertThat(migrationDocument.getActivityMigrationMappings()).usingFieldByFieldElementComparator().containsExactly(oneToOneMapping, oneToManyMapping, manyToOneMapping);
+        assertThat(migrationDocument.getMigrateToProcessDefinitionId()).isEqualTo(definitionId);
+        assertThat(migrationDocument.getMigrateToProcessDefinitionKey()).isEqualTo(definitionKey);
+        assertThat(migrationDocument.getMigrateToProcessDefinitionVersion()).isEqualTo(definitionVer);
+        assertThat(migrationDocument.getMigrateToProcessDefinitionTenantId()).isEqualTo(definitionTenantId);
+        assertThat(migrationDocument.getActivityMigrationMappings()).usingFieldByFieldElementComparator()
+                .containsExactly(oneToOneMapping, oneToManyMapping, manyToOneMapping);
         assertThat(migrationDocument.getActivitiesLocalVariables()).isEqualTo(activityLocalVariables);
         assertThat(migrationDocument.getProcessInstanceVariables()).isEqualTo(processInstanceVariables);
         assertThat(migrationDocument.getPreUpgradeScript()).isEqualToComparingFieldByField(new Script("groovy", "1+1"));
@@ -167,24 +170,26 @@ public class ProcessInstanceMigrationDocumentTest extends AbstractTestCase {
             }
         };
         ActivityMigrationMapping.OneToOneMapping oneToOneMapping = ActivityMigrationMapping.createMappingFor("originalActivity1", "newActivity1")
-            .withLocalVariable("varForNewActivity1", "varValue")
-            .withNewAssignee("kermit");
-        ActivityMigrationMapping.ManyToOneMapping manyToOneMapping = ActivityMigrationMapping.createMappingFor(Arrays.asList("originalActivity3", "originalActivity4"), "newActivity3")
-            .withLocalVariable("varForNewActivity3", 9876);
-        ActivityMigrationMapping.OneToManyMapping oneToManyMapping = ActivityMigrationMapping.createMappingFor("originalActivity2", Arrays.asList("newActivity2.1", "newActivity2.2"))
-            .withLocalVariablesForActivity("newActivity2.1", varsForNewActivity2_1)
-            .withLocalVariablesForActivity("newActivity2.2", varsForNewActivity2_2);
+                .withLocalVariable("varForNewActivity1", "varValue")
+                .withNewAssignee("kermit");
+        ActivityMigrationMapping.ManyToOneMapping manyToOneMapping = ActivityMigrationMapping
+                .createMappingFor(Arrays.asList("originalActivity3", "originalActivity4"), "newActivity3")
+                .withLocalVariable("varForNewActivity3", 9876);
+        ActivityMigrationMapping.OneToManyMapping oneToManyMapping = ActivityMigrationMapping
+                .createMappingFor("originalActivity2", Arrays.asList("newActivity2.1", "newActivity2.2"))
+                .withLocalVariablesForActivity("newActivity2.1", varsForNewActivity2_1)
+                .withLocalVariablesForActivity("newActivity2.2", varsForNewActivity2_2);
 
         ProcessInstanceMigrationDocument document = new ProcessInstanceMigrationBuilderImpl(null)
-            .migrateToProcessDefinition(definitionId)
-            .preUpgradeScript(new Script("groovy", "1+1"))
-            .postUpgradeScript(new Script("groovy", "2+2"))
-            .addActivityMigrationMapping(oneToOneMapping)
-            .addActivityMigrationMapping(oneToManyMapping)
-            .addActivityMigrationMapping(manyToOneMapping)
-            .withProcessInstanceVariable("processVar1", "varValue1")
-            .withProcessInstanceVariable("processVar2", 456.789)
-            .getProcessInstanceMigrationDocument();
+                .migrateToProcessDefinition(definitionId)
+                .preUpgradeScript(new Script("groovy", "1+1"))
+                .postUpgradeScript(new Script("groovy", "2+2"))
+                .addActivityMigrationMapping(oneToOneMapping)
+                .addActivityMigrationMapping(oneToManyMapping)
+                .addActivityMigrationMapping(manyToOneMapping)
+                .withProcessInstanceVariable("processVar1", "varValue1")
+                .withProcessInstanceVariable("processVar2", 456.789)
+                .getProcessInstanceMigrationDocument();
 
         //Serialize the document as Json
         String serializedDocument = document.asJsonString();
@@ -192,11 +197,12 @@ public class ProcessInstanceMigrationDocumentTest extends AbstractTestCase {
         //DeSerialize the document
         ProcessInstanceMigrationDocument migrationDocument = ProcessInstanceMigrationDocumentImpl.fromJson(serializedDocument);
 
-        assertEquals(definitionId, migrationDocument.getMigrateToProcessDefinitionId());
-        assertNull(migrationDocument.getMigrateToProcessDefinitionKey());
-        assertNull(migrationDocument.getMigrateToProcessDefinitionVersion());
-        assertNull(migrationDocument.getMigrateToProcessDefinitionTenantId());
-        assertThat(migrationDocument.getActivityMigrationMappings()).usingFieldByFieldElementComparator().containsAnyOf(oneToOneMapping, oneToManyMapping, manyToOneMapping);
+        assertThat(migrationDocument.getMigrateToProcessDefinitionId()).isEqualTo(definitionId);
+        assertThat(migrationDocument.getMigrateToProcessDefinitionKey()).isNull();
+        assertThat(migrationDocument.getMigrateToProcessDefinitionVersion()).isNull();
+        assertThat(migrationDocument.getMigrateToProcessDefinitionTenantId()).isNull();
+        assertThat(migrationDocument.getActivityMigrationMappings()).usingFieldByFieldElementComparator()
+                .containsAnyOf(oneToOneMapping, oneToManyMapping, manyToOneMapping);
         assertThat(migrationDocument.getActivitiesLocalVariables()).isEqualTo(activityLocalVariables);
         assertThat(migrationDocument.getProcessInstanceVariables()).isEqualTo(processInstanceVariables);
         assertThat(migrationDocument.getPreUpgradeScript().getLanguage()).isEqualTo("groovy");
@@ -210,10 +216,10 @@ public class ProcessInstanceMigrationDocumentTest extends AbstractTestCase {
         String definitionId = "someProcessId";
 
         ProcessInstanceMigrationDocument document = new ProcessInstanceMigrationBuilderImpl(null)
-            .migrateToProcessDefinition(definitionId)
-            .preUpgradeJavaDelegate("new javadelegate")
-            .postUpgradeJavaDelegate("new post javadelegate")
-            .getProcessInstanceMigrationDocument();
+                .migrateToProcessDefinition(definitionId)
+                .preUpgradeJavaDelegate("new javadelegate")
+                .postUpgradeJavaDelegate("new post javadelegate")
+                .getProcessInstanceMigrationDocument();
 
         //Serialize the document as Json
         String serializedDocument = document.asJsonString();
@@ -221,7 +227,7 @@ public class ProcessInstanceMigrationDocumentTest extends AbstractTestCase {
         //DeSerialize the document
         ProcessInstanceMigrationDocument migrationDocument = ProcessInstanceMigrationDocumentImpl.fromJson(serializedDocument);
 
-        assertEquals(definitionId, migrationDocument.getMigrateToProcessDefinitionId());
+        assertThat(migrationDocument.getMigrateToProcessDefinitionId()).isEqualTo(definitionId);
         assertThat(migrationDocument.getPreUpgradeJavaDelegate()).isEqualTo("new javadelegate");
         assertThat(migrationDocument.getPostUpgradeJavaDelegate()).isEqualTo("new post javadelegate");
     }
@@ -231,10 +237,10 @@ public class ProcessInstanceMigrationDocumentTest extends AbstractTestCase {
         String definitionId = "someProcessId";
 
         ProcessInstanceMigrationDocument document = new ProcessInstanceMigrationBuilderImpl(null)
-            .migrateToProcessDefinition(definitionId)
-            .preUpgradeJavaDelegateExpression("new expression")
-            .postUpgradeJavaDelegateExpression("new post expression")
-            .getProcessInstanceMigrationDocument();
+                .migrateToProcessDefinition(definitionId)
+                .preUpgradeJavaDelegateExpression("new expression")
+                .postUpgradeJavaDelegateExpression("new post expression")
+                .getProcessInstanceMigrationDocument();
 
         //Serialize the document as Json
         String serializedDocument = document.asJsonString();
@@ -242,7 +248,7 @@ public class ProcessInstanceMigrationDocumentTest extends AbstractTestCase {
         //DeSerialize the document
         ProcessInstanceMigrationDocument migrationDocument = ProcessInstanceMigrationDocumentImpl.fromJson(serializedDocument);
 
-        assertEquals(definitionId, migrationDocument.getMigrateToProcessDefinitionId());
+        assertThat(migrationDocument.getMigrateToProcessDefinitionId()).isEqualTo(definitionId);
         assertThat(migrationDocument.getPreUpgradeJavaDelegateExpression()).isEqualTo("new expression");
         assertThat(migrationDocument.getPostUpgradeJavaDelegateExpression()).isEqualTo("new post expression");
     }
@@ -250,49 +256,49 @@ public class ProcessInstanceMigrationDocumentTest extends AbstractTestCase {
     @Test
     void preUpgradeAllowsOneTaskOnly_ScriptExpression() {
         assertThatThrownBy(() -> new ProcessInstanceMigrationBuilderImpl(null)
-            .migrateToProcessDefinition("testProcessDefinition")
-            .preUpgradeScript(new Script("groovy", "1+1"))
-            .preUpgradeJavaDelegateExpression("new Expression()")
-            .getProcessInstanceMigrationDocument()
-        ).
-            isInstanceOf(IllegalArgumentException.class).
-            hasMessage("Pre upgrade expression can't be set when another pre-upgrade task was already specified.");
+                .migrateToProcessDefinition("testProcessDefinition")
+                .preUpgradeScript(new Script("groovy", "1+1"))
+                .preUpgradeJavaDelegateExpression("new Expression()")
+                .getProcessInstanceMigrationDocument()
+        )
+                .isInstanceOf(IllegalArgumentException.class).
+                hasMessage("Pre upgrade expression can't be set when another pre-upgrade task was already specified.");
     }
 
     @Test
     void postUpgradeAllowsOneTaskOnly_ScriptExpression() {
         assertThatThrownBy(() -> new ProcessInstanceMigrationBuilderImpl(null)
-            .migrateToProcessDefinition("testProcessDefinition")
-            .postUpgradeScript(new Script("groovy", "1+1"))
-            .postUpgradeJavaDelegateExpression("new Expression()")
-            .getProcessInstanceMigrationDocument()
-        ).
-            isInstanceOf(IllegalArgumentException.class).
-            hasMessage("Post upgrade expression can't be set when another post-upgrade task was already specified.");
+                .migrateToProcessDefinition("testProcessDefinition")
+                .postUpgradeScript(new Script("groovy", "1+1"))
+                .postUpgradeJavaDelegateExpression("new Expression()")
+                .getProcessInstanceMigrationDocument()
+        )
+                .isInstanceOf(IllegalArgumentException.class).
+                hasMessage("Post upgrade expression can't be set when another post-upgrade task was already specified.");
     }
 
     @Test
     void preUpgradeAllowsOneTaskOnly_ExpressionJavaDelegate() {
         assertThatThrownBy(() -> new ProcessInstanceMigrationBuilderImpl(null)
-            .migrateToProcessDefinition("testProcessDefinition")
-            .preUpgradeScript(new Script("groovy", "1+1"))
-            .preUpgradeJavaDelegate("JavaDelegate")
-            .getProcessInstanceMigrationDocument()
-        ).
-            isInstanceOf(IllegalArgumentException.class).
-            hasMessage("Pre upgrade java delegate can't be set when another pre-upgrade task was already specified.");
+                .migrateToProcessDefinition("testProcessDefinition")
+                .preUpgradeScript(new Script("groovy", "1+1"))
+                .preUpgradeJavaDelegate("JavaDelegate")
+                .getProcessInstanceMigrationDocument()
+        )
+                .isInstanceOf(IllegalArgumentException.class).
+                hasMessage("Pre upgrade java delegate can't be set when another pre-upgrade task was already specified.");
     }
 
     @Test
     void postUpgradeAllowsOneTaskOnly_ExpressionJavaDelegate() {
         assertThatThrownBy(() -> new ProcessInstanceMigrationBuilderImpl(null)
-            .migrateToProcessDefinition("testProcessDefinition")
-            .postUpgradeScript(new Script("groovy", "1+1"))
-            .postUpgradeJavaDelegate("JavaDelegate")
-            .getProcessInstanceMigrationDocument()
-        ).
-            isInstanceOf(IllegalArgumentException.class).
-            hasMessage("Post upgrade java delegate can't be set when another post-upgrade task was already specified.");
+                .migrateToProcessDefinition("testProcessDefinition")
+                .postUpgradeScript(new Script("groovy", "1+1"))
+                .postUpgradeJavaDelegate("JavaDelegate")
+                .getProcessInstanceMigrationDocument()
+        )
+                .isInstanceOf(IllegalArgumentException.class).
+                hasMessage("Post upgrade java delegate can't be set when another post-upgrade task was already specified.");
     }
 
     @Test
@@ -300,32 +306,33 @@ public class ProcessInstanceMigrationDocumentTest extends AbstractTestCase {
 
         String definitionId = "someProcessId";
 
-        try {
-            new ProcessInstanceMigrationBuilderImpl(null)
-                .migrateToProcessDefinition(definitionId)
-                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("originalActivity1", "newActivity1").withLocalVariable("varForNewActivity1", "varValue"))
-                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("originalActivity1", "newActivity2"))
-                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("originalActivity2", Arrays.asList("newActivity1", "newActivity2")))
-                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor(Arrays.asList("originalActivity2", "originalActivity3"), "newActivity3"))
-                .withProcessInstanceVariable("processVar1", "varValue1")
-                .getProcessInstanceMigrationDocument();
-            fail("Should not allow duplicated values in 'from' activity");
-        } catch (FlowableException e) {
-            assertTextPresent("From activity '[originalActivity1, originalActivity2]' is mapped more than once", e.getMessage());
-        }
+        assertThatThrownBy(() ->
+                new ProcessInstanceMigrationBuilderImpl(null)
+                        .migrateToProcessDefinition(definitionId)
+                        .addActivityMigrationMapping(
+                                ActivityMigrationMapping.createMappingFor("originalActivity1", "newActivity1")
+                                        .withLocalVariable("varForNewActivity1", "varValue"))
+                        .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("originalActivity1", "newActivity2"))
+                        .addActivityMigrationMapping(
+                                ActivityMigrationMapping.createMappingFor("originalActivity2", Arrays.asList("newActivity1", "newActivity2")))
+                        .addActivityMigrationMapping(
+                                ActivityMigrationMapping.createMappingFor(Arrays.asList("originalActivity2", "originalActivity3"), "newActivity3"))
+                        .withProcessInstanceVariable("processVar1", "varValue1")
+                        .getProcessInstanceMigrationDocument()
+        )
+                .isInstanceOf(FlowableException.class)
+                .hasMessage("From activity '[originalActivity1, originalActivity2]' is mapped more than once");
     }
 
     @Test
     public void testDeSerializeDuplicatedFromActivity() {
 
-        String jsonAsStr = IoUtil.readFileAsString("org/flowable/engine/test/api/runtime/migration/duplicatedFromActivitiesInFromMappingMigrationDocument.json");
+        String jsonAsStr = IoUtil
+                .readFileAsString("org/flowable/engine/test/api/runtime/migration/duplicatedFromActivitiesInFromMappingMigrationDocument.json");
 
-        try {
-            ProcessInstanceMigrationDocumentImpl.fromJson(jsonAsStr);
-            fail("Should not allow duplicated values in 'from' activity");
-        } catch (FlowableException e) {
-            assertTextPresent("From activity '[originalActivity1, originalActivity2]' is mapped more than once", e.getMessage());
-        }
+        assertThatThrownBy(() -> ProcessInstanceMigrationDocumentImpl.fromJson(jsonAsStr))
+                .isInstanceOf(FlowableException.class)
+                .hasMessage("From activity '[originalActivity1, originalActivity2]' is mapped more than once");
     }
 
     @Test
@@ -339,11 +346,11 @@ public class ProcessInstanceMigrationDocumentTest extends AbstractTestCase {
 
         //Build a process migration document
         ProcessInstanceMigrationDocument document = new ProcessInstanceMigrationBuilderImpl(null)
-            .migrateToProcessDefinition(definitionKey, definitionVer)
-            .withMigrateToProcessDefinitionTenantId(definitionTenantId)
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("originalActivity1", "newActivity1"))
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("originalActivity2", "newActivity2"))
-            .getProcessInstanceMigrationDocument();
+                .migrateToProcessDefinition(definitionKey, definitionVer)
+                .withMigrateToProcessDefinitionTenantId(definitionTenantId)
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("originalActivity1", "newActivity1"))
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("originalActivity2", "newActivity2"))
+                .getProcessInstanceMigrationDocument();
 
         //Serialize the document as Json
         String serializedDocument = document.asJsonString();
@@ -351,10 +358,10 @@ public class ProcessInstanceMigrationDocumentTest extends AbstractTestCase {
         //DeSerialize the document
         ProcessInstanceMigrationDocument migrationDocument = ProcessInstanceMigrationDocumentImpl.fromJson(serializedDocument);
 
-        assertNull(migrationDocument.getMigrateToProcessDefinitionId());
-        assertEquals(definitionKey, migrationDocument.getMigrateToProcessDefinitionKey());
-        assertEquals(definitionVer, migrationDocument.getMigrateToProcessDefinitionVersion());
-        assertEquals(definitionTenantId, migrationDocument.getMigrateToProcessDefinitionTenantId());
+        assertThat(migrationDocument.getMigrateToProcessDefinitionId()).isNull();
+        assertThat(migrationDocument.getMigrateToProcessDefinitionKey()).isEqualTo(definitionKey);
+        assertThat(migrationDocument.getMigrateToProcessDefinitionVersion()).isEqualTo(definitionVer);
+        assertThat(migrationDocument.getMigrateToProcessDefinitionTenantId()).isEqualTo(definitionTenantId);
         assertThat(migrationDocument.getActivityMigrationMappings()).usingFieldByFieldElementComparator().containsExactly(oneToOne1, oneToOne2);
     }
 
@@ -365,9 +372,9 @@ public class ProcessInstanceMigrationDocumentTest extends AbstractTestCase {
         String definitionTenantId = "admin";
 
         ActivityMigrationMapping.OneToOneMapping oneToOne1 = ActivityMigrationMapping.createMappingFor("originalActivity1", "newActivity1")
-            .withLocalVariables(Collections.singletonMap("variableString", "variableValue"));
+                .withLocalVariables(Collections.singletonMap("variableString", "variableValue"));
         ActivityMigrationMapping.OneToOneMapping oneToOne2 = ActivityMigrationMapping.createMappingFor("originalActivity2", "newActivity2")
-            .withLocalVariable("variableDouble", 12345.6789);
+                .withLocalVariable("variableDouble", 12345.6789);
 
         HashMap processInstanceVars = new HashMap<String, Object>() {
 
@@ -379,13 +386,15 @@ public class ProcessInstanceMigrationDocumentTest extends AbstractTestCase {
 
         //Build a process migration document
         ProcessInstanceMigrationDocument document = new ProcessInstanceMigrationBuilderImpl(null)
-            .migrateToProcessDefinition(definitionKey, definitionVer)
-            .withMigrateToProcessDefinitionTenantId(definitionTenantId)
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("originalActivity1", "newActivity1").withLocalVariables(Collections.singletonMap("variableString", "variableValue")))
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("originalActivity2", "newActivity2").withLocalVariable("variableDouble", 12345.6789))
-            .withProcessInstanceVariable("instanceVar1", "stringValue")
-            .withProcessInstanceVariable("instanceVar2", 12345.6789)
-            .getProcessInstanceMigrationDocument();
+                .migrateToProcessDefinition(definitionKey, definitionVer)
+                .withMigrateToProcessDefinitionTenantId(definitionTenantId)
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("originalActivity1", "newActivity1")
+                        .withLocalVariables(Collections.singletonMap("variableString", "variableValue")))
+                .addActivityMigrationMapping(
+                        ActivityMigrationMapping.createMappingFor("originalActivity2", "newActivity2").withLocalVariable("variableDouble", 12345.6789))
+                .withProcessInstanceVariable("instanceVar1", "stringValue")
+                .withProcessInstanceVariable("instanceVar2", 12345.6789)
+                .getProcessInstanceMigrationDocument();
 
         //Serialize the document as Json
         String serializedDocument = document.asJsonString();
@@ -393,13 +402,14 @@ public class ProcessInstanceMigrationDocumentTest extends AbstractTestCase {
         //DeSerialize the document
         ProcessInstanceMigrationDocument migrationDocument = ProcessInstanceMigrationDocumentImpl.fromJson(serializedDocument);
 
-        assertNull(migrationDocument.getMigrateToProcessDefinitionId());
-        assertEquals(definitionKey, migrationDocument.getMigrateToProcessDefinitionKey());
-        assertEquals(definitionVer, migrationDocument.getMigrateToProcessDefinitionVersion());
-        assertEquals(definitionTenantId, migrationDocument.getMigrateToProcessDefinitionTenantId());
+        assertThat(migrationDocument.getMigrateToProcessDefinitionId()).isNull();
+        assertThat(migrationDocument.getMigrateToProcessDefinitionKey()).isEqualTo(definitionKey);
+        assertThat(migrationDocument.getMigrateToProcessDefinitionVersion()).isEqualTo(definitionVer);
+        assertThat(migrationDocument.getMigrateToProcessDefinitionTenantId()).isEqualTo(definitionTenantId);
         assertThat(migrationDocument.getActivityMigrationMappings()).usingFieldByFieldElementComparator().containsExactly(oneToOne1, oneToOne2);
         assertThat(migrationDocument.getActivitiesLocalVariables()).containsKeys("newActivity1", "newActivity2");
-        assertThat(migrationDocument.getActivitiesLocalVariables().get("newActivity1")).isEqualTo((Collections.singletonMap("variableString", "variableValue")));
+        assertThat(migrationDocument.getActivitiesLocalVariables().get("newActivity1"))
+                .isEqualTo((Collections.singletonMap("variableString", "variableValue")));
         assertThat(migrationDocument.getActivitiesLocalVariables().get("newActivity2")).isEqualTo((Collections.singletonMap("variableDouble", 12345.6789)));
         assertThat(migrationDocument.getProcessInstanceVariables()).isEqualTo(processInstanceVars);
     }
@@ -414,23 +424,25 @@ public class ProcessInstanceMigrationDocumentTest extends AbstractTestCase {
 
         //last occurrence of inSubProcessOfCallActivityId prevails
         ActivityMigrationMapping oneToOneMapping = ActivityMigrationMapping.createMappingFor("originalActivity1", "newActivity1")
-            .inSubProcessOfCallActivityId("wrongCallActivity", -4)
-            .inSubProcessOfCallActivityId("callActivityId")
-            .withLocalVariable("varForNewActivity1", "varValue")
-            .withNewAssignee("kermit");
+                .inSubProcessOfCallActivityId("wrongCallActivity", -4)
+                .inSubProcessOfCallActivityId("callActivityId")
+                .withLocalVariable("varForNewActivity1", "varValue")
+                .withNewAssignee("kermit");
 
         //inParentProcessOfCallActivityId and inSubProcess are mutually exclusive, last occurrence prevails
-        ActivityMigrationMapping oneToManyMapping = ActivityMigrationMapping.createMappingFor("originalActivity2", Arrays.asList("newActivity2.1", "newActivity2.2"))
-            .withLocalVariableForAllActivities("var1ForNewActivity2.x", "varValue")
-            .withLocalVariableForAllActivities("var2ForNewActivity2.x", 1234.567)
-            .inParentProcessOfCallActivityId("someCallActivityId")
-            .inSubProcessOfCallActivityId("someCallActivityId", 2);
+        ActivityMigrationMapping oneToManyMapping = ActivityMigrationMapping
+                .createMappingFor("originalActivity2", Arrays.asList("newActivity2.1", "newActivity2.2"))
+                .withLocalVariableForAllActivities("var1ForNewActivity2.x", "varValue")
+                .withLocalVariableForAllActivities("var2ForNewActivity2.x", 1234.567)
+                .inParentProcessOfCallActivityId("someCallActivityId")
+                .inSubProcessOfCallActivityId("someCallActivityId", 2);
 
         //inParentProcessOfCallActivityId and inSubProcess are mutually exclusive, last occurrence prevails
-        ActivityMigrationMapping manyToOneMapping = ActivityMigrationMapping.createMappingFor(Arrays.asList("originalActivity3", "originalActivity4"), "newActivity3")
-            .withLocalVariable("varForNewActivity3", 9876)
-            .inSubProcessOfCallActivityId("subProcKey", 2)
-            .inParentProcessOfCallActivityId("someCallActivityId");
+        ActivityMigrationMapping manyToOneMapping = ActivityMigrationMapping
+                .createMappingFor(Arrays.asList("originalActivity3", "originalActivity4"), "newActivity3")
+                .withLocalVariable("varForNewActivity3", 9876)
+                .inSubProcessOfCallActivityId("subProcKey", 2)
+                .inParentProcessOfCallActivityId("someCallActivityId");
 
         HashMap<String, Map<String, Object>> activityLocalVariables = new HashMap<String, Map<String, Object>>() {
 
@@ -475,11 +487,12 @@ public class ProcessInstanceMigrationDocumentTest extends AbstractTestCase {
         String jsonAsStr = IoUtil.readFileAsString("org/flowable/engine/test/api/runtime/migration/withCallActivityProcessInstanceMigrationDocument.json");
 
         ProcessInstanceMigrationDocument migrationDocument = ProcessInstanceMigrationDocumentImpl.fromJson(jsonAsStr);
-        assertEquals(definitionId, migrationDocument.getMigrateToProcessDefinitionId());
-        assertEquals(definitionKey, migrationDocument.getMigrateToProcessDefinitionKey());
-        assertEquals(definitionVer, migrationDocument.getMigrateToProcessDefinitionVersion());
-        assertEquals(definitionTenantId, migrationDocument.getMigrateToProcessDefinitionTenantId());
-        assertThat(migrationDocument.getActivityMigrationMappings()).usingFieldByFieldElementComparator().containsExactly(oneToOneMapping, oneToManyMapping, manyToOneMapping);
+        assertThat(migrationDocument.getMigrateToProcessDefinitionId()).isEqualTo(definitionId);
+        assertThat(migrationDocument.getMigrateToProcessDefinitionKey()).isEqualTo(definitionKey);
+        assertThat(migrationDocument.getMigrateToProcessDefinitionVersion()).isEqualTo(definitionVer);
+        assertThat(migrationDocument.getMigrateToProcessDefinitionTenantId()).isEqualTo(definitionTenantId);
+        assertThat(migrationDocument.getActivityMigrationMappings()).usingFieldByFieldElementComparator()
+                .containsExactly(oneToOneMapping, oneToManyMapping, manyToOneMapping);
         assertThat(migrationDocument.getActivitiesLocalVariables()).isEqualTo(activityLocalVariables);
         assertThat(migrationDocument.getProcessInstanceVariables()).isEqualTo(processInstanceVariables);
     }


### PR DESCRIPTION
Because of the large number of changes this is Part 1 of 2 for the test files in the
`org.flowable.engine.test.api.runtime.migration` package.

Continuing quest to use only a single style in each file and in the module.

