### PR TITLE
Replace Java 13 with Java 14 build on Github and Travis.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [1.8, 11, 13]
+        java: [1.8, 11, 14]
     steps:
     - uses: actions/checkout@v2-beta
       with:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
       cd scripts && ./run-flowable5-tests.sh
   - jdk: openjdk11
     dist: xenial
-  - jdk: openjdk13
+  - jdk: openjdk14
   - jdk: openjdk-ea
     branches:
       only:


### PR DESCRIPTION
Java 13 is effectively end-of-life, so replace it with Java 14.